### PR TITLE
Set Dashboard UI version to v1.5.0

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0-beta1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dashboard/dashboard-controller.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0-beta1
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
Updating the dashboard version to v1.5.0

see our release notes at https://github.com/kubernetes/dashboard/releases/tag/v1.5.0