### PR TITLE
Kubelet log modification

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1183,8 +1183,7 @@ func (kl *Kubelet) initializeModules() error {
 	// Step 5: Start container manager.
 	node, err := kl.getNodeAnyWay()
 	if err != nil {
-		glog.Errorf("Cannot get Node info: %v", err)
-		return fmt.Errorf("Kubelet failed to get node info.")
+		return fmt.Errorf("Kubelet failed to get node info: %v", err)
 	}
 
 	if err := kl.containerManager.Start(node); err != nil {


### PR DESCRIPTION
Keep in line with the other error logs in the function.
After return, the caller records the error log.Delete redundant logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37420)
<!-- Reviewable:end -->
