### PR TITLE
GCE and AWS provisioners, dynamic provisioning: admins and user can configure zones where PV shall be created

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -300,14 +300,11 @@ const (
 
 // VolumeOptions specifies capacity and tags for a volume.
 type VolumeOptions struct {
-	CapacityGB        int
-	Tags              map[string]string
-	PVCName           string
-	VolumeType        string
-	ZonePresent       bool
-	ZonesPresent      bool
-	AvailabilityZone  string
-	AvailabilityZones string
+	CapacityGB       int
+	Tags             map[string]string
+	PVCName          string
+	VolumeType       string
+	AvailabilityZone string
 	// IOPSPerGB x CapacityGB will give total IOPS of the volume to create.
 	// Calculated total IOPS will be capped at MaxTotalIOPS.
 	IOPSPerGB int
@@ -799,7 +796,7 @@ func getAvailabilityZone(metadata EC2Metadata) (string, error) {
 
 // Derives the region from a valid az name.
 // Returns an error if the az is known invalid (empty)
-func azToRegion(az string) (string, error) {
+func AzToRegion(az string) (string, error) {
 	if len(az) < 1 {
 		return "", fmt.Errorf("invalid (empty) AZ")
 	}
@@ -828,7 +825,7 @@ func newAWSCloud(config io.Reader, awsServices Services) (*Cloud, error) {
 	if len(zone) <= 1 {
 		return nil, fmt.Errorf("invalid AWS zone in config file: %s", zone)
 	}
-	regionName, err := azToRegion(zone)
+	regionName, err := AzToRegion(zone)
 	if err != nil {
 		return nil, err
 	}
@@ -1124,9 +1121,9 @@ func (c *Cloud) InstanceType(nodeName types.NodeName) (string, error) {
 	return aws.StringValue(inst.InstanceType), nil
 }
 
-// getCandidateZonesForDynamicVolume retrieves  a list of all the zones in which nodes are running
+// GetCandidateZonesForDynamicVolume retrieves  a list of all the zones in which nodes are running
 // It currently involves querying all instances
-func (c *Cloud) getCandidateZonesForDynamicVolume() (sets.String, error) {
+func (c *Cloud) GetCandidateZonesForDynamicVolume() (sets.String, error) {
 	// We don't currently cache this; it is currently used only in volume
 	// creation which is expected to be a comparatively rare occurrence.
 
@@ -1689,29 +1686,6 @@ func (c *Cloud) DetachDisk(diskName KubernetesVolumeID, nodeName types.NodeName)
 
 // CreateDisk implements Volumes.CreateDisk
 func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, error) {
-	allZones, err := c.getCandidateZonesForDynamicVolume()
-	if err != nil {
-		return "", fmt.Errorf("error querying for all zones: %v", err)
-	}
-
-	var createAZ string
-	if !volumeOptions.ZonePresent && !volumeOptions.ZonesPresent {
-		createAZ = volume.ChooseZoneForVolume(allZones, volumeOptions.PVCName)
-	}
-	if !volumeOptions.ZonePresent && volumeOptions.ZonesPresent {
-		if adminSetOfZones, err := volume.ZonesToSet(volumeOptions.AvailabilityZones); err != nil {
-			return "", err
-		} else {
-			createAZ = volume.ChooseZoneForVolume(adminSetOfZones, volumeOptions.PVCName)
-		}
-	}
-	if volumeOptions.ZonePresent && !volumeOptions.ZonesPresent {
-		if err := volume.ValidateZone(volumeOptions.AvailabilityZone); err != nil {
-			return "", err
-		}
-		createAZ = volumeOptions.AvailabilityZone
-	}
-
 	var createType string
 	var iops int64
 	switch volumeOptions.VolumeType {
@@ -1743,7 +1717,7 @@ func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, er
 
 	// TODO: Should we tag this with the cluster id (so it gets deleted when the cluster does?)
 	request := &ec2.CreateVolumeInput{}
-	request.AvailabilityZone = aws.String(createAZ)
+	request.AvailabilityZone = aws.String(volumeOptions.AvailabilityZone)
 	request.Size = aws.Int64(int64(volumeOptions.CapacityGB))
 	request.VolumeType = aws.String(createType)
 	request.Encrypted = aws.Bool(volumeOptions.Encrypted)
@@ -1805,7 +1779,7 @@ func (c *Cloud) GetVolumeLabels(volumeName KubernetesVolumeID) (map[string]strin
 	}
 
 	labels[kubeletapis.LabelZoneFailureDomain] = az
-	region, err := azToRegion(az)
+	region, err := AzToRegion(az)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/volume/BUILD
+++ b/pkg/volume/BUILD
@@ -25,6 +25,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/cloudprovider:go_default_library",
+        "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/io:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume/util:go_default_library",
@@ -54,6 +55,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/slice:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/volume/aws_ebs/BUILD
+++ b/pkg/volume/aws_ebs/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/pkg/volume/aws_ebs/aws_util.go
+++ b/pkg/volume/aws_ebs/aws_util.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	"k8s.io/kubernetes/pkg/volume"
@@ -91,18 +92,19 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (aws.K
 	}
 	// Apply Parameters (case-insensitive). We leave validation of
 	// the values to the cloud provider.
-	volumeOptions.ZonePresent = false
-	volumeOptions.ZonesPresent = false
+	zonesConf := new(volume.ZonesConf)
 	for k, v := range c.options.Parameters {
 		switch strings.ToLower(k) {
 		case "type":
 			volumeOptions.VolumeType = v
 		case "zone":
-			volumeOptions.ZonePresent = true
-			volumeOptions.AvailabilityZone = v
+			if err = zonesConf.SetZone(v); err != nil {
+				return "", 0, nil, err
+			}
 		case "zones":
-			volumeOptions.ZonesPresent = true
-			volumeOptions.AvailabilityZones = v
+			if err = zonesConf.SetZones(v); err != nil {
+				return "", 0, nil, err
+			}
 		case "iopspergb":
 			volumeOptions.IOPSPerGB, err = strconv.Atoi(v)
 			if err != nil {
@@ -120,15 +122,15 @@ func (util *AWSDiskUtil) CreateVolume(c *awsElasticBlockStoreProvisioner) (aws.K
 		}
 	}
 
-	if volumeOptions.ZonePresent && volumeOptions.ZonesPresent {
-		return "", 0, nil, fmt.Errorf("both zone and zones StorageClass parameters must not be used at the same time")
+	var zones sets.String
+	zonesConf.PVC = c.options.PVC
+	zonesConf.GetAllZones = cloud.GetCandidateZonesForDynamicVolume
+	zonesConf.ZoneToRegion = aws.AzToRegion
+	if zones, err = zonesConf.GetConfZones(); err != nil {
+		return "", 0, nil, err
 	}
 
-	// TODO: implement PVC.Selector parsing
-	if c.options.PVC.Spec.Selector != nil {
-		return "", 0, nil, fmt.Errorf("claim.Spec.Selector is not supported for dynamic provisioning on AWS")
-	}
-
+	volumeOptions.AvailabilityZone = volume.ChooseZoneForVolume(zones, c.options.PVC.Name)
 	name, err := cloud.CreateDisk(volumeOptions)
 	if err != nil {
 		glog.V(2).Infof("Error creating EBS Disk volume: %v", err)

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -86,53 +86,30 @@ func (gceutil *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner) (strin
 	// Apply Parameters (case-insensitive). We leave validation of
 	// the values to the cloud provider.
 	diskType := ""
-	configuredZone := ""
-	configuredZones := ""
-	zonePresent := false
-	zonesPresent := false
+	zonesConf := new(volume.ZonesConf)
 	for k, v := range c.options.Parameters {
 		switch strings.ToLower(k) {
 		case "type":
 			diskType = v
 		case "zone":
-			zonePresent = true
-			configuredZone = v
+			if err = zonesConf.SetZone(v); err != nil {
+				return "", 0, nil, err
+			}
 		case "zones":
-			zonesPresent = true
-			configuredZones = v
+			if err = zonesConf.SetZones(v); err != nil {
+				return "", 0, nil, err
+			}
 		default:
 			return "", 0, nil, fmt.Errorf("invalid option %q for volume plugin %s", k, c.plugin.GetPluginName())
 		}
 	}
 
-	if zonePresent && zonesPresent {
-		return "", 0, nil, fmt.Errorf("both zone and zones StorageClass parameters must not be used at the same time")
-	}
-
-	// TODO: implement PVC.Selector parsing
-	if c.options.PVC.Spec.Selector != nil {
-		return "", 0, nil, fmt.Errorf("claim.Spec.Selector is not supported for dynamic provisioning on GCE")
-	}
-
 	var zones sets.String
-	if !zonePresent && !zonesPresent {
-		zones, err = cloud.GetAllZones()
-		if err != nil {
-			glog.V(2).Infof("error getting zone information from GCE: %v", err)
-			return "", 0, nil, err
-		}
-	}
-	if !zonePresent && zonesPresent {
-		if zones, err = volume.ZonesToSet(configuredZones); err != nil {
-			return "", 0, nil, err
-		}
-	}
-	if zonePresent && !zonesPresent {
-		if err := volume.ValidateZone(configuredZone); err != nil {
-			return "", 0, nil, err
-		}
-		zones = make(sets.String)
-		zones.Insert(configuredZone)
+	zonesConf.PVC = c.options.PVC
+	zonesConf.GetAllZones = cloud.GetAllZones
+	zonesConf.ZoneToRegion = gcecloud.GetGCERegion
+	if zones, err = zonesConf.GetConfZones(); err != nil {
+		return "", 0, nil, err
 	}
 	zone := volume.ChooseZoneForVolume(zones, c.options.PVC.Name)
 

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -559,3 +559,189 @@ func getPVCMatchExpression(pvc *v1.PersistentVolumeClaim, key string, operator m
 	}
 	return ret, nil
 }
+
+// ZonesConf is a class for calculation of a set of zones that satisfy both admin configured zones and user configured regions and zones
+type ZonesConf struct {
+	// PVC data structure containing the user configured regions and zones
+	PVC *v1.PersistentVolumeClaim
+	// a func that returns a set of all available zones
+	GetAllZones func() (sets.String, error)
+	// a func that converts a zone to a region
+	ZoneToRegion func(string) (string, error)
+	// is the parameter zone specified in the Storage Class by an admin?
+	isSCZoneConfigured bool
+	// is the parameter zones specified in the Storage Class by an admin?
+	isSCZonesConfigured bool
+	// true if the func GetAllZones was already called
+	gotAllAvailableZones bool
+	// contains the return value of the func GetAllZones call
+	allAvailableZones sets.String
+	// the set of zones that satisfy both admin configured zones and user configured regions and zones is calculated in the resultingZones
+	resultingZones sets.String
+	// is the regionToZones map already calculated
+	isRegionToZonesMapValid bool
+	// maps a single region to a set of all zones that are available in the region
+	regionToZonesMap map[string]sets.String
+}
+
+// SetZone sets the zone StorageClass parameter configured by an admin and returns:
+// - error in case the zones StorageClass parameter was also configured
+// - nil the zone StorageClass parameter was successfully set
+func (z *ZonesConf) SetZone(zone string) error {
+	if z.isSCZonesConfigured {
+		return fmt.Errorf("both zone and zones StorageClass parameters must not be used at the same time")
+	}
+	if err := ValidateZone(zone); err != nil {
+		return err
+	}
+	z.resultingZones = make(sets.String)
+	z.resultingZones.Insert(zone)
+	z.isSCZoneConfigured = true
+	return nil
+}
+
+// SetZones sets the zones StorageClass parameter configured by an admin and returns:
+// - error in case the zone StorageClass parameter was also configured
+// - error in case the zones StorageClass parameter does not contain a comma separated list of zones
+// - nil the zones StorageClass parameter was successfully parsed and set
+func (z *ZonesConf) SetZones(zones string) error {
+	if z.isSCZoneConfigured {
+		return fmt.Errorf("both zone and zones StorageClass parameters must not be used at the same time")
+	}
+	var err error
+	if z.resultingZones, err = ZonesToSet(zones); err != nil {
+		return fmt.Errorf("corresponding storage class error: %v", err.Error())
+	}
+	z.isSCZonesConfigured = true
+	return nil
+}
+
+// getAllAvailableZones caches the result of the func GetAllZones call so it returns:
+// - cached result stored in z.allAvailableZones
+// - error in case the func GetAllZones returned and error
+// - the return value of the func GetAllZones call
+func (z *ZonesConf) getAllAvailableZones() (sets.String, error) {
+	if z.gotAllAvailableZones {
+		return z.allAvailableZones, nil
+	}
+	var err error
+	if z.allAvailableZones, err = z.GetAllZones(); err != nil {
+		return nil, err
+	}
+	z.gotAllAvailableZones = true
+	return z.allAvailableZones, nil
+}
+
+// regionToZones converts a single region into a set of zones
+func (z *ZonesConf) regionToZones(region string) (sets.String, error) {
+	if !z.isRegionToZonesMapValid {
+		if err := z.calculateRegionToZonesMap(); err != nil {
+			return nil, err
+		}
+	}
+	return z.regionToZonesMap[region], nil
+}
+
+// calculateRegionToZonesMap returns:
+// - nil if the z.regionToZonesMap was successfully calculated
+// - error if the func GetAllZones or func ZoneToRegion failed
+// Currently cloud providers do not provide a func RegionToZone that will return all zones that are available in a given region.
+// Thats why the func calculateRegionToZonesMap goes through allAvailableZones and creates a map region -> set of zones that are available in the region.
+func (z *ZonesConf) calculateRegionToZonesMap() error {
+	if z.isRegionToZonesMapValid {
+		return nil
+	}
+	z.regionToZonesMap = make(map[string]sets.String)
+	var err error
+	if !z.gotAllAvailableZones {
+		if z.allAvailableZones, err = z.getAllAvailableZones(); err != nil {
+			return err
+		}
+	}
+	var region string
+	for zone := range z.allAvailableZones {
+		if region, err = z.ZoneToRegion(zone); err != nil {
+			return fmt.Errorf("failed to convert zone (%v) to a region: %v", zone, err)
+		}
+		if _, ok := z.regionToZonesMap[region]; !ok {
+			z.regionToZonesMap[region] = make(sets.String)
+		}
+		z.regionToZonesMap[region].Insert(zone)
+	}
+	z.isRegionToZonesMapValid = true
+	return nil
+}
+
+// GetConfZones returns:
+// - either a set of zones resulting from currently available zones, allowed zone(s) by an admin in the corresponding storage class and zones preferred by the user in the selector part of the PVC
+// - or an error in case the resulting set of zones is empty or another error occurred
+func (z *ZonesConf) GetConfZones() (sets.String, error) {
+	var err error
+	if !z.isSCZoneConfigured && !z.isSCZonesConfigured {
+		if z.resultingZones, err = z.getAllAvailableZones(); err != nil {
+			return nil, err
+		}
+	} // else z.resultingZones were already set either in z.SetZone() or z.SetZones()
+	if emptySelector, err := validatePVCSelector(z.PVC); err != nil {
+		return nil, err
+	} else if emptySelector {
+		return z.resultingZones, nil
+	}
+	if matchLabelZone, err := getPVCMatchLabel(z.PVC, kubeletapis.LabelZoneFailureDomain); err == nil {
+		matchLabelZoneSet := make(sets.String)
+		matchLabelZoneSet.Insert(matchLabelZone)
+		z.resultingZones = z.resultingZones.Intersection(matchLabelZoneSet)
+	}
+	if matchLabelRegion, err := getPVCMatchLabel(z.PVC, kubeletapis.LabelZoneRegion); err == nil {
+		var zones sets.String
+		if zones, err = z.regionToZones(matchLabelRegion); err != nil {
+			return nil, err
+		}
+		z.resultingZones = z.resultingZones.Intersection(zones)
+	}
+	if matchExpressionZoneSets, err := getPVCMatchExpression(z.PVC, kubeletapis.LabelZoneFailureDomain, metav1.LabelSelectorOpIn); err == nil {
+		for _, matchExpressionZoneSet := range matchExpressionZoneSets {
+			z.resultingZones = z.resultingZones.Intersection(matchExpressionZoneSet)
+		}
+	}
+	if matchExpressionRegionSets, err := getPVCMatchExpression(z.PVC, kubeletapis.LabelZoneRegion, metav1.LabelSelectorOpIn); err == nil {
+		if !z.isRegionToZonesMapValid {
+			if err = z.calculateRegionToZonesMap(); err != nil {
+				return nil, err
+			}
+		}
+		var summedZonesForASetOfRegions sets.String
+		for _, matchExpressionRegionSet := range matchExpressionRegionSets {
+			summedZonesForASetOfRegions = make(sets.String)
+			for region := range matchExpressionRegionSet {
+				summedZonesForASetOfRegions = summedZonesForASetOfRegions.Union(z.regionToZonesMap[region])
+			}
+			z.resultingZones = z.resultingZones.Intersection(summedZonesForASetOfRegions)
+		}
+	}
+	if matchExpressionZoneSets, err := getPVCMatchExpression(z.PVC, kubeletapis.LabelZoneFailureDomain, metav1.LabelSelectorOpNotIn); err == nil {
+		for _, matchExpressionZoneSet := range matchExpressionZoneSets {
+			z.resultingZones = z.resultingZones.Difference(matchExpressionZoneSet)
+		}
+	}
+	if matchExpressionRegionSets, err := getPVCMatchExpression(z.PVC, kubeletapis.LabelZoneRegion, metav1.LabelSelectorOpNotIn); err == nil {
+		if !z.isRegionToZonesMapValid {
+			if err = z.calculateRegionToZonesMap(); err != nil {
+				return nil, err
+			}
+		}
+		var summedZonesForASetOfRegions sets.String
+		for _, matchExpressionRegionSet := range matchExpressionRegionSets {
+			summedZonesForASetOfRegions = make(sets.String)
+			for region := range matchExpressionRegionSet {
+				summedZonesForASetOfRegions = summedZonesForASetOfRegions.Union(z.regionToZonesMap[region])
+			}
+			z.resultingZones = z.resultingZones.Difference(summedZonesForASetOfRegions)
+		}
+	}
+	if len(z.resultingZones) < 1 {
+		return nil, fmt.Errorf("Could not find availability zone: combination of StorageClass parameters and selector of this claim cannot be satisfied by this cluster")
+	}
+
+	return z.resultingZones, nil
+}

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -415,8 +415,8 @@ func JoinMountOptions(userOptions []string, systemOptions []string) []string {
 	return allMountOptions.UnsortedList()
 }
 
-// ZonesToSet converts a string containing a comma separated list of zones to set
-func ZonesToSet(zonesString string) (sets.String, error) {
+// zonesToSet converts a string containing a comma separated list of zones to set
+func zonesToSet(zonesString string) (sets.String, error) {
 	zonesSlice := strings.Split(zonesString, ",")
 	zonesSet := make(sets.String)
 	for _, zone := range zonesSlice {
@@ -609,7 +609,7 @@ func (z *ZonesConf) SetZones(zones string) error {
 		return fmt.Errorf("both zone and zones StorageClass parameters must not be used at the same time")
 	}
 	var err error
-	if z.resultingZones, err = ZonesToSet(zones); err != nil {
+	if z.resultingZones, err = zonesToSet(zones); err != nil {
 		return fmt.Errorf("corresponding storage class error: %v", err.Error())
 	}
 	z.isSCZonesConfigured = true

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -497,3 +497,16 @@ func validatePVCSelector(pvc *v1.PersistentVolumeClaim) (bool, error) {
 	}
 	return false, nil
 }
+
+// getPVCMatchLabel returns:
+// - either (value, nil) for the key from the matchLabels Selector part of the PVC
+// - or ("", error) in case the key is missing in the matchLabels Selector part of the PVC
+func getPVCMatchLabel(pvc *v1.PersistentVolumeClaim, key string) (string, error) {
+	if pvc.Spec.Selector == nil {
+		return "", fmt.Errorf("missing selector.matchLabels")
+	}
+	if value, ok := pvc.Spec.Selector.MatchLabels[key]; ok {
+		return value, nil
+	}
+	return "", fmt.Errorf("key %q not found in selector.matchLabels", key)
+}

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 
 	"hash/fnv"
 	"math/rand"
@@ -456,4 +457,43 @@ func AccessModesContainedInAll(indexedModes []v1.PersistentVolumeAccessMode, req
 		}
 	}
 	return true
+}
+
+// validatePVCSelector validates Selector part of a PVC:
+// - in case there is no Selector the PVC is valid
+// - makes sure that only allowedKeys are present in the Selector matchLabels part
+// - makes sure that only allowedKeys and allowedOperators are present in the Selector matchExpressions part
+// Return value:
+// - (true, nil) means PVC is valid (error == nil) and there is NO Selector OR (NO matchLabels AND NO matchExpressions) (bool == true)
+// - (false, nil) means PVC is valid (error == nil) and there is at least a value in matchLabels or matchExpressions specified (bool == false)
+// - (false, error) means PVC is not valid
+// - (true, error) shall never happen
+func validatePVCSelector(pvc *v1.PersistentVolumeClaim) (bool, error) {
+	allowedKeys := map[string]bool{kubeletapis.LabelZoneFailureDomain: true, kubeletapis.LabelZoneRegion: true}
+	allowedOperators := map[metav1.LabelSelectorOperator]bool{metav1.LabelSelectorOpIn: true, metav1.LabelSelectorOpNotIn: true}
+	if pvc.Spec.Selector == nil {
+		return true, nil
+	}
+	if len(pvc.Spec.Selector.MatchExpressions) < 1 && len(pvc.Spec.Selector.MatchLabels) < 1 {
+		return true, nil
+	}
+	if len(pvc.Spec.Selector.MatchLabels) > 0 {
+		for label := range pvc.Spec.Selector.MatchLabels {
+			if !allowedKeys[label] {
+				return false, fmt.Errorf("key %q is not permitted in selector.matchLabels", label)
+			}
+		}
+	}
+	for _, expr := range pvc.Spec.Selector.MatchExpressions {
+		if !allowedKeys[expr.Key] {
+			return false, fmt.Errorf("key %q is not permitted in selector.matchExpressions", expr.Key)
+		}
+		if !allowedOperators[expr.Operator] {
+			return false, fmt.Errorf("operator %q is not permitted in selector.matchExpressions", expr.Operator)
+		}
+		if len(expr.Values) < 1 {
+			return false, fmt.Errorf("key %q, operator %q pair does not contain any value(s) in selector.matchExpressions", expr.Key, expr.Operator)
+		}
+	}
+	return false, nil
 }

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -429,10 +429,10 @@ func zonesToSet(zonesString string) (sets.String, error) {
 	return zonesSet, nil
 }
 
-// ValidateZone returns:
+// validateZone returns:
 // - an error in case zone is an empty string or contains only any combination of spaces and tab characters
 // - nil otherwise
-func ValidateZone(zone string) error {
+func validateZone(zone string) error {
 	if strings.TrimSpace(zone) == "" {
 		return fmt.Errorf("the provided %q zone is not valid, it's an empty string or contains only spaces and tab characters", zone)
 	}
@@ -591,7 +591,7 @@ func (z *ZonesConf) SetZone(zone string) error {
 	if z.isSCZonesConfigured {
 		return fmt.Errorf("both zone and zones StorageClass parameters must not be used at the same time")
 	}
-	if err := ValidateZone(zone); err != nil {
+	if err := validateZone(zone); err != nil {
 		return err
 	}
 	z.resultingZones = make(sets.String)

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -510,3 +510,52 @@ func getPVCMatchLabel(pvc *v1.PersistentVolumeClaim, key string) (string, error)
 	}
 	return "", fmt.Errorf("key %q not found in selector.matchLabels", key)
 }
+
+// getPVCMatchExpression returns:
+// - either ([]setOfValues, nil) for all matching (key, operator) from the matchExpressions Selector part of the PVC
+// - or ([]emptySet, error) in case the operator or the key is missing in the matchExpressions Selector part of the PVC
+// Example:
+// selector:
+//     matchExpressions:
+//       - key: failure-domain.beta.kubernetes.io/zone
+//         operator: In
+//         values:
+//           - us-east-1a
+//           - us-east-2a
+//           - us-east-3a
+//       - key: failure-domain.beta.kubernetes.io/zone
+//             operator: In
+//             values:
+//               - us-east-3a
+//               - us-east-4a
+// Returns ({sets.String{"us-east-1a": sets.Empty{}, "us-east-2a": sets.Empty{}, "us-east-3a": sets.Empty{}}, sets.String{"us-east-3a": sets.Empty{}, "us-east-4a": sets.Empty{}}}, nil)
+func getPVCMatchExpression(pvc *v1.PersistentVolumeClaim, key string, operator metav1.LabelSelectorOperator) ([]sets.String, error) {
+	if pvc.Spec.Selector == nil {
+		return make([]sets.String, 0), fmt.Errorf("missing selector.matchExpressions")
+	}
+	if len(pvc.Spec.Selector.MatchExpressions) < 1 {
+		return make([]sets.String, 0), fmt.Errorf("key(s), operator(s) and value(s) are missing in selector.matchExpressions")
+	}
+	capacity := 0
+	for _, item := range pvc.Spec.Selector.MatchExpressions {
+		if item.Key == key && item.Operator == operator && len(item.Values) > 0 {
+			capacity++
+		}
+	}
+	if capacity == 0 {
+		return make([]sets.String, 0), fmt.Errorf("operator %q for key %q not found in selector.matchExpressions", key, operator)
+	}
+
+	ret := make([]sets.String, 0, capacity)
+	index := 0
+	for _, item := range pvc.Spec.Selector.MatchExpressions {
+		if item.Key == key && item.Operator == operator && len(item.Values) > 0 {
+			ret = append(ret, make(sets.String))
+			for _, value := range item.Values {
+				ret[index].Insert(value)
+			}
+			index++
+		}
+	}
+	return ret, nil
+}

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -795,3 +795,164 @@ func TestGetPVCMatchLabel(t *testing.T) {
 		}
 	}
 }
+
+func isEqualSliceOfSets(s1, s2 []sets.String) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i := 0; i < len(s1); i++ {
+		if !s1[i].Equal(s2[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestGetPVCMatchExpression(t *testing.T) {
+	functionUnderTest := "getPVCMatchExpression"
+	emptySet := make(sets.String)
+	// First part: want no error
+	succTests := []struct {
+		pvc      v1.PersistentVolumeClaim
+		key      string
+		operator metav1.LabelSelectorOperator
+		want     []sets.String
+	}{
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneFailureDomain,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"us-east-1a", "us-east-1b"},
+							},
+						},
+					},
+				},
+			},
+			key:      kubeletapis.LabelZoneFailureDomain,
+			operator: metav1.LabelSelectorOpIn,
+			want:     []sets.String{{"us-east-1a": sets.Empty{}, "us-east-1b": sets.Empty{}}},
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneFailureDomain,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"us-east-1a", "us-east-2a", "us-east-3a"},
+							},
+							{
+								Key:      kubeletapis.LabelZoneFailureDomain,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"us-east-3a", "us-east-4a"},
+							},
+						},
+					},
+				},
+			},
+			key:      kubeletapis.LabelZoneFailureDomain,
+			operator: metav1.LabelSelectorOpIn,
+			want:     []sets.String{{"us-east-1a": sets.Empty{}, "us-east-2a": sets.Empty{}, "us-east-3a": sets.Empty{}}, {"us-east-3a": sets.Empty{}, "us-east-4a": sets.Empty{}}},
+		},
+	}
+	for _, succTest := range succTests {
+		if zones, err := getPVCMatchExpression(&succTest.pvc, succTest.key, succTest.operator); err != nil {
+			t.Errorf("%v(%v, %v, %v) returned (%v, %v), want (%v, %v)", functionUnderTest, succTest.pvc, succTest.key, succTest.operator, zones, err.Error(), succTest.want, nil)
+		} else if !isEqualSliceOfSets(zones, succTest.want) {
+			t.Errorf("%v(%v, %v, %v) returned (%v, %v), want (%v, %v)", functionUnderTest, succTest.pvc, succTest.key, succTest.operator, zones, err, succTest.want, nil)
+		}
+	}
+
+	// Second part: want an error
+	errCases := []struct {
+		pvc      v1.PersistentVolumeClaim
+		key      string
+		operator metav1.LabelSelectorOperator
+	}{
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			},
+			key:      kubeletapis.LabelZoneFailureDomain,
+			operator: metav1.LabelSelectorOpIn,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{},
+					},
+				},
+			},
+			key:      kubeletapis.LabelZoneRegion,
+			operator: metav1.LabelSelectorOpNotIn,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      "foo",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"us-east-1a", "us-east-1b"},
+							},
+						},
+					},
+				},
+			},
+			key:      kubeletapis.LabelZoneRegion,
+			operator: metav1.LabelSelectorOpIn,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneFailureDomain,
+								Operator: "foo",
+								Values:   []string{"us-east-1a", "us-east-1b"},
+							},
+						},
+					},
+				},
+			},
+			key:      kubeletapis.LabelZoneFailureDomain,
+			operator: metav1.LabelSelectorOpIn,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneFailureDomain,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{},
+							},
+						},
+					},
+				},
+			},
+			key:      kubeletapis.LabelZoneFailureDomain,
+			operator: metav1.LabelSelectorOpIn,
+		},
+	}
+	for _, errCase := range errCases {
+		if zones, err := getPVCMatchExpression(&errCase.pvc, errCase.key, errCase.operator); err == nil {
+			t.Errorf("%v(%v, %v, %v) returned (%v, %v), want (%v, %v)", functionUnderTest, errCase.pvc, errCase.key, errCase.operator, zones, err, emptySet, "an error")
+		}
+	}
+}

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -738,3 +738,60 @@ func TestValidatePVCSelector(t *testing.T) {
 		}
 	}
 }
