### PR TITLE
gcOrphaned check via the API that the node doesn’t exist

### DIFF
--- a/pkg/controller/podgc/BUILD
+++ b/pkg/controller/podgc/BUILD
@@ -24,11 +24,10 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/controller/informers:go_default_library",
         "//pkg/labels:go_default_library",
-        "//pkg/runtime:go_default_library",
         "//pkg/util/metrics:go_default_library",
         "//pkg/util/runtime:go_default_library",
+        "//pkg/util/sets:go_default_library",
         "//pkg/util/wait:go_default_library",
-        "//pkg/watch:go_default_library",
         "//vendor:github.com/golang/glog",
     ],
 )
@@ -41,8 +40,8 @@ go_test(
     deps = [
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
-        "//pkg/client/cache:go_default_library",
         "//pkg/client/clientset_generated/release_1_5/fake:go_default_library",
+        "//pkg/controller/node/testutil:go_default_library",
         "//pkg/labels:go_default_library",
         "//pkg/util/sets:go_default_library",
     ],


### PR DESCRIPTION
It's needed to make sure we don't make invalid decisions when system is overloaded and cache is not keeping up.

@wojtek-t - this adds one `Node.List()` per 20 sec. Listing Nodes is an expensive operation, so I'd like you to chime in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37365)
<!-- Reviewable:end -->
