### PR TITLE
delete meaningless judgments

### DIFF
--- a/pkg/kubelet/pod_workers.go
+++ b/pkg/kubelet/pod_workers.go
@@ -171,10 +171,7 @@ func (p *podWorkers) managePodLoop(podUpdates <-chan UpdatePodOptions) {
 				updateType:     update.UpdateType,
 			})
 			lastSyncTime = time.Now()
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		}()
 		// notify the call-back function if the operation succeeded or not
 		if update.OnCompleteFunc != nil {


### PR DESCRIPTION
What this PR does / why we need it：
      Whether "err" is nil or not, "err" can be return, so the judgment "err !=nil " is unnecessary

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37350)
<!-- Reviewable:end -->
