### PR TITLE
azure: support nics with multiple ipconfigs

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_util.go
+++ b/pkg/cloudprovider/providers/azure/azure_util.go
@@ -151,9 +151,12 @@ func getPrimaryIPConfig(nic network.Interface) (*network.InterfaceIPConfiguratio
 		return &((*nic.Properties.IPConfigurations)[0]), nil
 	}
 
-	// we're here because we either have multiple ipconfigs and can't determine the primary:
-	//   https://github.com/Azure/azure-rest-api-specs/issues/305
-	// or somehow we had zero ipconfigs
+	for _, ref := range *nic.Properties.IPConfigurations {
+		if *ref.Properties.Primary {
+			return &ref, nil
+		}
+	}
+
 	return nil, fmt.Errorf("failed to determine the determine primary ipconfig. nicname=%q", *nic.Name)
 }
 


### PR DESCRIPTION

**What this PR does / why we need it**:

When I initially wrote the cloudprovider, the ipconfig primary field either wasn't present or wasn't populated. Now it is and we have someone trying to use kubelet on a node with a nic with multiple ipconfigs and they ran into this.

**Which issue this PR fixes**: n/a no issue filed.

**Special notes for your reviewer**:

**Release note**:
```release-note
azure: support multiple ipconfigs on a NIC
```

If we can get this backported to 1.4.x, that would be great.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36841)
<!-- Reviewable:end -->
