### PR TITLE
fix glog message typo about init deserialization cache and watch cache

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -152,7 +152,7 @@ func Run(s *options.ServerRunOptions) error {
 	if s.Etcd.StorageConfig.DeserializationCacheSize == 0 {
 		// When size of cache is not explicitly set, estimate its size based on
 		// target memory usage.
-		glog.V(2).Infof("Initalizing deserialization cache size based on %dMB limit", s.GenericServerRunOptions.TargetRAMMB)
+		glog.V(2).Infof("Initializing deserialization cache size based on %dMB limit", s.GenericServerRunOptions.TargetRAMMB)
 
 		// This is the heuristics that from memory capacity is trying to infer
 		// the maximum number of nodes in the cluster and set cache sizes based
@@ -299,7 +299,7 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	if s.GenericServerRunOptions.EnableWatchCache {
-		glog.V(2).Infof("Initalizing cache sizes based on %dMB limit", s.GenericServerRunOptions.TargetRAMMB)
+		glog.V(2).Infof("Initializing cache sizes based on %dMB limit", s.GenericServerRunOptions.TargetRAMMB)
 		cachesize.InitializeWatchCacheSizes(s.GenericServerRunOptions.TargetRAMMB)
 		cachesize.SetWatchCacheSizes(s.GenericServerRunOptions.WatchCacheSizes)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
fix typo  `Initalizing` to `Initializing` 

Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>