### PR TITLE
Fixes kubedns logging level

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -81,9 +81,7 @@ spec:
         - --domain=__PILLAR__DNS__DOMAIN__.
         - --dns-port=10053
         - --config-map=kube-dns
-        # This should be set to v=2 only after the new image (cut from 1.5) has
-        # been released, otherwise we will flood the logs.
-        - --v=0
+        - --v=2
         __PILLAR__FEDERATIONS__DOMAIN__MAP__
         env:
         - name: PROMETHEUS_PORT

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -81,9 +81,7 @@ spec:
         - --domain={{ pillar['dns_domain'] }}.
         - --dns-port=10053
         - --config-map=kube-dns
-        # This should be set to v=2 only after the new image (cut from 1.5) has
-        # been released, otherwise we will flood the logs.
-        - --v=0
+        - --v=2
         {{ pillar['federations_domain_map'] }}
         env:
         - name: PROMETHEUS_PORT

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -81,9 +81,7 @@ spec:
         - --domain=$DNS_DOMAIN.
         - --dns-port=10053
         - --config-map=kube-dns
-        # This should be set to v=2 only after the new image (cut from 1.5) has
-        # been released, otherwise we will flood the logs.
-        - --v=0
+        - --v=2
         env:
         - name: PROMETHEUS_PORT
           value: "10055"

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -62,7 +62,7 @@ spec:
         - --domain=${DNS_DOMAIN}.
         - --dns-port=10053
         - --config-map=kube-dns
-        - --v=0
+        - --v=2
         env:
           - name: PROMETHEUS_PORT
             value: "10055"

--- a/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
@@ -78,7 +78,7 @@ spec:
         - --domain={{ pillar['dns_domain'] }}.
         - --dns-port=10053
         - --config-map=kube-dns
-        - --v=0
+        - --v=2
         - --kube_master_url=http://{{ private_address }}:8080
         {{ pillar['federations_domain_map'] }}
         env:


### PR DESCRIPTION
We should have bumped up the verbose level to v=2 for `kubedns` after cutting the last release, as the TODO indicates.

@bowei @thockin 