### PR TITLE
demonstrate separation of controller intializers

### DIFF
--- a/pkg/controller/informers/BUILD
+++ b/pkg/controller/informers/BUILD
@@ -39,5 +39,6 @@ go_library(
         "//pkg/runtime:go_default_library",
         "//pkg/runtime/schema:go_default_library",
         "//pkg/watch:go_default_library",
+        "//vendor:github.com/golang/glog",
     ],
 )

--- a/pkg/controller/informers/factory.go
+++ b/pkg/controller/informers/factory.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
@@ -90,8 +92,11 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	glog.V(1).Infoln("Starting informer factory")
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
+			glog.V(2).Infof("Starting informer for %v", informerType)
 			go informer.Run(stopCh)
 			f.startedInformers[informerType] = true
 		}


### PR DESCRIPTION
Currently, controllers are all initialized in a monster method that make it difficult to individually pick out whether there are side-effects, difficult to group related controllers for selective enablement, and impossible to determine if there are hidden dependencies.

This pull demonstrates how we can break apart the monolith and start start the process of grouping and naming controllers for selective enablement.  In addition, the use of a map will help expose dependency ordering amongst these controllers and the separate methods will make it a lot harder to have side effects.

This also moves us closer to being able to author reflective unit tests that help ensure that basic RBAC bootstrap roles are at least present, even if they aren't correct.

@nikhiljindal since you were looking at the federation controller manager
@sttts since we're looking at trying out RBAC on these.