### PR TITLE
Adding e2e tests for validating cascading deletion of federation resources

### DIFF
--- a/test/e2e/federation-deployment.go
+++ b/test/e2e/federation-deployment.go
@@ -19,9 +19,10 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
-	"k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -49,14 +50,9 @@ var _ = framework.KubeDescribe("Federation deployments [Feature:Federation]", fu
 		AfterEach(func() {
 			framework.SkipUnlessFederated(f.ClientSet)
 
-			// Delete registered deployments.
+			// Delete all deployments.
 			nsName := f.FederationNamespace.Name
-			deploymentList, err := f.FederationClientset_1_5.Extensions().Deployments(nsName).List(v1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			for _, deployment := range deploymentList.Items {
-				err := f.FederationClientset_1_5.Extensions().Deployments(nsName).Delete(deployment.Name, &v1.DeleteOptions{})
-				Expect(err).NotTo(HaveOccurred())
-			}
+			deleteAllDeploymentsOrFail(f.FederationClientset_1_5, nsName)
 		})
 
 		It("should be created and deleted successfully", func() {
@@ -89,6 +85,8 @@ var _ = framework.KubeDescribe("Federation deployments [Feature:Federation]", fu
 		})
 
 		AfterEach(func() {
+			nsName := f.FederationNamespace.Name
+			deleteAllDeploymentsOrFail(f.FederationClientset_1_5, nsName)
 			unregisterClusters(clusters, f)
 		})
 
@@ -111,25 +109,101 @@ var _ = framework.KubeDescribe("Federation deployments [Feature:Federation]", fu
 			waitForDeploymentOrFail(f.FederationClientset_1_5, nsName, dep.Name, clusters)
 			By(fmt.Sprintf("Successfuly updated and synced deployment %q/%q to clusters", nsName, dep.Name))
 		})
+
+		It("should be deleted from underlying clusters when OrphanDependents is false", func() {
+			framework.SkipUnlessFederated(f.ClientSet)
+			nsName := f.FederationNamespace.Name
+			orphanDependents := false
+			verifyCascadingDeletionForDeployment(f.FederationClientset_1_5, clusters, &orphanDependents, nsName)
+			By(fmt.Sprintf("Verified that deployments were deleted from underlying clusters"))
+		})
+
+		It("should not be deleted from underlying clusters when OrphanDependents is true", func() {
+			framework.SkipUnlessFederated(f.ClientSet)
+			nsName := f.FederationNamespace.Name
+			orphanDependents := true
+			verifyCascadingDeletionForDeployment(f.FederationClientset_1_5, clusters, &orphanDependents, nsName)
+			By(fmt.Sprintf("Verified that deployments were not deleted from underlying clusters"))
+		})
+
+		It("should not be deleted from underlying clusters when OrphanDependents is nil", func() {
+			framework.SkipUnlessFederated(f.ClientSet)
+			nsName := f.FederationNamespace.Name
+			verifyCascadingDeletionForDeployment(f.FederationClientset_1_5, clusters, nil, nsName)
+			By(fmt.Sprintf("Verified that deployments were not deleted from underlying clusters"))
+		})
+
 	})
 })
 
