### PR TITLE
Adding rescan scsi controller for cinder

### DIFF
--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -19,6 +19,7 @@ package cinder
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -174,6 +175,9 @@ func (util *CinderDiskUtil) CreateVolume(c *cinderVolumeProvisioner) (volumeID s
 }
 
 func probeAttachedVolume() error {
+	// rescan scsi bus
+	scsiHostRescan()
+
 	executor := exec.New()
 	args := []string{"trigger"}
 	cmd := executor.Command("/usr/bin/udevadm", args...)
@@ -184,4 +188,15 @@ func probeAttachedVolume() error {
 	}
 	glog.V(4).Infof("Successfully probed all attachments")
 	return nil
+}
+
+func scsiHostRescan() {
+	scsi_path := "/sys/class/scsi_host/"
+	if dirs, err := ioutil.ReadDir(scsi_path); err == nil {
+		for _, f := range dirs {
+			name := scsi_path + f.Name() + "/scan"
+			data := []byte("- - -")
+			ioutil.WriteFile(name, data, 0666)
+		}
+	}
 }


### PR DESCRIPTION
For lsilogic scsi controller, attached cinder volume does not
appear under /dev/ automatically unless do a rescan.
This approach was used in vSphere volume provider before PR #27496
dropped support for lsilogic scsi controller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37275)
<!-- Reviewable:end -->
