### PR TITLE
Fix container to pod in resource-qos.md

### DIFF
--- a/docs/design/resource-qos.md
+++ b/docs/design/resource-qos.md
@@ -51,7 +51,7 @@ The relationship between "Requests and Limits" and "QoS Classes" is subtle. Theo
 
 Pods can be of one of 3 different classes:
 
-- If `limits` and optionally `requests` (not equal to `0`) are set for all resources across all containers and they are *equal*, then the container is classified as **Guaranteed**.
+- If `limits` and optionally `requests` (not equal to `0`) are set for all resources across all containers and they are *equal*, then the pod is classified as **Guaranteed**.
 
 Examples:
 


### PR DESCRIPTION
`...then the container is classified as Guaranteed.`
Here `container` should be `pod`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36975)
<!-- Reviewable:end -->
