### PR TITLE
Fixes Addon Manager's pruning issue for old Deployments

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 6.1 (Tue November 29 2016 Zihong Zheng <zihongz@google.com>)
+ - Support pruning old Deployments.
+
 ### Version 6.0 (Fri November 18 2016 Zihong Zheng <zihongz@google.com>)
  - Upgrade Addon Manager to use `kubectl apply`.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v6.0
-KUBECTL_VERSION?=v1.5.0-beta.1
+VERSION=v6.1
+KUBECTL_VERSION?=v1.5.0-beta.2
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=bashell/alpine-bash

--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -195,6 +195,7 @@ done
 # otherwise they would be leaked during upgrade.
 log INFO "== Annotating the old addon resources at $(date -Is) =="
 annotate_addons ReplicationController
+annotate_addons Deployment
 
 # Create new addon resources by apply (with --prune=false).
 # The old RCs will not fight for pods created by new Deployments with the same label because the `controllerRef` feature.

--- a/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.0",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.1",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.0",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.1",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -10,7 +10,7 @@ spec:
   containers:
   - name: kube-addon-manager
     # When updating version also bump it in cluster/images/hyperkube/static-pods/addon-manager.json
-    image: gcr.io/google-containers/kube-addon-manager:v6.0
+    image: gcr.io/google-containers/kube-addon-manager:v6.1
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
Fixes #37641.

Attaches the `last-applied`annotations to the existing Deployments for pruning.

Below images are built and pushed:
- gcr.io/google-containers/kube-addon-manager:v6.1
- gcr.io/google-containers/kube-addon-manager-amd64:v6.1
- gcr.io/google-containers/kube-addon-manager-arm:v6.1
- gcr.io/google-containers/kube-addon-manager-arm64:v6.1
- gcr.io/google-containers/kube-addon-manager-ppc64le:v6.1

@mikedanese 

cc @saad-ali @krousey 