### PR TITLE
Kubelet Status Manager stores Status in the Pod Manager instead of in its own cache

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1924,7 +1924,7 @@ func (kl *Kubelet) HandlePodAdditions(pods []*v1.Pod) {
 		// manager as the source of truth for the desired state. If a pod does
 		// not exist in the pod manager, it means that it has been deleted in
 		// the apiserver and no action (other than cleanup) is required.
-		kl.podManager.AddPod(pod)
+		kl.statusManager.AddPod(pod)
 
 		if kubepod.IsMirrorPod(pod) {
 			kl.handleMirrorPod(pod, start)
@@ -1991,9 +1991,7 @@ func (kl *Kubelet) HandlePodRemoves(pods []*v1.Pod) {
 // that should be reconciled.
 func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 	for _, pod := range pods {
-		// Update the pod in pod manager, status manager will do periodically reconcile according
-		// to the pod manager.
-		kl.podManager.UpdatePod(pod)
+		kl.statusManager.ReconcilePod(pod.UID)
 
 		// After an evicted pod is synced, all dead containers in the pod can be removed.
 		if eviction.PodIsEvicted(pod.Status) {

--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -181,6 +181,7 @@ func TestCleanupBandwidthLimits(t *testing.T) {
 		testKube.kubelet.shaper = shaper
 
 		for _, pod := range test.pods {
+			testKube.kubelet.statusManager.AddPod(pod)
 			testKube.kubelet.statusManager.SetPodStatus(pod, *test.status)
 		}
 

--- a/pkg/kubelet/prober/worker_test.go
+++ b/pkg/kubelet/prober/worker_test.go
@@ -103,6 +103,7 @@ func TestDoProbe(t *testing.T) {
 		for i, test := range tests {
 			w := newTestWorker(m, probeType, test.probe)
 			if test.podStatus != nil {
+				m.statusManager.AddPod(w.pod)
 				m.statusManager.SetPodStatus(w.pod, *test.podStatus)
 			}
 			if c := w.doProbe(); c != test.expectContinue {

--- a/pkg/kubelet/status/BUILD
+++ b/pkg/kubelet/status/BUILD
@@ -28,8 +28,6 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/types",
-        "//vendor:k8s.io/apimachinery/pkg/util/diff",
-        "//vendor:k8s.io/apimachinery/pkg/util/wait",
     ],
 )
 

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -27,8 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/diff"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -38,34 +36,18 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 )
 
-// A wrapper around v1.PodStatus that includes a version to enforce that stale pod statuses are
-// not sent to the API server.
-type versionedPodStatus struct {
-	status v1.PodStatus
-	// Monotonically increasing version number (per pod).
-	version uint64
-	// Pod name & namespace, for sending updates to API server.
-	podName      string
-	podNamespace string
-}
-
-type podStatusSyncRequest struct {
-	podUID types.UID
-	status versionedPodStatus
-}
-
 // Updates pod statuses in apiserver. Writes only when new status has changed.
 // All methods are thread-safe.
 type manager struct {
 	kubeClient clientset.Interface
 	podManager kubepod.Manager
-	// Map from pod UID to sync status of the corresponding pod.
-	podStatuses      map[types.UID]versionedPodStatus
-	podStatusesLock  sync.RWMutex
-	podStatusChannel chan podStatusSyncRequest
-	// Map from (mirror) pod UID to latest status version successfully sent to the API server.
-	// apiStatusVersions must only be accessed from the sync thread.
-	apiStatusVersions map[types.UID]uint64
+	// The podStatusChannel preserves the order of status updates to the api server
+	podStatusChannel chan types.UID
+	// updateSetLock and updateSet enforce that if a pod is updated more than once
+	// between syncs with the api server, we will only update the api server once
+	updateSetLock sync.Mutex
+	// The updateSet contains the UIDs of pods that have outstanding changes to be sent to the server
+	updateSet map[types.UID]struct{}
 }
 
 // PodStatusProvider knows how to provide status for a pod.  It's intended to be used by other components
@@ -84,6 +66,9 @@ type Manager interface {
 	// Start the API server status sync loop.
 	Start()
 
+	// AddPod adds a pod
+	AddPod(pod *v1.Pod)
+
 	// SetPodStatus caches updates the cached status for the given pod, and triggers a status update.
 	SetPodStatus(pod *v1.Pod, status v1.PodStatus)
 
@@ -91,24 +76,26 @@ type Manager interface {
 	// triggers a status update.
 	SetContainerReadiness(podUID types.UID, containerID kubecontainer.ContainerID, ready bool)
 
+	// ReconcilePod updates the v1 server with the latest status for that pod in order to reconcile differences between
+	// the kubelet and the v1 server
+	ReconcilePod(uid types.UID)
+
 	// TerminatePod resets the container status for the provided pod to terminated and triggers
 	// a status update.
 	TerminatePod(pod *v1.Pod)
-
-	// RemoveOrphanedStatuses scans the status cache and removes any entries for pods not included in
-	// the provided podUIDs.
-	RemoveOrphanedStatuses(podUIDs map[types.UID]bool)
 }
 
-const syncPeriod = 10 * time.Second
+const (
+	syncPeriod  = 10 * time.Second
+	retryPeriod = 10 * time.Second
+)
 
 func NewManager(kubeClient clientset.Interface, podManager kubepod.Manager) Manager {
 	return &manager{
-		kubeClient:        kubeClient,
-		podManager:        podManager,
-		podStatuses:       make(map[types.UID]versionedPodStatus),
-		podStatusChannel:  make(chan podStatusSyncRequest, 1000), // Buffer up to 1000 statuses
-		apiStatusVersions: make(map[types.UID]uint64),
+		kubeClient:       kubeClient,
+		podManager:       podManager,
+		podStatusChannel: make(chan types.UID, 1000), // Buffer up to 1000 uids to update
+		updateSet:        make(map[types.UID]struct{}),
 	}
 }
 
@@ -129,95 +116,98 @@ func (m *manager) Start() {
 	}
 
 	glog.Info("Starting to sync pod status with apiserver")
-	syncTicker := time.Tick(syncPeriod)
-	// syncPod and syncBatch share the same go routine to avoid sync races.
-	go wait.Forever(func() {
-		select {
-		case syncRequest := <-m.podStatusChannel:
-			m.syncPod(syncRequest.podUID, syncRequest.status)
-		case <-syncTicker:
-			m.syncBatch()
+	go func() {
+		for update := range m.podStatusChannel {
+			// if it needs to be updated
+			if needsUpdate := m.needsUpdate(update); needsUpdate {
+				// if the update needs to be retried
+				if !m.syncPod(update) {
+					// retry the update after a delay
+					go func() {
+						time.Sleep(retryPeriod)
+						m.enqueueUpdate(update, nil)
+					}()
+				}
+			} else {
+				glog.Infof("Pod %v was already updated, skipping... ", update)
+			}
 		}
-	}, 0)
+	}()
+}
+
+func (m *manager) AddPod(pod *v1.Pod) {
+	m.podManager.AddPod(pod)
+
+	// when adding a mirror pod, update the status of the corresponding static pod
+	_, mirrorToPod := m.podManager.GetUIDTranslations()
+	if p, ok := mirrorToPod[pod.UID]; ok {
+		m.enqueueUpdate(p, nil)
+	}
 }
 
 func (m *manager) GetPodStatus(uid types.UID) (v1.PodStatus, bool) {
-	m.podStatusesLock.RLock()
-	defer m.podStatusesLock.RUnlock()
-	status, ok := m.podStatuses[m.podManager.TranslatePodUID(uid)]
-	return status.status, ok
+	pod, ok := m.podManager.GetPodByUID(m.podManager.TranslatePodUID(uid))
+	if ok {
+		return pod.Status, true
+	}
+	return v1.PodStatus{}, false
 }
 
 func (m *manager) SetPodStatus(pod *v1.Pod, status v1.PodStatus) {
-	m.podStatusesLock.Lock()
-	defer m.podStatusesLock.Unlock()
-	// Make sure we're caching a deep copy.
-	status, err := copyStatus(&status)
-	if err != nil {
-		return
-	}
-	// Force a status update if deletion timestamp is set. This is necessary
-	// because if the pod is in the non-running state, the pod worker still
-	// needs to be able to trigger an update and/or deletion.
-	m.updateStatusInternal(pod, status, pod.DeletionTimestamp != nil)
+	m.podManager.UpdatePodSafe(pod.UID, func(inputPod *v1.Pod) {
+		// Make sure we're caching a deep copy.
+		status, err := copyStatus(&status)
+		if err != nil {
+			return
+		}
+		// Force a status update if deletion timestamp is set. This is necessary
+		// because if the pod is in the non-running state, the pod worker still
+		// needs to be able to trigger an update and/or deletion.
+		m.updateStatusInternal(inputPod, status, pod.DeletionTimestamp != nil)
+	})
 }
 
 func (m *manager) SetContainerReadiness(podUID types.UID, containerID kubecontainer.ContainerID, ready bool) {
-	m.podStatusesLock.Lock()
-	defer m.podStatusesLock.Unlock()
-
-	pod, ok := m.podManager.GetPodByUID(podUID)
-	if !ok {
-		glog.V(4).Infof("Pod %q has been deleted, no need to update readiness", string(podUID))
-		return
-	}
-
-	oldStatus, found := m.podStatuses[pod.UID]
-	if !found {
-		glog.Warningf("Container readiness changed before pod has synced: %q - %q",
-			format.Pod(pod), containerID.String())
-		return
-	}
-
-	// Find the container to update.
-	containerStatus, _, ok := findContainerStatus(&oldStatus.status, containerID.String())
-	if !ok {
-		glog.Warningf("Container readiness changed for unknown container: %q - %q",
-			format.Pod(pod), containerID.String())
-		return
-	}
-
-	if containerStatus.Ready == ready {
-		glog.V(4).Infof("Container readiness unchanged (%v): %q - %q", ready,
-			format.Pod(pod), containerID.String())
-		return
-	}
-
-	// Make sure we're not updating the cached version.
-	status, err := copyStatus(&oldStatus.status)
-	if err != nil {
-		return
-	}
-	containerStatus, _, _ = findContainerStatus(&status, containerID.String())
-	containerStatus.Ready = ready
-
-	// Update pod condition.
-	readyConditionIndex := -1
-	for i, condition := range status.Conditions {
-		if condition.Type == v1.PodReady {
-			readyConditionIndex = i
-			break
+	m.podManager.UpdatePodSafe(podUID, func(pod *v1.Pod) {
+		// Find the container to update.
+		containerStatus, _, ok := findContainerStatus(&pod.Status, containerID.String())
+		if !ok {
+			glog.Warningf("Container readiness changed for unknown container: %q - %q",
+				format.Pod(pod), containerID.String())
+			return
 		}
-	}
-	readyCondition := GeneratePodReadyCondition(&pod.Spec, status.ContainerStatuses, status.Phase)
-	if readyConditionIndex != -1 {
-		status.Conditions[readyConditionIndex] = readyCondition
-	} else {
-		glog.Warningf("PodStatus missing PodReady condition: %+v", status)
-		status.Conditions = append(status.Conditions, readyCondition)
-	}
 
-	m.updateStatusInternal(pod, status, false)
+		if containerStatus.Ready == ready {
+			glog.V(4).Infof("Container readiness unchanged (%v): %q - %q", ready,
+				format.Pod(pod), containerID.String())
+			return
+		}
+		// Make sure we're not updating the cached version.
+		status, err := copyStatus(&pod.Status)
+		if err != nil {
+			return
+		}
+		containerStatus, _, _ = findContainerStatus(&status, containerID.String())
+		containerStatus.Ready = ready
+
+		// Update pod condition.
+		readyConditionIndex := -1
+		for i, condition := range status.Conditions {
+			if condition.Type == v1.PodReady {
+				readyConditionIndex = i
+				break
+			}
+		}
+		readyCondition := GeneratePodReadyCondition(&pod.Spec, status.ContainerStatuses, status.Phase)
+		if readyConditionIndex != -1 {
+			status.Conditions[readyConditionIndex] = readyCondition
+		} else {
+			glog.Warningf("PodStatus missing PodReady condition: %+v", status)
+			status.Conditions = append(status.Conditions, readyCondition)
+		}
+
+		m.updateStatusInternal(pod, status, false)
+	})
 }
 
 func findContainerStatus(status *v1.PodStatus, containerID string) (containerStatus *v1.ContainerStatus, init bool, ok bool) {
@@ -238,49 +228,38 @@ func findContainerStatus(status *v1.PodStatus, containerID string) (containerSta
 
 }
 
-func (m *manager) TerminatePod(pod *v1.Pod) {
-	m.podStatusesLock.Lock()
-	defer m.podStatusesLock.Unlock()
-	oldStatus := &pod.Status
-	if cachedStatus, ok := m.podStatuses[pod.UID]; ok {
-		oldStatus = &cachedStatus.status
-	}
-	status, err := copyStatus(oldStatus)
-	if err != nil {
-		return
-	}
-	for i := range status.ContainerStatuses {
-		status.ContainerStatuses[i].State = v1.ContainerState{
-			Terminated: &v1.ContainerStateTerminated{},
-		}
-	}
-	for i := range status.InitContainerStatuses {
-		status.InitContainerStatuses[i].State = v1.ContainerState{
-			Terminated: &v1.ContainerStateTerminated{},
-		}
-	}
-	m.updateStatusInternal(pod, pod.Status, true)
+func (m *manager) ReconcilePod(uid types.UID) {
+	// queue the uid for an upate to the api server
+	m.enqueueUpdate(uid, nil)
 }
 
-// updateStatusInternal updates the internal status cache, and queues an update to the api server if
-// necessary. Returns whether an update was triggered.
-// This method IS NOT THREAD SAFE and must be called from a locked function.
-func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUpdate bool) bool {
-	var oldStatus v1.PodStatus
-	cachedStatus, isCached := m.podStatuses[pod.UID]
-	if isCached {
-		oldStatus = cachedStatus.status
-	} else if mirrorPod, ok := m.podManager.GetMirrorPodByPod(pod); ok {
-		oldStatus = mirrorPod.Status
-	} else {
-		oldStatus = pod.Status
-	}
+func (m *manager) TerminatePod(pod *v1.Pod) {
+	m.podManager.UpdatePodSafe(pod.UID, func(inputPod *v1.Pod) {
+		newStatus, err := copyStatus(&inputPod.Status)
+		if err != nil {
+			return
+		}
+		for i := range newStatus.ContainerStatuses {
+			newStatus.ContainerStatuses[i].State = v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{},
+			}
+		}
+		for i := range newStatus.InitContainerStatuses {
+			newStatus.InitContainerStatuses[i].State = v1.ContainerState{
+				Terminated: &v1.ContainerStateTerminated{},
+			}
+		}
+		m.updateStatusInternal(inputPod, newStatus, true)
+	})
+}
 
+// updateStatusInternal updates the pod Manager's status, and queues an update to the api server if necessary.
+func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUpdate bool) {
 	// Set ReadyCondition.LastTransitionTime.
 	if _, readyCondition := v1.GetPodCondition(&status, v1.PodReady); readyCondition != nil {
 		// Need to set LastTransitionTime.
 		lastTransitionTime := metav1.Now()
-		_, oldReadyCondition := v1.GetPodCondition(&oldStatus, v1.PodReady)
+		_, oldReadyCondition := v1.GetPodCondition(&pod.Status, v1.PodReady)
 		if oldReadyCondition != nil && readyCondition.Status == oldReadyCondition.Status {
 			lastTransitionTime = oldReadyCondition.LastTransitionTime
 		}
@@ -291,7 +270,7 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	if _, initCondition := v1.GetPodCondition(&status, v1.PodInitialized); initCondition != nil {
 		// Need to set LastTransitionTime.
 		lastTransitionTime := metav1.Now()
-		_, oldInitCondition := v1.GetPodCondition(&oldStatus, v1.PodInitialized)
+		_, oldInitCondition := v1.GetPodCondition(&pod.Status, v1.PodInitialized)
 		if oldInitCondition != nil && initCondition.Status == oldInitCondition.Status {
 			lastTransitionTime = oldInitCondition.LastTransitionTime
 		}
@@ -299,8 +278,8 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	}
 
 	// ensure that the start time does not change across updates.
-	if oldStatus.StartTime != nil && !oldStatus.StartTime.IsZero() {
-		status.StartTime = oldStatus.StartTime
+	if pod.Status.StartTime != nil && !pod.Status.StartTime.IsZero() {
+		status.StartTime = pod.Status.StartTime
 	} else if status.StartTime.IsZero() {
 		// if the status has no start time, we need to set an initial time
 		now := metav1.Now()
@@ -310,199 +289,105 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	normalizeStatus(pod, &status)
 	// The intent here is to prevent concurrent updates to a pod's status from
 	// clobbering each other so the phase of a pod progresses monotonically.
-	if isCached && isStatusEqual(&cachedStatus.status, &status) && !forceUpdate {
+	if isStatusEqual(&pod.Status, &status) && !forceUpdate {
 		glog.V(3).Infof("Ignoring same status for pod %q, status: %+v", format.Pod(pod), status)
-		return false // No new status.
+		return
 	}
 
-	newStatus := versionedPodStatus{
-		status:       status,
-		version:      cachedStatus.version + 1,
-		podName:      pod.Name,
-		podNamespace: pod.Namespace,
-	}
-	m.podStatuses[pod.UID] = newStatus
-
-	select {
-	case m.podStatusChannel <- podStatusSyncRequest{pod.UID, newStatus}:
-		return true
-	default:
-		// Let the periodic syncBatch handle the update if the channel is full.
-		// We can't block, since we hold the mutex lock.
-		glog.V(4).Infof("Skpping the status update for pod %q for now because the channel is full; status: %+v",
-			format.Pod(pod), status)
-		return false
-	}
-}
-
-// deletePodStatus simply removes the given pod from the status cache.
-func (m *manager) deletePodStatus(uid types.UID) {
-	m.podStatusesLock.Lock()
-	defer m.podStatusesLock.Unlock()
-	delete(m.podStatuses, uid)
-}
-
-// TODO(filipg): It'd be cleaner if we can do this without signal from user.
-func (m *manager) RemoveOrphanedStatuses(podUIDs map[types.UID]bool) {
-	m.podStatusesLock.Lock()
-	defer m.podStatusesLock.Unlock()
-	for key := range m.podStatuses {
-		if _, ok := podUIDs[key]; !ok {
-			glog.V(5).Infof("Removing %q from status map.", key)
-			delete(m.podStatuses, key)
-		}
-	}
-}
-
-// syncBatch syncs pods statuses with the apiserver.
-func (m *manager) syncBatch() {
-	var updatedStatuses []podStatusSyncRequest
-	podToMirror, mirrorToPod := m.podManager.GetUIDTranslations()
-	func() { // Critical section
-		m.podStatusesLock.RLock()
-		defer m.podStatusesLock.RUnlock()
-
-		// Clean up orphaned versions.
-		for uid := range m.apiStatusVersions {
-			_, hasPod := m.podStatuses[uid]
-			_, hasMirror := mirrorToPod[uid]
-			if !hasPod && !hasMirror {
-				delete(m.apiStatusVersions, uid)
-			}
-		}
-
-		for uid, status := range m.podStatuses {
-			syncedUID := uid
-			if mirrorUID, ok := podToMirror[uid]; ok {
-				if mirrorUID == "" {
-					glog.V(5).Infof("Static pod %q (%s/%s) does not have a corresponding mirror pod; skipping", uid, status.podName, status.podNamespace)
-					continue
-				}
-				syncedUID = mirrorUID
-			}
-			if m.needsUpdate(syncedUID, status) {
-				updatedStatuses = append(updatedStatuses, podStatusSyncRequest{uid, status})
-			} else if m.needsReconcile(uid, status.status) {
-				// Delete the apiStatusVersions here to force an update on the pod status
-				// In most cases the deleted apiStatusVersions here should be filled
-				// soon after the following syncPod() [If the syncPod() sync an update
-				// successfully].
-				delete(m.apiStatusVersions, syncedUID)
-				updatedStatuses = append(updatedStatuses, podStatusSyncRequest{uid, status})
-			}
-		}
-	}()
-
-	for _, update := range updatedStatuses {
-		m.syncPod(update.podUID, update.status)
-	}
+	m.enqueueUpdate(pod.UID, func() { pod.Status = status })
 }
 
 // syncPod syncs the given status with the API server. The caller must not hold the lock.
-func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
-	if !m.needsUpdate(uid, status) {
-		glog.V(1).Infof("Status for pod %q is up-to-date; skipping", uid)
-		return
+// returns true if the update succeeded or is not neede; returns false if syncpod should be retried
+func (m *manager) syncPod(updateUID types.UID) bool {
+	updatedPod, found := m.podManager.GetPodByUID(updateUID)
+	if !found {
+		glog.V(3).Infof("pod %v not found. Skipping update", updateUID)
+		return true
 	}
-
 	// TODO: make me easier to express from client code
-	pod, err := m.kubeClient.Core().Pods(status.podNamespace).Get(status.podName, metav1.GetOptions{})
+	pod, err := m.kubeClient.Core().Pods(updatedPod.Namespace).Get(updatedPod.Name, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		glog.V(3).Infof("Pod %q (%s) does not exist on the server", status.podName, uid)
-		// If the Pod is deleted the status will be cleared in
-		// RemoveOrphanedStatuses, so we just ignore the update here.
-		return
+		glog.V(3).Infof("Pod %q (%s) does not exist on the server", updatedPod.Name, updatedPod.UID)
+		return true
 	}
-	if err == nil {
-		translatedUID := m.podManager.TranslatePodUID(pod.UID)
-		if len(translatedUID) > 0 && translatedUID != uid {
-			glog.V(2).Infof("Pod %q was deleted and then recreated, skipping status update; old UID %q, new UID %q", format.Pod(pod), uid, translatedUID)
-			m.deletePodStatus(uid)
-			return
-		}
-		pod.Status = status.status
-		if err := podutil.SetInitContainersStatusesAnnotations(pod); err != nil {
-			glog.Error(err)
-		}
-		// TODO: handle conflict as a retry, make that easier too.
-		pod, err = m.kubeClient.Core().Pods(pod.Namespace).UpdateStatus(pod)
-		if err == nil {
-			glog.V(3).Infof("Status for pod %q updated successfully: %+v", format.Pod(pod), status)
-			m.apiStatusVersions[pod.UID] = status.version
-			if kubepod.IsMirrorPod(pod) {
-				// We don't handle graceful deletion of mirror pods.
-				return
-			}
-			if pod.DeletionTimestamp == nil {
-				return
-			}
-			if !notRunning(pod.Status.ContainerStatuses) {
-				glog.V(3).Infof("Pod %q is terminated, but some containers are still running", format.Pod(pod))
-				return
-			}
-			deleteOptions := v1.NewDeleteOptions(0)
-			// Use the pod UID as the precondition for deletion to prevent deleting a newly created pod with the same name and namespace.
-			deleteOptions.Preconditions = v1.NewUIDPreconditions(string(pod.UID))
-			if err = m.kubeClient.Core().Pods(pod.Namespace).Delete(pod.Name, deleteOptions); err == nil {
-				glog.V(3).Infof("Pod %q fully terminated and removed from etcd", format.Pod(pod))
-				m.deletePodStatus(uid)
-				return
-			}
-		}
-	}
-
-	// We failed to update status, wait for periodic sync to retry.
-	glog.Warningf("Failed to update status for pod %q: %v", format.Pod(pod), err)
-}
-
-// needsUpdate returns whether the status is stale for the given pod UID.
-// This method is not thread safe, and most only be accessed by the sync thread.
-func (m *manager) needsUpdate(uid types.UID, status versionedPodStatus) bool {
-	latest, ok := m.apiStatusVersions[uid]
-	return !ok || latest < status.version
-}
-
-// needsReconcile compares the given status with the status in the pod manager (which
-// in fact comes from apiserver), returns whether the status needs to be reconciled with
-// the apiserver. Now when pod status is inconsistent between apiserver and kubelet,
-// kubelet should forcibly send an update to reconclie the inconsistence, because kubelet
-// should be the source of truth of pod status.
-// NOTE(random-liu): It's simpler to pass in mirror pod uid and get mirror pod by uid, but
-// now the pod manager only supports getting mirror pod by static pod, so we have to pass
-// static pod uid here.
-// TODO(random-liu): Simplify the logic when mirror pod manager is added.
-func (m *manager) needsReconcile(uid types.UID, status v1.PodStatus) bool {
-	// The pod could be a static pod, so we should translate first.
-	pod, ok := m.podManager.GetPodByUID(uid)
-	if !ok {
-		glog.V(4).Infof("Pod %q has been deleted, no need to reconcile", string(uid))
+	if err != nil {
+		glog.Warningf("Failed to get status for pod %q from api server: %v", format.Pod(pod), err)
 		return false
 	}
-	// If the pod is a static pod, we should check its mirror pod, because only status in mirror pod is meaningful to us.
-	if kubepod.IsStaticPod(pod) {
-		mirrorPod, ok := m.podManager.GetMirrorPodByPod(pod)
-		if !ok {
-			glog.V(4).Infof("Static pod %q has no corresponding mirror pod, no need to reconcile", format.Pod(pod))
+
+	translatedUID := m.podManager.TranslatePodUID(pod.UID)
+	if len(translatedUID) > 0 && translatedUID != updatedPod.UID {
+		glog.V(2).Infof("Pod %q was deleted and then recreated, skipping status update; old UID %q, new UID %q", format.Pod(pod), updatedPod.UID, translatedUID)
+		m.podManager.DeletePod(pod)
+		return true
+	}
+	pod.Status = updatedPod.Status
+	if err := podutil.SetInitContainersStatusesAnnotations(pod); err != nil {
+		glog.Error(err)
+	}
+	// TODO: handle conflict as a retry, make that easier too.
+	pod, err = m.kubeClient.Core().Pods(pod.Namespace).UpdateStatus(pod)
+	if err != nil {
+		glog.Warningf("Failed to update status for pod %q from api server: %v", format.Pod(pod), err)
+		return false
+	}
+	glog.V(3).Infof("Status for pod %q updated successfully: %+v", format.Pod(pod), updatedPod.Status)
+
+	// we dont handle graceful deletion of mirror pods
+	if !kubepod.IsMirrorPod(pod) && pod.DeletionTimestamp != nil {
+		if !notRunning(pod.Status.ContainerStatuses) {
+			glog.V(3).Infof("Pod %q is terminated, but some containers are still running", format.Pod(pod))
 			return false
 		}
-		pod = mirrorPod
+		deleteOptions := v1.NewDeleteOptions(0)
+		// Use the pod UID as the precondition for deletion to prevent deleting a newly created pod with the same name and namespace.
+		deleteOptions.Preconditions = v1.NewUIDPreconditions(string(pod.UID))
+		glog.V(2).Infof("Removing Pod %q from etcd", format.Pod(pod))
+		if err = m.kubeClient.Core().Pods(pod.Namespace).Delete(pod.Name, deleteOptions); err != nil {
+			glog.Warningf("Failed to delete pod %q from api server: %v", format.Pod(pod), err)
+			return false
+		}
+		glog.V(3).Infof("Pod %q fully terminated and removed from etcd", format.Pod(pod))
+		m.podManager.DeletePod(pod)
 	}
-
-	podStatus, err := copyStatus(&pod.Status)
-	if err != nil {
-		return false
-	}
-	normalizeStatus(pod, &podStatus)
-
-	if isStatusEqual(&podStatus, &status) {
-		// If the status from the source is the same with the cached status,
-		// reconcile is not needed. Just return.
-		return false
-	}
-	glog.V(3).Infof("Pod status is inconsistent with cached status for pod %q, a reconciliation should be triggered:\n %+v", format.Pod(pod),
-		diff.ObjectDiff(podStatus, status))
-
 	return true
+}
+
+// enqueueUpdate adds the update to the update channel without blocking.
+// returns true if it was successfully added to the queue
+// this should be called while holding the lock
+// onSuccess should not block, and is optional.
+func (m *manager) enqueueUpdate(update types.UID, onSuccess func()) bool {
+	m.updateSetLock.Lock()
+	defer m.updateSetLock.Unlock()
+	// Dont enqueue an update if an update to that uid is already queued.
+	if _, ok := m.updateSet[update]; !ok {
+		select {
+		case m.podStatusChannel <- update:
+			m.updateSet[update] = struct{}{}
+		default:
+			glog.V(4).Infof("Skpping the status update for pod %q for now because the channel is full", update)
+			return false
+		}
+	}
+	if onSuccess != nil {
+		onSuccess()
+	}
+	return true
+}
+
+// needsUpdate returns whether the pod in question has not been updated since it was added to the buffer
+// if it has not, then it needs to be updated
+func (m *manager) needsUpdate(uid types.UID) bool {
+	m.updateSetLock.Lock()
+	defer m.updateSetLock.Unlock()
+	if _, shouldUpdate := m.updateSet[uid]; shouldUpdate {
+		delete(m.updateSet, uid)
+		return true
+	}
+	// it was already updated by a different update.
+	return false
 }
 
 // We add this function, because apiserver only supports *RFC3339* now, which means that the timestamp returned by
@@ -512,7 +397,7 @@ func (m *manager) needsReconcile(uid types.UID, status v1.PodStatus) bool {
 // In fact, the best way to solve this is to do it on api side. However, for now, we normalize the status locally in
 // kubelet temporarily.
 // TODO(random-liu): Remove timestamp related logic after apiserver supports nanosecond or makes it consistent.
-func normalizeStatus(pod *v1.Pod, status *v1.PodStatus) *v1.PodStatus {
+func normalizeStatus(pod *v1.Pod, status *v1.PodStatus) {
 	normalizeTimeStamp := func(t *metav1.Time) {
 		*t = t.Rfc3339Copy()
 	}
@@ -552,7 +437,6 @@ func normalizeStatus(pod *v1.Pod, status *v1.PodStatus) *v1.PodStatus {
 	}
 	// Sort the container statuses, so that the order won't affect the result of comparison
 	kubetypes.SortInitContainerStatuses(pod, status.InitContainerStatuses)
-	return status
 }
 
 // notRunning returns true if every status is terminated or waiting, or the status list


### PR DESCRIPTION
This is the first attempt at solving #37118.  See that for details on why this is needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37119)
<!-- Reviewable:end -->
