### PR TITLE
fix(docker_manager): don't format Docker opts that are nil

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -1134,6 +1134,10 @@ func (dm *DockerManager) checkVersionCompatibility() error {
 }
 
 func (dm *DockerManager) fmtDockerOpts(opts []dockerOpt) ([]string, error) {
+	if opts == nil {
+		return nil, nil
+	}
+
 	version, err := dm.APIVersion()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes: https://github.com/kubernetes/kubernetes/issues/38031

If the opts passed in for formatting are nil, then they will be returned as an
empty slice instead of remaining as nil. The culprit for this issue lies in the
allocation & init done by `make` when creating `fmtOpts`.

If an empty slice is returned instead of nil, then this will ultimately
affect the JSON marshaling of the opts when they get passed to Docker.
Specifically, by returning an empty slice, JSON will encode it as an
empty array (`[]`), when in fact it should be `null`.

Also, by performing this check at the beginning of the func, we
can exit early if there are no opts to format.