### PR TITLE
adjusted timeouts for inode eviction and garbage collection tests

### DIFF
--- a/test/e2e_node/garbage_collector_test.go
+++ b/test/e2e_node/garbage_collector_test.go
@@ -38,10 +38,9 @@ const (
 	maxTotalContainers = -1
 
 	defaultRuntimeRequestTimeoutDuration = 1 * time.Minute
-	garbageCollectDuration               = 2 * time.Minute
+	garbageCollectDuration               = 3 * time.Minute
 	setupDuration                        = 10 * time.Minute
 	runtimePollInterval                  = 10 * time.Second
-	deleteTimeout                        = 4 * time.Minute
 )
 
 type testPodSpec struct {


### PR DESCRIPTION
Inode eviction tests appear to run slower on coreos than the other operating systems I tested on.
I adjusted the timeout for the test from 10 to 30 minutes to compensate.

Garbage collection tests also flake occasionally due to timeouts.
I adjusted the timeout for runtime commands from 2 to 3 minutes, and removed an unused constant.

cc: @Random-Liu 