### PR TITLE
[etcd] test cleanup: remove unnecessary AddPrefix()

### DIFF
--- a/pkg/registry/apps/petset/etcd/BUILD
+++ b/pkg/registry/apps/petset/etcd/BUILD
@@ -41,7 +41,6 @@ go_test(
         "//pkg/labels:go_default_library",
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
     ],
 )

--- a/pkg/registry/apps/petset/etcd/etcd_test.go
+++ b/pkg/registry/apps/petset/etcd/etcd_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 )
 
@@ -101,7 +100,7 @@ func TestStatusUpdate(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
 	ctx := api.WithNamespace(api.NewContext(), api.NamespaceDefault)
-	key := etcdtest.AddPrefix("/statefulsets/" + api.NamespaceDefault + "/foo")
+	key := "/statefulsets/" + api.NamespaceDefault + "/foo"
 	validStatefulSet := validNewStatefulSet()
 	if err := storage.Storage.Create(ctx, key, validStatefulSet, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/registry/core/namespace/etcd/BUILD
+++ b/pkg/registry/core/namespace/etcd/BUILD
@@ -41,7 +41,6 @@ go_test(
         "//pkg/labels:go_default_library",
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
     ],
 )

--- a/pkg/registry/core/namespace/etcd/etcd_test.go
+++ b/pkg/registry/core/namespace/etcd/etcd_test.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 )
 