-func waitForDeploymentOrFail(c *federation_release_1_5.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster) {
-	err := waitForDeployment(c, namespace, replicaSetName, clusters)
-	framework.ExpectNoError(err, "Failed to verify deployment %q/%q, err: %v", namespace, replicaSetName, err)
+// deleteAllDeploymentsOrFail deletes all deployments in the given namespace name.
+func deleteAllDeploymentsOrFail(clientset *fedclientset.Clientset, nsName string) {
+	deploymentList, err := clientset.Extensions().Deployments(nsName).List(v1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	orphanDependents := false
+	for _, deployment := range deploymentList.Items {
+		deleteDeploymentOrFail(clientset, nsName, deployment.Name, &orphanDependents)
+	}
 }
 
-func waitForDeployment(c *federation_release_1_5.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster) error {
+// verifyCascadingDeletionForDeployment verifies that deployments are deleted
+// from underlying clusters when orphan dependents is false and they are not
+// deleted when orphan dependents is true.
+func verifyCascadingDeletionForDeployment(clientset *fedclientset.Clientset, clusters map[string]*cluster, orphanDependents *bool, nsName string) {
+	deployment := createDeploymentOrFail(clientset, nsName)
+	deploymentName := deployment.Name
+	// Check subclusters if the deployment was created there.
+	By(fmt.Sprintf("Waiting for deployment %s to be created in all underlying clusters", deploymentName))
+	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		for _, cluster := range clusters {
+			_, err := cluster.Extensions().Deployments(nsName).Get(deploymentName)
+			if err != nil && errors.IsNotFound(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	})
+	framework.ExpectNoError(err, "Not all deployments created")
+
+	By(fmt.Sprintf("Deleting deployment %s", deploymentName))
+	deleteDeploymentOrFail(clientset, nsName, deploymentName, orphanDependents)
+
+	By(fmt.Sprintf("Verifying deployments %s in underlying clusters", deploymentName))
+	errMessages := []string{}
+	// deployment should be present in underlying clusters unless orphanDependents is false.
+	shouldExist := orphanDependents == nil || *orphanDependents == true
+	for clusterName, clusterClientset := range clusters {
+		_, err := clusterClientset.Extensions().Deployments(nsName).Get(deploymentName)
+		if shouldExist && errors.IsNotFound(err) {
+			errMessages = append(errMessages, fmt.Sprintf("unexpected NotFound error for deployment %s in cluster %s, expected deployment to exist", deploymentName, clusterName))
+		} else if shouldExist && !errors.IsNotFound(err) {
+			errMessages = append(errMessages, fmt.Sprintf("expected NotFound error for deployment %s in cluster %s, got error: %v", deploymentName, clusterName, err))
+		}
+	}
+	if len(errMessages) != 0 {
+		framework.Failf("%s", strings.Join(errMessages, "; "))
+	}
+}
+
+func waitForDeploymentOrFail(c *fedclientset.Clientset, namespace string, deploymentName string, clusters map[string]*cluster) {
+	err := waitForDeployment(c, namespace, deploymentName, clusters)
+	framework.ExpectNoError(err, "Failed to verify deployment %q/%q, err: %v", namespace, deploymentName, err)
+}
+
+func waitForDeployment(c *fedclientset.Clientset, namespace string, deploymentName string, clusters map[string]*cluster) error {
 	err := wait.Poll(10*time.Second, FederatedDeploymentTimeout, func() (bool, error) {
-		fdep, err := c.Deployments(namespace).Get(replicaSetName)
+		fdep, err := c.Deployments(namespace).Get(deploymentName)
 		if err != nil {
 			return false, err
 		}
 		specReplicas, statusReplicas := int32(0), int32(0)
 		for _, cluster := range clusters {
-			dep, err := cluster.Deployments(namespace).Get(replicaSetName)
+			dep, err := cluster.Deployments(namespace).Get(deploymentName)
 			if err != nil && !errors.IsNotFound(err) {
-				By(fmt.Sprintf("Failed getting deployment: %q/%q/%q, err: %v", cluster.name, namespace, replicaSetName, err))
+				By(fmt.Sprintf("Failed getting deployment: %q/%q/%q, err: %v", cluster.name, namespace, deploymentName, err))
 				return false, err
 			}
 			if err == nil {
@@ -158,7 +232,7 @@ func equivalentDeployment(fedDeployment, localDeployment *v1beta1.Deployment) bo
 		reflect.DeepEqual(fedDeployment.Spec, localDeploymentSpec)
 }
 
-func createDeploymentOrFail(clientset *federation_release_1_5.Clientset, namespace string) *v1beta1.Deployment {
+func createDeploymentOrFail(clientset *fedclientset.Clientset, namespace string) *v1beta1.Deployment {
 	if clientset == nil || len(namespace) == 0 {
 		Fail(fmt.Sprintf("Internal error: invalid parameters passed to createDeploymentOrFail: clientset: %v, namespace: %v", clientset, namespace))
 	}
@@ -172,7 +246,7 @@ func createDeploymentOrFail(clientset *federation_release_1_5.Clientset, namespa
 	return deployment
 }
 
-func updateDeploymentOrFail(clientset *federation_release_1_5.Clientset, namespace string) *v1beta1.Deployment {
+func updateDeploymentOrFail(clientset *fedclientset.Clientset, namespace string) *v1beta1.Deployment {
 	if clientset == nil || len(namespace) == 0 {
 		Fail(fmt.Sprintf("Internal error: invalid parameters passed to updateDeploymentOrFail: clientset: %v, namespace: %v", clientset, namespace))
 	}
@@ -185,6 +259,24 @@ func updateDeploymentOrFail(clientset *federation_release_1_5.Clientset, namespa
 	By(fmt.Sprintf("Successfully updated federation deployment %q in namespace %q", FederationDeploymentName, namespace))
 
 	return newRs
+}
+
+func deleteDeploymentOrFail(clientset *fedclientset.Clientset, nsName string, deploymentName string, orphanDependents *bool) {
+	By(fmt.Sprintf("Deleting deployment %q in namespace %q", deploymentName, nsName))
+	err := clientset.Extensions().Deployments(nsName).Delete(deploymentName, &v1.DeleteOptions{OrphanDependents: orphanDependents})
+	framework.ExpectNoError(err, "Error deleting deployment %q in namespace %q", deploymentName, nsName)
+
+	// Wait for the deployment to be deleted.
+	err = wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		_, err := clientset.Extensions().Deployments(nsName).Get(deploymentName)
+		if err != nil && errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		framework.Failf("Error in deleting deployment %s: %v", deploymentName, err)
+	}
 }
 
 func newDeploymentForFed(namespace string, name string, replicas int32) *v1beta1.Deployment {

--- a/test/e2e/federation-replicaset.go
+++ b/test/e2e/federation-replicaset.go
@@ -19,9 +19,10 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
-	"k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
+	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5"
 	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -49,14 +50,9 @@ var _ = framework.KubeDescribe("Federation replicasets [Feature:Federation]", fu
 		AfterEach(func() {
 			framework.SkipUnlessFederated(f.ClientSet)
 
-			// Delete registered replicasets.
+			// Delete all replicasets.
 			nsName := f.FederationNamespace.Name
-			replicasetList, err := f.FederationClientset_1_5.Extensions().ReplicaSets(nsName).List(v1.ListOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			for _, replicaset := range replicasetList.Items {
-				err := f.FederationClientset_1_5.Extensions().ReplicaSets(nsName).Delete(replicaset.Name, &v1.DeleteOptions{})
-				Expect(err).NotTo(HaveOccurred())
-			}
+			deleteAllReplicaSetsOrFail(f.FederationClientset_1_5, nsName)
 		})
 
 		It("should be created and deleted successfully", func() {
@@ -89,6 +85,9 @@ var _ = framework.KubeDescribe("Federation replicasets [Feature:Federation]", fu
 		})
 
 		AfterEach(func() {
+			// Delete all replicasets.
+			nsName := f.FederationNamespace.Name
+			deleteAllReplicaSetsOrFail(f.FederationClientset_1_5, nsName)
 			unregisterClusters(clusters, f)
 		})
 
@@ -111,15 +110,88 @@ var _ = framework.KubeDescribe("Federation replicasets [Feature:Federation]", fu
 			waitForReplicaSetOrFail(f.FederationClientset_1_5, nsName, rs.Name, clusters)
 			By(fmt.Sprintf("Successfuly updated and synced replicaset %q/%q to clusters", nsName, rs.Name))
 		})
+
+		It("should be deleted from underlying clusters when OrphanDependents is false", func() {
+			framework.SkipUnlessFederated(f.ClientSet)
+			nsName := f.FederationNamespace.Name
+			orphanDependents := false
+			verifyCascadingDeletionForReplicaSet(f.FederationClientset_1_5, clusters, &orphanDependents, nsName)
+			By(fmt.Sprintf("Verified that replica sets were deleted from underlying clusters"))
+		})
+
+		It("should not be deleted from underlying clusters when OrphanDependents is true", func() {
+			framework.SkipUnlessFederated(f.ClientSet)
+			nsName := f.FederationNamespace.Name
+			orphanDependents := true
+			verifyCascadingDeletionForReplicaSet(f.FederationClientset_1_5, clusters, &orphanDependents, nsName)
+			By(fmt.Sprintf("Verified that replica sets were not deleted from underlying clusters"))
+		})
+
+		It("should not be deleted from underlying clusters when OrphanDependents is nil", func() {
+			framework.SkipUnlessFederated(f.ClientSet)
+			nsName := f.FederationNamespace.Name
+			verifyCascadingDeletionForReplicaSet(f.FederationClientset_1_5, clusters, nil, nsName)
+			By(fmt.Sprintf("Verified that replica sets were not deleted from underlying clusters"))
+		})
 	})
 })
 
-func waitForReplicaSetOrFail(c *federation_release_1_5.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster) {
-	err := waitForReplicaSet(c, namespace, replicaSetName, clusters)
-	framework.ExpectNoError(err, "Failed to verify replicaset %q/%q, err: %v", namespace, replicaSetName, err)
+// deleteAllReplicaSetsOrFail deletes all replicasets in the given namespace name.
+func deleteAllReplicaSetsOrFail(clientset *fedclientset.Clientset, nsName string) {
+	replicasetList, err := clientset.Extensions().ReplicaSets(nsName).List(v1.ListOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	orphanDependents := false
+	for _, replicaset := range replicasetList.Items {
+		deleteReplicaSetOrFail(clientset, nsName, replicaset.Name, &orphanDependents)
+	}
 }
 
-func waitForReplicaSet(c *federation_release_1_5.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster) error {
+// verifyCascadingDeletionForReplicaSet verifies that replicaSets are deleted
+// from underlying clusters when orphan dependents is false and they are not
+// deleted when orphan dependents is true.
+func verifyCascadingDeletionForReplicaSet(clientset *fedclientset.Clientset, clusters map[string]*cluster, orphanDependents *bool, nsName string) {
+	replicaSet := createReplicaSetOrFail(clientset, nsName)
+	replicaSetName := replicaSet.Name
+	// Check subclusters if the replicaSet was created there.
+	By(fmt.Sprintf("Waiting for replica sets %s to be created in all underlying clusters", replicaSetName))
+	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		for _, cluster := range clusters {
+			_, err := cluster.Extensions().ReplicaSets(nsName).Get(replicaSetName)
+			if err != nil && errors.IsNotFound(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	})
+	framework.ExpectNoError(err, "Not all replica sets created")
+
+	By(fmt.Sprintf("Deleting replica set %s", replicaSetName))
+	deleteReplicaSetOrFail(clientset, nsName, replicaSetName, orphanDependents)
+
+	By(fmt.Sprintf("Verifying replica sets %s in underlying clusters", replicaSetName))
+	errMessages := []string{}
+	for clusterName, clusterClientset := range clusters {
+		_, err := clusterClientset.Extensions().ReplicaSets(nsName).Get(replicaSetName)
+		if (orphanDependents == nil || *orphanDependents == true) && errors.IsNotFound(err) {
+			errMessages = append(errMessages, fmt.Sprintf("unexpected NotFound error for replica set %s in cluster %s, expected replica set to exist", replicaSetName, clusterName))
+		} else if (orphanDependents != nil && *orphanDependents == false) && (err == nil || !errors.IsNotFound(err)) {
+			errMessages = append(errMessages, fmt.Sprintf("expected NotFound error for replica set %s in cluster %s, got error: %v", replicaSetName, clusterName, err))
+		}
+	}
+	if len(errMessages) != 0 {
+		framework.Failf("%s", strings.Join(errMessages, "; "))
+	}
+}
+
+func waitForReplicaSetOrFail(c *fedclientset.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster) {
+	err := waitForReplicaSet(c, namespace, replicaSetName, clusters)
+	framework.ExpectNoError(err, "Failed to verify replica set %q/%q, err: %v", namespace, replicaSetName, err)
+}
+
+func waitForReplicaSet(c *fedclientset.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster) error {
 	err := wait.Poll(10*time.Second, FederatedReplicaSetTimeout, func() (bool, error) {
 		frs, err := c.ReplicaSets(namespace).Get(replicaSetName)
 		if err != nil {
@@ -158,7 +230,7 @@ func equivalentReplicaSet(fedReplicaSet, localReplicaSet *v1beta1.ReplicaSet) bo
 		reflect.DeepEqual(fedReplicaSet.Spec, localReplicaSetSpec)
 }
 
-func createReplicaSetOrFail(clientset *federation_release_1_5.Clientset, namespace string) *v1beta1.ReplicaSet {
+func createReplicaSetOrFail(clientset *fedclientset.Clientset, namespace string) *v1beta1.ReplicaSet {
 	if clientset == nil || len(namespace) == 0 {
 		Fail(fmt.Sprintf("Internal error: invalid parameters passed to createReplicaSetOrFail: clientset: %v, namespace: %v", clientset, namespace))
 	}
@@ -172,7 +244,25 @@ func createReplicaSetOrFail(clientset *federation_release_1_5.Clientset, namespa
 	return replicaset
 }
 
-func updateReplicaSetOrFail(clientset *federation_release_1_5.Clientset, namespace string) *v1beta1.ReplicaSet {
+func deleteReplicaSetOrFail(clientset *fedclientset.Clientset, nsName string, replicaSetName string, orphanDependents *bool) {
+	By(fmt.Sprintf("Deleting replica set %q in namespace %q", replicaSetName, nsName))
+	err := clientset.Extensions().ReplicaSets(nsName).Delete(replicaSetName, &v1.DeleteOptions{OrphanDependents: orphanDependents})
+	framework.ExpectNoError(err, "Error deleting replica set %q in namespace %q", replicaSetName, nsName)
+
+	// Wait for the replicaSet to be deleted.
+	err = wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		_, err := clientset.Extensions().ReplicaSets(nsName).Get(replicaSetName)
+		if err != nil && errors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		framework.Failf("Error in deleting replica set %s: %v", replicaSetName, err)
+	}
+}
+
+func updateReplicaSetOrFail(clientset *fedclientset.Clientset, namespace string) *v1beta1.ReplicaSet {
 	if clientset == nil || len(namespace) == 0 {
 		Fail(fmt.Sprintf("Internal error: invalid parameters passed to updateReplicaSetOrFail: clientset: %v, namespace: %v", clientset, namespace))
 	}

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -142,27 +142,43 @@ Federated Services Service creation should create matching services in underlyin
 Federated Services Service creation should succeed,rmmh,1
 Federated ingresses Federated Ingresses Ingress connectivity and DNS should be able to connect to a federated ingress via its load balancer,rmmh,1
 Federated ingresses Federated Ingresses should be created and deleted successfully,dchen1107,1
+Federated ingresses Federated Ingresses should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0
 Federated ingresses Federated Ingresses should create and update matching ingresses in underlying clusters,ghodss,1
+Federated ingresses Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0
+Federated ingresses Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0
 Federation API server authentication should accept cluster resources when the client has right authentication credentials,davidopp,1
 Federation API server authentication should not accept cluster resources when the client has invalid authentication credentials,yujuhong,1
 Federation API server authentication should not accept cluster resources when the client has no authentication credentials,nikhiljindal,1
 Federation apiserver Admission control should not be able to create resources if namespace does not exist,alex-mohr,1
 Federation apiserver Cluster objects should be created and deleted successfully,ghodss,1
 Federation daemonsets DaemonSet objects should be created and deleted successfully,nikhiljindal,0
+Federation daemonsets DaemonSet objects should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0
+Federation daemonsets DaemonSet objects should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0
+Federation daemonsets DaemonSet objects should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0
 Federation deployments Deployment objects should be created and deleted successfully,soltysh,1
+Federation deployments Federated Deployment should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0
 Federation deployments Federated Deployment should create and update matching deployments in underling clusters,soltysh,1
+Federation deployments Federated Deployment should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0
+Federation deployments Federated Deployment should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0
 Federation events Event objects should be created and deleted successfully,karlkfi,1
 Federation namespace Namespace objects all resources in the namespace should be deleted when namespace is deleted,nikhiljindal,0
 Federation namespace Namespace objects should be created and deleted successfully,xiang90,1
 Federation namespace Namespace objects should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0
+Federation namespace Namespace objects should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0
 Federation namespace Namespace objects should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0
+Federation replicasets Federated ReplicaSet should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0
 Federation replicasets Federated ReplicaSet should create and update matching replicasets in underling clusters,childsb,1
+Federation replicasets Federated ReplicaSet should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0
+Federation replicasets Federated ReplicaSet should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0
 Federation replicasets ReplicaSet objects should be created and deleted successfully,apelisse,1
 Federation secrets Secret objects should be created and deleted successfully,pmorie,1
 Federation secrets Secret objects should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0
+Federation secrets Secret objects should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0
 Federation secrets Secret objects should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0
 GCP Volumes GlusterFS should be mountable,rkouj,0
 GCP Volumes NFSv4 should be mountable for NFSv4,rkouj,0
+GCP Volumes GlusterFS should be mountable,nikhiljindal,0
+GCP Volumes NFSv4 should be mountable for NFSv4,nikhiljindal,0
 GKE local SSD should write and read from node local SSD,fabioy,0
 GKE node pools should create a cluster with multiple node pools,fabioy,1
 Garbage collector should delete pods created by rc when not orphaning,justinsb,1
@@ -172,6 +188,8 @@ Garbage collector should orphan pods created by rc if deleteOptions.OrphanDepend
 "Generated release_1_5 clientset should create v2alpha1 cronJobs, delete cronJobs, watch cronJobs",soltysh,1
 HA-master pods survive addition/removal different zones,rkouj,0
 HA-master pods survive addition/removal same zone,rkouj,0
+HA-master pods survive addition/removal different zones,nikhiljindal,0
+HA-master pods survive addition/removal same zone,nikhiljindal,0
 Hazelcast should create and scale hazelcast,mikedanese,1
 Horizontal pod autoscaling (scale resource: CPU) Deployment Should scale from 1 pod to 3 pods and from 3 to 5,jszczepkowski,0
 Horizontal pod autoscaling (scale resource: CPU) Deployment Should scale from 5 pods to 3 pods and from 3 to 1,jszczepkowski,0


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/33612

Adding e2e tests for code in https://github.com/kubernetes/kubernetes/pull/36330 and https://github.com/kubernetes/kubernetes/pull/36476.

Adding test cases to ensure that cascading deletion happens as expected.
Also adding code to ensure that all resources are cleaned up in AfterEach.

cc @kubernetes/sig-cluster-federation @caesarxuchao @madhusudancs 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36630)
<!-- Reviewable:end -->
