### PR TITLE
Handle KubeMarkMasqChain on empty clusterCIDR

### DIFF
--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -737,6 +737,13 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 		errorf(fmt.Sprintf("Failed to find jump to lb chain %v", lbChain), kubeNodePortRules, t)
 	}
 
+	// Every cluster IP should have a rule to masqChain
+	masqChain := string(KubeMarkMasqChain)
+	kubeSvcRules := ipt.GetRules(string(kubeServicesChain))
+	if !hasJump(kubeSvcRules, masqChain, svcIP.String(), "") {
+		errorf(fmt.Sprintf("Failed to find jump to masq chain %v", masqChain), kubeSvcRules, t)
+	}
+
 	svcChain := string(servicePortChainName(svc, strings.ToLower(string(api.ProtocolTCP))))
 	lbRules := ipt.GetRules(lbChain)
 	if hasJump(lbRules, nonLocalEpChain, "", "") {


### PR DESCRIPTION
**What this PR does / why we need it**:
If ```clusterCIDR``` is not specified, ```KUBE-MARK-MASQ``` jump is not added ```KUBE-SERVICES`` chain for the service cluster ip.

Therefore the traffic to svc clusterip is not masqueraded and lost.

**Which issue this PR fixes**
fixes #36835 

**Special notes for your reviewer**:
Ensures that there is always a jump to KubeMarkMasqChain
in kubeServicesChain per cluster IP destination.

1. Handle Empty clusterCIDR
2. Do not add redundant rules if masqueradeAll == true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36925)
<!-- Reviewable:end -->
