### PR TITLE
Elasticsearch data mount is chowned after container start

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -44,9 +44,9 @@ COPY elasticsearch_logging_discovery /
 
 RUN useradd --no-create-home --user-group elasticsearch \
     && mkdir /data \
-    && chown -R elasticsearch:elasticsearch /elasticsearch /elasticsearch_logging_discovery /run.sh /data
+    && chown -R elasticsearch:elasticsearch /elasticsearch
 
 VOLUME ["/data"]
 EXPOSE 9200 9300
 
-CMD ["/bin/su", "-c", "/run.sh", "elasticsearch"]
+CMD /run.sh

--- a/cluster/addons/fluentd-elasticsearch/es-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/es-image/run.sh
@@ -22,4 +22,6 @@ export MINIMUM_MASTER_NODES=${MINIMUM_MASTER_NODES:-2}
 
 /elasticsearch_logging_discovery >> /elasticsearch/config/elasticsearch.yml
 
-/elasticsearch/bin/elasticsearch
+chown -R elasticsearch:elasticsearch /data
+
+/bin/su -c /elasticsearch/bin/elasticsearch elasticsearch


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/37030

@piosz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37219)
<!-- Reviewable:end -->
