### PR TITLE
kubelet should retry fetching ECR auth token

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -49,6 +49,9 @@ var AWSRegions = [...]string{
 	"sa-east-1",
 }
 
+const authTokenRetries = 20
+const authTokenDelayDuration = 1 * time.Second
+
 const registryURLTemplate = "*.dkr.ecr.%s.amazonaws.com"
 
 // awsHandlerLogger is a handler that logs all AWS SDK requests
@@ -63,6 +66,26 @@ func awsHandlerLogger(req *request.Request) {
 	}
 
 	glog.V(3).Infof("AWS request: %s:%s in %s", service, name, *region)
+}
+
+// Implements the RequestRetryer interface
+type authTokenRetryer struct{}
+
+// MaxRetries returns the number of maximum returns the service will use to make
+// an individual API request.
+func (a authTokenRetryer) MaxRetries() int {
+	return authTokenRetries
+}
+
+// RetryRules returns the delay duration before retrying this request again
+func (a authTokenRetryer) RetryRules(r *request.Request) time.Duration {
+	// Since AWS has a default limit of 1 ECR token per account per second and doing an exponential back off will block the kubelet longer
+	return authTokenDelayDuration
+}
+
+// ShouldRetry returns if the request should be retried.
+func (a authTokenRetryer) ShouldRetry(r *request.Request) bool {
+	return r.IsErrorRetryable()
 }
 
 // An interface for testing purposes.
@@ -174,6 +197,7 @@ func (p *ecrProvider) Enabled() bool {
 	getter := &ecrTokenGetter{svc: ecr.New(session.New(&aws.Config{
 		Credentials: nil,
 		Region:      &p.region,
+		Retryer:     authTokenRetryer{},
 	}))}
 	getter.svc.Handlers.Sign.PushFrontNamed(request.NamedHandler{
 		Name: "k8s/logger",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: 
Implements blocking retries in kubelet to get ECR auth token. 

**Which issue this PR fixes** 
fixes https://github.com/kubernetes/kubernetes/issues/37962

**Special notes for your reviewer**: 
The retryer intentionally blocks as per [this](https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/provider.go#L36) comment. I think its also acceptable to have the retry logic in another goroutine, I can modify the PR to do that just let me know. 

