### PR TITLE
Use Prometheus instrumentation conventions

### DIFF
--- a/pkg/client/metrics/prometheus/prometheus.go
+++ b/pkg/client/metrics/prometheus/prometheus.go
@@ -27,26 +27,22 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-const restClientSubsystem = "rest_client"
-
 var (
 	// requestLatency is a Prometheus Summary metric type partitioned by
 	// "verb" and "url" labels. It is used for the rest client latency metrics.
 	requestLatency = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Subsystem: restClientSubsystem,
-			Name:      "request_latency_microseconds",
-			Help:      "Request latency in microseconds. Broken down by verb and URL",
-			MaxAge:    time.Hour,
+			Name:   "rest_client_request_latency_seconds",
+			Help:   "Request latency in seconds. Broken down by verb and URL.",
+			MaxAge: time.Hour,
 		},
 		[]string{"verb", "url"},
 	)
 
 	requestResult = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Subsystem: restClientSubsystem,
-			Name:      "request_status_codes",
-			Help:      "Number of http requests, partitioned by metadata",
+			Name: "rest_client_requests_total",
+			Help: "Number of HTTP requests, partitioned by status code, method, and host.",
 		},
 		[]string{"code", "method", "host"},
 	)
@@ -63,8 +59,7 @@ type latencyAdapter struct {
 }
 
 func (l *latencyAdapter) Observe(verb string, u url.URL, latency time.Duration) {
-	microseconds := float64(latency) / float64(time.Microsecond)
-	l.m.WithLabelValues(verb, u.String()).Observe(microseconds)
+	l.m.WithLabelValues(verb, u.String()).Observe(latency.Seconds())
 }
 
 type resultAdapter struct {

--- a/pkg/client/metrics/prometheus/prometheus.go
+++ b/pkg/client/metrics/prometheus/prometheus.go
@@ -30,11 +30,11 @@ import (
 var (
 	// requestLatency is a Prometheus Summary metric type partitioned by
 	// "verb" and "url" labels. It is used for the rest client latency metrics.
-	requestLatency = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name:   "rest_client_request_latency_seconds",
-			Help:   "Request latency in seconds. Broken down by verb and URL.",
-			MaxAge: time.Hour,
+	requestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "rest_client_request_latency_seconds",
+			Help:    "Request latency in seconds. Broken down by verb and URL.",
+			Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
 		},
 		[]string{"verb", "url"},
 	)
@@ -55,7 +55,7 @@ func init() {
 }
 
 type latencyAdapter struct {
-	m *prometheus.SummaryVec
+	m *prometheus.HistogramVec
 }
 
 func (l *latencyAdapter) Observe(verb string, u url.URL, latency time.Duration) {


### PR DESCRIPTION
The `System` and `Subsystem` parameters are subject to removal.
(x-ref: https://github.com/prometheus/client_golang/issues/240)

All metrics should use base units, which is seconds in the duration
case.

Counters should always end in `_total` and metrics should avoid
referring to potential label dimensions. Those should rather be
mentioned in the documentation string.

@kubernetes/sig-instrumentation 

Reference docs:
https://prometheus.io/docs/practices/instrumentation/
https://prometheus.io/docs/practices/naming/

**Release note**:
```
Breaking change: Renamed REST client Prometheus metrics to follow the instrumentation conventions ("request_latency_microseconds" -> "rest_client_request_latency_seconds", "request_status_codes" -> "rest_client_requests_total"). Please update your alerting pipeline if you rely on them. 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36704)
<!-- Reviewable:end -->
