### PR TITLE
Fix the PATH that install-etcd.sh tells you to use

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -87,6 +87,6 @@ kube::etcd::install() {
       ln -fns "etcd-v${ETCD_VERSION}-linux-amd64" etcd
     fi
     kube::log::info "etcd v${ETCD_VERSION} installed. To use:"
-    kube::log::info "export PATH=\${PATH}:$(pwd)/etcd"
+    kube::log::info "export PATH=$(pwd)/etcd:\${PATH}"
   )
 }


### PR DESCRIPTION
After you run install-etcd.sh, it tells you:

    etcd v3.0.14 installed. To use:
    export PATH=${PATH}:/home/danw/rh/go/src/k8s.io/kubernetes/third_party/etcd

which doesn't work if you have an older etcd installed in /usr/bin:

    danw@w541:kubernetes (master)> PATH=${PATH}:/home/danw/rh/go/src/k8s.io/kubernetes/third_party/etcd etcd --version
    etcd Version: 2.2.5

You need to put the local etcd dir first in PATH, not last.
