### PR TITLE
use bytes.Buffer instead of append for error string concat

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -18,7 +18,7 @@ package preflight
 
 import (
 	"bufio"
-	"errors"
+	"bytes"
 	"fmt"
 	"io"
 	"net"
@@ -182,7 +182,7 @@ func (fac FileAvailableCheck) Check() (warnings, errors []error) {
 	return nil, errors
 }
 
-// InPathChecks checks if the given executable is present in the path.
+// InPathCheck checks if the given executable is present in the path.
 type InPathCheck struct {
 	executable string
 	mandatory  bool
@@ -359,16 +359,14 @@ func RunChecks(checks []PreFlightCheck, ww io.Writer) error {
 		for _, w := range warnings {
 			io.WriteString(ww, fmt.Sprintf("[preflight] WARNING: %s\n", w))
 		}
-		for _, e := range errs {
-			found = append(found, e)
-		}
+		found = append(found, errs...)
 	}
 	if len(found) > 0 {
-		errs := ""
+		var errs bytes.Buffer
 		for _, i := range found {
-			errs += "\t" + i.Error() + "\n"
+			errs.WriteString("\t" + i.Error() + "\n")
 		}
-		return &PreFlightError{Msg: errors.New(errs).Error()}
+		return &PreFlightError{Msg: errs.String()}
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
1. in my benchmark test, `bytes.Buffer` takes much less time ( about 1:1000 ) than string append( `+=` ). 
>BenchmarkAppendConcat-4           100000            151438 ns/op          578181 B/op          2 allocs/op
BenchmarkBufferSprintf-4         3000000               487 ns/op              65 B/op          3 allocs/op
BenchmarkBufferConcat-4          5000000               271 ns/op              47 B/op          1 allocs/op

the benchmark codes is here  https://play.golang.org/p/LS52zGuwZN

2. in our `RunInitMasterChecks`, `RunJoinNodeChecks` there are lots of preflight checks. they may result in a huge error message. so `bytes.Buffer` can bring considerable performance enhancement in the worst of conditions.

beyond that, this PR 
1. fix an exported struct comment,
1. and use `found = append( found, errs...)` instead of for loop for simplicity.


Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>