### PR TITLE
Make thirdparty codec able to decode DeleteOptions

### DIFF
--- a/pkg/registry/extensions/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/extensions/thirdpartyresourcedata/codec.go
@@ -370,6 +370,10 @@ func (t *thirdPartyResourceDataDecoder) Decode(data []byte, gvk *schema.GroupVer
 		}
 		return o, outGVK, nil
 	default:
+		if gvk != nil && registered.IsThirdPartyAPIGroupVersion(gvk.GroupVersion()) {
+			// delegate won't recognize a thirdparty group version
+			gvk = nil
+		}
 		return t.delegate.Decode(data, gvk, into)
 	}
 

--- a/test/e2e/third-party.go
+++ b/test/e2e/third-party.go
@@ -161,7 +161,15 @@ var _ = Describe("ThirdParty resources [Flaky] [Disruptive]", func() {
 				framework.Failf("expected: %#v, saw in list: %#v", foo, list.Items[0])
 			}
 
-			if _, err := f.ClientSet.Extensions().RESTClient().Delete().AbsPath("/apis/company.com/v1/namespaces/default/foos/foo").DoRaw(); err != nil {
+			// Need to manually do the serialization because otherwise the
+			// Content-Type header is set to protobuf, the thirdparty codec in
+			// the API server side only accepts JSON.
+			deleteOptionsData, err := json.Marshal(v1.NewDeleteOptions(10))
+			framework.ExpectNoError(err)
+			if _, err := f.ClientSet.Core().RESTClient().Delete().
+				AbsPath("/apis/company.com/v1/namespaces/default/foos/foo").
+				Body(deleteOptionsData).
+				DoRaw(); err != nil {
 				framework.Failf("failed to delete: %v", err)
 			}
 


### PR DESCRIPTION
Fix #37278. 

Without this PR, the gvk sent to the delegated codec will be the thirdparty one, which is not recognized by the delegated codec (usually api.Codecs).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37328)
<!-- Reviewable:end -->
