### PR TITLE
auth delegation role

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -194,6 +194,15 @@ func ClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("list", "watch").Groups(legacyGroup).Resources("services", "endpoints").RuleOrDie(),
 			},
 		},
+		{
+			// a role to use for allowing authentication and authorization delegation
+			ObjectMeta: api.ObjectMeta{Name: "system:auth-delegator"},
+			Rules: []rbac.PolicyRule{
+				// These creates are non-mutating
+				rbac.NewRule("create").Groups(authenticationGroup).Resources("tokenreviews").RuleOrDie(),
+				rbac.NewRule("create").Groups(authorizationGroup).Resources("subjectaccessreviews").RuleOrDie(),
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Add a bootstrap role for authentication and authorization delegation.  Useful for extension API servers.

@kubernetes/sig-auth

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37020)
<!-- Reviewable:end -->
