### PR TITLE
Deprecate the recycler function

### DIFF
--- a/pkg/controller/volume/persistentvolume/deprecated-recycle-api.md
+++ b/pkg/controller/volume/persistentvolume/deprecated-recycle-api.md
@@ -1,0 +1,32 @@
+## Deprecation of Persistent Volume Recycler Behavior
+The function of the persistent volume recycler will change in future kubernetes releases.  The current implementation will remain and function as is for the short term but is expected to be removed or replaced in future releases.  
+
+## Summary
+The current recycler design only allows for user space volume erasure operations.  This is inadequate for control plane or erasure that requires elevated privileges.  Future redesign is anticipated and this document serves as warning of future API change. 
+
+**USE RECYCLE API AT YOUR OWN RISK AS IT MAY BE REMOVED OR SIGNIFICANTLY CHANGED IN FUTURE KUBERNETES RELEASES**.
+
+## Problem Scenarios
+**Scenario 1**: User attaches a volume to their POD and is assigned a suplimental group but their default group is some other group.  New files are created as the default group and for the recycler to remove them it would have to run as the default group.  The scenario is similar and problimatic for chown'ed and chgroup'ed files.  The recycler has no way to determine at launch which group to run as to remove every file on a recycled volume.
+
+**Scenario 2**: Malicious user writes a POD that uses debugfs to inspect attached volumes for previously deleted files.  Malicious user would gain access to "recycled" files from other users.
+
+To work around either of these scenarios kubernetes will need to delete the partition on the storage volume and re-create.  In the current architecture the volume attached to the recycler is unavialble for deletion as its in use.  
+
+Additionally, delete/create is an admin control plane operation and the node hosting the recycle POD will need network access to the storage control plane and the admin credentials.  Its desirable to isolate storage control plan from the user network for security.
+
+## Rational
+With the inclusion of configurable dynamic provisioning and storage service classes its expected that most storage volumes will be created dynamically.  In situations where the volumes can be created dynamically its more reliable and secure to "recycle" by deleting a volume and recreating it.
+
+Additionally most filesystems do not remove block data when a user space delete operation occurs.  The next user of a recycled volume could gain access to the previous users data.
+
+In the short term the user space volume scrub will remain for backwards compatibility.  With the recent feature additions to dynamic provisioning the prefered route is to delete and create volumes instead of re-using old ones.  The recycler function will be removed from support as soon as the deprecation schedule allows. Users are encouraged to write dynamic provisioners and deleters and use that instead of recycling.
+
+## Deprecated Design
+As of Kubernetes 1.2 if a volume is marked for recycle when it is deleted a special recycle container is attached and 'rm -rf's the data on the volume.  This behavior is expected to change or be removed.
+
+
+## Timeline
+
+* Kube 1.5 : Notice of deprecation
+* Kube 1.5 + 1 year : Remove old recycler API

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -45,9 +45,14 @@ const (
 // Note: docker doesn't use LogDirectory (yet).
 func (ds *dockerService) RunPodSandbox(config *runtimeApi.PodSandboxConfig) (string, error) {
 	// Step 1: Pull the image for the sandbox.
-	// TODO: How should we handle pulling custom pod infra container image
-	// (with credentials)?
 	image := defaultSandboxImage
+	podSandboxImage := ds.podSandboxImage
+	if len(podSandboxImage) != 0 {
+		image = podSandboxImage
+	}
+
+	// NOTE: To use a custom sandbox image in a private repository, users need to configure the nodes with credentials properly.
+	// see: http://kubernetes.io/docs/user-guide/images/#configuring-nodes-to-authenticate-to-a-private-repository
 	if err := ds.client.PullImage(image, dockertypes.AuthConfig{}, dockertypes.ImagePullOptions{}); err != nil {
 		return "", fmt.Errorf("unable to pull image for the sandbox container: %v", err)
 	}

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -54,10 +54,11 @@ const (
 var internalLabelKeys []string = []string{containerTypeLabelKey, sandboxIDLabelKey}
 
 // NOTE: Anything passed to DockerService should be eventually handled in another way when we switch to running the shim as a different process.
-func NewDockerService(client dockertools.DockerInterface, seccompProfileRoot string) DockerLegacyService {
+func NewDockerService(client dockertools.DockerInterface, seccompProfileRoot string, podSandboxImage string) DockerLegacyService {
 	return &dockerService{
 		seccompProfileRoot: seccompProfileRoot,
 		client:             dockertools.NewInstrumentedDockerInterface(client),
+		podSandboxImage:    podSandboxImage,
 	}
 }
 
@@ -80,6 +81,7 @@ type DockerLegacyService interface {
 type dockerService struct {
 	seccompProfileRoot string
 	client             dockertools.DockerInterface
+	podSandboxImage    string
 }
 
 // Version returns the runtime name, runtime version and runtime API version

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -507,7 +507,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 		case "cri":
 			// Use the new CRI shim for docker. This is need for testing the
 			// docker integration through CRI, and may be removed in the future.
-			dockerService := dockershim.NewDockerService(klet.dockerClient, kubeCfg.SeccompProfileRoot)
+			dockerService := dockershim.NewDockerService(klet.dockerClient, kubeCfg.SeccompProfileRoot, kubeCfg.PodInfraContainerImage)
 			klet.containerRuntime, err = kuberuntime.NewKubeGenericRuntimeManager(
 				kubecontainer.FilterEventRecorder(kubeDeps.Recorder),
 				klet.livenessManager,


### PR DESCRIPTION
This PR is to give notice to user that the recycler function will be removed.

The recycler is difficult to support, breaks in many scenarios and the use cases its covering are replaced with dynamic provision and deletion of volumes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36758)
<!-- Reviewable:end -->
