### PR TITLE
Avoid overlapping controllers (including StatefulSets) to fight with StatefulSets 

### DIFF
--- a/pkg/controller/petset/pet_set_test.go
+++ b/pkg/controller/petset/pet_set_test.go
@@ -329,3 +329,51 @@ func TestStatefulSetReplicaCount(t *testing.T) {
 		t.Errorf("Replicas count sent as status update for StatefulSet should be 1, is %d instead", fpsc.replicas)
 	}
 }
+
+func TestExpectedPodName(t *testing.T) {
+	ss := newStatefulSet(3)
+
+	testCases := []struct {
+		podName  string
+		expected bool
+	}{
+		{
+			podName:  "foo-0",
+			expected: true,
+		},
+		{
+			podName:  "foo-2",
+			expected: true,
+		},
+		{
+			podName:  "foo-",
+			expected: false,
+		},
+		{
+			podName:  "foo-a",
+			expected: false,
+		},
+		{
+			podName:  "foo-3",
+			expected: false,
+		},
+		{
+			podName:  "foo-1.1",
+			expected: false,
+		},
+		{
+			podName:  "oo-1",
+			expected: false,
+		},
+	}
+
+	for _, test := range testCases {
+		if test.expected != expectedPodName(test.podName, ss) {
+			maybeNot := ""
+			if !test.expected {
+				maybeNot = " not"
+			}
+			t.Errorf("pod name %q should%s belong to Stateful Set %q with %d replicas", test.podName, maybeNot, ss.Name, ss.Spec.Replicas)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: To prevent fighting controllers that mess up statefulsets 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #36859

**Special notes for your reviewer**: cc @erictune @foxish @kow3ns @kubernetes/sig-apps 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

We find a StatefulSet's pods by filtering label selector, and this is not enough.
To avoid other fighting/overlapping controllers, we need to filter by parent UID as well.
The parent UID can be found in the created-by annotation.
We didn't use pod prefix, since other controllers can create pods with the same prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36866)
<!-- Reviewable:end -->
