### PR TITLE
add some help info about the 'all' arg

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -170,6 +170,7 @@ __custom_func() {
 	// TODO: This should be populated using the discovery information from apiserver.
 	valid_resources = `Valid resource types include:
 
+    * all
     * clusters (valid only for federation apiservers)
     * componentstatuses (aka 'cs')
     * configmaps (aka 'cm')

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -77,7 +77,10 @@ var (
 		kubectl get rc,services
 
 		# List one or more resources by their type and names.
-		kubectl get rc/web service/frontend pods/web-pod-13je7`)
+		kubectl get rc/web service/frontend pods/web-pod-13je7
+
+		# List all resources with different types.
+		kubectl get all`)
 )
 
 // NewCmdGet creates a command object for the generic "get" action, which


### PR DESCRIPTION
**What this PR does / why we need it**:
There is an arg named "all" in the get command, we can use it like "kubectl get all". But we can get nothing about this arg in the help description. Users may not know how to use it without looking into the source code. So here I'm going to add some description about this arg.

**Which issue this PR fixes** 
We discussed about this in 
In pkg/kubectl/cmd/get.go there is a confused arg named "all" [#37533](https://github.com/kubernetes/kubernetes/issues/37533)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37608)
<!-- Reviewable:end -->
