### PR TITLE
Limit unbound label cardinality on request errors

### DIFF
--- a/pkg/client/restclient/request.go
+++ b/pkg/client/restclient/request.go
@@ -693,9 +693,10 @@ func updateURLMetrics(req *Request, resp *http.Response, err error) {
 		url = req.baseURL.Host
 	}
 
-	// If we have an error (i.e. apiserver down) we report that as a metric label.
+	// Errors can be arbitrary strings. Unbound label cardinality is not suitable for a metric
+	// system so we just report them as `<error>`.
 	if err != nil {
-		metrics.RequestResult.Increment(err.Error(), req.verb, url)
+		metrics.RequestResult.Increment("<error>", req.verb, url)
 	} else {
 		//Metrics for failure codes
 		metrics.RequestResult.Increment(strconv.Itoa(resp.StatusCode), req.verb, url)


### PR DESCRIPTION
This converts all request errors to the string `<error>` instead of
passing the full error string. Error strings can have arbitrary values
and thus have a cardinality that is not suitable for a metric
use case.

Inspecting individual errors is a logging use case which can be handled separately by registering a client error handler.

@kubernetes/sig-instrumentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36702)
<!-- Reviewable:end -->
