### PR TITLE
fix typo in balanced_resource_allocation

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/balanced_resource_allocation.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/balanced_resource_allocation.go
@@ -100,7 +100,7 @@ func fractionOfCapacity(requested, capacity int64) float64 {
 
 // BalancedResourceAllocation favors nodes with balanced resource usage rate.
 // BalancedResourceAllocation should **NOT** be used alone, and **MUST** be used together with LeastRequestedPriority.
-// It calculates the difference between the cpu and memory fracion of capacity, and prioritizes the host based on how
+// It calculates the difference between the cpu and memory fraction of capacity, and prioritizes the host based on how
 // close the two metrics are to each other.
 // Detail: score = 10 - abs(cpuFraction-memoryFraction)*10. The algorithm is partly inspired by:
 // "Wei Huang et al. An Energy Efficient Virtual Machine Placement Algorithm with Balanced Resource Utilization"


### PR DESCRIPTION
fix typo in balanced_resource_allocation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37422)
<!-- Reviewable:end -->
