### PR TITLE
Generalize and improve hack/local_up_cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -160,6 +160,12 @@ function test_rkt {
 }
 
 
+function test_kubeconfig_present {
+    [[ -f ${CERT_DIR}/$1.kubeconfig ]] && return 0
+    echo "$1.kubeconfig not found in"${CERT_DIR}". Please ensure $1.kubeconfig and related certificates are installed in"${CERT_DIR}"."
+    exit 1
+}
+
 # Shut down anyway if there's an error.
 set +e
 
@@ -442,6 +448,7 @@ function start_apiserver {
 }
 
 function start_controller_manager {
+    test_kubeconfig_present controller
     node_cidr_args=""
     if [[ "${NET_PLUGIN}" == "kubenet" ]]; then
       node_cidr_args="--allocate-node-cidrs=true --cluster-cidr=10.1.0.0/16 "
@@ -464,6 +471,7 @@ function start_controller_manager {
 }
 
 function start_kubelet {
+    test_kubeconfig_present kubelet
     KUBELET_LOG=/tmp/kubelet.log
 
     priv_arg=""
@@ -586,6 +594,7 @@ function start_kubelet {
 }
 
 function start_kubeproxy {
+    test_kubeconfig_present kube-proxy
     PROXY_LOG=/tmp/kube-proxy.log
     sudo "${GO_OUT}/hyperkube" proxy \
       --v=${LOG_LEVEL} \


### PR DESCRIPTION
**What this PR does / why we need it**:

It extends the ability of the local_up_cluster to run distinct services in distinct nodes.
While the 3 start modes provided satisfy a number of common use cases, there could be different needs, for instance running the scheduler on a dedicated VM.

While far from deserving any sort of priority, the changes in this PR make the hack/local_up_cluster.sh more generic, enable different scenarios for building development environment, and make the script a bit more readable (according to the author's opinion at least...)

Special care was taken about ensuring backward compatibility w.r.t env variables. Even if the author believes backward compatibility was preserved, this kind of things always need to be checked 2 or 3 times by independent eyes!

**Which issue this PR fixes**

No issue was created on github.

**Special notes for your reviewer**:

The first 2 commits fix what the author believes could be considered bugs in local_up_cluster.sh
The 3rd commit is mostly about improving script output
The 4th commit actually includes most of the PR logic
The 5th commit is exclusively about the DNS service. The author is not really convinced about that commit, as there's a lot of special casing around DNS in local_up_cluster.sh

Moreover, the logic in this PR is inspired by (nice word for 'shamelessly copies') what devstack (www.devstack.org) does with the ENABLED-SERVICES variables. This is actually code the author had been using locally for a while and thought it might be worth checking whether the community thinks it could be useful also for other people.

(the author sincerely hopes this PR is in accordance with the project guidelines - and apologizes in advance for any mistake)

**Release note**:

The author does not think this deserves a release note because:
1) The author ignores whether changes in hack/local_up_cluster.sh deserve a release note
2) changes were done in a backward compatible way (hopefully)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36669)
<!-- Reviewable:end -->
