### PR TITLE
Automated cherry pick of #35013

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -34,6 +34,7 @@ import (
 // and credentialprovider.
 var AWSRegions = [...]string{
 	"us-east-1",
+	"us-east-2",
 	"us-west-1",
 	"us-west-2",
 	"eu-west-1",


### PR DESCRIPTION
Cherry pick of #35013 on release-1.4.

#35013: AWS: recognize us-east-2 region

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36826)
<!-- Reviewable:end -->
