### PR TITLE
build: clean platform envs to prevent cross-contamination

### DIFF
--- a/build-tools/common.sh
+++ b/build-tools/common.sh
@@ -560,6 +560,7 @@ function kube::build::run_build_command_ex() {
     --env "KUBE_FASTBUILD=${KUBE_FASTBUILD:-false}"
     --env "KUBE_BUILDER_OS=${OSTYPE:-notdetected}"
     --env "KUBE_BUILD_PPC64LE=${KUBE_BUILD_PPC64LE}"  # TODO(IBM): remove
+    --env "KUBE_VERBOSE=${KUBE_VERBOSE}"
   )
 
   # If we have stdin we can run interactive.  This allows things like 'shell.sh'

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -219,6 +219,8 @@ kube::golang::set_platform_envs() {
   [[ -n ${1-} ]] || {
     kube::log::error_exit "!!! Internal error. No platform set in kube::golang::set_platform_envs"
   }
+  # make sure we have a clean slate first
+  kube::golang::unset_platform_envs
 
   export GOOS=${platform%/*}
   export GOARCH=${platform##*/}
@@ -456,6 +458,8 @@ kube::golang::build_binaries_for_platform() {
   local -a nonstatics=()
   local -a tests=()
 
+  V=2 kube::log::info "Env for ${platform}: GOOS=${GOOS-} GOARCH=${GOARCH-} GOROOT=${GOROOT-} CGO_ENABLED=${CGO_ENABLED-} CC=${CC-}"
+
   for binary in "${binaries[@]}"; do
 
     if [[ "${binary}" =~ ".test"$ ]]; then
@@ -685,8 +689,10 @@ kube::golang::build_binaries() {
     else
       for platform in "${platforms[@]}"; do
         kube::log::status "Building go targets for ${platform}:" "${targets[@]}"
-        kube::golang::set_platform_envs "${platform}"
-        kube::golang::build_binaries_for_platform ${platform} ${use_go_build:-}
+        (
+          kube::golang::set_platform_envs "${platform}"
+          kube::golang::build_binaries_for_platform ${platform} ${use_go_build:-}
+        )
       done
     fi
   )


### PR DESCRIPTION
**What this PR does / why we need it**: As I described in https://github.com/kubernetes/kubernetes/issues/37079#issuecomment-263733509, we are leaking platform compilation envs between build stages for different platforms in the non-parallel dockerized cross build. This PR uses a subshell for the non-parallel build, more closely matching the parallel build.

This also adds some logging, which had it existed previously, may have made the bug more immediately obvious.

**Which issue this PR fixes**: fixes #37079 

cc @sebgoa @iTagir @saad-ali 