+
+func TestGetPVCMatchLabel(t *testing.T) {
+	functionUnderTest := "getPVCMatchLabel"
+	// First part: want no error
+	succTests := []struct {
+		pvc  v1.PersistentVolumeClaim
+		key  string
+		want string
+	}{
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{kubeletapis.LabelZoneFailureDomain: "us-east-1a"},
+					},
+				},
+			},
+			key:  kubeletapis.LabelZoneFailureDomain,
+			want: "us-east-1a",
+		},
+	}
+	for _, succTest := range succTests {
+		if zone, err := getPVCMatchLabel(&succTest.pvc, succTest.key); err != nil {
+			t.Errorf("%v(%v, %v) returned (%v, %v), want (%v, %v)", functionUnderTest, succTest.pvc, succTest.key, zone, err.Error(), succTest.want, nil)
+		}
+	}
+
+	// Second part: want an error
+	errCases := []struct {
+		pvc v1.PersistentVolumeClaim
+		key string
+	}{
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			},
+			key: kubeletapis.LabelZoneFailureDomain,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{},
+					},
+				},
+			},
+			key: kubeletapis.LabelZoneFailureDomain,
+		},
+	}
+	for _, errCase := range errCases {
+		if zone, err := getPVCMatchLabel(&errCase.pvc, errCase.key); err == nil {
+			t.Errorf("%v(%v, %v) returned (%v, %v), want (%v, %v)", functionUnderTest, errCase.pvc, errCase.key, zone, err, "", "an error")
+		}
+	}
+}

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -526,11 +526,11 @@ func TestChooseZoneForVolume(t *testing.T) {
 }
 
 func TestZonesToSet(t *testing.T) {
-	functionUnderTest := "ZonesToSet"
+	functionUnderTest := "zonesToSet"
 	// First part: want an error
 	sliceOfZones := []string{"", ",", "us-east-1a, , us-east-1d", ", us-west-1b", "us-west-2b,"}
 	for _, zones := range sliceOfZones {
-		if got, err := ZonesToSet(zones); err == nil {
+		if got, err := zonesToSet(zones); err == nil {
 			t.Errorf("%v(%v) returned (%v), want (%v)", functionUnderTest, zones, got, "an error")
 		}
 	}
@@ -553,7 +553,7 @@ func TestZonesToSet(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		if got, err := ZonesToSet(tt.zones); err != nil || !got.Equal(tt.want) {
+		if got, err := zonesToSet(tt.zones); err != nil || !got.Equal(tt.want) {
 			t.Errorf("%v(%v) returned (%v), want (%v)", functionUnderTest, tt.zones, got, tt.want)
 		}
 	}

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/pkg/api"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/util/slice"
 )
 
@@ -574,6 +575,166 @@ func TestValidateZone(t *testing.T) {
 	for _, succCase := range succCases {
 		if got := ValidateZone(succCase); got != nil {
 			t.Errorf("%v(%v) returned (%v), want (%v)", functionUnderTest, succCase, got, nil)
+		}
+	}
+}
+
+func TestValidatePVCSelector(t *testing.T) {
+	functionUnderTest := "validatePVCSelector"
+	// First part: want no error
+	succTests := []struct {
+		pvc       v1.PersistentVolumeClaim
+		wantEmpty bool
+	}{
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			},
+			wantEmpty: true,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: nil,
+				},
+			},
+			wantEmpty: true,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{},
+					},
+				},
+			},
+			wantEmpty: true,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{},
+					},
+				},
+			},
+			wantEmpty: true,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneFailureDomain,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"us-east-1a", "us-east-1b"},
+							},
+						},
+					},
+				},
+			},
+			wantEmpty: false,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneRegion,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"us-east-1a", "us-east-1b"},
+							},
+						},
+					},
+				},
+			},
+			wantEmpty: false,
+		},
+		{
+			pvc: v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{kubeletapis.LabelZoneFailureDomain: "us-east-1a"},
+					},
+				},
+			},
+			wantEmpty: false,
+		},
+	}
+	for _, succTest := range succTests {
+		if empty, err := validatePVCSelector(&succTest.pvc); err != nil {
+			t.Errorf("%v(%v) returned (%v, %v), want (%v, %v)", functionUnderTest, succTest.pvc, empty, err.Error(), succTest.wantEmpty, nil)
+		} else if empty != succTest.wantEmpty {
+			t.Errorf("%v(%v) returned (%v, %v), want (%v, %v)", functionUnderTest, succTest.pvc, empty, err, succTest.wantEmpty, nil)
+		}
+	}
+
+	// Second part: want an error
+	errCases := []v1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			Spec: v1.PersistentVolumeClaimSpec{
+				Selector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "key2",
+							Operator: "In",
+							Values:   []string{"value1", "value2"},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			Spec: v1.PersistentVolumeClaimSpec{
+				Selector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      kubeletapis.LabelZoneFailureDomain,
+							Operator: metav1.LabelSelectorOpExists,
+							Values:   []string{"value1", "value2"},
+						},
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			Spec: v1.PersistentVolumeClaimSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			Spec: v1.PersistentVolumeClaimSpec{
+				Selector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      kubeletapis.LabelZoneFailureDomain,
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, errCase := range errCases {
+		if empty, err := validatePVCSelector(&errCase); err == nil {
+			t.Errorf("%v(%v) returned (%v, %v), want (%v, %v)", functionUnderTest, errCase, empty, err, false, "an error")
+		} else if empty != false {
+			t.Errorf("%v(%v) returned (%v, %v), want (%v, %v)", functionUnderTest, errCase, empty, err.Error(), false, "an error")
 		}
 	}
 }

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -560,12 +560,12 @@ func TestZonesToSet(t *testing.T) {
 }
 
 func TestValidateZone(t *testing.T) {
-	functionUnderTest := "ValidateZone"
+	functionUnderTest := "validateZone"
 
 	// First part: want an error
 	errCases := []string{"", " 	 	 "}
 	for _, errCase := range errCases {
-		if got := ValidateZone(errCase); got == nil {
+		if got := validateZone(errCase); got == nil {
 			t.Errorf("%v(%v) returned (%v), want (%v)", functionUnderTest, errCase, got, "an error")
 		}
 	}
@@ -573,7 +573,7 @@ func TestValidateZone(t *testing.T) {
 	// Second part: want no error
 	succCases := []string{" us-east-1a	"}
 	for _, succCase := range succCases {
-		if got := ValidateZone(succCase); got != nil {
+		if got := validateZone(succCase); got != nil {
 			t.Errorf("%v(%v) returned (%v), want (%v)", functionUnderTest, succCase, got, nil)
 		}
 	}

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -956,3 +956,328 @@ func TestGetPVCMatchExpression(t *testing.T) {
 		}
 	}
 }
+
+func mockZoneToRegion(zone string) (string, error) {
+	if len(zone) < 1 {
+		return "", fmt.Errorf("Zone must not be an empty string")
+	}
+	return zone[:len(zone)-1], nil
+}
+
+func mockGetAllZones() (sets.String, error) {
+	ret := sets.String{"us-east-1a": sets.Empty{}, "us-east-1b": sets.Empty{}, "us-east-1c": sets.Empty{}, "us-east-2a": sets.Empty{}, "us-east-2b": sets.Empty{}, "us-east-3a": sets.Empty{}, "us-east-3b": sets.Empty{}}
+	return ret, nil
+}
+
+func TestVolumeZoneConf(t *testing.T) {
+	functionUnderTest := "GetConfZones"
+	emptySet := make(sets.String)
+	// First part: want no error
+	succTests := map[string]struct {
+		PVC                 *v1.PersistentVolumeClaim
+		IsSCZoneConfigured  bool
+		SCZone              string
+		IsSCZonesConfigured bool
+		SCZones             string
+		GetAllZones         func() (sets.String, error)
+		ZoneToRegion        func(string) (string, error)
+		want                sets.String
+	}{
+		"Test case 1:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: false,
+			SCZones:             "",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-1a": sets.Empty{}, "us-east-1b": sets.Empty{}, "us-east-1c": sets.Empty{}, "us-east-2a": sets.Empty{}, "us-east-2b": sets.Empty{}, "us-east-3a": sets.Empty{}, "us-east-3b": sets.Empty{}},
+		},
+		"Test case 2:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			},
+			IsSCZoneConfigured:  true,
+			SCZone:              "us-east-1a",
+			IsSCZonesConfigured: false,
+			SCZones:             "",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-1a": sets.Empty{}},
+		},
+		"Test case 3:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-1a": sets.Empty{}, "us-east-1b": sets.Empty{}, "us-east-2a": sets.Empty{}},
+		},
+		"Test case 4:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{kubeletapis.LabelZoneFailureDomain: "us-east-1a"},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-1a": sets.Empty{}},
+		},
+		"Test case 5:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{kubeletapis.LabelZoneRegion: "us-east-1"},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-1a": sets.Empty{}, "us-east-1b": sets.Empty{}},
+		},
+		"Test case 6:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneFailureDomain,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"us-east-1a", "us-east-1b"},
+							},
+						},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-1a": sets.Empty{}, "us-east-1b": sets.Empty{}},
+		},
+		"Test case 7:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneRegion,
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   []string{"us-east-1", "us-east-3"},
+							},
+						},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a, us-east-3b",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-1a": sets.Empty{}, "us-east-1b": sets.Empty{}, "us-east-3b": sets.Empty{}},
+		},
+		"Test case 8:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneFailureDomain,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"us-east-1a", "us-east-1b"},
+							},
+						},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-2a": sets.Empty{}},
+		},
+		"Test case 9:": {
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneRegion,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"us-east-1", "us-east-3"},
+							},
+						},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a, us-east-3b",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+			want:                sets.String{"us-east-2a": sets.Empty{}},
+		},
+	}
+	for key, succTest := range succTests {
+		zonesConf := new(ZonesConf)
+		zonesConf.PVC = succTest.PVC
+		if succTest.IsSCZoneConfigured {
+			if err := zonesConf.SetZone(succTest.SCZone); err != nil {
+				t.Errorf("%v %v() returned (%v), want (%v)", key, "SetZone", err, nil)
+				continue
+			}
+		}
+		if succTest.IsSCZonesConfigured {
+			if err := zonesConf.SetZones(succTest.SCZones); err != nil {
+				t.Errorf("%v %v() returned (%v), want (%v)", key, "SetZones", err, nil)
+				continue
+			}
+		}
+		zonesConf.GetAllZones = succTest.GetAllZones
+		zonesConf.ZoneToRegion = succTest.ZoneToRegion
+		if got, err := zonesConf.GetConfZones(); err != nil {
+			t.Errorf("%v %v() returned (%v, %v), want (%v, %v)", key, functionUnderTest, got, err.Error(), succTest.want, nil)
+		} else if !succTest.want.Equal(got) {
+			t.Errorf("%v %v() returned (%v, %v), want (%v, %v)", key, functionUnderTest, got, err, succTest.want, nil)
+		}
+	}
+
+	// Second part: want an error
+	errCases := []struct {
+		PVC                 *v1.PersistentVolumeClaim
+		IsSCZoneConfigured  bool
+		SCZone              string
+		IsSCZonesConfigured bool
+		SCZones             string
+		GetAllZones         func() (sets.String, error)
+		ZoneToRegion        func(string) (string, error)
+	}{
+		{
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: false,
+			SCZones:             "",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+		},
+		{
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{
+							{
+								Key:      kubeletapis.LabelZoneRegion,
+								Operator: metav1.LabelSelectorOpNotIn,
+								Values:   []string{"us-east-1", "us-east-2", "us-east-3"},
+							},
+						},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a, us-east-3b",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+		},
+		{ // user configured region is not among the GetAllZones zones
+			PVC: &v1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{Name: "pvc", Namespace: "foo"},
+				Spec: v1.PersistentVolumeClaimSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{kubeletapis.LabelZoneRegion: "us-east-4"},
+					},
+				},
+			},
+			IsSCZoneConfigured:  false,
+			SCZone:              "",
+			IsSCZonesConfigured: true,
+			SCZones:             "us-east-1a, us-east-1b, us-east-2a",
+			GetAllZones:         mockGetAllZones,
+			ZoneToRegion:        mockZoneToRegion,
+		},
+	}
+	for _, errCase := range errCases {
+		zonesConf := new(ZonesConf)
+		zonesConf.PVC = errCase.PVC
+		if errCase.IsSCZoneConfigured {
+			if err := zonesConf.SetZone(errCase.SCZone); err != nil {
+				t.Errorf("%v() returned (%v), want (%v)", "SetZone", err, nil)
+				continue
+			}
+		}
+		if errCase.IsSCZonesConfigured {
+			if err := zonesConf.SetZones(errCase.SCZones); err != nil {
+				t.Errorf("%v() returned (%v), want (%v)", "SetZones", err, nil)
+				continue
+			}
+		}
+		zonesConf.GetAllZones = errCase.GetAllZones
+		zonesConf.ZoneToRegion = errCase.ZoneToRegion
+		if got, err := zonesConf.GetConfZones(); err == nil {
+			t.Errorf("%v() returned (%v, %v), want (%v, %v)", functionUnderTest, got, err, emptySet, "an error")
+		}
+	}
+}
+
+func TestVolumeZoneConfBothZoneAndZonesAreConfigured(t *testing.T) {
+	zonesConf := new(ZonesConf)
+	if err := zonesConf.SetZone("us-east-1a"); err != nil {
+		t.Errorf("%v() returned (%v), want (%v)", "SetZone", err, nil)
+	}
+	if err := zonesConf.SetZones("us-east-1a, us-east-1b, us-east-1c"); err == nil {
+		t.Errorf("%v() returned (%v), want (%v)", "SetZones", err, "an error")
+	}
+}
+
+func TestVolumeZoneConfInvalidZonesInStorageClass(t *testing.T) {
+	zonesConf := new(ZonesConf)
+	if err := zonesConf.SetZones("us-east-1a, , us-east-2a"); err == nil {
+		t.Errorf("%v() returned (%v), want (%v)", "SetZones", err, "an error")
+	}
+}
+
+func TestVolumeZoneConfInvalidZoneInStorageClass(t *testing.T) {
+	zonesConf := new(ZonesConf)
+	if err := zonesConf.SetZone(" 	 "); err == nil {
+		t.Errorf("%v() returned (%v), want (%v)", "SetZone", err, "an error")
+	}
+}


### PR DESCRIPTION
Note: this PR is based on PR #38505 

Zone configuration capabilities for GCE and AWS dynamic provisioners are extended.
User can request in a persistent volume claim that the dynamically provisioned persistent volume will be created in one of the zone(s) specified by the user.

Fixes Trello cards:
- [GCE provisioner, parse pvc.Selector](https://trello.com/c/CyemTzsK/259-finish-gce-provisioner-parse-pvc-selector-dynamic-provision)
- [AWS provisioner, parse pvc.Selector](https://trello.com/c/2XjouSWw/260-finish-aws-provisioner-parse-pvc-selector-dynamic-provision)

```release-note
GCE and AWS dynamic provisioners extension: users can configure zone(s) in which a persistent volume shall be created.
```

cc: @jsafrane

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37497)
<!-- Reviewable:end -->
