### PR TITLE
WIP: Unversioned time is serialized with millisecond precision

### DIFF
--- a/pkg/api/unversioned/time_test.go
+++ b/pkg/api/unversioned/time_test.go
@@ -35,8 +35,8 @@ func TestTimeMarshalYAML(t *testing.T) {
 		result string
 	}{
 		{Time{}, "t: null\n"},
-		{Date(1998, time.May, 5, 1, 5, 5, 50, time.FixedZone("test", -4*60*60)), "t: 1998-05-05T05:05:05Z\n"},
-		{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC), "t: 1998-05-05T05:05:05Z\n"},
+		{Date(1998, time.May, 5, 1, 5, 5, 50, time.FixedZone("test", -4*60*60)), "t: 1998-05-05T05:05:05.000Z\n"},
+		{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC), "t: 1998-05-05T05:05:05.000Z\n"},
 	}
 
 	for _, c := range cases {
@@ -57,7 +57,7 @@ func TestTimeUnmarshalYAML(t *testing.T) {
 		result Time
 	}{
 		{"t: null\n", Time{}},
-		{"t: 1998-05-05T05:05:05Z\n", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
+		{"t: 1998-05-05T05:05:05.000Z\n", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
 	}
 
 	for _, c := range cases {
@@ -77,8 +77,8 @@ func TestTimeMarshalJSON(t *testing.T) {
 		result string
 	}{
 		{Time{}, "{\"t\":null}"},
-		{Date(1998, time.May, 5, 5, 5, 5, 50, time.UTC), "{\"t\":\"1998-05-05T05:05:05Z\"}"},
-		{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC), "{\"t\":\"1998-05-05T05:05:05Z\"}"},
+		{Date(1998, time.May, 5, 5, 5, 5, 50, time.UTC), "{\"t\":\"1998-05-05T05:05:05.000Z\"}"},
+		{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC), "{\"t\":\"1998-05-05T05:05:05.000Z\"}"},
 	}
 
 	for _, c := range cases {
@@ -99,7 +99,7 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 		result Time
 	}{
 		{"{\"t\":null}", Time{}},
-		{"{\"t\":\"1998-05-05T05:05:05Z\"}", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
+		{"{\"t\":\"1998-05-05T05:05:05.000Z\"}", Time{Date(1998, time.May, 5, 5, 5, 5, 0, time.UTC).Local()}},
 	}
 
 	for _, c := range cases {

--- a/pkg/api/v1/conversion_test.go
+++ b/pkg/api/v1/conversion_test.go
@@ -61,7 +61,7 @@ func TestPodLogOptions(t *testing.T) {
 		"follow":       {"true"},
 		"previous":     {"true"},
 		"sinceSeconds": {"1"},
-		"sinceTime":    {"2000-01-01T12:34:56Z"},
+		"sinceTime":    {"2000-01-01T12:34:56.000Z"},
 		"timestamps":   {"true"},
 		"tailLines":    {"2"},
 		"limitBytes":   {"3"},

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -316,7 +316,7 @@ func TestValidateObjectMetaUpdatePreventsDeletionFieldMutation(t *testing.T) {
 			Old:          api.ObjectMeta{Name: "test", ResourceVersion: "1"},
 			New:          api.ObjectMeta{Name: "test", ResourceVersion: "1", DeletionTimestamp: &now},
 			ExpectedNew:  api.ObjectMeta{Name: "test", ResourceVersion: "1", DeletionTimestamp: &now},
-			ExpectedErrs: []string{"field.deletionTimestamp: Invalid value: \"1970-01-01T00:16:40Z\": field is immutable; may only be changed via deletion"},
+			ExpectedErrs: []string{"field.deletionTimestamp: Invalid value: \"1970-01-01T00:16:40.000Z\": field is immutable; may only be changed via deletion"},
 		},
 		"invalid clear deletionTimestamp": {
 			Old:          api.ObjectMeta{Name: "test", ResourceVersion: "1", DeletionTimestamp: &now},

--- a/pkg/conversion/queryparams/convert_test.go
+++ b/pkg/conversion/queryparams/convert_test.go
@@ -183,7 +183,7 @@ func TestConvert(t *testing.T) {
 				SinceTime:    &sinceTime, // test a custom marshaller
 				EmptyTime:    nil,        // test a nil custom marshaller without omitempty
 			},
-			expected: url.Values{"container": {"mycontainer"}, "follow": {"true"}, "previous": {"true"}, "sinceSeconds": {"123"}, "sinceTime": {"2000-01-01T12:34:56Z"}, "emptyTime": {""}},
+			expected: url.Values{"container": {"mycontainer"}, "follow": {"true"}, "previous": {"true"}, "sinceSeconds": {"123"}, "sinceTime": {"2000-01-01T12:34:56.000Z"}, "emptyTime": {""}},
 		},
 		{
 			input: &childStructs{

--- a/pkg/runtime/unstructured_test.go
+++ b/pkg/runtime/unstructured_test.go
@@ -135,8 +135,8 @@ func TestUnstructuredGetters(t *testing.T) {
 				"uid":               "test_uid",
 				"resourceVersion":   "test_resourceVersion",
 				"selfLink":          "test_selfLink",
-				"creationTimestamp": "2009-11-10T23:00:00Z",
-				"deletionTimestamp": "2010-11-10T23:00:00Z",
+				"creationTimestamp": "2009-11-10T23:00:00.000Z",
+				"deletionTimestamp": "2010-11-10T23:00:00.000Z",
 				"labels": map[string]interface{}{
 					"test_label": "test_value",
 				},
@@ -254,8 +254,8 @@ func TestUnstructuredSetters(t *testing.T) {
 				"uid":               "test_uid",
 				"resourceVersion":   "test_resourceVersion",
 				"selfLink":          "test_selfLink",
-				"creationTimestamp": "2009-11-10T23:00:00Z",
-				"deletionTimestamp": "2010-11-10T23:00:00Z",
+				"creationTimestamp": "2009-11-10T23:00:00.000Z",
+				"deletionTimestamp": "2010-11-10T23:00:00.000Z",
 				"labels": map[string]interface{}{
 					"test_label": "test_value",
 				},


### PR DESCRIPTION
Ref. #36752

This changes precision of timestamps generated by the system. Let's continue discussion in the issue to decide if we want to merge this. In current implementation there's no easy way to change this is Events only, so it's a system wide change.

This means that it needs to be backward compatible (we need to be able to parse both millisecond and second timestamps). We don't have a way to support rollbacks without adding an ability to parse milliseconds in one release, and actually change it in the next one...

```release-note
Change timestamps across the system to have millisecond granularity.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36982)
<!-- Reviewable:end -->
