### PR TITLE
Update selenium docker images

### DIFF
--- a/examples/selenium/selenium-hub-rc.yaml
+++ b/examples/selenium/selenium-hub-rc.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: selenium-hub
-        image: selenium/hub:2.47.1 
+        image: selenium/hub:2.53.0
         ports:
           - containerPort: 4444 
         resources:

--- a/examples/selenium/selenium-node-chrome-rc.yaml
+++ b/examples/selenium/selenium-node-chrome-rc.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: selenium-node-chrome
-        image: selenium/node-chrome-debug:2.47.1
+        image: selenium/node-chrome-debug:2.53.0
         ports:
           - containerPort: 5900 
         env:

--- a/examples/selenium/selenium-node-firefox-rc.yaml
+++ b/examples/selenium/selenium-node-firefox-rc.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: selenium-node-firefox
-        image: selenium/node-firefox-debug:2.47.1
+        image: selenium/node-firefox-debug:2.53.0
         ports:
           - containerPort: 5900 
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates selenium docker images (2.47 was released a year ago)

**Which issue this PR fixes**
-

**Special notes for your reviewer**:
-

**Release note**:
`NONE`


