### PR TITLE
e2e/federation: gke compatiblity

### DIFF
--- a/cluster/gke/util.sh
+++ b/cluster/gke/util.sh
@@ -348,6 +348,18 @@ function ssh-to-node() {
   gcloud compute ssh --ssh-flag="-o LogLevel=quiet" --ssh-flag="-o ConnectTimeout=30" --project "${PROJECT}" --zone="${ZONE}" "${node}" --command "${cmd}"
 }
 
+
+# Create a temp dir that'll be deleted at the end of this bash session.
+#
+# Vars set:
+#   KUBE_TEMP
+function ensure-temp-dir() {
+  if [[ -z ${KUBE_TEMP-} ]]; then
+    KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
+    trap 'rm -rf "${KUBE_TEMP}"' EXIT
+  fi
+}
+
 # Execute after running tests to perform any required clean-up.  This is called
 # from hack/e2e.go. This calls kube-down, so the cluster still exists when this
 # is called.

--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -52,7 +52,11 @@ function set-federation-zone-vars {
   elif [[ "$KUBERNETES_PROVIDER" == "gke"  ]];then
 
     export CLUSTER_NAME="${USER}-${zone}"
+    export ZONE="${zone}"
+    export KUBE_GKE_NETWORK="${CLUSTER_NAME}-network"
+    export OVERRIDE_CONTEXT="gke_${PROJECT}_${ZONE}_${CLUSTER_NAME}"
 
+    source "${KUBE_ROOT}/cluster/gke/util.sh"
   elif [[ "$KUBERNETES_PROVIDER" == "aws"  ]];then
 
     export KUBE_AWS_ZONE="$zone"

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -127,6 +127,7 @@ function create-federation-api-objects {
 	# we check for ingress.ip and ingress.hostname, so should work for any loadbalancer-providing provider
 	# allows 30x5 = 150 seconds for loadbalancer creation
 	$template "${manifests_root}/federation-apiserver-lb-service.yaml" | $host_kubectl create -f -
+	set +e
 	for i in {1..30};do
 	    echo "attempting to get federation-apiserver loadbalancer hostname ($i / 30)"
 	    LB_STATUS=`${host_kubectl} get -o=jsonpath svc/${FEDERATION_APISERVER_DEPLOYMENT_NAME} --template '{.status.loadBalancer}'`
@@ -138,8 +139,8 @@ function create-federation-api-objects {
 	    fi
 	    for field in ip hostname;do
 		FEDERATION_API_HOST=`${host_kubectl} get -o=jsonpath svc/${FEDERATION_APISERVER_DEPLOYMENT_NAME} --template '{.status.loadBalancer.ingress[*].'"${field}}"`
-		if [[ ! -z "${FEDERATION_API_HOST// }" ]];then
-		    break 2
+		if [[ $? -eq 0 && ! -z "${FEDERATION_API_HOST// }" ]];then
+		  break 2
 		fi
 	    done
 	    if [[ $i -eq 30 ]];then
@@ -148,6 +149,7 @@ function create-federation-api-objects {
 	    fi
 	    sleep 5
 	done
+	set -e
 	KUBE_MASTER_IP="${FEDERATION_API_HOST}:443"
     else
 	echo "provider ${KUBERNETES_PROVIDER} is not (yet) supported for e2e testing"


### PR DESCRIPTION
Note: you must run `e2e.go` with `--check_version_skew=false` when `KUBERNETES_PROVIDER=gke`.

We're seeing 17 federation-related failures right now.
```sh
Summarizing 17 Failures:

[Panic!] [k8s.io] [Feature:Federation] Federation API server authentication [It] should not accept cluster resources w
hen the client has invalid authentication credentials
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation secrets [Feature:Federation] Secret objects [BeforeEach] should be deleted from underlyin
g clusters when OrphanDependents is false
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [BeforeEach] should create and update m
atching ingresses in underlying clusters
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] [Feature:Federation] Federated Services [BeforeEach] DNS non-local federated service [Slow] missing
local service should never find DNS entries for a missing local service
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation namespace [Feature:Federation] Namespace objects [BeforeEach] should be created and delet
ed successfully
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation deployments [Feature:Federation] Federated Deployment [BeforeEach] should create and upda
te matching deployments in underling clusters
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation namespace [Feature:Federation] Namespace objects [BeforeEach] should be deleted from unde
rlying clusters when OrphanDependents is false
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] [Feature:Federation] Federated Services [BeforeEach] Service creation should create matching service
s in underlying clusters
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation namespace [Feature:Federation] Namespace objects [BeforeEach] all resources in the namesp
ace should be deleted when namespace is deleted
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation secrets [Feature:Federation] Secret objects [BeforeEach] should not be deleted from under
lying clusters when OrphanDependents is true
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] [Feature:Federation] Federated Services [BeforeEach] DNS non-local federated service should be able
to discover a non-local federated service
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation namespace [Feature:Federation] Namespace objects [BeforeEach] should not be deleted from
underlying clusters when OrphanDependents is true
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federated ingresses [Feature:Federation] Federated Ingresses [BeforeEach] Ingress connectivity and D
NS should be able to connect to a federated ingress via its load balancer
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] [Feature:Federation] Federated Services [BeforeEach] Service creation should succeed
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation replicasets [Feature:Federation] Federated ReplicaSet [BeforeEach] should create and upda
te matching replicasets in underling clusters
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] Federation secrets [Feature:Federation] Secret objects [BeforeEach] should be created and deleted su
ccessfully
/usr/local/go/src/runtime/panic.go:458

[Panic!] [k8s.io] [Feature:Federation] Federated Services [BeforeEach] DNS should be able to discover a federated serv
ice
/usr/local/go/src/runtime/panic.go:458

Ran 25 of 451 Specs in 324.995 seconds
FAIL! -- 8 Passed | 17 Failed | 1 Pending | 425 Skipped --- FAIL: TestE2E (325.01s)
FAIL

```
\cc @madhusudancs @quinton-hoole 

madhu- as always the full logs are in your inbox ;)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37016)
<!-- Reviewable:end -->
