### PR TITLE
Enable updates in unit test for federated daemonset controller

### DIFF
--- a/federation/pkg/federation-controller/daemonset/BUILD
+++ b/federation/pkg/federation-controller/daemonset/BUILD
@@ -46,6 +46,7 @@ go_test(
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_release_1_5/fake:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
+        "//federation/pkg/federation-controller/util/deletionhelper:go_default_library",
         "//federation/pkg/federation-controller/util/test:go_default_library",
         "//pkg/api/unversioned:go_default_library",
         "//pkg/api/v1:go_default_library",


### PR DESCRIPTION
Fixes flakiness in federated daemonset controller unit tests. Adds an option to rerun the tests multiple times. 

cc: @nikhiljindal @madhusudancs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37291)
<!-- Reviewable:end -->
