### PR TITLE
HA master: configurable replica name during kube-down.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1328,7 +1328,7 @@ function kube-down() {
     done
   fi
 
-  local -r REPLICA_NAME="$(get-replica-name)"
+  local -r REPLICA_NAME="${KUBE_REPLICA_NAME:-$(get-replica-name)}"
 
   set-existing-master
 


### PR DESCRIPTION
HA master: configurable replica name during kube-down.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37381)
<!-- Reviewable:end -->
