### PR TITLE
plumb in front proxy group header

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -484,6 +484,8 @@ report-dir
 report-prefix
 requestheader-allowed-names
 requestheader-client-ca-file
+requestheader-extra-headers-prefix
+requestheader-group-headers
 requestheader-username-headers
 require-kubeconfig
 required-contexts

--- a/pkg/apiserver/authenticator/builtin.go
+++ b/pkg/apiserver/authenticator/builtin.go
@@ -88,6 +88,9 @@ func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefin
 			config.RequestHeaderConfig.ClientCA,
 			config.RequestHeaderConfig.AllowedClientNames,
 			config.RequestHeaderConfig.UsernameHeaders,
+			// TODO add wiring after options are refactored in 1.6
+			[]string{},
+			[]string{},
 		)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/apiserver/authenticator/builtin.go
+++ b/pkg/apiserver/authenticator/builtin.go
@@ -43,6 +43,11 @@ import (
 type RequestHeaderConfig struct {
 	// UsernameHeaders are the headers to check (in order, case-insensitively) for an identity. The first header with a value wins.
 	UsernameHeaders []string
+	// GroupHeaders are the headers to check (case-insensitively) for a group names.  All values will be used.
+	GroupHeaders []string
+	// ExtraHeaderPrefixes are the head prefixes to check (case-insentively) for filling in
+	// the user.Info.Extra.  All values of all matching headers will be added.
+	ExtraHeaderPrefixes []string
 	// ClientCA points to CA bundle file which is used verify the identity of the front proxy
 	ClientCA string
 	// AllowedClientNames is a list of common names that may be presented by the authenticating front proxy.  Empty means: accept any.
@@ -88,9 +93,8 @@ func New(config AuthenticatorConfig) (authenticator.Request, *spec.SecurityDefin
 			config.RequestHeaderConfig.ClientCA,
 			config.RequestHeaderConfig.AllowedClientNames,
 			config.RequestHeaderConfig.UsernameHeaders,
-			// TODO add wiring after options are refactored in 1.6
-			[]string{},
-			[]string{},
+			config.RequestHeaderConfig.GroupHeaders,
+			config.RequestHeaderConfig.ExtraHeaderPrefixes,
 		)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
Builds on https://github.com/kubernetes/kubernetes/pull/36662 and https://github.com/kubernetes/kubernetes/pull/36774, so only the last commit is unique.

This completes the plumbing for front proxy header information and makes it possible to add just the front proxy header authenticator.

WIP because I'm going to assess it in use downstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36816)
<!-- Reviewable:end -->
