### PR TITLE
change unconfined_t to spc_t

### DIFF
--- a/cmd/kubeadm/app/master/discovery.go
+++ b/cmd/kubeadm/app/master/discovery.go
@@ -88,7 +88,7 @@ func newKubeDiscoveryPodSpec(cfg *kubeadmapi.MasterConfiguration) api.PodSpec {
 					// SELinux. This is not optimal and would be nice to adjust in future
 					// so it can read /tmp/secret, but for now this avoids recommending
 					// setenforce 0 system-wide.
-					Type: "unconfined_t",
+					Type: "spc_t",
 				},
 			},
 		}},

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -101,7 +101,7 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 					// SELinux. This is not optimal and would be nice to adjust in future
 					// so it can create and write /var/lib/etcd, but for now this avoids
 					// recommending setenforce 0 system-wide.
-					Type: "unconfined_t",
+					Type: "spc_t",
 				},
 			},
 		}, certsVolume(cfg), etcdVolume(cfg), k8sVolume(cfg))


### PR DESCRIPTION
**What this PR does / why we need it**:

When installing kube via kubeadm on a system w/ selinux enabled, it's necessary to disable selinux in order for the etcd and kube-discovery containers to run. 

The kube etcd and discovery pods are currently set to unconfined_t in order to avoid disabling selinux, but the correct type for an unconfined container is spc_t. For more information, see http://danwalsh.livejournal.com/2016/10/03/.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37327)
<!-- Reviewable:end -->
