### PR TITLE
Todo:Create Rest Client Comment

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -133,6 +133,8 @@ func Run(s *options.CMServer) error {
 	// Override kubeconfig qps/burst settings from flags
 	kubeconfig.QPS = s.KubeAPIQPS
 	kubeconfig.Burst = int(s.KubeAPIBurst)
+
+	// Create a Rest Client Object used to access the Kubernetes api Server provides API services
 	kubeClient, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, "controller-manager"))
 	if err != nil {
 		glog.Fatalf("Invalid API configuration: %v", err)


### PR DESCRIPTION

**What this PR does / why we need it**:
Code:
"kubeClient, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, "controller-manager"))"

by annotation better reading, in order to better understanding of source.

Comment:"// Create a Rest Client Object used to access the Kubernetes api Server provides API services"

In Kubernetes - controller, the controller of the manager manager. Go create a Rest in the key processes Run the Client object is used to access Kubernetes API  service provided by API the Server

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

Signed-off-by: StudyNick <wei.chuanhui1@zte.com.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36801)
<!-- Reviewable:end -->
