### PR TITLE
build: don't call unset_platform_envs before building

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -219,8 +219,6 @@ kube::golang::set_platform_envs() {
   [[ -n ${1-} ]] || {
     kube::log::error_exit "!!! Internal error. No platform set in kube::golang::set_platform_envs"
   }
-  # make sure we have a clean slate first
-  kube::golang::unset_platform_envs
 
   export GOOS=${platform%/*}
   export GOARCH=${platform##*/}


### PR DESCRIPTION
**What this PR does / why we need it**: unbreaks local builds that override `GOROOT`.

It partially reverts #37665, but the sub-shelling introduced in #37665 remains and should continue to fix #37079. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #37802

cc @jsafrane @sttts @sebgoa @iTagir 