### PR TITLE
Add option to disable federation ingress controller

### DIFF
--- a/federation/cmd/federation-controller-manager/app/BUILD
+++ b/federation/cmd/federation-controller-manager/app/BUILD
@@ -33,9 +33,13 @@ go_library(
         "//federation/pkg/federation-controller/secret:go_default_library",
         "//federation/pkg/federation-controller/service:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/restclient:go_default_library",
+        "//pkg/client/typed/discovery:go_default_library",
         "//pkg/client/unversioned/clientcmd:go_default_library",
         "//pkg/healthz:go_default_library",
+        "//pkg/runtime/schema:go_default_library",
+        "//pkg/util/config:go_default_library",
         "//pkg/util/configz:go_default_library",
         "//pkg/util/wait:go_default_library",
         "//pkg/version:go_default_library",
@@ -43,5 +47,18 @@ go_library(
         "//vendor:github.com/prometheus/client_golang/prometheus",
         "//vendor:github.com/spf13/cobra",
         "//vendor:github.com/spf13/pflag",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["controllermanager_test.go"],
+    library = "go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//federation/pkg/federation-controller/ingress:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/runtime/schema:go_default_library",
+        "//pkg/util/config:go_default_library",
     ],
 )

--- a/federation/cmd/federation-controller-manager/app/controllermanager_test.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	ingresscontroller "k8s.io/kubernetes/federation/pkg/federation-controller/ingress"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/util/config"
+	"testing"
+)
+
+func TestControllerEnabled(t *testing.T) {
+
+	testCases := []struct {
+		controllersConfig config.ConfigurationMap
+		serverResources   []*metav1.APIResourceList
+		controller        string
+		requiredResources []schema.GroupVersionResource
+		defaultValue      bool
+		expectedResult    bool
+	}{
+		// no override, API server has Ingress enabled
+		{
+			controllersConfig: config.ConfigurationMap{},
+			serverResources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "extensions/v1beta1",
+					APIResources: []metav1.APIResource{
+						{Name: "ingresses", Namespaced: true, Kind: "Ingress"},
+					},
+				},
+			},
+			controller:        ingresscontroller.ControllerName,
+			requiredResources: ingresscontroller.RequiredResources,
+			defaultValue:      true,
+			expectedResult:    true,
+		},
+		// no override, API server has Ingress disabled
+		{
+			controllersConfig: config.ConfigurationMap{},
+			serverResources:   []*metav1.APIResourceList{},
+			controller:        ingresscontroller.ControllerName,
+			requiredResources: ingresscontroller.RequiredResources,
+			defaultValue:      true,
+			expectedResult:    false,
+		},
+		// API server has Ingress enabled, override config to disable Ingress controller
+		{
+			controllersConfig: config.ConfigurationMap{
+				ingresscontroller.ControllerName: "false",
+			},
+			serverResources: []*metav1.APIResourceList{
+				{
+					GroupVersion: "extensions/v1beta1",
+					APIResources: []metav1.APIResource{
+						{Name: "ingresses", Namespaced: true, Kind: "Ingress"},
+					},
+				},
+			},
+			controller:        ingresscontroller.ControllerName,
+			requiredResources: ingresscontroller.RequiredResources,
+			defaultValue:      true,
+			expectedResult:    false,
+		},
+	}
+
+	for _, test := range testCases {
+		actualEnabled := controllerEnabled(test.controllersConfig, test.serverResources, test.controller, test.requiredResources, test.defaultValue)
+		if actualEnabled != test.expectedResult {
+			t.Errorf("%s controller: expected %v, got %v", test.controller, test.expectedResult, actualEnabled)
+		}
+	}
+}

--- a/federation/cmd/federation-controller-manager/app/options/BUILD
+++ b/federation/cmd/federation-controller-manager/app/options/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/apis/componentconfig:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/leaderelection:go_default_library",
+        "//pkg/util/config:go_default_library",
         "//vendor:github.com/spf13/pflag",
     ],
 )

