### PR TITLE
Adds -w flag for iptables command to wait for xtables lock

### DIFF
--- a/test/e2e/reboot.go
+++ b/test/e2e/reboot.go
@@ -116,9 +116,9 @@ var _ = framework.KubeDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before starting dropping inbound packets.
 		// We still accept packages send from localhost to prevent monit from restarting kubelet.
 		tmpLogPath := "/tmp/drop-inbound.log"
-		testReboot(f.ClientSet, fmt.Sprintf("nohup sh -c 'set -x && sleep 10 && sudo iptables -I INPUT 1 -s 127.0.0.1 -j ACCEPT"+
-			" && sudo iptables -I INPUT 2 -j DROP && sudo iptables -t filter -nL INPUT && date && sleep 120 && sudo iptables -t filter -nL INPUT"+
-			" && sudo iptables -D INPUT -j DROP && sudo iptables -D INPUT -s 127.0.0.1 -j ACCEPT' >%v 2>&1 &", tmpLogPath), catLogHook(tmpLogPath))
+		testReboot(f.ClientSet, fmt.Sprintf("nohup sh -c 'set -x && sleep 10 && sudo iptables -I INPUT 1 -s 127.0.0.1 -j ACCEPT -w"+
+			" && sudo iptables -I INPUT 2 -j DROP -w && sudo iptables -t filter -nL INPUT && date && sleep 120 && sudo iptables -t filter -nL INPUT"+
+			" && sudo iptables -D INPUT -j DROP -w && sudo iptables -D INPUT -s 127.0.0.1 -j ACCEPT -w' >%v 2>&1 &", tmpLogPath), catLogHook(tmpLogPath))
 	})
 
 	It("each node by dropping all outbound packets for a while and ensure they function afterwards", func() {
@@ -126,9 +126,9 @@ var _ = framework.KubeDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before starting dropping outbound packets.
 		// We still accept packages send to localhost to prevent monit from restarting kubelet.
 		tmpLogPath := "/tmp/drop-outbound.log"
-		testReboot(f.ClientSet, fmt.Sprintf("nohup sh -c 'set -x && sleep 10 &&  sudo iptables -I OUTPUT 1 -s 127.0.0.1 -j ACCEPT"+
-			" && sudo iptables -I OUTPUT 2 -j DROP && sudo iptables -t filter -nL OUTPUT && date && sleep 120 && sudo iptables -t filter -nL OUTPUT"+
-			" && sudo iptables -D OUTPUT -j DROP && sudo iptables -D OUTPUT -s 127.0.0.1 -j ACCEPT' >%v 2>&1 &", tmpLogPath), catLogHook(tmpLogPath))
+		testReboot(f.ClientSet, fmt.Sprintf("nohup sh -c 'set -x && sleep 10 &&  sudo iptables -I OUTPUT 1 -s 127.0.0.1 -j ACCEPT -w"+
+			" && sudo iptables -I OUTPUT 2 -j DROP -w && sudo iptables -t filter -nL OUTPUT && date && sleep 120 && sudo iptables -t filter -nL OUTPUT"+
+			" && sudo iptables -D OUTPUT -j DROP -w && sudo iptables -D OUTPUT -s 127.0.0.1 -j ACCEPT -w' >%v 2>&1 &", tmpLogPath), catLogHook(tmpLogPath))
 	})
 })
 


### PR DESCRIPTION
Fixes the main case in #33405 and #36230.

During the reboot test, the iptables command that was supposed to take the node offline failed to exec. Turned out the xtables lock was holding by other process leads to this failure. Logs as below:
```
I1202 20:00:29.686] Dec  2 20:00:29.685: INFO: ssh jenkins@146.148.111.167:22: stdout:
"+ sleep 10
+ sudo iptables -I INPUT 1 -s 127.0.0.1 -j ACCEPT
Another app is currently holding the xtables lock. Perhaps you want to use the -w option?"
I1202 20:00:29.686] Dec  2 20:00:29.685: INFO: ssh jenkins@146.148.111.167:22: stderr:    ""
I1202 20:00:29.686] Dec  2 20:00:29.685: INFO: ssh jenkins@146.148.111.167:22: exit code: 0
```

Adding `-w` flag to let iptables command wait for xtables lock.

@bprashanth 

@saad-ali  If this PR could do the fix I think, it would be better to cherry-pick it to 1.5 together with #37639. 