### PR TITLE
portfordwardtester: avoid data loss during send+close+exit

### DIFF
--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -56,7 +56,7 @@ func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string) *v
 			Containers: []v1.Container{
 				{
 					Name:  "portforwardtester",
-					Image: "gcr.io/google_containers/portforwardtester:1.0",
+					Image: "gcr.io/google_containers/portforwardtester:1.2",
 					Env: []v1.EnvVar{
 						{
 							Name:  "BIND_PORT",

--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 1.1
+TAG = 1.2
 PREFIX = gcr.io/google_containers
 
 all: push


### PR DESCRIPTION
Following https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable when closing the sending connection in the port-forward-tester container.

Potentially fixing https://github.com/kubernetes/kubernetes/issues/27680

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37103)
<!-- Reviewable:end -->
