### PR TITLE
[kubeadm] Fail fast if there already is a node in the cluster with that name

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -145,6 +145,11 @@ func (j *Join) Run(out io.Writer) error {
 		return err
 	}
 
+	err = kubenode.CheckForNodeNameDuplicates(connectionDetails)
+	if err != nil {
+		return err
+	}
+
 	kubeconfig, err := kubenode.PerformTLSBootstrap(connectionDetails)
 	if err != nil {
 		return err

--- a/cmd/kubeadm/app/node/BUILD
+++ b/cmd/kubeadm/app/node/BUILD
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
+        "//pkg/api/v1:go_default_library",
         "//pkg/apis/certificates:go_default_library",
         "//pkg/client/clientset_generated/release_1_5:go_default_library",
         "//pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1:go_default_library",


### PR DESCRIPTION
kubeadm Fail fast if there is another node with the same name already in the cluster. 

Fixes #36255

cc @kubernetes/sig-cluster-federation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37084)
<!-- Reviewable:end -->
