### PR TITLE
CreateNodeSelectorPods respects nodeSelector

### DIFF
--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -465,7 +465,7 @@ func CreateNodeSelectorPods(f *framework.Framework, id string, replicas int, nod
 		Image:        framework.GetPauseImageName(f.ClientSet),
 		Replicas:     replicas,
 		HostPorts:    map[string]int{"port1": 4321},
-		NodeSelector: map[string]string{"cluster-autoscaling-test.special-node": "true"},
+		NodeSelector: nodeSelector,
 	}
 	err := framework.RunRC(*config)
 	if expectRunning {


### PR DESCRIPTION
The current `CreateNodeSelectorPods` does not use `nodeSelector` parameter, it hard coded a label instead.

The reason current e2e does not influenced because we happened use the same label: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/cluster_size_autoscaling.go#L177

Found this bug during test in #36238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36795)
<!-- Reviewable:end -->
