### PR TITLE
[Federation][join-flags] Add flags for cluster context and secret names while joining clusters to federation.

### DIFF
--- a/federation/pkg/kubefed/BUILD
+++ b/federation/pkg/kubefed/BUILD
@@ -63,5 +63,6 @@ go_test(
         "//pkg/client/unversioned/clientcmd/api:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
+        "//vendor:k8s.io/client-go/pkg/util/diff",
     ],
 )

--- a/federation/pkg/kubefed/unjoin_test.go
+++ b/federation/pkg/kubefed/unjoin_test.go
@@ -159,7 +159,7 @@ func TestUnjoinFederation(t *testing.T) {
 func testUnjoinFederationFactory(name, server, secret string) cmdutil.Factory {
 	urlPrefix := "/clusters/"
 
-	cluster := fakeCluster(name, server)
+	cluster := fakeCluster(name, name, server)
 	if secret != "" {
 		cluster.Spec.SecretRef.Name = secret
 	}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -73,6 +73,7 @@ clientset-path
 cloud-config
 cloud-provider
 cluster-cidr
+cluster-context
 cluster-dns
 cluster-domain
 cluster-ip
@@ -507,6 +508,7 @@ schema-cache-dir
 scopes
 seccomp-profile-root
 secondary-node-eviction-rate
+secret-name
 secure-port
 serialize-image-pulls
 server-start-timeout


### PR DESCRIPTION
Vast majority of cluster contexts are not RFC 1123 subdomains. Since
cluster and secret names for the API objects are derived from the
cluster context name, there is no way for users to join clusters
with such context names to federation, unless they modify the context
name in their kubeconfigs itself. That's a lot of inconvenience and
entirely goes against the goal and beats the purpose of the `kubefed`
tool. So we are providing these flags to allow users to override these
values.

Also, since users register their clusters with federation, it is makes
sense in terms of user experience to make the cluster name a positional
argument because that feels more natural. Also, specifying cluster name
in the join command as a mandatory positional argument make
`kubefed join` consistent with `kubefed unjoin`. This also means
`--cluster-context` is now made a flag and defaults to cluster name if
unspecified.

`--secret-name` also defaults to the cluster name if unspecified.

Fixes: Issue #35954

cc @kubernetes/sig-cluster-federation @quinton-hoole @irfanurrehman

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36869)
<!-- Reviewable:end -->
