### PR TITLE
docs: devel: Add some notes about OWNERS process

### DIFF
--- a/docs/devel/owners.md
+++ b/docs/devel/owners.md
@@ -1,6 +1,6 @@
 # Owners files
 
-_Note_: This is a design for a feature that is not yet implemented.
+_Note_: This is a design for a feature that is not yet implemented. See the [contrib PR](https://github.com/kubernetes/contrib/issues/1389) for the current progress.
 
 ## Overview
 

--- a/docs/devel/owners.md
+++ b/docs/devel/owners.md
@@ -9,6 +9,8 @@ will serve as the approvers for code to be submitted to these parts of the repos
 are not necessarily expected to do the first code review for all commits to these areas, but they are
 required to approve changes before they can be merged.
 
+**Note** The Kubernetes project has a hiatus on adding new approvers to OWNERS files. At this time we are [adding more reviewers](https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr%20%22Curating%20owners%3A%22%20) to take the load off of the current set of approvers and once we have had a chance to flush this out for a release we will begin adding new approvers again. Adding new approvers is planned for after the Kubernetes 1.6.0 release.
+
 ## High Level flow
 
 ### Step One: A PR is submitted


### PR DESCRIPTION
docs: devel: point people at place for OWNERS status

All of the tracking is happening here
https://github.com/kubernetes/contrib/issues/1389 point people at it.

docs: devel: describe the current state of adding approvers

Document that we are currently holding off on adding new approvers until
the reviewers process is in place. And set a target deadline.

cc @calebamiles @bgrant0607 @apelisse