### PR TITLE
Update the timeout in CLOSE_WAIT e2e test

### DIFF
--- a/test/e2e/kube_proxy.go
+++ b/test/e2e/kube_proxy.go
@@ -180,7 +180,8 @@ var _ = framework.KubeDescribe("Network", func() {
 			fmt.Sprintf(
 				"sudo cat /proc/net/ip_conntrack "+
 					"| grep 'CLOSE_WAIT.*dst=%v.*dport=%v' "+
-					"| awk '{print $3}'",
+					"| tail -n 1"+
+					"| awk '{print $3}' ",
 				serverNodeInfo.nodeIp,
 				testDaemonTcpPort),
 			framework.TestContext.Provider,
@@ -193,7 +194,7 @@ var _ = framework.KubeDescribe("Network", func() {
 		// These must be synchronized from the default values set in
 		// pkg/apis/../defaults.go ConntrackTCPCloseWaitTimeout. The
 		// current defaults are hidden in the initialization code.
-		const epsilonSeconds = 10
+		const epsilonSeconds = 60
 		const expectedTimeoutSeconds = 60 * 60
 
 		framework.Logf("conntrack entry timeout was: %v, expected: %v",


### PR DESCRIPTION
I see some test flakes due to the timeout being too strict,
updating to a larger value.

Adding tail -n 1, it looks like there may be leftover state for other
runs. We really only care about one of the CLOSE_WAIT entries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37236)
<!-- Reviewable:end -->
