### PR TITLE
Bump GCI version to gci-dev-56-8977-0-0

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -44,7 +44,7 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
 # variable. Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
 CVM_VERSION=container-vm-v20161025
-GCI_VERSION="gci-dev-56-8938-0-0"
+GCI_VERSION="gci-dev-56-8977-0-0"
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -45,7 +45,7 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
 # variable. Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
 CVM_VERSION=container-vm-v20161025
-GCI_VERSION="gci-dev-56-8938-0-0"
+GCI_VERSION="gci-dev-56-8977-0-0"
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -5,7 +5,7 @@ images:
     project: kubernetes-node-e2e-images
     machine: n1-standard-1
     tests:
-      - 'create 35 pods with 0s? interval \[Benchmark\]'    
+      - 'create 35 pods with 0s? interval \[Benchmark\]'
   containervm-density2:
     image: e2e-node-containervm-v20160604-image
     project: kubernetes-node-e2e-images
@@ -49,21 +49,21 @@ images:
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
   gci-resource1:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   gci-resource2:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   gci-resource3:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"

--- a/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
@@ -1,56 +1,56 @@
 ---
 images:
   gci-density1:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   gci-density2:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   gci-density2-qps60:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   gci-density3:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-2
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   gci-density4:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
   gci-resource1:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   gci-resource2:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   gci-resource3:
-    image: gci-dev-55-8872-18-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -16,6 +16,6 @@ images:
     image: e2e-node-containervm-v20160604-image
     project: kubernetes-node-e2e-images
   gci-family:
-    image_regex: gci-dev-55-8872-18-0
+    image_regex: gci-dev-56-8977-0-0
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"


### PR DESCRIPTION
@vishh @saad
```release-note
gci-dev-56-8977-0-0:
Date:           Nov 03, 2016
Kernel:         ChromiumOS-4.4
Kubernetes:     v1.4.5
Docker:         v1.11.2
Changelog (vs 55-8872-18-0)
    * Updated kubernetes to v1.4.5
    * Fixed a bug in e2fsprogs that caused mke2fs to take a very long time. Upstream fix: http://git.kernel.org/cgit/fs/ext2/e2fsprogs.git/commit/?h=next&id=d33e690fe7a6cbeb51349d9f2c7fb16a6ebec9c2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36681)
<!-- Reviewable:end -->
