### PR TITLE
Add logs near force deletions of Pods

### DIFF
--- a/pkg/controller/node/controller_utils.go
+++ b/pkg/controller/node/controller_utils.go
@@ -118,6 +118,7 @@ func setPodTerminationReason(kubeClient clientset.Interface, pod *api.Pod, nodeN
 
 func forcefullyDeletePod(c clientset.Interface, pod *api.Pod) error {
 	var zero int64
+	glog.Infof("NodeController is force deleting Pod: %v:%v", pod.Namespace, pod.Name)
 	err := c.Core().Pods(pod.Namespace).Delete(pod.Name, &api.DeleteOptions{GracePeriodSeconds: &zero})
 	if err == nil {
 		glog.V(4).Infof("forceful deletion of %s succeeded", pod.Name)

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -68,6 +68,7 @@ func NewPodGC(kubeClient clientset.Interface, podInformer cache.SharedIndexInfor
 		kubeClient:             kubeClient,
 		terminatedPodThreshold: terminatedPodThreshold,
 		deletePod: func(namespace, name string) error {
+			glog.Infof("PodGC is force deleting Pod: %v:%v", namespace, name)
 			return kubeClient.Core().Pods(namespace).Delete(name, api.NewDeleteOptions(0))
 		},
 	}


### PR DESCRIPTION
We should always log something when control plane force deletes the Pod.

@davidopp I think that logging force deletions is enough, or do you think we should log soft deletions as well?

cc @deads2k

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36892)
<!-- Reviewable:end -->
