### PR TITLE
kubectl top pod|node should handle when Heapster is somewhere else

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -247,6 +247,10 @@ hard
 hard-pod-affinity-symmetric-weight
 healthz-bind-address
 healthz-port
+heapster-namespace
+heapster-port
+heapster-scheme
+heapster-service
 horizontal-pod-autoscaler-sync-period
 host-cluster-context
 host-ipc-sources

--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -118,6 +118,7 @@ go_library(
         "//vendor:github.com/jonboulle/clockwork",
         "//vendor:github.com/renstrom/dedent",
         "//vendor:github.com/spf13/cobra",
+        "//vendor:github.com/spf13/pflag",
     ],
 )
 

--- a/pkg/kubectl/cmd/top_pod.go
+++ b/pkg/kubectl/cmd/top_pod.go
@@ -40,6 +40,7 @@ type TopPodOptions struct {
 	AllNamespaces   bool
 	PrintContainers bool
 	PodClient       coreclient.PodsGetter
+	HeapsterOptions HeapsterTopOptions
 	Client          *metricsutil.HeapsterMetricsClient
 	Printer         *metricsutil.TopCmdPrinter
 }
@@ -93,6 +94,7 @@ func NewCmdTopPod(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", "", "Selector (label query) to filter on")
 	cmd.Flags().BoolVar(&options.PrintContainers, "containers", false, "If present, print usage of containers within a pod.")
 	cmd.Flags().BoolVar(&options.AllNamespaces, "all-namespaces", false, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	options.HeapsterOptions.Bind(cmd.Flags())
 	return cmd
 }
 
@@ -113,7 +115,7 @@ func (o *TopPodOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 		return err
 	}
 	o.PodClient = clientset.Core()
-	o.Client = metricsutil.DefaultHeapsterMetricsClient(clientset.Core())
+	o.Client = metricsutil.NewHeapsterMetricsClient(clientset.Core(), o.HeapsterOptions.Namespace, o.HeapsterOptions.Scheme, o.HeapsterOptions.Service, o.HeapsterOptions.Port)
 	o.Printer = metricsutil.NewTopCmdPrinter(out)
 	return nil
 }


### PR DESCRIPTION
OpenShift runs Heapster on HTTPS, which means `top node` and `top pod`
are broken because they hardcode 'http' as the scheme. Provide an
options struct allowing users to specify `--heapster-namespace`,
`--heapster-service`, `--heapster-scheme`, and `--heapster-port` to the
commands (leveraging the existing defaults).

@kubernetes/sig-metrics makes top a little more useful in other spots