### PR TITLE
fix: elasticsearch template mapping to parse kubernetes.labels

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/template-k8s-logstash.json
+++ b/cluster/addons/fluentd-elasticsearch/es-image/template-k8s-logstash.json
@@ -1,22 +1,35 @@
 {
-  "template_k8s_logstash" : {
-    "template" : "logstash-*",
-    "settings" : {
-      "index.refresh_interval" : "5s"
-    },
-    "mappings" : {
-      "_default_" : {
-        "dynamic_templates" : [ {
-          "kubernetes_field" : {
-            "path_match" : "kubernetes.*",
-            "mapping" : {
-              "type" : "string",
-              "index" : "not_analyzed"
-            }
+  "template" : "logstash-*",
+  "settings" : {
+    "index.refresh_interval" : "5s"
+  },
+  "mappings" : {
+    "_default_" : {
+      "dynamic_templates" : [ {
+        "kubernetes_labels" : {
+          "path_match" : "kubernetes.labels",
+          "mapping" : {
+            "type" : "object",
+            "dynamic_templates" : [ {
+              "match_mapping_type": "string",
+              "path_match" : "*",
+              "mapping" : {
+                "type" : "string",
+                "index" : "not_analyzed"
+              }
+            } ]
           }
-        } ]
-      }
+        }
+      }, {
+        "kubernetes_field" : {
+          "match_mapping_type": "string",
+          "path_match" : "kubernetes.*",
+          "mapping" : {
+            "type" : "string",
+            "index" : "not_analyzed"
+          }
+        }
+      } ]
     }
   }
 }
-


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the field mappings for the elasticsearch template that ships with the EFK stack implementation.

Specifically, elasticsearch cannot parse the `kubernetes.labels` object because it attempts to treat it as a string and produces an error. This update treats `kubernetes.labels` as an object and all of the properties within as a string, allowing accurate indexing and allowing users in kibana to search on `kubernetes.labels.*`.

**Release note**:
```release-note
Fluentd/Elastisearch add-on: correctly parse and index kubernetes labels
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36857)
<!-- Reviewable:end -->
