### PR TITLE
Fix etcd unavailable error when performing kube-up.sh for Ubuntu prov…

### DIFF
--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -224,7 +224,7 @@ function create-etcd-opts() {
   cat <<EOF > ~/kube/default/etcd
 ETCD_OPTS="\
  -name infra\
- -listen-client-urls http://127.0.0.1:4001,http://${1}:4001\
+ --listen-client-urls=http://127.0.0.1:4001,http://${1}:4001\
  -advertise-client-urls http://${1}:4001"
 EOF
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes 'etcd unavailable error' when performing kube-up.sh for Ubuntu provider

**Which issue this PR fixes** 
fixes: https://github.com/kubernetes/kubernetes/issues/36340

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37069)
<!-- Reviewable:end -->
