### PR TITLE
Test flake: ignore dig failure; wait until timeout

### DIFF
--- a/test/e2e/dns_configmap.go
+++ b/test/e2e/dns_configmap.go
@@ -200,10 +200,8 @@ func (t *dnsConfigMapTest) runDig(dnsName string) []string {
 		CaptureStderr: true,
 	})
 
-	Expect(err).NotTo(HaveOccurred())
-
-	framework.Logf("Running dig: %v, stdout: %q, stderr: %q",
-		cmd, stdout, stderr)
+	framework.Logf("Running dig: %v, stdout: %q, stderr: %q, err: %v",
+		cmd, stdout, stderr, err)
 
 	if stdout == "" {
 		return []string{}


### PR DESCRIPTION
The intent of this test was to continue trying until the timeout has
been reached. The extra assertion makes the test fail early when it
should not.

https://github.com/kubernetes/kubernetes/issues/37144

fix 37114

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37235)
<!-- Reviewable:end -->
