### PR TITLE
rename constant MaxPatchConflicts to maxRetryWhenPatchConflicts

### DIFF
--- a/pkg/apiserver/resthandler.go
+++ b/pkg/apiserver/resthandler.go
@@ -93,8 +93,8 @@ func (scope *RequestScope) err(err error, w http.ResponseWriter, req *http.Reque
 // may be used to deserialize an options object to pass to the getter.
 type getterFunc func(ctx api.Context, name string, req *restful.Request) (runtime.Object, error)
 
-// MaxPatchConflicts is the maximum number of conflicts retry for during a patch operation before returning failure
-const MaxPatchConflicts = 5
+// maxRetryWhenPatchConflicts is the maximum number of conflicts retry during a patch operation before returning failure
+const maxRetryWhenPatchConflicts = 5
 
 // getResourceHandler is an HTTP handler function for get requests. It delegates to the
 // passed-in getterFunc to perform the actual get.
@@ -645,7 +645,7 @@ func patchResource(
 
 	return finishRequest(timeout, func() (runtime.Object, error) {
 		updateObject, _, updateErr := patcher.Update(ctx, name, updatedObjectInfo)
-		for i := 0; i < MaxPatchConflicts && (errors.IsConflict(updateErr)); i++ {
+		for i := 0; i < maxRetryWhenPatchConflicts && (errors.IsConflict(updateErr)); i++ {
 			lastConflictErr = updateErr
 			updateObject, _, updateErr = patcher.Update(ctx, name, updatedObjectInfo)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. literally `MaxPatchConflicts` means max number of patch conflicts allowed during a patch operation. but actually in codes it is used to indicate max number of patch retry when patch conflicts happened.
2. there is no need to export this constant because it is only used in `resthandler.go`  and shouldn't be used in other packages.


Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37468)
<!-- Reviewable:end -->
