### PR TITLE
simplify the authorization attribute getter

### DIFF
--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -752,7 +752,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		default:
 			return nil, fmt.Errorf("unrecognized action verb: %s", action.Verb)
 		}
-		// Note: update GetAttribs() when adding a custom handler.
+		// Note: update GetAuthorizerAttributes() when adding a custom handler.
 	}
 	return &apiResource, nil
 }

--- a/pkg/apiserver/filters/audit_test.go
+++ b/pkg/apiserver/filters/audit_test.go
@@ -74,10 +74,9 @@ func (*fakeHTTPHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func TestAudit(t *testing.T) {
 	var buf bytes.Buffer
 
-	attributeGetter := NewRequestAttributeGetter(&fakeRequestContextMapper{
+	handler := WithAudit(&fakeHTTPHandler{}, &fakeRequestContextMapper{
 		user: &user.DefaultInfo{Name: "admin"},
-	})
-	handler := WithAudit(&fakeHTTPHandler{}, attributeGetter, &buf)
+	}, &buf)
 
 	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
 	req.RemoteAddr = "127.0.0.1"

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -485,8 +485,6 @@ func (c *Config) MaybeGenerateServingCerts(alternateIPs ...net.IP) error {
 }
 
 func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) (secure, insecure http.Handler) {
-	attributeGetter := apiserverfilters.NewRequestAttributeGetter(c.RequestContextMapper)
-
 	generic := func(handler http.Handler) http.Handler {
 		handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
 		handler = genericfilters.WithPanicRecovery(handler, c.RequestContextMapper)
@@ -497,10 +495,10 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) (secure, insec
 		return handler
 	}
 	audit := func(handler http.Handler) http.Handler {
-		return apiserverfilters.WithAudit(handler, attributeGetter, c.AuditWriter)
+		return apiserverfilters.WithAudit(handler, c.RequestContextMapper, c.AuditWriter)
 	}
 	protect := func(handler http.Handler) http.Handler {
-		handler = apiserverfilters.WithAuthorization(handler, attributeGetter, c.Authorizer)
+		handler = apiserverfilters.WithAuthorization(handler, c.RequestContextMapper, c.Authorizer)
 		handler = apiserverfilters.WithImpersonation(handler, c.RequestContextMapper, c.Authorizer)
 		handler = audit(handler) // before impersonation to read original user
 		handler = authhandlers.WithAuthentication(handler, c.RequestContextMapper, c.Authenticator, authhandlers.Unauthorized(c.SupportsBasicAuth))


### PR DESCRIPTION
Construct the authorization attributes directly from the context.  This eliminates unnecessary redirection.  

@sttts 