### PR TITLE
Fix conditional in log-dump.sh

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -68,7 +68,7 @@ function setup() {
 }
 
 function log-dump-ssh() {
-  if [[ -n "${use_custom_instance_list}" ]]; then
+  if [[ -z "${use_custom_instance_list}" ]]; then
     ssh-to-node "$@"
     return
   fi


### PR DESCRIPTION
I think a `-n` was unintentionally changed to a `-z` in #37646, [here](https://github.com/kubernetes/kubernetes/commit/a1bd743118a3fbbff4d7d19c89ebdb43b61c33f6#commitcomment-20039393), which caused us to stop collecting master/node logs. This undoes that change.

cc @zmerlynn @spxtr @krzyzacy @jingxu97 @saad-ali

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/kubernetes/37857)
<!-- Reviewable:end -->
