### PR TITLE
--export flag belongs to kubectl get, not kubectl

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -34,7 +34,7 @@ kube::test::get_object_assert() {
   local expected=$3
   local args=${4:-}
 
-  res=$(eval kubectl ${args} get "${kube_flags[@]}" $object -o go-template=\"$request\")
+  res=$(eval kubectl get "${kube_flags[@]}" ${args} $object -o go-template=\"$request\")
 
   if [[ "$res" =~ ^$expected$ ]]; then
       echo -n ${green}


### PR DESCRIPTION
**What this PR does / why we need it**:

When running the kubectl via symlink to hyperkube, the ``--export`` flag is not delegated to `kubectl get` but to `kubectl` only. Ending with unrecognized flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36700)
<!-- Reviewable:end -->
