### PR TITLE
Customizable vagrant rsync args and excludes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,6 +30,8 @@ $kube_os = ENV['KUBERNETES_OS'] || "fedora"
 
 # Determine whether vagrant should use nfs to sync folders
 $use_nfs = ENV['KUBERNETES_VAGRANT_USE_NFS'] == 'true'
+# Determine whether vagrant should use rsync to sync folders
+$use_rsync = ENV['KUBERNETES_VAGRANT_USE_RSYNC'] == 'true'
 
 # To override the vagrant provider, use (e.g.):
 #   KUBERNETES_PROVIDER=vagrant VAGRANT_DEFAULT_PROVIDER=... .../cluster/kube-up.sh
@@ -156,6 +158,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     if $use_nfs then
       config.vm.synced_folder ".", "/vagrant", nfs: true
+    elsif $use_rsync then
+      opts = {}
+      if ENV['KUBERNETES_VAGRANT_RSYNC_ARGS'] then
+        opts[:rsync__args] = ENV['KUBERNETES_VAGRANT_RSYNC_ARGS'].split(" ")
+      end
+      if ENV['KUBERNETES_VAGRANT_RSYNC_EXCLUDE'] then
+        opts[:rsync__exclude] = ENV['KUBERNETES_VAGRANT_RSYNC_EXCLUDE'].split(" ")
+      end
+      config.vm.synced_folder ".", "/vagrant", opts
     end
 
     # Try VMWare Fusion first (see


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

There are some annoyances with Vagrant+rsync currently.

When using rsync file synchronization with Vagrant, the whole kubernetes
repo directory is copied over into the virtual machine. This includes
the _output directory, which tends to be gigabytes in size, while often
just _output/release-tars (a few hundred MB) would be enough.

Furthermore, if the some of the directories contains a recursive
symlink, rsync with the default args will keep descending and copying
files endlessly until filling up the VM disk.

**The improvement**:

Making the rsync args and excluded dirs/files customizable via
KUBERNETES_VAGRANT_RSYNC_ARGS and KUBERNETES_VAGRANT_RSYNC_EXLUDE,
respectively, allows the developer to prevent the issues mentioned
above. A new KUBERNETES_VAGRANT_USE_RSYNC variable is also added to
control whether Vagrant should force usage of rsync as the file
synchronization backend. The args/exclude customizations only take
effect when KUBERNETES_VAGRANT_USE_RSYNC is 'true'.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36740)
<!-- Reviewable:end -->
