### PR TITLE
add a new cmd flag enable-curl-debug to enable printing curl debug info

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	etcdclient "github.com/coreos/etcd/client"
 	"github.com/golang/glog"
 	"github.com/pborman/uuid"
 	"github.com/spf13/cobra"
@@ -178,6 +179,10 @@ func Run(s *options.ServerRunOptions) error {
 		if s.Etcd.StorageConfig.DeserializationCacheSize < 1000 {
 			s.Etcd.StorageConfig.DeserializationCacheSize = 1000
 		}
+	}
+	
+	if s.Etcd.StorageConfig.EnableCURLDebug {
+		etcdclient.EnablecURLDebug()
 	}
 
 	storageGroupsToEncodingVersion, err := s.GenericServerRunOptions.StorageGroupsToEncodingVersion()

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -65,7 +65,7 @@ import (
 	certutil "k8s.io/kubernetes/pkg/util/cert"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/version"
-	authenticatorunion "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union"
+	authenticatorunion "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/union"	
 )
 
 const (

--- a/pkg/genericapiserver/options/etcd.go
+++ b/pkg/genericapiserver/options/etcd.go
@@ -83,4 +83,7 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&s.StorageConfig.Quorum, "etcd-quorum-read", s.StorageConfig.Quorum,
 		"If true, enable quorum read.")
+
+	fs.BoolVar(&s.StorageConfig.EnableCURLDebug, "enable-curl-debug", s.StorageConfig.EnableCURLDebug,
+		"Enable cURL debug info to the stderr.")
 }

--- a/pkg/storage/storagebackend/config.go
+++ b/pkg/storage/storagebackend/config.go
@@ -44,4 +44,6 @@ type Config struct {
 	DeserializationCacheSize int
 
 	Codec runtime.Codec
+	// enable the curl debug info if is true
+	EnableCURLDebug bool
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
There is function in etcd/client/curl.go which prints curl info, but no flag to set this function on. 
Here I'm going to add a new cmd flag named "enable-curl-debug" to set it on.
Please review for this, thanks!!

**Release note**:
``` 
add --enable-curl-debug flag to enable printing the curl debug info to the stderr.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37433)
<!-- Reviewable:end -->