### PR TITLE
Fix skipping - protobuf fields

### DIFF
--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/generator.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/generator.go
@@ -630,7 +630,12 @@ func membersToFields(locator ProtobufLocator, t *types.Type, localPackage types.
 			Extras: make(map[string]string),
 		}
 
-		if err := protobufTagToField(tags.Get("protobuf"), &field, m, t, localPackage); err != nil {
+		protobufTag := tags.Get("protobuf")
+		if protobufTag == "-" {
+			continue
+		}
+
+		if err := protobufTagToField(protobufTag, &field, m, t, localPackage); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: fixes the protobuf generator to skip fields with a protobuf tag of `"-"`

Match changes in https://github.com/kubernetes/gengo/pull/19

I couldn't get godeps to work to vendor this change in from gengo, so I made the same edits manually in cmd/libs/go2idl. A task for another day...

@smarterclayton

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37296)
<!-- Reviewable:end -->
