### PR TITLE
eliminate kuberentes

### DIFF
--- a/staging/copy.sh
+++ b/staging/copy.sh
@@ -85,7 +85,7 @@ echo "generating vendor/"
 GO15VENDOREXPERIMENT=1 godep save ./...
 popd > /dev/null
 
-echo "moving vendor/k8s.io/kuberentes"
+echo "moving vendor/k8s.io/kubernetes"
 cp -rn "${CLIENT_REPO_TEMP}"/vendor/k8s.io/kubernetes/. "${CLIENT_REPO_TEMP}"/
 rm -rf "${CLIENT_REPO_TEMP}"/vendor/k8s.io/kubernetes
 # client-go will share the vendor of the main repo for now. When client-go


### PR DESCRIPTION
Luckily only caught one from echo!

@kubernetes/test-infra-maintainers 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
It's important, and really hard, to identify kuberentes from kubernetes. As a human being, one's brain tends to auto fix the spelling for you thus when a dev was staring at the log for a good 30-min or so he will start question about his life and belief.

Luckily this is the only place in k/k, it's super important to fix it to avoid future pain.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37319)
<!-- Reviewable:end -->
