### PR TITLE
Report totals as network stats for containers

### DIFF
--- a/pkg/kubelet/server/stats/BUILD
+++ b/pkg/kubelet/server/stats/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/leaky:go_default_library",
-        "//pkg/kubelet/network:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/types:go_default_library",

--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/leaky"
-	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	kubetypes "k8s.io/kubernetes/pkg/types"
 
@@ -369,19 +368,22 @@ func (sb *summaryBuilder) containerInfoV2ToNetworkStats(name string, info *cadvi
 	if !found {
 		return nil
 	}
+	var rxBytes, rxErrors, txBytes, txErrors uint64
 	for _, inter := range cstat.Network.Interfaces {
-		if inter.Name == network.DefaultInterfaceName {
-			return &stats.NetworkStats{
-				Time:     metav1.NewTime(cstat.Timestamp),
-				RxBytes:  &inter.RxBytes,
-				RxErrors: &inter.RxErrors,
-				TxBytes:  &inter.TxBytes,
-				TxErrors: &inter.TxErrors,
-			}
+		if inter.Name != "lo" {
+			rxBytes += inter.RxBytes
+			rxErrors += inter.RxErrors
+			txBytes += inter.TxBytes
+			txErrors += inter.TxErrors
 		}
 	}
-	glog.V(4).Infof("Missing default interface %q for %s", network.DefaultInterfaceName, name)
-	return nil
+	return &stats.NetworkStats{
+		Time:     metav1.NewTime(cstat.Timestamp),
+		RxBytes:  &rxBytes,
+		RxErrors: &rxErrors,
+		TxBytes:  &txBytes,
+		TxErrors: &txErrors,
+	}
 }
 
 func (sb *summaryBuilder) containerInfoV2ToUserDefinedMetrics(info *cadvisorapiv2.ContainerInfo) []stats.UserDefinedMetric {

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -47,6 +47,9 @@ const (
 	offsetNetTxBytes
 	offsetNetTxErrors
 )
+const (
+	cbrCounter = 100
+)
 
 var (
 	timestamp    = time.Now()
@@ -326,10 +329,10 @@ func summaryTestContainerInfo(seed int, podName string, podNamespace string, con
 				TxErrors: uint64(seed + offsetNetTxErrors),
 			}, {
 				Name:     "cbr0",
-				RxBytes:  100,
-				RxErrors: 100,
-				TxBytes:  100,
-				TxErrors: 100,
+				RxBytes:  cbrCounter,
+				RxErrors: cbrCounter,
+				TxBytes:  cbrCounter,
+				TxErrors: cbrCounter,
 			}},
 		},
 		CustomMetrics: generateCustomMetrics(spec.CustomMetrics),
@@ -349,10 +352,10 @@ func testTime(base time.Time, seed int) time.Time {
 func checkNetworkStats(t *testing.T, label string, seed int, stats *kubestats.NetworkStats) {
 	assert.NotNil(t, stats)
 	assert.EqualValues(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".Net.Time")
-	assert.EqualValues(t, seed+offsetNetRxBytes, *stats.RxBytes, label+".Net.RxBytes")
-	assert.EqualValues(t, seed+offsetNetRxErrors, *stats.RxErrors, label+".Net.RxErrors")
-	assert.EqualValues(t, seed+offsetNetTxBytes, *stats.TxBytes, label+".Net.TxBytes")
-	assert.EqualValues(t, seed+offsetNetTxErrors, *stats.TxErrors, label+".Net.TxErrors")
+	assert.EqualValues(t, seed+offsetNetRxBytes+cbrCounter, *stats.RxBytes, label+".Net.RxBytes")
+	assert.EqualValues(t, seed+offsetNetRxErrors+cbrCounter, *stats.RxErrors, label+".Net.RxErrors")
+	assert.EqualValues(t, seed+offsetNetTxBytes+cbrCounter, *stats.TxBytes, label+".Net.TxBytes")
+	assert.EqualValues(t, seed+offsetNetTxErrors+cbrCounter, *stats.TxErrors, label+".Net.TxErrors")
 }
 
 func checkCPUStats(t *testing.T, label string, seed int, stats *kubestats.CPUStats) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Containers might have multiple network interfaces (e.g. privileged).
Or it might be so that host network interface eth0 does not exist.
Thus, it is better to provide total counters for all interfaces of
container except loopback.

Eleminates errors from kubelet about missing eth0 interface on e.g. CentOS hosts.
```
Nov 17 23:17:32 k8s-c1 kubelet[7649]: I1117 23:17:32.826633    7649 summary.go:352] Missing default interface "eth0" for pod:kube-system_kube-controller-manager-k8s-c1
Nov 17 23:17:32 k8s-c1 kubelet[7649]: I1117 23:17:32.827754    7649 summary.go:352] Missing default interface "eth0" for pod:kube-system_kube-discovery-1150918428-l9lzy
Nov 17 23:17:32 k8s-c1 kubelet[7649]: I1117 23:17:32.828798    7649 summary.go:352] Missing default interface "eth0" for pod:kube-system_weave-net-eoocb
Nov 17 23:17:32 k8s-c1 kubelet[7649]: I1117 23:17:32.829854    7649 summary.go:352] Missing default interface "eth0" for pod:kube-system_kube-proxy-zm92b
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
**Release note**:
```release-note
- network stats collected from all interfaces in the pod.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37029)
<!-- Reviewable:end -->
