### PR TITLE
Fix invalid node name in openstack-heat provider

### DIFF
--- a/cluster/openstack-heat/config-default.sh
+++ b/cluster/openstack-heat/config-default.sh
@@ -17,7 +17,7 @@
 ## Contains configuration values for the Openstack cluster
 
 # Stack name
-STACK_NAME=${STACK_NAME:-KubernetesStack}
+STACK_NAME=${STACK_NAME:-kube-stack}
 
 # Keypair for kubernetes stack
 KUBERNETES_KEYPAIR_NAME=${KUBERNETES_KEYPAIR_NAME:-kubernetes_keypair}

--- a/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
@@ -247,6 +247,7 @@ resources:
   server_name_post_fix:
     type: OS::Heat::RandomString
     properties:
+      character_classes: [{'class': 'lowercase', 'min': 1}]
       length: 8
 
   kube_minion:


### PR DESCRIPTION
Cluster node name must follow name syntax in RFC 1123.
But currently, openstack-heat provider generate invalid
node name which contains upper-case characters.
This patch fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37264)
<!-- Reviewable:end -->
