### PR TITLE
Update [Feature:PetSet] e2e tests to [Feature:StatefulSet]

### DIFF
--- a/test/e2e/network_partition.go
+++ b/test/e2e/network_partition.go
@@ -383,7 +383,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			deleteAllStatefulSets(c, ns)
 		})
 
-		It("should come back up if node goes down [Slow] [Disruptive] [Feature:PetSet]", func() {
+		It("should come back up if node goes down [Slow] [Disruptive]", func() {
 			petMounts := []api.VolumeMount{{Name: "datadir", MountPath: "/data/"}}
 			podMounts := []api.VolumeMount{{Name: "home", MountPath: "/home"}}
 			ps := newStatefulSet(psName, ns, headlessSvcName, 3, petMounts, podMounts, labels)
@@ -401,7 +401,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			pst.waitForRunningAndReady(ps.Spec.Replicas, ps)
 		})
 
-		It("should not reschedule pets if there is a network partition [Slow] [Disruptive] [Feature:PetSet]", func() {
+		It("should not reschedule pets if there is a network partition [Slow] [Disruptive]", func() {
 			ps := newStatefulSet(psName, ns, headlessSvcName, 3, []api.VolumeMount{}, []api.VolumeMount{}, labels)
 			_, err := c.Apps().StatefulSets(ns).Create(ps)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -64,10 +64,9 @@ const (
 	readTimeout = 60 * time.Second
 )
 
-// Time: 25m, slow by design.
 // GCE Quota requirements: 3 pds, one per pet manifest declared above.
 // GCE Api requirements: nodes and master need storage r/w permissions.
-var _ = framework.KubeDescribe("StatefulSet [Slow]", func() {
+var _ = framework.KubeDescribe("StatefulSet", func() {
 	f := framework.NewDefaultFramework("statefulset")
 	var ns string
 	var c clientset.Interface
@@ -348,7 +347,7 @@ var _ = framework.KubeDescribe("StatefulSet [Slow]", func() {
 		})
 	})
 
-	framework.KubeDescribe("Deploy clustered applications [Feature:StatefulSet]", func() {
+	framework.KubeDescribe("Deploy clustered applications [Feature:StatefulSet] [Slow]", func() {
 		var pst *statefulSetTester
 		var appTester *clusterAppTester
 
@@ -387,7 +386,7 @@ var _ = framework.KubeDescribe("StatefulSet [Slow]", func() {
 	})
 })
 
-var _ = framework.KubeDescribe("Stateful Set recreate [Slow]", func() {
+var _ = framework.KubeDescribe("Stateful Set recreate", func() {
 	f := framework.NewDefaultFramework("pet-set-recreate")
 	var c clientset.Interface
 	var ns string

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -67,7 +67,7 @@ const (
 // Time: 25m, slow by design.
 // GCE Quota requirements: 3 pds, one per pet manifest declared above.
 // GCE Api requirements: nodes and master need storage r/w permissions.
-var _ = framework.KubeDescribe("StatefulSet [Slow] [Feature:PetSet]", func() {
+var _ = framework.KubeDescribe("StatefulSet [Slow]", func() {
 	f := framework.NewDefaultFramework("statefulset")
 	var ns string
 	var c clientset.Interface
@@ -106,7 +106,7 @@ var _ = framework.KubeDescribe("StatefulSet [Slow] [Feature:PetSet]", func() {
 			deleteAllStatefulSets(c, ns)
 		})
 
-		It("should provide basic identity [Feature:StatefulSet]", func() {
+		It("should provide basic identity", func() {
 			By("Creating statefulset " + psName + " in namespace " + ns)
 			ps.Spec.Replicas = 3
 			setInitializedAnnotation(ps, "false")
@@ -116,7 +116,7 @@ var _ = framework.KubeDescribe("StatefulSet [Slow] [Feature:PetSet]", func() {
 
 			pst := statefulSetTester{c: c}
 
-			By("Saturating pet set " + ps.Name)
+			By("Saturating stateful set " + ps.Name)
 			pst.saturate(ps)
 
 			By("Verifying statefulset mounted data directory is usable")
@@ -141,7 +141,7 @@ var _ = framework.KubeDescribe("StatefulSet [Slow] [Feature:PetSet]", func() {
 			ExpectNoError(pst.execInPets(ps, cmd))
 		})
 
-		It("should handle healthy pet restarts during scale [Feature:PetSet]", func() {
+		It("should handle healthy pet restarts during scale", func() {
 			By("Creating statefulset " + psName + " in namespace " + ns)
 			ps.Spec.Replicas = 2
 			setInitializedAnnotation(ps, "false")
@@ -348,7 +348,7 @@ var _ = framework.KubeDescribe("StatefulSet [Slow] [Feature:PetSet]", func() {
 		})
 	})
 
-	framework.KubeDescribe("Deploy clustered applications [Slow] [Feature:PetSet]", func() {
+	framework.KubeDescribe("Deploy clustered applications [Feature:StatefulSet]", func() {
 		var pst *statefulSetTester
 		var appTester *clusterAppTester
 
@@ -365,29 +365,29 @@ var _ = framework.KubeDescribe("StatefulSet [Slow] [Feature:PetSet]", func() {
 			deleteAllStatefulSets(c, ns)
 		})
 
-		It("should creating a working zookeeper cluster [Feature:PetSet]", func() {
+		It("should creating a working zookeeper cluster", func() {
 			appTester.pet = &zookeeperTester{tester: pst}
 			appTester.run()
 		})
 
-		It("should creating a working redis cluster [Feature:PetSet]", func() {
+		It("should creating a working redis cluster", func() {
 			appTester.pet = &redisTester{tester: pst}
 			appTester.run()
 		})
 
-		It("should creating a working mysql cluster [Feature:PetSet]", func() {
+		It("should creating a working mysql cluster", func() {
 			appTester.pet = &mysqlGaleraTester{tester: pst}
 			appTester.run()
 		})
 
-		It("should creating a working CockroachDB cluster [Feature:PetSet]", func() {
+		It("should creating a working CockroachDB cluster", func() {
 			appTester.pet = &cockroachDBTester{tester: pst}
 			appTester.run()
 		})
 	})
 })
 
-var _ = framework.KubeDescribe("Pet set recreate [Slow] [Feature:PetSet]", func() {
+var _ = framework.KubeDescribe("Stateful Set recreate [Slow]", func() {
 	f := framework.NewDefaultFramework("pet-set-recreate")
 	var c clientset.Interface
 	var ns string
@@ -420,7 +420,7 @@ var _ = framework.KubeDescribe("Pet set recreate [Slow] [Feature:PetSet]", func(
 	})
 
 	It("should recreate evicted statefulset", func() {
-		By("looking for a node to schedule pet set and pod")
+		By("looking for a node to schedule stateful set and pod")
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 		node := nodes.Items[0]
 
@@ -461,7 +461,7 @@ var _ = framework.KubeDescribe("Pet set recreate [Slow] [Feature:PetSet]", func(
 		By("waiting until pet pod " + petPodName + " will be recreated and deleted at least once in namespace " + f.Namespace.Name)
 		w, err := f.ClientSet.Core().Pods(f.Namespace.Name).Watch(api.SingleObject(api.ObjectMeta{Name: petPodName}))
 		framework.ExpectNoError(err)
-		// we need to get UID from pod in any state and wait until pet set controller will remove pod atleast once
+		// we need to get UID from pod in any state and wait until stateful set controller will remove pod atleast once
 		_, err = watch.Until(petPodTimeout, w, func(event watch.Event) (bool, error) {
 			pod := event.Object.(*api.Pod)
 			switch event.Type {
@@ -984,13 +984,13 @@ func (p *statefulSetTester) waitForStatus(ps *apps.StatefulSet, expectedReplicas
 				return false, err
 			}
 			if psGet.Status.Replicas != expectedReplicas {
-				framework.Logf("Waiting for pet set status to become %d, currently %d", expectedReplicas, psGet.Status.Replicas)
+				framework.Logf("Waiting for stateful set status to become %d, currently %d", expectedReplicas, psGet.Status.Replicas)
 				return false, nil
 			}
 			return true, nil
 		})
 	if pollErr != nil {
-		framework.Failf("Failed waiting for pet set status.replicas updated to %d: %v", expectedReplicas, pollErr)
+		framework.Failf("Failed waiting for stateful set status.replicas updated to %d: %v", expectedReplicas, pollErr)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Update StatefulSet e2e test feature tags from [Feature:PetSet] to [Feature:StatefulSet]

**Special notes for your reviewer**: Ref test-infra changes https://github.com/kubernetes/test-infra/pull/1151

cc @erictune @foxish @kow3ns @enisoc @kubernetes/sig-apps

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37243)
<!-- Reviewable:end -->
