### PR TITLE
Update quota scope descriptions

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -382,13 +382,13 @@ func (d *ResourceQuotaDescriber) Describe(namespace, name string, describerSetti
 func helpTextForResourceQuotaScope(scope api.ResourceQuotaScope) string {
 	switch scope {
 	case api.ResourceQuotaScopeTerminating:
-		return "Matches all pods that have an active deadline."
+		return "Matches all pods that have an active deadline. These pods have a limited lifespan on a node before being actively terminated by the system."
 	case api.ResourceQuotaScopeNotTerminating:
-		return "Matches all pods that do not have an active deadline."
+		return "Matches all pods that do not have an active deadline. These pods usually include long running pods whose container command is not expected to terminate."
 	case api.ResourceQuotaScopeBestEffort:
-		return "Matches all pods that have best effort quality of service."
+		return "Matches all pods that do not have resource requirements set. These pods have a best effort quality of service."
 	case api.ResourceQuotaScopeNotBestEffort:
-		return "Matches all pods that do not have best effort quality of service."
+		return "Matches all pods that have at least one resource requirement set. These pods have a burstable or guaranteed quality of service."
 	default:
 		return ""
 	}


### PR DESCRIPTION
```release-note
release-note-none
```

This patch improves the help text descriptions for quota scopes.

@kubernetes/kubectl

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37288)
<!-- Reviewable:end -->
