### PR TITLE
Add python-client to supported client list

### DIFF
--- a/docs/devel/client-libraries.md
+++ b/docs/devel/client-libraries.md
@@ -3,6 +3,7 @@
 ### Supported
 
    * [Go](https://github.com/kubernetes/client-go)
+   * [Python] (https://github.com/kubernetes-incubator/client-python)
 
 ### User Contributed
 


### PR DESCRIPTION
Client is in development and soon to be released out of alpha, but it is supported. I would like to add it to this list so it gets more attraction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37719)
<!-- Reviewable:end -->
