### PR TITLE
CRI: address knows issues of seccomp

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -665,7 +665,8 @@ type PodSandboxConfig struct {
 	//      * runtime/default: the default profile for the container runtime
 	//      * unconfined: unconfined profile, ie, no seccomp sandboxing
 	//      * localhost/<profile-name>: the profile installed to the node's
-	//        local seccomp profile root
+	//        local seccomp profile root. Note that profile root is set in
+	//        kubelet, and it is not passed in CRI yet, see https://issues.k8s.io/36997.
 	//
 	// 3. Sysctls
 	//

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -255,7 +255,8 @@ message PodSandboxConfig {
     //      * runtime/default: the default profile for the container runtime
     //      * unconfined: unconfined profile, ie, no seccomp sandboxing
     //      * localhost/<profile-name>: the profile installed to the node's
-    //        local seccomp profile root
+    //        local seccomp profile root. Note that profile root is set in
+    //        kubelet, and it is not passed in CRI yet, see https://issues.k8s.io/36997.
     //
     // 3. Sysctls
     //


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/36997.

To move forward, we decided to list seccomp profile path problem as a know issue in CRI (see [here](https://github.com/kubernetes/kubernetes/issues/36997#issuecomment-261673120)).

cc/ @yujuhong @euank @kubernetes/sig-node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37135)
<!-- Reviewable:end -->
