### PR TITLE
Add a flag allowing contention profiling of the API server

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -106,6 +106,7 @@ container-port
 container-runtime
 container-runtime-endpoint
 contain-pod-resources
+contention-profiling
 controller-start-interval
 cors-allowed-origins
 cpu-cfs-quota

--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -83,6 +83,7 @@ type ServerRunOptions struct {
 	AuditLogMaxSize              int
 	EnableGarbageCollection      bool
 	EnableProfiling              bool
+	EnableContentionProfiling    bool
 	EnableSwaggerUI              bool
 	EnableWatchCache             bool
 	EtcdServersOverrides         []string
@@ -139,6 +140,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		DeleteCollectionWorkers:                  1,
 		EnableGarbageCollection:                  true,
 		EnableProfiling:                          true,
+		EnableContentionProfiling:                false,
 		EnableWatchCache:                         true,
 		InsecureBindAddress:                      net.ParseIP("127.0.0.1"),
 		InsecurePort:                             8080,
@@ -347,6 +349,8 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&s.EnableProfiling, "profiling", s.EnableProfiling,
 		"Enable profiling via web interface host:port/debug/pprof/")
+	fs.BoolVar(&s.EnableContentionProfiling, "contention-profiling", s.EnableContentionProfiling,
+		"Enable contention profiling. Requires --profiling to be set to work.")
 
 	fs.BoolVar(&s.EnableSwaggerUI, "enable-swagger-ui", s.EnableSwaggerUI,
 		"Enables swagger ui on the apiserver at /swagger-ui")


### PR DESCRIPTION
Useful for performance debugging.

cc @smarterclayton @timothysc @lavalamp

```release-note
Add a flag allowing contention profiling of the API server
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36756)
<!-- Reviewable:end -->
