### PR TITLE
Added comments on running update-bazel.sh in "$GOPATH/src/k8s.io/kubernetes"

### DIFF
--- a/docs/devel/bazel.md
+++ b/docs/devel/bazel.md
@@ -23,6 +23,7 @@ To update automanaged build files, run:
 $ ./hack/update-bazel.sh
 ```
 
+**NOTES**: `update-bazel.sh` only works if check out directory of Kubernetes is "$GOPATH/src/k8s.io/kubernetes".
 
 To update a single build file, run:
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This path made `hack/update-bazel.sh` to accept `$GOPATH` with multiple path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36699)
<!-- Reviewable:end -->
