### PR TITLE
Update OWNERS in Vsphere

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/OWNERS
+++ b/pkg/cloudprovider/providers/vsphere/OWNERS
@@ -1,4 +1,4 @@
-maintainers:
+assignees:
 - dagnello
 - abithap
 - imkin

--- a/pkg/cloudprovider/providers/vsphere/OWNERS
+++ b/pkg/cloudprovider/providers/vsphere/OWNERS
@@ -1,5 +1,4 @@
 assignees:
-- dagnello
 - abithap
 - imkin
 - abrarshivani


### PR DESCRIPTION
**Release note**:```NONE```


Currently mungegithub doesn't process "maintainers" lists in OWNERS files.  It looks for assignees.
Note: This is a temporary fix until we move to reviewers and approvers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37013)
<!-- Reviewable:end -->
