### PR TITLE
Add restclientconfig helper fn for parsing timeout

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -1282,7 +1282,7 @@ __EOF__
 
   ## check --request-timeout value with invalid time unit
   output_message=$(! kubectl get pod valid-pod --request-timeout="1p" 2>&1)
-  kube::test::if_has_string "${output_message}" 'Invalid value for option'
+  kube::test::if_has_string "${output_message}" 'Invalid timeout value'
 
   # cleanup
   kubectl delete pods valid-pod "${kube_flags[@]}"

--- a/pkg/client/unversioned/clientcmd/BUILD
+++ b/pkg/client/unversioned/clientcmd/BUILD
@@ -17,6 +17,7 @@ go_library(
         "client_config.go",
         "config.go",
         "doc.go",
+        "helpers.go",
         "loader.go",
         "merged_client_builder.go",
         "overrides.go",

--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -27,9 +27,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/imdario/mergo"
 
-	"strconv"
-	"time"
-
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	clientauth "k8s.io/kubernetes/pkg/client/unversioned/auth"
@@ -129,13 +126,11 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 	clientConfig.Host = configClusterInfo.Server
 
 	if len(config.overrides.Timeout) > 0 {
-		if i, err := strconv.ParseInt(config.overrides.Timeout, 10, 64); err == nil && i >= 0 {
-			clientConfig.Timeout = time.Duration(i) * time.Second
-		} else if requestTimeout, err := time.ParseDuration(config.overrides.Timeout); err == nil {
-			clientConfig.Timeout = requestTimeout
-		} else {
-			return nil, fmt.Errorf("Invalid value for option '--request-timeout'. Value must be a single integer, or an integer followed by a corresponding time unit (e.g. 1s | 2m | 3h)")
+		timeout, err := ParseTimeout(config.overrides.Timeout)
+		if err != nil {
+			return nil, err
 		}
+		clientConfig.Timeout = timeout
 	}
 
 	if u, err := url.ParseRequestURI(clientConfig.Host); err == nil && u.Opaque == "" && len(u.Path) > 1 {

--- a/pkg/client/unversioned/clientcmd/helpers.go
+++ b/pkg/client/unversioned/clientcmd/helpers.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// ParseTimeout returns a parsed duration from a string
+// A duration string value must be a positive integer, optionally followed by a corresponding time unit (s|m|h).
+func ParseTimeout(duration string) (time.Duration, error) {
+	if i, err := strconv.ParseInt(duration, 10, 64); err == nil && i >= 0 {
+		return (time.Duration(i) * time.Second), nil
+	}
+	if requestTimeout, err := time.ParseDuration(duration); err == nil {
+		return requestTimeout, nil
+	}
+	return 0, fmt.Errorf("Invalid timeout value. Timeout must be a single integer in seconds, or an integer followed by a corresponding time unit (e.g. 1s | 2m | 3h)")
+}


### PR DESCRIPTION
Related downstream PR: https://github.com/openshift/origin/pull/12062 (example of use-case for this patch)

**Release note**:
```release-note
release-note-none
```

This patch adds a package `pkg/client/unversioned/clientcmd/util` and
defines a `ParseTimeout` helper function for parsing time from a
user-defined string. This allows code re-use in other packages that
require the creation of a new restclient (and therefore must set the
`--global-timeout` flag value manually).

@fabianofranz @kubernetes/cli-review