### PR TITLE
Fix nil pointer dereference in test framework

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3550,16 +3550,10 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult,
 }
 
 func IssueSSHCommand(cmd, provider string, node *v1.Node) error {
-	result, err := IssueSSHCommandWithResult(cmd, provider, node)
-	if result != nil {
-		LogSSHResult(*result)
+	_, err := IssueSSHCommandWithResult(cmd, provider, node)
+	if err != nil {
+		return err
 	}
-
-	if result.Code != 0 || err != nil {
-		return fmt.Errorf("failed running %q: %v (exit code %d)",
-			cmd, err, result.Code)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Checking the `result.Code` prior to `err` in the if statement causes a panic if result is `nil`. It turns out the formatting of the error is already in `IssueSSHCommandWithResult`, so removing redundant code is enough to fix the issue. Logging the SSH result was also redundant, so I removed that as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37583)
<!-- Reviewable:end -->
