### PR TITLE
pod evictor could leave completed pod

### DIFF
--- a/pkg/controller/node/controller_utils.go
+++ b/pkg/controller/node/controller_utils.go
@@ -84,6 +84,10 @@ func deletePods(kubeClient clientset.Interface, recorder record.EventRecorder, n
 		if err == nil { // No error means at least one daemonset was found
 			continue
 		}
+		// if the pod is completed, ignore it
+		if pod.Status.Phase == v1.PodFailed || pod.Status.Phase == v1.PodSucceeded {
+			continue
+		}
 
 		glog.V(2).Infof("Starting deletion of pod %v/%v", pod.Namespace, pod.Name)
 		recorder.Eventf(&pod, v1.EventTypeNormal, "NodeControllerEviction", "Marking for deletion Pod %s from Node %s", pod.Name, nodeName)


### PR DESCRIPTION

**What this PR does / why we need it**:
pod evictor in node controller will delete all pods on node,  seems not nessesary to delete completed pods, because it may created by a job controller, we may analyze the completed pod

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37440)
<!-- Reviewable:end -->
