### PR TITLE
Keep host port socket open for kubenet

### DIFF
--- a/pkg/kubelet/network/hostport/hostport.go
+++ b/pkg/kubelet/network/hostport/hostport.go
@@ -370,7 +370,7 @@ func (h *handler) cleanupHostportMap(containerPortMap map[v1.ContainerPort]targe
 	for containerPort := range containerPortMap {
 		hp := hostport{
 			port:     containerPort.HostPort,
-			protocol: string(containerPort.Protocol),
+			protocol: strings.ToLower(string(containerPort.Protocol)),
 		}
 		currentHostports[hp] = true
 	}
@@ -379,6 +379,7 @@ func (h *handler) cleanupHostportMap(containerPortMap map[v1.ContainerPort]targe
 	for hp, socket := range h.hostPortMap {
 		if _, ok := currentHostports[hp]; !ok {
 			socket.Close()
+			glog.V(3).Infof("Closed local port %s", hp.String())
 			delete(h.hostPortMap, hp)
 		}
 	}

--- a/pkg/kubelet/network/hostport/hostport_test.go
+++ b/pkg/kubelet/network/hostport/hostport_test.go
@@ -19,6 +19,7 @@ package hostport
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -185,6 +186,17 @@ func TestOpenPodHostports(t *testing.T) {
 		})
 	}
 
+	// Already running pod's host port
+	hp := hostport{
+		tests[1].pod.Spec.Containers[0].Ports[0].HostPort,
+		strings.ToLower(string(tests[1].pod.Spec.Containers[0].Ports[0].Protocol)),
+	}
+	h.hostPortMap[hp] = &fakeSocket{
+		tests[1].pod.Spec.Containers[0].Ports[0].HostPort,
+		strings.ToLower(string(tests[1].pod.Spec.Containers[0].Ports[0].Protocol)),
+		false,
+	}
+
 	err := h.OpenPodHostportsAndSync(&ActivePod{Pod: tests[0].pod, IP: net.ParseIP(tests[0].ip)}, "br0", activePods)
 	if err != nil {
 		t.Fatalf("Failed to OpenPodHostportsAndSync: %v", err)
@@ -219,6 +231,16 @@ func TestOpenPodHostports(t *testing.T) {
 				t.Fatalf("Expected NAT chain %s rule containing '%s' not found", match.chain, match.match)
 			}
 		}
+	}
+
+	// Socket
+	hostPortMap := map[hostport]closeable{
+		hostport{123, "tcp"}:  &fakeSocket{123, "tcp", false},
+		hostport{4567, "tcp"}: &fakeSocket{4567, "tcp", false},
+		hostport{5678, "udp"}: &fakeSocket{5678, "udp", false},
+	}
+	if !reflect.DeepEqual(hostPortMap, h.hostPortMap) {
+		t.Fatalf("Mismatch in expected hostPortMap. Expected '%v', got '%v'", hostPortMap, h.hostPortMap)
 	}
 }
 


### PR DESCRIPTION
fixes #37087


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

When cni is set to kubenet, kubelet should hold the host port socket,
so that other application in this node could not listen/bind this port
any more. However, the sockets are closed accidentally, because
kubelet forget to reconcile the protocol format before comparing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37088)
<!-- Reviewable:end -->
@kubernetes/sig-network
