### PR TITLE
Node E2E: Update ubuntu image to e2e-node-ubuntu-trusty-docker10-v2-image.

### DIFF
--- a/test/e2e_node/environment/setup_host.sh
+++ b/test/e2e_node/environment/setup_host.sh
@@ -89,6 +89,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Allow jenkins access to docker
+id jenkins || sudo useradd jenkins -m
 sudo usermod -a -G docker jenkins
 
 # install lxc

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -2,11 +2,8 @@
 # `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
-  ubuntu-docker9:
-    image: e2e-node-ubuntu-trusty-docker9-v1-image
-    project: kubernetes-node-e2e-images
   ubuntu-docker10:
-    image: e2e-node-ubuntu-trusty-docker10-v1-image
+    image: e2e-node-ubuntu-trusty-docker10-v2-image
     project: kubernetes-node-e2e-images
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727


### PR DESCRIPTION
@sjenning Hopefully this will unblock  https://github.com/kubernetes/kubernetes/pull/32577.

I built a new ubuntu trusty image with docker 10 - `e2e-node-ubuntu-trusty-docker10-v2-image`. The kernel version of the new ubuntu image is `4.4.0-47-generic`.

@dchen1107 
/cc @kubernetes/sig-node 

Mark v1.5 because this unblocks a v1.5 feature https://github.com/kubernetes/kubernetes/pull/32577.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37277)
<!-- Reviewable:end -->
