### PR TITLE
Use Get instead of List for DNS zones and records

### DIFF
--- a/federation/pkg/dnsprovider/dns.go
+++ b/federation/pkg/dnsprovider/dns.go
@@ -31,6 +31,8 @@ type Interface interface {
 type Zones interface {
 	// List returns the managed Zones, or an error if the list operation failed.
 	List() ([]Zone, error)
+	// Get returns the managed Zone with dnsZoneID or dnsZoneName (returns nil if not found), or an error if the get operation failed.
+	Get(dnsZoneName string, dnsZoneID string) (Zone, error)
 	// Add creates and returns a new managed zone, or an error if the operation failed
 	Add(Zone) (Zone, error)
 	// Remove deletes a managed zone, or returns an error if the operation failed.

--- a/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
@@ -124,6 +124,14 @@ func listRrsOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets) []dnspro
 	return rrset
 }
 
+func getRrsWithNameOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, dnsName string) dnsprovider.ResourceRecordSet {
+	rrset, err := rrsets.Get(dnsName)
+	if err != nil {
+		t.Fatalf("Failed to get recordset with DNS Name: %s, %v", dnsName, err)
+	}
+	return rrset
+}
+
 func getExampleRrs(zone dnsprovider.Zone) dnsprovider.ResourceRecordSet {
 	rrsets, _ := zone.ResourceRecordSets()
 	return rrsets.New("www11."+zone.Name(), []string{"10.10.10.10", "169.20.20.20"}, 180, rrstype.A)
@@ -146,14 +154,29 @@ func TestZonesList(t *testing.T) {
 	firstZone(t)
 }
 
-/* TestZonesID verifies that the id of the zone is returned with the prefix removed */
-func TestZonesID(t *testing.T) {
+/* TestGetZoneByID verifies that getting zone by id succeeds */
+func TestGetZoneByID(t *testing.T) {
 	zone := firstZone(t)
+	z := zones(t)
+	zoneById, _ := z.Get("", zone.ID())
+	if zoneById.ID() != zone.ID() {
+		t.Fatalf("Unexpected zone id: %q, expect: %q", zone.ID(), zoneById.ID())
+	}
+	if zoneById.Name() != zone.Name() {
+		t.Fatalf("Unexpected zone name: %q, expect: %q", zone.Name(), zoneById.Name())
+	}
+}
 
-	// Check /hostedzone/ prefix is removed
-	zoneID := zone.ID()
-	if zoneID != zone.Name() {
-		t.Fatalf("Unexpected zone id: %q", zoneID)
+/* TestGetZoneByName verifies that getting zone by name succeeds */
+func TestGetZoneByName(t *testing.T) {
+	zone := firstZone(t)
+	z := zones(t)
+	zoneByName, _ := z.Get(zone.Name(), "")
+	if zoneByName.ID() != zone.ID() {
+		t.Fatalf("Unexpected zone id: %q, expect: %q", zone.ID(), zoneByName.ID())
+	}
+	if zoneByName.Name() != zone.Name() {
+		t.Fatalf("Unexpected zone name: %q, expect: %q", zone.Name(), zoneByName.Name())
 	}
 }
 
@@ -182,6 +205,19 @@ func TestZoneAddSuccess(t *testing.T) {
 /* TestResourceRecordSetsList verifies that listing of RRS's succeeds */
 func TestResourceRecordSetsList(t *testing.T) {
 	listRrsOrFail(t, rrs(t, firstZone(t)))
+}
+
+/* TestResourceRecordSetsGet verifies that getting of RRS's succeeds */
+func TestResourceRecordSetsGet(t *testing.T) {
+	zone := firstZone(t)
+	sets := rrs(t, zone)
+	set := getExampleRrs(zone)
+	addRrsetOrFail(t, sets, set)
+	defer sets.StartChangeset().Remove(set).Apply()
+	rrsItem := getRrsWithNameOrFail(t, sets, set.Name())
+	if rrsItem.Name() != set.Name() {
+		t.Fatalf("Unexpected ResourceRecordSet name: %q", rrsItem.Name())
+	}
 }
 
 /* TestResourceRecordSetsAddSuccess verifies that addition of a valid RRS succeeds */

--- a/federation/pkg/dnsprovider/providers/aws/route53/stubs/BUILD
+++ b/federation/pkg/dnsprovider/providers/aws/route53/stubs/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//vendor:github.com/aws/aws-sdk-go/aws",
         "//vendor:github.com/aws/aws-sdk-go/service/route53",
+        "//vendor:k8s.io/apimachinery/pkg/util/uuid",
     ],
 )
 

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces/interfaces.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces/interfaces.go
@@ -176,7 +176,7 @@ type (
 		Do(opts ...googleapi.CallOption) (ResourceRecordSetsListResponse, error)
 		// Fields(s ...googleapi.Field) *ResourceRecordSetsListCall  // TODO: Add as needed
 		// IfNoneMatch(entityTag string) *ResourceRecordSetsListCall  // TODO: Add as needed
-		// MaxResults(maxResults int64) *ResourceRecordSetsListCall  // TODO: Add as needed
+		MaxResults(maxResults int64) ResourceRecordSetsListCall
 		Name(name string) ResourceRecordSetsListCall
 		// PageToken(pageToken string) *ResourceRecordSetsListCall  // TODO: Add as needed
 		Type(type_ string) ResourceRecordSetsListCall

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrsets_list_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/rrsets_list_call.go
@@ -39,6 +39,11 @@ func (call *ResourceRecordSetsListCall) Name(name string) interfaces.ResourceRec
 	return call
 }
 
+func (call *ResourceRecordSetsListCall) MaxResults(maxResults int64) interfaces.ResourceRecordSetsListCall {
+	call.impl.MaxResults(maxResults)
+	return call
+}
+
 func (call *ResourceRecordSetsListCall) Type(type_ string) interfaces.ResourceRecordSetsListCall {
 	call.impl.Type(type_)
 	return call

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go
@@ -37,9 +37,9 @@ func (call ManagedZonesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.
 	if call.Error != nil {
 		return nil, *call.Error
 	}
-	if call.Service.Impl[call.Project][call.ManagedZone.DnsName()] != nil {
+	if call.Service.Impl[call.Project][call.ManagedZone.Name()] != nil {
 		return nil, fmt.Errorf("Error - attempt to create duplicate zone %s in project %s.",
-			call.ManagedZone.DnsName(), call.Project)
+			call.ManagedZone.Name(), call.Project)
 	}
 	if call.Service.Impl == nil {
 		call.Service.Impl = map[string]map[string]interfaces.ManagedZone{}
@@ -47,6 +47,6 @@ func (call ManagedZonesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.
 	if call.Service.Impl[call.Project] == nil {
 		call.Service.Impl[call.Project] = map[string]interfaces.ManagedZone{}
 	}
-	call.Service.Impl[call.Project][call.ManagedZone.DnsName()] = call.ManagedZone
+	call.Service.Impl[call.Project][call.ManagedZone.Name()] = call.ManagedZone
 	return call.ManagedZone, nil
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_list_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_list_call.go
@@ -19,24 +19,40 @@ package stubs
 import (
 	"google.golang.org/api/googleapi"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+	"strings"
 )
 
 // Compile time check for interface adherence
 var _ interfaces.ResourceRecordSetsListCall = &ResourceRecordSetsListCall{}
 
 type ResourceRecordSetsListCall struct {
-	Response_ *ResourceRecordSetsListResponse
-	Err_      error
-	Name_     string
-	Type_     string
+	Response_   *ResourceRecordSetsListResponse
+	Err_        error
+	Name_       string
+	Type_       string
+	MaxResults_ int64
 }
 
 func (call *ResourceRecordSetsListCall) Do(opts ...googleapi.CallOption) (interfaces.ResourceRecordSetsListResponse, error) {
+	if len(call.Name_) > 0 {
+		records := make([]interfaces.ResourceRecordSet, 0)
+		for _, record := range call.Response_.impl {
+			if strings.TrimSuffix(call.Name_, ".") == strings.TrimSuffix(record.Name(), ".") {
+				records = append(records, record)
+			}
+		}
+		call.Response_.impl = records
+	}
 	return call.Response_, call.Err_
 }
 
 func (call *ResourceRecordSetsListCall) Name(name string) interfaces.ResourceRecordSetsListCall {
 	call.Name_ = name
+	return call
+}
+
+func (call *ResourceRecordSetsListCall) MaxResults(maxResults int64) interfaces.ResourceRecordSetsListCall {
+	call.MaxResults_ = maxResults
 	return call
 }
 

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -424,11 +424,12 @@ func (s *ServiceController) init() error {
 		return fmt.Errorf("the dns provider does not support zone enumeration, which is required for creating dns records")
 	}
 	s.dnsZones = zones
-	matchingZones, err := getDnsZones(s.zoneName, s.zoneID, s.dnsZones)
+
+	dnsZone, err := s.dnsZones.Get(s.zoneName, s.zoneID)
 	if err != nil {
 		return fmt.Errorf("error querying for DNS zones: %v", err)
 	}
-	if len(matchingZones) == 0 {
+	if dnsZone == nil {
 		if s.zoneName == "" {
 			return fmt.Errorf("ServiceController must be run with zoneName to create zone automatically.")
 		}
@@ -443,9 +444,6 @@ func (s *ServiceController) init() error {
 		}
 		glog.Infof("DNS zone %q successfully created.  Note that DNS resolution will not work until you have registered this name with "+
 			"a DNS registrar and they have changed the authoritative name servers for your domain to point to your DNS provider.", zone.Name())
-	}
-	if len(matchingZones) > 1 {
-		return fmt.Errorf("Multiple matching DNS zones found for %q; please specify zoneID", s.zoneName)
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, federation DNS provider uses List to find DNS zone and record, this is inefficient if there are lots of zones or lots of records in the zone. This PR adds a Get method to DNS provider interface for zones and record sets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37506)
<!-- Reviewable:end -->
