### PR TITLE
fix permissions when using fsGroup

### DIFF
--- a/pkg/volume/volume_linux.go
+++ b/pkg/volume/volume_linux.go
@@ -51,6 +51,17 @@ func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
 			return err
 		}
 
+		// chown and chmod pass through to the underlying file for symlinks.
+		// Symlinks have a mode of 777 but this really doesn't mean anything.
+		// The permissions of the underlying file are what matter.
+		// However, if one reads the mode of a symlink then chmods the symlink
+		// with that mode, it changes the mode of the underlying file, overridden
+		// the defaultMode and permissions initialized by the volume plugin, which
+		// is not what we want; thus, we skip chown/chmod for symlinks.
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil
+		}
+
 		stat, ok := info.Sys().(*syscall.Stat_t)
 		if !ok {
 			return nil

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -41,6 +41,11 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 		doConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
 
+	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup]", func() {
+		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
+		doConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode)
+	})
+
 	It("should be consumable from pods in volume as non-root [Conformance]", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
@@ -343,14 +348,10 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, uid, fsGroup int64, d
 		defaultMode = &mode
 	}
 
-	// Just check file mode if fsGroup is not set. If fsGroup is set, the
-	// final mode is adjusted and we are not testing that case.
+	modeString := fmt.Sprintf("%v", os.FileMode(*defaultMode))
 	output := []string{
 		"content of file \"/etc/configmap-volume/data-1\": value-1",
-	}
-	if fsGroup == 0 {
-		modeString := fmt.Sprintf("%v", os.FileMode(*defaultMode))
-		output = append(output, "mode of file \"/etc/configmap-volume/data-1\": "+modeString)
+		"mode of file \"/etc/configmap-volume/data-1\": " + modeString,
 	}
 	f.TestContainerOutput("consume configMaps", pod, 0, output)
 }

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -81,6 +81,21 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
+	It("should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup]", func() {
+		podName := "metadata-volume-" + string(uuid.NewUUID())
+		uid := int64(1001)
+		gid := int64(1234)
+		mode := int32(0440) /* setting fsGroup sets mode to at least 440 */
+		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podname", &mode, nil)
+		pod.Spec.SecurityContext = &v1.PodSecurityContext{
+			RunAsUser: &uid,
+			FSGroup:   &gid,
+		}
+		f.TestContainerOutput("downward API volume plugin", pod, 0, []string{
+			"mode of file \"/etc/podname\": -r--r-----",
+		})
+	})
+
 	It("should update labels on modification [Conformance]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"


### PR DESCRIPTION
Currently, when an fsGroup is specified, the permissions of the defaultMode are not respected and all files created by the atomic writer have mode 777.  This is because in `SetVolumeOwnership()` the `filepath.Walk` includes the symlinks created by the atomic writer.  The symlinks have mode 777 when read from `info.Mode()`.  However, when they are chmod'ed later, the chmod applies to the file the symlink points to, not the symlink itself, resulting in the wrong mode for the underlying file.

This PR skips chmod/chown for symlinks in the walk since those operations are carried out on the underlying file which will be included elsewhere in the walk.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1384458

@derekwaynecarr @pmorie

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37009)
<!-- Reviewable:end -->
