### PR TITLE
hack/e2e.go: Dump cluster logs in case of Up failure

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -236,6 +236,11 @@ func run(deploy deployer) error {
 		}
 		// Start the cluster using this version.
 		if err := xmlWrap("Up", deploy.Up); err != nil {
+			if *dump != "" {
+				xmlWrap("DumpClusterLogs", func() error {
+					return DumpClusterLogs(*dump)
+				})
+			}
 			return fmt.Errorf("starting e2e cluster: %s", err)
 		}
 		if *dump != "" {


### PR DESCRIPTION
**What this PR does / why we need it**: A failure in `Up` currently results in no attempt to grab cluster logs. This fixes that hole. (Sigh, a ton of holes for this diagnosis path.)
