### PR TITLE
Add log rotation to kubemark

### DIFF
--- a/test/kubemark/resources/kubemark_logrotate
+++ b/test/kubemark/resources/kubemark_logrotate
@@ -1,0 +1,19 @@
+compress
+
+/var/log/kube-apiserver.log {
+	rotate 12
+	copytruncate
+	size 100M
+}
+
+/var/log/kube-scheduler.log {
+	rotate 12
+	copytruncate
+	size 100M
+}
+
+/var/log/kube-controller-manager.log {
+	rotate 12
+	copytruncate
+	size 100M
+}

--- a/test/kubemark/start-kubemark-master.sh
+++ b/test/kubemark/start-kubemark-master.sh
@@ -111,6 +111,9 @@ retry sudo docker run --net=host \
 	--listen-client-urls=http://0.0.0.0:2379 \
 	--data-dir=/var/etcd/data ${ETCD_QUOTA_BYTES} 1>> /var/log/etcd.log 2>&1"
 
+# Run logrotate regularly
+echo '*/5 * * * * root logrotate /etc/logrotate.conf' >> "/etc/crontab"
+
 # Increase the allowed number of open file descriptors
 ulimit -n 65536
 

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -167,6 +167,11 @@ gcloud compute copy-files --zone="${ZONE}" --project="${PROJECT}" \
   "${RESOURCE_DIRECTORY}/controllers_flags" \
   "${MASTER_NAME}":~
 
+gcloud compute copy-files --zone="${ZONE}" --project="${PROJECT}" \
+    "${RESOURCE_DIRECTORY}/kubemark_logrotate" \
+    "root@${MASTER_NAME}:/etc/logrotate.d"
+
+
 gcloud compute ssh "${MASTER_NAME}" --zone="${ZONE}" --project="${PROJECT}" \
   --command="chmod a+x configure-kubectl.sh && chmod a+x start-kubemark-master.sh && \
              sudo ./start-kubemark-master.sh ${EVENT_STORE_IP:-127.0.0.1} ${NUM_NODES:-0} ${EVENT_PD:-false} ${ETCD_IMAGE:-}"


### PR DESCRIPTION
We were running out of disk in our large cluster tests, as we didn't have log rotation enabled.

cc @saad-ali

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37095)
<!-- Reviewable:end -->
