### PR TITLE
Fix some lint errors.

### DIFF
--- a/cmd/genyaml/gen_kubectl_yaml.go
+++ b/cmd/genyaml/gen_kubectl_yaml.go
@@ -83,7 +83,7 @@ func forceMultiLine(s string) string {
 }
 
 func genFlagResult(flags *pflag.FlagSet) []cmdOption {
-	result := make([]cmdOption, 0)
+	result := []cmdOption{}
 
 	flags.VisitAll(func(flag *pflag.Flag) {
 		// Todo, when we mark a shorthand is deprecated, but specify an empty message.
@@ -131,7 +131,7 @@ func genYaml(command *cobra.Command, parent, docsDir string) {
 	}
 
 	if len(command.Commands()) > 0 || len(parent) > 0 {
-		result := make([]string, 0)
+		result := []string{}
 		if len(parent) > 0 {
 			result = append(result, parent)
 		}

--- a/plugin/pkg/auth/authenticator/request/x509/x509_test.go
+++ b/plugin/pkg/auth/authenticator/request/x509/x509_test.go
@@ -925,7 +925,7 @@ func getCert(t *testing.T, pemData string) *x509.Certificate {
 }
 
 func getCerts(t *testing.T, pemData ...string) []*x509.Certificate {
-	certs := make([]*x509.Certificate, 0)
+	certs := []*x509.Certificate{}
 	for _, pemData := range pemData {
 		certs = append(certs, getCert(t, pemData))
 	}


### PR DESCRIPTION
`golint` for some reason doesn't like `make([]foo, 0)` so switch to explicit instantiation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36713)
<!-- Reviewable:end -->
