### PR TITLE
Verify the network interface before deleting it

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -241,6 +241,16 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 	return &network.PodNetworkStatus{IP: ip}, nil
 }
 
+// Verify the network interface exists
+func (plugin *cniNetworkPlugin) VerifyPodInterface(namespace string, name string, id kubecontainer.ContainerID) (error) {
+        netnsPath, err := plugin.host.GetNetNS(id.ID)
+	if err != nil {
+		return fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
+	}
+
+	return network.VerifyPodInterface(plugin.execer, plugin.nsenterPath, netnsPath, network.DefaultInterfaceName)
+}
+
 func (network *cniNetwork) addToNetwork(podName string, podNamespace string, podInfraContainerID kubecontainer.ContainerID, podNetnsPath string) (*cnitypes.Result, error) {
 	rt, err := buildCNIRuntimeConf(podName, podNamespace, podInfraContainerID, podNetnsPath)
 	if err != nil {

--- a/pkg/kubelet/network/mock_network/network_plugins.go
+++ b/pkg/kubelet/network/mock_network/network_plugins.go
@@ -78,6 +78,12 @@ func (_m *MockNetworkPlugin) GetPodNetworkStatus(_param0 string, _param1 string,
 	return ret0, ret1
 }
 
+func (_m *MockNetworkPlugin) VerifyPodInterface(_param0 string, _param1 string, _param2 container.ContainerID) (error) {
+	ret := _m.ctrl.Call(_m, "VerifyPodInterface", _param0, _param1, _param2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
 func (_mr *_MockNetworkPluginRecorder) GetPodNetworkStatus(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetPodNetworkStatus", arg0, arg1, arg2)
 }


### PR DESCRIPTION
Because of graceful deletion support in kubelet, we could delete one
pod several times. However we should not call cni to delete the network
interface every time. This change makes sure we only delete network
plugin once with cni plugin.

Fixes kubernetes/kubernetes#36746
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36747)
<!-- Reviewable:end -->
Release note:
```release-note
NONE
```