### PR TITLE
kubeadm: Skip etcd related preflight checks and reset actions for external etcd

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -221,7 +221,6 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		ServiceCheck{Service: "kubelet"},
 		ServiceCheck{Service: "docker"},
 		PortOpenCheck{port: int(cfg.API.BindPort)},
-		PortOpenCheck{port: 2379},
 		PortOpenCheck{port: 8080},
 		PortOpenCheck{port: int(cfg.Discovery.BindPort)},
 		PortOpenCheck{port: 10250},
@@ -230,7 +229,6 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		HttpProxyCheck{Proto: "https", Host: cfg.API.AdvertiseAddresses[0], Port: int(cfg.API.BindPort)},
 		DirAvailableCheck{Path: "/etc/kubernetes/manifests"},
 		DirAvailableCheck{Path: "/etc/kubernetes/pki"},
-		DirAvailableCheck{Path: "/var/lib/etcd"},
 		DirAvailableCheck{Path: "/var/lib/kubelet"},
 		FileAvailableCheck{Path: "/etc/kubernetes/admin.conf"},
 		FileAvailableCheck{Path: "/etc/kubernetes/kubelet.conf"},
@@ -243,6 +241,14 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		InPathCheck{executable: "socat", mandatory: true},
 		InPathCheck{executable: "tc", mandatory: false},
 		InPathCheck{executable: "touch", mandatory: false},
+	}
+
+	if len(cfg.Etcd.Endpoints) == 0 {
+		// Only do etcd related checks when no external endpoints were specified
+		checks = append(checks,
+			PortOpenCheck{port: 2379},
+			DirAvailableCheck{Path: "/var/lib/etcd"},
+		)
 	}
 
 	return runChecks(checks, os.Stderr)


### PR DESCRIPTION
**What this PR does / why we need it**:
Skip etcd related preflight checks and reset actions for external etcd

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://github.com/kubernetes/kubeadm/issues/69#issuecomment-262988388

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
kubeadm: Skip etcd related preflight checks and reset actions for external etcd
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37524)
<!-- Reviewable:end -->
