### PR TITLE
Add Virtlet to CRI doc for developers

### DIFF
--- a/docs/devel/container-runtime-interface.md
+++ b/docs/devel/container-runtime-interface.md
@@ -85,6 +85,7 @@ besides discussions on Github issues.
  - [cri-o](https://github.com/kubernetes-incubator/cri-o)
  - [rktlet](https://github.com/kubernetes-incubator/rktlet)
  - [frakti](https://github.com/kubernetes/frakti)
+ - [virtlet](https://github.com/Mirantis/virtlet)
 
 
 ## [Status update](#status-update)


### PR DESCRIPTION
Additional info about [virtlet](https://github.com/Mirantis/virtlet) for recently merged (#37311) doc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37351)
<!-- Reviewable:end -->
