### PR TITLE
forbid restricted psp user delete privileged pod

### DIFF
--- a/pkg/admission/errors.go
+++ b/pkg/admission/errors.go
@@ -25,7 +25,9 @@ import (
 
 func extractResourceName(a Attributes) (name string, resource unversioned.GroupResource, err error) {
 	name = "Unknown"
-	resource = a.GetResource().GroupResource()
+	if len(a.GetName()) > 0 {
+		name = a.GetName()
+	}
 	obj := a.GetObject()
 	if obj != nil {
 		accessor, err := meta.Accessor(obj)
@@ -40,6 +42,7 @@ func extractResourceName(a Attributes) (name string, resource unversioned.GroupR
 			name = accessor.GetGenerateName()
 		}
 	}
+	resource = a.GetResource().GroupResource()
 	return name, resource, nil
 }
 

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -104,7 +104,7 @@ func NewPlugin(kclient clientset.Interface, strategyFactory psp.StrategyFactory,
 	)
 
 	return &podSecurityPolicyPlugin{
-		Handler:          admission.NewHandler(admission.Create, admission.Update),
+		Handler:          admission.NewHandler(admission.Create, admission.Update, admission.Delete),
 		client:           kclient,
 		strategyFactory:  strategyFactory,
 		pspMatcher:       pspMatcher,
@@ -145,10 +145,20 @@ func (c *podSecurityPolicyPlugin) Admit(a admission.Attributes) error {
 		return nil
 	}
 
-	pod, ok := a.GetObject().(*api.Pod)
-	// if we can't convert then we don't handle this object so just return
-	if !ok {
-		return nil
+	var pod *api.Pod
+	if a.GetOperation() == admission.Delete {
+		var err error
+		pod, err = c.client.Core().Pods(a.GetNamespace()).Get(a.GetName())
+		if err != nil {
+			return nil
+		}
+	} else {
+		var ok bool
+		pod, ok = a.GetObject().(*api.Pod)
+		// if we can't convert then we don't handle this object so just return
+		if !ok {
+			return nil
+		}
 	}
 
 	// get all constraints that are usable by the user


### PR DESCRIPTION
cf. docs [psp rbac](https://github.com/kubernetes/kubernetes/blob/master/examples/podsecuritypolicy/rbac/README.md)

forbid restricted psp user delete privileged pod
the result is:
```shell
$ ./cluster/kubectl.sh --token=foo/restricted-psp-users delete -f examples/podsecuritypolicy/rbac/pod_priv.yaml 
Error from server (Forbidden): error when stopping "examples/podsecuritypolicy/rbac/pod_priv.yaml": pods "nginx" is forbidden: unable to validate against any pod security policy: [spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed]

$ ./cluster/kubectl.sh --token=foo/privileged-psp-users delete -f examples/podsecuritypolicy/rbac/pod_priv.yaml
pod "nginx" deleted
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36865)
<!-- Reviewable:end -->
