### PR TITLE
make spdy.roundtripper usable with UpgradeAwareProxyHandler

### DIFF
--- a/pkg/util/httpstream/spdy/roundtripper.go
+++ b/pkg/util/httpstream/spdy/roundtripper.go
@@ -72,6 +72,11 @@ func NewSpdyRoundTripper(tlsConfig *tls.Config) *SpdyRoundTripper {
 	return &SpdyRoundTripper{tlsConfig: tlsConfig}
 }
 
+// implements pkg/util/net.TLSClientConfigHolder for proper TLS checking during proxying with a spdy roundtripper
+func (s *SpdyRoundTripper) TLSClientConfig() *tls.Config {
+	return s.tlsConfig
+}
+
 // dial dials the host specified by req, using TLS if appropriate, optionally
 // using a proxy server if one is configured via environment variables.
 func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {

--- a/pkg/util/net/http.go
+++ b/pkg/util/net/http.go
@@ -138,6 +138,10 @@ func CloneTLSConfig(cfg *tls.Config) *tls.Config {
 	}
 }
 
+type TLSClientConfigHolder interface {
+	TLSClientConfig() *tls.Config
+}
+
 func TLSClientConfig(transport http.RoundTripper) (*tls.Config, error) {
 	if transport == nil {
 		return nil, nil
@@ -146,6 +150,8 @@ func TLSClientConfig(transport http.RoundTripper) (*tls.Config, error) {
 	switch transport := transport.(type) {
 	case *http.Transport:
 		return transport.TLSClientConfig, nil
+	case TLSClientConfigHolder:
+		return transport.TLSClientConfig(), nil
 	case RoundTripperWrapper:
 		return TLSClientConfig(transport.WrappedRoundTripper())
 	default:

--- a/pkg/util/net/http_test.go
+++ b/pkg/util/net/http_test.go
@@ -218,3 +218,24 @@ func TestProxierWithNoProxyCIDR(t *testing.T) {
 		}
 	}
 }
+
+type fakeTLSClientConfigHolder struct {
+	called bool
+}
+
+func (f *fakeTLSClientConfigHolder) TLSClientConfig() *tls.Config {
+	f.called = true
+	return nil
+}
+func (f *fakeTLSClientConfigHolder) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func TestTLSClientConfigHolder(t *testing.T) {
+	rt := &fakeTLSClientConfigHolder{}
+	TLSClientConfig(rt)
+
+	if !rt.called {
+		t.Errorf("didn't find tls config")
+	}
+}


### PR DESCRIPTION
the `spdy.RoundTripper` was incompatible for use on `https` connections by the `UpgradeAwareProxyHandler` because it couldn't find the TLS config.

This check would get `nil` https://github.com/kubernetes/kubernetes/blob/master/pkg/util/proxy/dial.go#L48 because it didn't recognize the type which would result in failures later on.  That would cause a failure that ripples out to here: https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/generic/rest/proxy.go#L151 and prevents the proxy from working.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36662)
<!-- Reviewable:end -->
