### PR TITLE
Do not emit event for AlreadyExists errors

### DIFF
--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -359,7 +359,8 @@ func (dc *DeploymentController) getNewReplicaSet(deployment *extensions.Deployme
 	// We may end up hitting this due to a slow cache or a fast resync of the deployment.
 	// TODO: Restore once https://github.com/kubernetes/kubernetes/issues/29735 is fixed
 	// ie. we start using a new hashing algorithm.
-	// case errors.IsAlreadyExists(err):
+	case errors.IsAlreadyExists(err):
+		return nil, err
 	//	return dc.rsLister.ReplicaSets(namespace).Get(newRS.Name)
 	case err != nil:
 		msg := fmt.Sprintf("Failed to create new replica set %q: %v", newRS.Name, err)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/36598 also reduced the clutter of events since the AlreadyExists error is a common error (may be a slow rs cache or a fast resync of the deployment that causes it apart from hash collisions)

@kubernetes/deployment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36642)
<!-- Reviewable:end -->
