### PR TITLE
fix incorrect parameter pass to metrics.Monitor method call in ServeHTTP

### DIFF
--- a/pkg/apiserver/handlers/proxy.go
+++ b/pkg/apiserver/handlers/proxy.go
@@ -59,7 +59,12 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var apiResource string
 	var httpCode int
 	reqStart := time.Now()
-	defer metrics.Monitor(&verb, &apiResource, net.GetHTTPClient(req), w.Header().Get("Content-Type"), httpCode, reqStart)
+	defer func() {
+		metrics.Monitor(&verb, &apiResource,
+			net.GetHTTPClient(req),
+			w.Header().Get("Content-Type"),
+			httpCode, reqStart)
+	}()
 
 	ctx, ok := r.Mapper.Get(req)
 	if !ok {


### PR DESCRIPTION
**What this PR does / why we need it**:

before this PR:
1. `httpCode` is evaluated when defer statement executes, so all later assignments to `httpCode` is actually ineffectual. this obviously is not the design purpose.
2. `w.Header().Get("Content-Type")` is  evaluated when defer statement executes, so all later `w.Header().Set("Content-Type",xxx)` ( in `writeNegotiated` ) is ineffectual to `metrics.Monitor`, i think this also is not the design purpose.

after this PR:
1. `httpCode` and `w.Header().Get("Content-Type")` is evaluated when the defered anonymous function executes, so `metrics.Monitor` will get correct `httpCode` and `Content-Type` field value.
2. in `ServeHTTP` method there is not any modification to `req` parameter, so it's safe to defer its evaluation.

Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37477)
<!-- Reviewable:end -->
