### PR TITLE
remove TPR registration, ease validation requirements

### DIFF
--- a/test/integration/kubectl/kubectl_test.go
+++ b/test/integration/kubectl/kubectl_test.go
@@ -30,17 +30,18 @@ import (
 func TestKubectlValidation(t *testing.T) {
 	testCases := []struct {
 		data string
-		err  bool
+		// Validation should not fail on missing type information.
+		err bool
 	}{
 		{`{"apiVersion": "v1", "kind": "thisObjectShouldNotExistInAnyGroup"}`, true},
-		{`{"apiVersion": "invalidVersion", "kind": "Pod"}`, true},
+		{`{"apiVersion": "invalidVersion", "kind": "Pod"}`, false},
 		{`{"apiVersion": "v1", "kind": "Pod"}`, false},
 
 		// The following test the experimental api.
 		// TODO: Replace with something more robust. These may move.
 		{`{"apiVersion": "extensions/v1beta1", "kind": "Ingress"}`, false},
 		{`{"apiVersion": "extensions/v1beta1", "kind": "Job"}`, false},
-		{`{"apiVersion": "vNotAVersion", "kind": "Job"}`, true},
+		{`{"apiVersion": "vNotAVersion", "kind": "Job"}`, false},
 	}
 	components := framework.NewMasterComponents(&framework.Config{})
 	defer components.Stop(true, true)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/36007 .

This removes the special casing for TPRs inside of the `UnstructuredObject`, which should allow CRUD against skewed kube api server levels.

@kubernetes/kubectl @kubernetes/sig-cli 
@janetkuo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36898)
<!-- Reviewable:end -->
