### PR TITLE
tests: update memory resource limits

### DIFF
--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -132,7 +132,7 @@ var _ = framework.KubeDescribe("InitContainer", func() {
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-								api.ResourceMemory: *resource.NewQuantity(10*1024*1024, resource.DecimalSI),
+								api.ResourceMemory: *resource.NewQuantity(30*1024*1024, resource.DecimalSI),
 							},
 						},
 					},
@@ -195,7 +195,7 @@ var _ = framework.KubeDescribe("InitContainer", func() {
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-								api.ResourceMemory: *resource.NewQuantity(10*1024*1024, resource.DecimalSI),
+								api.ResourceMemory: *resource.NewQuantity(30*1024*1024, resource.DecimalSI),
 							},
 						},
 					},
@@ -306,7 +306,7 @@ var _ = framework.KubeDescribe("InitContainer", func() {
 						Resources: api.ResourceRequirements{
 							Limits: api.ResourceList{
 								api.ResourceCPU:    *resource.NewMilliQuantity(100, resource.DecimalSI),
-								api.ResourceMemory: *resource.NewQuantity(10*1024*1024, resource.DecimalSI),
+								api.ResourceMemory: *resource.NewQuantity(30*1024*1024, resource.DecimalSI),
 							},
 						},
 					},


### PR DESCRIPTION
```release-note
NONE
```

On ubuntu, the `RestartNever` test OOMs its cgroup limit fairly
frequently.

This bumps the number up to something suitably large since the test
isn't testing anything related to this anyways.

Fixes #36159

Fix based on https://github.com/kubernetes/kubernetes/issues/36159#issuecomment-258992255

cc @yujuhong @saad-ali 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36771)
<!-- Reviewable:end -->
