### PR TITLE
kubernetes attempts to unmount a wrong vSphere volume and stops making any progress after that

### DIFF
--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -122,6 +122,7 @@ func (plugin *vsphereVolumePlugin) ConstructVolumeSpec(volumeName, mountPath str
 	mounter := plugin.host.GetMounter()
 	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
 	volumePath, _ := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
+	glog.V(5).Infof("vSphere volume path is %q", volumePath)
 	vsphereVolume := &api.Volume{
 		Name: volumeName,
 		VolumeSource: api.VolumeSource{

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -119,11 +119,14 @@ func (plugin *vsphereVolumePlugin) newUnmounterInternal(volName string, podUID t
 }
 
 func (plugin *vsphereVolumePlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
+	mounter := plugin.host.GetMounter()
+	pluginDir := plugin.host.GetPluginDir(plugin.GetPluginName())
+	volumePath, _ := mounter.GetDeviceNameFromMount(mountPath, pluginDir)
 	vsphereVolume := &api.Volume{
 		Name: volumeName,
 		VolumeSource: api.VolumeSource{
 			VsphereVolume: &api.VsphereVirtualDiskVolumeSource{
-				VolumePath: volumeName,
+				VolumePath: volumePath,
 			},
 		},
 	}


### PR DESCRIPTION
Kubernetes attempts to unmount a wrong vSphere volume in v1.4.5. This fix addresses issue #37022 

The following steps are made to reproduce the issue:
1. kubectl create -f guestbook.yaml
A deployment is created with a volume spec - "hello-master" and volumePath - "[datastore1] kubevols/sample-volume". At this point, the pod has the volume "[datastore1]kubevols/sample-volume" mounted on it.

2. kubectl delete -f guestbook.yaml
When the deployment is deleted, kubernetes attempts to unmount the volume with volumeName - hello-master. Since it cannot find the volume "hello-master" mounted on the node, it stalls and doesn't make any progress after it.

Because of this, any subsequent recreation of deployments fails to mount the volume on the node as  the node stalls.

This problem occurred after fixing for issue #33203 on kubernetes repo -  Fix volume states out of sync problem after kubelet restarts. There were changes to SYNC loop logic in this fix.

There are 2 fixes that needs to made on 1.4.5 branch
1. The changes to constructVolumeSpec() in the vSphere plugin to get the volumePath instead of volumeName.
2. The changes to getDeviceNameFromMount() to get the full volumePath - "[datastore1]kubevols/sample-volume" instead of the just base of the volumePath -"sample-volume". I just observed that this function is fixed as a part of #36840 on master branch.

After these changes, the deployment creations and deletions worked perfectly fine. Also the recreation of the deployment worked fine. The volumes are mounted to the pods correctly.

@abrarshivani @kerneltime 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37332)
<!-- Reviewable:end -->
