### PR TITLE
CreateNodeSelectorPods should respect parameter

### DIFF
--- a/test/e2e/cluster_size_autoscaling.go
+++ b/test/e2e/cluster_size_autoscaling.go
@@ -460,13 +460,13 @@ func CreateNodeSelectorPods(f *framework.Framework, id string, replicas int, nod
 	config := &testutils.RCConfig{
 		Client:         f.ClientSet,
 		InternalClient: f.InternalClientset,
-		Name:           "node-selector",
+		Name:           id,
 		Namespace:      f.Namespace.Name,
 		Timeout:        defaultTimeout,
 		Image:          framework.GetPauseImageName(f.ClientSet),
 		Replicas:       replicas,
 		HostPorts:      map[string]int{"port1": 4321},
-		NodeSelector:   map[string]string{"cluster-autoscaling-test.special-node": "true"},
+		NodeSelector:   nodeSelector,
 	}
 	err := framework.RunRC(*config)
 	if expectRunning {


### PR DESCRIPTION
Fix (1): `CreateNodeSelectorPods` should respect parameter `id`.

The existing e2e does not break because it happened use "node-selector" as id, which  is the same as the hard coded value.

Fix (2): The current `CreateNodeSelectorPods` does not use `nodeSelector` parameter, it hard coded a label instead.

The reason current e2e does not influenced because we happened use the same label: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/cluster_size_autoscaling.go#L177

Found these bugs during testing #36238

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37512)
<!-- Reviewable:end -->
