### PR TITLE
Node Conformance Test: Final cleanup for node conformance test.

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -351,7 +351,6 @@ long-running-request-regexp
 low-diskspace-threshold-mb
 make-iptables-util-chains
 make-symlinks
-manifest-path
 manifest-url
 manifest-url-header
 masquerade-all

--- a/test/e2e_node/conformance/build/Dockerfile
+++ b/test/e2e_node/conformance/build/Dockerfile
@@ -19,17 +19,15 @@ COPY e2e_node.test /usr/local/bin
 
 # The following environment variables can be override when starting the container.
 # FOCUS is regex matching test to run. By default run all conformance test.
-# SKIP is regex matching test to skip. By default empty.
+# SKIP is regex matching test to skip. By default skip flaky and serial test.
 # PARALLELISM is the number of processes the test will run in parallel.
 # REPORT_PATH is the path in the container to save test result and logs.
-# MANIFEST_PATH is the kubelet manifest path in the container.
 # FLAKE_ATTEMPTS is the time to retry when there is a test failure. By default 2.
 # TEST_ARGS is the test arguments passed into the test.
 ENV FOCUS="\[Conformance\]" \
 	   SKIP="\[Flaky\]|\[Serial\]" \
 	   PARALLELISM=8 \
 	   REPORT_PATH="/var/result" \
-	   MANIFEST_PATH="/etc/manifest" \
 	   FLAKE_ATTEMPTS=2 \
 	   TEST_ARGS=""
 
@@ -40,5 +38,5 @@ ENTRYPOINT ginkgo --focus="$FOCUS" \
 	/usr/local/bin/e2e_node.test \
 	-- --conformance=true \
 	--prepull-images=false \
-	--manifest-path="$MANIFEST_PATH"\
-	--report-dir="$REPORT_PATH $TEST_ARGS"
+	--report-dir="$REPORT_PATH" \
+	$TEST_ARGS

--- a/test/e2e_node/conformance/build/Makefile
+++ b/test/e2e_node/conformance/build/Makefile
@@ -56,5 +56,9 @@ endif
 
 push: build
 	gcloud docker push ${REGISTRY}/node-test-${ARCH}:${VERSION}
+ifeq ($(ARCH),amd64)
+	docker tag ${REGISTRY}/node-test-${ARCH}:${VERSION} ${REGISTRY}/node-test:${VERSION}
+	gcloud docker -- push ${REGISTRY}/node-test:${VERSION}
+endif
 
 .PHONY: all

--- a/test/e2e_node/garbage_collector_test.go
+++ b/test/e2e_node/garbage_collector_test.go
@@ -257,7 +257,10 @@ func containerGCTest(f *framework.Framework, test testRun) {
 
 // Runs containerGCTest using the docker runtime.
 func dockerContainerGCTest(f *framework.Framework, test testRun) {
-	runtime := docker.ConnectToDockerOrDie(defaultDockerEndpoint, defaultRuntimeRequestTimeoutDuration)
+	var runtime docker.DockerInterface
+	BeforeEach(func() {
+		runtime = docker.ConnectToDockerOrDie(defaultDockerEndpoint, defaultRuntimeRequestTimeoutDuration)
+	})
 	for _, pod := range test.testPods {
 		// Initialize the getContainerNames function to use the dockertools api
 		thisPrefix := pod.containerPrefix


### PR DESCRIPTION
This PR fits node conformance test with recent change.
* Remove `--manifest-path` because the test will get kubelet configuration through `/configz` now. https://github.com/kubernetes/kubernetes/pull/36919
* Add `$TEST_ARGS` so that we can override arguments inside the container.
* Fix a bug in garbage_collector_test.go which will cause the framework tries to connect docker no matter running the test or not. @dashpole 
* Add `${REGISTRY}/node-test:${VERSION}` for convenience. 
* Bump up the image version to `0.2`. (the one released with v1.4 is `v0.1`)

I've run the test both with `run_test.sh` script and directly `docker run`. Both of them passed.

After this gets merged, I'll build and push the new test image.

@dchen1107 
/cc @kubernetes/sig-node

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37392)
<!-- Reviewable:end -->
