### PR TITLE
Add error handling for store operations in cache/reflector

### DIFF
--- a/pkg/client/cache/reflector.go
+++ b/pkg/client/cache/reflector.go
@@ -363,14 +363,23 @@ loop:
 			newResourceVersion := meta.GetResourceVersion()
 			switch event.Type {
 			case watch.Added:
-				r.store.Add(event.Object)
+				err := r.store.Add(event.Object)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("%s: unable to add watch event object to store %#v", r.name, event))
+				}
 			case watch.Modified:
-				r.store.Update(event.Object)
+				err := r.store.Update(event.Object)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("%s: unable to update watch event object to store %#v", r.name, event))
+				}
 			case watch.Deleted:
 				// TODO: Will any consumers need access to the "last known
 				// state", which is passed in event.Object? If so, may need
 				// to change this.
-				r.store.Delete(event.Object)
+				err := r.store.Delete(event.Object)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("%s: unable to delete watch event object from store %#v", r.name, event))
+				}
 			default:
 				utilruntime.HandleError(fmt.Errorf("%s: unable to understand watch event %#v", r.name, event))
 			}


### PR DESCRIPTION
In my opinion the errors there should be returned, but to have minimal impact I just added runtime error handler.

Let me know what you think.
