### PR TITLE
Add phonetic name generation for new pod names

### DIFF
--- a/pkg/api/generate.go
+++ b/pkg/api/generate.go
@@ -44,10 +44,18 @@ func GenerateName(u NameGenerator, meta *ObjectMeta) {
 // simpleNameGenerator generates random names.
 type simpleNameGenerator struct{}
 
+// phoneticNameGenerator generates random phonetic names.
+type phoneticNameGenerator struct{}
+
 // SimpleNameGenerator is a generator that returns the name plus a random suffix of five alphanumerics
 // when a name is requested. The string is guaranteed to not exceed the length of a standard Kubernetes
 // name (63 characters)
 var SimpleNameGenerator NameGenerator = simpleNameGenerator{}
+
+// PhoneticNameGenerator is a generator that returns the name plus a suffic of five alphanumerics with
+// alternating consonants and vowels, when a name is requested. The string is guaranteed to not exceed
+// the length of a standard Kubernetes name (63 characters)
+var PhoneticNameGenerator NameGenerator = phoneticNameGenerator{}
 
 const (
 	// TODO: make this flexible for non-core resources with alternate naming rules.
@@ -61,4 +69,11 @@ func (simpleNameGenerator) GenerateName(base string) string {
 		base = base[:maxGeneratedNameLength]
 	}
 	return fmt.Sprintf("%s%s", base, utilrand.String(randomLength))
+}
+
+func (phoneticNameGenerator) GenerateName(base string) string {
+	if len(base) > maxGeneratedNameLength {
+		base = base[:maxGeneratedNameLength]
+	}
+	return fmt.Sprintf("%s%s", base, utilrand.PhoneticString(randomLength))
 }

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -49,7 +49,7 @@ type podStrategy struct {
 
 // Strategy is the default logic that applies when creating and updating Pod
 // objects via the REST API.
-var Strategy = podStrategy{api.Scheme, api.SimpleNameGenerator}
+var Strategy = podStrategy{api.Scheme, api.PhoneticNameGenerator}
 
 // NamespaceScoped is true for pods.
 func (podStrategy) NamespaceScoped() bool {

--- a/pkg/util/rand/rand.go
+++ b/pkg/util/rand/rand.go
@@ -74,12 +74,68 @@ func Perm(n int) []int {
 // of "bad words" being formed.
 var alphanums = []rune("bcdfghjklmnpqrstvwxz0123456789")
 
+// Returns a random rune from the given rune list
+func randElem(set []rune) rune {
+	return set[Intn(len(set))]
+}
+
 // String generates a random alphanumeric string, without vowels, which is n
 // characters long.  This will panic if n is less than zero.
 func String(length int) string {
 	b := make([]rune, length)
 	for i := range b {
-		b[i] = alphanums[Intn(len(alphanums))]
+		b[i] = randElem(alphanums)
 	}
 	return string(b)
+}
+
+// Required for creating phonetic strings.
+// Letter 'l' is omitted to avoid ambiguity.
+var vowels = []rune("aeiou")
+var consonants = []rune("bcdfghjkmnpqrstvwxyz")
+var letters = []rune("abcdefghijkmnpqrstuvwxyz")
+var numbers = []rune("0123456789")
+
+// Returns a rune list of length 'length' with alternating
+// vowels and consonants. Randomly starting from any of the two.
+// If length is 1, returns any random alphabet
+func getAltRune(length int) []rune {
+	phoneticSets := [...][]rune{consonants, vowels}
+	out := make([]rune, length)
+	seed := Intn(len(phoneticSets))
+
+	for i := 0; i < length; i++ {
+		out[i] = randElem(phoneticSets[(seed+i)%len(phoneticSets)])
+	}
+
+	return out
+}
+
+// PhoneticString generates a random string compising of alternating
+// consonants and vowels, with a number after every small chunk (2-4 letters),
+// 'length' characters long. Panics if 'length' is less than zero.
+func PhoneticString(length int) string {
+	if length <= 1 {
+		return string(getAltRune(length))
+	}
+
+	var out []rune
+	seed := Intn(2)
+
+	for len(out) < length {
+		if seed == 0 {
+			// Number
+			out = append(out, randElem(numbers))
+		} else {
+			// Letters
+			size := IntnRange(2, 5)
+			if size > length-len(out) {
+				size = length - len(out)
+			}
+			out = append(out, getAltRune(size)...)
+		}
+		seed = (seed + 1) % 2
+	}
+
+	return string(out)
 }

--- a/pkg/util/rand/rand_test.go
+++ b/pkg/util/rand/rand_test.go
@@ -41,6 +41,62 @@ func TestString(t *testing.T) {
 	}
 }
 
+var validvowels = "aeiou"
+var validconsonants = "bcdfghjkmnpqrstvwxyz"
+var validletters = "abcdefghijkmnpqrstuvwxyz"
+var validnumbers = "0123456789"
+
+func checkAlternating(t *testing.T, s string) {
+	length := len(s)
+	if length == 0 {
+		return
+	}
+
+	phoneticSets := [...]string{validconsonants, validvowels}
+	seed := -1
+	for i, _ := range phoneticSets {
+		if strings.IndexByte(phoneticSets[i], s[0]) != -1 {
+			seed = i
+			break
+		}
+	}
+
+	if seed == -1 {
+		t.Errorf("expected a valid letter, got %c", s[0])
+		return
+	}
+
+	for i := 1; i < length; i++ {
+		if strings.IndexByte(phoneticSets[(seed+i)%len(phoneticSets)], s[i]) == -1 {
+			t.Errorf("expected alternating sequence at position %v, got %v", i, s)
+			return
+		}
+	}
+}
+
+func TestPhoneticString(t *testing.T) {
+	validnumbers := "0123456789"
+
+	for _, l := range []int{0, 1, 2, 3, 4, 5, 6, 10, 123} {
+		s := PhoneticString(l)
+		if len(s) != l {
+			t.Errorf("expected phonetic string of size %d, got %q", l, s)
+		}
+
+		// Split on numbers
+		splits := strings.FieldsFunc(s, func(r rune) bool {
+			return strings.ContainsRune(validnumbers, r)
+		})
+
+		for _, split := range splits {
+			if len(split) > 5 {
+				t.Errorf("expected string length <= 5 letters, got %q", split)
+			}
+			checkAlternating(t, split)
+		}
+	}
+}
+
 // Confirm that panic occurs on invalid input.
 func TestRangePanic(t *testing.T) {
 	defer func() {


### PR DESCRIPTION
fixes #14963 
Lets you memorize and type around the pod names without having to look them up multiple times. Useful for people who have to repeatedly create and delete pods debugging things.

Uses alternating consonants and vowels (Update: changed now) instead of the original string of 5 random words. Generates phonetic words fine enough I think, but reduces the pool to around 3% of the original pool. It is still large enough, 439400 possible random permutations.

A possible modification can be to increase the length of the random string to 7, as @smarterclayton said in the mentioned issue; it makes the pool size as big as the original pool, and make names phonetic, but I'm not a fan of increasing the size if the 439400 pool size suffices.

Also, this can be used with other items (services etc) as well, I've just added it to the creation of new pods and tested with that; since that is what the issue is about. Ideas on where else this may help are welcome.

Finally, since this is my first PR on k8s, do point out if I've not followed the conventions somewhere. My code does fail a few tests on `make test`, but perhaps that's my setup, since they are unrelated files which fail, and they also fail with the master branch.

**Update**: Here's the currently proposed solution:
```
<consonant> <vowel> <consonant> <number> <consonant> <vowel> <consonant>
```
eg: `bot7cat`

* Seems harmless when it comes to bad-words superficially.
* Increases length of names by 2.
* Keeps names phonetic.
* Pool size is 10 times the current size, but at the cost of increasing the length by 2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37523)
<!-- Reviewable:end -->
