### PR TITLE
Fix salt master check using hard coded string

### DIFF
--- a/cluster/vsphere/util.sh
+++ b/cluster/vsphere/util.sh
@@ -505,7 +505,7 @@ function kube-up {
   remote-pgrep ${KUBE_MASTER_IP} "salt-master"
 
   printf "Waiting for all packages to be installed on ${KUBE_MASTER} ...\n"
-  kube-check  ${KUBE_MASTER_IP} 'sudo salt "kubernetes-master" state.highstate -t 30 | grep -E "Failed:[[:space:]]+0"'
+  kube-check  ${KUBE_MASTER_IP} "sudo salt \"${MASTER_NAME}\" state.highstate -t 30 | grep -E \"Failed:[[:space:]]+0\""
 
   local i
   for (( i=0; i<${#NODE_NAMES[@]}; i++)); do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
**Which issue this PR fixes** 
This is for vsphere only.

If var $INSTANCE_PREFIX is changed in cluster/vsphere/config-default.sh, then salt master check will fail due to the hard coded string "kubernetes-master".  The fix uses $MASTER_NAME instead.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36974)
<!-- Reviewable:end -->
