### PR TITLE
Automated cherry pick of #34462 #37070 #37203

### DIFF
--- a/cluster/saltbase/salt/e2e-image-puller/e2e-image-puller.manifest
+++ b/cluster/saltbase/salt/e2e-image-puller/e2e-image-puller.manifest
@@ -55,7 +55,7 @@ spec:
       path: /usr/bin/docker
     name: docker
   # This pod is really fire-and-forget.
-  restartPolicy: Never
+  restartPolicy: OnFailure
   # This pod needs hostNetworking for true VM perf measurement as well as avoiding cbr0 issues
   hostNetwork: true
 

--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/fields"
+	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/labels"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -29,6 +30,28 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+func isRestartNeverMirrorPod(p *api.Pod) bool {
+	if !kubepod.IsMirrorPod(p) {
+		return false
+	}
+	return p.Spec.RestartPolicy == api.RestartPolicyNever
+}
+
+func filterIrrelevantPods(pods []*api.Pod) []*api.Pod {
+	var results []*api.Pod
+	for _, p := range pods {
+		if isRestartNeverMirrorPod(p) {
+			// Mirror pods with restart policy == Never will not get
+			// recreated if they are deleted after the pods have
+			// terminated. For now, we discount such pods.
+			// https://github.com/kubernetes/kubernetes/issues/34003
+			continue
+		}
+		results = append(results, p)
+	}
+	return results
+}
 
 var _ = framework.KubeDescribe("Restart [Disruptive]", func() {
 	f := framework.NewDefaultFramework("restart")
@@ -57,7 +80,9 @@ var _ = framework.KubeDescribe("Restart [Disruptive]", func() {
 		framework.Logf("Got the following nodes before restart: %v", nodeNamesBefore)
 
 		By("ensuring all pods are running and ready")
-		pods := ps.List()
+		allPods := ps.List()
+		pods := filterIrrelevantPods(allPods)
+
 		podNamesBefore := make([]string, len(pods))
 		for i, p := range pods {
 			podNamesBefore[i] = p.ObjectMeta.Name
@@ -105,7 +130,8 @@ func waitForNPods(ps *framework.PodStore, expect int, timeout time.Duration) ([]
 	var pods []*api.Pod
 	var errLast error
 	found := wait.Poll(framework.Poll, timeout, func() (bool, error) {
-		pods = ps.List()
+		allPods := ps.List()
+		pods := filterIrrelevantPods(allPods)
 		if len(pods) != expect {
 			errLast = fmt.Errorf("expected to find %d pods but found only %d", expect, len(pods))
 			framework.Logf("Error getting pods: %v", errLast)

--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -31,17 +31,17 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func isRestartNeverMirrorPod(p *api.Pod) bool {
+func isNotRestartAlwaysMirrorPod(p *api.Pod) bool {
 	if !kubepod.IsMirrorPod(p) {
 		return false
 	}
-	return p.Spec.RestartPolicy == api.RestartPolicyNever
+	return p.Spec.RestartPolicy != api.RestartPolicyAlways
 }
 
 func filterIrrelevantPods(pods []*api.Pod) []*api.Pod {
 	var results []*api.Pod
 	for _, p := range pods {
-		if isRestartNeverMirrorPod(p) {
+		if isNotRestartAlwaysMirrorPod(p) {
 			// Mirror pods with restart policy == Never will not get
 			// recreated if they are deleted after the pods have
 			// terminated. For now, we discount such pods.


### PR DESCRIPTION
This should help with some of 1.4-branch `BeforeEach` failures.

cc @dchen1107 @yujuhong @Random-Liu 

Cherry pick of #34462 #37070 #37203 on release-1.4.

#34462: Ignore mirror pods with RestartPolicy == Never in restart
#37070: Change image-puller restart policy to OnFailure
#37203: Filter out non-RestartAlways mirror pod in restart test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37544)
<!-- Reviewable:end -->
