### PR TITLE
Add namespace index for limit ranger

### DIFF
--- a/pkg/controller/informers/core.go
+++ b/pkg/controller/informers/core.go
@@ -467,7 +467,7 @@ func NewInternalLimitRangeInformer(internalclient internalclientset.Interface, r
 		},
 		&api.LimitRange{},
 		resyncPeriod,
-		cache.Indexers{})
+		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 
 	return sharedIndexInformer
 }


### PR DESCRIPTION
Without this PR I'm seeing a huge number of lines like this:
```
Index with name namespace does not exist
```

Those are coming from LimitRanger admission controller - this PR fixes those.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37613)
<!-- Reviewable:end -->
