### PR TITLE
Fix hostname truncate.

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1494,3 +1494,32 @@ func TestHasHostNamespace(t *testing.T) {
 		}
 	}
 }
+
+func TestTruncatePodHostname(t *testing.T) {
+	for c, test := range map[string]struct {
+		input  string
+		output string
+	}{
+		"valid hostname": {
+			input:  "test.pod.hostname",
+			output: "test.pod.hostname",
+		},
+		"too long hostname": {
+			input:  "1234567.1234567.1234567.1234567.1234567.1234567.1234567.1234567.1234567.", // 8*9=72 chars
+			output: "1234567.1234567.1234567.1234567.1234567.1234567.1234567.1234567",          //8*8-1=63 chars
+		},
+		"hostname end with .": {
+			input:  "1234567.1234567.1234567.1234567.1234567.1234567.1234567.123456.1234567.", // 8*9-1=71 chars
+			output: "1234567.1234567.1234567.1234567.1234567.1234567.1234567.123456",          //8*8-2=62 chars
+		},
+		"hostname end with -": {
+			input:  "1234567.1234567.1234567.1234567.1234567.1234567.1234567.123456-1234567.", // 8*9-1=71 chars
+			output: "1234567.1234567.1234567.1234567.1234567.1234567.1234567.123456",          //8*8-2=62 chars
+		},
+	} {
+		t.Logf("TestCase: %q", c)
+		output, err := truncatePodHostnameIfNeeded("test-pod", test.input)
+		assert.NoError(t, err)
+		assert.Equal(t, test.output, output)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/36951.

This PR will keep truncating the hostname until the ending character is valid.

/cc @kubernetes/sig-node 

Mark v1.5 because this is a bug fix.
/cc @saad-ali

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36965)
<!-- Reviewable:end -->
