### PR TITLE
Set version and job-version in started.json/metadata.json

### DIFF
--- a/hack/jenkins/upload-to-gcs.sh
+++ b/hack/jenkins/upload-to-gcs.sh
@@ -131,7 +131,8 @@ function find_version() {
 function print_started() {
   local metadata_keys=$(compgen -e | grep ^BUILD_METADATA_)
   echo "{"
-  echo "    \"version\": \"${version}\","
+  echo "    \"version\": \"${version}\","  # TODO(fejta): retire
+  echo "    \"job-version\": \"${version}\","
   echo "    \"timestamp\": ${timestamp},"
   if [[ -n "${metadata_keys}" ]]; then
     # Any exported variables of the form BUILD_METADATA_KEY=VALUE


### PR DESCRIPTION
Ref https://github.com/kubernetes/test-infra/issues/1032

We can delete version once all CI jobs are migrated to bootstrap

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36654)
<!-- Reviewable:end -->
