### PR TITLE
Adding statefulset to the list of things kubectl says it knows about

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -195,6 +195,7 @@ __custom_func() {
     * secrets
     * serviceaccounts (aka 'sa')
     * services (aka 'svc')
+    * statefulsets
     * storageclasses
     * thirdpartyresources
     `


### PR DESCRIPTION
**What this PR does / why we need it**: Adding statefulset to the list of things kubectl says it knows about.

**Special notes for your reviewer**: 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

cc @kubernetes/sig-apps @erictune

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37031)
<!-- Reviewable:end -->
