### PR TITLE
allow auth proxy to set groups and extra

### DIFF
--- a/pkg/apiserver/authenticator/builtin.go
+++ b/pkg/apiserver/authenticator/builtin.go
@@ -88,6 +88,9 @@ func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefin
 			config.RequestHeaderConfig.ClientCA,
 			config.RequestHeaderConfig.AllowedClientNames,
 			config.RequestHeaderConfig.UsernameHeaders,
+			// TODO add wiring after options are refactored in 1.6
+			[]string{},
+			[]string{},
 		)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
This allows a trusted front proxy to set headers on requests to the API server which will set groups and extra information on the resulting user.Info.

I got here by building a apifederation server which terminated TLS and thus terminated client cert authentication.  Once you've done that, you have to proxy the request the final API server, but identify that request as being for a different user.  I initially built that using impersonation and it worked quite well.  Unfortunately, that exposes a bearer token which has the power to impersonate all users.  

The proxy always has the power to do anything on the cluster (I can say I'm anyone), but using a request header approach means that I don't have to propagate those powers to every constituent API server.  This does mean that the initial config is a little more difficult since you have to create CAs and communicate those to pods which should live in different namespaces.

@kubernetes/sig-auth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36774)
<!-- Reviewable:end -->
