### PR TITLE
Check sysfs Type instead of Device

### DIFF
--- a/cmd/kube-proxy/app/conntrack.go
+++ b/cmd/kube-proxy/app/conntrack.go
@@ -98,7 +98,7 @@ func isSysFSWritable() (bool, error) {
 
 	for _, mountPoint := range mountPoints {
 		const sysfsDevice = "sysfs"
-		if mountPoint.Device != sysfsDevice {
+		if mountPoint.Type != sysfsDevice {
 			continue
 		}
 		// Check whether sysfs is 'rw'


### PR DESCRIPTION
Some distribution uses "none" device to mount "sysfs" type, so kube-proxy needs to list mount points and check "types" instead of "device".

fixes #37183 

```release-note
Change sysfs mountpoint tests from Device to Type to be able to find sysfs mountpoint on "none" device
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37220)
<!-- Reviewable:end -->
