### PR TITLE
Wait for all Nodes to be schedulable before running e2e tests

### DIFF
--- a/test/e2e/density.go
+++ b/test/e2e/density.go
@@ -310,10 +310,6 @@ var _ = framework.KubeDescribe("Density", func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
 
-		// In large clusters we may get to this point but still have a bunch
-		// of nodes without Routes created. Since this would make a node
-		// unschedulable, we need to wait until all of them are schedulable.
-		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.NodeSchedulableTimeout))
 		masters, nodes = framework.GetMasterAndWorkerNodesOrDie(c)
 		nodeCount = len(nodes.Items)
 		Expect(nodeCount).NotTo(BeZero())

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -116,6 +116,11 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		}
 	}
 
+	// In large clusters we may get to this point but still have a bunch
+	// of nodes without Routes created. Since this would make a node
+	// unschedulable, we need to wait until all of them are schedulable.
+	framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.NodeSchedulableTimeout))
+
 	// Ensure all pods are running and ready before starting tests (otherwise,
 	// cluster infrastructure pods that are being pulled or started can block
 	// test pods from running, and tests that ensure all pods are running and

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -98,11 +98,6 @@ var _ = framework.KubeDescribe("Load capacity", func() {
 	BeforeEach(func() {
 		clientset = f.ClientSet
 
-		// In large clusters we may get to this point but still have a bunch
-		// of nodes without Routes created. Since this would make a node
-		// unschedulable, we need to wait until all of them are schedulable.
-		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(clientset, framework.NodeSchedulableTimeout))
-
 		ns = f.Namespace.Name
 		nodes := framework.GetReadySchedulableNodesOrDie(clientset)
 		nodeCount = len(nodes.Items)


### PR DESCRIPTION
This should fix the problem we're seeing when running tests on large clusters.

cc @dchen1107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37001)
<!-- Reviewable:end -->
