### PR TITLE
Node E2E: Fix remote node e2e focus.

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -38,11 +38,11 @@ if [[ $parallelism > 1 ]]; then
 fi
 
 if [[ $focus != "" ]]; then
-  ginkgoflags="$ginkgoflags -focus='$focus' "
+  ginkgoflags="$ginkgoflags -focus=\"$focus\" "
 fi
 
 if [[ $skip != "" ]]; then
-  ginkgoflags="$ginkgoflags -skip='$skip' "
+  ginkgoflags="$ginkgoflags -skip=\"$skip\" "
 fi
 
 if [[ $run_until_failure != "" ]]; then


### PR DESCRIPTION
Before, we use `'focus'` and `'skip'` in `hack/make-rules/test-e2e-node.sh`.

When we run `make test-e2e-node REMOTE=true FOCUS="Some Thing"`, it will eventually be translated to `-focus='Some Thing'` [here](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/remote/remote.go#L284-L285).

However, golang `exec.Command` wraps each argument with single quote, the argument will become `'xx -focus='Some Thing' xx'`, and cause error because of the 2 layer single quote.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37301)
<!-- Reviewable:end -->
