### PR TITLE
Remove references to Google CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,25 +23,18 @@ issue](https://github.com/kubernetes/kubernetes/issues/new).
 We'd love to accept your patches! Before we can take them, we have to jump a
 couple of legal hurdles.
 
+That the Cloud Native Computing Foundation (CNCF) CLA must be signed by all contributors.
 Please fill out either the individual or corporate Contributor License
-Agreement (CLA).  As of Q4 2016, we're transitioning from Google's CLA to the
-Cloud Native Computing Foundation (CNCF) CLA.
+Agreement (CLA).
 
-Google:
-  * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual
-    CLA](http://code.google.com/legal/individual-cla-v1.0.html).
-  * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate
-    CLA](http://code.google.com/legal/corporate-cla-v1.0.html).
-
-CNCF:
   * To contribute as an individual or as am employee of a signed organization,
     [go here](https://identity.linuxfoundation.org/projects/cncf).
   * To sign up as an organization, [go
     here](https://identity.linuxfoundation.org/node/285/organization-signup).
 
-Once you are CLA'ed, we'll be able to accept your pull requests.
+Once you are CLA'ed, we'll be able to accept your pull requests. 
+For any issues that you face during this process, please refer to 
+the [CLA FAQ](https://github.com/kubernetes/kubernetes/wiki/CLA-FAQ).
 
 ***NOTE***: Only original source code from you and other people that have
 signed the CLA can be accepted into the repository. This policy does not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,9 +25,8 @@ couple of legal hurdles.
 
 The Cloud Native Computing Foundation (CNCF) CLA [must be signed](https://github.com/kubernetes/community/blob/master/CLA.md) by all contributors.
 Please fill out either the individual or corporate Contributor License
-Agreement (CLA).
+Agreement (CLA). Once you are CLA'ed, we'll be able to accept your pull requests. 
 
-Once you are CLA'ed, we'll be able to accept your pull requests. 
 For any issues that you face during this process which is not covered by the [FAQ](https://github.com/kubernetes/community/blob/master/CLA.md)
 please add a comment [here](https://github.com/kubernetes/kubernetes/issues/27796).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,10 +25,10 @@ couple of legal hurdles.
 
 The Cloud Native Computing Foundation (CNCF) CLA [must be signed](https://github.com/kubernetes/community/blob/master/CLA.md) by all contributors.
 Please fill out either the individual or corporate Contributor License
-Agreement (CLA). Once you are CLA'ed, we'll be able to accept your pull requests. 
+Agreement (CLA). 
 
-For any issues that you face during this process which is not covered by the [FAQ](https://github.com/kubernetes/community/blob/master/CLA.md)
-please add a comment [here](https://github.com/kubernetes/kubernetes/issues/27796).
+Once you are CLA'ed, we'll be able to accept your pull requests. For any issues that you face during this process which is not covered by the [FAQ](https://github.com/kubernetes/community/blob/master/CLA.md)
+please add a comment [here](https://github.com/kubernetes/kubernetes/issues/27796) explaining the issue and we will help get it sorted out.
 
 ***NOTE***: Only original source code from you and other people that have
 signed the CLA can be accepted into the repository. This policy does not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,18 +23,13 @@ issue](https://github.com/kubernetes/kubernetes/issues/new).
 We'd love to accept your patches! Before we can take them, we have to jump a
 couple of legal hurdles.
 
-That the Cloud Native Computing Foundation (CNCF) CLA must be signed by all contributors.
+The Cloud Native Computing Foundation (CNCF) CLA [must be signed](https://github.com/kubernetes/community/blob/master/CLA.md) by all contributors.
 Please fill out either the individual or corporate Contributor License
 Agreement (CLA).
 
-  * To contribute as an individual or as am employee of a signed organization,
-    [go here](https://identity.linuxfoundation.org/projects/cncf).
-  * To sign up as an organization, [go
-    here](https://identity.linuxfoundation.org/node/285/organization-signup).
-
 Once you are CLA'ed, we'll be able to accept your pull requests. 
-For any issues that you face during this process, please refer to 
-the [CLA FAQ](https://github.com/kubernetes/kubernetes/wiki/CLA-FAQ).
+For any issues that you face during this process which is not covered by the [FAQ](https://github.com/kubernetes/community/blob/master/CLA.md)
+please add a comment [here](https://github.com/kubernetes/kubernetes/issues/27796).
 
 ***NOTE***: Only original source code from you and other people that have
 signed the CLA can be accepted into the repository. This policy does not


### PR DESCRIPTION
This PR removes references to the Google CLA process which will no longer be relevant once we transition completely to the CNCF CLA.

TODO before merge:

- [x] Update wiki.
- [x] Communicate to developers via email.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37028)
<!-- Reviewable:end -->
