### PR TITLE
Bump version of the fluentd-gcp image

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -29,7 +29,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google_containers
-TAG = 1.27
+TAG = 1.28
 
 build:
 	docker build -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.27
+    image: gcr.io/google_containers/fluentd-gcp:1.28
     command:
       - '/bin/sh'
       - '-c'

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.27
+    image: gcr.io/google_containers/fluentd-gcp:1.28
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/37107

Follow-up of https://github.com/kubernetes/kubernetes/pull/37123

@piosz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37281)
<!-- Reviewable:end -->
