### PR TITLE
remove used front-proxy headers

### DIFF
--- a/plugin/pkg/auth/authenticator/request/headerrequest/requestheader.go
+++ b/plugin/pkg/auth/authenticator/request/headerrequest/requestheader.go
@@ -82,6 +82,11 @@ func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request)
 		return nil, false, nil
 	}
 
+	// clear headers used for authentication
+	for _, headerName := range a.nameHeaders {
+		req.Header.Del(headerName)
+	}
+
 	return &user.DefaultInfo{Name: name}, true, nil
 }
 


### PR DESCRIPTION
Found this while looking at how to add group support to the auth proxy.  I'm less sure of whether we should clear these or not.

@kubernetes/sig-auth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36772)
<!-- Reviewable:end -->