--- a/federation/cmd/federation-controller-manager/app/options/options.go
+++ b/federation/cmd/federation-controller-manager/app/options/options.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/client/leaderelection"
+	"k8s.io/kubernetes/pkg/util/config"
 )
 
 type ControllerManagerConfiguration struct {
@@ -67,6 +68,8 @@ type ControllerManagerConfiguration struct {
 	LeaderElection componentconfig.LeaderElectionConfiguration `json:"leaderElection"`
 	// contentType is contentType of requests sent to apiserver.
 	ContentType string `json:"contentType"`
+	// ConfigurationMap determining which controllers should be enabled or disabled
+	Controllers config.ConfigurationMap `json:"controllers"`
 }
 
 // CMServer is the main context object for the controller manager.
@@ -94,6 +97,7 @@ func NewCMServer() *CMServer {
 			APIServerQPS:              20.0,
 			APIServerBurst:            30,
 			LeaderElection:            leaderelection.DefaultLeaderElectionConfiguration(),
+			Controllers:               make(config.ConfigurationMap),
 		},
 	}
 	return &s
@@ -118,5 +122,9 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.APIServerBurst, "federated-api-burst", s.APIServerBurst, "Burst to use while talking with federation apiserver")
 	fs.StringVar(&s.DnsProvider, "dns-provider", s.DnsProvider, "DNS provider. Valid values are: "+fmt.Sprintf("%q", dnsprovider.RegisteredDnsProviders()))
 	fs.StringVar(&s.DnsConfigFile, "dns-provider-config", s.DnsConfigFile, "Path to config file for configuring DNS provider.")
+	fs.Var(&s.Controllers, "controllers", ""+
+		"A set of key=value pairs that describe controller configuration that may be passed "+
+		"to controller manager to enable/disable specific controllers. Valid options are: \n"+
+		"ingress=true|false (default=true)")
 	leaderelection.BindFlags(&s.LeaderElection, fs)
 }

--- a/federation/pkg/federation-controller/ingress/BUILD
+++ b/federation/pkg/federation-controller/ingress/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/conversion:go_default_library",
         "//pkg/runtime:go_default_library",
+        "//pkg/runtime/schema:go_default_library",
         "//pkg/types:go_default_library",
         "//pkg/util/flowcontrol:go_default_library",
         "//pkg/watch:go_default_library",

--- a/federation/pkg/federation-controller/ingress/ingress_controller_test.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller_test.go
@@ -129,14 +129,14 @@ func TestIngressController(t *testing.T) {
 	t.Log("Adding Ingress UID ConfigMap to cluster 1")
 	cluster1ConfigMapWatch.Add(cfg1)
 
-	t.Log("Checking that UID annotation on Cluster 1 annotation was correctly updated")
-	cluster := GetClusterFromChan(fedClusterUpdateChan)
-	assert.NotNil(t, cluster)
-	assert.Equal(t, cluster.ObjectMeta.Annotations[uidAnnotationKey], cfg1.Data[uidKey])
-
 	// Test add federated ingress.
 	t.Log("Adding Federated Ingress")
 	fedIngressWatch.Add(&fedIngress)
+
+	t.Log("Checking that UID annotation on Cluster 1 annotation was correctly updated after adding Federated Ingress")
+	cluster := GetClusterFromChan(fedClusterUpdateChan)
+	assert.NotNil(t, cluster)
+	assert.Equal(t, cluster.ObjectMeta.Annotations[uidAnnotationKey], cfg1.Data[uidKey])
 
 	t.Logf("Checking that approproate finalizers are added")
 	// There should be 2 updates to add both the finalizers.

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -519,6 +519,7 @@ k8s.io/kubernetes/cmd/mungedocs,mwielgus,1
 k8s.io/kubernetes/examples,Random-Liu,0
 k8s.io/kubernetes/federation/apis/federation/install,nikhiljindal,0
 k8s.io/kubernetes/federation/apis/federation/validation,nikhiljindal,0
+k8s.io/kubernetes/federation/cmd/federation-controller-manager/app,kzwang,0
 k8s.io/kubernetes/federation/pkg/dnsprovider,sttts,1
 k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53,cjcullen,1
 k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns,jsafrane,1


### PR DESCRIPTION
**What this PR does / why we need it**:
Added an option to enable/disable federation ingress controller as currently federated ingresses doesn't work in environments other than GCE/GKE. Also ignore reconcile config maps if no federated ingresses exist.

**Which issue this PR fixes** 
fixes #33943

@quinton-hoole

**Release note**:
```release-note
Add `--controllers` flag to federation controller manager for enable/disable federation ingress controller
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36643)
<!-- Reviewable:end -->
