### PR TITLE
Enable containerized mounter only for nfs and glusterfs types

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -74,9 +74,9 @@ func (mounter *Mounter) Mount(source string, target string, fstype string, optio
 		}
 		return doMount(mounterPath, source, target, fstype, bindRemountOpts)
 	}
-	// These filesystem types are expected to be supported by the mount utility on the host across all Linux distros.
-	var defaultMounterFsTypes = sets.NewString("tmpfs", "ext4", "ext3", "ext2")
-	if !defaultMounterFsTypes.Has(fstype) {
+	// The list of filesystems that require containerized mounter on GCI image cluster
+	fsTypesNeedMounter := sets.NewString("nfs", "glusterfs")
+	if fsTypesNeedMounter.Has(fstype) {
 		mounterPath = mounter.mounterPath
 	}
 	return doMount(mounterPath, source, target, fstype, options)


### PR DESCRIPTION
This change is to only enable containerized mounter for nfs and
glusterfs types. For other types such as tmpfs, ext2/3/4 or empty type,
we should still use mount from $PATH to minimize the effect of containerized mounter.