### PR TITLE
fix if condition question in kubelet run() function

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -392,8 +392,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.KubeletDeps) (err error) {
 			eventClientConfig.QPS = float32(s.EventRecordQPS)
 			eventClientConfig.Burst = int(s.EventBurst)
 			eventClient, err = clientset.NewForConfig(&eventClientConfig)
-		}
-		if err != nil {
+		} else {
 			if s.RequireKubeConfig {
 				return fmt.Errorf("invalid kubeconfig: %v", err)
 			}


### PR DESCRIPTION

Here variable err returned by function NewForConfig(&eventClientConfig) if CreateAPIServerClientConfig() function runs correctly .  And we should not print "invalid kubeconfig" info.
Should we use else instead of if.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37442)
<!-- Reviewable:end -->
