### PR TITLE
Fix path to kubectl on host in kubectl-in-pod

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -566,8 +566,15 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			framework.SkipUnlessProviderIs("gke")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			podJson := readTestFileOrDie(kubectlInPodFilename)
+
+			// Replace the host path to kubectl in json
+			podString := strings.Replace(string(podJson),
+				"$KUBECTL_PATH",
+				framework.TestContext.KubectlPath,
+				1)
+
 			By("validating api verions")
-			framework.RunKubectlOrDieInput(string(podJson), "create", "-f", "-", nsFlag)
+			framework.RunKubectlOrDieInput(podString, "create", "-f", "-", nsFlag)
 			err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 				output := framework.RunKubectlOrDie("get", "pods/kubectl-in-pod", nsFlag)
 				if strings.Contains(output, "Running") {

--- a/test/e2e/testing-manifests/kubectl/kubectl-in-pod.json
+++ b/test/e2e/testing-manifests/kubectl/kubectl-in-pod.json
@@ -20,7 +20,7 @@
     ],
     "volumes": [{
       "name":"kubectl",
-      "hostPath":{"path": "/usr/bin/kubectl"}
+      "hostPath":{"path": "$KUBECTL_PATH"}
     }]
   }
 }


### PR DESCRIPTION
kubectl-in-pod.json has a hardcoded path for
kubectl in its hostPath ('/usr/bin/kubectl').
When the test actually runs on gke, kubectl
is available at '/workspace/kubernetes/platforms/linux/amd64/kubectl'
and NOT at '/usr/bin/kubectl'. So we need to
fix the hostPath for the test to work properly.

Fixes #36586

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36864)
<!-- Reviewable:end -->
