### PR TITLE
Bump fluentd-es image version

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -14,11 +14,12 @@
 
 .PHONY:	build push
 
+PREFIX = gcr.io/google_containers
 IMAGE = fluentd-elasticsearch
-TAG = 1.19
+TAG = 1.20
 
 build:
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push:
-	gcloud docker --server=gcr.io -- push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=gcr.io -- push $(PREFIX)/$(IMAGE):$(TAG)

--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   containers:
   - name: fluentd-elasticsearch
-    image: gcr.io/google_containers/fluentd-elasticsearch:1.19
+    image: gcr.io/google_containers/fluentd-elasticsearch:1.20
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
New image version, containing changes from https://github.com/kubernetes/kubernetes/pull/37123 and https://github.com/kubernetes/kubernetes/pull/37219

Should be merged only after those two

@piosz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37283)
<!-- Reviewable:end -->
