### PR TITLE
Interface EventSink implementation should not use pointer receivers

### DIFF
--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/event_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/event_expansion.go
@@ -148,14 +148,14 @@ type EventSinkImpl struct {
 	Interface EventInterface
 }
 
-func (e *EventSinkImpl) Create(event *api.Event) (*api.Event, error) {
+func (e EventSinkImpl) Create(event *api.Event) (*api.Event, error) {
 	return e.Interface.CreateWithEventNamespace(event)
 }
 
-func (e *EventSinkImpl) Update(event *api.Event) (*api.Event, error) {
+func (e EventSinkImpl) Update(event *api.Event) (*api.Event, error) {
 	return e.Interface.UpdateWithEventNamespace(event)
 }
 
-func (e *EventSinkImpl) Patch(event *api.Event, data []byte) (*api.Event, error) {
+func (e EventSinkImpl) Patch(event *api.Event, data []byte) (*api.Event, error) {
 	return e.Interface.PatchWithEventNamespace(event, data)
 }

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/event_expansion.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/event_expansion.go
@@ -149,14 +149,14 @@ type EventSinkImpl struct {
 	Interface EventInterface
 }
 
-func (e *EventSinkImpl) Create(event *v1.Event) (*v1.Event, error) {
+func (e EventSinkImpl) Create(event *v1.Event) (*v1.Event, error) {
 	return e.Interface.CreateWithEventNamespace(event)
 }
 
-func (e *EventSinkImpl) Update(event *v1.Event) (*v1.Event, error) {
+func (e EventSinkImpl) Update(event *v1.Event) (*v1.Event, error) {
 	return e.Interface.UpdateWithEventNamespace(event)
 }
 
-func (e *EventSinkImpl) Patch(event *v1.Event, data []byte) (*v1.Event, error) {
+func (e EventSinkImpl) Patch(event *v1.Event, data []byte) (*v1.Event, error) {
 	return e.Interface.PatchWithEventNamespace(event, data)
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go
@@ -149,14 +149,14 @@ type EventSinkImpl struct {
 	Interface EventInterface
 }
 
-func (e *EventSinkImpl) Create(event *v1.Event) (*v1.Event, error) {
+func (e EventSinkImpl) Create(event *v1.Event) (*v1.Event, error) {
 	return e.Interface.CreateWithEventNamespace(event)
 }
 
-func (e *EventSinkImpl) Update(event *v1.Event) (*v1.Event, error) {
+func (e EventSinkImpl) Update(event *v1.Event) (*v1.Event, error) {
 	return e.Interface.UpdateWithEventNamespace(event)
 }
 
-func (e *EventSinkImpl) Patch(event *v1.Event, data []byte) (*v1.Event, error) {
+func (e EventSinkImpl) Patch(event *v1.Event, data []byte) (*v1.Event, error) {
 	return e.Interface.PatchWithEventNamespace(event, data)
 }


### PR DESCRIPTION
Fixes:
```
does not implement record.EventSink (Create method has pointer receiver)
```

when is used in event broadcaster:
```
eventBroadcaster := record.NewBroadcaster()
eventBroadcaster.StartLogging(glog.Infof)
eventBroadcaster.StartRecordingToSink(unversionedcore.EventSinkImpl{
    Interface: config.Client.Core().Events(config.Namespace),
})
```

@caesarxuchao

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36742)
<!-- Reviewable:end -->
