### PR TITLE
Remove duplicate get errs

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/runtime"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/interrupt"
+	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/watch"
 )
 
@@ -392,6 +393,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 	}
 
 	allErrs := []error{}
+	errs := sets.NewString()
 	infos, err := r.Infos()
 	if err != nil {
 		allErrs = append(allErrs, err)
@@ -444,7 +446,10 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 			}
 			printer, err = f.PrinterForMapping(cmd, mapping, allNamespaces)
 			if err != nil {
-				allErrs = append(allErrs, err)
+				if !errs.Has(err.Error()) {
+					errs.Insert(err.Error())
+					allErrs = append(allErrs, err)
+				}
 				continue
 			}
 
@@ -464,7 +469,10 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 				filteredResourceCount++
 				continue
 			}
-			allErrs = append(allErrs, err)
+			if !errs.Has(err.Error()) {
+				errs.Insert(err.Error())
+				allErrs = append(allErrs, err)
+			}
 		}
 
 		if resourcePrinter, found := printer.(*kubectl.HumanReadablePrinter); found {
@@ -487,12 +495,18 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 			}
 
 			if err := printer.PrintObj(original, w); err != nil {
-				allErrs = append(allErrs, err)
+				if !errs.Has(err.Error()) {
+					errs.Insert(err.Error())
+					allErrs = append(allErrs, err)
+				}
 			}
 			continue
 		}
 		if err := printer.PrintObj(original, w); err != nil {
-			allErrs = append(allErrs, err)
+			if !errs.Has(err.Error()) {
+				errs.Insert(err.Error())
+				allErrs = append(allErrs, err)
+			}
 			continue
 		}
 	}


### PR DESCRIPTION
old:
```shell
$ kubectl get ns
NAME          STATUS    AGE
default       Active    2m
kube-system   Active    2m

$ kubectl get ns --all-namespaces
NAMESPACE   NAME      STATUS    AGE
error: namespace is not namespaced
error: namespace is not namespaced
```
new:
```shell
$ kubectl get ns --all-namespaces
NAMESPACE   NAME      STATUS    AGE
error: namespace is not namespaced
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37270)
<!-- Reviewable:end -->
