### PR TITLE
clear impersonation headers

### DIFF
--- a/pkg/apiserver/filters/impersonation.go
+++ b/pkg/apiserver/filters/impersonation.go
@@ -123,6 +123,15 @@ func WithImpersonation(handler http.Handler, requestContextMapper api.RequestCon
 		oldUser, _ := api.UserFrom(ctx)
 		httplog.LogOf(req, w).Addf("%v is acting as %v", oldUser, newUser)
 
+		// clear all the impersonation headers from the request
+		req.Header.Del(authenticationapi.ImpersonateUserHeader)
+		req.Header.Del(authenticationapi.ImpersonateGroupHeader)
+		for headerName := range req.Header {
+			if strings.HasPrefix(headerName, authenticationapi.ImpersonateUserExtraHeaderPrefix) {
+				req.Header.Del(headerName)
+			}
+		}
+
 		handler.ServeHTTP(w, req)
 	})
 }


### PR DESCRIPTION
If you clone a request that came in after impersonation, you were also cloning the impersonation headers that came with it.  These seem roughly analogous to the `Authorization` header, so this clears them.

@kubernetes/sig-auth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36769)
<!-- Reviewable:end -->
