### PR TITLE
add auth proxy roundtripper

### DIFF
--- a/pkg/client/transport/round_trippers.go
+++ b/pkg/client/transport/round_trippers.go
@@ -19,6 +19,7 @@ package transport
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -75,6 +76,66 @@ func DebugWrappers(rt http.RoundTripper) http.RoundTripper {
 type requestCanceler interface {
 	CancelRequest(*http.Request)
 }
+
+type authProxyRoundTripper struct {
+	username string
+	groups   []string
+	extra    map[string][]string
+
+	rt http.RoundTripper
+}
+
+// NewAuthProxyRoundTripper provides a roundtripper which will add auth proxy fields to requests for
+// authentication terminating proxy cases
+// assuming you pull the user from the context:
+// username is the user.Info.GetName() of the user
+// groups is the user.Info.GetGroups() of the user
+// extra is the user.Info.GetExtra() of the user
+// extra can contain any additional information that the authenticator
+// thought was interesting, for example authorization scopes.
+// In order to faithfully round-trip through an impersonation flow, these keys
+// MUST be lowercase.
+func NewAuthProxyRoundTripper(username string, groups []string, extra map[string][]string, rt http.RoundTripper) http.RoundTripper {
+	return &authProxyRoundTripper{
+		username: username,
+		groups:   groups,
+		extra:    extra,
+		rt:       rt,
+	}
+}
+
+func (rt *authProxyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = cloneRequest(req)
+	req.Header.Del("X-Remote-User")
+	req.Header.Del("X-Remote-Group")
+	for key := range req.Header {
+		if strings.HasPrefix(strings.ToLower(key), strings.ToLower("X-Remote-Extra-")) {
+			req.Header.Del(key)
+		}
+	}
+
+	req.Header.Set("X-Remote-User", rt.username)
+	for _, group := range rt.groups {
+		req.Header.Add("X-Remote-Group", group)
+	}
+	for key, values := range rt.extra {
+		for _, value := range values {
+			req.Header.Add("X-Remote-Extra-"+key, value)
+		}
+	}
+
+	return rt.rt.RoundTrip(req)
+}
+
+func (rt *authProxyRoundTripper) CancelRequest(req *http.Request) {
+	if canceler, ok := rt.rt.(requestCanceler); ok {
+		canceler.CancelRequest(req)
+	} else {
+		glog.Errorf("CancelRequest not implemented")
+	}
+}
+
+func (rt *authProxyRoundTripper) WrappedRoundTripper() http.RoundTripper { return rt.rt }
 
 type userAgentRoundTripper struct {
 	agent string


### PR DESCRIPTION
Adds a round tripper which adds auth proxy fields based on user.Info you can pull from a context.  It clears existing headers first to be sure that these aren't accidentally set ahead of time.

@nikhiljindal per our conversation.  This is what I'm using downstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37003)
<!-- Reviewable:end -->
