### PR TITLE
Collect logs for dead kubelets too

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -131,7 +131,7 @@ function save-logs() {
       esac
     fi
 
-    if log-dump-ssh "${node_name}" "sudo systemctl status kubelet.service" &> /dev/null; then
+    if log-dump-ssh "${node_name}" "command -v journalctl" &> /dev/null; then
         log-dump-ssh "${node_name}" "sudo journalctl --output=short-precise -u kube-node-installation.service" > "${dir}/kube-node-installation.log" || true
         log-dump-ssh "${node_name}" "sudo journalctl --output=short-precise -u kube-node-configuration.service" > "${dir}/kube-node-configuration.log" || true
         log-dump-ssh "${node_name}" "sudo journalctl --output=cat -u kubelet.service" > "${dir}/kubelet.log" || true


### PR DESCRIPTION
Collect logs via journalctl if journalctl is installed, rather than only if
kubelet.service is running. The old way resulted in us losing logs any
time the kubelet was failing. This, of course, breaks on a node if
someone decided to install journalctl but not use it. But that is not
the case on any of the images used by cluster-level tests at present.

^^^^FYI @Random-Liu not sure if `which journalctl` implies that journalctl is actually used on all of the nodes we test in the node-e2e suites. This may be of consequence if we move to using `cluster/log-dump.sh` to scrape logs for node-e2e.

P0 because this is somewhat in the way of debugging https://github.com/kubernetes/kubernetes/issues/33882

@jessfraz @saad-ali This should be cherry-picked to 1.4 and 1.5 as well.