### PR TITLE
Delete taint annotation when removing last taint

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2587,10 +2587,14 @@ func RemoveTaintOffNode(c clientset.Interface, nodeName string, taint api.Taint)
 
 		newTaints, err := deleteTaint(nodeTaints, taint)
 		ExpectNoError(err)
+		if len(newTaints) == 0 {
+			delete(node.Annotations, api.TaintsAnnotationKey)
+		} else {
+			taintsData, err := json.Marshal(newTaints)
+			ExpectNoError(err)
+			node.Annotations[api.TaintsAnnotationKey] = string(taintsData)
+		}
 
-		taintsData, err := json.Marshal(newTaints)
-		ExpectNoError(err)
-		node.Annotations[api.TaintsAnnotationKey] = string(taintsData)
 		_, err = c.Core().Nodes().Update(node)
 		if err != nil {
 			if !apierrs.IsConflict(err) {


### PR DESCRIPTION
It messes with debugging of tests failures.

cc @davidopp @kevin-wangzefeng

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/36994)
<!-- Reviewable:end -->
