### PR TITLE
LICENSE: revert modifications to Apache license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2014 The Kubernetes Authors.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The Apache 2.0 license includes an Appendix about how to apply the
license terms to files. We should not modify the license file and
instead should tell people what to do as far as dates, etc in the devel
guides.

Reverts commits:
ef0c9f0c5b8efbba948a0be2c98d9d2e32e0b68c
4800b9dbcbf871278b276e8bb3e862b98e30a7ba

See discusison here: https://github.com/kubernetes/kubernetes-template-project/issues/3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37305)
<!-- Reviewable:end -->
