### PR TITLE
openstack: add swift prefix param and generate token

### DIFF
--- a/cluster/openstack-heat/config-default.sh
+++ b/cluster/openstack-heat/config-default.sh
@@ -61,6 +61,15 @@ STACK_CREATE_TIMEOUT=${STACK_CREATE_TIMEOUT:-60}
 # Enable Proxy, if true kube-up will apply your current proxy settings(defined by *_PROXY environment variables) to the deployment.
 ENABLE_PROXY=${ENABLE_PROXY:-false}
 
+# Prefix for the swift container
+KUBE_SWIFT_PREFIX=${KUBE_SWIFT_PREFIX:-}
+
+# Generate a token for this cluster
+KUBE_BEARER_TOKEN=${KUBE_BEARER_TOKEN:-$(openssl rand -hex 32)}
+
+# Default Network CIDR
+FIXED_NETWORK_CIDR=${FIXED_NETWORK_CIDR-10.0.0.0/24}
+
 # Per-protocol proxy settings.
 FTP_PROXY=${FTP_PROXY:-}
 HTTP_PROXY=${HTTP_PROXY:-}


### PR DESCRIPTION
**What this PR does / why we need it**:
Security and usability

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Multiple kubernetes clusters on one openstack instance.

**Special notes for your reviewer**:

**Release note**:
Add the ability to set both kube token and swift
container prefix from command line, with env variables.

Will generate a random kube token if not one is supplied.
Swift prefix is needed if you want multiple clusters om the same
openstack install.

/R

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37074)
<!-- Reviewable:end -->
