### PR TITLE
E2E tests cleanup: regexp for master replica in a separate function

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4011,6 +4011,10 @@ func WaitForClusterSize(c clientset.Interface, size int, timeout time.Duration) 
 	return fmt.Errorf("timeout waiting %v for cluster size to be %d", timeout, size)
 }
 
+func GenerateMasterRegexp(prefix string) string {
+	return prefix + "(-...)?"
+}
+
 // waitForMasters waits until the cluster has the desired number of ready masters in it.
 func WaitForMasters(masterPrefix string, c clientset.Interface, size int, timeout time.Duration) error {
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(20 * time.Second) {
@@ -4022,7 +4026,7 @@ func WaitForMasters(masterPrefix string, c clientset.Interface, size int, timeou
 
 		// Filter out nodes that are not master replicas
 		FilterNodes(nodes, func(node api.Node) bool {
-			res, err := regexp.Match(masterPrefix+"(-...)?", ([]byte)(node.Name))
+			res, err := regexp.Match(GenerateMasterRegexp(masterPrefix), ([]byte)(node.Name))
 			if err != nil {
 				Logf("Failed to match regexp to node name: %v", err)
 				return false

--- a/test/e2e/ha_master.go
+++ b/test/e2e/ha_master.go
@@ -64,7 +64,7 @@ func createNewRC(c clientset.Interface, ns string, name string) {
 func verifyNumberOfMasterReplicas(expected int) {
 	output, err := exec.Command("gcloud", "compute", "instances", "list",
 		"--project="+framework.TestContext.CloudConfig.ProjectID,
-		"--regexp="+framework.TestContext.CloudConfig.MasterName+"(-...)?",
+		"--regexp="+framework.GenerateMasterRegexp(framework.TestContext.CloudConfig.MasterName),
 		"--filter=status=RUNNING",
 		"--format=[no-heading]").CombinedOutput()
 	framework.Logf("%s", output)


### PR DESCRIPTION
E2E tests cleanup: moved generation of regexp for master replica to a separate function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37286)
<!-- Reviewable:end -->
