### PR TITLE
error strings should not end with punctuation

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -178,7 +178,7 @@ func getRemoteKubeletConfig(s *options.KubeletServer, kubeDeps *kubelet.KubeletD
 		if kubeDeps != nil && kubeDeps.Cloud != nil {
 			instances, ok := kubeDeps.Cloud.Instances()
 			if !ok {
-				err = fmt.Errorf("failed to get instances from cloud provider, can't determine nodename.")
+				err = fmt.Errorf("failed to get instances from cloud provider, can't determine nodename")
 				return nil, err
 			}
 			nodename, err = instances.CurrentNodeName(hostname)
@@ -720,7 +720,7 @@ func RunKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *kubelet
 	// NewMainKubelet should have set up a pod source config if one didn't exist
 	// when the builder was run. This is just a precaution.
 	if kubeDeps.PodConfig == nil {
-		return fmt.Errorf("failed to create kubelet, pod source config was nil!")
+		return fmt.Errorf("failed to create kubelet, pod source config was nil")
 	}
 	podCfg := kubeDeps.PodConfig
 

--- a/cmd/libs/go2idl/openapi-gen/generators/openapi.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi.go
@@ -393,7 +393,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member) error {
 	}
 	switch t.Kind {
 	case types.Builtin:
-		return fmt.Errorf("please add type %v to getOpenAPITypeFormat function.", t)
+		return fmt.Errorf("please add type %v to getOpenAPITypeFormat function", t)
 	case types.Map:
 		if err := g.generateMapProperty(t); err != nil {
 			return err
@@ -405,7 +405,7 @@ func (g openAPITypeWriter) generateProperty(m *types.Member) error {
 	case types.Struct, types.Interface:
 		g.generateReferenceProperty(t)
 	default:
-		return fmt.Errorf("cannot generate spec for type %v.", t)
+		return fmt.Errorf("cannot generate spec for type %v", t)
 	}
 	g.Do("},\n},\n", nil)
 	return g.Error()

--- a/federation/pkg/federation-controller/service/dns.go
+++ b/federation/pkg/federation-controller/service/dns.go
@@ -141,9 +141,9 @@ func getDnsZone(dnsZoneName string, dnsZoneID string, dnsZonesInterface dnsprovi
 	}
 
 	if len(dnsZones) == 0 {
-		return nil, fmt.Errorf("DNS zone %s not found.", name)
+		return nil, fmt.Errorf("DNS zone %s not found", name)
 	} else {
-		return nil, fmt.Errorf("DNS zone %s is ambiguous (please specify zoneID).", name)
+		return nil, fmt.Errorf("DNS zone %s is ambiguous (please specify zoneID)", name)
 	}
 }
 

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -290,7 +290,7 @@ func (s *ServiceController) init() error {
 	}
 	zones, ok := s.dns.Zones()
 	if !ok {
-		return fmt.Errorf("the dns provider does not support zone enumeration, which is required for creating dns records.")
+		return fmt.Errorf("the dns provider does not support zone enumeration, which is required for creating dns records")
 	}
 	s.dnsZones = zones
 	matchingZones, err := getDnsZones(s.zoneName, s.zoneID, s.dnsZones)

--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -510,13 +510,13 @@ type kops struct {
 
 func NewKops() (*kops, error) {
 	if *kopsPath == "" {
-		return nil, fmt.Errorf("--kops must be set to a valid binary path for kops deployment.")
+		return nil, fmt.Errorf("--kops must be set to a valid binary path for kops deployment")
 	}
 	if *kopsCluster == "" {
-		return nil, fmt.Errorf("--kops-cluster must be set to a valid cluster name for kops deployment.")
+		return nil, fmt.Errorf("--kops-cluster must be set to a valid cluster name for kops deployment")
 	}
 	if *kopsState == "" {
-		return nil, fmt.Errorf("--kops-state must be set to a valid S3 path for kops deployment.")
+		return nil, fmt.Errorf("--kops-state must be set to a valid S3 path for kops deployment")
 	}
 	sshKey := *kopsSSHKey
 	if sshKey == "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Delete the end punctuation of error strings
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
https://github.com/golang/go/wiki/CodeReviewComments#error-strings
**Release note**:

```release-note
```

Signed-off-by: yupeng <yu.peng36@zte.com.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36734)
<!-- Reviewable:end -->
