### PR TITLE
WIP: portforward: symmetric half-open connection logic for client and kubelet

### DIFF
--- a/pkg/client/unversioned/portforward/portforward.go
+++ b/pkg/client/unversioned/portforward/portforward.go
@@ -203,8 +203,13 @@ func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol st
 
 // getListener creates a listener on the interface targeted by the given hostname on the given port with
 // the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
-func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
-	listener, err := net.Listen(protocol, fmt.Sprintf("%s:%d", hostname, port.Local))
+func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (*net.TCPListener, error) {
+	addr, err := net.ResolveTCPAddr(protocol, net.JoinHostPort(hostname, fmt.Sprintf("%d", port.Local)))
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("Unable to resolve address: Error %s", err))
+		return nil, err
+	}
+	listener, err := net.ListenTCP(protocol, addr)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Unable to create listener: Error %s", err))
 		return nil, err
@@ -226,9 +231,9 @@ func (pf *PortForwarder) getListener(protocol string, hostname string, port *For
 
 // waitForConnection waits for new connections to listener and handles them in
 // the background.
-func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
+func (pf *PortForwarder) waitForConnection(listener *net.TCPListener, port ForwardedPort) {
 	for {
-		conn, err := listener.Accept()
+		conn, err := listener.AcceptTCP()
 		if err != nil {
 			// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
 			if !strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
@@ -250,7 +255,7 @@ func (pf *PortForwarder) nextRequestID() int {
 
 // handleConnection copies data between the local connection and the stream to
 // the remote server.
-func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
+func (pf *PortForwarder) handleConnection(conn *net.TCPConn, port ForwardedPort) {
 	defer conn.Close()
 
 	if pf.out != nil {
@@ -291,40 +296,18 @@ func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
 		runtime.HandleError(fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err))
 		return
 	}
+	defer dataStream.Reset()
 
-	localError := make(chan struct{})
-	remoteDone := make(chan struct{})
+	connIn, connOut := httpstream.SplitTCPConn(conn)
+	streamIn, streamOut := httpstream.SplitStream(dataStream)
+	err = httpstream.CopyBothWays(connIn, connOut, streamIn, streamOut)
 
-	go func() {
-		// Copy from the remote side to the local port.
-		if _, err := io.Copy(conn, dataStream); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			runtime.HandleError(fmt.Errorf("error copying from remote stream to local connection: %v", err))
-		}
-
-		// inform the select below that the remote copy is done
-		close(remoteDone)
-	}()
-
-	go func() {
-		// inform server we're not sending any more data after copy unblocks
-		defer dataStream.Close()
-
-		// Copy from the local port to the remote side.
-		if _, err := io.Copy(dataStream, conn); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			runtime.HandleError(fmt.Errorf("error copying from local connection to remote stream: %v", err))
-			// break out of the select below without waiting for the other copy to finish
-			close(localError)
-		}
-	}()
-
-	// wait for either a local->remote error or for copying from remote->local to finish
-	select {
-	case <-remoteDone:
-	case <-localError:
+	// always expect something on errorChan.
+	if errChan := <-errorChan; errChan != nil {
+		// give precedence to error channel error as it is more high level
+		err = errChan
 	}
 
-	// always expect something on errorChan (it may be nil)
-	err = <-errorChan
 	if err != nil {
 		runtime.HandleError(err)
 	}

--- a/pkg/client/unversioned/portforward/portforward.go
+++ b/pkg/client/unversioned/portforward/portforward.go
@@ -182,7 +182,7 @@ func (pf *PortForwarder) forward() error {
 // If both listener creation fail, an error is raised.
 func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
 	errTcp4 := pf.listenOnPortAndAddress(port, "tcp4", "127.0.0.1")
-	errTcp6 := pf.listenOnPortAndAddress(port, "tcp6", "[::1]")
+	errTcp6 := pf.listenOnPortAndAddress(port, "tcp6", "::1")
 	if errTcp4 != nil && errTcp6 != nil {
 		return fmt.Errorf("All listeners failed to create with the following errors: %s, %s", errTcp4, errTcp6)
 	}

--- a/pkg/client/unversioned/portforward/portforward.go
+++ b/pkg/client/unversioned/portforward/portforward.go
@@ -300,7 +300,7 @@ func (pf *PortForwarder) handleConnection(conn *net.TCPConn, port ForwardedPort)
 
 	connIn, connOut := httpstream.SplitTCPConn(conn)
 	streamIn, streamOut := httpstream.SplitStream(dataStream)
-	err = httpstream.CopyBothWays(connIn, connOut, streamIn, streamOut)
+	err = httpstream.CopyBothWays(connIn, connOut, streamIn, streamOut, []string{"use of closed network connection"})
 
 	// always expect something on errorChan.
 	if errChan := <-errorChan; errChan != nil {

--- a/pkg/client/unversioned/portforward/portforward.go
+++ b/pkg/client/unversioned/portforward/portforward.go
@@ -181,18 +181,18 @@ func (pf *PortForwarder) forward() error {
 // listenOnPort delegates tcp4 and tcp6 listener creation and waits for connections on both of these addresses.
 // If both listener creation fail, an error is raised.
 func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
-	errTcp4 := pf.listenOnPortAndAddress(port, "tcp4", "127.0.0.1")
-	errTcp6 := pf.listenOnPortAndAddress(port, "tcp6", "::1")
+	errTcp4 := pf.listenOnPortAndHost(port, "tcp4", "127.0.0.1")
+	errTcp6 := pf.listenOnPortAndHost(port, "tcp6", "::1")
 	if errTcp4 != nil && errTcp6 != nil {
 		return fmt.Errorf("All listeners failed to create with the following errors: %s, %s", errTcp4, errTcp6)
 	}
 	return nil
 }
 
-// listenOnPortAndAddress delegates listener creation and waits for new connections
+// listenOnPortAndHost delegates listener creation and waits for new connections
 // in the background f
-func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
-	listener, err := pf.getListener(protocol, address, port)
+func (pf *PortForwarder) listenOnPortAndHost(port *ForwardedPort, protocol string, host string) error {
+	listener, err := pf.getListener(protocol, host, port)
 	if err != nil {
 		return err
 	}
@@ -203,8 +203,8 @@ func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol st
 
 // getListener creates a listener on the interface targeted by the given hostname on the given port with
 // the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
-func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (*net.TCPListener, error) {
-	addr, err := net.ResolveTCPAddr(protocol, net.JoinHostPort(hostname, fmt.Sprintf("%d", port.Local)))
+func (pf *PortForwarder) getListener(protocol string, host string, port *ForwardedPort) (*net.TCPListener, error) {
+	addr, err := net.ResolveTCPAddr(protocol, net.JoinHostPort(host, fmt.Sprintf("%d", port.Local)))
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("Unable to resolve address: Error %s", err))
 		return nil, err
@@ -223,7 +223,7 @@ func (pf *PortForwarder) getListener(protocol string, hostname string, port *For
 	}
 	port.Local = uint16(localPortUInt)
 	if pf.out != nil {
-		fmt.Fprintf(pf.out, "Forwarding from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+		fmt.Fprintf(pf.out, "Forwarding from %s:%d -> %d\n", host, localPortUInt, port.Remote)
 	}
 
 	return listener, nil

--- a/pkg/client/unversioned/portforward/portforward_test.go
+++ b/pkg/client/unversioned/portforward/portforward_test.go
@@ -124,7 +124,7 @@ func TestParsePortsAndNew(t *testing.T) {
 }
 
 type GetListenerTestCase struct {
-	Hostname                string
+	Host                    string
 	Protocol                string
 	ShouldRaiseError        bool
 	ExpectedListenerAddress string
@@ -134,36 +134,36 @@ func TestGetListener(t *testing.T) {
 	var pf PortForwarder
 	testCases := []GetListenerTestCase{
 		{
-			Hostname:                "localhost",
+			Host:                    "localhost",
 			Protocol:                "tcp4",
 			ShouldRaiseError:        false,
 			ExpectedListenerAddress: "127.0.0.1",
 		},
 		{
-			Hostname:                "127.0.0.1",
+			Host:                    "127.0.0.1",
 			Protocol:                "tcp4",
 			ShouldRaiseError:        false,
 			ExpectedListenerAddress: "127.0.0.1",
 		},
 		{
-			Hostname:                "::1",
+			Host:                    "::1",
 			Protocol:                "tcp6",
 			ShouldRaiseError:        false,
 			ExpectedListenerAddress: "::1",
 		},
 		{
-			Hostname:         "::1",
+			Host:             "::1",
 			Protocol:         "tcp4",
 			ShouldRaiseError: true,
 		},
 		{
-			Hostname:         "127.0.0.1",
+			Host:             "127.0.0.1",
 			Protocol:         "tcp6",
 			ShouldRaiseError: true,
 		},
 		{
-			// IPv6 address must be put into brackets. This test reveals this.
-			Hostname:         "[::1]",
+			// IPv6 address must not be put into brackets. This test reveals this.
+			Host:             "[::1]",
 			Protocol:         "tcp6",
 			ShouldRaiseError: true,
 		},
@@ -171,7 +171,7 @@ func TestGetListener(t *testing.T) {
 
 	for i, testCase := range testCases {
 		expectedListenerPort := "12345"
-		listener, err := pf.getListener(testCase.Protocol, testCase.Hostname, &ForwardedPort{12345, 12345})
+		listener, err := pf.getListener(testCase.Protocol, testCase.Host, &ForwardedPort{12345, 12345})
 		if err != nil && strings.Contains(err.Error(), "cannot assign requested address") {
 			t.Logf("Can't test #%d: %v", i, err)
 			continue
@@ -192,7 +192,7 @@ func TestGetListener(t *testing.T) {
 		}
 
 		host, port, _ := net.SplitHostPort(listener.Addr().String())
-		t.Logf("Asked a %s forward for: %s:%v, got listener %s:%s, expected: %s", testCase.Protocol, testCase.Hostname, 12345, host, port, expectedListenerPort)
+		t.Logf("Asked a %s forward for: %s:%v, got listener %s:%s, expected: %s", testCase.Protocol, testCase.Host, 12345, host, port, expectedListenerPort)
 		if host != testCase.ExpectedListenerAddress {
 			t.Errorf("Test case #%d failed: Listener does not listen on exepected address: asked %v got %v", i, testCase.ExpectedListenerAddress, host)
 		}

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -130,7 +130,7 @@ type DirectStreamingRuntime interface {
 	// tty.
 	ExecInContainer(containerID ContainerID, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan term.Size, timeout time.Duration) error
 	// Forward the specified port from the specified pod to the stream.
-	PortForward(pod *Pod, port uint16, stream io.ReadWriteCloser) error
+	PortForward(pod *Pod, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error
 	// ContainerAttach encapsulates the attaching to containers for testability
 	ContainerAttacher
 }

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -72,9 +72,10 @@ type FakeDirectStreamingRuntime struct {
 		Stderr      io.WriteCloser
 		TTY         bool
 		// Port-forward args
-		Pod    *Pod
-		Port   uint16
-		Stream io.ReadWriteCloser
+		Pod       *Pod
+		Port      uint16
+		StreamIn  io.WriteCloser
+		StreamOut io.ReadCloser
 	}
 }
 
@@ -390,14 +391,15 @@ func (f *FakeRuntime) RemoveImage(image ImageSpec) error {
 	return f.Err
 }
 
-func (f *FakeDirectStreamingRuntime) PortForward(pod *Pod, port uint16, stream io.ReadWriteCloser) error {
+func (f *FakeDirectStreamingRuntime) PortForward(pod *Pod, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error {
 	f.Lock()
 	defer f.Unlock()
 
 	f.CalledFunctions = append(f.CalledFunctions, "PortForward")
 	f.Args.Pod = pod
 	f.Args.Port = port
-	f.Args.Stream = stream
+	f.Args.StreamIn = streamIn
+	f.Args.StreamOut = streamOut
 
 	return f.Err
 }

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -125,8 +125,8 @@ func (r *Mock) RemoveImage(image ImageSpec) error {
 	return args.Error(0)
 }
 
-func (r *Mock) PortForward(pod *Pod, port uint16, stream io.ReadWriteCloser) error {
-	args := r.Called(pod, port, stream)
+func (r *Mock) PortForward(pod *Pod, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error {
+	args := r.Called(pod, port, streamIn, streamOut)
 	return args.Error(0)
 }
 

--- a/pkg/kubelet/dockershim/docker_streaming.go
+++ b/pkg/kubelet/dockershim/docker_streaming.go
@@ -61,11 +61,11 @@ func (r *streamingRuntime) Attach(containerID string, in io.Reader, out, errw io
 	return dockertools.AttachContainer(r.client, containerID, in, out, errw, tty, resize)
 }
 
-func (r *streamingRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+func (r *streamingRuntime) PortForward(podSandboxID string, port int32, streamIn io.WriteCloser, streamOut io.ReadCloser) error {
 	if port < 0 || port > math.MaxUint16 {
 		return fmt.Errorf("invalid port %d", port)
 	}
-	return dockertools.PortForward(r.client, podSandboxID, uint16(port), stream)
+	return dockertools.PortForward(r.client, podSandboxID, uint16(port), streamIn, streamOut)
 }
 
 // ExecSync executes a command in the container, and returns the stdout output.

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -1410,7 +1410,7 @@ func PortForward(client DockerInterface, podInfraContainerID string, port uint16
 	// wait for stdout/stdin processing, because if StdoutPipe() is used, Wait() must not be called before that
 	err = <-copyErr
 
-	if commandErr := command.Wait(); err != nil {
+	if commandErr := command.Wait(); commandErr != nil {
 		return fmt.Errorf("%v: %s", commandErr, stderr.String())
 	}
 

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -64,6 +64,7 @@ import (
 	"k8s.io/kubernetes/pkg/securitycontext"
 	kubetypes "k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/flowcontrol"
+	"k8s.io/kubernetes/pkg/util/httpstream"
 	"k8s.io/kubernetes/pkg/util/oom"
 	"k8s.io/kubernetes/pkg/util/procfs"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
@@ -1328,13 +1329,13 @@ func noPodInfraContainerError(podName, podNamespace string) error {
 //  - match cgroups of container
 //  - should we support nsenter + socat on the host? (current impl)
 //  - should we support nsenter + socat in a container, running with elevated privs and --pid=host?
-func (dm *DockerManager) PortForward(pod *kubecontainer.Pod, port uint16, stream io.ReadWriteCloser) error {
+func (dm *DockerManager) PortForward(pod *kubecontainer.Pod, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error {
 	podInfraContainer := pod.FindContainerByName(PodInfraContainerName)
 	if podInfraContainer == nil {
 		return noPodInfraContainerError(pod.Name, pod.Namespace)
 	}
 
-	return PortForward(dm.client, podInfraContainer.ID.ID, port, stream)
+	return PortForward(dm.client, podInfraContainer.ID.ID, port, streamIn, streamOut)
 }
 
 // UpdatePodCIDR updates the podCIDR for the runtime.
@@ -1344,7 +1345,10 @@ func (dm *DockerManager) UpdatePodCIDR(podCIDR string) error {
 }
 
 // Temporarily export this function to share with dockershim.
-func PortForward(client DockerInterface, podInfraContainerID string, port uint16, stream io.ReadWriteCloser) error {
+func PortForward(client DockerInterface, podInfraContainerID string, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error {
+	defer streamIn.Close()
+	defer streamOut.Close()
+
 	container, err := client.InspectContainer(podInfraContainerID)
 	if err != nil {
 		return err
@@ -1371,10 +1375,6 @@ func PortForward(client DockerInterface, podInfraContainerID string, port uint16
 	glog.V(4).Infof("executing port forwarding command: %s", commandString)
 
 	command := exec.Command(nsenterPath, args...)
-	command.Stdout = stream
-
-	stderr := new(bytes.Buffer)
-	command.Stderr = stderr
 
 	// If we use Stdin, command.Run() won't return until the goroutine that's copying
 	// from stream finishes. Unfortunately, if you have a client like telnet connected
@@ -1389,16 +1389,32 @@ func PortForward(client DockerInterface, podInfraContainerID string, port uint16
 	if err != nil {
 		return fmt.Errorf("unable to do port forwarding: error creating stdin pipe: %v", err)
 	}
+
+	outPipe, err := command.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("unable to do port forwarding: error creating stdout pipe: %v", err)
+	}
+
+	stderr := new(bytes.Buffer)
+	command.Stderr = stderr
+
+	copyErr := make(chan error)
 	go func() {
-		io.Copy(inPipe, stream)
-		inPipe.Close()
+		copyErr <- httpstream.CopyBothWays(inPipe, outPipe, streamIn, streamOut)
 	}()
 
-	if err := command.Run(); err != nil {
+	if err := command.Start(); err != nil {
 		return fmt.Errorf("%v: %s", err, stderr.String())
 	}
 
-	return nil
+	// wait for stdout/stdin processing, because if StdoutPipe() is used, Wait() must not be called before that
+	err = <-copyErr
+
+	if commandErr := command.Wait(); err != nil {
+		return fmt.Errorf("%v: %s", commandErr, stderr.String())
+	}
+
+	return err
 }
 
 // TODO(random-liu): Change running pod to pod status in the future. We can't do it now, because kubelet also uses this function without pod status.

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -1400,7 +1400,7 @@ func PortForward(client DockerInterface, podInfraContainerID string, port uint16
 
 	copyErr := make(chan error)
 	go func() {
-		copyErr <- httpstream.CopyBothWays(inPipe, outPipe, streamIn, streamOut)
+		copyErr <- httpstream.CopyBothWays(inPipe, outPipe, streamIn, streamOut, []string{"broken pipe"})
 	}()
 
 	if err := command.Start(); err != nil {

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -1224,11 +1224,15 @@ func TestSyncPodEventHandlerFails(t *testing.T) {
 	}
 }
 
-type fakeReadWriteCloser struct{}
+type fakeWriteCloser struct{}
 
-func (*fakeReadWriteCloser) Read([]byte) (int, error)  { return 0, nil }
-func (*fakeReadWriteCloser) Write([]byte) (int, error) { return 0, nil }
-func (*fakeReadWriteCloser) Close() error              { return nil }
+func (*fakeWriteCloser) Write([]byte) (int, error) { return 0, nil }
+func (*fakeWriteCloser) Close() error              { return nil }
+
+type fakeReadCloser struct{}
+
+func (*fakeReadCloser) Read([]byte) (int, error) { return 0, nil }
+func (*fakeReadCloser) Close() error             { return nil }
 
 func TestPortForwardNoSuchContainer(t *testing.T) {
 	dm, _ := newTestDockerManager()
@@ -1243,7 +1247,8 @@ func TestPortForwardNoSuchContainer(t *testing.T) {
 		},
 		5000,
 		// need a valid io.ReadWriteCloser here
-		&fakeReadWriteCloser{},
+		&fakeWriteCloser{},
+		&fakeReadCloser{},
 	)
 	if err == nil {
 		t.Fatal("unexpected non-error")

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1299,7 +1299,7 @@ func (kl *Kubelet) AttachContainer(podFullName string, podUID types.UID, contain
 
 // PortForward connects to the pod's port and copies data between the port
 // and the stream.
-func (kl *Kubelet) PortForward(podFullName string, podUID types.UID, port uint16, stream io.ReadWriteCloser) error {
+func (kl *Kubelet) PortForward(podFullName string, podUID types.UID, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error {
 	streamingRuntime, ok := kl.containerRuntime.(kubecontainer.DirectStreamingRuntime)
 	if !ok {
 		return fmt.Errorf("streaming methods not supported by runtime")
@@ -1314,7 +1314,7 @@ func (kl *Kubelet) PortForward(podFullName string, podUID types.UID, port uint16
 	if pod.IsEmpty() {
 		return fmt.Errorf("pod not found (%q)", podFullName)
 	}
-	return streamingRuntime.PortForward(&pod, port, stream)
+	return streamingRuntime.PortForward(&pod, port, streamIn, streamOut)
 }
 
 // GetExec gets the URL the exec will be served from, or nil if the Kubelet will serve it.

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1025,6 +1025,26 @@ func (f *fakeReadWriteCloser) Close() error {
 	return nil
 }
 
+type fakeWriteCloser struct{}
+
+func (f *fakeWriteCloser) Write(data []byte) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeWriteCloser) Close() error {
+	return nil
+}
+
+type fakeReadCloser struct{}
+
+func (f *fakeReadCloser) Read(data []byte) (int, error) {
+	return 0, nil
+}
+
+func (f *fakeReadCloser) Close() error {
+	return nil
+}
+
 func TestExec(t *testing.T) {
 	const (
 		podName                = "podFoo"
@@ -1136,7 +1156,8 @@ func TestPortForward(t *testing.T) {
 		port         uint16    = 5000
 	)
 	var (
-		stream = &fakeReadWriteCloser{}
+		streamIn  = &fakeWriteCloser{}
+		streamOut = &fakeReadCloser{}
 	)
 
 	testcases := []struct {
@@ -1175,7 +1196,7 @@ func TestPortForward(t *testing.T) {
 			assert.Error(t, err, description)
 			assert.Nil(t, redirect, description)
 
-			err = kubelet.PortForward(podFullName, podUID, port, stream)
+			err = kubelet.PortForward(podFullName, podUID, port, streamIn, streamOut)
 			assert.Error(t, err, description)
 		}
 		{ // Direct streaming case
@@ -1187,14 +1208,15 @@ func TestPortForward(t *testing.T) {
 			assert.NoError(t, err, description)
 			assert.Nil(t, redirect, description)
 
-			err = kubelet.PortForward(podFullName, podUID, port, stream)
+			err = kubelet.PortForward(podFullName, podUID, port, streamIn, streamOut)
 			if tc.expectError {
 				assert.Error(t, err, description)
 			} else {
 				assert.NoError(t, err, description)
 				require.Equal(t, fakeRuntime.Args.Pod.ID, podUID, description+": Pod UID")
 				require.Equal(t, fakeRuntime.Args.Port, port, description+": Port")
-				require.Equal(t, fakeRuntime.Args.Stream, stream, description+": stream")
+				require.Equal(t, fakeRuntime.Args.StreamIn, streamIn, description+": stream")
+				require.Equal(t, fakeRuntime.Args.StreamOut, streamOut, description+": stream")
 			}
 		}
 		{ // Indirect streaming case
@@ -1210,7 +1232,7 @@ func TestPortForward(t *testing.T) {
 				assert.Equal(t, containertest.FakeHost, redirect.Host, description+": redirect")
 			}
 
-			err = kubelet.PortForward(podFullName, podUID, port, stream)
+			err = kubelet.PortForward(podFullName, podUID, port, streamIn, streamOut)
 			assert.Error(t, err, description)
 		}
 	}

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -2187,7 +2187,7 @@ func (r *Runtime) PortForward(pod *kubecontainer.Pod, port uint16, streamIn io.W
 
 	copyErr := make(chan error)
 	go func() {
-		copyErr <- httpstream.CopyBothWays(inPipe, outPipe, streamIn, streamOut)
+		copyErr <- httpstream.CopyBothWays(inPipe, outPipe, streamIn, streamOut, []string{"broken pipe"})
 	}()
 
 	if err := command.Start(); err != nil {

--- a/pkg/kubelet/server/portforward/portforward.go
+++ b/pkg/kubelet/server/portforward/portforward.go
@@ -38,7 +38,7 @@ import (
 // in a pod.
 type PortForwarder interface {
 	// PortForwarder copies data between a data stream and a port in a pod.
-	PortForward(name string, uid types.UID, port uint16, stream io.ReadWriteCloser) error
+	PortForward(name string, uid types.UID, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error
 }
 
 // ServePortForward handles a port forwarding request.  A single request is
@@ -257,7 +257,8 @@ func (h *portForwardStreamHandler) portForward(p *portForwardStreamPair) {
 	port, _ := strconv.ParseUint(portString, 10, 16)
 
 	glog.V(5).Infof("(conn=%p, request=%s) invoking forwarder.PortForward for port %s", h.conn, p.requestID, portString)
-	err := h.forwarder.PortForward(h.pod, h.uid, uint16(port), p.dataStream)
+	streamIn, streamOut := httpstream.SplitStream(p.dataStream)
+	err := h.forwarder.PortForward(h.pod, h.uid, uint16(port), streamIn, streamOut)
 	glog.V(5).Infof("(conn=%p, request=%s) done invoking forwarder.PortForward for port %s", h.conn, p.requestID, portString)
 
 	if err != nil {

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -170,7 +170,7 @@ type HostInterface interface {
 	AttachContainer(name string, uid types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan term.Size) error
 	GetKubeletContainerLogs(podFullName, containerName string, logOptions *api.PodLogOptions, stdout, stderr io.Writer) error
 	ServeLogs(w http.ResponseWriter, req *http.Request)
-	PortForward(name string, uid types.UID, port uint16, stream io.ReadWriteCloser) error
+	PortForward(name string, uid types.UID, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error
 	StreamingConnectionIdleTimeout() time.Duration
 	ResyncInterval() time.Duration
 	GetHostname() string

--- a/pkg/kubelet/server/streaming/server.go
+++ b/pkg/kubelet/server/streaming/server.go
@@ -59,7 +59,7 @@ type Server interface {
 type Runtime interface {
 	Exec(containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan term.Size) error
 	Attach(containerID string, in io.Reader, out, err io.WriteCloser, resize <-chan term.Size) error
-	PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error
+	PortForward(podSandboxID string, port int32, streamIn io.WriteCloser, streamOut io.ReadCloser) error
 }
 
 // Config defines the options used for running the stream server.
@@ -317,6 +317,6 @@ func (a *criAdapter) AttachContainer(podName string, podUID types.UID, container
 	return a.Attach(container, in, out, err, resize)
 }
 
-func (a *criAdapter) PortForward(podName string, podUID types.UID, port uint16, stream io.ReadWriteCloser) error {
-	return a.Runtime.PortForward(podName, int32(port), stream)
+func (a *criAdapter) PortForward(podName string, podUID types.UID, port uint16, streamIn io.WriteCloser, streamOut io.ReadCloser) error {
+	return a.Runtime.PortForward(podName, int32(port), streamIn, streamOut)
 }

--- a/pkg/kubelet/server/streaming/server_test.go
+++ b/pkg/kubelet/server/streaming/server_test.go
@@ -305,10 +305,10 @@ func (f *fakeRuntime) Attach(containerID string, stdin io.Reader, stdout, stderr
 	return nil
 }
 
-func (f *fakeRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+func (f *fakeRuntime) PortForward(podSandboxID string, port int32, streamIn io.WriteCloser, streamOut io.ReadCloser) error {
 	assert.Equal(f.t, testPodSandboxID, podSandboxID)
 	assert.EqualValues(f.t, testPort, port)
-	doServerStreams(f.t, "portforward", stream, stream, nil)
+	doServerStreams(f.t, "portforward", streamOut, streamIn, nil)
 	return nil
 }
 

--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -56,7 +56,7 @@ func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string) *a
 			Containers: []api.Container{
 				{
 					Name:  "portforwardtester",
-					Image: "gcr.io/google_containers/portforwardtester:1.0",
+					Image: "gcr.io/google_containers/portforwardtester:1.2",
 					Env: []api.EnvVar{
 						{
 							Name:  "BIND_PORT",

--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -56,7 +56,7 @@ func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string) *a
 			Containers: []api.Container{
 				{
 					Name:  "portforwardtester",
-					Image: "gcr.io/google_containers/portforwardtester:1.2",
+					Image: "sttts/portforwardtester:1.2",
 					Env: []api.EnvVar{
 						{
 							Name:  "BIND_PORT",

--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 1.1
+TAG = 1.2
 PREFIX = gcr.io/google_containers
 
 all: push

--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 1.2
-PREFIX = gcr.io/google_containers
+PREFIX = sttts
 
 all: push
 

--- a/test/images/port-forward-tester/portforwardtester.go
+++ b/test/images/port-forward-tester/portforwardtester.go
@@ -75,6 +75,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	fmt.Printf("Listening on %s\n", net.JoinHostPort(bindAddress, bindPort))
+
 	conn, err := listener.AcceptTCP()
 	if err != nil {
 		fmt.Printf("Error accepting connection: %v\n", err)


### PR DESCRIPTION
This PR adds support for half-open connections in both directions to the port-forwarding code in the client (used by `kubectl port-foward`) and the container runtimes in the kubelet.

The layers between those two ends of a port-forward use htpstreams (using SPDY right now, but soon also websockets: https://github.com/kubernetes/kubernetes/pull/33684) instead of raw TCP. This PR is purely about tunneling TCP in SPDY (or soon websockets).

TODO:
- [x] probably fix some unit tests
- [ ] add e2e tests for the server closing a connection early

Fixes https://github.com/sttts/kubernetes/commit/ed021fed4c38b5c82696fea84b3173e98bc16922#commitcomment-19876346.

This is in the context of https://github.com/kubernetes/kubernetes/issues/27680 which might be a race with closed connections somewhere. Though it seems that this very change will not fix #27680 as the former is about early client close, the later about early server close.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37072)
<!-- Reviewable:end -->
