### PR TITLE
extend admissions with stop channel

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -284,7 +284,7 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	admissionControlPluginNames := strings.Split(s.GenericServerRunOptions.AdmissionControl, ",")
-	pluginInitializer := kubeadmission.NewPluginInitializer(client, sharedInformers, apiAuthorizer)
+	pluginInitializer := kubeadmission.NewPluginInitializer(client, sharedInformers, apiAuthorizer, nil)
 	admissionConfigProvider, err := admission.ReadAdmissionConfiguration(admissionControlPluginNames, s.GenericServerRunOptions.AdmissionControlConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to read plugin config: %v", err)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -172,7 +172,7 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	admissionControlPluginNames := strings.Split(s.GenericServerRunOptions.AdmissionControl, ",")
-	pluginInitializer := kubeapiserveradmission.NewPluginInitializer(client, sharedInformers, apiAuthorizer)
+	pluginInitializer := kubeapiserveradmission.NewPluginInitializer(client, sharedInformers, apiAuthorizer, nil)
 	admissionConfigProvider, err := admission.ReadAdmissionConfiguration(admissionControlPluginNames, s.GenericServerRunOptions.AdmissionControlConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to read plugin config: %v", err)

--- a/pkg/kubeapiserver/admission/BUILD
+++ b/pkg/kubeapiserver/admission/BUILD
@@ -26,6 +26,7 @@ go_library(
     deps = [
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/controller/informers:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/apiserver/pkg/admission",
         "//vendor:k8s.io/apiserver/pkg/authorization/authorizer",
     ],

--- a/pkg/kubeapiserver/admission/init_test.go
+++ b/pkg/kubeapiserver/admission/init_test.go
@@ -51,7 +51,7 @@ var _ WantsAuthorizer = &WantAuthorizerAdmission{}
 // TestWantsAuthorizer ensures that the authorizer is injected when the WantsAuthorizer
 // interface is implemented.
 func TestWantsAuthorizer(t *testing.T) {
-	initializer := NewPluginInitializer(nil, nil, &TestAuthorizer{})
+	initializer := NewPluginInitializer(nil, nil, &TestAuthorizer{}, nil)
 	wantAuthorizerAdmission := &WantAuthorizerAdmission{}
 	initializer.Initialize(wantAuthorizerAdmission)
 	if wantAuthorizerAdmission.auth == nil {

--- a/pkg/kubeapiserver/admission/initializer.go
+++ b/pkg/kubeapiserver/admission/initializer.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/controller/informers"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // TODO add a `WantsToRun` which takes a stopCh.  Might make it generic.
@@ -37,6 +38,11 @@ type WantsInformerFactory interface {
 	admission.Validator
 }
 
+// WantsToRun defines a function which Runs admission plugins that need it
+type WantsToRun interface {
+	Run(stopCh <-chan struct{})
+}
+
 // WantsAuthorizer defines a function which sets Authorizer for admission plugins that need it.
 type WantsAuthorizer interface {
 	SetAuthorizer(authorizer.Authorizer)
@@ -47,16 +53,18 @@ type pluginInitializer struct {
 	internalClient internalclientset.Interface
 	informers      informers.SharedInformerFactory
 	authorizer     authorizer.Authorizer
+	stopCh         <-chan struct{}
 }
 
 var _ admission.PluginInitializer = pluginInitializer{}
 
 // NewPluginInitializer constructs new instance of PluginInitializer
-func NewPluginInitializer(internalClient internalclientset.Interface, sharedInformers informers.SharedInformerFactory, authz authorizer.Authorizer) admission.PluginInitializer {
+func NewPluginInitializer(internalClient internalclientset.Interface, sharedInformers informers.SharedInformerFactory, authz authorizer.Authorizer, stopCh <-chan struct{}) admission.PluginInitializer {
 	return pluginInitializer{
 		internalClient: internalClient,
 		informers:      sharedInformers,
 		authorizer:     authz,
+		stopCh:         stopCh,
 	}
 }
 
@@ -65,6 +73,14 @@ func NewPluginInitializer(internalClient internalclientset.Interface, sharedInfo
 func (i pluginInitializer) Initialize(plugin admission.Interface) {
 	if wants, ok := plugin.(WantsInternalClientSet); ok {
 		wants.SetInternalClientSet(i.internalClient)
+	}
+
+	if wants, ok := plugin.(WantsToRun); ok {
+		if i.stopCh == nil {
+			wants.Run(wait.NeverStop)
+		} else {
+			wants.Run(i.stopCh)
+		}
 	}
 
 	if wants, ok := plugin.(WantsInformerFactory); ok {

--- a/plugin/pkg/admission/limitranger/admission_test.go
+++ b/plugin/pkg/admission/limitranger/admission_test.go
@@ -595,7 +595,7 @@ func newHandlerForTest(c clientset.Interface) (admission.Interface, informers.Sh
 	if err != nil {
 		return nil, f, err
 	}
-	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil)
+	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err = admission.Validate(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/namespace/autoprovision/admission_test.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission_test.go
@@ -38,7 +38,7 @@ import (
 func newHandlerForTest(c clientset.Interface) (admission.Interface, informers.SharedInformerFactory, error) {
 	f := informers.NewSharedInformerFactory(nil, c, 5*time.Minute)
 	handler := NewProvision()
-	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil)
+	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err := admission.Validate(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/namespace/exists/admission_test.go
+++ b/plugin/pkg/admission/namespace/exists/admission_test.go
@@ -37,7 +37,7 @@ import (
 func newHandlerForTest(c clientset.Interface) (admission.Interface, informers.SharedInformerFactory, error) {
 	f := informers.NewSharedInformerFactory(nil, c, 5*time.Minute)
 	handler := NewExists()
-	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil)
+	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err := admission.Validate(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/namespace/lifecycle/admission_test.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission_test.go
@@ -47,7 +47,7 @@ func newHandlerForTestWithClock(c clientset.Interface, cacheClock clock.Clock) (
 	if err != nil {
 		return nil, f, err
 	}
-	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil)
+	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err = admission.Validate(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/podnodeselector/admission_test.go
+++ b/plugin/pkg/admission/podnodeselector/admission_test.go
@@ -182,7 +182,7 @@ func TestHandles(t *testing.T) {
 func newHandlerForTest(c clientset.Interface) (*podNodeSelector, informers.SharedInformerFactory, error) {
 	f := informers.NewSharedInformerFactory(nil, c, 5*time.Minute)
 	handler := NewPodNodeSelector(nil)
-	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil)
+	pluginInitializer := kubeadmission.NewPluginInitializer(c, f, nil, nil)
 	pluginInitializer.Initialize(handler)
 	err := admission.Validate(handler)
 	return handler, f, err

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -129,13 +129,15 @@ func TestAdmissionIgnoresDelete(t *testing.T) {
 
 	quotaAccessor, _ := newQuotaAccessor(kubeClient)
 	quotaAccessor.indexer = indexer
-	go quotaAccessor.Run(stopCh)
-	evaluator := NewQuotaEvaluator(quotaAccessor, install.NewRegistry(nil, nil), nil, 5, stopCh)
 
 	handler := &quotaAdmission{
-		Handler:   admission.NewHandler(admission.Create, admission.Update),
-		evaluator: evaluator,
+		Handler:       admission.NewHandler(admission.Create, admission.Update),
+		quotaAccessor: quotaAccessor,
+		registry:      install.NewRegistry(nil, nil),
+		numEvaluators: 5,
 	}
+	handler.Run(stopCh)
+
 	namespace := "default"
 	err := handler.Admit(admission.NewAttributesRecord(nil, nil, api.Kind("Pod").WithVersion("version"), namespace, "name", api.Resource("pods").WithVersion("version"), "", admission.Delete, nil))
 	if err != nil {

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -65,11 +65,12 @@ func TestQuota(t *testing.T) {
 	admissionCh := make(chan struct{})
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{QPS: -1, Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
 	internalClientset := internalclientset.NewForConfigOrDie(&restclient.Config{QPS: -1, Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	admission, err := resourcequota.NewResourceQuota(quotainstall.NewRegistry(nil, nil), 5, admissionCh)
+	admission, err := resourcequota.NewResourceQuota(quotainstall.NewRegistry(nil, nil), 5)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	admission.(kubeadmission.WantsInternalClientSet).SetInternalClientSet(internalClientset)
+	admission.(kubeadmission.WantsToRun).Run(admissionCh)
 	defer close(admissionCh)
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -425,11 +425,10 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	informers.Start(stopCh)
 	go serviceAccountController.Run(5, stopCh)
 	// Start the admission plugin reflectors
-	serviceAccountAdmission.Run()
+	serviceAccountAdmission.Run(stopCh)
 
 	stop := func() {
 		close(stopCh)
-		serviceAccountAdmission.Stop()
 		apiServer.Close()
 	}
 


### PR DESCRIPTION
Some admissions (``ResourceQuota``, ``ServiceAccount``) run reflectors which are never stopped. When re-creating admission controller in a loop (e.g. for simulation purposes) the number of goroutines grows instead of maintaining approximately constant number of them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37148)
<!-- Reviewable:end -->