@@ -141,7 +140,7 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	key := etcdtest.AddPrefix("namespaces/foo")
+	key := "namespaces/foo"
 	ctx := api.NewContext()
 	now := unversioned.Now()
 	namespace := &api.Namespace{
@@ -166,7 +165,7 @@ func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	key := etcdtest.AddPrefix("namespaces/foo")
+	key := "namespaces/foo"
 	ctx := api.NewContext()
 	now := unversioned.Now()
 	namespace := &api.Namespace{

--- a/pkg/registry/core/persistentvolume/etcd/BUILD
+++ b/pkg/registry/core/persistentvolume/etcd/BUILD
@@ -40,7 +40,6 @@ go_test(
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//pkg/runtime:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/util/diff:go_default_library",
     ],

--- a/pkg/registry/core/persistentvolume/etcd/etcd_test.go
+++ b/pkg/registry/core/persistentvolume/etcd/etcd_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/util/diff"
 )
@@ -159,7 +158,6 @@ func TestUpdateStatus(t *testing.T) {
 	defer storage.Store.DestroyFunc()
 	ctx := api.NewContext()
 	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	pvStart := validNewPersistentVolume("foo")
 	err := storage.Storage.Create(ctx, key, pvStart, nil, 0)
 	if err != nil {

--- a/pkg/registry/core/persistentvolumeclaim/etcd/BUILD
+++ b/pkg/registry/core/persistentvolumeclaim/etcd/BUILD
@@ -40,7 +40,6 @@ go_test(
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//pkg/runtime:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/util/diff:go_default_library",
     ],

--- a/pkg/registry/core/persistentvolumeclaim/etcd/etcd_test.go
+++ b/pkg/registry/core/persistentvolumeclaim/etcd/etcd_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/util/diff"
 )
@@ -150,7 +149,6 @@ func TestUpdateStatus(t *testing.T) {
 	ctx := api.NewDefaultContext()
 
 	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	pvcStart := validNewPersistentVolumeClaim("foo", api.NamespaceDefault)
 	err := storage.Storage.Create(ctx, key, pvcStart, nil, 0)
 

--- a/pkg/registry/core/pod/etcd/BUILD
+++ b/pkg/registry/core/pod/etcd/BUILD
@@ -55,7 +55,6 @@ go_test(
         "//pkg/runtime:go_default_library",
         "//pkg/securitycontext:go_default_library",
         "//pkg/storage:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/util/diff:go_default_library",
         "//vendor:golang.org/x/net/context",

--- a/pkg/registry/core/pod/etcd/etcd_test.go
+++ b/pkg/registry/core/pod/etcd/etcd_test.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/securitycontext"
 	"k8s.io/kubernetes/pkg/storage"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/util/diff"
 )
@@ -319,7 +318,6 @@ func TestResourceLocation(t *testing.T) {
 	for _, tc := range testCases {
 		storage, _, _, server := newStorage(t)
 		key, _ := storage.KeyFunc(ctx, tc.pod.Name)
-		key = etcdtest.AddPrefix(key)
 		if err := storage.Storage.Create(ctx, key, &tc.pod, nil, 0); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -388,8 +386,6 @@ func TestEtcdCreate(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
 	ctx := api.NewDefaultContext()
-	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	_, err := storage.Create(ctx, validNewPod())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -418,8 +414,6 @@ func TestEtcdCreateBindingNoPod(t *testing.T) {
 	defer storage.Store.DestroyFunc()
 	ctx := api.NewDefaultContext()
 
-	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	// Assume that a pod has undergone the following:
 	// - Create (apiserver)
 	// - Schedule (scheduler)
@@ -462,8 +456,6 @@ func TestEtcdCreateWithContainersNotFound(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
 	ctx := api.NewDefaultContext()
-	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	_, err := storage.Create(ctx, validNewPod())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -529,8 +521,6 @@ func TestEtcdCreateWithExistingContainers(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
 	ctx := api.NewDefaultContext()
-	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	_, err := storage.Create(ctx, validNewPod())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -589,8 +579,6 @@ func TestEtcdCreateBinding(t *testing.T) {
 	}
 	for k, test := range testCases {
 		storage, bindingStorage, _, server := newStorage(t)
-		key, _ := storage.KeyFunc(ctx, "foo")
-		key = etcdtest.AddPrefix(key)
 
 		if _, err := storage.Create(ctx, validNewPod()); err != nil {
 			t.Fatalf("%s: unexpected error: %v", k, err)
@@ -617,8 +605,6 @@ func TestEtcdUpdateNotScheduled(t *testing.T) {
 	defer storage.Store.DestroyFunc()
 	ctx := api.NewDefaultContext()
 
-	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	if _, err := storage.Create(ctx, validNewPod()); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -646,7 +632,6 @@ func TestEtcdUpdateScheduled(t *testing.T) {
 	ctx := api.NewDefaultContext()
 
 	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	err := storage.Storage.Create(ctx, key, &api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "foo",
@@ -716,7 +701,6 @@ func TestEtcdUpdateStatus(t *testing.T) {
 	ctx := api.NewDefaultContext()
 
 	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	podStart := api.Pod{
 		ObjectMeta: api.ObjectMeta{
 			Name:      "foo",

--- a/pkg/registry/core/resourcequota/etcd/BUILD
+++ b/pkg/registry/core/resourcequota/etcd/BUILD
@@ -39,7 +39,6 @@ go_test(
         "//pkg/labels:go_default_library",
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/util/diff:go_default_library",
     ],

--- a/pkg/registry/core/resourcequota/etcd/etcd_test.go
+++ b/pkg/registry/core/resourcequota/etcd/etcd_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/util/diff"
 )
@@ -153,7 +152,6 @@ func TestUpdateStatus(t *testing.T) {
 	ctx := api.NewDefaultContext()
 
 	key, _ := storage.KeyFunc(ctx, "foo")
-	key = etcdtest.AddPrefix(key)
 	resourcequotaStart := validNewResourceQuota()
 	err := storage.Storage.Create(ctx, key, resourcequotaStart, nil, 0)
 	if err != nil {

--- a/pkg/registry/core/service/allocator/etcd/BUILD
+++ b/pkg/registry/core/service/allocator/etcd/BUILD
@@ -38,7 +38,6 @@ go_test(
         "//pkg/api:go_default_library",
         "//pkg/registry/core/service/allocator:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/storage/storagebackend:go_default_library",
         "//vendor:golang.org/x/net/context",

--- a/pkg/registry/core/service/allocator/etcd/etcd_test.go
+++ b/pkg/registry/core/service/allocator/etcd/etcd_test.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/registry/core/service/allocator"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/storage/storagebackend"
 
@@ -44,8 +43,7 @@ func validNewRangeAllocation() *api.RangeAllocation {
 }
 
 func key() string {
-	s := "/ranges/serviceips"
-	return etcdtest.AddPrefix(s)
+	return "/ranges/serviceips"
 }
 
 func TestEmpty(t *testing.T) {

--- a/pkg/registry/core/service/ipallocator/etcd/BUILD
+++ b/pkg/registry/core/service/ipallocator/etcd/BUILD
@@ -29,7 +29,6 @@ go_test(
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//pkg/storage:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/storage/storagebackend/factory:go_default_library",
         "//vendor:golang.org/x/net/context",

--- a/pkg/registry/core/service/ipallocator/etcd/etcd_test.go
+++ b/pkg/registry/core/service/ipallocator/etcd/etcd_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/storage"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/storage/storagebackend/factory"
 
@@ -65,8 +64,7 @@ func validNewRangeAllocation() *api.RangeAllocation {
 }
 
 func key() string {
-	s := "/ranges/serviceips"
-	return etcdtest.AddPrefix(s)
+	return "/ranges/serviceips"
 }
 
 func TestEmpty(t *testing.T) {

--- a/pkg/registry/extensions/controller/etcd/BUILD
+++ b/pkg/registry/extensions/controller/etcd/BUILD
@@ -41,7 +41,6 @@ go_test(
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//pkg/storage:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/storage/storagebackend/factory:go_default_library",
     ],

--- a/pkg/registry/extensions/controller/etcd/etcd_test.go
+++ b/pkg/registry/extensions/controller/etcd/etcd_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/storage"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/storage/storagebackend/factory"
 )
@@ -92,7 +91,7 @@ func TestGet(t *testing.T) {
 	defer destroyFunc()
 
 	ctx := api.WithNamespace(api.NewContext(), "test")
-	key := etcdtest.AddPrefix("/controllers/test/foo")
+	key := "/controllers/test/foo"
 	if err := si.Create(ctx, key, &validController, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -111,7 +110,7 @@ func TestUpdate(t *testing.T) {
 	defer destroyFunc()
 
 	ctx := api.WithNamespace(api.NewContext(), "test")
-	key := etcdtest.AddPrefix("/controllers/test/foo")
+	key := "/controllers/test/foo"
 	if err := si.Create(ctx, key, &validController, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/registry/extensions/deployment/etcd/BUILD
+++ b/pkg/registry/extensions/deployment/etcd/BUILD
@@ -48,7 +48,6 @@ go_test(
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//pkg/runtime:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/util/diff:go_default_library",
         "//pkg/util/intstr:go_default_library",

--- a/pkg/registry/extensions/deployment/etcd/etcd_test.go
+++ b/pkg/registry/extensions/deployment/etcd/etcd_test.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/util/diff"
 	"k8s.io/kubernetes/pkg/util/intstr"
@@ -199,7 +198,7 @@ func TestScaleGet(t *testing.T) {
 	defer storage.Deployment.Store.DestroyFunc()
 	var deployment extensions.Deployment
 	ctx := api.WithNamespace(api.NewContext(), namespace)
-	key := etcdtest.AddPrefix("/deployments/" + namespace + "/" + name)
+	key := "/deployments/" + namespace + "/" + name
 	if err := storage.Deployment.Storage.Create(ctx, key, &validDeployment, &deployment, 0); err != nil {
 		t.Fatalf("error setting new deployment (key: %s) %v: %v", key, validDeployment, err)
 	}
@@ -236,7 +235,7 @@ func TestScaleUpdate(t *testing.T) {
 	defer storage.Deployment.Store.DestroyFunc()
 	var deployment extensions.Deployment
 	ctx := api.WithNamespace(api.NewContext(), namespace)
-	key := etcdtest.AddPrefix("/deployments/" + namespace + "/" + name)
+	key := "/deployments/" + namespace + "/" + name
 	if err := storage.Deployment.Storage.Create(ctx, key, &validDeployment, &deployment, 0); err != nil {
 		t.Fatalf("error setting new deployment (key: %s) %v: %v", key, validDeployment, err)
 	}
@@ -273,7 +272,7 @@ func TestStatusUpdate(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.Deployment.Store.DestroyFunc()
 	ctx := api.WithNamespace(api.NewContext(), namespace)
-	key := etcdtest.AddPrefix("/deployments/" + namespace + "/" + name)
+	key := "/deployments/" + namespace + "/" + name
 	if err := storage.Deployment.Storage.Create(ctx, key, &validDeployment, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -337,8 +336,6 @@ func TestEtcdCreateDeploymentRollback(t *testing.T) {
 	for k, test := range testCases {
 		storage, server := newStorage(t)
 		rollbackStorage := storage.Rollback
-		key, _ := storage.Deployment.KeyFunc(ctx, name)
-		key = etcdtest.AddPrefix(key)
 
 		if _, err := storage.Deployment.Create(ctx, validNewDeployment()); err != nil {
 			t.Fatalf("%s: unexpected error: %v", k, err)
@@ -368,8 +365,6 @@ func TestEtcdCreateDeploymentRollbackNoDeployment(t *testing.T) {
 	rollbackStorage := storage.Rollback
 	ctx := api.WithNamespace(api.NewContext(), namespace)
 
-	key, _ := storage.Deployment.KeyFunc(ctx, name)
-	key = etcdtest.AddPrefix(key)
 	_, err := rollbackStorage.Create(ctx, &extensions.DeploymentRollback{
 		Name:               name,
 		UpdatedAnnotations: map[string]string{},

--- a/pkg/registry/extensions/replicaset/etcd/BUILD
+++ b/pkg/registry/extensions/replicaset/etcd/BUILD
@@ -45,7 +45,6 @@ go_test(
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//pkg/runtime:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/util/diff:go_default_library",
     ],

--- a/pkg/registry/extensions/replicaset/etcd/etcd_test.go
+++ b/pkg/registry/extensions/replicaset/etcd/etcd_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/runtime"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/util/diff"
 )
@@ -254,7 +253,7 @@ func TestScaleGet(t *testing.T) {
 
 	var rs extensions.ReplicaSet
 	ctx := api.WithNamespace(api.NewContext(), api.NamespaceDefault)
-	key := etcdtest.AddPrefix("/replicasets/" + api.NamespaceDefault + "/" + name)
+	key := "/replicasets/" + api.NamespaceDefault + "/" + name
 	if err := storage.ReplicaSet.Storage.Create(ctx, key, &validReplicaSet, &rs, 0); err != nil {
 		t.Fatalf("error setting new replica set (key: %s) %v: %v", key, validReplicaSet, err)
 	}
@@ -294,7 +293,7 @@ func TestScaleUpdate(t *testing.T) {
 
 	var rs extensions.ReplicaSet
 	ctx := api.WithNamespace(api.NewContext(), api.NamespaceDefault)
-	key := etcdtest.AddPrefix("/replicasets/" + api.NamespaceDefault + "/" + name)
+	key := "/replicasets/" + api.NamespaceDefault + "/" + name
 	if err := storage.ReplicaSet.Storage.Create(ctx, key, &validReplicaSet, &rs, 0); err != nil {
 		t.Fatalf("error setting new replica set (key: %s) %v: %v", key, validReplicaSet, err)
 	}
@@ -336,7 +335,7 @@ func TestStatusUpdate(t *testing.T) {
 	defer storage.ReplicaSet.Store.DestroyFunc()
 
 	ctx := api.WithNamespace(api.NewContext(), api.NamespaceDefault)
-	key := etcdtest.AddPrefix("/replicasets/" + api.NamespaceDefault + "/foo")
+	key := "/replicasets/" + api.NamespaceDefault + "/foo"
 	if err := storage.ReplicaSet.Storage.Create(ctx, key, &validReplicaSet, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/registry/policy/poddisruptionbudget/etcd/BUILD
+++ b/pkg/registry/policy/poddisruptionbudget/etcd/BUILD
@@ -41,7 +41,6 @@ go_test(
         "//pkg/labels:go_default_library",
         "//pkg/registry/generic:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
-        "//pkg/storage/etcd/etcdtest:go_default_library",
         "//pkg/storage/etcd/testing:go_default_library",
         "//pkg/util/intstr:go_default_library",
     ],

--- a/pkg/registry/policy/poddisruptionbudget/etcd/etcd_test.go
+++ b/pkg/registry/policy/poddisruptionbudget/etcd/etcd_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/registry/generic"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
-	"k8s.io/kubernetes/pkg/storage/etcd/etcdtest"
 	etcdtesting "k8s.io/kubernetes/pkg/storage/etcd/testing"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
@@ -86,7 +85,7 @@ func TestStatusUpdate(t *testing.T) {
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
 	ctx := api.WithNamespace(api.NewContext(), api.NamespaceDefault)
-	key := etcdtest.AddPrefix("/poddisruptionbudgets/" + api.NamespaceDefault + "/foo")
+	key := "/poddisruptionbudgets/" + api.NamespaceDefault + "/foo"
 	validPodDisruptionBudget := validNewPodDisruptionBudget()
 	if err := storage.Storage.Create(ctx, key, validPodDisruptionBudget, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/storage/cacher_test.go
+++ b/pkg/storage/cacher_test.go
@@ -81,7 +81,7 @@ func updatePod(t *testing.T, s storage.Interface, obj, old *api.Pod) *api.Pod {
 		}
 		return newObj.(*api.Pod), nil, nil
 	}
-	key := etcdtest.AddPrefix("pods/" + obj.Namespace + "/" + obj.Name)
+	key := "pods/" + obj.Namespace + "/" + obj.Name
 	if err := s.GuaranteedUpdate(context.TODO(), key, &api.Pod{}, old == nil, nil, updateFn); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -119,7 +119,7 @@ func TestList(t *testing.T) {
 	updatePod(t, etcdStorage, podFooNS2, nil)
 
 	deleted := api.Pod{}
-	if err := etcdStorage.Delete(context.TODO(), etcdtest.AddPrefix("pods/ns/bar"), &deleted, nil); err != nil {
+	if err := etcdStorage.Delete(context.TODO(), "pods/ns/bar", &deleted, nil); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
@@ -351,7 +351,7 @@ func TestFiltering(t *testing.T) {
 	_ = updatePod(t, etcdStorage, podFooPrime, fooUnfiltered)
 
 	deleted := api.Pod{}
-	if err := etcdStorage.Delete(context.TODO(), etcdtest.AddPrefix("pods/ns/foo"), &deleted, nil); err != nil {
+	if err := etcdStorage.Delete(context.TODO(), "pods/ns/foo", &deleted, nil); err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
What?
Remove etcdtest.AddPrefix() in tests. They will be automatically prepended in etcd storage.

Why?
ref: #36290 #36374
After the change, it will double prepend.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36709)
<!-- Reviewable:end -->
