### PR TITLE
Better compat with very old iptables (e.g. CentOS 6)

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -374,6 +374,12 @@ func (runner *runner) checkRule(table Table, chain Chain, args ...string) (bool,
 	}
 }
 
+var hexnumRE = regexp.MustCompile("0x0+([0-9])")
+
+func trimhex(s string) string {
+	return hexnumRE.ReplaceAllString(s, "0x$1")
+}
+
 // Executes the rule check without using the "-C" flag, instead parsing iptables-save.
 // Present for compatibility with <1.4.11 versions of iptables.  This is full
 // of hack and half-measures.  We should nix this ASAP.
@@ -392,6 +398,7 @@ func (runner *runner) checkRuleWithoutCheck(table Table, chain Chain, args ...st
 	var argsCopy []string
 	for i := range args {
 		tmpField := strings.Trim(args[i], "\"")
+		tmpField = trimhex(tmpField)
 		argsCopy = append(argsCopy, strings.Fields(tmpField)...)
 	}
 	argset := sets.NewString(argsCopy...)
@@ -409,6 +416,7 @@ func (runner *runner) checkRuleWithoutCheck(table Table, chain Chain, args ...st
 		// Just remove all quotes.
 		for i := range fields {
 			fields[i] = strings.Trim(fields[i], "\"")
+			fields[i] = trimhex(fields[i])
 		}
 
 		// TODO: This misses reorderings e.g. "-x foo ! -y bar" will match "! -x foo -y bar"

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -470,7 +470,7 @@ func TestCheckRuleWithoutCheckPresent(t *testing.T) {
 :PREROUTING ACCEPT [2136997:197881818]
 :POSTROUTING ACCEPT [4284525:258542680]
 :OUTPUT ACCEPT [5901660:357267963]
--A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
+-A PREROUTING -m addrtype --dst-type LOCAL -m mark --mark 0x00004000/0x00004000 -j DOCKER
 COMMIT
 # Completed on Wed Oct 29 14:56:01 2014`
 
@@ -487,7 +487,12 @@ COMMIT
 		},
 	}
 	runner := &runner{exec: &fexec}
-	exists, err := runner.checkRuleWithoutCheck(TableNAT, ChainPrerouting, "-m", "addrtype", "-j", "DOCKER", "--dst-type", "LOCAL")
+	exists, err := runner.checkRuleWithoutCheck(
+		TableNAT, ChainPrerouting,
+		"-m", "addrtype",
+		"-m", "mark", "--mark", "0x4000/0x4000",
+		"-j", "DOCKER",
+		"--dst-type", "LOCAL")
 	if err != nil {
 		t.Errorf("expected success, got %v", err)
 	}


### PR DESCRIPTION
Fixes reported issue with CentOS6 iptables 1.4.7 (ancient)

Older iptables expanded things like 0x4000 into 0x00004000, which defeats the
fallback "check" logic.

Fixes #37416

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37594)
<!-- Reviewable:end -->
