### PR TITLE
Fix renaming order shown on terminal

### DIFF
--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -520,7 +520,7 @@ func (r *RollingUpdater) cleanupWithClients(oldRc, newRc *api.ReplicationControl
 		if err := r.rcClient.ReplicationControllers(r.ns).Delete(oldRc.Name, nil); err != nil {
 			return err
 		}
-		fmt.Fprintf(config.Out, "Renaming %s to %s\n", oldRc.Name, newRc.Name)
+		fmt.Fprintf(config.Out, "Renaming %s to %s\n", newRc.Name, oldRc.Name)
 		return Rename(r.rcClient, newRc, oldRc.Name)
 	case PreserveRollingUpdateCleanupPolicy:
 		return nil


### PR DESCRIPTION
When finishing a rolling update, a message is shown :
'Renaming oldRc to newRc'
In my case that'd be:
'Renaming nginx to nginx-df8d9fafc5007d83968cd37c8353d52e'
That naming order is incorrect, as the new name is temporary, and the final name should be the old one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37096)
<!-- Reviewable:end -->
