### PR TITLE
Optimize predicate of pod affinity in scheduler

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -84,7 +84,8 @@ func (p *podAffinityPriorityMap) setError(err error) {
 }
 
 func (p *podAffinityPriorityMap) processTerm(term *v1.PodAffinityTerm, podDefiningAffinityTerm, podToCheck *v1.Pod, fixedNode *v1.Node, weight float64) {
-	match, err := priorityutil.PodMatchesTermsNamespaceAndSelector(podToCheck, podDefiningAffinityTerm, term)
+	namespaces := priorityutil.GetNamespacesFromPodAffinityTerm(podDefiningAffinityTerm, *term)
+	match, err := priorityutil.PodMatchesTermsNamespaceAndSelector(podToCheck, namespaces, term)
 	if err != nil {
 		p.setError(err)
 		return

--- a/plugin/pkg/scheduler/algorithm/priorities/util/topologies.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/util/topologies.go
@@ -27,7 +27,7 @@ import (
 // according to the namespaces indicated in podAffinityTerm.
 // 1. If the namespaces is nil considers the given pod's namespace
 // 2. If the namespaces is empty list then considers all the namespaces
-func getNamespacesFromPodAffinityTerm(pod *v1.Pod, podAffinityTerm v1.PodAffinityTerm) sets.String {
+func GetNamespacesFromPodAffinityTerm(pod *v1.Pod, podAffinityTerm v1.PodAffinityTerm) sets.String {
 	names := sets.String{}
 	if podAffinityTerm.Namespaces == nil {
 		names.Insert(pod.Namespace)
@@ -38,9 +38,8 @@ func getNamespacesFromPodAffinityTerm(pod *v1.Pod, podAffinityTerm v1.PodAffinit
 }
 
 // PodMatchesTermsNamespaceAndSelector returns true if the given <pod>
-// matches the namespace and selector defined by <affinityPod>`s <term>.
-func PodMatchesTermsNamespaceAndSelector(pod *v1.Pod, affinityPod *v1.Pod, term *v1.PodAffinityTerm) (bool, error) {
-	namespaces := getNamespacesFromPodAffinityTerm(affinityPod, *term)
+// matches the <namespaces> and selector defined by <term>.
+func PodMatchesTermsNamespaceAndSelector(pod *v1.Pod, namespaces sets.String, term *v1.PodAffinityTerm) (bool, error) {
 	if len(namespaces) != 0 && !namespaces.Has(pod.Namespace) {
 		return false, nil
 	}


### PR DESCRIPTION
Take the common GetNamespacesFromPodAffinityTerm out of loop to avoid invoking repeated times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37559)
<!-- Reviewable:end -->
