### PR TITLE
[kubelet]update some --cgroups-per-qos to --experimental-cgroups-per-qos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,7 @@ test-e2e: ginkgo generated_files
 # Example:
 #   make test-e2e-node FOCUS=Kubelet SKIP=container
 #   make test-e2e-node REMOTE=true DELETE_INSTANCES=true
-#   make test-e2e-node TEST_ARGS="--cgroups-per-qos=true"
+#   make test-e2e-node TEST_ARGS="--experimental-cgroups-per-qos=true"
 # Build and run tests.
 .PHONY: test-e2e-node
 test-e2e-node: ginkgo generated_files

--- a/docs/devel/e2e-node-tests.md
+++ b/docs/devel/e2e-node-tests.md
@@ -208,10 +208,10 @@ make test_e2e_node TEST_ARGS="--disable-kubenet=false" # disable kubenet
 
 ## Additional QoS Cgroups Hierarchy level testing
 
-For testing with the QoS Cgroup Hierarchy enabled, you can pass --cgroups-per-qos flag as an argument into Ginkgo using TEST_ARGS
+For testing with the QoS Cgroup Hierarchy enabled, you can pass --experimental-cgroups-per-qos flag as an argument into Ginkgo using TEST_ARGS
 
 ```sh
-make test_e2e_node TEST_ARGS="--cgroups-per-qos=true"
+make test_e2e_node TEST_ARGS="--experimental-cgroups-per-qos=true"
 ```
 
 # Notes on tests run by the Kubernetes project during pre-, post- submit.

--- a/docs/proposals/pod-resource-management.md
+++ b/docs/proposals/pod-resource-management.md
@@ -341,7 +341,7 @@ $ROOT
 ## Implementation Plan
 
 The implementation plan is outlined in the next sections.
-We will have a 'cgroups-per-qos' flag to specify if the user wants to use the QoS based cgroup hierarchy. The flag would be set to false by default at least in v1.4.
+We will have a 'experimental-cgroups-per-qos' flag to specify if the user wants to use the QoS based cgroup hierarchy. The flag would be set to false by default at least in v1.5.
 
 #### Top level Cgroups for QoS tiers
 

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -33,9 +33,9 @@ NET_PLUGIN_DIR=${NET_PLUGIN_DIR:-""}
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 SERVICE_CLUSTER_IP_RANGE=${SERVICE_CLUSTER_IP_RANGE:-10.0.0.0/24}
 # if enabled, must set CGROUP_ROOT
-CGROUPS_PER_QOS=${CGROUPS_PER_QOS:-false}
+EXPERIMENTAL_CGROUPS_PER_QOS=${EXPERIMENTAL_CGROUPS_PER_QOS:-false}
 # this is not defaulted to preserve backward compatibility.
-# if CGROUPS_PER_QOS is enabled, recommend setting to /
+# if EXPERIMENTAL_CGROUPS_PER_QOS is enabled, recommend setting to /
 CGROUP_ROOT=${CGROUP_ROOT:""}
 # name of the cgroup driver, i.e. cgroupfs or systemd
 CGROUP_DRIVER=${CGROUP_DRIVER:-""}
@@ -502,7 +502,7 @@ function start_kubelet {
         --feature-gates="${FEATURE_GATES}" \
         --cpu-cfs-quota=${CPU_CFS_QUOTA} \
         --enable-controller-attach-detach="${ENABLE_CONTROLLER_ATTACH_DETACH}" \
-        --cgroups-per-qos=${CGROUPS_PER_QOS} \
+        --experimental-cgroups-per-qos=${EXPERIMENTAL_CGROUPS_PER_QOS} \
         --cgroup-driver=${CGROUP_DRIVER} \
         --cgroup-root=${CGROUP_ROOT} \
         ${auth_args} \

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -307,7 +307,7 @@ type KubeletConfiguration struct {
 	// +optional
 	SystemCgroups string `json:"systemCgroups,omitempty"`
 	// CgroupRoot is the root cgroup to use for pods.
-	// If CgroupsPerQOS is enabled, this is the root of the QoS cgroup hierarchy.
+	// If ExperimentalCgroupsPerQOS is enabled, this is the root of the QoS cgroup hierarchy.
 	// +optional
 	CgroupRoot string `json:"cgroupRoot,omitempty"`
 	// containerRuntime is the container runtime to use.

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -2630,7 +2630,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 					"cgroupRoot": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CgroupRoot is the root cgroup to use for pods. If CgroupsPerQOS is enabled, this is the root of the QoS cgroup hierarchy.",
+							Description: "CgroupRoot is the root cgroup to use for pods. If ExperimentalCgroupsPerQOS is enabled, this is the root of the QoS cgroup hierarchy.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -209,7 +209,7 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	if nodeConfig.CgroupsPerQOS {
 		// this does default to / when enabled, but this tests against regressions.
 		if nodeConfig.CgroupRoot == "" {
-			return nil, fmt.Errorf("invalid configuration: cgroups-per-qos was specified and cgroup-root was not specified. To enable the QoS cgroup hierarchy you need to specify a valid cgroup-root")
+			return nil, fmt.Errorf("invalid configuration: experimental-cgroups-per-qos was specified and cgroup-root was not specified. To enable the QoS cgroup hierarchy you need to specify a valid cgroup-root")
 		}
 
 		// we need to check that the cgroup root actually exists for each subsystem


### PR DESCRIPTION
Follow https://github.com/kubernetes/kubernetes/pull/36767, there are some fields still need update in docs or hack/local-up-cluster.sh

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36800)
<!-- Reviewable:end -->
