### PR TITLE
While updating NodeStatus, only first get served from cache

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -298,7 +298,7 @@ func (kl *Kubelet) syncNodeStatus() {
 // updateNodeStatus updates node status to master with retries.
 func (kl *Kubelet) updateNodeStatus() error {
 	for i := 0; i < nodeStatusUpdateRetry; i++ {
-		if err := kl.tryUpdateNodeStatus(); err != nil {
+		if err := kl.tryUpdateNodeStatus(i); err != nil {
 			glog.Errorf("Error updating node status, will retry: %v", err)
 		} else {
 			return nil
@@ -309,20 +309,23 @@ func (kl *Kubelet) updateNodeStatus() error {
 
 // tryUpdateNodeStatus tries to update node status to master. If ReconcileCBR0
 // is set, this function will also confirm that cbr0 is configured correctly.
-func (kl *Kubelet) tryUpdateNodeStatus() error {
+func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 	// In large clusters, GET and PUT operations on Node objects coming
 	// from here are the majority of load on apiserver and etcd.
 	// To reduce the load on etcd, we are serving GET operations from
 	// apiserver cache (the data might be slightly delayed but it doesn't
 	// seem to cause more confilict - the delays are pretty small).
+	// If it result in a conflict, all retries are served directly from etcd.
 	// TODO: Currently apiserver doesn't support serving GET operations
 	// from its cache. Thus we are hacking it by issuing LIST with
 	// field selector for the name of the node (field selectors with
 	// specified name are handled efficiently by apiserver). Once
 	// apiserver supports GET from cache, change it here.
 	opts := api.ListOptions{
-		FieldSelector:   fields.Set{"metadata.name": string(kl.nodeName)}.AsSelector(),
-		ResourceVersion: "0",
+		FieldSelector: fields.Set{"metadata.name": string(kl.nodeName)}.AsSelector(),
+	}
+	if tryNumber == 0 {
+		opts.ResourceVersion = "0"
 	}
 	nodes, err := kl.kubeClient.Core().Nodes().List(opts)
 	if err != nil {


### PR DESCRIPTION
Cherrypick #37788 to 1.5 branch.