### PR TITLE
Update Stateful Set example files for 1.5

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-etcd-statefulset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-etcd-statefulset.yaml
@@ -11,8 +11,6 @@ spec:
   replicas: 1
   template:
     metadata:
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
       labels:
         kubernetes.io/cluster-service: "true"
         k8s-app: calico-etcd

--- a/examples/cockroachdb/cockroachdb-statefulset.yaml
+++ b/examples/cockroachdb/cockroachdb-statefulset.yaml
@@ -66,7 +66,6 @@ spec:
       labels:
         app: cockroachdb
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         # Init containers are run only once in the lifetime of a pod, before
         # it's started up for the first time. It has to exit successfully
         # before the pod's main containers are allowed to start.

--- a/examples/storage/cassandra/README.md
+++ b/examples/storage/cassandra/README.md
@@ -396,16 +396,13 @@ functionality, like a Deployment, ReplicaSet, Replication Controller, or Job.
 
 ## Step 4: Delete Cassandra StatefulSet
 
-There are some limitations with the Alpha release of PetSet in 1.3. From the [documentation](http://kubernetes.io/docs/user-guide/petset/):
-
-"Deleting the StatefulSet will not delete any pods. You will either have to manually scale it down to 0 pods first, or delete the pods yourself.
-Deleting and/or scaling a StatefulSet down will not delete the volumes associated with the StatefulSet. This is done to ensure safety first, your data is more valuable than an auto purge of all related StatefulSet resources. Deleting the Persistent Volume Claims will result in a deletion of the associated volumes."
+Deleting and/or scaling a StatefulSet down will not delete the volumes associated with the StatefulSet. This is done to ensure safety first, your data is more valuable than an auto purge of all related StatefulSet resources. Deleting the Persistent Volume Claims may result in a deletion of the associated volumes, depending on the storage class and reclaim policy. You should never assume ability to access a volume after claim deletion.
 
 Use the following commands to delete the StatefulSet.
 
 ```console
 $ grace=$(kubectl get po cassandra-0 --template '{{.spec.terminationGracePeriodSeconds}}') \
-  && kubectl delete statefulset,po -l app=cassandra \
+  && kubectl delete statefulset -l app=cassandra \
   && echo "Sleeping $grace" \
   && sleep $grace \
   && kubectl delete pvc -l app=cassandra

--- a/examples/storage/cassandra/README.md
+++ b/examples/storage/cassandra/README.md
@@ -188,8 +188,6 @@ spec:
   replicas: 3
   template:
     metadata:
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
       labels:
         app: cassandra
     spec:

--- a/examples/storage/cassandra/cassandra-statefulset.yaml
+++ b/examples/storage/cassandra/cassandra-statefulset.yaml
@@ -7,8 +7,6 @@ spec:
   replicas: 3
   template:
     metadata:
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
       labels:
         app: cassandra
     spec:

--- a/hack/testdata/nginx-statefulset.yaml
+++ b/hack/testdata/nginx-statefulset.yaml
@@ -27,8 +27,6 @@ spec:
     metadata:
       labels:
         app: nginx-statefulset
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
     spec:
       terminationGracePeriodSeconds: 0
       containers:

--- a/test/e2e/testing-manifests/petset/cockroachdb/petset.yaml
+++ b/test/e2e/testing-manifests/petset/cockroachdb/petset.yaml
@@ -10,7 +10,6 @@ spec:
       labels:
         app: cockroachdb
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         # Init containers are run only once in the lifetime of a pod, before
         # it's started up for the first time. It has to exit successfully
         # before the pod's main containers are allowed to start.

--- a/test/e2e/testing-manifests/petset/mysql-galera/petset.yaml
+++ b/test/e2e/testing-manifests/petset/mysql-galera/petset.yaml
@@ -10,7 +10,6 @@ spec:
       labels:
         app: mysql
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         pod.alpha.kubernetes.io/init-containers: '[
             {
                 "name": "install",

--- a/test/e2e/testing-manifests/petset/redis/petset.yaml
+++ b/test/e2e/testing-manifests/petset/redis/petset.yaml
@@ -10,7 +10,6 @@ spec:
       labels:
         app: redis
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         pod.alpha.kubernetes.io/init-containers: '[
             {
                 "name": "install",

--- a/test/e2e/testing-manifests/petset/zookeeper/petset.yaml
+++ b/test/e2e/testing-manifests/petset/zookeeper/petset.yaml
@@ -10,7 +10,6 @@ spec:
       labels:
         app: zk
       annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
         pod.alpha.kubernetes.io/init-containers: '[
             {
                 "name": "install",


### PR DESCRIPTION
1. Remove initialized annotation from statefulset examples
2. Update storage class annotation to beta in statefulset examples
3. Remove alpha limitation on PetSet in cassandra example

cc @erictune @foxish @kow3ns @enisoc @chrislovecnm @kubernetes/sig-apps

```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37231)
<!-- Reviewable:end -->
