### PR TITLE
Bump fluentd-gcp image version

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -29,7 +29,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google_containers
-TAG = 1.26
+TAG = 1.27
 
 build:
 	docker build -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.26
+    image: gcr.io/google_containers/fluentd-gcp:1.27
     command:
       - '/bin/sh'
       - '-c'

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.26
+    image: gcr.io/google_containers/fluentd-gcp:1.27
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
To propagate https://github.com/kubernetes/kubernetes/pull/36993

Including release noted for the whole bunch of fluentd changes (https://github.com/kubernetes/kubernetes/pull/35618 mainly):

```release-note
Default logging subsystem's resiliency was greatly improved, fluentd memory consumption and OOM error probability was reduced.
```

@piosz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37021)
<!-- Reviewable:end -->
