### PR TITLE
Bumps up Addon Manager to v6.0 with full support of kubectl apply

### DIFF
--- a/cluster/addons/README.md
+++ b/cluster/addons/README.md
@@ -7,8 +7,7 @@ Kubernetes clusters. The add-ons are visible through the API (they can be listed
 because the system will bring them back to the original state, in particular:
 - If an add-on is deleted, it will be recreated automatically.
 - If an add-on is updated through Apiserver, it will be reconfigured to the state given by
-the supplied fields in the initial config. Though it is fine to modify a field that was
-unspecified.
+the supplied fields in the initial config.
 
 On the cluster, the add-ons are kept in `/etc/kubernetes/addons` on the master node, in
 yaml / json files. The addon manager periodically `kubectl apply`s the contents of this

--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 6.0 (Fri November 18 2016 Zihong Zheng <zihongz@google.com>)
+ - Upgrade Addon Manager to use `kubectl apply`.
+
 ### Version 5.2 (Wed October 26 2016 Zihong Zheng <zihongz@google.com>)
  - Added support for ConfigMap and upgraded kubectl version to v1.4.4 (pr #35255)
 

--- a/cluster/addons/addon-manager/Dockerfile
+++ b/cluster/addons/addon-manager/Dockerfile
@@ -14,12 +14,6 @@
 
 FROM BASEIMAGE
 
-# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
-# If we're building normally, for amd64, CROSS_BUILD lines are removed
-CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
-
-RUN pip install pyyaml
-
 ADD kube-addons.sh /opt/
 ADD namespace.yaml /opt/
 ADD kubectl /usr/local/bin/

--- a/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.0-alpha.1",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.0",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.0-alpha.1",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.0",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -10,7 +10,7 @@ spec:
   containers:
   - name: kube-addon-manager
     # When updating version also bump it in cluster/images/hyperkube/static-pods/addon-manager.json
-    image: gcr.io/google-containers/kube-addon-manager:v6.0-alpha.1
+    image: gcr.io/google-containers/kube-addon-manager:v6.0
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
Below images are built and pushed:
- gcr.io/google-containers/kube-addon-manager:v6.0
- gcr.io/google-containers/kube-addon-manager-amd64:v6.0
- gcr.io/google-containers/kube-addon-manager-arm:v6.0
- gcr.io/google-containers/kube-addon-manager-arm64:v6.0
- gcr.io/google-containers/kube-addon-manager-ppc64le:v6.0

The actual change made is upgrade kubectl version from `v1.5.0-alpha.1` to `v1.5.0-beta.1`, which is released today.

@mikedanese 

@saad-ali This need to get into 1.5 because Addon Manager v6.0-alpha.1 (currently in used) does not have full support of `kubectl apply --prune`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37139)
<!-- Reviewable:end -->
