### PR TITLE
set container accessible selinux context on CERT_DIR

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -203,6 +203,18 @@ DISCOVERY_SECURE_PORT=${DISCOVERY_SECURE_PORT:-9090}
 # Ensure CERT_DIR is created for auto-generated crt/key and kubeconfig
 mkdir -p "${CERT_DIR}" &>/dev/null || sudo mkdir -p "${CERT_DIR}"
 CONTROLPLANE_SUDO=$(test -w "${CERT_DIR}" || echo "sudo -E")
+# If on an selinux system, need to set the correct context so cfssl container can access it
+if command -v getenforce &>/dev/null; then
+    if [[ "$(getenforce)" != "Disabled" ]]; then
+        # Try newer container_file_t type first
+        if ! sudo chcon -R -t container_file_t "${CERT_DIR}"; then
+            # Use older svirt_sandbox_file_t type
+            if ! sudo chcon -R -t svirt_sandbox_file_t "${CERT_DIR}"; then
+                echo "ERROR: Unable to set selinux context on ${CERT_DIR}. Certificate generation may fail."
+            fi
+        fi
+    fi
+fi
 
 function test_apiserver_off {
     # For the common local scenario, fail fast if server is already running.


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/36707 made it necessary for the `CERT_DIR` to be accessible from within a container.  On systems with selinux enforcing, this is prohibited.

This PR updates `local-up-cluster.sh` to check for selinux enforcing mode and sets the required context on the `CERT_DIR`

@ncdc @sttts @derekwaynecarr @deads2k 

Fixes #38165