### PR TITLE
Enable update tests for federated secret controller

### DIFF
--- a/federation/pkg/federation-controller/secret/BUILD
+++ b/federation/pkg/federation-controller/secret/BUILD
@@ -53,6 +53,7 @@ go_test(
         "//pkg/runtime:go_default_library",
         "//pkg/types:go_default_library",
         "//pkg/util/wait:go_default_library",
+        "//vendor:github.com/golang/glog",
         "//vendor:github.com/stretchr/testify/assert",
     ],
 )

--- a/federation/pkg/federation-controller/secret/secret_controller_test.go
+++ b/federation/pkg/federation-controller/secret/secret_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/wait"
 
+	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +53,7 @@ func TestSecretController(t *testing.T) {
 	cluster1Watch := RegisterFakeWatch("secrets", &cluster1Client.Fake)
 	RegisterFakeList("secrets", &cluster1Client.Fake, &apiv1.SecretList{Items: []apiv1.Secret{}})
 	cluster1CreateChan := RegisterFakeCopyOnCreate("secrets", &cluster1Client.Fake, cluster1Watch)
-	//	cluster1UpdateChan := RegisterFakeCopyOnUpdate("secrets", &cluster1Client.Fake, cluster1Watch)
+	cluster1UpdateChan := RegisterFakeCopyOnUpdate("secrets", &cluster1Client.Fake, cluster1Watch)
 
 	cluster2Client := &fakekubeclientset.Clientset{}
 	cluster2Watch := RegisterFakeWatch("secrets", &cluster2Client.Fake)
@@ -116,38 +117,45 @@ func TestSecretController(t *testing.T) {
 		cluster1.Name, types.NamespacedName{Namespace: secret1.Namespace, Name: secret1.Name}.String(), wait.ForeverTestTimeout)
 	assert.Nil(t, err, "secret should have appeared in the informer store")
 
-	/*
-		        // TODO: Uncomment this once we have figured out why this is flaky.
-			// Test update federated secret.
-			secret1.Annotations = map[string]string{
-				"A": "B",
+	checkAll := func(expected apiv1.Secret) CheckingFunction {
+		return func(obj runtime.Object) error {
+			glog.V(4).Infof("Checking %v", obj)
+			s := obj.(*apiv1.Secret)
+			if err := CompareObjectMeta(expected.ObjectMeta, s.ObjectMeta); err != nil {
+				return err
 			}
-			secretWatch.Modify(&secret1)
-			updatedSecret = GetSecretFromChan(cluster1UpdateChan)
-			assert.NotNil(t, updatedSecret)
-			assert.Equal(t, secret1.Name, updatedSecret.Name)
-			assert.Equal(t, secret1.Namespace, updatedSecret.Namespace)
-			assert.True(t, secretsEqual(secret1, *updatedSecret),
-				fmt.Sprintf("expected: %v, actual: %v", secret1, *updatedSecret))
-			// Wait for the secret to be updated in the informer store.
-			err = WaitForSecretStoreUpdate(
-				secretController.secretFederatedInformer.GetTargetStore(),
-				cluster1.Name, types.NamespacedName{Namespace: secret1.Namespace, Name: secret1.Name}.String(),
-				updatedSecret, wait.ForeverTestTimeout)
-			assert.Nil(t, err, "secret should have been updated in the informer store")
+			if !reflect.DeepEqual(expected.Data, s.Data) {
+				return fmt.Errorf("Data is different expected:%v actual:%v", expected.Data, s.Data)
+			}
+			if expected.Type != s.Type {
+				return fmt.Errorf("Type is different expected:%v actual:%v", expected.Type, s.Type)
+			}
+			return nil
+		}
+	}
 
-				// Test update federated secret.
-				secret1.Data = map[string][]byte{
-					"config": []byte("myconfigurationfile"),
-				}
-				secretWatch.Modify(&secret1)
-				updatedSecret2 := GetSecretFromChan(cluster1UpdateChan)
-				assert.NotNil(t, updatedSecret2)
-				assert.Equal(t, secret1.Name, updatedSecret2.Name)
-				assert.Equal(t, secret1.Namespace, updatedSecret.Namespace)
-				assert.True(t, secretsEqual(secret1, *updatedSecret2),
-					fmt.Sprintf("expected: %v, actual: %v", secret1, *updatedSecret2))
-	*/
+	// Test update federated secret.
+	secret1.Annotations = map[string]string{
+		"A": "B",
+	}
+	secretWatch.Modify(&secret1)
+	err = CheckObjectFromChan(cluster1UpdateChan, checkAll(secret1))
+	assert.NoError(t, err)
+
+	// Wait for the secret to be updated in the informer store.
+	err = WaitForSecretStoreUpdate(
+		secretController.secretFederatedInformer.GetTargetStore(),
+		cluster1.Name, types.NamespacedName{Namespace: secret1.Namespace, Name: secret1.Name}.String(),
+		&secret1, wait.ForeverTestTimeout)
+	assert.NoError(t, err, "secret should have been updated in the informer store")
+
+	// Test update federated secret.
+	secret1.Data = map[string][]byte{
+		"config": []byte("myconfigurationfile"),
+	}
+	secretWatch.Modify(&secret1)
+	err = CheckObjectFromChan(cluster1UpdateChan, checkAll(secret1))
+	assert.NoError(t, err)
 
 	// Test add cluster
 	clusterWatch.Add(cluster2)
@@ -183,13 +191,17 @@ func GetSecretFromChan(c chan runtime.Object) *apiv1.Secret {
 
 // Wait till the store is updated with latest secret.
 func WaitForSecretStoreUpdate(store util.FederatedReadOnlyStore, clusterName, key string, desiredSecret *apiv1.Secret, timeout time.Duration) error {
-	retryInterval := 100 * time.Millisecond
+	retryInterval := 200 * time.Millisecond
 	err := wait.PollImmediate(retryInterval, timeout, func() (bool, error) {
 		obj, found, err := store.GetByKey(clusterName, key)
 		if !found || err != nil {
+			glog.Infof("%s is not in the store", key)
 			return false, err
 		}
 		equal := secretsEqual(*obj.(*apiv1.Secret), *desiredSecret)
+		if !equal {
+			glog.Infof("wrong content in the store expected:\n%v\nactual:\n%v\n", *desiredSecret, *obj.(*apiv1.Secret))
+		}
 		return equal, err
 	})
 	return err

--- a/federation/pkg/federation-controller/util/test/test_helper.go
+++ b/federation/pkg/federation-controller/util/test/test_helper.go
@@ -333,6 +333,6 @@ func MetaAndSpecCheckingFunction(expected runtime.Object) CheckingFunction {
 		if util.ObjectMetaAndSpecEquivalent(obj, expected) {
 			return nil
 		}
-		return fmt.Errorf("Object different expected=%#v  received=%#v", expected, obj)
+		return fmt.Errorf("Object different expected=%#v received=%#v", expected, obj)
 	}
 }


### PR DESCRIPTION
Enable update tests in secret controller + add option to execute multiple iterations in the same run.

cc: @nikhiljindal @madhusudancs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37307)
<!-- Reviewable:end -->
