### PR TITLE
hyperkube: Build image from locally build binary.

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -67,7 +67,11 @@ endif
 	cp ${TEMP_DIR}/addons/singlenode/*.yaml ${TEMP_DIR}/addons/multinode/
 	cp kube-proxy-ds.yaml ${TEMP_DIR}/addons/multinode/kube-proxy.yaml
 
+ifdef LOCAL
+	cp ../../../_output/local/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
+else
 	cp ../../../_output/dockerized/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
+endif
 
 	cd ${TEMP_DIR} && sed -i.back "s|VERSION|${VERSION}|g" addons/singlenode/*.yaml addons/multinode/*.yaml static-pods/*.json
 	cd ${TEMP_DIR} && sed -i.back "s|REGISTRY|${REGISTRY}|g" addons/singlenode/*.yaml addons/multinode/*.yaml static-pods/*.json


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Currently it's only possible to build a hyperkube docker image from the binaries placed in `_output/dockerized/bin/....` when running:
```
$ build-tools/run.sh make cross
```
This is great when building for multiple architectures, but if you only care about one architecture e.i amd64, then it's faster/simpler to build the hyperkube binary with something like:
```
$ make all WHAT=cmd/hyperkube
```
Where you don't depend on a custom dockerized build chain.

This patch makes it possible to build a hyperkube image from a locally build binary using the optional flag `LOCAL` when running make in `cluster/images/hyperkube`. So you would do something like this to build a amd64 compatible hyperkube image (assuming the build machine is amd64):

```
$ make all WHAT=cmd/hyperkube
$ cd cluster/images/hyperkube
$ make build REGISTRY=my-registry VERSION=k8s-version ARCH=amd64 LOCAL=true
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36773)
<!-- Reviewable:end -->
