### PR TITLE
Rename pet to stateful pods in statefulset e2e tests logs

### DIFF
--- a/test/e2e/network_partition.go
+++ b/test/e2e/network_partition.go
@@ -361,7 +361,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 	})
 
 	framework.KubeDescribe("[StatefulSet]", func() {
-		psName := "pet"
+		psName := "ss"
 		labels := map[string]string{
 			"foo": "bar",
 		}
@@ -381,7 +381,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			if CurrentGinkgoTestDescription().Failed {
 				dumpDebugInfo(c, ns)
 			}
-			framework.Logf("Deleting all petset in ns %v", ns)
+			framework.Logf("Deleting all stateful set in ns %v", ns)
 			deleteAllStatefulSets(c, ns)
 		})
 
@@ -403,7 +403,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			pst.waitForRunningAndReady(*ps.Spec.Replicas, ps)
 		})
 
-		It("should not reschedule pets if there is a network partition [Slow] [Disruptive]", func() {
+		It("should not reschedule stateful pods if there is a network partition [Slow] [Disruptive]", func() {
 			ps := newStatefulSet(psName, ns, headlessSvcName, 3, []v1.VolumeMount{}, []v1.VolumeMount{}, labels)
 			_, err := c.Apps().StatefulSets(ns).Create(ps)
 			Expect(err).NotTo(HaveOccurred())
@@ -416,10 +416,10 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 			framework.ExpectNoError(err)
 
 			// Blocks outgoing network traffic on 'node'. Then verifies that 'podNameToDisappear',
-			// that belongs to StatefulSet 'petSetName', **does not** disappear due to forced deletion from the apiserver.
-			// The grace period on the petset pods is set to a value > 0.
+			// that belongs to StatefulSet 'statefulSetName', **does not** disappear due to forced deletion from the apiserver.
+			// The grace period on the stateful pods is set to a value > 0.
 			testUnderTemporaryNetworkFailure(c, ns, node, func() {
-				framework.Logf("Checking that the NodeController does not force delete pet %v", pod.Name)
+				framework.Logf("Checking that the NodeController does not force delete stateful pods %v", pod.Name)
 				err := framework.WaitTimeoutForPodNoLongerRunningInNamespace(c, pod.Name, ns, pod.ResourceVersion, 10*time.Minute)
 				Expect(err).To(Equal(wait.ErrWaitTimeout), "Pod was not deleted during network partition.")
 			})


### PR DESCRIPTION
Follow up https://github.com/kubernetes/kubernetes/pull/37243#discussion_r89193790

Note that only mentions of pet in logs are renamed, but not variable name, or file name / import path 

@foxish 

```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37330)
<!-- Reviewable:end -->
