### PR TITLE
Set Dashboard UI version to v1.5.0-beta1

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.2
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0-beta1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.4.0
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0-beta1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
There will be one more such PR coming for 1.5 release. In one week.

Setting release note to none. Will set notes for final version PR. 

Github release info:
https://github.com/kubernetes/dashboard/releases/tag/v1.5.0-beta1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37287)
<!-- Reviewable:end -->
