### PR TITLE
Node E2E: Collect serial output

### DIFF
--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -350,6 +350,19 @@ func getTestArtifacts(host, testDir string) error {
 	return nil
 }
 
+// WriteLog is a temporary function to make it possible to write log
+// in the runner. This is used to collect serial console log.
+// TODO(random-liu): Use the log-dump script in cluster e2e.
+func WriteLog(host, filename, content string) error {
+	f, err := os.Create(filepath.Join(*resultsDir, host, filename))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(content)
+	return err
+}
+
 // getSSHCommand handles proper quoting so that multiple commands are executed in the same shell over ssh
 func getSSHCommand(sep string, args ...string) string {
 	return fmt.Sprintf("'%s'", strings.Join(args, sep))


### PR DESCRIPTION
This is a temporary solution to collect serial output from test GCE node in node e2e.

We should come up with a better idea later. Ideally, node e2e should share the same log collection logic with cluster e2e. https://github.com/kubernetes/kubernetes/blob/master/cluster/log-dump.sh

Mark v1.5 because this helps debug https://github.com/kubernetes/kubernetes/issues/37333.

@mtaufen @dchen1107 
/cc @kubernetes/sig-node 