### PR TITLE
Update API server CPU constraints in the density test

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -87,14 +87,14 @@ func density30AddonResourceVerifier(numNodes int) map[string]framework.ResourceC
 			schedulerCPU = 0.75
 			schedulerMem = 500 * (1024 * 1024)
 		} else if numNodes <= 500 {
-			apiserverCPU = 2.5
+			apiserverCPU = 3.5
 			apiserverMem = 3400 * (1024 * 1024)
 			controllerCPU = 1.3
 			controllerMem = 1100 * (1024 * 1024)
 			schedulerCPU = 1.5
 			schedulerMem = 500 * (1024 * 1024)
 		} else if numNodes <= 1000 {
-			apiserverCPU = 4
+			apiserverCPU = 5.5
 			apiserverMem = 4000 * (1024 * 1024)
 			controllerCPU = 3
 			controllerMem = 2000 * (1024 * 1024)


### PR DESCRIPTION
We need to bump constraints after we enabled ServiceAccount tokens in kubemark.

It's required to unblock the submit queue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36899)
<!-- Reviewable:end -->
