### PR TITLE
Add kube-proxy logs to fluentd configs

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -170,6 +170,7 @@
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
@@ -179,10 +180,25 @@
 </source>
 
 # Example:
+# I1118 21:26:53.975789       6 proxier.go:1096] Port "nodePort for kube-system/default-http-backend:http" (:31429/tcp) was open before and is still needed
+<source>
+  type tail
+  format multiline
+  multiline_flush_interval 5s
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+  time_format %m%d %H:%M:%S.%N
+  path /var/log/kube-proxy.log
+  pos_file /var/log/es-kube-proxy.log.pos
+  tag kube-proxy
+</source>
+
+# Example:
 # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
@@ -196,6 +212,7 @@
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
@@ -209,6 +226,7 @@
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
@@ -222,6 +240,7 @@
 <source>
   type tail
   format multiline
+  multiline_flush_interval 5s
   format_firstline /^\w\d{4}/
   format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
   time_format %m%d %H:%M:%S.%N
@@ -229,10 +248,6 @@
   pos_file /var/log/es-rescheduler.log.pos
   tag rescheduler
 </source>
-
-#<filter kubernetes.**>
-#  type kubernetes_metadata
-#</filter>
 
 # Example:
 # I0603 15:31:05.793605       6 cluster_manager.go:230] Reading config from path /etc/gce.conf
@@ -261,6 +276,10 @@
   pos_file /var/log/es-cluster-autoscaler.log.pos
   tag cluster-autoscaler
 </source>
+
+#<filter kubernetes.**>
+#  type kubernetes_metadata
+#</filter>
 
 <match **>
    type elasticsearch

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd-journal.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd-journal.conf
@@ -129,6 +129,20 @@
 </source>
 
 # Example:
+# I1118 21:26:53.975789       6 proxier.go:1096] Port "nodePort for kube-system/default-http-backend:http" (:31429/tcp) was open before and is still needed
+<source>
+  type tail
+  format multiline
+  multiline_flush_interval 5s
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+  time_format %m%d %H:%M:%S.%N
+  path /var/log/kube-proxy.log
+  pos_file /var/log/gcp-kube-proxy.log.pos
+  tag kube-proxy
+</source>
+
+# Example:
 # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
 <source>
   type tail

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
@@ -130,6 +130,20 @@
 </source>
 
 # Example:
+# I1118 21:26:53.975789       6 proxier.go:1096] Port "nodePort for kube-system/default-http-backend:http" (:31429/tcp) was open before and is still needed
+<source>
+  type tail
+  format multiline
+  multiline_flush_interval 5s
+  format_firstline /^\w\d{4}/
+  format1 /^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<message>.*)/
+  time_format %m%d %H:%M:%S.%N
+  path /var/log/kube-proxy.log
+  pos_file /var/log/gcp-kube-proxy.log.pos
+  tag kube-proxy
+</source>
+
+# Example:
 # I0204 07:00:19.604280       5 handlers.go:131] GET /api/v1/nodes: (1.624207ms) 200 [[kube-controller-manager/v1.1.3 (linux/amd64) kubernetes/6a81b50] 127.0.0.1:38266]
 <source>
   type tail


### PR DESCRIPTION
Related to https://github.com/kubernetes/kubernetes/issues/37107

Makes fluentd collect logs from kube-proxy. It's completely backward-compatible change that does not cause problems currently, so I suggest not to bump version.

cc @piosz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37123)
<!-- Reviewable:end -->
