### PR TITLE
refactor make mounts

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -111,8 +111,7 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 		mountEtcHostsFile = mountEtcHostsFile && (mount.MountPath != etcHostsPath)
 		vol, ok := podVolumes[mount.Name]
 		if !ok {
-			glog.Warningf("Mount cannot be satisfied for container %q, because the volume is missing: %q", container.Name, mount)
-			continue
+			return nil, fmt.Errorf("Mount cannot be satisfied for container %q, because the volume is missing: %v", container.Name, mount)
 		}
 
 		relabelVolume := false


### PR DESCRIPTION
I think the errors should be exposed  as early as possible. 
I'm not sure if there is any other consideration to use '_**continue**_' here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37540)
<!-- Reviewable:end -->
