### PR TITLE
Skip StatefulSet e2e tests if this resource is not found

### DIFF
--- a/test/e2e/network_partition.go
+++ b/test/e2e/network_partition.go
@@ -367,6 +367,7 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 
 		BeforeEach(func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
+			framework.SkipIfMissingResource(f.ClientPool, StatefulSetGroupVersionResource, f.Namespace.Name)
 			By("creating service " + headlessSvcName + " in namespace " + f.Namespace.Name)
 			headlessService := createServiceSpec(headlessSvcName, "", true, labels)
 			_, err := f.ClientSet.Core().Services(f.Namespace.Name).Create(headlessService)

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -64,6 +64,10 @@ const (
 	readTimeout = 60 * time.Second
 )
 
+var (
+	StatefulSetGroupVersionResource = unversioned.GroupVersionResource{Group: apps.GroupName, Version: "v1beta1", Resource: "statefulsets"}
+)
+
 // Time: 25m, slow by design.
 // GCE Quota requirements: 3 pds, one per pet manifest declared above.
 // GCE Api requirements: nodes and master need storage r/w permissions.
@@ -75,6 +79,7 @@ var _ = framework.KubeDescribe("StatefulSet [Slow]", func() {
 	BeforeEach(func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
+		framework.SkipIfMissingResource(f.ClientPool, StatefulSetGroupVersionResource, f.Namespace.Name)
 	})
 
 	framework.KubeDescribe("Basic StatefulSet functionality", func() {
@@ -402,7 +407,7 @@ var _ = framework.KubeDescribe("Stateful Set recreate [Slow]", func() {
 	petPodName := "web-0"
 
 	BeforeEach(func() {
-		framework.SkipUnlessProviderIs("gce", "vagrant")
+		framework.SkipIfMissingResource(f.ClientPool, StatefulSetGroupVersionResource, f.Namespace.Name)
 		By("creating service " + headlessSvcName + " in namespace " + f.Namespace.Name)
 		headlessService := createServiceSpec(headlessSvcName, "", true, labels)
 		_, err := f.ClientSet.Core().Services(f.Namespace.Name).Create(headlessService)


### PR DESCRIPTION
Ref #37184, #37243

Skip the tests if statefulset is not found. 

cc @erictune @foxish @kow3ns @enisoc @kubernetes/sig-apps 

```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37389)
<!-- Reviewable:end -->
