### PR TITLE
Add version to OpenAPI spec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
    "title": "Kubernetes",
-   "version": "unversioned"
+   "version": "v1.6.0"
   },
   "paths": {
    "/api/": {

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
    "title": "Generic API Server",
-   "version": "unversioned"
+   "version": "v1.6.0"
   },
   "paths": {
    "/api/": {

--- a/pkg/genericapiserver/server/config.go
+++ b/pkg/genericapiserver/server/config.go
@@ -219,8 +219,7 @@ func DefaultOpenAPIConfig(definitions *openapicommon.OpenAPIDefinitions) *openap
 		IgnorePrefixes: []string{"/swaggerapi"},
 		Info: &spec.Info{
 			InfoProps: spec.InfoProps{
-				Title:   "Generic API Server",
-				Version: "unversioned",
+				Title: "Generic API Server",
 			},
 		},
 		DefaultResponse: &spec.Response{
@@ -547,6 +546,19 @@ func (c completedConfig) New() (*GenericAPIServer, error) {
 	}
 
 	s.HandlerContainer = mux.NewAPIContainer(http.NewServeMux(), c.Serializer)
+
+	if s.openAPIConfig != nil {
+		if s.openAPIConfig.Info == nil {
+			s.openAPIConfig.Info = &spec.Info{}
+		}
+		if s.openAPIConfig.Info.Version == "" {
+			if c.Version != nil {
+				s.openAPIConfig.Info.Version = strings.Split(c.Version.String(), "-")[0]
+			} else {
+				s.openAPIConfig.Info.Version = "unversioned"
+			}
+		}
+	}
 
 	s.installAPI(c.Config)
 


### PR DESCRIPTION
OpenAPI is missing a version string. It should follow kubernetes version. It is a bugfix that need to be cherrypicked in 1.5 too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37055)
<!-- Reviewable:end -->
