### PR TITLE
Automated cherry pick of #33848 #34778 #35013 #36924

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1134,7 +1134,7 @@ function start-rescheduler {
 # Setup working directory for kubelet.
 function setup-kubelet-dir {
     echo "Making /var/lib/kubelet executable for kubelet"
-    mount --bind /var/lib/kubelet /var/lib/kubelet/
+    mount -B /var/lib/kubelet /var/lib/kubelet/
     mount -B -o remount,exec,suid,dev /var/lib/kubelet
 }
 

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -589,7 +589,7 @@ function start-kube-proxy {
     params+=" --feature-gates=${FEATURE_GATES}"
   fi
   if [[ -n "${KUBEPROXY_TEST_ARGS:-}" ]]; then
-    params+=" ${KUBE_PROXY_TEST_ARGS}"
+    params+=" ${KUBEPROXY_TEST_ARGS}"
   fi
   sed -i -e "s@{{kubeconfig}}@${kubeconfig}@g" ${src_file}
   sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${kube_docker_registry}@g" ${src_file}
@@ -1135,7 +1135,7 @@ function start-rescheduler {
 function setup-kubelet-dir {
     echo "Making /var/lib/kubelet executable for kubelet"
     mount --bind /var/lib/kubelet /var/lib/kubelet/
-    mount -B -o remount,exec,suid,dev /var/lib/kubelet    
+    mount -B -o remount,exec,suid,dev /var/lib/kubelet
 }
 
 function reset-motd {

--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -34,6 +34,7 @@ import (
 // and credentialprovider.
 var AWSRegions = [...]string{
 	"us-east-1",
+	"us-east-2",
 	"us-west-1",
 	"us-west-2",
 	"eu-west-1",

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -52,6 +52,7 @@ type DrainOptions struct {
 	nodeInfo           *resource.Info
 	out                io.Writer
 	typer              runtime.ObjectTyper
+	ifPrint            bool
 }
 
 // Takes a pod and returns a bool indicating whether or not to operate on the
@@ -193,6 +194,8 @@ func (o *DrainOptions) SetupDrain(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	o.ifPrint = true
 
 	r := o.factory.NewBuilder(cmdutil.GetIncludeThirdPartyAPIs(cmd)).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
@@ -393,26 +396,42 @@ func (o *DrainOptions) deletePods(pods []api.Pod) error {
 		cmdutil.PrintSuccess(o.mapper, false, o.out, "pod", pod.Name, "deleted")
 	}
 
-	return wait.PollImmediate(kubectl.Interval, o.Timeout, func() (bool, error) {
-		pendingPodCnt := 0
+	getPodFn := func(namespace, name string) (*api.Pod, error) {
+		return o.client.Core().Pods(namespace).Get(name)
+	}
+	pendingPods, err := o.waitForDelete(pods, kubectl.Interval, o.Timeout, getPodFn)
+	if err != nil {
+		fmt.Fprintf(o.out, "There are pending pods when an error occured:\n")
+		for _, pendindPod := range pendingPods {
+			cmdutil.PrintSuccess(o.mapper, true, o.out, "pod", pendindPod.Name, false, "")
+		}
+	}
+	return err
+}
+
+func (o *DrainOptions) waitForDelete(pods []api.Pod, interval, timeout time.Duration, getPodFn func(namespace, name string) (*api.Pod, error)) ([]api.Pod, error) {
+	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
+		pendingPods := []api.Pod{}
 		for i, pod := range pods {
-			p, err := o.client.Core().Pods(pod.Namespace).Get(pod.Name)
+			p, err := getPodFn(pod.Namespace, pod.Name)
 			if apierrors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
-				cmdutil.PrintSuccess(o.mapper, false, o.out, "pod", pod.Name, false, "deleted")
+				if o.ifPrint {
+					cmdutil.PrintSuccess(o.mapper, false, o.out, "pod", pod.Name, false, "deleted")
+				}
 				continue
 			} else if err != nil {
 				return false, err
 			} else {
-				pods[pendingPodCnt] = pods[i]
-				pendingPodCnt++
+				pendingPods = append(pendingPods, pods[i])
 			}
 		}
-		if pendingPodCnt > 0 {
-			pods = pods[:pendingPodCnt]
+		pods = pendingPods
+		if len(pendingPods) > 0 {
 			return false, nil
 		}
 		return true, nil
 	})
+	return pods, err
 }
 
 // RunCordonOrUncordon runs either Cordon or Uncordon.  The desired value for

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -397,13 +397,13 @@ func (o *DrainOptions) deletePods(pods []api.Pod) error {
 	}
 
 	getPodFn := func(namespace, name string) (*api.Pod, error) {
-		return o.client.Core().Pods(namespace).Get(name)
+		return o.client.Pods(namespace).Get(name)
 	}
 	pendingPods, err := o.waitForDelete(pods, kubectl.Interval, o.Timeout, getPodFn)
 	if err != nil {
 		fmt.Fprintf(o.out, "There are pending pods when an error occured:\n")
 		for _, pendindPod := range pendingPods {
-			cmdutil.PrintSuccess(o.mapper, true, o.out, "pod", pendindPod.Name, false, "")
+			cmdutil.PrintSuccess(o.mapper, true, o.out, "pod", pendindPod.Name, "")
 		}
 	}
 	return err
@@ -416,7 +416,7 @@ func (o *DrainOptions) waitForDelete(pods []api.Pod, interval, timeout time.Dura
 			p, err := getPodFn(pod.Namespace, pod.Name)
 			if apierrors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
 				if o.ifPrint {
-					cmdutil.PrintSuccess(o.mapper, false, o.out, "pod", pod.Name, false, "deleted")
+					cmdutil.PrintSuccess(o.mapper, false, o.out, "pod", pod.Name, "deleted")
 				}
 				continue
 			} else if err != nil {

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -22,18 +22,22 @@ import (
 	"io"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	client "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/kubectl"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/wait"
 )
 
 type DrainOptions struct {
@@ -42,6 +46,7 @@ type DrainOptions struct {
 	Force              bool
 	GracePeriodSeconds int
 	IgnoreDaemonsets   bool
+	Timeout            time.Duration
 	DeleteLocalData    bool
 	mapper             meta.RESTMapper
 	nodeInfo           *resource.Info
@@ -166,6 +171,7 @@ func NewCmdDrain(f *cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&options.IgnoreDaemonsets, "ignore-daemonsets", false, "Ignore DaemonSet-managed pods.")
 	cmd.Flags().BoolVar(&options.DeleteLocalData, "delete-local-data", false, "Continue even if there are pods using emptyDir (local data that will be deleted when the node is drained).")
 	cmd.Flags().IntVar(&options.GracePeriodSeconds, "grace-period", -1, "Period of time in seconds given to each pod to terminate gracefully. If negative, the default value specified in the pod will be used.")
+	cmd.Flags().DurationVar(&options.Timeout, "timeout", 0, "The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object")
 	return cmd
 }
 
@@ -387,7 +393,26 @@ func (o *DrainOptions) deletePods(pods []api.Pod) error {
 		cmdutil.PrintSuccess(o.mapper, false, o.out, "pod", pod.Name, "deleted")
 	}
 
-	return nil
+	return wait.PollImmediate(kubectl.Interval, o.Timeout, func() (bool, error) {
+		pendingPodCnt := 0
+		for i, pod := range pods {
+			p, err := o.client.Core().Pods(pod.Namespace).Get(pod.Name)
+			if apierrors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID) {
+				cmdutil.PrintSuccess(o.mapper, false, o.out, "pod", pod.Name, false, "deleted")
+				continue
+			} else if err != nil {
+				return false, err
+			} else {
+				pods[pendingPodCnt] = pods[i]
+				pendingPodCnt++
+			}
+		}
+		if pendingPodCnt > 0 {
+			pods = pods[:pendingPodCnt]
+			return false, nil
+		}
+		return true, nil
+	})
 }
 
 // RunCordonOrUncordon runs either Cordon or Uncordon.  The desired value for

--- a/pkg/kubectl/cmd/drain_test.go
+++ b/pkg/kubectl/cmd/drain_test.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -44,6 +43,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/types"
+	"k8s.io/kubernetes/pkg/util/wait"
 )
 
 var node *api.Node
@@ -553,12 +553,14 @@ func TestDrain(t *testing.T) {
 }
 
 func TestDeletePods(t *testing.T) {
+	ifHasBeenCalled := map[string]bool{}
 	tests := []struct {
 		description       string
 		interval          time.Duration
 		timeout           time.Duration
 		expectPendingPods bool
 		expectError       bool
+		expectedError     *error
 		getPodFn          func(namespace, name string) (*api.Pod, error)
 	}{
 		{
@@ -567,24 +569,24 @@ func TestDeletePods(t *testing.T) {
 			timeout:           10 * time.Second,
 			expectPendingPods: false,
 			expectError:       false,
+			expectedError:     nil,
 			getPodFn: func(namespace, name string) (*api.Pod, error) {
 				oldPodMap, _ := createPods(false)
 				newPodMap, _ := createPods(true)
-				if newPod, found := newPodMap[name]; found {
-					// randomly return old pod
-					if rand.Float32() < 0.6 {
-						oldPod := oldPodMap[name]
+				if oldPod, found := oldPodMap[name]; found {
+					if _, ok := ifHasBeenCalled[name]; !ok {
+						ifHasBeenCalled[name] = true
 						return &oldPod, nil
 					} else {
-						// randomly return a new pod or a NotFound error
-						if rand.Float32() < 0.5 {
+						if oldPod.ObjectMeta.Generation < 4 {
+							newPod := newPodMap[name]
 							return &newPod, nil
 						} else {
-							return &api.Pod{}, apierrors.NewNotFound(unversioned.GroupResource{Resource: "pods"}, name)
+							return nil, apierrors.NewNotFound(unversioned.GroupResource{Resource: "pods"}, name)
 						}
 					}
 				}
-				return &api.Pod{}, apierrors.NewNotFound(unversioned.GroupResource{Resource: "pods"}, name)
+				return nil, apierrors.NewNotFound(unversioned.GroupResource{Resource: "pods"}, name)
 			},
 		},
 		{
@@ -593,12 +595,24 @@ func TestDeletePods(t *testing.T) {
 			timeout:           3 * time.Second,
 			expectPendingPods: true,
 			expectError:       true,
+			expectedError:     &wait.ErrWaitTimeout,
 			getPodFn: func(namespace, name string) (*api.Pod, error) {
 				oldPodMap, _ := createPods(false)
 				if oldPod, found := oldPodMap[name]; found {
 					return &oldPod, nil
 				}
-				return &api.Pod{}, errors.New(fmt.Sprintf("%q: not found", name))
+				return nil, errors.New(fmt.Sprintf("%q: not found", name))
+			},
+		},
+		{
+			description:       "Client error could be passed out",
+			interval:          200 * time.Millisecond,
+			timeout:           5 * time.Second,
+			expectPendingPods: true,
+			expectError:       true,
+			expectedError:     nil,
+			getPodFn: func(namespace, name string) (*api.Pod, error) {
+				return nil, errors.New("This is a random error for testing")
 			},
 		},
 	}
@@ -609,15 +623,25 @@ func TestDeletePods(t *testing.T) {
 		_, pods := createPods(false)
 		pendingPods, err := o.waitForDelete(pods, test.interval, test.timeout, test.getPodFn)
 
-		if test.expectError && err == nil && test.expectPendingPods && len(pendingPods) > 0 {
-			t.Fatalf("%s: unexpected non-error", test.description)
+		if test.expectError {
+			if err == nil {
+				t.Fatalf("%s: unexpected non-error", test.description)
+			} else if test.expectedError != nil {
+				if *test.expectedError != err {
+					t.Fatalf("%s: the error does not match expected error", test.description)
+				}
+			}
 		}
-		if !test.expectError && err != nil && !test.expectPendingPods && len(pendingPods) == 0 {
+		if !test.expectError && err != nil {
 			t.Fatalf("%s: unexpected error", test.description)
 		}
-
+		if test.expectPendingPods && len(pendingPods) == 0 {
+			t.Fatalf("%s: unexpected empty pods", test.description)
+		}
+		if !test.expectPendingPods && len(pendingPods) > 0 {
+			t.Fatalf("%s: unexpected pending pods", test.description)
+		}
 	}
-
 }
 
 func createPods(ifCreateNewPods bool) (map[string]api.Pod, []api.Pod) {
@@ -632,9 +656,10 @@ func createPods(ifCreateNewPods bool) (map[string]api.Pod, []api.Pod) {
 		}
 		pod := api.Pod{
 			ObjectMeta: api.ObjectMeta{
-				Name:      "pod" + string(i),
-				Namespace: "default",
-				UID:       uid,
+				Name:       "pod" + string(i),
+				Namespace:  "default",
+				UID:        uid,
+				Generation: int64(i),
 			},
 		}
 		podMap[pod.Name] = pod

--- a/pkg/kubectl/cmd/drain_test.go
+++ b/pkg/kubectl/cmd/drain_test.go
@@ -473,6 +473,8 @@ func TestDrain(t *testing.T) {
 					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(testapi.Extensions.Codec(), &job)}, nil
 				case m.isFor("GET", "/namespaces/default/replicasets/rs"):
 					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(testapi.Extensions.Codec(), &test.replicaSets[0])}, nil
+				case m.isFor("GET", "/namespaces/default/pods/bar"):
+					return &http.Response{StatusCode: 404, Header: defaultHeader(), Body: objBody(codec, nil)}, nil
 				case m.isFor("GET", "/pods"):
 					values, err := url.ParseQuery(req.URL.RawQuery)
 					if err != nil {

--- a/pkg/kubectl/cmd/drain_test.go
+++ b/pkg/kubectl/cmd/drain_test.go
@@ -18,8 +18,11 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"os"
@@ -31,6 +34,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/batch"
@@ -39,6 +43,7 @@ import (
 	"k8s.io/kubernetes/pkg/conversion"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/types"
 )
 
 var node *api.Node
@@ -545,6 +550,97 @@ func TestDrain(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestDeletePods(t *testing.T) {
+	tests := []struct {
+		description       string
+		interval          time.Duration
+		timeout           time.Duration
+		expectPendingPods bool
+		expectError       bool
+		getPodFn          func(namespace, name string) (*api.Pod, error)
+	}{
+		{
+			description:       "Wait for deleting to complete",
+			interval:          100 * time.Millisecond,
+			timeout:           10 * time.Second,
+			expectPendingPods: false,
+			expectError:       false,
+			getPodFn: func(namespace, name string) (*api.Pod, error) {
+				oldPodMap, _ := createPods(false)
+				newPodMap, _ := createPods(true)
+				if newPod, found := newPodMap[name]; found {
+					// randomly return old pod
+					if rand.Float32() < 0.6 {
+						oldPod := oldPodMap[name]
+						return &oldPod, nil
+					} else {
+						// randomly return a new pod or a NotFound error
+						if rand.Float32() < 0.5 {
+							return &newPod, nil
+						} else {
+							return &api.Pod{}, apierrors.NewNotFound(unversioned.GroupResource{Resource: "pods"}, name)
+						}
+					}
+				}
+				return &api.Pod{}, apierrors.NewNotFound(unversioned.GroupResource{Resource: "pods"}, name)
+			},
+		},
+		{
+			description:       "Deleting could timeout",
+			interval:          200 * time.Millisecond,
+			timeout:           3 * time.Second,
+			expectPendingPods: true,
+			expectError:       true,
+			getPodFn: func(namespace, name string) (*api.Pod, error) {
+				oldPodMap, _ := createPods(false)
+				if oldPod, found := oldPodMap[name]; found {
+					return &oldPod, nil
+				}
+				return &api.Pod{}, errors.New(fmt.Sprintf("%q: not found", name))
+			},
+		},
+	}
+
+	o := DrainOptions{}
+	o.ifPrint = false
+	for _, test := range tests {
+		_, pods := createPods(false)
+		pendingPods, err := o.waitForDelete(pods, test.interval, test.timeout, test.getPodFn)
+
+		if test.expectError && err == nil && test.expectPendingPods && len(pendingPods) > 0 {
+			t.Fatalf("%s: unexpected non-error", test.description)
+		}
+		if !test.expectError && err != nil && !test.expectPendingPods && len(pendingPods) == 0 {
+			t.Fatalf("%s: unexpected error", test.description)
+		}
+
+	}
+
+}
+
+func createPods(ifCreateNewPods bool) (map[string]api.Pod, []api.Pod) {
+	podMap := make(map[string]api.Pod)
+	podSlice := []api.Pod{}
+	for i := 0; i < 8; i++ {
+		var uid types.UID
+		if ifCreateNewPods {
+			uid = types.UID(i)
+		} else {
+			uid = types.UID(string(i) + string(i))
+		}
+		pod := api.Pod{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "pod" + string(i),
+				Namespace: "default",
+				UID:       uid,
+			},
+		}
+		podMap[pod.Name] = pod
+		podSlice = append(podSlice, pod)
+	}
+	return podMap, podSlice
 }
 
 type MyReq struct {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -614,9 +614,9 @@ func WaitForPodsSuccess(c *client.Client, ns string, successPodLabels map[string
 
 // WaitForPodsRunningReady waits up to timeout to ensure that all pods in
 // namespace ns are either running and ready, or failed but controlled by a
-// replication controller. Also, it ensures that at least minPods are running
-// and ready. It has separate behavior from other 'wait for' pods functions in
-// that it requires the list of pods on every iteration. This is useful, for
+// controller. Also, it ensures that at least minPods are running and
+// ready. It has separate behavior from other 'wait for' pods functions in
+// that it requests the list of pods on every iteration. This is useful, for
 // example, in cluster startup, because the number of pods increases while
 // waiting.
 // If ignoreLabels is not empty, pods matching this selector are ignored and
@@ -641,17 +641,30 @@ func WaitForPodsRunningReady(c *client.Client, ns string, minPods int32, timeout
 	}()
 
 	if wait.PollImmediate(Poll, timeout, func() (bool, error) {
-		// We get the new list of pods and replication controllers in every
-		// iteration because more pods come online during startup and we want to
-		// ensure they are also checked.
+		// We get the new list of pods, replication controllers, and
+		// replica sets in every iteration because more pods come
+		// online during startup and we want to ensure they are also
+		// checked.
+		replicas, replicaOk := int32(0), int32(0)
+
 		rcList, err := c.ReplicationControllers(ns).List(api.ListOptions{})
 		if err != nil {
 			Logf("Error getting replication controllers in namespace '%s': %v", ns, err)
 			return false, nil
 		}
-		replicas := int32(0)
 		for _, rc := range rcList.Items {
 			replicas += rc.Spec.Replicas
+			replicaOk += rc.Status.ReadyReplicas
+		}
+
+		rsList, err := c.Extensions().ReplicaSets(ns).List(api.ListOptions{})
+		if err != nil {
+			Logf("Error getting replication sets in namespace %q: %v", ns, err)
+			return false, nil
+		}
+		for _, rs := range rsList.Items {
+			replicas += rs.Spec.Replicas
+			replicaOk += rs.Status.ReadyReplicas
 		}
 
 		podList, err := c.Pods(ns).List(api.ListOptions{})
@@ -659,7 +672,7 @@ func WaitForPodsRunningReady(c *client.Client, ns string, minPods int32, timeout
 			Logf("Error getting pods in namespace '%s': %v", ns, err)
 			return false, nil
 		}
-		nOk, replicaOk := int32(0), int32(0)
+		nOk := int32(0)
 		badPods = []api.Pod{}
 		desiredPods = len(podList.Items)
 		for _, pod := range podList.Items {
@@ -669,18 +682,15 @@ func WaitForPodsRunningReady(c *client.Client, ns string, minPods int32, timeout
 			}
 			if res, err := PodRunningReady(&pod); res && err == nil {
 				nOk++
-				if hasReplicationControllersForPod(rcList, pod) {
-					replicaOk++
-				}
 			} else {
 				if pod.Status.Phase != api.PodFailed {
 					Logf("The status of Pod %s is %s, waiting for it to be either Running or Failed", pod.ObjectMeta.Name, pod.Status.Phase)
 					badPods = append(badPods, pod)
-				} else if !hasReplicationControllersForPod(rcList, pod) {
-					Logf("Pod %s is Failed, but it's not controlled by a ReplicationController", pod.ObjectMeta.Name)
+				} else if _, ok := pod.Annotations[api.CreatedByAnnotation]; !ok {
+					Logf("Pod %s is Failed, but it's not controlled by a controller", pod.ObjectMeta.Name)
 					badPods = append(badPods, pod)
 				}
-				//ignore failed pods that are controlled by a replication controller
+				//ignore failed pods that are controlled by some controller
 			}
 		}
 


### PR DESCRIPTION
Cherry pick of #33848 #34778 #35013 #36924 on release-1.4.

#33848: Correct env var name in configure-helper
#34778: wait until the pods are deleted completely
#35013: AWS: recognize us-east-2 region
#36924: Replace controller presence checking logic

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37140)
<!-- Reviewable:end -->
