### PR TITLE
Never set hairpin mode on every interface

### DIFF
--- a/pkg/kubelet/network/hairpin/hairpin.go
+++ b/pkg/kubelet/network/hairpin/hairpin.go
@@ -58,8 +58,7 @@ func setUpContainerInternal(containerInterfaceName, containerDesc string, nsente
 	e := exec.New()
 	hostIfName, err := findPairInterfaceOfContainerInterface(e, containerInterfaceName, containerDesc, nsenterArgs)
 	if err != nil {
-		glog.Infof("Unable to find pair interface, setting up all interfaces: %v", err)
-		return setUpAllInterfaces()
+		return err
 	}
 	return setUpInterface(hostIfName)
 }
@@ -93,17 +92,6 @@ func findPairInterfaceOfContainerInterface(e exec.Interface, containerInterfaceN
 		return "", err
 	}
 	return iface.Name, nil
-}
-
-func setUpAllInterfaces() error {
-	interfaces, err := net.Interfaces()
-	if err != nil {
-		return err
-	}
-	for _, netIf := range interfaces {
-		setUpInterface(netIf.Name) // ignore errors
-	}
-	return nil
 }
 
 func setUpInterface(ifName string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Abandon setting hairpin mode if finding the peer interface fails; simply return an error.

There are many reasons why finding the peer could fail - "`ethtool` not installed" is popular.  Going ahead and changing the hairpin setting on every bridge-connected interface on the machine may have unwanted effects on other things installed on the machine (e.g. https://github.com/kubernetes/kops/issues/879)

**Which issue this PR fixes** : fixes #19766

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Kubelet will no longer set hairpin mode on every interface on the machine when an error occurs in setting up hairpin for a specific interface.
```

/cc @thockin who appears to have requested this implementation at https://github.com/kubernetes/kubernetes/pull/13628#issuecomment-138128180

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36990)
<!-- Reviewable:end -->
