### PR TITLE
fix kube::log::error in `start_rsyncd_container`.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -626,7 +626,7 @@ function kube::build::start_rsyncd_container() {
 
   local mapped_port
   if ! mapped_port=$("${DOCKER[@]}" port "${KUBE_RSYNC_CONTAINER_NAME}" ${KUBE_CONTAINER_RSYNC_PORT} 2> /dev/null | cut -d: -f 2) ; then
-    kube:log:error "Could not get effective rsync port"
+    kube::log::error "Could not get effective rsync port"
     return 1
   fi
 


### PR DESCRIPTION
fix kube::log::error of `start_rsyncd_container` in common.sh.
Signed-off-by: xuxinkun <xuxinkun@gmail.com>