### PR TITLE
CRI: add docs for sysctls

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -668,6 +668,16 @@ type PodSandboxConfig struct {
 	//      * localhost/<profile-name>: the profile installed to the node's
 	//        local seccomp profile root
 	//
+	// 3. Sysctls
+	//
+	//      key: security.alpha.kubernetes.io/sysctls
+	//      description: list of safe sysctls which are set for the sandbox.
+	//      value: comma separated list of sysctl_name=value key-value pairs.
+	//
+	//      key: security.alpha.kubernetes.io/unsafe-sysctls
+	//      description: list of unsafe sysctls which are set for the sandbox.
+	//      value: comma separated list of sysctl_name=value key-value pairs.
+	//
 	Annotations map[string]string `protobuf:"bytes,7,rep,name=annotations" json:"annotations,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	// Optional configurations specific to Linux hosts.
 	Linux            *LinuxPodSandboxConfig `protobuf:"bytes,8,opt,name=linux" json:"linux,omitempty"`

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -258,6 +258,16 @@ message PodSandboxConfig {
     //      * localhost/<profile-name>: the profile installed to the node's
     //        local seccomp profile root
     //
+    // 3. Sysctls
+    //
+    //      key: security.alpha.kubernetes.io/sysctls
+    //      description: list of safe sysctls which are set for the sandbox.
+    //      value: comma separated list of sysctl_name=value key-value pairs.
+    //
+    //      key: security.alpha.kubernetes.io/unsafe-sysctls
+    //      description: list of unsafe sysctls which are set for the sandbox.
+    //      value: comma separated list of sysctl_name=value key-value pairs.
+    //
     map<string, string> annotations = 7;
     // Optional configurations specific to Linux hosts.
     optional LinuxPodSandboxConfig linux = 8;


### PR DESCRIPTION
#34830 adds `sysctls` features in CRI, it is based on sandbox annotations, this PR adds docs for it. 

@yujuhong @timstclair @jonboulle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36728)
<!-- Reviewable:end -->
