### PR TITLE
Fixing a typo in deployment e2e

### DIFF
--- a/test/e2e/federation-deployment.go
+++ b/test/e2e/federation-deployment.go
@@ -179,7 +179,7 @@ func verifyCascadingDeletionForDeployment(clientset *fedclientset.Clientset, clu
 		_, err := clusterClientset.Extensions().Deployments(nsName).Get(deploymentName)
 		if shouldExist && errors.IsNotFound(err) {
 			errMessages = append(errMessages, fmt.Sprintf("unexpected NotFound error for deployment %s in cluster %s, expected deployment to exist", deploymentName, clusterName))
-		} else if shouldExist && !errors.IsNotFound(err) {
+		} else if !shouldExist && !errors.IsNotFound(err) {
 			errMessages = append(errMessages, fmt.Sprintf("expected NotFound error for deployment %s in cluster %s, got error: %v", deploymentName, clusterName, err))
 		}
 	}


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/37105 and https://github.com/kubernetes/kubernetes/issues/37143.

Fixing the failing deployment e2e.
There are 3 deployment cases failing right now. https://github.com/kubernetes/kubernetes/pull/37290 fixes the first and this PR fixes the other 2.

cc @kubernetes/sig-cluster-federation @madhusudancs @mwielgus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37394)
<!-- Reviewable:end -->
