### PR TITLE
thirdparty controller add versions check

### DIFF
--- a/pkg/registry/extensions/rest/BUILD
+++ b/pkg/registry/extensions/rest/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//pkg/registry/extensions/thirdpartyresource/etcd:go_default_library",
         "//pkg/registry/extensions/thirdpartyresourcedata:go_default_library",
         "//pkg/runtime:go_default_library",
+        "//pkg/util/errors:go_default_library",
         "//pkg/util/runtime:go_default_library",
         "//pkg/util/sets:go_default_library",
         "//pkg/util/wait:go_default_library",

--- a/pkg/registry/extensions/rest/thirdparty_controller.go
+++ b/pkg/registry/extensions/rest/thirdparty_controller.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	extensionsclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion"
@@ -82,6 +84,12 @@ func (t *ThirdPartyController) syncResourceList(list runtime.Object) error {
 		// Loop across all schema objects for third party resources
 		for ix := range list.Items {
 			item := &list.Items[ix]
+
+			if len(item.Versions) == 0 {
+				glog.Fatalf("ThirdPartyResource %s has no defined version, skip sync", item.Name)
+				continue
+			}
+
 			// extract the api group and resource kind from the schema
 			_, group, err := thirdpartyresourcedata.ExtractApiGroupAndKind(item)
 			if err != nil {

--- a/pkg/registry/extensions/rest/thirdparty_controller.go
+++ b/pkg/registry/extensions/rest/thirdparty_controller.go
@@ -27,6 +27,7 @@ import (
 	extensionsclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion"
 	"k8s.io/kubernetes/pkg/registry/extensions/thirdpartyresourcedata"
 	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/sets"
 )
 
@@ -81,26 +82,32 @@ func (t *ThirdPartyController) syncResourceList(list runtime.Object) error {
 	existing := sets.String{}
 	switch list := list.(type) {
 	case *extensions.ThirdPartyResourceList:
+		var errs []error
 		// Loop across all schema objects for third party resources
 		for ix := range list.Items {
 			item := &list.Items[ix]
 
 			if len(item.Versions) == 0 {
-				glog.Fatalf("ThirdPartyResource %s has no defined version, skip sync", item.Name)
+				errs = append(errs, fmt.Errorf("ThirdPartyResource %s has no defined version, skip sync", item.Name))
 				continue
 			}
 
 			// extract the api group and resource kind from the schema
 			_, group, err := thirdpartyresourcedata.ExtractApiGroupAndKind(item)
 			if err != nil {
-				return err
+				errs = append(errs, err)
+				continue
 			}
 			// place it in the set of resources that we expect, so that we don't delete it in the delete pass
 			existing.Insert(MakeThirdPartyPath(group))
 			// ensure a RESTful resource for this schema exists on the master
 			if err := t.SyncOneResource(item); err != nil {
-				return err
+				errs = append(errs, fmt.Errorf("Failed to sync ThirdPartyResource %s: %v", item.Name, err))
 			}
+		}
+		if len(errs) != 0 {
+			allErrs := errors.NewAggregate(errs)
+			glog.Errorf("sync ThirdPartyResource get error: %s", allErrs.Error())
 		}
 	default:
 		return fmt.Errorf("expected a *ThirdPartyResourceList, got %#v", list)

--- a/pkg/registry/extensions/rest/thirdparty_controller_test.go
+++ b/pkg/registry/extensions/rest/thirdparty_controller_test.go
@@ -66,7 +66,12 @@ func TestSyncAPIs(t *testing.T) {
 	resourcesNamed := func(names ...string) []expapi.ThirdPartyResource {
 		result := []expapi.ThirdPartyResource{}
 		for _, name := range names {
-			result = append(result, expapi.ThirdPartyResource{ObjectMeta: api.ObjectMeta{Name: name}})
+			result = append(result, expapi.ThirdPartyResource{
+				ObjectMeta: api.ObjectMeta{Name: name},
+				Versions: []expapi.APIVersion{
+					{Name: "v1"},
+				},
+			})
 		}
 		return result
 	}

--- a/pkg/registry/extensions/rest/thirdparty_controller_test.go
+++ b/pkg/registry/extensions/rest/thirdparty_controller_test.go
@@ -63,17 +63,17 @@ func (f *FakeAPIInterface) ListThirdPartyResources() []string {
 }
 
 func TestSyncAPIs(t *testing.T) {
-	resourcesNamed := func(names ...string) []expapi.ThirdPartyResource {
-		result := []expapi.ThirdPartyResource{}
-		for _, name := range names {
-			result = append(result, expapi.ThirdPartyResource{
-				ObjectMeta: api.ObjectMeta{Name: name},
-				Versions: []expapi.APIVersion{
-					{Name: "v1"},
-				},
+	resourceNamed := func(name string, versions ...string) expapi.ThirdPartyResource {
+		apiVersions := []expapi.APIVersion{}
+		for _, version := range versions {
+			apiVersions = append(apiVersions, expapi.APIVersion{
+				Name: version,
 			})
 		}
-		return result
+		return expapi.ThirdPartyResource{
+			ObjectMeta: api.ObjectMeta{Name: name},
+			Versions:   apiVersions,
+		}
 	}
 
 	tests := []struct {
@@ -85,14 +85,19 @@ func TestSyncAPIs(t *testing.T) {
 	}{
 		{
 			list: &expapi.ThirdPartyResourceList{
-				Items: resourcesNamed("foo.example.com"),
+				Items: []expapi.ThirdPartyResource{
+					resourceNamed("foo.example.com", "v1"),
+					resourceNamed("bar.example.com"),
+				},
 			},
 			expectedInstalled: []string{"foo.example.com"},
 			name:              "simple add",
 		},
 		{
 			list: &expapi.ThirdPartyResourceList{
-				Items: resourcesNamed("foo.example.com"),
+				Items: []expapi.ThirdPartyResource{
+					resourceNamed("foo.example.com", "v1"),
+				},
 			},
 			apis: []string{
 				"/apis/example.com",
@@ -102,7 +107,9 @@ func TestSyncAPIs(t *testing.T) {
 		},
 		{
 			list: &expapi.ThirdPartyResourceList{
-				Items: resourcesNamed("foo.example.com"),
+				Items: []expapi.ThirdPartyResource{
+					resourceNamed("foo.example.com", "v1"),
+				},
 			},
 			apis: []string{
 				"/apis/example.com",
@@ -118,7 +125,10 @@ func TestSyncAPIs(t *testing.T) {
 		},
 		{
 			list: &expapi.ThirdPartyResourceList{
-				Items: resourcesNamed("foo.example.com", "foo.company.com"),
+				Items: []expapi.ThirdPartyResource{
+					resourceNamed("foo.example.com", "v1"),
+					resourceNamed("foo.company.com", "v1"),
+				},
 			},
 			apis: []string{
 				"/apis/company.com",
@@ -129,7 +139,9 @@ func TestSyncAPIs(t *testing.T) {
 		},
 		{
 			list: &expapi.ThirdPartyResourceList{
-				Items: resourcesNamed("foo.example.com"),
+				Items: []expapi.ThirdPartyResource{
+					resourceNamed("foo.example.com", "v1"),
+				},
 			},
 			apis: []string{
 				"/apis/company.com",


### PR DESCRIPTION
@liggitt I just remove version check to top level loop, also I think this loop has problem, a single TPR resource sync failure should not break the entire sync process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37192)
<!-- Reviewable:end -->
