### PR TITLE
Adds a Flag to Disable Security Measures for External IPs on Kube-Proxy

### DIFF
--- a/cmd/kube-proxy/app/options/options.go
+++ b/cmd/kube-proxy/app/options/options.go
@@ -38,15 +38,16 @@ const (
 // ProxyServerConfig configures and runs a Kubernetes proxy server
 type ProxyServerConfig struct {
 	componentconfig.KubeProxyConfiguration
-	ResourceContainer string
-	ContentType       string
-	KubeAPIQPS        float32
-	KubeAPIBurst      int32
-	ConfigSyncPeriod  time.Duration
-	CleanupAndExit    bool
-	NodeRef           *api.ObjectReference
-	Master            string
-	Kubeconfig        string
+	ResourceContainer                 string
+	ContentType                       string
+	KubeAPIQPS                        float32
+	KubeAPIBurst                      int32
+	ConfigSyncPeriod                  time.Duration
+	CleanupAndExit                    bool
+	NodeRef                           *api.ObjectReference
+	Master                            string
+	Kubeconfig                        string
+	DisableExternalIPSecurityMeasures bool
 }
 
 func NewProxyConfig() *ProxyServerConfig {
@@ -99,6 +100,7 @@ func (s *ProxyServerConfig) AddFlags(fs *pflag.FlagSet) {
 		&s.ConntrackTCPCloseWaitTimeout.Duration, "conntrack-tcp-timeout-close-wait",
 		s.ConntrackTCPCloseWaitTimeout.Duration,
 		"NAT timeout for TCP connections in the CLOSE_WAIT state")
+	fs.BoolVar(&s.DisableExternalIPSecurityMeasures, "disable-externalip-security-measures", s.DisableExternalIPSecurityMeasures, "If true disables all security checks for traffic hitting external IPs.")
 
 	config.DefaultFeatureGate.AddFlag(fs)
 }

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -218,7 +218,7 @@ func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, err
 			// IPTablesMasqueradeBit must be specified or defaulted.
 			return nil, fmt.Errorf("Unable to read IPTablesMasqueradeBit from config")
 		}
-		proxierIPTables, err := iptables.NewProxier(iptInterface, utilsysctl.New(), execer, config.IPTablesSyncPeriod.Duration, config.IPTablesMinSyncPeriod.Duration, config.MasqueradeAll, int(*config.IPTablesMasqueradeBit), config.ClusterCIDR, hostname, getNodeIP(client, hostname))
+		proxierIPTables, err := iptables.NewProxier(iptInterface, utilsysctl.New(), execer, config.IPTablesSyncPeriod.Duration, config.IPTablesMinSyncPeriod.Duration, config.MasqueradeAll, int(*config.IPTablesMasqueradeBit), config.ClusterCIDR, hostname, getNodeIP(client, hostname), config.DisableExternalIPSecurityMeasures)
 		if err != nil {
 			glog.Fatalf("Unable to create proxier: %v", err)
 		}


### PR DESCRIPTION
External IPs on services can contain arbitrary IP addresses. It is therefore
possible that a malicious user could spoof any IP and replace it with her own
service, e.g. `8.8.4.4`. To prevent this `kube-proxy` adds a security check and
discards any traffic that does not appear to come from a physical device.

This in return requires machinery to put allowed IPs on an interface on each
machine running `kube-proxy`. Like reading a list of allowed addresses from some
metadata service or from the API and running a process to add it to a dummy
interface. Another way is to statically configure the ips on each node.

One downside of this approach is that should the service be unavailable local
traffic will be hitting the dummy interface and get discarded. This is usually
not a problem and most of the time even desired (blackholeing and avoiding
loops).

In our specific use-case the IP address is an anycast endpoint served from
multiple clusters simultaneously. We want the traffic to stay locally in
a cluster but if the local service falls down it should not blackhole the
traffic but fallback to the next cluster still serving the IP.

This would require us to build a sidekick that dynamically adds/removes IPs
depending on service health for each node. Though not impossible at all, we
would prefer this 2 line fix 😄

It might be a useful flag for other users running trusted clusters. The default
is to keep the security measure in place.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36720)
<!-- Reviewable:end -->
