### PR TITLE
error in setNodeStatus func should not abort node status update

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -299,9 +299,7 @@ func (kl *Kubelet) initialNode() (*v1.Node, error) {
 			}
 		}
 	}
-	if err := kl.setNodeStatus(node); err != nil {
-		return nil, err
-	}
+	kl.setNodeStatus(node)
 
 	return node, nil
 }
@@ -375,9 +373,7 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 
 	kl.updatePodCIDR(node.Spec.PodCIDR)
 
-	if err := kl.setNodeStatus(node); err != nil {
-		return err
-	}
+	kl.setNodeStatus(node)
 	// Patch the current status on the API server
 	updatedNode, err := nodeutil.PatchNodeStatus(kl.kubeClient, types.NodeName(kl.nodeName), originalNode, node)
 	if err != nil {
@@ -902,13 +898,12 @@ func (kl *Kubelet) setNodeVolumesInUseStatus(node *v1.Node) {
 // any fields that are currently set.
 // TODO(madhusudancs): Simplify the logic for setting node conditions and
 // refactor the node status condition code out to a different file.
-func (kl *Kubelet) setNodeStatus(node *v1.Node) error {
+func (kl *Kubelet) setNodeStatus(node *v1.Node) {
 	for _, f := range kl.setNodeStatusFuncs {
 		if err := f(node); err != nil {
-			return err
+			glog.Warningf("Failed to set some node status fields: %s", err)
 		}
 	}
-	return nil
 }
 
 // defaultNodeStatusFuncs is a factory that generates the default set of


### PR DESCRIPTION
`setNodeStatus()` currently errors out if any of the functions in the `kl.setNodeStatusFuncs` returns an error, resulting in the node not reporting status and eventually being marked as `NotReady`.

`setNodeAddress()` is currently the only function in `defaultNodeStatusFuncs()` that can return an error and it does if the cloud provider can't be contacted for any number of reasons like token expiration, API outage, ratelimit block, etc.

This PR changes `setNodeStatus()` to log, rather than return, when an error is returned by one of the `setNodeStatusFuncs` so that the node status update can proceed.

Fixes #34455

xref https://bugzilla.redhat.com/show_bug.cgi?id=1400574

@eparis @derekwaynecarr @mikedanese @anguslees