### PR TITLE
Revert "Skip StatefulSet e2e tests if this resource is not found"

### DIFF
--- a/test/e2e/network_partition.go
+++ b/test/e2e/network_partition.go
@@ -367,7 +367,6 @@ var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
 
 		BeforeEach(func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
-			framework.SkipIfMissingResource(f.ClientPool, StatefulSetGroupVersionResource, f.Namespace.Name)
 			By("creating service " + headlessSvcName + " in namespace " + f.Namespace.Name)
 			headlessService := createServiceSpec(headlessSvcName, "", true, labels)
 			_, err := f.ClientSet.Core().Services(f.Namespace.Name).Create(headlessService)

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -64,10 +64,6 @@ const (
 	readTimeout = 60 * time.Second
 )
 
-var (
-	StatefulSetGroupVersionResource = unversioned.GroupVersionResource{Group: apps.GroupName, Version: "v1beta1", Resource: "statefulsets"}
-)
-
 // Time: 25m, slow by design.
 // GCE Quota requirements: 3 pds, one per pet manifest declared above.
 // GCE Api requirements: nodes and master need storage r/w permissions.
@@ -79,7 +75,6 @@ var _ = framework.KubeDescribe("StatefulSet [Slow]", func() {
 	BeforeEach(func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
-		framework.SkipIfMissingResource(f.ClientPool, StatefulSetGroupVersionResource, f.Namespace.Name)
 	})
 
 	framework.KubeDescribe("Basic StatefulSet functionality", func() {
@@ -407,7 +402,7 @@ var _ = framework.KubeDescribe("Stateful Set recreate [Slow]", func() {
 	petPodName := "web-0"
 
 	BeforeEach(func() {
-		framework.SkipIfMissingResource(f.ClientPool, StatefulSetGroupVersionResource, f.Namespace.Name)
+		framework.SkipUnlessProviderIs("gce", "vagrant")
 		By("creating service " + headlessSvcName + " in namespace " + f.Namespace.Name)
 		headlessService := createServiceSpec(headlessSvcName, "", true, labels)
 		_, err := f.ClientSet.Core().Services(f.Namespace.Name).Create(headlessService)

--- a/test/e2e/petset.go
+++ b/test/e2e/petset.go
@@ -64,7 +64,6 @@ const (
 	readTimeout = 60 * time.Second
 )
 
-// Time: 25m, slow by design.
 // GCE Quota requirements: 3 pds, one per pet manifest declared above.
 // GCE Api requirements: nodes and master need storage r/w permissions.
 var _ = framework.KubeDescribe("StatefulSet [Slow]", func() {


### PR DESCRIPTION
Reverts kubernetes/kubernetes#37389

The reason of reverting this pr is at: https://github.com/kubernetes/kubernetes/pull/37389#issuecomment-262613914

Once @foxish's fix was checked in, we should merge this one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37398)
<!-- Reviewable:end -->
