### PR TITLE
Skip rather than fail networking tests on single node

### DIFF
--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -448,7 +448,7 @@ func (config *NetworkingTestConfig) setup(selector map[string]string) {
 		// fall back to legacy IPs
 		config.ExternalAddrs = NodeAddresses(nodeList, api.NodeLegacyHostIP)
 	}
-	Expect(len(config.ExternalAddrs)).To(BeNumerically(">=", 2), fmt.Sprintf("At least two nodes necessary with an external or LegacyHostIP"))
+	SkipUnlessNodeCountIsAtLeast(2)
 	config.Nodes = nodeList.Items
 
 	By("Creating the service on top of the pods in kubernetes")


### PR DESCRIPTION
**What this PR does / why we need it**:

Needed for the general e2e tidying we need to do for flakey slow tests, imo pre 1.5, see #31402  and so on.

**Which issue this PR fixes** * 

Dont fail multinode tests if on a single node cluster, skip instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37006)
<!-- Reviewable:end -->
