### PR TITLE
Add missing variable to openstack provider

### DIFF
--- a/cluster/openstack-heat/config-default.sh
+++ b/cluster/openstack-heat/config-default.sh
@@ -37,6 +37,8 @@ EXTERNAL_NETWORK=${EXTERNAL_NETWORK:-public}
 
 LBAAS_VERSION=${LBAAS_VERSION:-}
 
+FIXED_NETWORK_CIDR=${FIXED_NETWORK_CIDR:-10.0.0.0/24}
+
 SWIFT_SERVER_URL=${SWIFT_SERVER_URL:-}
 
 # Flag indicates if new image must be created. If 'false' then image with IMAGE_ID will be used.


### PR DESCRIPTION
`FIXED_NETWORK_CIDR` environment variable is mandatory by
openstack-heat kubernetes provider, but it's missing as
default value. Adding this environment variable is helpful
to build kubernetes cluster using openstack-heat provider.
So this patch adds it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37262)
<!-- Reviewable:end -->
