### PR TITLE
Fix typo in cluster/gce/util.sh

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -429,7 +429,7 @@ function create-static-ip() {
       break
     fi
 
-    if cloud compute addresses describe "$1" \
+    if gcloud compute addresses describe "$1" \
       --project "${PROJECT}" \
       --region "${REGION}" >/dev/null 2>&1; then
       # it exists - postcondition satisfied


### PR DESCRIPTION
Somehow the gcloud command is written as "cloud".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36824)
<!-- Reviewable:end -->
