### PR TITLE
Automated cherry pick of #34991

### DIFF
--- a/test/e2e/framework/kubelet_stats.go
+++ b/test/e2e/framework/kubelet_stats.go
@@ -463,7 +463,6 @@ func TargetContainers() []string {
 		rootContainerName,
 		stats.SystemContainerRuntime,
 		stats.SystemContainerKubelet,
-		stats.SystemContainerMisc,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #34991 on release-1.3.

#34991: e2e: stop tracking resource usage for the "misc" container