### PR TITLE
fc: Drop multipath.conf snippet

### DIFF
--- a/pkg/volume/README.md
+++ b/pkg/volume/README.md
@@ -1,0 +1,27 @@
+## Multipath
+
+To leverage multiple paths for block storage, it is important to perform the
+multipath configuration on the host.
+If your distribution does not provide `/etc/multipath.conf`, then you can
+either use the following minimalistic one:
+
+    defaults {
+        find_multipaths yes
+        user_friendly_names yes
+    }
+
+or create a new one by running:
+
+    $ mpathconf --enable
+
+Finally you'll need to ensure to start or reload and enable multipath:
+
+    $ systemctl enable multipathd.service
+    $ systemctl restart multipathd.service
+
+**Note:** Any change to `multipath.conf` or enabling multipath can lead to
+inaccessible block devices, because they'll be claimed by multipath and
+exposed as a device in /dev/mapper/*.
+
+Some additional informations about multipath can be found in the
+[iSCSI documentation](iscsi/README.md)

--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -89,21 +89,6 @@ func findDisk(wwn, lun string, io ioHandler) (string, string) {
 	return "", ""
 }
 
-func createMultipathConf(path string, io ioHandler) {
-	if _, err := os.Lstat(path); err != nil {
-		data := []byte(`defaults {
-	find_multipaths yes
-	user_friendly_names yes
-}
-
-
-blacklist {
-}
-`)
-		io.WriteFile(path, data, 0664)
-	}
-}
-
 // rescan scsi bus
 func scsiHostRescan(io ioHandler) {
 	scsi_path := "/sys/class/scsi_host/"
@@ -148,8 +133,6 @@ func searchDisk(wwns []string, lun string, io ioHandler) (string, string) {
 			break
 		}
 		// rescan and search again
-		// create multipath conf if it is not there
-		createMultipathConf("/etc/multipath.conf", io)
 		// rescan scsi bus
 		scsiHostRescan(io)
 		rescaned = true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Removes multipath.conf - The code does not make use of it - or ensure s that it's getting used - and it should in addition be handled elsewehre.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

A minimalistic multipath.conf got written, but it was useless, as
it is unclear if multipathd is running and there was also no
config reload triggered.

This patch drops this snippet. In general it's probably a better idea
to leave the multipath.conf to the component managing the host.

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36698)
<!-- Reviewable:end -->
