### PR TITLE
Exit with error if <version number or publication> is not the final parameter.

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -33,13 +33,13 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 function usage() {
   echo "!!! EXPERIMENTAL !!!"
   echo ""
-  echo "${0} [-M|-N|-P] -l -o | <version number or publication>"
+  echo "${0} [-M | -N | -P] [-o] (-l | <version number or publication>)"
   echo "  Upgrades master and nodes by default"
   echo "  -M:  Upgrade master only"
   echo "  -N:  Upgrade nodes only"
   echo "  -P:  Node upgrade prerequisites only (create a new instance template)"
   echo "  -o:  Use os distro sepcified in KUBE_NODE_OS_DISTRIBUTION for new nodes. Options include 'debian' or 'gci'"
-  echo "  -l:  Use local(dev) binaries"
+  echo "  -l:  Use local(dev) binaries. This is only supported for master upgrades."
   echo ""
   echo '  Version number or publication is either a proper version number'
   echo '  (e.g. "v1.0.6", "v1.2.0-alpha.1.881+376438b69c7612") or a version'
@@ -357,6 +357,12 @@ while getopts ":MNPlho" opt; do
   esac
 done
 shift $((OPTIND-1))
+
+if [[ $# -gt 1 ]]; then
+  echo "Error: Only one parameter (<version number or publication>) may be passed after the set of flags!" >&2
+  usage
+  exit 1
+fi
 
 if [[ $# -lt 1 ]] && [[ "${local_binaries}" == "false" ]]; then
   usage


### PR DESCRIPTION
getopts stops parsing flags after a non-flag, non-arg-to-a-flag parameter.
This commit adds an error message if any parameters are passed after the
first non-flag, non-arg-to-a-flag parameter in the arg list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37723)
<!-- Reviewable:end -->
