### PR TITLE
Fix quoting of $PATH in instructions.

### DIFF
--- a/docs/devel/testing.md
+++ b/docs/devel/testing.md
@@ -177,12 +177,12 @@ includes a script to help install etcd on your machine.
 
 # Option a) install inside kubernetes root
 hack/install-etcd.sh  # Installs in ./third_party/etcd
-echo export PATH="$PATH:$(pwd)/third_party/etcd" >> ~/.profile  # Add to PATH
+echo export PATH="\$PATH:$(pwd)/third_party/etcd" >> ~/.profile  # Add to PATH
 
 # Option b) install manually
 grep -E "image.*etcd" cluster/saltbase/etcd/etcd.manifest  # Find version
 # Install that version using yum/apt-get/etc
-echo export PATH="$PATH:<LOCATION>" >> ~/.profile  # Add to PATH
+echo export PATH="\$PATH:<LOCATION>" >> ~/.profile  # Add to PATH
 ```
 
 ### Etcd test data


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix for development instructions.
Otherwise the current $PATH, *expanded* lands in .profile.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37068)
<!-- Reviewable:end -->
