### PR TITLE
Filter out non-RestartAlways mirror pod in restart test.

### DIFF
--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -32,17 +32,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func isRestartNeverMirrorPod(p *api.Pod) bool {
+func isNotRestartAlwaysMirrorPod(p *api.Pod) bool {
 	if !kubepod.IsMirrorPod(p) {
 		return false
 	}
-	return p.Spec.RestartPolicy == api.RestartPolicyNever
+	return p.Spec.RestartPolicy != api.RestartPolicyAlways
 }
 
 func filterIrrelevantPods(pods []*api.Pod) []*api.Pod {
 	var results []*api.Pod
 	for _, p := range pods {
-		if isRestartNeverMirrorPod(p) {
+		if isNotRestartAlwaysMirrorPod(p) {
 			// Mirror pods with restart policy == Never will not get
 			// recreated if they are deleted after the pods have
 			// terminated. For now, we discount such pods.


### PR DESCRIPTION
Fixes #37202.

> A quick fix is to filter out non-RestartAlways pods. Because either RestartNever and RestartOnFailure pods could succeed, and we can not deal with terminated mirror pods very well now.

@yujuhong @gmarek 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37203)
<!-- Reviewable:end -->
