### PR TITLE
Change dnsutils image to use alpine

### DIFF
--- a/test/images/dnsutils/Dockerfile
+++ b/test/images/dnsutils/Dockerfile
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:wheezy
-MAINTAINER Tim Hockin "thockin@google.com"
+FROM alpine
+MAINTAINER Bowei Du "bowei@google.com"
 
-RUN apt-get -q update && \
-    apt-get install -y dnsutils && \
-    apt-get clean
+RUN apk update --no-cache
+RUN apk add bind-tools

--- a/test/images/dnsutils/Makefile
+++ b/test/images/dnsutils/Makefile
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # This image does not tag
-#TAG =
-PREFIX = gcr.io/google_containers
+TAG ?=
+PREFIX ?= gcr.io/google_containers
 
 all: push
 


### PR DESCRIPTION
This reduces the size of the dnsutils image and should reduce the # of failed e2e test runs due to image pull timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36776)
<!-- Reviewable:end -->
