### PR TITLE
Add a log at the start of a watch request.

### DIFF
--- a/pkg/genericapiserver/endpoints/handlers/rest.go
+++ b/pkg/genericapiserver/endpoints/handlers/rest.go
@@ -302,6 +302,7 @@ func ListResource(r rest.Lister, rw rest.Watcher, scope RequestScope, forceWatch
 		}
 
 		if (opts.Watch || forceWatch) && rw != nil {
+			glog.Infof("Started to log from %v for %v", ctx, req.Request.URL.RequestURI())
 			watcher, err := rw.Watch(ctx, &opts)
 			if err != nil {
 				scope.err(err, res.ResponseWriter, req.Request)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/16899  (> than a year old!)

@lavalamp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37273)
<!-- Reviewable:end -->
