### PR TITLE
Add fast-path for Listing with ResourceVersion=0

### DIFF
--- a/pkg/storage/watch_cache.go
+++ b/pkg/storage/watch_cache.go
@@ -283,10 +283,13 @@ func (w *watchCache) waitUntilFreshAndBlock(resourceVersion uint64, trace *util.
 
 // WaitUntilFreshAndList returns list of pointers to <storeElement> objects.
 func (w *watchCache) WaitUntilFreshAndList(resourceVersion uint64, trace *util.Trace) ([]interface{}, uint64, error) {
-	err := w.waitUntilFreshAndBlock(resourceVersion, trace)
-	defer w.RUnlock()
-	if err != nil {
-		return nil, 0, err
+	// If resourceVersion == 0 we'll return the data that we currently have in cache.
+	if resourceVersion != 0 {
+		err := w.waitUntilFreshAndBlock(resourceVersion, trace)
+		defer w.RUnlock()
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 	return w.store.List(), w.resourceVersion, nil
 }


### PR DESCRIPTION
We slightly change the behavior, but we keep the current contract, so release note is not needed.

cc @saad-ali 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37085)
<!-- Reviewable:end -->
