### PR TITLE
Revert "Avoid hard-coding list of Node Conditions"

### DIFF
--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -507,22 +507,15 @@ func getNodeConditionPredicate() cache.NodeConditionPredicate {
 			// - NodeReady condition status is ConditionTrue,
 			// - NodeOutOfDisk condition status is ConditionFalse,
 			// - NodeNetworkUnavailable condition status is ConditionFalse.
-			switch cond.Type {
-			case api.NodeReady:
-				if cond.Status != api.ConditionTrue {
-					glog.V(4).Infof("Ignoring node %v with %v condition status %v", node.Name, cond.Type, cond.Status)
-					return false
-				}
-
-			case api.NodeMemoryPressure, api.NodeDiskPressure:
-			// We don't block on "pressure" conditions; these are warnings, not errors!
-
-			default:
-				// We assume everything else is blocking if the condition is True or Unknown
-				if cond.Status != api.ConditionFalse {
-					glog.V(4).Infof("Ignoring node %v with %v condition status %v", node.Name, cond.Type, cond.Status)
-					return false
-				}
+			if cond.Type == api.NodeReady && cond.Status != api.ConditionTrue {
+				glog.V(4).Infof("Ignoring node %v with %v condition status %v", node.Name, cond.Type, cond.Status)
+				return false
+			} else if cond.Type == api.NodeOutOfDisk && cond.Status != api.ConditionFalse {
+				glog.V(4).Infof("Ignoring node %v with %v condition status %v", node.Name, cond.Type, cond.Status)
+				return false
+			} else if cond.Type == api.NodeNetworkUnavailable && cond.Status != api.ConditionFalse {
+				glog.V(4).Infof("Ignoring node %v with %v condition status %v", node.Name, cond.Type, cond.Status)
+				return false
 			}
 		}
 		// Ignore nodes that are marked unschedulable


### PR DESCRIPTION
* we don't know how other API consumers are using node conditions (there was no prior expectation that the scheduler would block on custom conditions)
* not all conditions map directly to schedulability (e.g. `MemoryPressure`/`DiskPressure`)
* not all conditions use True to mean "unschedulable" (e.g. `Ready`)

This reverts commit 511b2ecaa8025364e8ef43427ff08709b056f0cb to avoid breaking existing API users and to avoid constraining future uses of the node conditions API

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37234)
<!-- Reviewable:end -->
