### PR TITLE
Include serial port output in GCP log-dump

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -97,6 +97,8 @@ function copy-logs-from-node() {
     else
       case "${KUBERNETES_PROVIDER}" in
         gce|gke|kubemark)
+          # get-serial-port-output lets you ask for ports 1-4, but currently (11/21/2016) only port 1 contains useful information
+          gcloud compute instances get-serial-port-output --project "${PROJECT}" --zone "${ZONE}" --port 1 "${node}" > "${dir}/serial-1.log" || true
           gcloud compute copy-files --project "${PROJECT}" --zone "${ZONE}" "${node}:${scp_files}" "${dir}" > /dev/null || true
           ;;
         aws)


### PR DESCRIPTION
This should help us debug reboot failures e.g. https://github.com/kubernetes/kubernetes/issues/33882
Also useful for OOM-kill investigation.

/cc @dchen1107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37248)
<!-- Reviewable:end -->
