### PR TITLE
Add --json option to kubectl version command

### DIFF
--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -36,37 +37,53 @@ func NewCmdVersion(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolP("client", "c", false, "Client version only (no server required).")
+	cmd.Flags().BoolP("json", "", false, "Print version info in JSON format.")
 	cmd.Flags().BoolP("short", "", false, "Print just the version number.")
 	cmd.Flags().MarkShorthandDeprecated("client", "please use --client instead.")
 	return cmd
 }
 
+type versionInfo struct {
+	Client version.Info  `json:"client"`
+	Server *version.Info `json:"server,omitempty"`
+}
+
 func RunVersion(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
-	v := fmt.Sprintf("%#v", version.Get())
-	if cmdutil.GetFlagBool(cmd, "short") {
-		v = version.Get().GitVersion
+	if cmdutil.GetFlagBool(cmd, "json") && cmdutil.GetFlagBool(cmd, "short") {
+		return fmt.Errorf("Cannot use --json and --short!")
+	}
+	v := versionInfo{Client: version.Get(), Server: nil}
+
+	var serverErr error
+	if !cmdutil.GetFlagBool(cmd, "client") {
+		clientset, err := f.ClientSet()
+		serverErr = err
+		if serverErr == nil {
+			(v.Server), serverErr = clientset.Discovery().ServerVersion()
+		}
 	}
 
-	fmt.Fprintf(out, "Client Version: %s\n", v)
-	if cmdutil.GetFlagBool(cmd, "client") {
-		return nil
+	if cmdutil.GetFlagBool(cmd, "json") {
+		jsonOut, err := json.MarshalIndent(v, "", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(out, "%s\n", jsonOut)
+		return serverErr
 	}
 
-	clientset, err := f.ClientSet()
-	if err != nil {
-		return err
+	verStr := func(v version.Info) string {
+		if cmdutil.GetFlagBool(cmd, "short") {
+			return v.GitVersion
+		}
+		return fmt.Sprintf("%#v", v)
 	}
-
-	serverVersion, err := clientset.Discovery().ServerVersion()
-	if err != nil {
-		return err
+	fmt.Fprintf(out, "Client Version: %s\n", verStr(v.Client))
+	if serverErr != nil {
+		return serverErr
 	}
-
-	v = fmt.Sprintf("%#v", *serverVersion)
-	if cmdutil.GetFlagBool(cmd, "short") {
-		v = serverVersion.GitVersion
+	if v.Server != nil {
+		fmt.Fprintf(out, "Server Version: %s\n", verStr(*v.Server))
 	}
-
-	fmt.Fprintf(out, "Server Version: %s\n", v)
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: similar in spirit to #35543. The goal is to get a `kubectl output` format that's more easily parseable by tools.

For example, with this change, I can do
```console
$ cluster/kubectl.sh version --json | jq -r .server.gitCommit
5a0a696437ad35c133c0c8493f7e9d22b0f9b81b
```

The default output remains unchanged:
```console
$ cluster/kubectl.sh version
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-alpha.0.636+681bd31ffefc92", GitCommit:"681bd31ffefc928a64529519421a5f8e474d5512", GitTreeState:"clean", BuildDate:"2016-11-18T00:33:55Z", GoVersion:"go1.7.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"4", GitVersion:"v1.4.5", GitCommit:"5a0a696437ad35c133c0c8493f7e9d22b0f9b81b", GitTreeState:"clean", BuildDate:"2016-10-29T01:32:42Z", GoVersion:"go1.6.3", Compiler:"gc", Platform:"linux/amd64"}
```

cc @philips (who added `--short`, which I'm keeping, though it's incompatible with `--json`), @kubernetes/sig-cli

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37049)
<!-- Reviewable:end -->
