### PR TITLE
Revert "Fix path to kubectl on host in kubectl-in-pod"

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -566,15 +566,8 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			framework.SkipUnlessProviderIs("gke")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			podJson := readTestFileOrDie(kubectlInPodFilename)
-
-			// Replace the host path to kubectl in json
-			podString := strings.Replace(string(podJson),
-				"$KUBECTL_PATH",
-				framework.TestContext.KubectlPath,
-				1)
-
 			By("validating api verions")
-			framework.RunKubectlOrDieInput(podString, "create", "-f", "-", nsFlag)
+			framework.RunKubectlOrDieInput(string(podJson), "create", "-f", "-", nsFlag)
 			err := wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
 				output := framework.RunKubectlOrDie("get", "pods/kubectl-in-pod", nsFlag)
 				if strings.Contains(output, "Running") {

--- a/test/e2e/testing-manifests/kubectl/kubectl-in-pod.json
+++ b/test/e2e/testing-manifests/kubectl/kubectl-in-pod.json
@@ -20,7 +20,7 @@
     ],
     "volumes": [{
       "name":"kubectl",
-      "hostPath":{"path": "$KUBECTL_PATH"}
+      "hostPath":{"path": "/usr/bin/kubectl"}
     }]
   }
 }


### PR DESCRIPTION
Reverts kubernetes/kubernetes#36864

It broke [kubernetes-e2e-gci-gke](https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/logs/kubernetes-e2e-gci-gke). Example failure https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/kubernetes-e2e-gci-gke/4083/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36971)
<!-- Reviewable:end -->
