### PR TITLE
OpenAPI generated definition names are not unique across groups

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -913,18 +913,18 @@
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "v1.2-96-g09691a3",
-			"Rev": "09691a3b6378b740595c1002f40c34dd5f218a22"
+			"Comment": "v1.2-103-gd916db2",
+			"Rev": "d916db217751a3fef55337f799c31fde4b8efcf1"
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful/log",
-			"Comment": "v1.2-96-g09691a3",
-			"Rev": "09691a3b6378b740595c1002f40c34dd5f218a22"
+			"Comment": "v1.2-103-gd916db2",
+			"Rev": "d916db217751a3fef55337f799c31fde4b8efcf1"
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful/swagger",
-			"Comment": "v1.2-96-g09691a3",
-			"Rev": "09691a3b6378b740595c1002f40c34dd5f218a22"
+			"Comment": "v1.2-103-gd916db2",
+			"Rev": "d916db217751a3fef55337f799c31fde4b8efcf1"
 		},
 		{
 			"ImportPath": "github.com/evanphx/json-patch",

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -29,7 +29,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIVersions"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIVersions"
        }
       },
       "401": {
@@ -62,7 +62,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -670,7 +670,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -910,7 +910,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -1066,7 +1066,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -1099,7 +1099,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -1307,7 +1307,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -1463,7 +1463,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -1496,7 +1496,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -1704,7 +1704,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -1860,7 +1860,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -1893,7 +1893,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -2101,7 +2101,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -2257,7 +2257,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -2290,7 +2290,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -2498,7 +2498,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -2654,7 +2654,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -2687,7 +2687,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -2823,7 +2823,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -3031,7 +3031,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -3187,7 +3187,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -3220,7 +3220,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -3457,7 +3457,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Eviction"
+        "$ref": "#/definitions/policy.v1beta1.Eviction"
        }
       },
       "401": {
@@ -3471,7 +3471,7 @@
       "in": "body",
       "required": true,
       "schema": {
-       "$ref": "#/definitions/v1beta1.Eviction"
+       "$ref": "#/definitions/policy.v1beta1.Eviction"
       }
      },
      {
@@ -4275,7 +4275,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -4483,7 +4483,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -4639,7 +4639,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -4672,7 +4672,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -4880,7 +4880,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -5036,7 +5036,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -5069,7 +5069,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -5133,7 +5133,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Scale"
+        "$ref": "#/definitions/autoscaling.v1.Scale"
        }
       },
       "401": {
@@ -5164,7 +5164,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Scale"
+        "$ref": "#/definitions/autoscaling.v1.Scale"
        }
       }
      ],
@@ -5172,7 +5172,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Scale"
+        "$ref": "#/definitions/autoscaling.v1.Scale"
        }
       },
       "401": {
@@ -5205,7 +5205,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -5213,7 +5213,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Scale"
+        "$ref": "#/definitions/autoscaling.v1.Scale"
        }
       },
       "401": {
@@ -5341,7 +5341,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -5549,7 +5549,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -5705,7 +5705,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -5738,7 +5738,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -5874,7 +5874,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -6082,7 +6082,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -6238,7 +6238,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -6271,7 +6271,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -6479,7 +6479,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -6635,7 +6635,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -6668,7 +6668,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -6942,7 +6942,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -6975,7 +6975,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -7497,7 +7497,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -7669,7 +7669,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -7702,7 +7702,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -7886,7 +7886,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -8086,7 +8086,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -8234,7 +8234,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -8267,7 +8267,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -8765,7 +8765,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -9042,7 +9042,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -9190,7 +9190,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -9223,7 +9223,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -9351,7 +9351,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -11048,7 +11048,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11125,7 +11125,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11202,7 +11202,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11279,7 +11279,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11356,7 +11356,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11433,7 +11433,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11518,7 +11518,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11611,7 +11611,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11696,7 +11696,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11789,7 +11789,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11874,7 +11874,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -11967,7 +11967,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12052,7 +12052,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12145,7 +12145,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12230,7 +12230,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12323,7 +12323,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12408,7 +12408,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12501,7 +12501,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12586,7 +12586,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12679,7 +12679,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12764,7 +12764,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12857,7 +12857,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -12942,7 +12942,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13035,7 +13035,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13120,7 +13120,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13213,7 +13213,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13298,7 +13298,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13391,7 +13391,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13476,7 +13476,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13569,7 +13569,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13654,7 +13654,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13731,7 +13731,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13816,7 +13816,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13893,7 +13893,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -13970,7 +13970,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -14055,7 +14055,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -14132,7 +14132,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -14209,7 +14209,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -14286,7 +14286,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -14363,7 +14363,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -14440,7 +14440,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -14517,7 +14517,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -14594,7 +14594,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroupList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroupList"
        }
       },
       "401": {
@@ -14627,7 +14627,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -14660,7 +14660,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -14730,7 +14730,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSetList"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSetList"
        }
       },
       "401": {
@@ -14761,7 +14761,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       }
      ],
@@ -14769,7 +14769,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       },
       "401": {
@@ -14835,7 +14835,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -14899,7 +14899,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       },
       "401": {
@@ -14930,7 +14930,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       }
      ],
@@ -14938,7 +14938,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       },
       "401": {
@@ -14991,7 +14991,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -15024,7 +15024,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -15032,7 +15032,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       },
       "401": {
@@ -15088,7 +15088,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       },
       "401": {
@@ -15119,7 +15119,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       }
      ],
@@ -15127,7 +15127,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       },
       "401": {
@@ -15160,7 +15160,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -15168,7 +15168,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSet"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSet"
        }
       },
       "401": {
@@ -15226,7 +15226,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StatefulSetList"
+        "$ref": "#/definitions/apps.v1beta1.StatefulSetList"
        }
       },
       "401": {
@@ -15303,7 +15303,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -15388,7 +15388,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -15481,7 +15481,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -15558,7 +15558,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -15591,7 +15591,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -15622,7 +15622,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.TokenReview"
+        "$ref": "#/definitions/io.k8s.authentication.v1beta1.TokenReview"
        }
       },
       "401": {
@@ -15636,7 +15636,7 @@
       "in": "body",
       "required": true,
       "schema": {
-       "$ref": "#/definitions/v1beta1.TokenReview"
+       "$ref": "#/definitions/io.k8s.authentication.v1beta1.TokenReview"
       }
      },
      {
@@ -15672,7 +15672,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -15705,7 +15705,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -15736,7 +15736,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.LocalSubjectAccessReview"
+        "$ref": "#/definitions/io.k8s.authorization.v1beta1.LocalSubjectAccessReview"
        }
       },
       "401": {
@@ -15750,7 +15750,7 @@
       "in": "body",
       "required": true,
       "schema": {
-       "$ref": "#/definitions/v1beta1.LocalSubjectAccessReview"
+       "$ref": "#/definitions/io.k8s.authorization.v1beta1.LocalSubjectAccessReview"
       }
      },
      {
@@ -15792,7 +15792,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.SelfSubjectAccessReview"
+        "$ref": "#/definitions/io.k8s.authorization.v1beta1.SelfSubjectAccessReview"
        }
       },
       "401": {
@@ -15806,7 +15806,7 @@
       "in": "body",
       "required": true,
       "schema": {
-       "$ref": "#/definitions/v1beta1.SelfSubjectAccessReview"
+       "$ref": "#/definitions/io.k8s.authorization.v1beta1.SelfSubjectAccessReview"
       }
      },
      {
@@ -15840,7 +15840,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.SubjectAccessReview"
+        "$ref": "#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReview"
        }
       },
       "401": {
@@ -15854,7 +15854,7 @@
       "in": "body",
       "required": true,
       "schema": {
-       "$ref": "#/definitions/v1beta1.SubjectAccessReview"
+       "$ref": "#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReview"
       }
      },
      {
@@ -15890,7 +15890,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -15923,7 +15923,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -15956,7 +15956,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscalerList"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscalerList"
        }
       },
       "401": {
@@ -16070,7 +16070,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscalerList"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscalerList"
        }
       },
       "401": {
@@ -16101,7 +16101,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       }
      ],
@@ -16109,7 +16109,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -16175,7 +16175,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -16239,7 +16239,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -16270,7 +16270,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       }
      ],
@@ -16278,7 +16278,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -16331,7 +16331,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -16364,7 +16364,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -16372,7 +16372,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -16428,7 +16428,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -16459,7 +16459,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       }
      ],
@@ -16467,7 +16467,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -16500,7 +16500,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -16508,7 +16508,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -16566,7 +16566,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -16643,7 +16643,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -16728,7 +16728,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -16821,7 +16821,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -16854,7 +16854,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -16887,7 +16887,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.JobList"
+        "$ref": "#/definitions/batch.v1.JobList"
        }
       },
       "401": {
@@ -17001,7 +17001,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.JobList"
+        "$ref": "#/definitions/batch.v1.JobList"
        }
       },
       "401": {
@@ -17032,7 +17032,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       }
      ],
@@ -17040,7 +17040,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       },
       "401": {
@@ -17106,7 +17106,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -17170,7 +17170,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       },
       "401": {
@@ -17201,7 +17201,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       }
      ],
@@ -17209,7 +17209,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       },
       "401": {
@@ -17262,7 +17262,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -17295,7 +17295,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -17303,7 +17303,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       },
       "401": {
@@ -17359,7 +17359,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       },
       "401": {
@@ -17390,7 +17390,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       }
      ],
@@ -17398,7 +17398,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       },
       "401": {
@@ -17431,7 +17431,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -17439,7 +17439,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Job"
+        "$ref": "#/definitions/batch.v1.Job"
        }
       },
       "401": {
@@ -17497,7 +17497,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -17574,7 +17574,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -17659,7 +17659,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -17752,7 +17752,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -17785,7 +17785,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJobList"
+        "$ref": "#/definitions/batch.v2alpha1.CronJobList"
        }
       },
       "401": {
@@ -17862,7 +17862,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.JobList"
+        "$ref": "#/definitions/batch.v2alpha1.JobList"
        }
       },
       "401": {
@@ -17976,7 +17976,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJobList"
+        "$ref": "#/definitions/batch.v2alpha1.CronJobList"
        }
       },
       "401": {
@@ -18007,7 +18007,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       }
      ],
@@ -18015,7 +18015,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -18081,7 +18081,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -18145,7 +18145,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -18176,7 +18176,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       }
      ],
@@ -18184,7 +18184,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -18237,7 +18237,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -18270,7 +18270,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -18278,7 +18278,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -18334,7 +18334,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -18365,7 +18365,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       }
      ],
@@ -18373,7 +18373,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -18406,7 +18406,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -18414,7 +18414,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -18509,7 +18509,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.JobList"
+        "$ref": "#/definitions/batch.v2alpha1.JobList"
        }
       },
       "401": {
@@ -18540,7 +18540,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       }
      ],
@@ -18548,7 +18548,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       },
       "401": {
@@ -18614,7 +18614,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -18678,7 +18678,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       },
       "401": {
@@ -18709,7 +18709,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       }
      ],
@@ -18717,7 +18717,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       },
       "401": {
@@ -18770,7 +18770,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -18803,7 +18803,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -18811,7 +18811,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       },
       "401": {
@@ -18867,7 +18867,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       },
       "401": {
@@ -18898,7 +18898,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       }
      ],
@@ -18906,7 +18906,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       },
       "401": {
@@ -18939,7 +18939,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -18947,7 +18947,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.Job"
+        "$ref": "#/definitions/batch.v2alpha1.Job"
        }
       },
       "401": {
@@ -19042,7 +19042,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJobList"
+        "$ref": "#/definitions/batch.v2alpha1.CronJobList"
        }
       },
       "401": {
@@ -19073,7 +19073,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       }
      ],
@@ -19081,7 +19081,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -19147,7 +19147,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -19211,7 +19211,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -19242,7 +19242,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       }
      ],
@@ -19250,7 +19250,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -19303,7 +19303,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -19336,7 +19336,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -19344,7 +19344,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -19400,7 +19400,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -19431,7 +19431,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       }
      ],
@@ -19439,7 +19439,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -19472,7 +19472,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -19480,7 +19480,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJob"
+        "$ref": "#/definitions/batch.v2alpha1.CronJob"
        }
       },
       "401": {
@@ -19538,7 +19538,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v2alpha1.CronJobList"
+        "$ref": "#/definitions/batch.v2alpha1.CronJobList"
        }
       },
       "401": {
@@ -19615,7 +19615,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -19692,7 +19692,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -19769,7 +19769,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -19854,7 +19854,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -19947,7 +19947,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -20032,7 +20032,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -20125,7 +20125,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -20210,7 +20210,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -20303,7 +20303,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -20380,7 +20380,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -20413,7 +20413,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -20483,7 +20483,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequestList"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestList"
        }
       },
       "401": {
@@ -20514,7 +20514,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
        }
       }
      ],
@@ -20522,7 +20522,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
        }
       },
       "401": {
@@ -20588,7 +20588,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -20644,7 +20644,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
        }
       },
       "401": {
@@ -20675,7 +20675,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
        }
       }
      ],
@@ -20683,7 +20683,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
        }
       },
       "401": {
@@ -20736,7 +20736,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -20769,7 +20769,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -20777,7 +20777,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
        }
       },
       "401": {
@@ -20825,7 +20825,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
        }
       },
       "401": {
@@ -20839,7 +20839,7 @@
       "in": "body",
       "required": true,
       "schema": {
-       "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+       "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
       }
      },
      {
@@ -20881,7 +20881,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+        "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
        }
       },
       "401": {
@@ -20895,7 +20895,7 @@
       "in": "body",
       "required": true,
       "schema": {
-       "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
+       "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
       }
      },
      {
@@ -20939,7 +20939,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -21016,7 +21016,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -21101,7 +21101,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -21134,7 +21134,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -21167,7 +21167,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSetList"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSetList"
        }
       },
       "401": {
@@ -21244,7 +21244,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DeploymentList"
+        "$ref": "#/definitions/extensions.v1beta1.DeploymentList"
        }
       },
       "401": {
@@ -21321,7 +21321,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscalerList"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscalerList"
        }
       },
       "401": {
@@ -21398,7 +21398,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.IngressList"
+        "$ref": "#/definitions/extensions.v1beta1.IngressList"
        }
       },
       "401": {
@@ -21512,7 +21512,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSetList"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSetList"
        }
       },
       "401": {
@@ -21543,7 +21543,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       }
      ],
@@ -21551,7 +21551,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       },
       "401": {
@@ -21617,7 +21617,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -21681,7 +21681,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       },
       "401": {
@@ -21712,7 +21712,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       }
      ],
@@ -21720,7 +21720,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       },
       "401": {
@@ -21773,7 +21773,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -21806,7 +21806,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -21814,7 +21814,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       },
       "401": {
@@ -21870,7 +21870,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       },
       "401": {
@@ -21901,7 +21901,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       }
      ],
@@ -21909,7 +21909,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       },
       "401": {
@@ -21942,7 +21942,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -21950,7 +21950,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DaemonSet"
+        "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
        }
       },
       "401": {
@@ -22045,7 +22045,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DeploymentList"
+        "$ref": "#/definitions/extensions.v1beta1.DeploymentList"
        }
       },
       "401": {
@@ -22076,7 +22076,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       }
      ],
@@ -22084,7 +22084,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       },
       "401": {
@@ -22150,7 +22150,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -22214,7 +22214,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       },
       "401": {
@@ -22245,7 +22245,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       }
      ],
@@ -22253,7 +22253,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       },
       "401": {
@@ -22306,7 +22306,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -22339,7 +22339,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -22347,7 +22347,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       },
       "401": {
@@ -22403,7 +22403,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.DeploymentRollback"
+        "$ref": "#/definitions/extensions.v1beta1.DeploymentRollback"
        }
       },
       "401": {
@@ -22417,7 +22417,7 @@
       "in": "body",
       "required": true,
       "schema": {
-       "$ref": "#/definitions/v1beta1.DeploymentRollback"
+       "$ref": "#/definitions/extensions.v1beta1.DeploymentRollback"
       }
      },
      {
@@ -22467,7 +22467,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -22498,7 +22498,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       }
      ],
@@ -22506,7 +22506,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -22539,7 +22539,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -22547,7 +22547,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -22603,7 +22603,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       },
       "401": {
@@ -22634,7 +22634,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       }
      ],
@@ -22642,7 +22642,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       },
       "401": {
@@ -22675,7 +22675,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -22683,7 +22683,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Deployment"
+        "$ref": "#/definitions/extensions.v1beta1.Deployment"
        }
       },
       "401": {
@@ -22778,7 +22778,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscalerList"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscalerList"
        }
       },
       "401": {
@@ -22809,7 +22809,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       }
      ],
@@ -22817,7 +22817,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -22883,7 +22883,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -22947,7 +22947,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -22978,7 +22978,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       }
      ],
@@ -22986,7 +22986,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -23039,7 +23039,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -23072,7 +23072,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -23080,7 +23080,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -23136,7 +23136,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -23167,7 +23167,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       }
      ],
@@ -23175,7 +23175,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -23208,7 +23208,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -23216,7 +23216,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
+        "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
        }
       },
       "401": {
@@ -23311,7 +23311,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.IngressList"
+        "$ref": "#/definitions/extensions.v1beta1.IngressList"
        }
       },
       "401": {
@@ -23342,7 +23342,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       }
      ],
@@ -23350,7 +23350,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       },
       "401": {
@@ -23416,7 +23416,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -23480,7 +23480,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       },
       "401": {
@@ -23511,7 +23511,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       }
      ],
@@ -23519,7 +23519,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       },
       "401": {
@@ -23572,7 +23572,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -23605,7 +23605,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -23613,7 +23613,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       },
       "401": {
@@ -23669,7 +23669,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       },
       "401": {
@@ -23700,7 +23700,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       }
      ],
@@ -23708,7 +23708,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       },
       "401": {
@@ -23741,7 +23741,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -23749,7 +23749,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Ingress"
+        "$ref": "#/definitions/extensions.v1beta1.Ingress"
        }
       },
       "401": {
@@ -23844,7 +23844,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.NetworkPolicyList"
+        "$ref": "#/definitions/extensions.v1beta1.NetworkPolicyList"
        }
       },
       "401": {
@@ -23875,7 +23875,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.NetworkPolicy"
+        "$ref": "#/definitions/extensions.v1beta1.NetworkPolicy"
        }
       }
      ],
@@ -23883,7 +23883,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.NetworkPolicy"
+        "$ref": "#/definitions/extensions.v1beta1.NetworkPolicy"
        }
       },
       "401": {
@@ -23949,7 +23949,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -24013,7 +24013,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.NetworkPolicy"
+        "$ref": "#/definitions/extensions.v1beta1.NetworkPolicy"
        }
       },
       "401": {
@@ -24044,7 +24044,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.NetworkPolicy"
+        "$ref": "#/definitions/extensions.v1beta1.NetworkPolicy"
        }
       }
      ],
@@ -24052,7 +24052,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.NetworkPolicy"
+        "$ref": "#/definitions/extensions.v1beta1.NetworkPolicy"
        }
       },
       "401": {
@@ -24105,7 +24105,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -24138,7 +24138,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -24146,7 +24146,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.NetworkPolicy"
+        "$ref": "#/definitions/extensions.v1beta1.NetworkPolicy"
        }
       },
       "401": {
@@ -24241,7 +24241,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSetList"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSetList"
        }
       },
       "401": {
@@ -24272,7 +24272,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       }
      ],
@@ -24280,7 +24280,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       },
       "401": {
@@ -24346,7 +24346,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -24410,7 +24410,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       },
       "401": {
@@ -24441,7 +24441,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       }
      ],
@@ -24449,7 +24449,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       },
       "401": {
@@ -24502,7 +24502,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -24535,7 +24535,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -24543,7 +24543,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       },
       "401": {
@@ -24599,7 +24599,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -24630,7 +24630,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       }
      ],
@@ -24638,7 +24638,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -24671,7 +24671,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -24679,7 +24679,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -24735,7 +24735,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       },
       "401": {
@@ -24766,7 +24766,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       }
      ],
@@ -24774,7 +24774,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       },
       "401": {
@@ -24807,7 +24807,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -24815,7 +24815,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSet"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
        }
       },
       "401": {
@@ -24871,7 +24871,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -24902,7 +24902,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       }
      ],
@@ -24910,7 +24910,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -24943,7 +24943,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -24951,7 +24951,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.Scale"
+        "$ref": "#/definitions/extensions.v1beta1.Scale"
        }
       },
       "401": {
@@ -25009,7 +25009,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.NetworkPolicyList"
+        "$ref": "#/definitions/extensions.v1beta1.NetworkPolicyList"
        }
       },
       "401": {
@@ -25086,7 +25086,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ReplicaSetList"
+        "$ref": "#/definitions/extensions.v1beta1.ReplicaSetList"
        }
       },
       "401": {
@@ -25200,7 +25200,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ThirdPartyResourceList"
+        "$ref": "#/definitions/extensions.v1beta1.ThirdPartyResourceList"
        }
       },
       "401": {
@@ -25231,7 +25231,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.ThirdPartyResource"
+        "$ref": "#/definitions/extensions.v1beta1.ThirdPartyResource"
        }
       }
      ],
@@ -25239,7 +25239,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ThirdPartyResource"
+        "$ref": "#/definitions/extensions.v1beta1.ThirdPartyResource"
        }
       },
       "401": {
@@ -25305,7 +25305,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -25361,7 +25361,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ThirdPartyResource"
+        "$ref": "#/definitions/extensions.v1beta1.ThirdPartyResource"
        }
       },
       "401": {
@@ -25392,7 +25392,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.ThirdPartyResource"
+        "$ref": "#/definitions/extensions.v1beta1.ThirdPartyResource"
        }
       }
      ],
@@ -25400,7 +25400,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ThirdPartyResource"
+        "$ref": "#/definitions/extensions.v1beta1.ThirdPartyResource"
        }
       },
       "401": {
@@ -25453,7 +25453,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -25486,7 +25486,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -25494,7 +25494,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.ThirdPartyResource"
+        "$ref": "#/definitions/extensions.v1beta1.ThirdPartyResource"
        }
       },
       "401": {
@@ -25544,7 +25544,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -25621,7 +25621,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -25698,7 +25698,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -25775,7 +25775,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -25852,7 +25852,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -25937,7 +25937,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26030,7 +26030,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26115,7 +26115,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26208,7 +26208,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26293,7 +26293,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26386,7 +26386,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26471,7 +26471,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26564,7 +26564,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26649,7 +26649,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26742,7 +26742,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26827,7 +26827,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26920,7 +26920,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -26997,7 +26997,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -27074,7 +27074,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -27151,7 +27151,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -27236,7 +27236,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -27269,7 +27269,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -27339,7 +27339,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudgetList"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudgetList"
        }
       },
       "401": {
@@ -27370,7 +27370,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       }
      ],
@@ -27378,7 +27378,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       },
       "401": {
@@ -27444,7 +27444,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -27508,7 +27508,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       },
       "401": {
@@ -27539,7 +27539,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       }
      ],
@@ -27547,7 +27547,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       },
       "401": {
@@ -27600,7 +27600,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -27633,7 +27633,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -27641,7 +27641,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       },
       "401": {
@@ -27697,7 +27697,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       },
       "401": {
@@ -27728,7 +27728,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       }
      ],
@@ -27736,7 +27736,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       },
       "401": {
@@ -27769,7 +27769,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -27777,7 +27777,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
        }
       },
       "401": {
@@ -27835,7 +27835,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.PodDisruptionBudgetList"
+        "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudgetList"
        }
       },
       "401": {
@@ -27912,7 +27912,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -27997,7 +27997,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -28090,7 +28090,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -28167,7 +28167,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -28200,7 +28200,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -28270,7 +28270,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRoleBindingList"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingList"
        }
       },
       "401": {
@@ -28301,7 +28301,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"
        }
       }
      ],
@@ -28309,7 +28309,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"
        }
       },
       "401": {
@@ -28375,7 +28375,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -28415,7 +28415,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"
        }
       },
       "401": {
@@ -28446,7 +28446,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"
        }
       }
      ],
@@ -28454,7 +28454,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"
        }
       },
       "401": {
@@ -28507,7 +28507,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -28540,7 +28540,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -28548,7 +28548,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"
        }
       },
       "401": {
@@ -28635,7 +28635,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRoleList"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleList"
        }
       },
       "401": {
@@ -28666,7 +28666,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRole"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"
        }
       }
      ],
@@ -28674,7 +28674,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRole"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"
        }
       },
       "401": {
@@ -28740,7 +28740,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -28780,7 +28780,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRole"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"
        }
       },
       "401": {
@@ -28811,7 +28811,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRole"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"
        }
       }
      ],
@@ -28819,7 +28819,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRole"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"
        }
       },
       "401": {
@@ -28872,7 +28872,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -28905,7 +28905,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -28913,7 +28913,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.ClusterRole"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"
        }
       },
       "401": {
@@ -29000,7 +29000,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleBindingList"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBindingList"
        }
       },
       "401": {
@@ -29031,7 +29031,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"
        }
       }
      ],
@@ -29039,7 +29039,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"
        }
       },
       "401": {
@@ -29105,7 +29105,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -29153,7 +29153,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"
        }
       },
       "401": {
@@ -29184,7 +29184,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"
        }
       }
      ],
@@ -29192,7 +29192,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"
        }
       },
       "401": {
@@ -29245,7 +29245,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -29278,7 +29278,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -29286,7 +29286,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleBinding"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"
        }
       },
       "401": {
@@ -29381,7 +29381,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleList"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleList"
        }
       },
       "401": {
@@ -29412,7 +29412,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.Role"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"
        }
       }
      ],
@@ -29420,7 +29420,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.Role"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"
        }
       },
       "401": {
@@ -29486,7 +29486,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -29534,7 +29534,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.Role"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"
        }
       },
       "401": {
@@ -29565,7 +29565,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1alpha1.Role"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"
        }
       }
      ],
@@ -29573,7 +29573,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.Role"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"
        }
       },
       "401": {
@@ -29626,7 +29626,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -29659,7 +29659,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -29667,7 +29667,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.Role"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"
        }
       },
       "401": {
@@ -29725,7 +29725,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleBindingList"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBindingList"
        }
       },
       "401": {
@@ -29802,7 +29802,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1alpha1.RoleList"
+        "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleList"
        }
       },
       "401": {
@@ -29879,7 +29879,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -29956,7 +29956,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30041,7 +30041,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30118,7 +30118,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30203,7 +30203,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30288,7 +30288,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30381,7 +30381,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30466,7 +30466,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30559,7 +30559,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30636,7 +30636,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -30713,7 +30713,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIGroup"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
        }
       },
       "401": {
@@ -30746,7 +30746,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.APIResourceList"
+        "$ref": "#/definitions/io.k8s.meta.v1.APIResourceList"
        }
       },
       "401": {
@@ -30816,7 +30816,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StorageClassList"
+        "$ref": "#/definitions/io.k8s.storage.v1beta1.StorageClassList"
        }
       },
       "401": {
@@ -30847,7 +30847,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.StorageClass"
+        "$ref": "#/definitions/io.k8s.storage.v1beta1.StorageClass"
        }
       }
      ],
@@ -30855,7 +30855,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StorageClass"
+        "$ref": "#/definitions/io.k8s.storage.v1beta1.StorageClass"
        }
       },
       "401": {
@@ -30921,7 +30921,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -30977,7 +30977,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StorageClass"
+        "$ref": "#/definitions/io.k8s.storage.v1beta1.StorageClass"
        }
       },
       "401": {
@@ -31008,7 +31008,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1beta1.StorageClass"
+        "$ref": "#/definitions/io.k8s.storage.v1beta1.StorageClass"
        }
       }
      ],
@@ -31016,7 +31016,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StorageClass"
+        "$ref": "#/definitions/io.k8s.storage.v1beta1.StorageClass"
        }
       },
       "401": {
@@ -31069,7 +31069,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Status"
+        "$ref": "#/definitions/io.k8s.meta.v1.Status"
        }
       },
       "401": {
@@ -31102,7 +31102,7 @@
        "in": "body",
        "required": true,
        "schema": {
-        "$ref": "#/definitions/v1.Patch"
+        "$ref": "#/definitions/io.k8s.meta.v1.Patch"
        }
       }
      ],
@@ -31110,7 +31110,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1beta1.StorageClass"
+        "$ref": "#/definitions/io.k8s.storage.v1beta1.StorageClass"
        }
       },
       "401": {
@@ -31160,7 +31160,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -31237,7 +31237,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/versioned.Event"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.watch.versioned.Event"
        }
       },
       "401": {
@@ -31360,7 +31360,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/version.Info"
+        "$ref": "#/definitions/io.k8s.kubernetes.pkg.version.Info"
        }
       },
       "401": {
@@ -31371,14 +31371,2091 @@
    }
   },
   "definitions": {
-   "intstr.IntOrString": {
-    "type": "string",
-    "format": "int-or-string"
+   "apps.v1beta1.StatefulSet": {
+    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "properties": {
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec defines the desired identities of pods in this set.",
+      "$ref": "#/definitions/apps.v1beta1.StatefulSetSpec"
+     },
+     "status": {
+      "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
+      "$ref": "#/definitions/apps.v1beta1.StatefulSetStatus"
+     }
+    }
    },
-   "resource.Quantity": {
+   "apps.v1beta1.StatefulSetList": {
+    "description": "StatefulSetList is a collection of StatefulSets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/apps.v1beta1.StatefulSet"
+      }
+     },
+     "metadata": {
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "apps.v1beta1.StatefulSetSpec": {
+    "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+    "required": [
+     "template",
+     "serviceName"
+    ],
+    "properties": {
+     "replicas": {
+      "description": "Replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "selector": {
+      "description": "Selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     },
+     "serviceName": {
+      "description": "ServiceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
+      "type": "string"
+     },
+     "template": {
+      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.",
+      "$ref": "#/definitions/v1.PodTemplateSpec"
+     },
+     "volumeClaimTemplates": {
+      "description": "VolumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/v1.PersistentVolumeClaim"
+      }
+     }
+    }
+   },
+   "apps.v1beta1.StatefulSetStatus": {
+    "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "observedGeneration": {
+      "description": "most recent generation observed by this StatefulSet.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "replicas": {
+      "description": "Replicas is the number of actual replicas.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "autoscaling.v1.CrossVersionObjectReference": {
+    "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+    "required": [
+     "kind",
+     "name"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "API version of the referent",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds\"",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+      "type": "string"
+     }
+    }
+   },
+   "autoscaling.v1.HorizontalPodAutoscaler": {
+    "description": "configuration of a horizontal pod autoscaler.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+      "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscalerSpec"
+     },
+     "status": {
+      "description": "current information about the autoscaler.",
+      "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscalerStatus"
+     }
+    }
+   },
+   "autoscaling.v1.HorizontalPodAutoscalerList": {
+    "description": "list of horizontal pod autoscaler objects.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "list of horizontal pod autoscaler objects.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/autoscaling.v1.HorizontalPodAutoscaler"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata.",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "autoscaling.v1.HorizontalPodAutoscalerSpec": {
+    "description": "specification of a horizontal pod autoscaler.",
+    "required": [
+     "scaleTargetRef",
+     "maxReplicas"
+    ],
+    "properties": {
+     "maxReplicas": {
+      "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "minReplicas": {
+      "description": "lower limit for the number of pods that can be set by the autoscaler, default 1.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "scaleTargetRef": {
+      "description": "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.",
+      "$ref": "#/definitions/autoscaling.v1.CrossVersionObjectReference"
+     },
+     "targetCPUUtilizationPercentage": {
+      "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "autoscaling.v1.HorizontalPodAutoscalerStatus": {
+    "description": "current status of a horizontal pod autoscaler",
+    "required": [
+     "currentReplicas",
+     "desiredReplicas"
+    ],
+    "properties": {
+     "currentCPUUtilizationPercentage": {
+      "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "currentReplicas": {
+      "description": "current number of replicas of pods managed by this autoscaler.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "desiredReplicas": {
+      "description": "desired number of replicas of pods managed by this autoscaler.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "lastScaleTime": {
+      "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "observedGeneration": {
+      "description": "most recent generation observed by this autoscaler.",
+      "type": "integer",
+      "format": "int64"
+     }
+    }
+   },
+   "autoscaling.v1.Scale": {
+    "description": "Scale represents a scaling request for a resource.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+      "$ref": "#/definitions/autoscaling.v1.ScaleSpec"
+     },
+     "status": {
+      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
+      "$ref": "#/definitions/autoscaling.v1.ScaleStatus"
+     }
+    }
+   },
+   "autoscaling.v1.ScaleSpec": {
+    "description": "ScaleSpec describes the attributes of a scale subresource.",
+    "properties": {
+     "replicas": {
+      "description": "desired number of instances for the scaled object.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "autoscaling.v1.ScaleStatus": {
+    "description": "ScaleStatus represents the current status of a scale subresource.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "description": "actual number of observed instances of the scaled object.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "selector": {
+      "description": "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "type": "string"
+     }
+    }
+   },
+   "batch.v1.Job": {
+    "description": "Job represents the configuration of a single job.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/batch.v1.JobSpec"
+     },
+     "status": {
+      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/batch.v1.JobStatus"
+     }
+    }
+   },
+   "batch.v1.JobCondition": {
+    "description": "JobCondition describes current state of a job.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastProbeTime": {
+      "description": "Last time the condition was checked.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "lastTransitionTime": {
+      "description": "Last time the condition transit from one status to another.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "message": {
+      "description": "Human readable message indicating details about last transition.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "(brief) reason for the condition's last transition.",
+      "type": "string"
+     },
+     "status": {
+      "description": "Status of the condition, one of True, False, Unknown.",
+      "type": "string"
+     },
+     "type": {
+      "description": "Type of job condition, Complete or Failed.",
+      "type": "string"
+     }
+    }
+   },
+   "batch.v1.JobList": {
+    "description": "JobList is a collection of jobs.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of Job.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/batch.v1.Job"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "batch.v1.JobSpec": {
+    "description": "JobSpec describes how the job execution will look like.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "activeDeadlineSeconds": {
+      "description": "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
+      "type": "integer",
+      "format": "int64"
+     },
+     "completions": {
+      "description": "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "integer",
+      "format": "int32"
+     },
+     "manualSelector": {
+      "description": "ManualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md",
+      "type": "boolean"
+     },
+     "parallelism": {
+      "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "integer",
+      "format": "int32"
+     },
+     "selector": {
+      "description": "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     },
+     "template": {
+      "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "$ref": "#/definitions/v1.PodTemplateSpec"
+     }
+    }
+   },
+   "batch.v1.JobStatus": {
+    "description": "JobStatus represents the current state of a Job.",
+    "properties": {
+     "active": {
+      "description": "Active is the number of actively running pods.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "completionTime": {
+      "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "conditions": {
+      "description": "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/batch.v1.JobCondition"
+      }
+     },
+     "failed": {
+      "description": "Failed is the number of pods which reached Phase Failed.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "startTime": {
+      "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "succeeded": {
+      "description": "Succeeded is the number of pods which reached Phase Succeeded.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "batch.v2alpha1.CronJob": {
+    "description": "CronJob represents the configuration of a single cron job.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec is a structure defining the expected behavior of a job, including the schedule. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/batch.v2alpha1.CronJobSpec"
+     },
+     "status": {
+      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/batch.v2alpha1.CronJobStatus"
+     }
+    }
+   },
+   "batch.v2alpha1.CronJobList": {
+    "description": "CronJobList is a collection of cron jobs.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of CronJob.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/batch.v2alpha1.CronJob"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "batch.v2alpha1.CronJobSpec": {
+    "description": "CronJobSpec describes how the job execution will look like and when it will actually run.",
+    "required": [
+     "schedule",
+     "jobTemplate"
+    ],
+    "properties": {
+     "concurrencyPolicy": {
+      "description": "ConcurrencyPolicy specifies how to treat concurrent executions of a Job.",
+      "type": "string"
+     },
+     "jobTemplate": {
+      "description": "JobTemplate is the object that describes the job that will be created when executing a CronJob.",
+      "$ref": "#/definitions/batch.v2alpha1.JobTemplateSpec"
+     },
+     "schedule": {
+      "description": "Schedule contains the schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
+      "type": "string"
+     },
+     "startingDeadlineSeconds": {
+      "description": "Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "suspend": {
+      "description": "Suspend flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.",
+      "type": "boolean"
+     }
+    }
+   },
+   "batch.v2alpha1.CronJobStatus": {
+    "description": "CronJobStatus represents the current state of a cron job.",
+    "properties": {
+     "active": {
+      "description": "Active holds pointers to currently running jobs.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/v1.ObjectReference"
+      }
+     },
+     "lastScheduleTime": {
+      "description": "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     }
+    }
+   },
+   "batch.v2alpha1.Job": {
+    "description": "Job represents the configuration of a single job.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/batch.v2alpha1.JobSpec"
+     },
+     "status": {
+      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/batch.v2alpha1.JobStatus"
+     }
+    }
+   },
+   "batch.v2alpha1.JobCondition": {
+    "description": "JobCondition describes current state of a job.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastProbeTime": {
+      "description": "Last time the condition was checked.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "lastTransitionTime": {
+      "description": "Last time the condition transit from one status to another.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "message": {
+      "description": "Human readable message indicating details about last transition.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "(brief) reason for the condition's last transition.",
+      "type": "string"
+     },
+     "status": {
+      "description": "Status of the condition, one of True, False, Unknown.",
+      "type": "string"
+     },
+     "type": {
+      "description": "Type of job condition, Complete or Failed.",
+      "type": "string"
+     }
+    }
+   },
+   "batch.v2alpha1.JobList": {
+    "description": "JobList is a collection of jobs.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of Job.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/batch.v2alpha1.Job"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "batch.v2alpha1.JobSpec": {
+    "description": "JobSpec describes how the job execution will look like.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "activeDeadlineSeconds": {
+      "description": "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
+      "type": "integer",
+      "format": "int64"
+     },
+     "completions": {
+      "description": "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "integer",
+      "format": "int32"
+     },
+     "manualSelector": {
+      "description": "ManualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md",
+      "type": "boolean"
+     },
+     "parallelism": {
+      "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "integer",
+      "format": "int32"
+     },
+     "selector": {
+      "description": "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     },
+     "template": {
+      "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "$ref": "#/definitions/v1.PodTemplateSpec"
+     }
+    }
+   },
+   "batch.v2alpha1.JobStatus": {
+    "description": "JobStatus represents the current state of a Job.",
+    "properties": {
+     "active": {
+      "description": "Active is the number of actively running pods.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "completionTime": {
+      "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "conditions": {
+      "description": "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/batch.v2alpha1.JobCondition"
+      }
+     },
+     "failed": {
+      "description": "Failed is the number of pods which reached Phase Failed.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "startTime": {
+      "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "succeeded": {
+      "description": "Succeeded is the number of pods which reached Phase Succeeded.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "batch.v2alpha1.JobTemplateSpec": {
+    "description": "JobTemplateSpec describes the data a Job should have when created from a template",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata of the jobs created from this template. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Specification of the desired behavior of the job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/batch.v2alpha1.JobSpec"
+     }
+    }
+   },
+   "extensions.v1beta1.APIVersion": {
+    "description": "An APIVersion represents a single concrete version of an object model.",
+    "properties": {
+     "name": {
+      "description": "Name of this version (e.g. 'v1').",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.CPUTargetUtilization": {
+    "required": [
+     "targetPercentage"
+    ],
+    "properties": {
+     "targetPercentage": {
+      "description": "fraction of the requested CPU that should be utilized/used, e.g. 70 means that 70% of the requested CPU should be in use.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSet": {
+    "description": "DaemonSet represents the configuration of a daemon set.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/extensions.v1beta1.DaemonSetSpec"
+     },
+     "status": {
+      "description": "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/extensions.v1beta1.DaemonSetStatus"
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetList": {
+    "description": "DaemonSetList is a collection of daemon sets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is a list of daemon sets.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.DaemonSet"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetSpec": {
+    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "selector": {
+      "description": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     },
+     "template": {
+      "description": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template",
+      "$ref": "#/definitions/v1.PodTemplateSpec"
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetStatus": {
+    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "required": [
+     "currentNumberScheduled",
+     "numberMisscheduled",
+     "desiredNumberScheduled",
+     "numberReady"
+    ],
+    "properties": {
+     "currentNumberScheduled": {
+      "description": "CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
+      "type": "integer",
+      "format": "int32"
+     },
+     "desiredNumberScheduled": {
+      "description": "DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
+      "type": "integer",
+      "format": "int32"
+     },
+     "numberMisscheduled": {
+      "description": "NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
+      "type": "integer",
+      "format": "int32"
+     },
+     "numberReady": {
+      "description": "NumberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "observedGeneration": {
+      "description": "ObservedGeneration is the most recent generation observed by the daemon set controller.",
+      "type": "integer",
+      "format": "int64"
+     }
+    }
+   },
+   "extensions.v1beta1.Deployment": {
+    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object metadata.",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Specification of the desired behavior of the Deployment.",
+      "$ref": "#/definitions/extensions.v1beta1.DeploymentSpec"
+     },
+     "status": {
+      "description": "Most recently observed status of the Deployment.",
+      "$ref": "#/definitions/extensions.v1beta1.DeploymentStatus"
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentCondition": {
+    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastTransitionTime": {
+      "description": "Last time the condition transitioned from one status to another.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "lastUpdateTime": {
+      "description": "The last time this condition was updated.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "message": {
+      "description": "A human readable message indicating details about the transition.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "The reason for the condition's last transition.",
+      "type": "string"
+     },
+     "status": {
+      "description": "Status of the condition, one of True, False, Unknown.",
+      "type": "string"
+     },
+     "type": {
+      "description": "Type of deployment condition.",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentList": {
+    "description": "DeploymentList is a list of Deployments.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of Deployments.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.Deployment"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata.",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentRollback": {
+    "description": "DeploymentRollback stores the information required to rollback a deployment.",
+    "required": [
+     "name",
+     "rollbackTo"
+    ],
+    "properties": {
+     "name": {
+      "description": "Required: This must match the Name of a deployment.",
+      "type": "string"
+     },
+     "rollbackTo": {
+      "description": "The config of this deployment rollback.",
+      "$ref": "#/definitions/extensions.v1beta1.RollbackConfig"
+     },
+     "updatedAnnotations": {
+      "description": "The annotations to be updated to a deployment",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentSpec": {
+    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "minReadySeconds": {
+      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+      "type": "integer",
+      "format": "int32"
+     },
+     "paused": {
+      "description": "Indicates that the deployment is paused and will not be processed by the deployment controller.",
+      "type": "boolean"
+     },
+     "progressDeadlineSeconds": {
+      "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. This is not set by default.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "replicas": {
+      "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "revisionHistoryLimit": {
+      "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "rollbackTo": {
+      "description": "The config this deployment is rolling back to. Will be cleared after rollback is done.",
+      "$ref": "#/definitions/extensions.v1beta1.RollbackConfig"
+     },
+     "selector": {
+      "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     },
+     "strategy": {
+      "description": "The deployment strategy to use to replace existing pods with new ones.",
+      "$ref": "#/definitions/extensions.v1beta1.DeploymentStrategy"
+     },
+     "template": {
+      "description": "Template describes the pods that will be created.",
+      "$ref": "#/definitions/v1.PodTemplateSpec"
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentStatus": {
+    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "properties": {
+     "availableReplicas": {
+      "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "conditions": {
+      "description": "Represents the latest available observations of a deployment's current state.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.DeploymentCondition"
+      }
+     },
+     "observedGeneration": {
+      "description": "The generation observed by the deployment controller.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "readyReplicas": {
+      "description": "Total number of ready pods targeted by this deployment.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "replicas": {
+      "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
+      "type": "integer",
+      "format": "int32"
+     },
+     "unavailableReplicas": {
+      "description": "Total number of unavailable pods targeted by this deployment.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "updatedReplicas": {
+      "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentStrategy": {
+    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "properties": {
+     "rollingUpdate": {
+      "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
+      "$ref": "#/definitions/extensions.v1beta1.RollingUpdateDeployment"
+     },
+     "type": {
+      "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.HorizontalPodAutoscaler": {
+    "description": "configuration of a horizontal pod autoscaler.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+      "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscalerSpec"
+     },
+     "status": {
+      "description": "current information about the autoscaler.",
+      "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscalerStatus"
+     }
+    }
+   },
+   "extensions.v1beta1.HorizontalPodAutoscalerList": {
+    "description": "list of horizontal pod autoscaler objects.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "list of horizontal pod autoscaler objects.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata.",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "extensions.v1beta1.HorizontalPodAutoscalerSpec": {
+    "description": "specification of a horizontal pod autoscaler.",
+    "required": [
+     "scaleRef",
+     "maxReplicas"
+    ],
+    "properties": {
+     "cpuUtilization": {
+      "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified it defaults to the target CPU utilization at 80% of the requested resources.",
+      "$ref": "#/definitions/extensions.v1beta1.CPUTargetUtilization"
+     },
+     "maxReplicas": {
+      "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "minReplicas": {
+      "description": "lower limit for the number of pods that can be set by the autoscaler, default 1.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "scaleRef": {
+      "description": "reference to Scale subresource; horizontal pod autoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modifying its spec.",
+      "$ref": "#/definitions/extensions.v1beta1.SubresourceReference"
+     }
+    }
+   },
+   "extensions.v1beta1.HorizontalPodAutoscalerStatus": {
+    "description": "current status of a horizontal pod autoscaler",
+    "required": [
+     "currentReplicas",
+     "desiredReplicas"
+    ],
+    "properties": {
+     "currentCPUUtilizationPercentage": {
+      "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "currentReplicas": {
+      "description": "current number of replicas of pods managed by this autoscaler.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "desiredReplicas": {
+      "description": "desired number of replicas of pods managed by this autoscaler.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "lastScaleTime": {
+      "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "observedGeneration": {
+      "description": "most recent generation observed by this autoscaler.",
+      "type": "integer",
+      "format": "int64"
+     }
+    }
+   },
+   "extensions.v1beta1.Ingress": {
+    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/extensions.v1beta1.IngressSpec"
+     },
+     "status": {
+      "description": "Status is the current state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/extensions.v1beta1.IngressStatus"
+     }
+    }
+   },
+   "extensions.v1beta1.IngressBackend": {
+    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "required": [
+     "serviceName",
+     "servicePort"
+    ],
+    "properties": {
+     "serviceName": {
+      "description": "Specifies the name of the referenced service.",
+      "type": "string"
+     },
+     "servicePort": {
+      "description": "Specifies the port of the referenced service.",
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"
+     }
+    }
+   },
+   "extensions.v1beta1.IngressList": {
+    "description": "IngressList is a collection of Ingress.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of Ingress.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.Ingress"
+      }
+     },
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "extensions.v1beta1.IngressRule": {
+    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "properties": {
+     "host": {
+      "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.IngressSpec": {
+    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "properties": {
+     "backend": {
+      "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
+      "$ref": "#/definitions/extensions.v1beta1.IngressBackend"
+     },
+     "rules": {
+      "description": "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.IngressRule"
+      }
+     },
+     "tls": {
+      "description": "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.IngressTLS"
+      }
+     }
+    }
+   },
+   "extensions.v1beta1.IngressStatus": {
+    "description": "IngressStatus describe the current state of the Ingress.",
+    "properties": {
+     "loadBalancer": {
+      "description": "LoadBalancer contains the current status of the load-balancer.",
+      "$ref": "#/definitions/v1.LoadBalancerStatus"
+     }
+    }
+   },
+   "extensions.v1beta1.IngressTLS": {
+    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "properties": {
+     "hosts": {
+      "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "secretName": {
+      "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicy": {
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Specification of the desired behavior for this NetworkPolicy.",
+      "$ref": "#/definitions/extensions.v1beta1.NetworkPolicySpec"
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicyIngressRule": {
+    "description": "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+    "properties": {
+     "from": {
+      "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is not provided, this rule matches all sources (traffic not restricted by source). If this field is empty, this rule matches no sources (no traffic matches). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.NetworkPolicyPeer"
+      }
+     },
+     "ports": {
+      "description": "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is not provided, this rule matches all ports (traffic not restricted by port). If this field is empty, this rule matches no ports (no traffic matches). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.NetworkPolicyPort"
+      }
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicyList": {
+    "description": "Network Policy List is a list of NetworkPolicy objects.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is a list of schema objects.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.NetworkPolicy"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicyPeer": {
+    "properties": {
+     "namespaceSelector": {
+      "description": "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If omitted, this selector selects no namespaces. If present but empty, this selector selects all namespaces.",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     },
+     "podSelector": {
+      "description": "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If not provided, this selector selects no pods. If present but empty, this selector selects all pods in this namespace.",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicyPort": {
+    "properties": {
+     "port": {
+      "description": "If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.",
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"
+     },
+     "protocol": {
+      "description": "Optional.  The protocol (TCP or UDP) which traffic must match. If not specified, this field defaults to TCP.",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicySpec": {
+    "required": [
+     "podSelector"
+    ],
+    "properties": {
+     "ingress": {
+      "description": "List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if namespace.networkPolicy.ingress.isolation is undefined and cluster policy allows it, OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not affect ingress isolation. If this field is present and contains at least one rule, this policy allows any traffic which matches at least one of the ingress rules in this list.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.NetworkPolicyIngressRule"
+      }
+     },
+     "podSelector": {
+      "description": "Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSet": {
+    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "properties": {
+     "metadata": {
+      "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/extensions.v1beta1.ReplicaSetSpec"
+     },
+     "status": {
+      "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "$ref": "#/definitions/extensions.v1beta1.ReplicaSetStatus"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetCondition": {
+    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "lastTransitionTime": {
+      "description": "The last time the condition transitioned from one status to another.",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "message": {
+      "description": "A human readable message indicating details about the transition.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "The reason for the condition's last transition.",
+      "type": "string"
+     },
+     "status": {
+      "description": "Status of the condition, one of True, False, Unknown.",
+      "type": "string"
+     },
+     "type": {
+      "description": "Type of replica set condition.",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetList": {
+    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "List of ReplicaSets. More info: http://kubernetes.io/docs/user-guide/replication-controller",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.ReplicaSet"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetSpec": {
+    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "properties": {
+     "minReadySeconds": {
+      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+      "type": "integer",
+      "format": "int32"
+     },
+     "replicas": {
+      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller",
+      "type": "integer",
+      "format": "int32"
+     },
+     "selector": {
+      "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     },
+     "template": {
+      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template",
+      "$ref": "#/definitions/v1.PodTemplateSpec"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetStatus": {
+    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "availableReplicas": {
+      "description": "The number of available replicas (ready for at least minReadySeconds) for this replica set.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "conditions": {
+      "description": "Represents the latest available observations of a replica set's current state.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.ReplicaSetCondition"
+      }
+     },
+     "fullyLabeledReplicas": {
+      "description": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "observedGeneration": {
+      "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+      "type": "integer",
+      "format": "int64"
+     },
+     "readyReplicas": {
+      "description": "The number of ready replicas for this replica set.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "replicas": {
+      "description": "Replicas is the most recently oberved number of replicas. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "extensions.v1beta1.RollbackConfig": {
+    "properties": {
+     "revision": {
+      "description": "The revision to rollback to. If set to 0, rollbck to the last revision.",
+      "type": "integer",
+      "format": "int64"
+     }
+    }
+   },
+   "extensions.v1beta1.RollingUpdateDeployment": {
+    "description": "Spec to control the desired behavior of rolling update.",
+    "properties": {
+     "maxSurge": {
+      "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"
+     },
+     "maxUnavailable": {
+      "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"
+     }
+    }
+   },
+   "extensions.v1beta1.Scale": {
+    "description": "represents a scaling request for a resource.",
+    "properties": {
+     "metadata": {
+      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+      "$ref": "#/definitions/extensions.v1beta1.ScaleSpec"
+     },
+     "status": {
+      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
+      "$ref": "#/definitions/extensions.v1beta1.ScaleStatus"
+     }
+    }
+   },
+   "extensions.v1beta1.ScaleSpec": {
+    "description": "describes the attributes of a scale subresource",
+    "properties": {
+     "replicas": {
+      "description": "desired number of instances for the scaled object.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "extensions.v1beta1.ScaleStatus": {
+    "description": "represents the current status of a scale subresource.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "description": "actual number of observed instances of the scaled object.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "selector": {
+      "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     },
+     "targetSelector": {
+      "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.SubresourceReference": {
+    "description": "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
+    "properties": {
+     "apiVersion": {
+      "description": "API version of the referent",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+      "type": "string"
+     },
+     "subresource": {
+      "description": "Subresource name of the referent",
+      "type": "string"
+     }
+    }
+   },
+   "extensions.v1beta1.ThirdPartyResource": {
+    "description": "A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.",
+    "properties": {
+     "description": {
+      "description": "Description is the description of this object.",
+      "type": "string"
+     },
+     "metadata": {
+      "description": "Standard object metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "versions": {
+      "description": "Versions are versions for this third party object",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.APIVersion"
+      }
+     }
+    }
+   },
+   "extensions.v1beta1.ThirdPartyResourceList": {
+    "description": "ThirdPartyResourceList is a list of ThirdPartyResources.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of ThirdPartyResources.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/extensions.v1beta1.ThirdPartyResource"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata.",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "io.k8s.authentication.v1beta1.TokenReview": {
+    "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec holds information about the request being evaluated",
+      "$ref": "#/definitions/io.k8s.authentication.v1beta1.TokenReviewSpec"
+     },
+     "status": {
+      "description": "Status is filled in by the server and indicates whether the request can be authenticated.",
+      "$ref": "#/definitions/io.k8s.authentication.v1beta1.TokenReviewStatus"
+     }
+    }
+   },
+   "io.k8s.authentication.v1beta1.TokenReviewSpec": {
+    "description": "TokenReviewSpec is a description of the token authentication request.",
+    "properties": {
+     "token": {
+      "description": "Token is the opaque bearer token.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.authentication.v1beta1.TokenReviewStatus": {
+    "description": "TokenReviewStatus is the result of the token authentication request.",
+    "properties": {
+     "authenticated": {
+      "description": "Authenticated indicates that the token was associated with a known user.",
+      "type": "boolean"
+     },
+     "error": {
+      "description": "Error indicates that the token couldn't be checked",
+      "type": "string"
+     },
+     "user": {
+      "description": "User is the UserInfo associated with the provided token.",
+      "$ref": "#/definitions/io.k8s.authentication.v1beta1.UserInfo"
+     }
+    }
+   },
+   "io.k8s.authentication.v1beta1.UserInfo": {
+    "description": "UserInfo holds the information about the user needed to implement the user.Info interface.",
+    "properties": {
+     "extra": {
+      "description": "Any additional information provided by the authenticator.",
+      "type": "object",
+      "additionalProperties": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      }
+     },
+     "groups": {
+      "description": "The names of groups this user is a part of.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "uid": {
+      "description": "A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.",
+      "type": "string"
+     },
+     "username": {
+      "description": "The name that uniquely identifies this user among all active users.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.ClusterRole": {
+    "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+    "required": [
+     "rules"
+    ],
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata.",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "rules": {
+      "description": "Rules holds all the PolicyRules for this ClusterRole",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.PolicyRule"
+      }
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding": {
+    "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+    "required": [
+     "subjects",
+     "roleRef"
+    ],
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata.",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "roleRef": {
+      "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+      "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleRef"
+     },
+     "subjects": {
+      "description": "Subjects holds references to the objects the role applies to.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Subject"
+      }
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingList": {
+    "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is a list of ClusterRoleBindings",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"
+      }
+     },
+     "metadata": {
+      "description": "Standard object's metadata.",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.ClusterRoleList": {
+    "description": "ClusterRoleList is a collection of ClusterRoles",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is a list of ClusterRoles",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"
+      }
+     },
+     "metadata": {
+      "description": "Standard object's metadata.",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.PolicyRule": {
+    "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+    "required": [
+     "verbs"
+    ],
+    "properties": {
+     "apiGroups": {
+      "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "attributeRestrictions": {
+      "description": "AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports. If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.",
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.runtime.RawExtension"
+     },
+     "nonResourceURLs": {
+      "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different. Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "resourceNames": {
+      "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "resources": {
+      "description": "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "verbs": {
+      "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.Role": {
+    "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+    "required": [
+     "rules"
+    ],
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata.",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "rules": {
+      "description": "Rules holds all the PolicyRules for this Role",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.PolicyRule"
+      }
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.RoleBinding": {
+    "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+    "required": [
+     "subjects",
+     "roleRef"
+    ],
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata.",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "roleRef": {
+      "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+      "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleRef"
+     },
+     "subjects": {
+      "description": "Subjects holds references to the objects the role applies to.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Subject"
+      }
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.RoleBindingList": {
+    "description": "RoleBindingList is a collection of RoleBindings",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is a list of RoleBindings",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"
+      }
+     },
+     "metadata": {
+      "description": "Standard object's metadata.",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.RoleList": {
+    "description": "RoleList is a collection of Roles",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is a list of Roles",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"
+      }
+     },
+     "metadata": {
+      "description": "Standard object's metadata.",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.RoleRef": {
+    "description": "RoleRef contains information that points to the role being used",
+    "required": [
+     "apiGroup",
+     "kind",
+     "name"
+    ],
+    "properties": {
+     "apiGroup": {
+      "description": "APIGroup is the group for the resource being referenced",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind is the type of resource being referenced",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name is the name of resource being referenced",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.Subject": {
+    "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+    "required": [
+     "kind",
+     "name"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "APIVersion holds the API group and version of the referenced object.",
+      "type": "string"
+     },
+     "kind": {
+      "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name of the object being referenced.",
+      "type": "string"
+     },
+     "namespace": {
+      "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.LocalSubjectAccessReview": {
+    "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewSpec"
+     },
+     "status": {
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.NonResourceAttributes": {
+    "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+    "properties": {
+     "path": {
+      "description": "Path is the URL path of the request",
+      "type": "string"
+     },
+     "verb": {
+      "description": "Verb is the standard HTTP verb",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.ResourceAttributes": {
+    "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+    "properties": {
+     "group": {
+      "description": "Group is the API Group of the Resource.  \"*\" means all.",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+      "type": "string"
+     },
+     "namespace": {
+      "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+      "type": "string"
+     },
+     "resource": {
+      "description": "Resource is one of the existing resource types.  \"*\" means all.",
+      "type": "string"
+     },
+     "subresource": {
+      "description": "Subresource is one of the existing resource types.  \"\" means none.",
+      "type": "string"
+     },
+     "verb": {
+      "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+      "type": "string"
+     },
+     "version": {
+      "description": "Version is the API Version of the Resource.  \"*\" means all.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SelfSubjectAccessReview": {
+    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec holds information about the request being evaluated.  user and groups must be empty",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec"
+     },
+     "status": {
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec": {
+    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "properties": {
+     "nonResourceAttributes": {
+      "description": "NonResourceAttributes describes information for a non-resource access request",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.NonResourceAttributes"
+     },
+     "resourceAttributes": {
+      "description": "ResourceAuthorizationAttributes describes information for a resource access request",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.ResourceAttributes"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SubjectAccessReview": {
+    "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Spec holds information about the request being evaluated",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewSpec"
+     },
+     "status": {
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SubjectAccessReviewSpec": {
+    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "properties": {
+     "extra": {
+      "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
+      "type": "object",
+      "additionalProperties": {
+       "type": "array",
+       "items": {
+        "type": "string"
+       }
+      }
+     },
+     "group": {
+      "description": "Groups is the groups you're testing for.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "nonResourceAttributes": {
+      "description": "NonResourceAttributes describes information for a non-resource access request",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.NonResourceAttributes"
+     },
+     "resourceAttributes": {
+      "description": "ResourceAuthorizationAttributes describes information for a resource access request",
+      "$ref": "#/definitions/io.k8s.authorization.v1beta1.ResourceAttributes"
+     },
+     "user": {
+      "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus": {
+    "description": "SubjectAccessReviewStatus",
+    "required": [
+     "allowed"
+    ],
+    "properties": {
+     "allowed": {
+      "description": "Allowed is required.  True if the action would be allowed, false otherwise.",
+      "type": "boolean"
+     },
+     "evaluationError": {
+      "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "Reason is optional.  It indicates why a request was allowed or denied.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequest": {
+    "description": "Describes a certificate signing request",
+    "properties": {
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "The certificate request itself and any additional information.",
+      "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec"
+     },
+     "status": {
+      "description": "Derived information about the request.",
+      "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus"
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition": {
+    "required": [
+     "type"
+    ],
+    "properties": {
+     "lastUpdateTime": {
+      "description": "timestamp for the last update to this condition",
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
+     },
+     "message": {
+      "description": "human readable message with details about the request state",
+      "type": "string"
+     },
+     "reason": {
+      "description": "brief reason for the request state",
+      "type": "string"
+     },
+     "type": {
+      "description": "request approval state, currently Approved or Denied.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequestList": {
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"
+      }
+     },
+     "metadata": {
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec": {
+    "description": "This information is immutable after the request is created. Only the Request and ExtraInfo fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.",
+    "required": [
+     "request"
+    ],
+    "properties": {
+     "groups": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     },
+     "request": {
+      "description": "Base64-encoded PKCS#10 CSR data",
+      "type": "string",
+      "format": "byte"
+     },
+     "uid": {
+      "type": "string"
+     },
+     "username": {
+      "description": "Information about the requesting user (if relevant) See user.Info interface for details",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus": {
+    "properties": {
+     "certificate": {
+      "description": "If request was approved, the controller will place the issued certificate here.",
+      "type": "string",
+      "format": "byte"
+     },
+     "conditions": {
+      "description": "Conditions applied to the request, such as approval or denial.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition"
+      }
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.api.resource.Quantity": {
     "type": "string"
    },
-   "runtime.RawExtension": {
+   "io.k8s.kubernetes.pkg.runtime.RawExtension": {
     "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
     "required": [
      "Raw"
@@ -31391,7 +33468,70 @@
      }
     }
    },
-   "v1.APIGroup": {
+   "io.k8s.kubernetes.pkg.util.intstr.IntOrString": {
+    "type": "string",
+    "format": "int-or-string"
+   },
+   "io.k8s.kubernetes.pkg.version.Info": {
+    "description": "Info contains versioning information. how we'll want to distribute that information.",
+    "required": [
+     "major",
+     "minor",
+     "gitVersion",
+     "gitCommit",
+     "gitTreeState",
+     "buildDate",
+     "goVersion",
+     "compiler",
+     "platform"
+    ],
+    "properties": {
+     "buildDate": {
+      "type": "string"
+     },
+     "compiler": {
+      "type": "string"
+     },
+     "gitCommit": {
+      "type": "string"
+     },
+     "gitTreeState": {
+      "type": "string"
+     },
+     "gitVersion": {
+      "type": "string"
+     },
+     "goVersion": {
+      "type": "string"
+     },
+     "major": {
+      "type": "string"
+     },
+     "minor": {
+      "type": "string"
+     },
+     "platform": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "description": "Event represents a single event to a watched resource.",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "object": {
+      "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *api.Status is recommended; other types may make sense\n   depending on context.",
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.runtime.RawExtension"
+     },
+     "type": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
     "required": [
      "name",
@@ -31405,25 +33545,25 @@
      },
      "preferredVersion": {
       "description": "preferredVersion is the version preferred by the API server, which probably is the storage version.",
-      "$ref": "#/definitions/v1.GroupVersionForDiscovery"
+      "$ref": "#/definitions/io.k8s.meta.v1.GroupVersionForDiscovery"
      },
      "serverAddressByClientCIDRs": {
       "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.ServerAddressByClientCIDR"
+       "$ref": "#/definitions/io.k8s.meta.v1.ServerAddressByClientCIDR"
       }
      },
      "versions": {
       "description": "versions are the versions supported in this group.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.GroupVersionForDiscovery"
+       "$ref": "#/definitions/io.k8s.meta.v1.GroupVersionForDiscovery"
       }
      }
     }
    },
-   "v1.APIGroupList": {
+   "io.k8s.meta.v1.APIGroupList": {
     "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
     "required": [
      "groups"
@@ -31433,12 +33573,12 @@
       "description": "groups is a list of APIGroup.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.APIGroup"
+       "$ref": "#/definitions/io.k8s.meta.v1.APIGroup"
       }
      }
     }
    },
-   "v1.APIResource": {
+   "io.k8s.meta.v1.APIResource": {
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",
@@ -31468,7 +33608,7 @@
      }
     }
    },
-   "v1.APIResourceList": {
+   "io.k8s.meta.v1.APIResourceList": {
     "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
     "required": [
      "groupVersion",
@@ -31483,12 +33623,12 @@
       "description": "resources contains the name of the resources and if they are namespaced.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.APIResource"
+       "$ref": "#/definitions/io.k8s.meta.v1.APIResource"
       }
      }
     }
    },
-   "v1.APIVersions": {
+   "io.k8s.meta.v1.APIVersions": {
     "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
     "required": [
      "versions",
@@ -31499,7 +33639,7 @@
       "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.ServerAddressByClientCIDR"
+       "$ref": "#/definitions/io.k8s.meta.v1.ServerAddressByClientCIDR"
       }
      },
      "versions": {
@@ -31508,6 +33648,355 @@
       "items": {
        "type": "string"
       }
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "description": "groupVersion specifies the API group and version in the form \"group/version\"",
+      "type": "string"
+     },
+     "version": {
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelector": {
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchExpressions": {
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.meta.v1.LabelSelectorRequirement"
+      }
+     },
+     "matchLabels": {
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelectorRequirement": {
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "description": "key is the label key that the selector applies to.",
+      "type": "string"
+     },
+     "operator": {
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
+      "type": "string"
+     },
+     "values": {
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "resourceVersion": {
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency",
+      "type": "string"
+     },
+     "selfLink": {
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "description": "API version of the referent.",
+      "type": "string"
+     },
+     "controller": {
+      "description": "If true, this reference points to the managing controller.",
+      "type": "boolean"
+     },
+     "kind": {
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "name": {
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+      "type": "string"
+     },
+     "uid": {
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+      "type": "string"
+     },
+     "serverAddress": {
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "code": {
+      "description": "Suggested HTTP return code for this status, 0 if not set.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "details": {
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+      "$ref": "#/definitions/io.k8s.meta.v1.StatusDetails"
+     },
+     "message": {
+      "description": "A human-readable description of the status of this operation.",
+      "type": "string"
+     },
+     "metadata": {
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     },
+     "reason": {
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+      "type": "string"
+     },
+     "status": {
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "field": {
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+      "type": "string"
+     },
+     "message": {
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+      "type": "string"
+     },
+     "reason": {
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "causes": {
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.meta.v1.StatusCause"
+      }
+     },
+     "group": {
+      "description": "The group attribute of the resource associated with the status StatusReason.",
+      "type": "string"
+     },
+     "kind": {
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+      "type": "string"
+     },
+     "name": {
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+      "type": "string"
+     },
+     "retryAfterSeconds": {
+      "description": "If specified, the time in seconds before the operation should be retried.",
+      "type": "integer",
+      "format": "int32"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Time": {
+    "type": "string",
+    "format": "date-time"
+   },
+   "io.k8s.storage.v1beta1.StorageClass": {
+    "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+    "required": [
+     "provisioner"
+    ],
+    "properties": {
+     "metadata": {
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "parameters": {
+      "description": "Parameters holds the parameters for the provisioner that should create volumes of this storage class.",
+      "type": "object",
+      "additionalProperties": {
+       "type": "string"
+      }
+     },
+     "provisioner": {
+      "description": "Provisioner indicates the type of the provisioner.",
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.storage.v1beta1.StorageClassList": {
+    "description": "StorageClassList is a collection of storage classes.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "description": "Items is the list of StorageClasses",
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/io.k8s.storage.v1beta1.StorageClass"
+      }
+     },
+     "metadata": {
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "policy.v1beta1.Eviction": {
+    "description": "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/\u003cpod name\u003e/evictions.",
+    "properties": {
+     "deleteOptions": {
+      "description": "DeleteOptions may be provided",
+      "$ref": "#/definitions/v1.DeleteOptions"
+     },
+     "metadata": {
+      "description": "ObjectMeta describes the pod that is being evicted.",
+      "$ref": "#/definitions/v1.ObjectMeta"
+     }
+    }
+   },
+   "policy.v1beta1.PodDisruptionBudget": {
+    "description": "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods",
+    "properties": {
+     "metadata": {
+      "$ref": "#/definitions/v1.ObjectMeta"
+     },
+     "spec": {
+      "description": "Specification of the desired behavior of the PodDisruptionBudget.",
+      "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudgetSpec"
+     },
+     "status": {
+      "description": "Most recently observed status of the PodDisruptionBudget.",
+      "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudgetStatus"
+     }
+    }
+   },
+   "policy.v1beta1.PodDisruptionBudgetList": {
+    "description": "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "#/definitions/policy.v1beta1.PodDisruptionBudget"
+      }
+     },
+     "metadata": {
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
+     }
+    }
+   },
+   "policy.v1beta1.PodDisruptionBudgetSpec": {
+    "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
+    "properties": {
+     "minAvailable": {
+      "description": "An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\".",
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"
+     },
+     "selector": {
+      "description": "Label query over pods whose evictions are managed by the disruption budget.",
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
+     }
+    }
+   },
+   "policy.v1beta1.PodDisruptionBudgetStatus": {
+    "description": "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
+    "required": [
+     "disruptedPods",
+     "disruptionsAllowed",
+     "currentHealthy",
+     "desiredHealthy",
+     "expectedPods"
+    ],
+    "properties": {
+     "currentHealthy": {
+      "description": "current number of healthy pods",
+      "type": "integer",
+      "format": "int32"
+     },
+     "desiredHealthy": {
+      "description": "minimum desired number of healthy pods",
+      "type": "integer",
+      "format": "int32"
+     },
+     "disruptedPods": {
+      "description": "DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.",
+      "type": "object",
+      "additionalProperties": {
+       "$ref": "#/definitions/io.k8s.meta.v1.Time"
+      }
+     },
+     "disruptionsAllowed": {
+      "description": "Number of pod disruptions that are currently allowed.",
+      "type": "integer",
+      "format": "int32"
+     },
+     "expectedPods": {
+      "description": "total number of pods counted by this disruption budget",
+      "type": "integer",
+      "format": "int32"
+     },
+     "observedGeneration": {
+      "description": "Most recent generation observed when updating this PDB status. PodDisruptionsAllowed and other status informatio is valid only if observedGeneration equals to PDB's object generation.",
+      "type": "integer",
+      "format": "int64"
      }
     }
    },
@@ -31636,7 +34125,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -31686,7 +34175,7 @@
      },
      "metadata": {
       "description": "More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -31864,7 +34353,7 @@
     "properties": {
      "startedAt": {
       "description": "Time at which the container was last (re-)started",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      }
     }
    },
@@ -31885,7 +34374,7 @@
      },
      "finishedAt": {
       "description": "Time at which the container last terminated",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "message": {
       "description": "Message regarding the last termination of the container",
@@ -31902,7 +34391,7 @@
      },
      "startedAt": {
       "description": "Time at which previous execution of the container started",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      }
     }
    },
@@ -31961,27 +34450,6 @@
      "state": {
       "description": "Details about the container's current condition.",
       "$ref": "#/definitions/v1.ContainerState"
-     }
-    }
-   },
-   "v1.CrossVersionObjectReference": {
-    "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
-    "required": [
-     "kind",
-     "name"
-    ],
-    "properties": {
-     "apiVersion": {
-      "description": "API version of the referent",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds\"",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-      "type": "string"
      }
     }
    },
@@ -32121,7 +34589,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -32193,7 +34661,7 @@
      },
      "firstTimestamp": {
       "description": "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "involvedObject": {
       "description": "The object that this event is about.",
@@ -32201,7 +34669,7 @@
      },
      "lastTimestamp": {
       "description": "The time at which the most recent occurrence of this event was recorded.",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "message": {
       "description": "A human-readable description of the status of this operation.",
@@ -32240,7 +34708,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -32269,23 +34737,6 @@
      }
     }
    },
-   "v1.GroupVersionForDiscovery": {
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
-    "required": [
-     "groupVersion",
-     "version"
-    ],
-    "properties": {
-     "groupVersion": {
-      "description": "groupVersion specifies the API group and version in the form \"group/version\"",
-      "type": "string"
-     },
-     "version": {
-      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
-      "type": "string"
-     }
-    }
-   },
    "v1.HTTPGetAction": {
     "description": "HTTPGetAction describes an action based on HTTP Get requests.",
     "required": [
@@ -32309,7 +34760,7 @@
      },
      "port": {
       "description": "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-      "$ref": "#/definitions/intstr.IntOrString"
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"
      },
      "scheme": {
       "description": "Scheme to use for connecting to the host. Defaults to HTTP.",
@@ -32351,285 +34802,6 @@
      }
     }
    },
-   "v1.HorizontalPodAutoscaler": {
-    "description": "configuration of a horizontal pod autoscaler.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-      "$ref": "#/definitions/v1.HorizontalPodAutoscalerSpec"
-     },
-     "status": {
-      "description": "current information about the autoscaler.",
-      "$ref": "#/definitions/v1.HorizontalPodAutoscalerStatus"
-     }
-    }
-   },
-   "v1.HorizontalPodAutoscalerList": {
-    "description": "list of horizontal pod autoscaler objects.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "list of horizontal pod autoscaler objects.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.HorizontalPodAutoscaler"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata.",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1.HorizontalPodAutoscalerSpec": {
-    "description": "specification of a horizontal pod autoscaler.",
-    "required": [
-     "scaleTargetRef",
-     "maxReplicas"
-    ],
-    "properties": {
-     "maxReplicas": {
-      "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "minReplicas": {
-      "description": "lower limit for the number of pods that can be set by the autoscaler, default 1.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "scaleTargetRef": {
-      "description": "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.",
-      "$ref": "#/definitions/v1.CrossVersionObjectReference"
-     },
-     "targetCPUUtilizationPercentage": {
-      "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1.HorizontalPodAutoscalerStatus": {
-    "description": "current status of a horizontal pod autoscaler",
-    "required": [
-     "currentReplicas",
-     "desiredReplicas"
-    ],
-    "properties": {
-     "currentCPUUtilizationPercentage": {
-      "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "currentReplicas": {
-      "description": "current number of replicas of pods managed by this autoscaler.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "desiredReplicas": {
-      "description": "desired number of replicas of pods managed by this autoscaler.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "lastScaleTime": {
-      "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "observedGeneration": {
-      "description": "most recent generation observed by this autoscaler.",
-      "type": "integer",
-      "format": "int64"
-     }
-    }
-   },
-   "v1.Job": {
-    "description": "Job represents the configuration of a single job.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v1.JobSpec"
-     },
-     "status": {
-      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v1.JobStatus"
-     }
-    }
-   },
-   "v1.JobCondition": {
-    "description": "JobCondition describes current state of a job.",
-    "required": [
-     "type",
-     "status"
-    ],
-    "properties": {
-     "lastProbeTime": {
-      "description": "Last time the condition was checked.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "lastTransitionTime": {
-      "description": "Last time the condition transit from one status to another.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "message": {
-      "description": "Human readable message indicating details about last transition.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "(brief) reason for the condition's last transition.",
-      "type": "string"
-     },
-     "status": {
-      "description": "Status of the condition, one of True, False, Unknown.",
-      "type": "string"
-     },
-     "type": {
-      "description": "Type of job condition, Complete or Failed.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.JobList": {
-    "description": "JobList is a collection of jobs.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is the list of Job.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.Job"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1.JobSpec": {
-    "description": "JobSpec describes how the job execution will look like.",
-    "required": [
-     "template"
-    ],
-    "properties": {
-     "activeDeadlineSeconds": {
-      "description": "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
-      "type": "integer",
-      "format": "int64"
-     },
-     "completions": {
-      "description": "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs",
-      "type": "integer",
-      "format": "int32"
-     },
-     "manualSelector": {
-      "description": "ManualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md",
-      "type": "boolean"
-     },
-     "parallelism": {
-      "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs",
-      "type": "integer",
-      "format": "int32"
-     },
-     "selector": {
-      "description": "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "template": {
-      "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs",
-      "$ref": "#/definitions/v1.PodTemplateSpec"
-     }
-    }
-   },
-   "v1.JobStatus": {
-    "description": "JobStatus represents the current state of a Job.",
-    "properties": {
-     "active": {
-      "description": "Active is the number of actively running pods.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "completionTime": {
-      "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "conditions": {
-      "description": "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.JobCondition"
-      }
-     },
-     "failed": {
-      "description": "Failed is the number of pods which reached Phase Failed.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "startTime": {
-      "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "succeeded": {
-      "description": "Succeeded is the number of pods which reached Phase Succeeded.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1.LabelSelector": {
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
-    "properties": {
-     "matchExpressions": {
-      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.LabelSelectorRequirement"
-      }
-     },
-     "matchLabels": {
-      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1.LabelSelectorRequirement": {
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
-    "required": [
-     "key",
-     "operator"
-    ],
-    "properties": {
-     "key": {
-      "description": "key is the label key that the selector applies to.",
-      "type": "string"
-     },
-     "operator": {
-      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
-      "type": "string"
-     },
-     "values": {
-      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
    "v1.Lifecycle": {
     "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
     "properties": {
@@ -32663,35 +34835,35 @@
       "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "defaultRequest": {
       "description": "DefaultRequest is the default resource requirement request value by resource name if resource request is omitted.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "max": {
       "description": "Max usage constraints on this kind by resource name.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "maxLimitRequestRatio": {
       "description": "MaxLimitRequestRatio if specified, the named resource must have a request and limit that are both non-zero where limit divided by request is less than or equal to the enumerated value; this represents the max burst for the named resource.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "min": {
       "description": "Min usage constraints on this kind by resource name.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "type": {
@@ -32715,7 +34887,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -32731,19 +34903,6 @@
       "items": {
        "$ref": "#/definitions/v1.LimitRangeItem"
       }
-     }
-    }
-   },
-   "v1.ListMeta": {
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
-    "properties": {
-     "resourceVersion": {
-      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency",
-      "type": "string"
-     },
-     "selfLink": {
-      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only.",
-      "type": "string"
      }
     }
    },
@@ -32813,7 +34972,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -32897,11 +35056,11 @@
     "properties": {
      "lastHeartbeatTime": {
       "description": "Last time we got an update on a given condition.",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "lastTransitionTime": {
       "description": "Last time the condition transit from one status to another.",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "message": {
       "description": "Human readable message indicating details about last transition.",
@@ -32945,7 +35104,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -33038,14 +35197,14 @@
       "description": "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "capacity": {
       "description": "Capacity represents the total resources of a node. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#capacity for more details.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "conditions": {
@@ -33179,7 +35338,7 @@
      },
      "creationTimestamp": {
       "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "deletionGracePeriodSeconds": {
       "description": "Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.",
@@ -33188,7 +35347,7 @@
      },
      "deletionTimestamp": {
       "description": "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "finalizers": {
       "description": "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
@@ -33225,7 +35384,7 @@
       "description": "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
       "type": "array",
       "items": {
-       "$ref": "#/definitions/v1.OwnerReference"
+       "$ref": "#/definitions/io.k8s.meta.v1.OwnerReference"
       }
      },
      "resourceVersion": {
@@ -33274,40 +35433,6 @@
       "type": "string"
      }
     }
-   },
-   "v1.OwnerReference": {
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
-    "required": [
-     "apiVersion",
-     "kind",
-     "name",
-     "uid"
-    ],
-    "properties": {
-     "apiVersion": {
-      "description": "API version of the referent.",
-      "type": "string"
-     },
-     "controller": {
-      "description": "If true, this reference points to the managing controller.",
-      "type": "boolean"
-     },
-     "kind": {
-      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-      "type": "string"
-     },
-     "uid": {
-      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Patch": {
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
    },
    "v1.PersistentVolume": {
     "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: http://kubernetes.io/docs/user-guide/persistent-volumes",
@@ -33358,7 +35483,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -33378,7 +35503,7 @@
      },
      "selector": {
       "description": "A label query over volumes to consider for binding.",
-      "$ref": "#/definitions/v1.LabelSelector"
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
      },
      "volumeName": {
       "description": "VolumeName is the binding reference to the PersistentVolume backing this claim.",
@@ -33400,7 +35525,7 @@
       "description": "Represents the actual resources of the underlying volume.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "phase": {
@@ -33424,7 +35549,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -33442,7 +35567,7 @@
       "description": "A description of the persistent volume's resources and capacity. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#capacity",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "claimRef": {
@@ -33516,7 +35641,7 @@
     "properties": {
      "labelSelector": {
       "description": "A label query over a set of resources, in this case pods.",
-      "$ref": "#/definitions/v1.LabelSelector"
+      "$ref": "#/definitions/io.k8s.meta.v1.LabelSelector"
      },
      "namespaces": {
       "description": "namespaces specifies which namespaces the labelSelector applies to (matches against); nil list means \"this pod's namespace,\" empty list means \"all namespaces\" The json tag here is not \"omitempty\" since we need to distinguish nil and empty. See https://golang.org/pkg/encoding/json/#Marshal for more details.",
@@ -33559,11 +35684,11 @@
     "properties": {
      "lastProbeTime": {
       "description": "Last time we probed the condition.",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "lastTransitionTime": {
       "description": "Last time the condition transitioned from one status to another.",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "message": {
       "description": "Human-readable message indicating details about last transition.",
@@ -33598,7 +35723,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -33770,7 +35895,7 @@
      },
      "startTime": {
       "description": "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      }
     }
    },
@@ -33802,7 +35927,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -33902,7 +36027,7 @@
     "properties": {
      "lastTransitionTime": {
       "description": "The last time the condition transitioned from one status to another.",
-      "$ref": "#/definitions/v1.Time"
+      "$ref": "#/definitions/io.k8s.meta.v1.Time"
      },
      "message": {
       "description": "A human readable message indicating details about the transition.",
@@ -33937,7 +36062,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -34019,7 +36144,7 @@
      },
      "divisor": {
       "description": "Specifies the output format of the exposed resources, defaults to \"1\"",
-      "$ref": "#/definitions/resource.Quantity"
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
      },
      "resource": {
       "description": "Required: resource to select",
@@ -34059,7 +36184,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -34070,7 +36195,7 @@
       "description": "Hard is the set of desired hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "scopes": {
@@ -34089,14 +36214,14 @@
       "description": "Hard is the set of enforced hard limits for each named resource. More info: http://releases.k8s.io/HEAD/docs/design/admission_control_resource_quota.md#admissioncontrol-plugin-resourcequota",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "used": {
       "description": "Used is the current observed total usage of the resource in the namespace.",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      }
     }
@@ -34108,14 +36233,14 @@
       "description": "Limits describes the maximum amount of compute resources allowed. More info: http://kubernetes.io/docs/user-guide/compute-resources/",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      },
      "requests": {
       "description": "Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: http://kubernetes.io/docs/user-guide/compute-resources/",
       "type": "object",
       "additionalProperties": {
-       "$ref": "#/definitions/resource.Quantity"
+       "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"
       }
      }
     }
@@ -34137,50 +36262,6 @@
      },
      "user": {
       "description": "User is a SELinux user label that applies to the container.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.Scale": {
-    "description": "Scale represents a scaling request for a resource.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-      "$ref": "#/definitions/v1.ScaleSpec"
-     },
-     "status": {
-      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
-      "$ref": "#/definitions/v1.ScaleStatus"
-     }
-    }
-   },
-   "v1.ScaleSpec": {
-    "description": "ScaleSpec describes the attributes of a scale subresource.",
-    "properties": {
-     "replicas": {
-      "description": "desired number of instances for the scaled object.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1.ScaleStatus": {
-    "description": "ScaleStatus represents the current status of a scale subresource.",
-    "required": [
-     "replicas"
-    ],
-    "properties": {
-     "replicas": {
-      "description": "actual number of observed instances of the scaled object.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "selector": {
-      "description": "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
       "type": "string"
      }
     }
@@ -34240,7 +36321,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -34271,23 +36352,6 @@
      "seLinuxOptions": {
       "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
       "$ref": "#/definitions/v1.SELinuxOptions"
-     }
-    }
-   },
-   "v1.ServerAddressByClientCIDR": {
-    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
-    "required": [
-     "clientCIDR",
-     "serverAddress"
-    ],
-    "properties": {
-     "clientCIDR": {
-      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use.",
-      "type": "string"
-     },
-     "serverAddress": {
-      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
-      "type": "string"
      }
     }
    },
@@ -34346,7 +36410,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -34365,7 +36429,7 @@
      },
      "metadata": {
       "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
+      "$ref": "#/definitions/io.k8s.meta.v1.ListMeta"
      }
     }
    },
@@ -34395,7 +36459,7 @@
      },
      "targetPort": {
       "description": "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service",
-      "$ref": "#/definitions/intstr.IntOrString"
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"
      }
     }
    },
@@ -34468,82 +36532,6 @@
      }
     }
    },
-   "v1.Status": {
-    "description": "Status is a return value for calls that don't return other objects.",
-    "properties": {
-     "code": {
-      "description": "Suggested HTTP return code for this status, 0 if not set.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "details": {
-      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
-      "$ref": "#/definitions/v1.StatusDetails"
-     },
-     "message": {
-      "description": "A human-readable description of the status of this operation.",
-      "type": "string"
-     },
-     "metadata": {
-      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
-     },
-     "reason": {
-      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
-      "type": "string"
-     },
-     "status": {
-      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "type": "string"
-     }
-    }
-   },
-   "v1.StatusCause": {
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
-    "properties": {
-     "field": {
-      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
-      "type": "string"
-     },
-     "message": {
-      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
-      "type": "string"
-     }
-    }
-   },
-   "v1.StatusDetails": {
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
-    "properties": {
-     "causes": {
-      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.StatusCause"
-      }
-     },
-     "group": {
-      "description": "The group attribute of the resource associated with the status StatusReason.",
-      "type": "string"
-     },
-     "kind": {
-      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "name": {
-      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
-      "type": "string"
-     },
-     "retryAfterSeconds": {
-      "description": "If specified, the time in seconds before the operation should be retried.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
    "v1.TCPSocketAction": {
     "description": "TCPSocketAction describes an action based on opening a socket",
     "required": [
@@ -34552,13 +36540,9 @@
     "properties": {
      "port": {
       "description": "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-      "$ref": "#/definitions/intstr.IntOrString"
+      "$ref": "#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"
      }
     }
-   },
-   "v1.Time": {
-    "type": "string",
-    "format": "date-time"
    },
    "v1.Volume": {
     "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
@@ -34612,1990 +36596,6 @@
       "description": "weight associated with matching the corresponding podAffinityTerm, in the range 1-100.",
       "type": "integer",
       "format": "int32"
-     }
-    }
-   },
-   "v1alpha1.CertificateSigningRequest": {
-    "description": "Describes a certificate signing request",
-    "properties": {
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "The certificate request itself and any additional information.",
-      "$ref": "#/definitions/v1alpha1.CertificateSigningRequestSpec"
-     },
-     "status": {
-      "description": "Derived information about the request.",
-      "$ref": "#/definitions/v1alpha1.CertificateSigningRequestStatus"
-     }
-    }
-   },
-   "v1alpha1.CertificateSigningRequestCondition": {
-    "required": [
-     "type"
-    ],
-    "properties": {
-     "lastUpdateTime": {
-      "description": "timestamp for the last update to this condition",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "message": {
-      "description": "human readable message with details about the request state",
-      "type": "string"
-     },
-     "reason": {
-      "description": "brief reason for the request state",
-      "type": "string"
-     },
-     "type": {
-      "description": "request approval state, currently Approved or Denied.",
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.CertificateSigningRequestList": {
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.CertificateSigningRequest"
-      }
-     },
-     "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1alpha1.CertificateSigningRequestSpec": {
-    "description": "This information is immutable after the request is created. Only the Request and ExtraInfo fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.",
-    "required": [
-     "request"
-    ],
-    "properties": {
-     "groups": {
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "request": {
-      "description": "Base64-encoded PKCS#10 CSR data",
-      "type": "string",
-      "format": "byte"
-     },
-     "uid": {
-      "type": "string"
-     },
-     "username": {
-      "description": "Information about the requesting user (if relevant) See user.Info interface for details",
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.CertificateSigningRequestStatus": {
-    "properties": {
-     "certificate": {
-      "description": "If request was approved, the controller will place the issued certificate here.",
-      "type": "string",
-      "format": "byte"
-     },
-     "conditions": {
-      "description": "Conditions applied to the request, such as approval or denial.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.CertificateSigningRequestCondition"
-      }
-     }
-    }
-   },
-   "v1alpha1.ClusterRole": {
-    "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
-    "required": [
-     "rules"
-    ],
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata.",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "rules": {
-      "description": "Rules holds all the PolicyRules for this ClusterRole",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.PolicyRule"
-      }
-     }
-    }
-   },
-   "v1alpha1.ClusterRoleBinding": {
-    "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
-    "required": [
-     "subjects",
-     "roleRef"
-    ],
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata.",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "roleRef": {
-      "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
-      "$ref": "#/definitions/v1alpha1.RoleRef"
-     },
-     "subjects": {
-      "description": "Subjects holds references to the objects the role applies to.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.Subject"
-      }
-     }
-    }
-   },
-   "v1alpha1.ClusterRoleBindingList": {
-    "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is a list of ClusterRoleBindings",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.ClusterRoleBinding"
-      }
-     },
-     "metadata": {
-      "description": "Standard object's metadata.",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1alpha1.ClusterRoleList": {
-    "description": "ClusterRoleList is a collection of ClusterRoles",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is a list of ClusterRoles",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.ClusterRole"
-      }
-     },
-     "metadata": {
-      "description": "Standard object's metadata.",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1alpha1.PolicyRule": {
-    "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
-    "required": [
-     "verbs"
-    ],
-    "properties": {
-     "apiGroups": {
-      "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "attributeRestrictions": {
-      "description": "AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports. If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.",
-      "$ref": "#/definitions/runtime.RawExtension"
-     },
-     "nonResourceURLs": {
-      "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different. Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "resourceNames": {
-      "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "resources": {
-      "description": "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "verbs": {
-      "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1alpha1.Role": {
-    "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
-    "required": [
-     "rules"
-    ],
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata.",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "rules": {
-      "description": "Rules holds all the PolicyRules for this Role",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.PolicyRule"
-      }
-     }
-    }
-   },
-   "v1alpha1.RoleBinding": {
-    "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
-    "required": [
-     "subjects",
-     "roleRef"
-    ],
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata.",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "roleRef": {
-      "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
-      "$ref": "#/definitions/v1alpha1.RoleRef"
-     },
-     "subjects": {
-      "description": "Subjects holds references to the objects the role applies to.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.Subject"
-      }
-     }
-    }
-   },
-   "v1alpha1.RoleBindingList": {
-    "description": "RoleBindingList is a collection of RoleBindings",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is a list of RoleBindings",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.RoleBinding"
-      }
-     },
-     "metadata": {
-      "description": "Standard object's metadata.",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1alpha1.RoleList": {
-    "description": "RoleList is a collection of Roles",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is a list of Roles",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1alpha1.Role"
-      }
-     },
-     "metadata": {
-      "description": "Standard object's metadata.",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1alpha1.RoleRef": {
-    "description": "RoleRef contains information that points to the role being used",
-    "required": [
-     "apiGroup",
-     "kind",
-     "name"
-    ],
-    "properties": {
-     "apiGroup": {
-      "description": "APIGroup is the group for the resource being referenced",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind is the type of resource being referenced",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name is the name of resource being referenced",
-      "type": "string"
-     }
-    }
-   },
-   "v1alpha1.Subject": {
-    "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
-    "required": [
-     "kind",
-     "name"
-    ],
-    "properties": {
-     "apiVersion": {
-      "description": "APIVersion holds the API group and version of the referenced object.",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name of the object being referenced.",
-      "type": "string"
-     },
-     "namespace": {
-      "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.APIVersion": {
-    "description": "An APIVersion represents a single concrete version of an object model.",
-    "properties": {
-     "name": {
-      "description": "Name of this version (e.g. 'v1').",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.CPUTargetUtilization": {
-    "required": [
-     "targetPercentage"
-    ],
-    "properties": {
-     "targetPercentage": {
-      "description": "fraction of the requested CPU that should be utilized/used, e.g. 70 means that 70% of the requested CPU should be in use.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1beta1.DaemonSet": {
-    "description": "DaemonSet represents the configuration of a daemon set.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v1beta1.DaemonSetSpec"
-     },
-     "status": {
-      "description": "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v1beta1.DaemonSetStatus"
-     }
-    }
-   },
-   "v1beta1.DaemonSetList": {
-    "description": "DaemonSetList is a collection of daemon sets.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is a list of daemon sets.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.DaemonSet"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.DaemonSetSpec": {
-    "description": "DaemonSetSpec is the specification of a daemon set.",
-    "required": [
-     "template"
-    ],
-    "properties": {
-     "selector": {
-      "description": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "template": {
-      "description": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template",
-      "$ref": "#/definitions/v1.PodTemplateSpec"
-     }
-    }
-   },
-   "v1beta1.DaemonSetStatus": {
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
-    "required": [
-     "currentNumberScheduled",
-     "numberMisscheduled",
-     "desiredNumberScheduled",
-     "numberReady"
-    ],
-    "properties": {
-     "currentNumberScheduled": {
-      "description": "CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
-      "type": "integer",
-      "format": "int32"
-     },
-     "desiredNumberScheduled": {
-      "description": "DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
-      "type": "integer",
-      "format": "int32"
-     },
-     "numberMisscheduled": {
-      "description": "NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
-      "type": "integer",
-      "format": "int32"
-     },
-     "numberReady": {
-      "description": "NumberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "observedGeneration": {
-      "description": "ObservedGeneration is the most recent generation observed by the daemon set controller.",
-      "type": "integer",
-      "format": "int64"
-     }
-    }
-   },
-   "v1beta1.Deployment": {
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object metadata.",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Specification of the desired behavior of the Deployment.",
-      "$ref": "#/definitions/v1beta1.DeploymentSpec"
-     },
-     "status": {
-      "description": "Most recently observed status of the Deployment.",
-      "$ref": "#/definitions/v1beta1.DeploymentStatus"
-     }
-    }
-   },
-   "v1beta1.DeploymentCondition": {
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
-    "required": [
-     "type",
-     "status"
-    ],
-    "properties": {
-     "lastTransitionTime": {
-      "description": "Last time the condition transitioned from one status to another.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "lastUpdateTime": {
-      "description": "The last time this condition was updated.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "message": {
-      "description": "A human readable message indicating details about the transition.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "The reason for the condition's last transition.",
-      "type": "string"
-     },
-     "status": {
-      "description": "Status of the condition, one of True, False, Unknown.",
-      "type": "string"
-     },
-     "type": {
-      "description": "Type of deployment condition.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.DeploymentList": {
-    "description": "DeploymentList is a list of Deployments.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is the list of Deployments.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.Deployment"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata.",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.DeploymentRollback": {
-    "description": "DeploymentRollback stores the information required to rollback a deployment.",
-    "required": [
-     "name",
-     "rollbackTo"
-    ],
-    "properties": {
-     "name": {
-      "description": "Required: This must match the Name of a deployment.",
-      "type": "string"
-     },
-     "rollbackTo": {
-      "description": "The config of this deployment rollback.",
-      "$ref": "#/definitions/v1beta1.RollbackConfig"
-     },
-     "updatedAnnotations": {
-      "description": "The annotations to be updated to a deployment",
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     }
-    }
-   },
-   "v1beta1.DeploymentSpec": {
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
-    "required": [
-     "template"
-    ],
-    "properties": {
-     "minReadySeconds": {
-      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-      "type": "integer",
-      "format": "int32"
-     },
-     "paused": {
-      "description": "Indicates that the deployment is paused and will not be processed by the deployment controller.",
-      "type": "boolean"
-     },
-     "progressDeadlineSeconds": {
-      "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. This is not set by default.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "replicas": {
-      "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "revisionHistoryLimit": {
-      "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "rollbackTo": {
-      "description": "The config this deployment is rolling back to. Will be cleared after rollback is done.",
-      "$ref": "#/definitions/v1beta1.RollbackConfig"
-     },
-     "selector": {
-      "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "strategy": {
-      "description": "The deployment strategy to use to replace existing pods with new ones.",
-      "$ref": "#/definitions/v1beta1.DeploymentStrategy"
-     },
-     "template": {
-      "description": "Template describes the pods that will be created.",
-      "$ref": "#/definitions/v1.PodTemplateSpec"
-     }
-    }
-   },
-   "v1beta1.DeploymentStatus": {
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
-    "properties": {
-     "availableReplicas": {
-      "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "conditions": {
-      "description": "Represents the latest available observations of a deployment's current state.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.DeploymentCondition"
-      }
-     },
-     "observedGeneration": {
-      "description": "The generation observed by the deployment controller.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "readyReplicas": {
-      "description": "Total number of ready pods targeted by this deployment.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "replicas": {
-      "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
-      "type": "integer",
-      "format": "int32"
-     },
-     "unavailableReplicas": {
-      "description": "Total number of unavailable pods targeted by this deployment.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "updatedReplicas": {
-      "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1beta1.DeploymentStrategy": {
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
-    "properties": {
-     "rollingUpdate": {
-      "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
-      "$ref": "#/definitions/v1beta1.RollingUpdateDeployment"
-     },
-     "type": {
-      "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.Eviction": {
-    "description": "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/\u003cpod name\u003e/evictions.",
-    "properties": {
-     "deleteOptions": {
-      "description": "DeleteOptions may be provided",
-      "$ref": "#/definitions/v1.DeleteOptions"
-     },
-     "metadata": {
-      "description": "ObjectMeta describes the pod that is being evicted.",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     }
-    }
-   },
-   "v1beta1.HorizontalPodAutoscaler": {
-    "description": "configuration of a horizontal pod autoscaler.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-      "$ref": "#/definitions/v1beta1.HorizontalPodAutoscalerSpec"
-     },
-     "status": {
-      "description": "current information about the autoscaler.",
-      "$ref": "#/definitions/v1beta1.HorizontalPodAutoscalerStatus"
-     }
-    }
-   },
-   "v1beta1.HorizontalPodAutoscalerList": {
-    "description": "list of horizontal pod autoscaler objects.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "list of horizontal pod autoscaler objects.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.HorizontalPodAutoscaler"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata.",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.HorizontalPodAutoscalerSpec": {
-    "description": "specification of a horizontal pod autoscaler.",
-    "required": [
-     "scaleRef",
-     "maxReplicas"
-    ],
-    "properties": {
-     "cpuUtilization": {
-      "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified it defaults to the target CPU utilization at 80% of the requested resources.",
-      "$ref": "#/definitions/v1beta1.CPUTargetUtilization"
-     },
-     "maxReplicas": {
-      "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "minReplicas": {
-      "description": "lower limit for the number of pods that can be set by the autoscaler, default 1.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "scaleRef": {
-      "description": "reference to Scale subresource; horizontal pod autoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modifying its spec.",
-      "$ref": "#/definitions/v1beta1.SubresourceReference"
-     }
-    }
-   },
-   "v1beta1.HorizontalPodAutoscalerStatus": {
-    "description": "current status of a horizontal pod autoscaler",
-    "required": [
-     "currentReplicas",
-     "desiredReplicas"
-    ],
-    "properties": {
-     "currentCPUUtilizationPercentage": {
-      "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "currentReplicas": {
-      "description": "current number of replicas of pods managed by this autoscaler.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "desiredReplicas": {
-      "description": "desired number of replicas of pods managed by this autoscaler.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "lastScaleTime": {
-      "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "observedGeneration": {
-      "description": "most recent generation observed by this autoscaler.",
-      "type": "integer",
-      "format": "int64"
-     }
-    }
-   },
-   "v1beta1.Ingress": {
-    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v1beta1.IngressSpec"
-     },
-     "status": {
-      "description": "Status is the current state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v1beta1.IngressStatus"
-     }
-    }
-   },
-   "v1beta1.IngressBackend": {
-    "description": "IngressBackend describes all endpoints for a given service and port.",
-    "required": [
-     "serviceName",
-     "servicePort"
-    ],
-    "properties": {
-     "serviceName": {
-      "description": "Specifies the name of the referenced service.",
-      "type": "string"
-     },
-     "servicePort": {
-      "description": "Specifies the port of the referenced service.",
-      "$ref": "#/definitions/intstr.IntOrString"
-     }
-    }
-   },
-   "v1beta1.IngressList": {
-    "description": "IngressList is a collection of Ingress.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is the list of Ingress.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.Ingress"
-      }
-     },
-     "metadata": {
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.IngressRule": {
-    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
-    "properties": {
-     "host": {
-      "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.IngressSpec": {
-    "description": "IngressSpec describes the Ingress the user wishes to exist.",
-    "properties": {
-     "backend": {
-      "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
-      "$ref": "#/definitions/v1beta1.IngressBackend"
-     },
-     "rules": {
-      "description": "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.IngressRule"
-      }
-     },
-     "tls": {
-      "description": "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.IngressTLS"
-      }
-     }
-    }
-   },
-   "v1beta1.IngressStatus": {
-    "description": "IngressStatus describe the current state of the Ingress.",
-    "properties": {
-     "loadBalancer": {
-      "description": "LoadBalancer contains the current status of the load-balancer.",
-      "$ref": "#/definitions/v1.LoadBalancerStatus"
-     }
-    }
-   },
-   "v1beta1.IngressTLS": {
-    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
-    "properties": {
-     "hosts": {
-      "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "secretName": {
-      "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.LocalSubjectAccessReview": {
-    "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
-    "required": [
-     "spec"
-    ],
-    "properties": {
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
-      "$ref": "#/definitions/v1beta1.SubjectAccessReviewSpec"
-     },
-     "status": {
-      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-      "$ref": "#/definitions/v1beta1.SubjectAccessReviewStatus"
-     }
-    }
-   },
-   "v1beta1.NetworkPolicy": {
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Specification of the desired behavior for this NetworkPolicy.",
-      "$ref": "#/definitions/v1beta1.NetworkPolicySpec"
-     }
-    }
-   },
-   "v1beta1.NetworkPolicyIngressRule": {
-    "description": "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
-    "properties": {
-     "from": {
-      "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is not provided, this rule matches all sources (traffic not restricted by source). If this field is empty, this rule matches no sources (no traffic matches). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.NetworkPolicyPeer"
-      }
-     },
-     "ports": {
-      "description": "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is not provided, this rule matches all ports (traffic not restricted by port). If this field is empty, this rule matches no ports (no traffic matches). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.NetworkPolicyPort"
-      }
-     }
-    }
-   },
-   "v1beta1.NetworkPolicyList": {
-    "description": "Network Policy List is a list of NetworkPolicy objects.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is a list of schema objects.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.NetworkPolicy"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.NetworkPolicyPeer": {
-    "properties": {
-     "namespaceSelector": {
-      "description": "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If omitted, this selector selects no namespaces. If present but empty, this selector selects all namespaces.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "podSelector": {
-      "description": "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If not provided, this selector selects no pods. If present but empty, this selector selects all pods in this namespace.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     }
-    }
-   },
-   "v1beta1.NetworkPolicyPort": {
-    "properties": {
-     "port": {
-      "description": "If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.",
-      "$ref": "#/definitions/intstr.IntOrString"
-     },
-     "protocol": {
-      "description": "Optional.  The protocol (TCP or UDP) which traffic must match. If not specified, this field defaults to TCP.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.NetworkPolicySpec": {
-    "required": [
-     "podSelector"
-    ],
-    "properties": {
-     "ingress": {
-      "description": "List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if namespace.networkPolicy.ingress.isolation is undefined and cluster policy allows it, OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not affect ingress isolation. If this field is present and contains at least one rule, this policy allows any traffic which matches at least one of the ingress rules in this list.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.NetworkPolicyIngressRule"
-      }
-     },
-     "podSelector": {
-      "description": "Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     }
-    }
-   },
-   "v1beta1.NonResourceAttributes": {
-    "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
-    "properties": {
-     "path": {
-      "description": "Path is the URL path of the request",
-      "type": "string"
-     },
-     "verb": {
-      "description": "Verb is the standard HTTP verb",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.PodDisruptionBudget": {
-    "description": "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods",
-    "properties": {
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Specification of the desired behavior of the PodDisruptionBudget.",
-      "$ref": "#/definitions/v1beta1.PodDisruptionBudgetSpec"
-     },
-     "status": {
-      "description": "Most recently observed status of the PodDisruptionBudget.",
-      "$ref": "#/definitions/v1beta1.PodDisruptionBudgetStatus"
-     }
-    }
-   },
-   "v1beta1.PodDisruptionBudgetList": {
-    "description": "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.PodDisruptionBudget"
-      }
-     },
-     "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.PodDisruptionBudgetSpec": {
-    "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
-    "properties": {
-     "minAvailable": {
-      "description": "An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\".",
-      "$ref": "#/definitions/intstr.IntOrString"
-     },
-     "selector": {
-      "description": "Label query over pods whose evictions are managed by the disruption budget.",
-      "$ref": "#/definitions/v1.LabelSelector"
-     }
-    }
-   },
-   "v1beta1.PodDisruptionBudgetStatus": {
-    "description": "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
-    "required": [
-     "disruptedPods",
-     "disruptionsAllowed",
-     "currentHealthy",
-     "desiredHealthy",
-     "expectedPods"
-    ],
-    "properties": {
-     "currentHealthy": {
-      "description": "current number of healthy pods",
-      "type": "integer",
-      "format": "int32"
-     },
-     "desiredHealthy": {
-      "description": "minimum desired number of healthy pods",
-      "type": "integer",
-      "format": "int32"
-     },
-     "disruptedPods": {
-      "description": "DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.",
-      "type": "object",
-      "additionalProperties": {
-       "$ref": "#/definitions/v1.Time"
-      }
-     },
-     "disruptionsAllowed": {
-      "description": "Number of pod disruptions that are currently allowed.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "expectedPods": {
-      "description": "total number of pods counted by this disruption budget",
-      "type": "integer",
-      "format": "int32"
-     },
-     "observedGeneration": {
-      "description": "Most recent generation observed when updating this PDB status. PodDisruptionsAllowed and other status informatio is valid only if observedGeneration equals to PDB's object generation.",
-      "type": "integer",
-      "format": "int64"
-     }
-    }
-   },
-   "v1beta1.ReplicaSet": {
-    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
-    "properties": {
-     "metadata": {
-      "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v1beta1.ReplicaSetSpec"
-     },
-     "status": {
-      "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v1beta1.ReplicaSetStatus"
-     }
-    }
-   },
-   "v1beta1.ReplicaSetCondition": {
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
-    "required": [
-     "type",
-     "status"
-    ],
-    "properties": {
-     "lastTransitionTime": {
-      "description": "The last time the condition transitioned from one status to another.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "message": {
-      "description": "A human readable message indicating details about the transition.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "The reason for the condition's last transition.",
-      "type": "string"
-     },
-     "status": {
-      "description": "Status of the condition, one of True, False, Unknown.",
-      "type": "string"
-     },
-     "type": {
-      "description": "Type of replica set condition.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.ReplicaSetList": {
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "List of ReplicaSets. More info: http://kubernetes.io/docs/user-guide/replication-controller",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.ReplicaSet"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.ReplicaSetSpec": {
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
-    "properties": {
-     "minReadySeconds": {
-      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-      "type": "integer",
-      "format": "int32"
-     },
-     "replicas": {
-      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller",
-      "type": "integer",
-      "format": "int32"
-     },
-     "selector": {
-      "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "template": {
-      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template",
-      "$ref": "#/definitions/v1.PodTemplateSpec"
-     }
-    }
-   },
-   "v1beta1.ReplicaSetStatus": {
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
-    "required": [
-     "replicas"
-    ],
-    "properties": {
-     "availableReplicas": {
-      "description": "The number of available replicas (ready for at least minReadySeconds) for this replica set.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "conditions": {
-      "description": "Represents the latest available observations of a replica set's current state.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.ReplicaSetCondition"
-      }
-     },
-     "fullyLabeledReplicas": {
-      "description": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "observedGeneration": {
-      "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "readyReplicas": {
-      "description": "The number of ready replicas for this replica set.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "replicas": {
-      "description": "Replicas is the most recently oberved number of replicas. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1beta1.ResourceAttributes": {
-    "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
-    "properties": {
-     "group": {
-      "description": "Group is the API Group of the Resource.  \"*\" means all.",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
-      "type": "string"
-     },
-     "namespace": {
-      "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
-      "type": "string"
-     },
-     "resource": {
-      "description": "Resource is one of the existing resource types.  \"*\" means all.",
-      "type": "string"
-     },
-     "subresource": {
-      "description": "Subresource is one of the existing resource types.  \"\" means none.",
-      "type": "string"
-     },
-     "verb": {
-      "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
-      "type": "string"
-     },
-     "version": {
-      "description": "Version is the API Version of the Resource.  \"*\" means all.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.RollbackConfig": {
-    "properties": {
-     "revision": {
-      "description": "The revision to rollback to. If set to 0, rollbck to the last revision.",
-      "type": "integer",
-      "format": "int64"
-     }
-    }
-   },
-   "v1beta1.RollingUpdateDeployment": {
-    "description": "Spec to control the desired behavior of rolling update.",
-    "properties": {
-     "maxSurge": {
-      "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
-      "$ref": "#/definitions/intstr.IntOrString"
-     },
-     "maxUnavailable": {
-      "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
-      "$ref": "#/definitions/intstr.IntOrString"
-     }
-    }
-   },
-   "v1beta1.Scale": {
-    "description": "represents a scaling request for a resource.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-      "$ref": "#/definitions/v1beta1.ScaleSpec"
-     },
-     "status": {
-      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
-      "$ref": "#/definitions/v1beta1.ScaleStatus"
-     }
-    }
-   },
-   "v1beta1.ScaleSpec": {
-    "description": "describes the attributes of a scale subresource",
-    "properties": {
-     "replicas": {
-      "description": "desired number of instances for the scaled object.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1beta1.ScaleStatus": {
-    "description": "represents the current status of a scale subresource.",
-    "required": [
-     "replicas"
-    ],
-    "properties": {
-     "replicas": {
-      "description": "actual number of observed instances of the scaled object.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "selector": {
-      "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     },
-     "targetSelector": {
-      "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.SelfSubjectAccessReview": {
-    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
-    "required": [
-     "spec"
-    ],
-    "properties": {
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec holds information about the request being evaluated.  user and groups must be empty",
-      "$ref": "#/definitions/v1beta1.SelfSubjectAccessReviewSpec"
-     },
-     "status": {
-      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-      "$ref": "#/definitions/v1beta1.SubjectAccessReviewStatus"
-     }
-    }
-   },
-   "v1beta1.SelfSubjectAccessReviewSpec": {
-    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-    "properties": {
-     "nonResourceAttributes": {
-      "description": "NonResourceAttributes describes information for a non-resource access request",
-      "$ref": "#/definitions/v1beta1.NonResourceAttributes"
-     },
-     "resourceAttributes": {
-      "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-      "$ref": "#/definitions/v1beta1.ResourceAttributes"
-     }
-    }
-   },
-   "v1beta1.StatefulSet": {
-    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
-    "properties": {
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec defines the desired identities of pods in this set.",
-      "$ref": "#/definitions/v1beta1.StatefulSetSpec"
-     },
-     "status": {
-      "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
-      "$ref": "#/definitions/v1beta1.StatefulSetStatus"
-     }
-    }
-   },
-   "v1beta1.StatefulSetList": {
-    "description": "StatefulSetList is a collection of StatefulSets.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.StatefulSet"
-      }
-     },
-     "metadata": {
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.StatefulSetSpec": {
-    "description": "A StatefulSetSpec is the specification of a StatefulSet.",
-    "required": [
-     "template",
-     "serviceName"
-    ],
-    "properties": {
-     "replicas": {
-      "description": "Replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "selector": {
-      "description": "Selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "serviceName": {
-      "description": "ServiceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
-      "type": "string"
-     },
-     "template": {
-      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.",
-      "$ref": "#/definitions/v1.PodTemplateSpec"
-     },
-     "volumeClaimTemplates": {
-      "description": "VolumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.PersistentVolumeClaim"
-      }
-     }
-    }
-   },
-   "v1beta1.StatefulSetStatus": {
-    "description": "StatefulSetStatus represents the current state of a StatefulSet.",
-    "required": [
-     "replicas"
-    ],
-    "properties": {
-     "observedGeneration": {
-      "description": "most recent generation observed by this StatefulSet.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "replicas": {
-      "description": "Replicas is the number of actual replicas.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v1beta1.StorageClass": {
-    "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
-    "required": [
-     "provisioner"
-    ],
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "parameters": {
-      "description": "Parameters holds the parameters for the provisioner that should create volumes of this storage class.",
-      "type": "object",
-      "additionalProperties": {
-       "type": "string"
-      }
-     },
-     "provisioner": {
-      "description": "Provisioner indicates the type of the provisioner.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.StorageClassList": {
-    "description": "StorageClassList is a collection of storage classes.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is the list of StorageClasses",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.StorageClass"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.SubjectAccessReview": {
-    "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
-    "required": [
-     "spec"
-    ],
-    "properties": {
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec holds information about the request being evaluated",
-      "$ref": "#/definitions/v1beta1.SubjectAccessReviewSpec"
-     },
-     "status": {
-      "description": "Status is filled in by the server and indicates whether the request is allowed or not",
-      "$ref": "#/definitions/v1beta1.SubjectAccessReviewStatus"
-     }
-    }
-   },
-   "v1beta1.SubjectAccessReviewSpec": {
-    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
-    "properties": {
-     "extra": {
-      "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
-      "type": "object",
-      "additionalProperties": {
-       "type": "array",
-       "items": {
-        "type": "string"
-       }
-      }
-     },
-     "group": {
-      "description": "Groups is the groups you're testing for.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "nonResourceAttributes": {
-      "description": "NonResourceAttributes describes information for a non-resource access request",
-      "$ref": "#/definitions/v1beta1.NonResourceAttributes"
-     },
-     "resourceAttributes": {
-      "description": "ResourceAuthorizationAttributes describes information for a resource access request",
-      "$ref": "#/definitions/v1beta1.ResourceAttributes"
-     },
-     "user": {
-      "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.SubjectAccessReviewStatus": {
-    "description": "SubjectAccessReviewStatus",
-    "required": [
-     "allowed"
-    ],
-    "properties": {
-     "allowed": {
-      "description": "Allowed is required.  True if the action would be allowed, false otherwise.",
-      "type": "boolean"
-     },
-     "evaluationError": {
-      "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "Reason is optional.  It indicates why a request was allowed or denied.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.SubresourceReference": {
-    "description": "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
-    "properties": {
-     "apiVersion": {
-      "description": "API version of the referent",
-      "type": "string"
-     },
-     "kind": {
-      "description": "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-      "type": "string"
-     },
-     "name": {
-      "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
-      "type": "string"
-     },
-     "subresource": {
-      "description": "Subresource name of the referent",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.ThirdPartyResource": {
-    "description": "A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.",
-    "properties": {
-     "description": {
-      "description": "Description is the description of this object.",
-      "type": "string"
-     },
-     "metadata": {
-      "description": "Standard object metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "versions": {
-      "description": "Versions are versions for this third party object",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.APIVersion"
-      }
-     }
-    }
-   },
-   "v1beta1.ThirdPartyResourceList": {
-    "description": "ThirdPartyResourceList is a list of ThirdPartyResources.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is the list of ThirdPartyResources.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1beta1.ThirdPartyResource"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata.",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v1beta1.TokenReview": {
-    "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
-    "required": [
-     "spec"
-    ],
-    "properties": {
-     "metadata": {
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec holds information about the request being evaluated",
-      "$ref": "#/definitions/v1beta1.TokenReviewSpec"
-     },
-     "status": {
-      "description": "Status is filled in by the server and indicates whether the request can be authenticated.",
-      "$ref": "#/definitions/v1beta1.TokenReviewStatus"
-     }
-    }
-   },
-   "v1beta1.TokenReviewSpec": {
-    "description": "TokenReviewSpec is a description of the token authentication request.",
-    "properties": {
-     "token": {
-      "description": "Token is the opaque bearer token.",
-      "type": "string"
-     }
-    }
-   },
-   "v1beta1.TokenReviewStatus": {
-    "description": "TokenReviewStatus is the result of the token authentication request.",
-    "properties": {
-     "authenticated": {
-      "description": "Authenticated indicates that the token was associated with a known user.",
-      "type": "boolean"
-     },
-     "error": {
-      "description": "Error indicates that the token couldn't be checked",
-      "type": "string"
-     },
-     "user": {
-      "description": "User is the UserInfo associated with the provided token.",
-      "$ref": "#/definitions/v1beta1.UserInfo"
-     }
-    }
-   },
-   "v1beta1.UserInfo": {
-    "description": "UserInfo holds the information about the user needed to implement the user.Info interface.",
-    "properties": {
-     "extra": {
-      "description": "Any additional information provided by the authenticator.",
-      "type": "object",
-      "additionalProperties": {
-       "type": "array",
-       "items": {
-        "type": "string"
-       }
-      }
-     },
-     "groups": {
-      "description": "The names of groups this user is a part of.",
-      "type": "array",
-      "items": {
-       "type": "string"
-      }
-     },
-     "uid": {
-      "description": "A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.",
-      "type": "string"
-     },
-     "username": {
-      "description": "The name that uniquely identifies this user among all active users.",
-      "type": "string"
-     }
-    }
-   },
-   "v2alpha1.CronJob": {
-    "description": "CronJob represents the configuration of a single cron job.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec is a structure defining the expected behavior of a job, including the schedule. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v2alpha1.CronJobSpec"
-     },
-     "status": {
-      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v2alpha1.CronJobStatus"
-     }
-    }
-   },
-   "v2alpha1.CronJobList": {
-    "description": "CronJobList is a collection of cron jobs.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is the list of CronJob.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v2alpha1.CronJob"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v2alpha1.CronJobSpec": {
-    "description": "CronJobSpec describes how the job execution will look like and when it will actually run.",
-    "required": [
-     "schedule",
-     "jobTemplate"
-    ],
-    "properties": {
-     "concurrencyPolicy": {
-      "description": "ConcurrencyPolicy specifies how to treat concurrent executions of a Job.",
-      "type": "string"
-     },
-     "jobTemplate": {
-      "description": "JobTemplate is the object that describes the job that will be created when executing a CronJob.",
-      "$ref": "#/definitions/v2alpha1.JobTemplateSpec"
-     },
-     "schedule": {
-      "description": "Schedule contains the schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
-      "type": "string"
-     },
-     "startingDeadlineSeconds": {
-      "description": "Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.",
-      "type": "integer",
-      "format": "int64"
-     },
-     "suspend": {
-      "description": "Suspend flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.",
-      "type": "boolean"
-     }
-    }
-   },
-   "v2alpha1.CronJobStatus": {
-    "description": "CronJobStatus represents the current state of a cron job.",
-    "properties": {
-     "active": {
-      "description": "Active holds pointers to currently running jobs.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v1.ObjectReference"
-      }
-     },
-     "lastScheduleTime": {
-      "description": "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
-      "$ref": "#/definitions/v1.Time"
-     }
-    }
-   },
-   "v2alpha1.Job": {
-    "description": "Job represents the configuration of a single job.",
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v2alpha1.JobSpec"
-     },
-     "status": {
-      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v2alpha1.JobStatus"
-     }
-    }
-   },
-   "v2alpha1.JobCondition": {
-    "description": "JobCondition describes current state of a job.",
-    "required": [
-     "type",
-     "status"
-    ],
-    "properties": {
-     "lastProbeTime": {
-      "description": "Last time the condition was checked.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "lastTransitionTime": {
-      "description": "Last time the condition transit from one status to another.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "message": {
-      "description": "Human readable message indicating details about last transition.",
-      "type": "string"
-     },
-     "reason": {
-      "description": "(brief) reason for the condition's last transition.",
-      "type": "string"
-     },
-     "status": {
-      "description": "Status of the condition, one of True, False, Unknown.",
-      "type": "string"
-     },
-     "type": {
-      "description": "Type of job condition, Complete or Failed.",
-      "type": "string"
-     }
-    }
-   },
-   "v2alpha1.JobList": {
-    "description": "JobList is a collection of jobs.",
-    "required": [
-     "items"
-    ],
-    "properties": {
-     "items": {
-      "description": "Items is the list of Job.",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v2alpha1.Job"
-      }
-     },
-     "metadata": {
-      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ListMeta"
-     }
-    }
-   },
-   "v2alpha1.JobSpec": {
-    "description": "JobSpec describes how the job execution will look like.",
-    "required": [
-     "template"
-    ],
-    "properties": {
-     "activeDeadlineSeconds": {
-      "description": "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
-      "type": "integer",
-      "format": "int64"
-     },
-     "completions": {
-      "description": "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs",
-      "type": "integer",
-      "format": "int32"
-     },
-     "manualSelector": {
-      "description": "ManualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md",
-      "type": "boolean"
-     },
-     "parallelism": {
-      "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs",
-      "type": "integer",
-      "format": "int32"
-     },
-     "selector": {
-      "description": "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-      "$ref": "#/definitions/v1.LabelSelector"
-     },
-     "template": {
-      "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs",
-      "$ref": "#/definitions/v1.PodTemplateSpec"
-     }
-    }
-   },
-   "v2alpha1.JobStatus": {
-    "description": "JobStatus represents the current state of a Job.",
-    "properties": {
-     "active": {
-      "description": "Active is the number of actively running pods.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "completionTime": {
-      "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "conditions": {
-      "description": "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
-      "type": "array",
-      "items": {
-       "$ref": "#/definitions/v2alpha1.JobCondition"
-      }
-     },
-     "failed": {
-      "description": "Failed is the number of pods which reached Phase Failed.",
-      "type": "integer",
-      "format": "int32"
-     },
-     "startTime": {
-      "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
-      "$ref": "#/definitions/v1.Time"
-     },
-     "succeeded": {
-      "description": "Succeeded is the number of pods which reached Phase Succeeded.",
-      "type": "integer",
-      "format": "int32"
-     }
-    }
-   },
-   "v2alpha1.JobTemplateSpec": {
-    "description": "JobTemplateSpec describes the data a Job should have when created from a template",
-    "properties": {
-     "metadata": {
-      "description": "Standard object's metadata of the jobs created from this template. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-      "$ref": "#/definitions/v1.ObjectMeta"
-     },
-     "spec": {
-      "description": "Specification of the desired behavior of the job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-      "$ref": "#/definitions/v2alpha1.JobSpec"
-     }
-    }
-   },
-   "version.Info": {
-    "description": "Info contains versioning information. how we'll want to distribute that information.",
-    "required": [
-     "major",
-     "minor",
-     "gitVersion",
-     "gitCommit",
-     "gitTreeState",
-     "buildDate",
-     "goVersion",
-     "compiler",
-     "platform"
-    ],
-    "properties": {
-     "buildDate": {
-      "type": "string"
-     },
-     "compiler": {
-      "type": "string"
-     },
-     "gitCommit": {
-      "type": "string"
-     },
-     "gitTreeState": {
-      "type": "string"
-     },
-     "gitVersion": {
-      "type": "string"
-     },
-     "goVersion": {
-      "type": "string"
-     },
-     "major": {
-      "type": "string"
-     },
-     "minor": {
-      "type": "string"
-     },
-     "platform": {
-      "type": "string"
-     }
-    }
-   },
-   "versioned.Event": {
-    "description": "Event represents a single event to a watched resource.",
-    "required": [
-     "type",
-     "object"
-    ],
-    "properties": {
-     "object": {
-      "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *api.Status is recommended; other types may make sense\n   depending on context.",
-      "$ref": "#/definitions/runtime.RawExtension"
-     },
-     "type": {
-      "type": "string"
      }
     }
    }

--- a/api/swagger-spec/api.json
+++ b/api/swagger-spec/api.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIVersions": {
     "id": "v1.APIVersions",
-    "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
+    "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIVersions' instead.",
     "required": [
      "versions",
      "serverAddressByClientCIDRs"
@@ -67,6 +67,56 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIVersions": {
+    "id": "io.k8s.meta.v1.APIVersions",
+    "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
+    "required": [
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "versions are the api versions that are available."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/apis.json
+++ b/api/swagger-spec/apis.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroupList": {
     "id": "v1.APIGroupList",
-    "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+    "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroupList' instead.",
     "required": [
      "groups"
     ],
@@ -59,7 +59,7 @@
    },
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -100,7 +100,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -118,6 +118,107 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroupList": {
+    "id": "io.k8s.meta.v1.APIGroupList",
+    "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+    "required": [
+     "groups"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groups": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIGroup"
+      },
+      "description": "groups is a list of APIGroup."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/apps.json
+++ b/api/swagger-spec/apps.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -108,7 +108,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.StatefulSet",
+        "type": "apps.v1beta1.StatefulSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -390,7 +390,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.StatefulSet",
+        "type": "apps.v1beta1.StatefulSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -445,7 +445,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -879,7 +879,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.StatefulSet",
+        "type": "apps.v1beta1.StatefulSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -934,7 +934,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1005,7 +1005,7 @@
   "models": {
    "v1beta1.StatefulSetList": {
     "id": "v1beta1.StatefulSetList",
-    "description": "StatefulSetList is a collection of StatefulSets.",
+    "description": "StatefulSetList is a collection of StatefulSets.\n\nDEPRECATED: Use 'apps.v1beta1.StatefulSetList' instead.",
     "required": [
      "items"
     ],
@@ -1031,7 +1031,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -1045,7 +1045,7 @@
    },
    "v1beta1.StatefulSet": {
     "id": "v1beta1.StatefulSet",
-    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.\n\nDEPRECATED: Use 'apps.v1beta1.StatefulSet' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -1144,7 +1144,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -1176,7 +1176,7 @@
    },
    "v1beta1.StatefulSetSpec": {
     "id": "v1beta1.StatefulSetSpec",
-    "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+    "description": "A StatefulSetSpec is the specification of a StatefulSet.\n\nDEPRECATED: Use 'apps.v1beta1.StatefulSetSpec' instead.",
     "required": [
      "template",
      "serviceName"
@@ -1210,7 +1210,7 @@
    },
    "v1.LabelSelector": {
     "id": "v1.LabelSelector",
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelector' instead.",
     "properties": {
      "matchLabels": {
       "type": "object",
@@ -1227,7 +1227,7 @@
    },
    "v1.LabelSelectorRequirement": {
     "id": "v1.LabelSelectorRequirement",
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelectorRequirement' instead.",
     "required": [
      "key",
      "operator"
@@ -2074,7 +2074,7 @@
       "description": "The URI the data disk in the blob storage"
      },
      "cachingMode": {
-      "$ref": "v1.AzureDataDiskCachingMode",
+      "$ref": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
       "description": "Host Caching mode: None, Read Only, Read Write."
      },
      "fsType": {
@@ -2087,8 +2087,8 @@
      }
     }
    },
-   "v1.AzureDataDiskCachingMode": {
-    "id": "v1.AzureDataDiskCachingMode",
+   "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
     "properties": {}
    },
    "v1.PhotonPersistentDiskVolumeSource": {
@@ -2572,21 +2572,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Removed capabilities"
      }
     }
    },
-   "v1.Capability": {
-    "id": "v1.Capability",
+   "io.k8s.kubernetes.pkg.api.v1.Capability": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.Capability",
     "properties": {}
    },
    "v1.SELinuxOptions": {
@@ -2869,7 +2869,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1.PersistentVolumeAccessMode"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode"
       },
       "description": "AccessModes contains the desired access modes the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes-1"
      },
@@ -2887,8 +2887,8 @@
      }
     }
    },
-   "v1.PersistentVolumeAccessMode": {
-    "id": "v1.PersistentVolumeAccessMode",
+   "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode",
     "properties": {}
    },
    "v1.PersistentVolumeClaimStatus": {
@@ -2902,7 +2902,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1.PersistentVolumeAccessMode"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode"
       },
       "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes-1"
      },
@@ -2914,7 +2914,7 @@
    },
    "v1beta1.StatefulSetStatus": {
     "id": "v1beta1.StatefulSetStatus",
-    "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+    "description": "StatefulSetStatus represents the current state of a StatefulSet.\n\nDEPRECATED: Use 'apps.v1beta1.StatefulSetStatus' instead.",
     "required": [
      "replicas"
     ],
@@ -2933,7 +2933,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -2972,7 +2972,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -3002,7 +3002,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -3020,6 +3020,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -3035,7 +3036,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -3070,18 +3071,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -3110,6 +3111,365 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "apps.v1beta1.StatefulSetList": {
+    "id": "apps.v1beta1.StatefulSetList",
+    "description": "StatefulSetList is a collection of StatefulSets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.StatefulSet"
+      }
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "apps.v1beta1.StatefulSet": {
+    "id": "apps.v1beta1.StatefulSet",
+    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta1.StatefulSetSpec",
+      "description": "Spec defines the desired identities of pods in this set."
+     },
+     "status": {
+      "$ref": "v1beta1.StatefulSetStatus",
+      "description": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time."
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "apps.v1beta1.StatefulSetSpec": {
+    "id": "apps.v1beta1.StatefulSetSpec",
+    "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+    "required": [
+     "template",
+     "serviceName"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1."
+     },
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     },
+     "template": {
+      "$ref": "v1.PodTemplateSpec",
+      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet."
+     },
+     "volumeClaimTemplates": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.PersistentVolumeClaim"
+      },
+      "description": "VolumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name."
+     },
+     "serviceName": {
+      "type": "string",
+      "description": "ServiceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller."
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelector": {
+    "id": "io.k8s.meta.v1.LabelSelector",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchLabels": {
+      "type": "object",
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+     },
+     "matchExpressions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.LabelSelectorRequirement"
+      },
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed."
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelectorRequirement": {
+    "id": "io.k8s.meta.v1.LabelSelectorRequirement",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "key is the label key that the selector applies to."
+     },
+     "operator": {
+      "type": "string",
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist."
+     },
+     "values": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+     }
+    }
+   },
+   "apps.v1beta1.StatefulSetStatus": {
+    "id": "apps.v1beta1.StatefulSetStatus",
+    "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "most recent generation observed by this StatefulSet."
+     },
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Replicas is the number of actual replicas."
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/authentication.k8s.io.json
+++ b/api/swagger-spec/authentication.k8s.io.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/authentication.k8s.io_v1beta1.json
+++ b/api/swagger-spec/authentication.k8s.io_v1beta1.json
@@ -27,7 +27,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.TokenReview",
+        "type": "io.k8s.authentication.v1beta1.TokenReview",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -80,7 +80,7 @@
   "models": {
    "v1beta1.TokenReview": {
     "id": "v1beta1.TokenReview",
-    "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
+    "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.\n\nDEPRECATED: Use 'io.k8s.authentication.v1beta1.TokenReview' instead.",
     "required": [
      "spec"
     ],
@@ -182,7 +182,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -214,7 +214,7 @@
    },
    "v1beta1.TokenReviewSpec": {
     "id": "v1beta1.TokenReviewSpec",
-    "description": "TokenReviewSpec is a description of the token authentication request.",
+    "description": "TokenReviewSpec is a description of the token authentication request.\n\nDEPRECATED: Use 'io.k8s.authentication.v1beta1.TokenReviewSpec' instead.",
     "properties": {
      "token": {
       "type": "string",
@@ -224,7 +224,7 @@
    },
    "v1beta1.TokenReviewStatus": {
     "id": "v1beta1.TokenReviewStatus",
-    "description": "TokenReviewStatus is the result of the token authentication request.",
+    "description": "TokenReviewStatus is the result of the token authentication request.\n\nDEPRECATED: Use 'io.k8s.authentication.v1beta1.TokenReviewStatus' instead.",
     "properties": {
      "authenticated": {
       "type": "boolean",
@@ -242,7 +242,7 @@
    },
    "v1beta1.UserInfo": {
     "id": "v1beta1.UserInfo",
-    "description": "UserInfo holds the information about the user needed to implement the user.Info interface.",
+    "description": "UserInfo holds the information about the user needed to implement the user.Info interface.\n\nDEPRECATED: Use 'io.k8s.authentication.v1beta1.UserInfo' instead.",
     "properties": {
      "username": {
       "type": "string",
@@ -267,7 +267,7 @@
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -296,6 +296,179 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "io.k8s.authentication.v1beta1.TokenReview": {
+    "id": "io.k8s.authentication.v1beta1.TokenReview",
+    "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta1.TokenReviewSpec",
+      "description": "Spec holds information about the request being evaluated"
+     },
+     "status": {
+      "$ref": "v1beta1.TokenReviewStatus",
+      "description": "Status is filled in by the server and indicates whether the request can be authenticated."
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "io.k8s.authentication.v1beta1.TokenReviewSpec": {
+    "id": "io.k8s.authentication.v1beta1.TokenReviewSpec",
+    "description": "TokenReviewSpec is a description of the token authentication request.",
+    "properties": {
+     "token": {
+      "type": "string",
+      "description": "Token is the opaque bearer token."
+     }
+    }
+   },
+   "io.k8s.authentication.v1beta1.TokenReviewStatus": {
+    "id": "io.k8s.authentication.v1beta1.TokenReviewStatus",
+    "description": "TokenReviewStatus is the result of the token authentication request.",
+    "properties": {
+     "authenticated": {
+      "type": "boolean",
+      "description": "Authenticated indicates that the token was associated with a known user."
+     },
+     "user": {
+      "$ref": "v1beta1.UserInfo",
+      "description": "User is the UserInfo associated with the provided token."
+     },
+     "error": {
+      "type": "string",
+      "description": "Error indicates that the token couldn't be checked"
+     }
+    }
+   },
+   "io.k8s.authentication.v1beta1.UserInfo": {
+    "id": "io.k8s.authentication.v1beta1.UserInfo",
+    "description": "UserInfo holds the information about the user needed to implement the user.Info interface.",
+    "properties": {
+     "username": {
+      "type": "string",
+      "description": "The name that uniquely identifies this user among all active users."
+     },
+     "uid": {
+      "type": "string",
+      "description": "A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs."
+     },
+     "groups": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "The names of groups this user is a part of."
+     },
+     "extra": {
+      "type": "object",
+      "description": "Any additional information provided by the authenticator."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/authorization.k8s.io.json
+++ b/api/swagger-spec/authorization.k8s.io.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/authorization.k8s.io_v1beta1.json
+++ b/api/swagger-spec/authorization.k8s.io_v1beta1.json
@@ -27,7 +27,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.LocalSubjectAccessReview",
+        "type": "io.k8s.authorization.v1beta1.LocalSubjectAccessReview",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -80,7 +80,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.SelfSubjectAccessReview",
+        "type": "io.k8s.authorization.v1beta1.SelfSubjectAccessReview",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -125,7 +125,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.SubjectAccessReview",
+        "type": "io.k8s.authorization.v1beta1.SubjectAccessReview",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -178,7 +178,7 @@
   "models": {
    "v1beta1.LocalSubjectAccessReview": {
     "id": "v1beta1.LocalSubjectAccessReview",
-    "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+    "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.\n\nDEPRECATED: Use 'io.k8s.authorization.v1beta1.LocalSubjectAccessReview' instead.",
     "required": [
      "spec"
     ],
@@ -280,7 +280,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -312,7 +312,7 @@
    },
    "v1beta1.SubjectAccessReviewSpec": {
     "id": "v1beta1.SubjectAccessReviewSpec",
-    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set\n\nDEPRECATED: Use 'io.k8s.authorization.v1beta1.SubjectAccessReviewSpec' instead.",
     "properties": {
      "resourceAttributes": {
       "$ref": "v1beta1.ResourceAttributes",
@@ -341,7 +341,7 @@
    },
    "v1beta1.ResourceAttributes": {
     "id": "v1beta1.ResourceAttributes",
-    "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+    "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface\n\nDEPRECATED: Use 'io.k8s.authorization.v1beta1.ResourceAttributes' instead.",
     "properties": {
      "namespace": {
       "type": "string",
@@ -375,7 +375,7 @@
    },
    "v1beta1.NonResourceAttributes": {
     "id": "v1beta1.NonResourceAttributes",
-    "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+    "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface\n\nDEPRECATED: Use 'io.k8s.authorization.v1beta1.NonResourceAttributes' instead.",
     "properties": {
      "path": {
       "type": "string",
@@ -389,7 +389,7 @@
    },
    "v1beta1.SubjectAccessReviewStatus": {
     "id": "v1beta1.SubjectAccessReviewStatus",
-    "description": "SubjectAccessReviewStatus",
+    "description": "SubjectAccessReviewStatus\n\nDEPRECATED: Use 'io.k8s.authorization.v1beta1.SubjectAccessReviewStatus' instead.",
     "required": [
      "allowed"
     ],
@@ -410,7 +410,7 @@
    },
    "v1beta1.SelfSubjectAccessReview": {
     "id": "v1beta1.SelfSubjectAccessReview",
-    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action\n\nDEPRECATED: Use 'io.k8s.authorization.v1beta1.SelfSubjectAccessReview' instead.",
     "required": [
      "spec"
     ],
@@ -438,7 +438,7 @@
    },
    "v1beta1.SelfSubjectAccessReviewSpec": {
     "id": "v1beta1.SelfSubjectAccessReviewSpec",
-    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set\n\nDEPRECATED: Use 'io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec' instead.",
     "properties": {
      "resourceAttributes": {
       "$ref": "v1beta1.ResourceAttributes",
@@ -452,7 +452,7 @@
    },
    "v1beta1.SubjectAccessReview": {
     "id": "v1beta1.SubjectAccessReview",
-    "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+    "description": "SubjectAccessReview checks whether or not a user or group can perform an action.\n\nDEPRECATED: Use 'io.k8s.authorization.v1beta1.SubjectAccessReview' instead.",
     "required": [
      "spec"
     ],
@@ -480,7 +480,7 @@
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -509,6 +509,294 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.LocalSubjectAccessReview": {
+    "id": "io.k8s.authorization.v1beta1.LocalSubjectAccessReview",
+    "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta1.SubjectAccessReviewSpec",
+      "description": "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted."
+     },
+     "status": {
+      "$ref": "v1beta1.SubjectAccessReviewStatus",
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SubjectAccessReviewSpec": {
+    "id": "io.k8s.authorization.v1beta1.SubjectAccessReviewSpec",
+    "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "properties": {
+     "resourceAttributes": {
+      "$ref": "v1beta1.ResourceAttributes",
+      "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+     },
+     "nonResourceAttributes": {
+      "$ref": "v1beta1.NonResourceAttributes",
+      "description": "NonResourceAttributes describes information for a non-resource access request"
+     },
+     "user": {
+      "type": "string",
+      "description": "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups"
+     },
+     "group": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Groups is the groups you're testing for."
+     },
+     "extra": {
+      "type": "object",
+      "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here."
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.ResourceAttributes": {
+    "id": "io.k8s.authorization.v1beta1.ResourceAttributes",
+    "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+    "properties": {
+     "namespace": {
+      "type": "string",
+      "description": "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview"
+     },
+     "verb": {
+      "type": "string",
+      "description": "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all."
+     },
+     "group": {
+      "type": "string",
+      "description": "Group is the API Group of the Resource.  \"*\" means all."
+     },
+     "version": {
+      "type": "string",
+      "description": "Version is the API Version of the Resource.  \"*\" means all."
+     },
+     "resource": {
+      "type": "string",
+      "description": "Resource is one of the existing resource types.  \"*\" means all."
+     },
+     "subresource": {
+      "type": "string",
+      "description": "Subresource is one of the existing resource types.  \"\" means none."
+     },
+     "name": {
+      "type": "string",
+      "description": "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all."
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.NonResourceAttributes": {
+    "id": "io.k8s.authorization.v1beta1.NonResourceAttributes",
+    "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "Path is the URL path of the request"
+     },
+     "verb": {
+      "type": "string",
+      "description": "Verb is the standard HTTP verb"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus": {
+    "id": "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus",
+    "description": "SubjectAccessReviewStatus",
+    "required": [
+     "allowed"
+    ],
+    "properties": {
+     "allowed": {
+      "type": "boolean",
+      "description": "Allowed is required.  True if the action would be allowed, false otherwise."
+     },
+     "reason": {
+      "type": "string",
+      "description": "Reason is optional.  It indicates why a request was allowed or denied."
+     },
+     "evaluationError": {
+      "type": "string",
+      "description": "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request."
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SelfSubjectAccessReview": {
+    "id": "io.k8s.authorization.v1beta1.SelfSubjectAccessReview",
+    "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta1.SelfSubjectAccessReviewSpec",
+      "description": "Spec holds information about the request being evaluated.  user and groups must be empty"
+     },
+     "status": {
+      "$ref": "v1beta1.SubjectAccessReviewStatus",
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec": {
+    "id": "io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec",
+    "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "properties": {
+     "resourceAttributes": {
+      "$ref": "v1beta1.ResourceAttributes",
+      "description": "ResourceAuthorizationAttributes describes information for a resource access request"
+     },
+     "nonResourceAttributes": {
+      "$ref": "v1beta1.NonResourceAttributes",
+      "description": "NonResourceAttributes describes information for a non-resource access request"
+     }
+    }
+   },
+   "io.k8s.authorization.v1beta1.SubjectAccessReview": {
+    "id": "io.k8s.authorization.v1beta1.SubjectAccessReview",
+    "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+    "required": [
+     "spec"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta1.SubjectAccessReviewSpec",
+      "description": "Spec holds information about the request being evaluated"
+     },
+     "status": {
+      "$ref": "v1beta1.SubjectAccessReviewStatus",
+      "description": "Status is filled in by the server and indicates whether the request is allowed or not"
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/autoscaling.json
+++ b/api/swagger-spec/autoscaling.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/autoscaling_v1.json
+++ b/api/swagger-spec/autoscaling_v1.json
@@ -108,7 +108,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.HorizontalPodAutoscaler",
+        "type": "autoscaling.v1.HorizontalPodAutoscaler",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -390,7 +390,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.HorizontalPodAutoscaler",
+        "type": "autoscaling.v1.HorizontalPodAutoscaler",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -445,7 +445,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -879,7 +879,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.HorizontalPodAutoscaler",
+        "type": "autoscaling.v1.HorizontalPodAutoscaler",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -934,7 +934,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1005,7 +1005,7 @@
   "models": {
    "v1.HorizontalPodAutoscalerList": {
     "id": "v1.HorizontalPodAutoscalerList",
-    "description": "list of horizontal pod autoscaler objects.",
+    "description": "list of horizontal pod autoscaler objects.\n\nDEPRECATED: Use 'autoscaling.v1.HorizontalPodAutoscalerList' instead.",
     "required": [
      "items"
     ],
@@ -1033,7 +1033,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -1047,7 +1047,7 @@
    },
    "v1.HorizontalPodAutoscaler": {
     "id": "v1.HorizontalPodAutoscaler",
-    "description": "configuration of a horizontal pod autoscaler.",
+    "description": "configuration of a horizontal pod autoscaler.\n\nDEPRECATED: Use 'autoscaling.v1.HorizontalPodAutoscaler' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -1147,7 +1147,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -1179,7 +1179,7 @@
    },
    "v1.HorizontalPodAutoscalerSpec": {
     "id": "v1.HorizontalPodAutoscalerSpec",
-    "description": "specification of a horizontal pod autoscaler.",
+    "description": "specification of a horizontal pod autoscaler.\n\nDEPRECATED: Use 'autoscaling.v1.HorizontalPodAutoscalerSpec' instead.",
     "required": [
      "scaleTargetRef",
      "maxReplicas"
@@ -1208,7 +1208,7 @@
    },
    "v1.CrossVersionObjectReference": {
     "id": "v1.CrossVersionObjectReference",
-    "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+    "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.\n\nDEPRECATED: Use 'autoscaling.v1.CrossVersionObjectReference' instead.",
     "required": [
      "kind",
      "name"
@@ -1230,7 +1230,7 @@
    },
    "v1.HorizontalPodAutoscalerStatus": {
     "id": "v1.HorizontalPodAutoscalerStatus",
-    "description": "current status of a horizontal pod autoscaler",
+    "description": "current status of a horizontal pod autoscaler\n\nDEPRECATED: Use 'autoscaling.v1.HorizontalPodAutoscalerStatus' instead.",
     "required": [
      "currentReplicas",
      "desiredReplicas"
@@ -1264,7 +1264,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -1303,7 +1303,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -1333,7 +1333,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -1351,6 +1351,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -1366,7 +1367,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -1401,18 +1402,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -1441,6 +1442,358 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "autoscaling.v1.HorizontalPodAutoscalerList": {
+    "id": "autoscaling.v1.HorizontalPodAutoscalerList",
+    "description": "list of horizontal pod autoscaler objects.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.HorizontalPodAutoscaler"
+      },
+      "description": "list of horizontal pod autoscaler objects."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "autoscaling.v1.HorizontalPodAutoscaler": {
+    "id": "autoscaling.v1.HorizontalPodAutoscaler",
+    "description": "configuration of a horizontal pod autoscaler.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1.HorizontalPodAutoscalerSpec",
+      "description": "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+     },
+     "status": {
+      "$ref": "v1.HorizontalPodAutoscalerStatus",
+      "description": "current information about the autoscaler."
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "autoscaling.v1.HorizontalPodAutoscalerSpec": {
+    "id": "autoscaling.v1.HorizontalPodAutoscalerSpec",
+    "description": "specification of a horizontal pod autoscaler.",
+    "required": [
+     "scaleTargetRef",
+     "maxReplicas"
+    ],
+    "properties": {
+     "scaleTargetRef": {
+      "$ref": "v1.CrossVersionObjectReference",
+      "description": "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource."
+     },
+     "minReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "lower limit for the number of pods that can be set by the autoscaler, default 1."
+     },
+     "maxReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas."
+     },
+     "targetCPUUtilizationPercentage": {
+      "type": "integer",
+      "format": "int32",
+      "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used."
+     }
+    }
+   },
+   "autoscaling.v1.CrossVersionObjectReference": {
+    "id": "autoscaling.v1.CrossVersionObjectReference",
+    "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+    "required": [
+     "kind",
+     "name"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds\""
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent"
+     }
+    }
+   },
+   "autoscaling.v1.HorizontalPodAutoscalerStatus": {
+    "id": "autoscaling.v1.HorizontalPodAutoscalerStatus",
+    "description": "current status of a horizontal pod autoscaler",
+    "required": [
+     "currentReplicas",
+     "desiredReplicas"
+    ],
+    "properties": {
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "most recent generation observed by this autoscaler."
+     },
+     "lastScaleTime": {
+      "type": "string",
+      "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
+     },
+     "currentReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "current number of replicas of pods managed by this autoscaler."
+     },
+     "desiredReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "desired number of replicas of pods managed by this autoscaler."
+     },
+     "currentCPUUtilizationPercentage": {
+      "type": "integer",
+      "format": "int32",
+      "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU."
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/batch.json
+++ b/api/swagger-spec/batch.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -108,7 +108,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Job",
+        "type": "batch.v1.Job",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -390,7 +390,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Job",
+        "type": "batch.v1.Job",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -445,7 +445,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -879,7 +879,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Job",
+        "type": "batch.v1.Job",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -934,7 +934,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1005,7 +1005,7 @@
   "models": {
    "v1.JobList": {
     "id": "v1.JobList",
-    "description": "JobList is a collection of jobs.",
+    "description": "JobList is a collection of jobs.\n\nDEPRECATED: Use 'batch.v1.JobList' instead.",
     "required": [
      "items"
     ],
@@ -1033,7 +1033,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -1047,7 +1047,7 @@
    },
    "v1.Job": {
     "id": "v1.Job",
-    "description": "Job represents the configuration of a single job.",
+    "description": "Job represents the configuration of a single job.\n\nDEPRECATED: Use 'batch.v1.Job' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -1147,7 +1147,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -1179,7 +1179,7 @@
    },
    "v1.JobSpec": {
     "id": "v1.JobSpec",
-    "description": "JobSpec describes how the job execution will look like.",
+    "description": "JobSpec describes how the job execution will look like.\n\nDEPRECATED: Use 'batch.v1.JobSpec' instead.",
     "required": [
      "template"
     ],
@@ -1215,7 +1215,7 @@
    },
    "v1.LabelSelector": {
     "id": "v1.LabelSelector",
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelector' instead.",
     "properties": {
      "matchLabels": {
       "type": "object",
@@ -1232,7 +1232,7 @@
    },
    "v1.LabelSelectorRequirement": {
     "id": "v1.LabelSelectorRequirement",
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelectorRequirement' instead.",
     "required": [
      "key",
      "operator"
@@ -2079,7 +2079,7 @@
       "description": "The URI the data disk in the blob storage"
      },
      "cachingMode": {
-      "$ref": "v1.AzureDataDiskCachingMode",
+      "$ref": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
       "description": "Host Caching mode: None, Read Only, Read Write."
      },
      "fsType": {
@@ -2092,8 +2092,8 @@
      }
     }
    },
-   "v1.AzureDataDiskCachingMode": {
-    "id": "v1.AzureDataDiskCachingMode",
+   "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
     "properties": {}
    },
    "v1.PhotonPersistentDiskVolumeSource": {
@@ -2577,21 +2577,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Removed capabilities"
      }
     }
    },
-   "v1.Capability": {
-    "id": "v1.Capability",
+   "io.k8s.kubernetes.pkg.api.v1.Capability": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.Capability",
     "properties": {}
    },
    "v1.SELinuxOptions": {
@@ -2843,7 +2843,7 @@
    },
    "v1.JobStatus": {
     "id": "v1.JobStatus",
-    "description": "JobStatus represents the current state of a Job.",
+    "description": "JobStatus represents the current state of a Job.\n\nDEPRECATED: Use 'batch.v1.JobStatus' instead.",
     "properties": {
      "conditions": {
       "type": "array",
@@ -2879,7 +2879,7 @@
    },
    "v1.JobCondition": {
     "id": "v1.JobCondition",
-    "description": "JobCondition describes current state of a job.",
+    "description": "JobCondition describes current state of a job.\n\nDEPRECATED: Use 'batch.v1.JobCondition' instead.",
     "required": [
      "type",
      "status"
@@ -2913,7 +2913,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -2952,7 +2952,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -2982,7 +2982,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -3000,6 +3000,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -3015,7 +3016,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -3050,18 +3051,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -3090,6 +3091,421 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "batch.v1.JobList": {
+    "id": "batch.v1.JobList",
+    "description": "JobList is a collection of jobs.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.Job"
+      },
+      "description": "Items is the list of Job."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "batch.v1.Job": {
+    "id": "batch.v1.Job",
+    "description": "Job represents the configuration of a single job.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1.JobSpec",
+      "description": "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "status": {
+      "$ref": "v1.JobStatus",
+      "description": "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "batch.v1.JobSpec": {
+    "id": "batch.v1.JobSpec",
+    "description": "JobSpec describes how the job execution will look like.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "parallelism": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) \u003c .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs"
+     },
+     "completions": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs"
+     },
+     "activeDeadlineSeconds": {
+      "type": "integer",
+      "format": "int64",
+      "description": "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer"
+     },
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     },
+     "manualSelector": {
+      "type": "boolean",
+      "description": "ManualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md"
+     },
+     "template": {
+      "$ref": "v1.PodTemplateSpec",
+      "description": "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs"
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelector": {
+    "id": "io.k8s.meta.v1.LabelSelector",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchLabels": {
+      "type": "object",
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+     },
+     "matchExpressions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.LabelSelectorRequirement"
+      },
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed."
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelectorRequirement": {
+    "id": "io.k8s.meta.v1.LabelSelectorRequirement",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "key is the label key that the selector applies to."
+     },
+     "operator": {
+      "type": "string",
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist."
+     },
+     "values": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+     }
+    }
+   },
+   "batch.v1.JobStatus": {
+    "id": "batch.v1.JobStatus",
+    "description": "JobStatus represents the current state of a Job.",
+    "properties": {
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.JobCondition"
+      },
+      "description": "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs"
+     },
+     "startTime": {
+      "type": "string",
+      "description": "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
+     },
+     "completionTime": {
+      "type": "string",
+      "description": "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC."
+     },
+     "active": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Active is the number of actively running pods."
+     },
+     "succeeded": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Succeeded is the number of pods which reached Phase Succeeded."
+     },
+     "failed": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Failed is the number of pods which reached Phase Failed."
+     }
+    }
+   },
+   "batch.v1.JobCondition": {
+    "id": "batch.v1.JobCondition",
+    "description": "JobCondition describes current state of a job.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of job condition, Complete or Failed."
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the condition, one of True, False, Unknown."
+     },
+     "lastProbeTime": {
+      "type": "string",
+      "description": "Last time the condition was checked."
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "description": "Last time the condition transit from one status to another."
+     },
+     "reason": {
+      "type": "string",
+      "description": "(brief) reason for the condition's last transition."
+     },
+     "message": {
+      "type": "string",
+      "description": "Human readable message indicating details about last transition."
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/batch_v2alpha1.json
+++ b/api/swagger-spec/batch_v2alpha1.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -64,6 +64,66 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/certificates.k8s.io.json
+++ b/api/swagger-spec/certificates.k8s.io.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/certificates.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/certificates.k8s.io_v1alpha1.json
@@ -100,7 +100,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.CertificateSigningRequest",
+        "type": "io.k8s.certificates.v1alpha1.CertificateSigningRequest",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -350,7 +350,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.CertificateSigningRequest",
+        "type": "io.k8s.certificates.v1alpha1.CertificateSigningRequest",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -397,7 +397,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -602,7 +602,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.CertificateSigningRequest",
+        "type": "io.k8s.certificates.v1alpha1.CertificateSigningRequest",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -655,7 +655,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.CertificateSigningRequest",
+        "type": "io.k8s.certificates.v1alpha1.CertificateSigningRequest",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -716,6 +716,7 @@
   "models": {
    "v1alpha1.CertificateSigningRequestList": {
     "id": "v1alpha1.CertificateSigningRequestList",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.certificates.v1alpha1.CertificateSigningRequestList' instead.",
     "required": [
      "items"
     ],
@@ -741,7 +742,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -755,7 +756,7 @@
    },
    "v1alpha1.CertificateSigningRequest": {
     "id": "v1alpha1.CertificateSigningRequest",
-    "description": "Describes a certificate signing request",
+    "description": "Describes a certificate signing request\n\nDEPRECATED: Use 'io.k8s.certificates.v1alpha1.CertificateSigningRequest' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -854,7 +855,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -886,7 +887,7 @@
    },
    "v1alpha1.CertificateSigningRequestSpec": {
     "id": "v1alpha1.CertificateSigningRequestSpec",
-    "description": "This information is immutable after the request is created. Only the Request and ExtraInfo fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.",
+    "description": "This information is immutable after the request is created. Only the Request and ExtraInfo fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.\n\nDEPRECATED: Use 'io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec' instead.",
     "required": [
      "request"
     ],
@@ -912,6 +913,7 @@
    },
    "v1alpha1.CertificateSigningRequestStatus": {
     "id": "v1alpha1.CertificateSigningRequestStatus",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus' instead.",
     "properties": {
      "conditions": {
       "type": "array",
@@ -928,6 +930,7 @@
    },
    "v1alpha1.CertificateSigningRequestCondition": {
     "id": "v1alpha1.CertificateSigningRequestCondition",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition' instead.",
     "required": [
      "type"
     ],
@@ -952,7 +955,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -991,7 +994,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -1021,7 +1024,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -1039,6 +1042,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -1054,7 +1058,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -1089,18 +1093,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -1129,6 +1133,335 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequestList": {
+    "id": "io.k8s.certificates.v1alpha1.CertificateSigningRequestList",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.CertificateSigningRequest"
+      }
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequest": {
+    "id": "io.k8s.certificates.v1alpha1.CertificateSigningRequest",
+    "description": "Describes a certificate signing request",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1alpha1.CertificateSigningRequestSpec",
+      "description": "The certificate request itself and any additional information."
+     },
+     "status": {
+      "$ref": "v1alpha1.CertificateSigningRequestStatus",
+      "description": "Derived information about the request."
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec": {
+    "id": "io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec",
+    "description": "This information is immutable after the request is created. Only the Request and ExtraInfo fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.",
+    "required": [
+     "request"
+    ],
+    "properties": {
+     "request": {
+      "type": "string",
+      "description": "Base64-encoded PKCS#10 CSR data"
+     },
+     "username": {
+      "type": "string",
+      "description": "Information about the requesting user (if relevant) See user.Info interface for details"
+     },
+     "uid": {
+      "type": "string"
+     },
+     "groups": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      }
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus": {
+    "id": "io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus",
+    "properties": {
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.CertificateSigningRequestCondition"
+      },
+      "description": "Conditions applied to the request, such as approval or denial."
+     },
+     "certificate": {
+      "type": "string",
+      "description": "If request was approved, the controller will place the issued certificate here."
+     }
+    }
+   },
+   "io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition": {
+    "id": "io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition",
+    "required": [
+     "type"
+    ],
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "request approval state, currently Approved or Denied."
+     },
+     "reason": {
+      "type": "string",
+      "description": "brief reason for the request state"
+     },
+     "message": {
+      "type": "string",
+      "description": "human readable message with details about the request state"
+     },
+     "lastUpdateTime": {
+      "type": "string",
+      "description": "timestamp for the last update to this condition"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/extensions.json
+++ b/api/swagger-spec/extensions.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -108,7 +108,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.DaemonSet",
+        "type": "extensions.v1beta1.DaemonSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -390,7 +390,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.DaemonSet",
+        "type": "extensions.v1beta1.DaemonSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -445,7 +445,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -879,7 +879,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.DaemonSet",
+        "type": "extensions.v1beta1.DaemonSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -934,7 +934,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1078,7 +1078,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Deployment",
+        "type": "extensions.v1beta1.Deployment",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1360,7 +1360,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Deployment",
+        "type": "extensions.v1beta1.Deployment",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1415,7 +1415,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1802,7 +1802,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.DeploymentRollback",
+        "type": "extensions.v1beta1.DeploymentRollback",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1910,7 +1910,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Scale",
+        "type": "extensions.v1beta1.Scale",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1965,7 +1965,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2075,7 +2075,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Deployment",
+        "type": "extensions.v1beta1.Deployment",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2130,7 +2130,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2274,7 +2274,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.HorizontalPodAutoscaler",
+        "type": "extensions.v1beta1.HorizontalPodAutoscaler",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2556,7 +2556,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.HorizontalPodAutoscaler",
+        "type": "extensions.v1beta1.HorizontalPodAutoscaler",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2611,7 +2611,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3045,7 +3045,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.HorizontalPodAutoscaler",
+        "type": "extensions.v1beta1.HorizontalPodAutoscaler",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3100,7 +3100,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3244,7 +3244,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Ingress",
+        "type": "extensions.v1beta1.Ingress",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3526,7 +3526,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Ingress",
+        "type": "extensions.v1beta1.Ingress",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3581,7 +3581,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4015,7 +4015,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Ingress",
+        "type": "extensions.v1beta1.Ingress",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4070,7 +4070,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4214,7 +4214,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.NetworkPolicy",
+        "type": "extensions.v1beta1.NetworkPolicy",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4496,7 +4496,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.NetworkPolicy",
+        "type": "extensions.v1beta1.NetworkPolicy",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4551,7 +4551,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -5019,7 +5019,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.ReplicaSet",
+        "type": "extensions.v1beta1.ReplicaSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -5301,7 +5301,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.ReplicaSet",
+        "type": "extensions.v1beta1.ReplicaSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -5356,7 +5356,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -5790,7 +5790,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Scale",
+        "type": "extensions.v1beta1.Scale",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -5845,7 +5845,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -5955,7 +5955,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.ReplicaSet",
+        "type": "extensions.v1beta1.ReplicaSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6010,7 +6010,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6120,7 +6120,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Scale",
+        "type": "extensions.v1beta1.Scale",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6175,7 +6175,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6311,7 +6311,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.ThirdPartyResource",
+        "type": "extensions.v1beta1.ThirdPartyResource",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6561,7 +6561,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.ThirdPartyResource",
+        "type": "extensions.v1beta1.ThirdPartyResource",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6608,7 +6608,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6821,7 +6821,7 @@
   "models": {
    "v1beta1.DaemonSetList": {
     "id": "v1beta1.DaemonSetList",
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "DaemonSetList is a collection of daemon sets.\n\nDEPRECATED: Use 'extensions.v1beta1.DaemonSetList' instead.",
     "required": [
      "items"
     ],
@@ -6849,7 +6849,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -6863,7 +6863,7 @@
    },
    "v1beta1.DaemonSet": {
     "id": "v1beta1.DaemonSet",
-    "description": "DaemonSet represents the configuration of a daemon set.",
+    "description": "DaemonSet represents the configuration of a daemon set.\n\nDEPRECATED: Use 'extensions.v1beta1.DaemonSet' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -6963,7 +6963,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -6995,7 +6995,7 @@
    },
    "v1beta1.DaemonSetSpec": {
     "id": "v1beta1.DaemonSetSpec",
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "DaemonSetSpec is the specification of a daemon set.\n\nDEPRECATED: Use 'extensions.v1beta1.DaemonSetSpec' instead.",
     "required": [
      "template"
     ],
@@ -7012,7 +7012,7 @@
    },
    "v1.LabelSelector": {
     "id": "v1.LabelSelector",
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelector' instead.",
     "properties": {
      "matchLabels": {
       "type": "object",
@@ -7029,7 +7029,7 @@
    },
    "v1.LabelSelectorRequirement": {
     "id": "v1.LabelSelectorRequirement",
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelectorRequirement' instead.",
     "required": [
      "key",
      "operator"
@@ -7876,7 +7876,7 @@
       "description": "The URI the data disk in the blob storage"
      },
      "cachingMode": {
-      "$ref": "v1.AzureDataDiskCachingMode",
+      "$ref": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
       "description": "Host Caching mode: None, Read Only, Read Write."
      },
      "fsType": {
@@ -7889,8 +7889,8 @@
      }
     }
    },
-   "v1.AzureDataDiskCachingMode": {
-    "id": "v1.AzureDataDiskCachingMode",
+   "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
     "properties": {}
    },
    "v1.PhotonPersistentDiskVolumeSource": {
@@ -8374,21 +8374,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Removed capabilities"
      }
     }
    },
-   "v1.Capability": {
-    "id": "v1.Capability",
+   "io.k8s.kubernetes.pkg.api.v1.Capability": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.Capability",
     "properties": {}
    },
    "v1.SELinuxOptions": {
@@ -8640,7 +8640,7 @@
    },
    "v1beta1.DaemonSetStatus": {
     "id": "v1beta1.DaemonSetStatus",
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "DaemonSetStatus represents the current status of a daemon set.\n\nDEPRECATED: Use 'extensions.v1beta1.DaemonSetStatus' instead.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -8677,7 +8677,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -8716,7 +8716,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -8746,7 +8746,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -8764,6 +8764,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -8779,7 +8780,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -8814,18 +8815,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1beta1.DeploymentList": {
     "id": "v1beta1.DeploymentList",
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "DeploymentList is a list of Deployments.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentList' instead.",
     "required": [
      "items"
     ],
@@ -8853,7 +8854,7 @@
    },
    "v1beta1.Deployment": {
     "id": "v1beta1.Deployment",
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "Deployment enables declarative updates for Pods and ReplicaSets.\n\nDEPRECATED: Use 'extensions.v1beta1.Deployment' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -8879,7 +8880,7 @@
    },
    "v1beta1.DeploymentSpec": {
     "id": "v1beta1.DeploymentSpec",
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentSpec' instead.",
     "required": [
      "template"
     ],
@@ -8928,7 +8929,7 @@
    },
    "v1beta1.DeploymentStrategy": {
     "id": "v1beta1.DeploymentStrategy",
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DeploymentStrategy describes how to replace existing pods with new ones.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentStrategy' instead.",
     "properties": {
      "type": {
       "type": "string",
@@ -8942,7 +8943,7 @@
    },
    "v1beta1.RollingUpdateDeployment": {
     "id": "v1beta1.RollingUpdateDeployment",
-    "description": "Spec to control the desired behavior of rolling update.",
+    "description": "Spec to control the desired behavior of rolling update.\n\nDEPRECATED: Use 'extensions.v1beta1.RollingUpdateDeployment' instead.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -8956,6 +8957,7 @@
    },
    "v1beta1.RollbackConfig": {
     "id": "v1beta1.RollbackConfig",
+    "description": "\n\nDEPRECATED: Use 'extensions.v1beta1.RollbackConfig' instead.",
     "properties": {
      "revision": {
       "type": "integer",
@@ -8966,7 +8968,7 @@
    },
    "v1beta1.DeploymentStatus": {
     "id": "v1beta1.DeploymentStatus",
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DeploymentStatus is the most recently observed status of the Deployment.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentStatus' instead.",
     "properties": {
      "observedGeneration": {
       "type": "integer",
@@ -9009,7 +9011,7 @@
    },
    "v1beta1.DeploymentCondition": {
     "id": "v1beta1.DeploymentCondition",
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DeploymentCondition describes the state of a deployment at a certain point.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentCondition' instead.",
     "required": [
      "type",
      "status"
@@ -9043,7 +9045,7 @@
    },
    "v1beta1.DeploymentRollback": {
     "id": "v1beta1.DeploymentRollback",
-    "description": "DeploymentRollback stores the information required to rollback a deployment.",
+    "description": "DeploymentRollback stores the information required to rollback a deployment.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentRollback' instead.",
     "required": [
      "name",
      "rollbackTo"
@@ -9073,7 +9075,7 @@
    },
    "v1beta1.Scale": {
     "id": "v1beta1.Scale",
-    "description": "represents a scaling request for a resource.",
+    "description": "represents a scaling request for a resource.\n\nDEPRECATED: Use 'extensions.v1beta1.Scale' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9099,7 +9101,7 @@
    },
    "v1beta1.ScaleSpec": {
     "id": "v1beta1.ScaleSpec",
-    "description": "describes the attributes of a scale subresource",
+    "description": "describes the attributes of a scale subresource\n\nDEPRECATED: Use 'extensions.v1beta1.ScaleSpec' instead.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -9110,7 +9112,7 @@
    },
    "v1beta1.ScaleStatus": {
     "id": "v1beta1.ScaleStatus",
-    "description": "represents the current status of a scale subresource.",
+    "description": "represents the current status of a scale subresource.\n\nDEPRECATED: Use 'extensions.v1beta1.ScaleStatus' instead.",
     "required": [
      "replicas"
     ],
@@ -9132,7 +9134,7 @@
    },
    "v1beta1.HorizontalPodAutoscalerList": {
     "id": "v1beta1.HorizontalPodAutoscalerList",
-    "description": "list of horizontal pod autoscaler objects.",
+    "description": "list of horizontal pod autoscaler objects.\n\nDEPRECATED: Use 'extensions.v1beta1.HorizontalPodAutoscalerList' instead.",
     "required": [
      "items"
     ],
@@ -9160,7 +9162,7 @@
    },
    "v1beta1.HorizontalPodAutoscaler": {
     "id": "v1beta1.HorizontalPodAutoscaler",
-    "description": "configuration of a horizontal pod autoscaler.",
+    "description": "configuration of a horizontal pod autoscaler.\n\nDEPRECATED: Use 'extensions.v1beta1.HorizontalPodAutoscaler' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9186,7 +9188,7 @@
    },
    "v1beta1.HorizontalPodAutoscalerSpec": {
     "id": "v1beta1.HorizontalPodAutoscalerSpec",
-    "description": "specification of a horizontal pod autoscaler.",
+    "description": "specification of a horizontal pod autoscaler.\n\nDEPRECATED: Use 'extensions.v1beta1.HorizontalPodAutoscalerSpec' instead.",
     "required": [
      "scaleRef",
      "maxReplicas"
@@ -9214,7 +9216,7 @@
    },
    "v1beta1.SubresourceReference": {
     "id": "v1beta1.SubresourceReference",
-    "description": "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
+    "description": "SubresourceReference contains enough information to let you inspect or modify the referred subresource.\n\nDEPRECATED: Use 'extensions.v1beta1.SubresourceReference' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9236,6 +9238,7 @@
    },
    "v1beta1.CPUTargetUtilization": {
     "id": "v1beta1.CPUTargetUtilization",
+    "description": "\n\nDEPRECATED: Use 'extensions.v1beta1.CPUTargetUtilization' instead.",
     "required": [
      "targetPercentage"
     ],
@@ -9249,7 +9252,7 @@
    },
    "v1beta1.HorizontalPodAutoscalerStatus": {
     "id": "v1beta1.HorizontalPodAutoscalerStatus",
-    "description": "current status of a horizontal pod autoscaler",
+    "description": "current status of a horizontal pod autoscaler\n\nDEPRECATED: Use 'extensions.v1beta1.HorizontalPodAutoscalerStatus' instead.",
     "required": [
      "currentReplicas",
      "desiredReplicas"
@@ -9283,7 +9286,7 @@
    },
    "v1beta1.IngressList": {
     "id": "v1beta1.IngressList",
-    "description": "IngressList is a collection of Ingress.",
+    "description": "IngressList is a collection of Ingress.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressList' instead.",
     "required": [
      "items"
     ],
@@ -9311,7 +9314,7 @@
    },
    "v1beta1.Ingress": {
     "id": "v1beta1.Ingress",
-    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.\n\nDEPRECATED: Use 'extensions.v1beta1.Ingress' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9337,7 +9340,7 @@
    },
    "v1beta1.IngressSpec": {
     "id": "v1beta1.IngressSpec",
-    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "description": "IngressSpec describes the Ingress the user wishes to exist.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressSpec' instead.",
     "properties": {
      "backend": {
       "$ref": "v1beta1.IngressBackend",
@@ -9361,7 +9364,7 @@
    },
    "v1beta1.IngressBackend": {
     "id": "v1beta1.IngressBackend",
-    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "description": "IngressBackend describes all endpoints for a given service and port.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressBackend' instead.",
     "required": [
      "serviceName",
      "servicePort"
@@ -9379,7 +9382,7 @@
    },
    "v1beta1.IngressTLS": {
     "id": "v1beta1.IngressTLS",
-    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "description": "IngressTLS describes the transport layer security associated with an Ingress.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressTLS' instead.",
     "properties": {
      "hosts": {
       "type": "array",
@@ -9396,7 +9399,7 @@
    },
    "v1beta1.IngressRule": {
     "id": "v1beta1.IngressRule",
-    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressRule' instead.",
     "properties": {
      "host": {
       "type": "string",
@@ -9409,7 +9412,7 @@
    },
    "v1beta1.HTTPIngressRuleValue": {
     "id": "v1beta1.HTTPIngressRuleValue",
-    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.\n\nDEPRECATED: Use 'extensions.v1beta1.HTTPIngressRuleValue' instead.",
     "required": [
      "paths"
     ],
@@ -9425,7 +9428,7 @@
    },
    "v1beta1.HTTPIngressPath": {
     "id": "v1beta1.HTTPIngressPath",
-    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.\n\nDEPRECATED: Use 'extensions.v1beta1.HTTPIngressPath' instead.",
     "required": [
      "backend"
     ],
@@ -9442,7 +9445,7 @@
    },
    "v1beta1.IngressStatus": {
     "id": "v1beta1.IngressStatus",
-    "description": "IngressStatus describe the current state of the Ingress.",
+    "description": "IngressStatus describe the current state of the Ingress.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressStatus' instead.",
     "properties": {
      "loadBalancer": {
       "$ref": "v1.LoadBalancerStatus",
@@ -9479,7 +9482,7 @@
    },
    "v1beta1.NetworkPolicyList": {
     "id": "v1beta1.NetworkPolicyList",
-    "description": "Network Policy List is a list of NetworkPolicy objects.",
+    "description": "Network Policy List is a list of NetworkPolicy objects.\n\nDEPRECATED: Use 'extensions.v1beta1.NetworkPolicyList' instead.",
     "required": [
      "items"
     ],
@@ -9507,6 +9510,7 @@
    },
    "v1beta1.NetworkPolicy": {
     "id": "v1beta1.NetworkPolicy",
+    "description": "\n\nDEPRECATED: Use 'extensions.v1beta1.NetworkPolicy' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9528,6 +9532,7 @@
    },
    "v1beta1.NetworkPolicySpec": {
     "id": "v1beta1.NetworkPolicySpec",
+    "description": "\n\nDEPRECATED: Use 'extensions.v1beta1.NetworkPolicySpec' instead.",
     "required": [
      "podSelector"
     ],
@@ -9547,7 +9552,7 @@
    },
    "v1beta1.NetworkPolicyIngressRule": {
     "id": "v1beta1.NetworkPolicyIngressRule",
-    "description": "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+    "description": "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.\n\nDEPRECATED: Use 'extensions.v1beta1.NetworkPolicyIngressRule' instead.",
     "properties": {
      "ports": {
       "type": "array",
@@ -9567,9 +9572,10 @@
    },
    "v1beta1.NetworkPolicyPort": {
     "id": "v1beta1.NetworkPolicyPort",
+    "description": "\n\nDEPRECATED: Use 'extensions.v1beta1.NetworkPolicyPort' instead.",
     "properties": {
      "protocol": {
-      "$ref": "v1.Protocol",
+      "$ref": "io.k8s.kubernetes.pkg.api.v1.Protocol",
       "description": "Optional.  The protocol (TCP or UDP) which traffic must match. If not specified, this field defaults to TCP."
      },
      "port": {
@@ -9578,12 +9584,13 @@
      }
     }
    },
-   "v1.Protocol": {
-    "id": "v1.Protocol",
+   "io.k8s.kubernetes.pkg.api.v1.Protocol": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.Protocol",
     "properties": {}
    },
    "v1beta1.NetworkPolicyPeer": {
     "id": "v1beta1.NetworkPolicyPeer",
+    "description": "\n\nDEPRECATED: Use 'extensions.v1beta1.NetworkPolicyPeer' instead.",
     "properties": {
      "podSelector": {
       "$ref": "v1.LabelSelector",
@@ -9597,7 +9604,7 @@
    },
    "v1beta1.ReplicaSetList": {
     "id": "v1beta1.ReplicaSetList",
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "ReplicaSetList is a collection of ReplicaSets.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSetList' instead.",
     "required": [
      "items"
     ],
@@ -9625,7 +9632,7 @@
    },
    "v1beta1.ReplicaSet": {
     "id": "v1beta1.ReplicaSet",
-    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "description": "ReplicaSet represents the configuration of a ReplicaSet.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSet' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9651,7 +9658,7 @@
    },
    "v1beta1.ReplicaSetSpec": {
     "id": "v1beta1.ReplicaSetSpec",
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "ReplicaSetSpec is the specification of a ReplicaSet.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSetSpec' instead.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -9675,7 +9682,7 @@
    },
    "v1beta1.ReplicaSetStatus": {
     "id": "v1beta1.ReplicaSetStatus",
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSetStatus' instead.",
     "required": [
      "replicas"
     ],
@@ -9716,7 +9723,7 @@
    },
    "v1beta1.ReplicaSetCondition": {
     "id": "v1beta1.ReplicaSetCondition",
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSetCondition' instead.",
     "required": [
      "type",
      "status"
@@ -9746,7 +9753,7 @@
    },
    "v1beta1.ThirdPartyResourceList": {
     "id": "v1beta1.ThirdPartyResourceList",
-    "description": "ThirdPartyResourceList is a list of ThirdPartyResources.",
+    "description": "ThirdPartyResourceList is a list of ThirdPartyResources.\n\nDEPRECATED: Use 'extensions.v1beta1.ThirdPartyResourceList' instead.",
     "required": [
      "items"
     ],
@@ -9774,7 +9781,7 @@
    },
    "v1beta1.ThirdPartyResource": {
     "id": "v1beta1.ThirdPartyResource",
-    "description": "A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.",
+    "description": "A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.\n\nDEPRECATED: Use 'extensions.v1beta1.ThirdPartyResource' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9803,7 +9810,7 @@
    },
    "v1beta1.APIVersion": {
     "id": "v1beta1.APIVersion",
-    "description": "An APIVersion represents a single concrete version of an object model.",
+    "description": "An APIVersion represents a single concrete version of an object model.\n\nDEPRECATED: Use 'extensions.v1beta1.APIVersion' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -9813,7 +9820,7 @@
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -9842,6 +9849,1326 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetList": {
+    "id": "extensions.v1beta1.DaemonSetList",
+    "description": "DaemonSetList is a collection of daemon sets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.DaemonSet"
+      },
+      "description": "Items is a list of daemon sets."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSet": {
+    "id": "extensions.v1beta1.DaemonSet",
+    "description": "DaemonSet represents the configuration of a daemon set.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.DaemonSetSpec",
+      "description": "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "status": {
+      "$ref": "v1beta1.DaemonSetStatus",
+      "description": "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetSpec": {
+    "id": "extensions.v1beta1.DaemonSetSpec",
+    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     },
+     "template": {
+      "$ref": "v1.PodTemplateSpec",
+      "description": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template"
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelector": {
+    "id": "io.k8s.meta.v1.LabelSelector",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchLabels": {
+      "type": "object",
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+     },
+     "matchExpressions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.LabelSelectorRequirement"
+      },
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed."
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelectorRequirement": {
+    "id": "io.k8s.meta.v1.LabelSelectorRequirement",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "key is the label key that the selector applies to."
+     },
+     "operator": {
+      "type": "string",
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist."
+     },
+     "values": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetStatus": {
+    "id": "extensions.v1beta1.DaemonSetStatus",
+    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "required": [
+     "currentNumberScheduled",
+     "numberMisscheduled",
+     "desiredNumberScheduled",
+     "numberReady"
+    ],
+    "properties": {
+     "currentNumberScheduled": {
+      "type": "integer",
+      "format": "int32",
+      "description": "CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+     },
+     "numberMisscheduled": {
+      "type": "integer",
+      "format": "int32",
+      "description": "NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+     },
+     "desiredNumberScheduled": {
+      "type": "integer",
+      "format": "int32",
+      "description": "DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+     },
+     "numberReady": {
+      "type": "integer",
+      "format": "int32",
+      "description": "NumberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready."
+     },
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "ObservedGeneration is the most recent generation observed by the daemon set controller."
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "extensions.v1beta1.DeploymentList": {
+    "id": "extensions.v1beta1.DeploymentList",
+    "description": "DeploymentList is a list of Deployments.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.Deployment"
+      },
+      "description": "Items is the list of Deployments."
+     }
+    }
+   },
+   "extensions.v1beta1.Deployment": {
+    "id": "extensions.v1beta1.Deployment",
+    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata."
+     },
+     "spec": {
+      "$ref": "v1beta1.DeploymentSpec",
+      "description": "Specification of the desired behavior of the Deployment."
+     },
+     "status": {
+      "$ref": "v1beta1.DeploymentStatus",
+      "description": "Most recently observed status of the Deployment."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentSpec": {
+    "id": "extensions.v1beta1.DeploymentSpec",
+    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1."
+     },
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment."
+     },
+     "template": {
+      "$ref": "v1.PodTemplateSpec",
+      "description": "Template describes the pods that will be created."
+     },
+     "strategy": {
+      "$ref": "v1beta1.DeploymentStrategy",
+      "description": "The deployment strategy to use to replace existing pods with new ones."
+     },
+     "minReadySeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)"
+     },
+     "revisionHistoryLimit": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified."
+     },
+     "paused": {
+      "type": "boolean",
+      "description": "Indicates that the deployment is paused and will not be processed by the deployment controller."
+     },
+     "rollbackTo": {
+      "$ref": "v1beta1.RollbackConfig",
+      "description": "The config this deployment is rolling back to. Will be cleared after rollback is done."
+     },
+     "progressDeadlineSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. This is not set by default."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentStrategy": {
+    "id": "extensions.v1beta1.DeploymentStrategy",
+    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate."
+     },
+     "rollingUpdate": {
+      "$ref": "v1beta1.RollingUpdateDeployment",
+      "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+     }
+    }
+   },
+   "extensions.v1beta1.RollingUpdateDeployment": {
+    "id": "extensions.v1beta1.RollingUpdateDeployment",
+    "description": "Spec to control the desired behavior of rolling update.",
+    "properties": {
+     "maxUnavailable": {
+      "type": "string",
+      "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+     },
+     "maxSurge": {
+      "type": "string",
+      "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods."
+     }
+    }
+   },
+   "extensions.v1beta1.RollbackConfig": {
+    "id": "extensions.v1beta1.RollbackConfig",
+    "properties": {
+     "revision": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The revision to rollback to. If set to 0, rollbck to the last revision."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentStatus": {
+    "id": "extensions.v1beta1.DeploymentStatus",
+    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "properties": {
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The generation observed by the deployment controller."
+     },
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector)."
+     },
+     "updatedReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec."
+     },
+     "readyReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of ready pods targeted by this deployment."
+     },
+     "availableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment."
+     },
+     "unavailableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of unavailable pods targeted by this deployment."
+     },
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.DeploymentCondition"
+      },
+      "description": "Represents the latest available observations of a deployment's current state."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentCondition": {
+    "id": "extensions.v1beta1.DeploymentCondition",
+    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of deployment condition."
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the condition, one of True, False, Unknown."
+     },
+     "lastUpdateTime": {
+      "type": "string",
+      "description": "The last time this condition was updated."
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "description": "Last time the condition transitioned from one status to another."
+     },
+     "reason": {
+      "type": "string",
+      "description": "The reason for the condition's last transition."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human readable message indicating details about the transition."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentRollback": {
+    "id": "extensions.v1beta1.DeploymentRollback",
+    "description": "DeploymentRollback stores the information required to rollback a deployment.",
+    "required": [
+     "name",
+     "rollbackTo"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "Required: This must match the Name of a deployment."
+     },
+     "updatedAnnotations": {
+      "type": "object",
+      "description": "The annotations to be updated to a deployment"
+     },
+     "rollbackTo": {
+      "$ref": "v1beta1.RollbackConfig",
+      "description": "The config of this deployment rollback."
+     }
+    }
+   },
+   "extensions.v1beta1.Scale": {
+    "id": "extensions.v1beta1.Scale",
+    "description": "represents a scaling request for a resource.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata."
+     },
+     "spec": {
+      "$ref": "v1beta1.ScaleSpec",
+      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+     },
+     "status": {
+      "$ref": "v1beta1.ScaleStatus",
+      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only."
+     }
+    }
+   },
+   "extensions.v1beta1.ScaleSpec": {
+    "id": "extensions.v1beta1.ScaleSpec",
+    "description": "describes the attributes of a scale subresource",
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "desired number of instances for the scaled object."
+     }
+    }
+   },
+   "extensions.v1beta1.ScaleStatus": {
+    "id": "extensions.v1beta1.ScaleStatus",
+    "description": "represents the current status of a scale subresource.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "actual number of observed instances of the scaled object."
+     },
+     "selector": {
+      "type": "object",
+      "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     },
+     "targetSelector": {
+      "type": "string",
+      "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     }
+    }
+   },
+   "extensions.v1beta1.HorizontalPodAutoscalerList": {
+    "id": "extensions.v1beta1.HorizontalPodAutoscalerList",
+    "description": "list of horizontal pod autoscaler objects.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.HorizontalPodAutoscaler"
+      },
+      "description": "list of horizontal pod autoscaler objects."
+     }
+    }
+   },
+   "extensions.v1beta1.HorizontalPodAutoscaler": {
+    "id": "extensions.v1beta1.HorizontalPodAutoscaler",
+    "description": "configuration of a horizontal pod autoscaler.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.HorizontalPodAutoscalerSpec",
+      "description": "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+     },
+     "status": {
+      "$ref": "v1beta1.HorizontalPodAutoscalerStatus",
+      "description": "current information about the autoscaler."
+     }
+    }
+   },
+   "extensions.v1beta1.HorizontalPodAutoscalerSpec": {
+    "id": "extensions.v1beta1.HorizontalPodAutoscalerSpec",
+    "description": "specification of a horizontal pod autoscaler.",
+    "required": [
+     "scaleRef",
+     "maxReplicas"
+    ],
+    "properties": {
+     "scaleRef": {
+      "$ref": "v1beta1.SubresourceReference",
+      "description": "reference to Scale subresource; horizontal pod autoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modifying its spec."
+     },
+     "minReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "lower limit for the number of pods that can be set by the autoscaler, default 1."
+     },
+     "maxReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas."
+     },
+     "cpuUtilization": {
+      "$ref": "v1beta1.CPUTargetUtilization",
+      "description": "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified it defaults to the target CPU utilization at 80% of the requested resources."
+     }
+    }
+   },
+   "extensions.v1beta1.SubresourceReference": {
+    "id": "extensions.v1beta1.SubresourceReference",
+    "description": "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent"
+     },
+     "subresource": {
+      "type": "string",
+      "description": "Subresource name of the referent"
+     }
+    }
+   },
+   "extensions.v1beta1.CPUTargetUtilization": {
+    "id": "extensions.v1beta1.CPUTargetUtilization",
+    "required": [
+     "targetPercentage"
+    ],
+    "properties": {
+     "targetPercentage": {
+      "type": "integer",
+      "format": "int32",
+      "description": "fraction of the requested CPU that should be utilized/used, e.g. 70 means that 70% of the requested CPU should be in use."
+     }
+    }
+   },
+   "extensions.v1beta1.HorizontalPodAutoscalerStatus": {
+    "id": "extensions.v1beta1.HorizontalPodAutoscalerStatus",
+    "description": "current status of a horizontal pod autoscaler",
+    "required": [
+     "currentReplicas",
+     "desiredReplicas"
+    ],
+    "properties": {
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "most recent generation observed by this autoscaler."
+     },
+     "lastScaleTime": {
+      "type": "string",
+      "description": "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed."
+     },
+     "currentReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "current number of replicas of pods managed by this autoscaler."
+     },
+     "desiredReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "desired number of replicas of pods managed by this autoscaler."
+     },
+     "currentCPUUtilizationPercentage": {
+      "type": "integer",
+      "format": "int32",
+      "description": "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressList": {
+    "id": "extensions.v1beta1.IngressList",
+    "description": "IngressList is a collection of Ingress.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.Ingress"
+      },
+      "description": "Items is the list of Ingress."
+     }
+    }
+   },
+   "extensions.v1beta1.Ingress": {
+    "id": "extensions.v1beta1.Ingress",
+    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.IngressSpec",
+      "description": "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "status": {
+      "$ref": "v1beta1.IngressStatus",
+      "description": "Status is the current state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     }
+    }
+   },
+   "extensions.v1beta1.IngressSpec": {
+    "id": "extensions.v1beta1.IngressSpec",
+    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "properties": {
+     "backend": {
+      "$ref": "v1beta1.IngressBackend",
+      "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default."
+     },
+     "tls": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.IngressTLS"
+      },
+      "description": "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI."
+     },
+     "rules": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.IngressRule"
+      },
+      "description": "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressBackend": {
+    "id": "extensions.v1beta1.IngressBackend",
+    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "required": [
+     "serviceName",
+     "servicePort"
+    ],
+    "properties": {
+     "serviceName": {
+      "type": "string",
+      "description": "Specifies the name of the referenced service."
+     },
+     "servicePort": {
+      "type": "string",
+      "description": "Specifies the port of the referenced service."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressTLS": {
+    "id": "extensions.v1beta1.IngressTLS",
+    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "properties": {
+     "hosts": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified."
+     },
+     "secretName": {
+      "type": "string",
+      "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressRule": {
+    "id": "extensions.v1beta1.IngressRule",
+    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "properties": {
+     "host": {
+      "type": "string",
+      "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue."
+     },
+     "http": {
+      "$ref": "v1beta1.HTTPIngressRuleValue"
+     }
+    }
+   },
+   "extensions.v1beta1.HTTPIngressRuleValue": {
+    "id": "extensions.v1beta1.HTTPIngressRuleValue",
+    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "required": [
+     "paths"
+    ],
+    "properties": {
+     "paths": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.HTTPIngressPath"
+      },
+      "description": "A collection of paths that map requests to backends."
+     }
+    }
+   },
+   "extensions.v1beta1.HTTPIngressPath": {
+    "id": "extensions.v1beta1.HTTPIngressPath",
+    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "required": [
+     "backend"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend."
+     },
+     "backend": {
+      "$ref": "v1beta1.IngressBackend",
+      "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressStatus": {
+    "id": "extensions.v1beta1.IngressStatus",
+    "description": "IngressStatus describe the current state of the Ingress.",
+    "properties": {
+     "loadBalancer": {
+      "$ref": "v1.LoadBalancerStatus",
+      "description": "LoadBalancer contains the current status of the load-balancer."
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicyList": {
+    "id": "extensions.v1beta1.NetworkPolicyList",
+    "description": "Network Policy List is a list of NetworkPolicy objects.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.NetworkPolicy"
+      },
+      "description": "Items is a list of schema objects."
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicy": {
+    "id": "extensions.v1beta1.NetworkPolicy",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.NetworkPolicySpec",
+      "description": "Specification of the desired behavior for this NetworkPolicy."
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicySpec": {
+    "id": "extensions.v1beta1.NetworkPolicySpec",
+    "required": [
+     "podSelector"
+    ],
+    "properties": {
+     "podSelector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace."
+     },
+     "ingress": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.NetworkPolicyIngressRule"
+      },
+      "description": "List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if namespace.networkPolicy.ingress.isolation is undefined and cluster policy allows it, OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not affect ingress isolation. If this field is present and contains at least one rule, this policy allows any traffic which matches at least one of the ingress rules in this list."
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicyIngressRule": {
+    "id": "extensions.v1beta1.NetworkPolicyIngressRule",
+    "description": "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+    "properties": {
+     "ports": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.NetworkPolicyPort"
+      },
+      "description": "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is not provided, this rule matches all ports (traffic not restricted by port). If this field is empty, this rule matches no ports (no traffic matches). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list."
+     },
+     "from": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.NetworkPolicyPeer"
+      },
+      "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is not provided, this rule matches all sources (traffic not restricted by source). If this field is empty, this rule matches no sources (no traffic matches). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list."
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicyPort": {
+    "id": "extensions.v1beta1.NetworkPolicyPort",
+    "properties": {
+     "protocol": {
+      "$ref": "io.k8s.kubernetes.pkg.api.v1.Protocol",
+      "description": "Optional.  The protocol (TCP or UDP) which traffic must match. If not specified, this field defaults to TCP."
+     },
+     "port": {
+      "type": "string",
+      "description": "If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched."
+     }
+    }
+   },
+   "extensions.v1beta1.NetworkPolicyPeer": {
+    "id": "extensions.v1beta1.NetworkPolicyPeer",
+    "properties": {
+     "podSelector": {
+      "$ref": "v1.LabelSelector",
+      "description": "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If not provided, this selector selects no pods. If present but empty, this selector selects all pods in this namespace."
+     },
+     "namespaceSelector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If omitted, this selector selects no namespaces. If present but empty, this selector selects all namespaces."
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetList": {
+    "id": "extensions.v1beta1.ReplicaSetList",
+    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.ReplicaSet"
+      },
+      "description": "List of ReplicaSets. More info: http://kubernetes.io/docs/user-guide/replication-controller"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSet": {
+    "id": "extensions.v1beta1.ReplicaSet",
+    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.ReplicaSetSpec",
+      "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "status": {
+      "$ref": "v1beta1.ReplicaSetStatus",
+      "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetSpec": {
+    "id": "extensions.v1beta1.ReplicaSetSpec",
+    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller"
+     },
+     "minReadySeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)"
+     },
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     },
+     "template": {
+      "$ref": "v1.PodTemplateSpec",
+      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetStatus": {
+    "id": "extensions.v1beta1.ReplicaSetStatus",
+    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Replicas is the most recently oberved number of replicas. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller"
+     },
+     "fullyLabeledReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of pods that have labels matching the labels of the pod template of the replicaset."
+     },
+     "readyReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of ready replicas for this replica set."
+     },
+     "availableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of available replicas (ready for at least minReadySeconds) for this replica set."
+     },
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet."
+     },
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.ReplicaSetCondition"
+      },
+      "description": "Represents the latest available observations of a replica set's current state."
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetCondition": {
+    "id": "extensions.v1beta1.ReplicaSetCondition",
+    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of replica set condition."
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the condition, one of True, False, Unknown."
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "description": "The last time the condition transitioned from one status to another."
+     },
+     "reason": {
+      "type": "string",
+      "description": "The reason for the condition's last transition."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human readable message indicating details about the transition."
+     }
+    }
+   },
+   "extensions.v1beta1.ThirdPartyResourceList": {
+    "id": "extensions.v1beta1.ThirdPartyResourceList",
+    "description": "ThirdPartyResourceList is a list of ThirdPartyResources.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.ThirdPartyResource"
+      },
+      "description": "Items is the list of ThirdPartyResources."
+     }
+    }
+   },
+   "extensions.v1beta1.ThirdPartyResource": {
+    "id": "extensions.v1beta1.ThirdPartyResource",
+    "description": "A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata"
+     },
+     "description": {
+      "type": "string",
+      "description": "Description is the description of this object."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.APIVersion"
+      },
+      "description": "Versions are versions for this third party object"
+     }
+    }
+   },
+   "extensions.v1beta1.APIVersion": {
+    "id": "extensions.v1beta1.APIVersion",
+    "description": "An APIVersion represents a single concrete version of an object model.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "Name of this version (e.g. 'v1')."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/policy.json
+++ b/api/swagger-spec/policy.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/policy_v1beta1.json
+++ b/api/swagger-spec/policy_v1beta1.json
@@ -108,7 +108,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.PodDisruptionBudget",
+        "type": "policy.v1beta1.PodDisruptionBudget",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -390,7 +390,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.PodDisruptionBudget",
+        "type": "policy.v1beta1.PodDisruptionBudget",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -445,7 +445,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -879,7 +879,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.PodDisruptionBudget",
+        "type": "policy.v1beta1.PodDisruptionBudget",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -934,7 +934,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1005,7 +1005,7 @@
   "models": {
    "v1beta1.PodDisruptionBudgetList": {
     "id": "v1beta1.PodDisruptionBudgetList",
-    "description": "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.",
+    "description": "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.\n\nDEPRECATED: Use 'policy.v1beta1.PodDisruptionBudgetList' instead.",
     "required": [
      "items"
     ],
@@ -1031,7 +1031,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -1045,7 +1045,7 @@
    },
    "v1beta1.PodDisruptionBudget": {
     "id": "v1beta1.PodDisruptionBudget",
-    "description": "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods",
+    "description": "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods\n\nDEPRECATED: Use 'policy.v1beta1.PodDisruptionBudget' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -1144,7 +1144,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -1176,7 +1176,7 @@
    },
    "v1beta1.PodDisruptionBudgetSpec": {
     "id": "v1beta1.PodDisruptionBudgetSpec",
-    "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
+    "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.\n\nDEPRECATED: Use 'policy.v1beta1.PodDisruptionBudgetSpec' instead.",
     "properties": {
      "minAvailable": {
       "type": "string",
@@ -1190,7 +1190,7 @@
    },
    "v1.LabelSelector": {
     "id": "v1.LabelSelector",
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelector' instead.",
     "properties": {
      "matchLabels": {
       "type": "object",
@@ -1207,7 +1207,7 @@
    },
    "v1.LabelSelectorRequirement": {
     "id": "v1.LabelSelectorRequirement",
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelectorRequirement' instead.",
     "required": [
      "key",
      "operator"
@@ -1232,7 +1232,7 @@
    },
    "v1beta1.PodDisruptionBudgetStatus": {
     "id": "v1beta1.PodDisruptionBudgetStatus",
-    "description": "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
+    "description": "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.\n\nDEPRECATED: Use 'policy.v1beta1.PodDisruptionBudgetStatus' instead.",
     "required": [
      "disruptedPods",
      "disruptionsAllowed",
@@ -1274,7 +1274,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -1313,7 +1313,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -1343,7 +1343,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -1361,6 +1361,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -1376,7 +1377,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -1411,18 +1412,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -1451,6 +1452,368 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "policy.v1beta1.PodDisruptionBudgetList": {
+    "id": "policy.v1beta1.PodDisruptionBudgetList",
+    "description": "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.PodDisruptionBudget"
+      }
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "policy.v1beta1.PodDisruptionBudget": {
+    "id": "policy.v1beta1.PodDisruptionBudget",
+    "description": "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta"
+     },
+     "spec": {
+      "$ref": "v1beta1.PodDisruptionBudgetSpec",
+      "description": "Specification of the desired behavior of the PodDisruptionBudget."
+     },
+     "status": {
+      "$ref": "v1beta1.PodDisruptionBudgetStatus",
+      "description": "Most recently observed status of the PodDisruptionBudget."
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "policy.v1beta1.PodDisruptionBudgetSpec": {
+    "id": "policy.v1beta1.PodDisruptionBudgetSpec",
+    "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
+    "properties": {
+     "minAvailable": {
+      "type": "string",
+      "description": "An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\"."
+     },
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Label query over pods whose evictions are managed by the disruption budget."
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelector": {
+    "id": "io.k8s.meta.v1.LabelSelector",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchLabels": {
+      "type": "object",
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+     },
+     "matchExpressions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.LabelSelectorRequirement"
+      },
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed."
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelectorRequirement": {
+    "id": "io.k8s.meta.v1.LabelSelectorRequirement",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "key is the label key that the selector applies to."
+     },
+     "operator": {
+      "type": "string",
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist."
+     },
+     "values": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+     }
+    }
+   },
+   "policy.v1beta1.PodDisruptionBudgetStatus": {
+    "id": "policy.v1beta1.PodDisruptionBudgetStatus",
+    "description": "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
+    "required": [
+     "disruptedPods",
+     "disruptionsAllowed",
+     "currentHealthy",
+     "desiredHealthy",
+     "expectedPods"
+    ],
+    "properties": {
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "Most recent generation observed when updating this PDB status. PodDisruptionsAllowed and other status informatio is valid only if observedGeneration equals to PDB's object generation."
+     },
+     "disruptedPods": {
+      "type": "object",
+      "description": "DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions."
+     },
+     "disruptionsAllowed": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Number of pod disruptions that are currently allowed."
+     },
+     "currentHealthy": {
+      "type": "integer",
+      "format": "int32",
+      "description": "current number of healthy pods"
+     },
+     "desiredHealthy": {
+      "type": "integer",
+      "format": "int32",
+      "description": "minimum desired number of healthy pods"
+     },
+     "expectedPods": {
+      "type": "integer",
+      "format": "int32",
+      "description": "total number of pods counted by this disruption budget"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/rbac.authorization.k8s.io.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
@@ -100,7 +100,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.ClusterRoleBinding",
+        "type": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -334,7 +334,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.ClusterRoleBinding",
+        "type": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -381,7 +381,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -659,7 +659,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.ClusterRole",
+        "type": "io.k8s.authorization.rbac.v1alpha1.ClusterRole",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -893,7 +893,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.ClusterRole",
+        "type": "io.k8s.authorization.rbac.v1alpha1.ClusterRole",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -940,7 +940,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1226,7 +1226,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.RoleBinding",
+        "type": "io.k8s.authorization.rbac.v1alpha1.RoleBinding",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1492,7 +1492,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.RoleBinding",
+        "type": "io.k8s.authorization.rbac.v1alpha1.RoleBinding",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1547,7 +1547,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2015,7 +2015,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.Role",
+        "type": "io.k8s.authorization.rbac.v1alpha1.Role",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2281,7 +2281,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1alpha1.Role",
+        "type": "io.k8s.authorization.rbac.v1alpha1.Role",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2336,7 +2336,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2731,7 +2731,7 @@
   "models": {
    "v1alpha1.ClusterRoleBindingList": {
     "id": "v1alpha1.ClusterRoleBindingList",
-    "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+    "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingList' instead.",
     "required": [
      "items"
     ],
@@ -2759,7 +2759,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -2773,7 +2773,7 @@
    },
    "v1alpha1.ClusterRoleBinding": {
     "id": "v1alpha1.ClusterRoleBinding",
-    "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+    "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding' instead.",
     "required": [
      "subjects",
      "roleRef"
@@ -2880,7 +2880,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -2912,7 +2912,7 @@
    },
    "v1alpha1.Subject": {
     "id": "v1alpha1.Subject",
-    "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+    "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.Subject' instead.",
     "required": [
      "kind",
      "name"
@@ -2938,7 +2938,7 @@
    },
    "v1alpha1.RoleRef": {
     "id": "v1alpha1.RoleRef",
-    "description": "RoleRef contains information that points to the role being used",
+    "description": "RoleRef contains information that points to the role being used\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.RoleRef' instead.",
     "required": [
      "apiGroup",
      "kind",
@@ -2961,7 +2961,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -3000,7 +3000,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -3030,7 +3030,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -3048,6 +3048,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -3063,7 +3064,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -3098,18 +3099,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1alpha1.ClusterRoleList": {
     "id": "v1alpha1.ClusterRoleList",
-    "description": "ClusterRoleList is a collection of ClusterRoles",
+    "description": "ClusterRoleList is a collection of ClusterRoles\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.ClusterRoleList' instead.",
     "required": [
      "items"
     ],
@@ -3137,7 +3138,7 @@
    },
    "v1alpha1.ClusterRole": {
     "id": "v1alpha1.ClusterRole",
-    "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+    "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.ClusterRole' instead.",
     "required": [
      "rules"
     ],
@@ -3165,7 +3166,7 @@
    },
    "v1alpha1.PolicyRule": {
     "id": "v1alpha1.PolicyRule",
-    "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+    "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.PolicyRule' instead.",
     "required": [
      "verbs"
     ],
@@ -3213,7 +3214,7 @@
    },
    "v1alpha1.RoleBindingList": {
     "id": "v1alpha1.RoleBindingList",
-    "description": "RoleBindingList is a collection of RoleBindings",
+    "description": "RoleBindingList is a collection of RoleBindings\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.RoleBindingList' instead.",
     "required": [
      "items"
     ],
@@ -3241,7 +3242,7 @@
    },
    "v1alpha1.RoleBinding": {
     "id": "v1alpha1.RoleBinding",
-    "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+    "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.RoleBinding' instead.",
     "required": [
      "subjects",
      "roleRef"
@@ -3274,7 +3275,7 @@
    },
    "v1alpha1.RoleList": {
     "id": "v1alpha1.RoleList",
-    "description": "RoleList is a collection of Roles",
+    "description": "RoleList is a collection of Roles\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.RoleList' instead.",
     "required": [
      "items"
     ],
@@ -3302,7 +3303,7 @@
    },
    "v1alpha1.Role": {
     "id": "v1alpha1.Role",
-    "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+    "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.\n\nDEPRECATED: Use 'io.k8s.authorization.rbac.v1alpha1.Role' instead.",
     "required": [
      "rules"
     ],
@@ -3330,7 +3331,7 @@
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -3359,6 +3360,550 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingList": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingList",
+    "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard object's metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.ClusterRoleBinding"
+      },
+      "description": "Items is a list of ClusterRoleBindings"
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding",
+    "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+    "required": [
+     "subjects",
+     "roleRef"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata."
+     },
+     "subjects": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.Subject"
+      },
+      "description": "Subjects holds references to the objects the role applies to."
+     },
+     "roleRef": {
+      "$ref": "v1alpha1.RoleRef",
+      "description": "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error."
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.Subject": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.Subject",
+    "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+    "required": [
+     "kind",
+     "name"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error."
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion holds the API group and version of the referenced object."
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the object being referenced."
+     },
+     "namespace": {
+      "type": "string",
+      "description": "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error."
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.RoleRef": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.RoleRef",
+    "description": "RoleRef contains information that points to the role being used",
+    "required": [
+     "apiGroup",
+     "kind",
+     "name"
+    ],
+    "properties": {
+     "apiGroup": {
+      "type": "string",
+      "description": "APIGroup is the group for the resource being referenced"
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind is the type of resource being referenced"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name is the name of resource being referenced"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.authorization.rbac.v1alpha1.ClusterRoleList": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleList",
+    "description": "ClusterRoleList is a collection of ClusterRoles",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard object's metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.ClusterRole"
+      },
+      "description": "Items is a list of ClusterRoles"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.ClusterRole": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.ClusterRole",
+    "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+    "required": [
+     "rules"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata."
+     },
+     "rules": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.PolicyRule"
+      },
+      "description": "Rules holds all the PolicyRules for this ClusterRole"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.PolicyRule": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.PolicyRule",
+    "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+    "required": [
+     "verbs"
+    ],
+    "properties": {
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds."
+     },
+     "attributeRestrictions": {
+      "type": "string",
+      "description": "AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports. If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error."
+     },
+     "apiGroups": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Resources is a list of resources this rule applies to.  ResourceAll represents all resources."
+     },
+     "resourceNames": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed."
+     },
+     "nonResourceURLs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different. Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both."
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.RoleBindingList": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.RoleBindingList",
+    "description": "RoleBindingList is a collection of RoleBindings",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard object's metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.RoleBinding"
+      },
+      "description": "Items is a list of RoleBindings"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.RoleBinding": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.RoleBinding",
+    "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+    "required": [
+     "subjects",
+     "roleRef"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata."
+     },
+     "subjects": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.Subject"
+      },
+      "description": "Subjects holds references to the objects the role applies to."
+     },
+     "roleRef": {
+      "$ref": "v1alpha1.RoleRef",
+      "description": "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error."
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.RoleList": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.RoleList",
+    "description": "RoleList is a collection of Roles",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard object's metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.Role"
+      },
+      "description": "Items is a list of Roles"
+     }
+    }
+   },
+   "io.k8s.authorization.rbac.v1alpha1.Role": {
+    "id": "io.k8s.authorization.rbac.v1alpha1.Role",
+    "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+    "required": [
+     "rules"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata."
+     },
+     "rules": {
+      "type": "array",
+      "items": {
+       "$ref": "v1alpha1.PolicyRule"
+      },
+      "description": "Rules holds all the PolicyRules for this Role"
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/storage.k8s.io.json
+++ b/api/swagger-spec/storage.k8s.io.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/api/swagger-spec/storage.k8s.io_v1beta1.json
+++ b/api/swagger-spec/storage.k8s.io_v1beta1.json
@@ -100,7 +100,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.StorageClass",
+        "type": "io.k8s.storage.v1beta1.StorageClass",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -350,7 +350,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.StorageClass",
+        "type": "io.k8s.storage.v1beta1.StorageClass",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -397,7 +397,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -610,7 +610,7 @@
   "models": {
    "v1beta1.StorageClassList": {
     "id": "v1beta1.StorageClassList",
-    "description": "StorageClassList is a collection of storage classes.",
+    "description": "StorageClassList is a collection of storage classes.\n\nDEPRECATED: Use 'io.k8s.storage.v1beta1.StorageClassList' instead.",
     "required": [
      "items"
     ],
@@ -638,7 +638,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -652,7 +652,7 @@
    },
    "v1beta1.StorageClass": {
     "id": "v1beta1.StorageClass",
-    "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+    "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.\n\nDEPRECATED: Use 'io.k8s.storage.v1beta1.StorageClass' instead.",
     "required": [
      "provisioner"
     ],
@@ -755,7 +755,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -787,7 +787,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -826,7 +826,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -856,7 +856,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -874,6 +874,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -889,7 +890,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -924,18 +925,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -964,6 +965,276 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "io.k8s.storage.v1beta1.StorageClassList": {
+    "id": "io.k8s.storage.v1beta1.StorageClassList",
+    "description": "StorageClassList is a collection of storage classes.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.StorageClass"
+      },
+      "description": "Items is the list of StorageClasses"
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "io.k8s.storage.v1beta1.StorageClass": {
+    "id": "io.k8s.storage.v1beta1.StorageClass",
+    "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+    "required": [
+     "provisioner"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "provisioner": {
+      "type": "string",
+      "description": "Provisioner indicates the type of the provisioner."
+     },
+     "parameters": {
+      "type": "object",
+      "description": "Parameters holds the parameters for the provisioner that should create volumes of this storage class."
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -622,7 +622,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1427,7 +1427,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2232,7 +2232,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3037,7 +3037,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3794,7 +3794,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4138,7 +4138,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4563,7 +4563,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -5598,7 +5598,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6071,7 +6071,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6560,7 +6560,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -6993,7 +6993,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -7284,7 +7284,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -7757,7 +7757,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -8771,7 +8771,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Eviction",
+        "type": "policy.v1beta1.Eviction",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -9788,7 +9788,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -10269,7 +10269,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -11074,7 +11074,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -11508,7 +11508,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Scale",
+        "type": "autoscaling.v1.Scale",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -11563,7 +11563,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -11728,7 +11728,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -12209,7 +12209,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -12698,7 +12698,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -13179,7 +13179,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -13984,7 +13984,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -14710,7 +14710,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -16111,7 +16111,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -16281,7 +16281,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -16375,7 +16375,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -16490,7 +16490,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -16529,7 +16529,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -16559,7 +16559,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -16577,6 +16577,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -16592,7 +16593,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -16627,13 +16628,13 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.EndpointsList": {
@@ -17020,14 +17021,14 @@
      "finalizers": {
       "type": "array",
       "items": {
-       "$ref": "v1.FinalizerName"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.FinalizerName"
       },
       "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: http://releases.k8s.io/HEAD/docs/design/namespaces.md#finalizers"
      }
     }
    },
-   "v1.FinalizerName": {
-    "id": "v1.FinalizerName",
+   "io.k8s.kubernetes.pkg.api.v1.FinalizerName": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.FinalizerName",
     "properties": {}
    },
    "v1.NamespaceStatus": {
@@ -17164,7 +17165,7 @@
      "volumesInUse": {
       "type": "array",
       "items": {
-       "$ref": "v1.UniqueVolumeName"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.UniqueVolumeName"
       },
       "description": "List of attachable volumes in use (mounted) by the node."
      },
@@ -17332,8 +17333,8 @@
      }
     }
    },
-   "v1.UniqueVolumeName": {
-    "id": "v1.UniqueVolumeName",
+   "io.k8s.kubernetes.pkg.api.v1.UniqueVolumeName": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.UniqueVolumeName",
     "properties": {}
    },
    "v1.AttachedVolume": {
@@ -17415,7 +17416,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1.PersistentVolumeAccessMode"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode"
       },
       "description": "AccessModes contains the desired access modes the volume should have. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes-1"
      },
@@ -17433,13 +17434,13 @@
      }
     }
    },
-   "v1.PersistentVolumeAccessMode": {
-    "id": "v1.PersistentVolumeAccessMode",
+   "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode",
     "properties": {}
    },
    "v1.LabelSelector": {
     "id": "v1.LabelSelector",
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelector' instead.",
     "properties": {
      "matchLabels": {
       "type": "object",
@@ -17456,7 +17457,7 @@
    },
    "v1.LabelSelectorRequirement": {
     "id": "v1.LabelSelectorRequirement",
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelectorRequirement' instead.",
     "required": [
      "key",
      "operator"
@@ -17504,7 +17505,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1.PersistentVolumeAccessMode"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode"
       },
       "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes-1"
      },
@@ -17647,7 +17648,7 @@
      "accessModes": {
       "type": "array",
       "items": {
-       "$ref": "v1.PersistentVolumeAccessMode"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.PersistentVolumeAccessMode"
       },
       "description": "AccessModes contains all ways the volume can be mounted. More info: http://kubernetes.io/docs/user-guide/persistent-volumes#access-modes"
      },
@@ -18077,7 +18078,7 @@
       "description": "The URI the data disk in the blob storage"
      },
      "cachingMode": {
-      "$ref": "v1.AzureDataDiskCachingMode",
+      "$ref": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
       "description": "Host Caching mode: None, Read Only, Read Write."
      },
      "fsType": {
@@ -18090,8 +18091,8 @@
      }
     }
    },
-   "v1.AzureDataDiskCachingMode": {
-    "id": "v1.AzureDataDiskCachingMode",
+   "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
     "properties": {}
    },
    "v1.PhotonPersistentDiskVolumeSource": {
@@ -19027,21 +19028,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Removed capabilities"
      }
     }
    },
-   "v1.Capability": {
-    "id": "v1.Capability",
+   "io.k8s.kubernetes.pkg.api.v1.Capability": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.Capability",
     "properties": {}
    },
    "v1.SELinuxOptions": {
@@ -19502,7 +19503,7 @@
    },
    "v1beta1.Eviction": {
     "id": "v1beta1.Eviction",
-    "description": "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/\u003cpod name\u003e/evictions.",
+    "description": "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/\u003cpod name\u003e/evictions.\n\nDEPRECATED: Use 'policy.v1beta1.Eviction' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -19737,7 +19738,7 @@
    },
    "v1.Scale": {
     "id": "v1.Scale",
-    "description": "Scale represents a scaling request for a resource.",
+    "description": "Scale represents a scaling request for a resource.\n\nDEPRECATED: Use 'autoscaling.v1.Scale' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -19763,7 +19764,7 @@
    },
    "v1.ScaleSpec": {
     "id": "v1.ScaleSpec",
-    "description": "ScaleSpec describes the attributes of a scale subresource.",
+    "description": "ScaleSpec describes the attributes of a scale subresource.\n\nDEPRECATED: Use 'autoscaling.v1.ScaleSpec' instead.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -19774,7 +19775,7 @@
    },
    "v1.ScaleStatus": {
     "id": "v1.ScaleStatus",
-    "description": "ScaleStatus represents the current status of a scale subresource.",
+    "description": "ScaleStatus represents the current status of a scale subresource.\n\nDEPRECATED: Use 'autoscaling.v1.ScaleStatus' instead.",
     "required": [
      "replicas"
     ],
@@ -19855,14 +19856,14 @@
      "scopes": {
       "type": "array",
       "items": {
-       "$ref": "v1.ResourceQuotaScope"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.ResourceQuotaScope"
       },
       "description": "A collection of filters that must match each object tracked by a quota. If not specified, the quota matches all objects."
      }
     }
    },
-   "v1.ResourceQuotaScope": {
-    "id": "v1.ResourceQuotaScope",
+   "io.k8s.kubernetes.pkg.api.v1.ResourceQuotaScope": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.ResourceQuotaScope",
     "properties": {}
    },
    "v1.ResourceQuotaStatus": {
@@ -20179,7 +20180,7 @@
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -20208,6 +20209,338 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.LabelSelector": {
+    "id": "io.k8s.meta.v1.LabelSelector",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchLabels": {
+      "type": "object",
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+     },
+     "matchExpressions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.LabelSelectorRequirement"
+      },
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed."
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelectorRequirement": {
+    "id": "io.k8s.meta.v1.LabelSelectorRequirement",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "key is the label key that the selector applies to."
+     },
+     "operator": {
+      "type": "string",
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist."
+     },
+     "values": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+     }
+    }
+   },
+   "policy.v1beta1.Eviction": {
+    "id": "policy.v1beta1.Eviction",
+    "description": "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/\u003cpod name\u003e/evictions.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "ObjectMeta describes the pod that is being evicted."
+     },
+     "deleteOptions": {
+      "$ref": "v1.DeleteOptions",
+      "description": "DeleteOptions may be provided"
+     }
+    }
+   },
+   "autoscaling.v1.Scale": {
+    "id": "autoscaling.v1.Scale",
+    "description": "Scale represents a scaling request for a resource.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata."
+     },
+     "spec": {
+      "$ref": "v1.ScaleSpec",
+      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+     },
+     "status": {
+      "$ref": "v1.ScaleStatus",
+      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only."
+     }
+    }
+   },
+   "autoscaling.v1.ScaleSpec": {
+    "id": "autoscaling.v1.ScaleSpec",
+    "description": "ScaleSpec describes the attributes of a scale subresource.",
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "desired number of instances for the scaled object."
+     }
+    }
+   },
+   "autoscaling.v1.ScaleStatus": {
+    "id": "autoscaling.v1.ScaleStatus",
+    "description": "ScaleStatus represents the current status of a scale subresource.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "actual number of observed instances of the scaled object."
+     },
+     "selector": {
+      "type": "string",
+      "description": "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/api/swagger-spec/version.json
+++ b/api/swagger-spec/version.json
@@ -31,6 +31,50 @@
   "models": {
    "version.Info": {
     "id": "version.Info",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.version.Info' instead.",
+    "required": [
+     "major",
+     "minor",
+     "gitVersion",
+     "gitCommit",
+     "gitTreeState",
+     "buildDate",
+     "goVersion",
+     "compiler",
+     "platform"
+    ],
+    "properties": {
+     "major": {
+      "type": "string"
+     },
+     "minor": {
+      "type": "string"
+     },
+     "gitVersion": {
+      "type": "string"
+     },
+     "gitCommit": {
+      "type": "string"
+     },
+     "gitTreeState": {
+      "type": "string"
+     },
+     "buildDate": {
+      "type": "string"
+     },
+     "goVersion": {
+      "type": "string"
+     },
+     "compiler": {
+      "type": "string"
+     },
+     "platform": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.version.Info": {
+    "id": "io.k8s.kubernetes.pkg.version.Info",
     "required": [
      "major",
      "minor",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -287,7 +287,7 @@ func Run(s *options.ServerRunOptions) error {
 	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(generatedopenapi.OpenAPIDefinitions)
 	genericConfig.OpenAPIConfig.SecurityDefinitions = securityDefinitions
 	genericConfig.OpenAPIConfig.Info.Title = "Kubernetes"
-	genericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
+	genericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig(generatedopenapi.OpenAPIDefinitions)
 	genericConfig.EnableMetrics = true
 	genericConfig.LongRunningFunc = filters.BasicLongRunningRequestCheck(
 		sets.NewString("watch", "proxy"),

--- a/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1/doc.go
+++ b/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1/doc.go
@@ -15,5 +15,6 @@ limitations under the License.
 */
 
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +groupName=testgroup.k8s.io
 package v1

--- a/cmd/libs/go2idl/openapi-gen/generators/openapi.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi.go
@@ -57,6 +57,14 @@ func hasOpenAPITagValue(comments []string, value string) bool {
 	return false
 }
 
+func hasGroupNameTag(comments []string) (string, bool) {
+	tagValues := types.ExtractCommentTags("+", comments)["groupName"]
+	if len(tagValues) > 0 {
+		return tagValues[0], true
+	}
+	return "", false
+}
+
 // hasOptionalTag returns true if the member has +optional in its comments or
 // omitempty in its json tags.
 func hasOptionalTag(m *types.Member) bool {
@@ -65,6 +73,54 @@ func hasOptionalTag(m *types.Member) bool {
 	hasOptionalJsonTag := strings.Contains(
 		reflect.StructTag(m.Tags).Get("json"), "omitempty")
 	return hasOptionalCommentTag || hasOptionalJsonTag
+}
+
+// openAPIPackageName returns the correct OpenAPI prefix for a type in this package
+// if the package is a public API package.
+func openAPIPackageName(pkg *types.Package) string {
+	name, ok := hasGroupNameTag(pkg.Comments)
+	if ok {
+		parts := strings.Split(name, ".")
+		for i := 0; i < len(parts)/2; i++ {
+			end := len(parts) - 1 - i
+			parts[i], parts[end] = parts[end], parts[i]
+		}
+		// assume the package is the version
+		if len(name) > 0 {
+			parts = append(parts, pkg.Name)
+		} else {
+			parts = []string{pkg.Name}
+		}
+		return strings.Join(parts, ".")
+	}
+
+	// use the last segment of package path and name
+	parts := strings.Split(pkg.Path, "/")
+	if len(parts) > 2 {
+		parts = parts[len(parts)-2:]
+	}
+	return strings.Join(parts, ".")
+}
+
+// genericOpenAPIPackageName returns a type prefix for a generic Go package that
+// matches the Java package naming style.
+func genericOpenAPIPackageName(name string) string {
+	dirs := strings.Split(name, "/")
+	// convert any segments that have dots into reverse domain notation
+	for i, s := range dirs {
+		if strings.Contains(s, ".") {
+			segments := strings.Split(s, ".")
+			for j := 0; j < len(segments)/2; j++ {
+				end := len(segments) - j - 1
+				segments[j], segments[end] = segments[end], segments[j]
+			}
+			dirs[i] = strings.Join(segments, ".")
+		}
+	}
+	name = strings.Join(dirs, ".")
+	name = strings.Replace(name, "-", "_", -1)
+	name = strings.ToLower(name)
+	return name
 }
 
 // NameSystems returns the name system used by the generators in this package.
@@ -99,13 +155,34 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 	if pkg == nil {
 		glog.Fatalf("Got nil output package: %v", err)
 	}
+
+	// identify all packages that request OpenAPI generation and assign them names
+	// based on their top two directory paths (apps/v1beta1) or their groupName +
+	// package name
+	apiNames := make(map[string]string)
+	for _, pkg := range context.Universe {
+		if hasOpenAPITagValue(pkg.Comments, tagValueTrue) {
+			name := openAPIPackageName(pkg)
+			apiNames[pkg.Path] = name
+		}
+	}
+
+	tracker := namer.NewDefaultImportTracker(types.Name{})
+	tracker.IsInvalidType = func(*types.Type) bool { return false }
+	tracker.LocalName = func(name types.Name) string {
+		if name, ok := apiNames[name.Package]; ok {
+			return name
+		}
+		return genericOpenAPIPackageName(name.Package)
+	}
+
 	return generator.Packages{
 		&generator.DefaultPackage{
 			PackageName: strings.Split(filepath.Base(pkg.Path), ".")[0],
 			PackagePath: pkg.Path,
 			HeaderText:  header,
 			GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {
-				return []generator.Generator{NewOpenAPIGen(arguments.OutputFileBaseName, pkg, context)}
+				return []generator.Generator{NewOpenAPIGen(arguments.OutputFileBaseName, pkg, context, tracker)}
 			},
 			FilterFunc: func(c *generator.Context, t *types.Type) bool {
 				// There is a conflict between this codegen and codecgen, we should avoid types generated for codecgen
@@ -134,26 +211,30 @@ const (
 type openAPIGen struct {
 	generator.DefaultGen
 	// TargetPackage is the package that will get OpenAPIDefinitions variable contains all open API definitions.
-	targetPackage *types.Package
-	imports       namer.ImportTracker
-	context       *generator.Context
+	targetPackage  *types.Package
+	imports        namer.ImportTracker
+	context        *generator.Context
+	openAPIImports namer.DefaultImportTracker
 }
 
-func NewOpenAPIGen(sanitizedName string, targetPackage *types.Package, context *generator.Context) generator.Generator {
+func NewOpenAPIGen(sanitizedName string, targetPackage *types.Package, context *generator.Context, openAPIImports namer.DefaultImportTracker) generator.Generator {
 	return &openAPIGen{
 		DefaultGen: generator.DefaultGen{
 			OptionalName: sanitizedName,
 		},
-		imports:       generator.NewImportTracker(),
-		targetPackage: targetPackage,
-		context:       context,
+		imports:        generator.NewImportTracker(),
+		targetPackage:  targetPackage,
+		context:        context,
+		openAPIImports: openAPIImports,
 	}
 }
 
 func (g *openAPIGen) Namers(c *generator.Context) namer.NameSystems {
-	// Have the raw namer for this file track what it imports.
 	return namer.NameSystems{
+		// Have the raw namer for this file track what it imports.
 		"raw": namer.NewRawNamer(g.targetPackage.Path, g.imports),
+		// Track the openapi names per file
+		"openapi": namer.NewRawNamer("", &g.openAPIImports),
 	}
 }
 
@@ -208,7 +289,7 @@ func (g *openAPIGen) Finalize(c *generator.Context, w io.Writer) error {
 func (g *openAPIGen) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
 	glog.V(5).Infof("generating for type %v", t)
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
-	err := newOpenAPITypeWriter(sw).generate(t)
+	err := newOpenAPITypeWriter(sw, c).generate(t)
 	if err != nil {
 		return err
 	}
@@ -240,12 +321,14 @@ type openAPITypeWriter struct {
 	*generator.SnippetWriter
 	refTypes               map[string]*types.Type
 	GetDefinitionInterface *types.Type
+	context                *generator.Context
 }
 
-func newOpenAPITypeWriter(sw *generator.SnippetWriter) openAPITypeWriter {
+func newOpenAPITypeWriter(sw *generator.SnippetWriter, c *generator.Context) openAPITypeWriter {
 	return openAPITypeWriter{
 		SnippetWriter: sw,
 		refTypes:      map[string]*types.Type{},
+		context:       c,
 	}
 }
 
@@ -266,17 +349,12 @@ func hasOpenAPIDefinitionMethod(t *types.Type) bool {
 	return false
 }
 
-// typeShortName returns short package name (e.g. the name x appears in package x definition) dot type name.
-func typeShortName(t *types.Type) string {
-	return filepath.Base(t.Name.Package) + "." + t.Name.Name
-}
-
 func (g openAPITypeWriter) generate(t *types.Type) error {
 	// Only generate for struct type and ignore the rest
 	switch t.Kind {
 	case types.Struct:
 		args := argsFromType(t)
-		g.Do("\"$.$\": ", typeShortName(t))
+		g.Do("\"$.|openapi$\": ", t)
 		if hasOpenAPIDefinitionMethod(t) {
 			g.Do("$.type|raw${}.OpenAPIDefinition(),", args)
 			return nil
@@ -304,7 +382,11 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		if len(required) > 0 {
 			g.Do("Required: []string{\"$.$\"},\n", strings.Join(required, "\",\""))
 		}
+		g.Do("},\n", nil)
+		g.Do("VendorExtensible: spec.VendorExtensible{\nExtensions: spec.Extensions{\n", nil)
+		g.Do("\"io.k8s.kubernetes.openapi.type.golang\": \"$.$\",\n", t.Name)
 		g.Do("},\n},\n", nil)
+		g.Do("},\n", nil)
 		g.Do("Dependencies: []string{\n", args)
 		// Map order is undefined, sort them or we may get a different file generated each time.
 		keys := []string{}
@@ -417,14 +499,9 @@ func (g openAPITypeWriter) generateSimpleProperty(typeString, format string) {
 }
 
 func (g openAPITypeWriter) generateReferenceProperty(t *types.Type) {
-	var name string
-	if t.Name.Package == "" {
-		name = t.Name.Name
-	} else {
-		name = filepath.Base(t.Name.Package) + "." + t.Name.Name
-	}
+	name := g.context.Namers["openapi"].Name(t)
 	g.refTypes[name] = t
-	g.Do("Ref: spec.MustCreateRef(\"#/definitions/$.$\"),\n", name)
+	g.Do("Ref: spec.MustCreateRef(\"#/definitions/$.|openapi$\"),\n", t)
 }
 
 func resolveAliasAndPtrType(t *types.Type) *types.Type {

--- a/cmd/libs/go2idl/openapi-gen/generators/openapi.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi.go
@@ -40,8 +40,9 @@ const tagOptional = "optional"
 
 // Known values for the tag.
 const (
-	tagValueTrue  = "true"
-	tagValueFalse = "false"
+	tagValueTrue       = "true"
+	tagValueFalse      = "false"
+	tagValueLegacyName = "legacy-name"
 )
 
 func hasOpenAPITagValue(comments []string, value string) bool {
@@ -215,6 +216,7 @@ type openAPIGen struct {
 	imports        namer.ImportTracker
 	context        *generator.Context
 	openAPIImports namer.DefaultImportTracker
+	useLegacyNames bool
 }
 
 func NewOpenAPIGen(sanitizedName string, targetPackage *types.Package, context *generator.Context, openAPIImports namer.DefaultImportTracker) generator.Generator {
@@ -349,62 +351,90 @@ func hasOpenAPIDefinitionMethod(t *types.Type) bool {
 	return false
 }
 
+// typeLegacyName returns short package name (e.g. the name x appears in package x definition) dot type name.
+// This naming style is not sufficiently unique and is deprecated - existing types may request it by adding
+// a type or package comment '+k8s:openapi-gen=legacy-name'
+func typeLegacyName(t *types.Type) string {
+	return filepath.Base(t.Name.Package) + "." + t.Name.Name
+}
+
 func (g openAPITypeWriter) generate(t *types.Type) error {
 	// Only generate for struct type and ignore the rest
 	switch t.Kind {
 	case types.Struct:
-		args := argsFromType(t)
 		g.Do("\"$.|openapi$\": ", t)
-		if hasOpenAPIDefinitionMethod(t) {
-			g.Do("$.type|raw${}.OpenAPIDefinition(),", args)
-			return nil
+		if err := g.generateStructInitializer(t, ""); err != nil {
+			return err
 		}
-		g.Do("{\nSchema: spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)
-		g.generateDescription(t.CommentLines)
-		g.Do("Properties: map[string]$.SpecSchemaType|raw${\n", args)
-		required := []string{}
-		for _, m := range t.Members {
-			if hasOpenAPITagValue(m.CommentLines, tagValueFalse) {
-				continue
-			}
-			name := getReferableName(&m)
-			if name == "" {
-				continue
-			}
-			if !hasOptionalTag(&m) {
-				required = append(required, name)
-			}
-			if err := g.generateProperty(&m); err != nil {
+		g.Do(",\n", nil)
+
+		// for backwards compatibility, register certain types under their old names
+		useLegacyName := hasOpenAPITagValue(g.context.Universe[t.Name.Package].Comments, tagValueLegacyName) || hasOpenAPITagValue(t.CommentLines, tagValueLegacyName)
+		if typeLegacyName(t) != g.context.Namers["openapi"].Name(t) && useLegacyName {
+			g.Do("\"$.$\": ", typeLegacyName(t))
+			if err := g.generateStructInitializer(t, g.context.Namers["openapi"].Name(t)); err != nil {
 				return err
 			}
+			g.Do(",\n", nil)
 		}
-		g.Do("},\n", nil)
-		if len(required) > 0 {
-			g.Do("Required: []string{\"$.$\"},\n", strings.Join(required, "\",\""))
-		}
-		g.Do("},\n", nil)
-		g.Do("VendorExtensible: spec.VendorExtensible{\nExtensions: spec.Extensions{\n", nil)
-		g.Do("\"io.k8s.kubernetes.openapi.type.golang\": \"$.$\",\n", t.Name)
-		g.Do("},\n},\n", nil)
-		g.Do("},\n", nil)
-		g.Do("Dependencies: []string{\n", args)
-		// Map order is undefined, sort them or we may get a different file generated each time.
-		keys := []string{}
-		for k := range g.refTypes {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, k := range keys {
-			v := g.refTypes[k]
-			if t, _ := common.GetOpenAPITypeFormat(v.String()); t != "" {
-				// This is a known type, we do not need a reference to it
-				// Will eliminate special case of time.Time
-				continue
-			}
-			g.Do("\"$.$\",", k)
-		}
-		g.Do("},\n},\n", nil)
 	}
+	return nil
+}
+
+func (g openAPITypeWriter) generateStructInitializer(t *types.Type, deprecatedBy string) error {
+	args := argsFromType(t)
+	if hasOpenAPIDefinitionMethod(t) {
+		g.Do("$.type|raw${}.OpenAPIDefinition()", args)
+		return nil
+	}
+	g.Do("{\nSchema: spec.Schema{\nSchemaProps: spec.SchemaProps{\n", nil)
+	g.generateDescription(t.CommentLines)
+	g.Do("Properties: map[string]$.SpecSchemaType|raw${\n", args)
+	required := []string{}
+	for _, m := range t.Members {
+		if hasOpenAPITagValue(m.CommentLines, tagValueFalse) {
+			continue
+		}
+		name := getReferableName(&m)
+		if name == "" {
+			continue
+		}
+		if !hasOptionalTag(&m) {
+			required = append(required, name)
+		}
+		if err := g.generateProperty(&m); err != nil {
+			return err
+		}
+	}
+	g.Do("},\n", nil)
+	if len(required) > 0 {
+		g.Do("Required: []string{\"$.$\"},\n", strings.Join(required, "\",\""))
+	}
+	g.Do("},\n", nil)
+	g.Do("VendorExtensible: spec.VendorExtensible{\nExtensions: spec.Extensions{\n", nil)
+	g.Do("\"io.k8s.kubernetes.openapi.type.golang\": \"$.$\",\n", t.Name)
+	if len(deprecatedBy) > 0 {
+		g.Do("\"io.k8s.kubernetes.openapi.type.deprecated.use\": \"$.$\",\n", deprecatedBy)
+	}
+	g.Do("},\n},\n", nil)
+	g.Do("},\n", nil)
+	g.Do("Dependencies: []string{\n", args)
+	// Map order is undefined, sort them or we may get a different file generated each time.
+	keys := []string{}
+	for k := range g.refTypes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := g.refTypes[k]
+		if t, _ := common.GetOpenAPITypeFormat(v.String()); t != "" {
+			// This is a known type, we do not need a reference to it
+			// Will eliminate special case of time.Time
+			continue
+		}
+		g.Do("\"$.$\",", k)
+	}
+	g.Do("},\n}", nil)
 	return nil
 }
 

--- a/cmd/libs/go2idl/openapi-gen/generators/openapi_test.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi_test.go
@@ -53,7 +53,8 @@ func testOpenAPITypeWritter(t *testing.T, code string) (error, *assert.Assertion
 	}
 	rawNamer := namer.NewRawNamer("o", nil)
 	namers := namer.NameSystems{
-		"raw": namer.NewRawNamer("", nil),
+		"raw":     namer.NewRawNamer("", nil),
+		"openapi": rawNamer,
 	}
 	builder, universe, _ := construct(t, testFiles, rawNamer)
 	context, err := generator.NewContext(builder, namers, "raw")
@@ -63,7 +64,7 @@ func testOpenAPITypeWritter(t *testing.T, code string) (error, *assert.Assertion
 	buffer := &bytes.Buffer{}
 	sw := generator.NewSnippetWriter(buffer, context, "$", "$")
 	blahT := universe.Type(types.Name{Package: "base/foo", Name: "Blah"})
-	return newOpenAPITypeWriter(sw).generate(blahT), assert, buffer
+	return newOpenAPITypeWriter(sw, context).generate(blahT), assert, buffer
 }
 
 func TestSimple(t *testing.T) {
@@ -225,6 +226,11 @@ Format: "byte",
 },
 Required: []string{"String","Int64","Int32","Int16","Int8","Uint","Uint64","Uint32","Uint16","Uint8","Byte","Bool","Float64","Float32","ByteArray"},
 },
+VendorExtensible: spec.VendorExtensible{
+Extensions: spec.Extensions{
+"io.k8s.kubernetes.openapi.type.golang": "base/foo.Blah",
+},
+},
 },
 Dependencies: []string{
 },
@@ -328,6 +334,11 @@ Format: "",
 },
 },
 Required: []string{"StringPointer","StructPointer","SlicePointer","MapPointer"},
+},
+VendorExtensible: spec.VendorExtensible{
+Extensions: spec.Extensions{
+"io.k8s.kubernetes.openapi.type.golang": "base/foo.Blah",
+},
 },
 },
 Dependencies: []string{

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -113,7 +113,7 @@ func (serverOptions *ServerRunOptions) Run(stopCh <-chan struct{}) error {
 	}
 
 	config.Authorizer = authorizer.NewAlwaysAllowAuthorizer()
-	config.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
+	config.SwaggerConfig = genericapiserver.DefaultSwaggerConfig(nil)
 
 	s, err := config.Complete().New()
 	if err != nil {

--- a/federation/apis/federation/v1beta1/doc.go
+++ b/federation/apis/federation/v1beta1/doc.go
@@ -17,5 +17,6 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/federation/apis/federation
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 package v1beta1 // import "k8s.io/kubernetes/federation/apis/federation/v1beta1"

--- a/federation/apis/swagger-spec/api.json
+++ b/federation/apis/swagger-spec/api.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIVersions": {
     "id": "v1.APIVersions",
-    "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
+    "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIVersions' instead.",
     "required": [
      "versions",
      "serverAddressByClientCIDRs"
@@ -67,6 +67,56 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIVersions": {
+    "id": "io.k8s.meta.v1.APIVersions",
+    "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
+    "required": [
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "versions are the api versions that are available."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/federation/apis/swagger-spec/apis.json
+++ b/federation/apis/swagger-spec/apis.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroupList": {
     "id": "v1.APIGroupList",
-    "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+    "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroupList' instead.",
     "required": [
      "groups"
     ],
@@ -59,7 +59,7 @@
    },
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -100,7 +100,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -118,6 +118,107 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroupList": {
+    "id": "io.k8s.meta.v1.APIGroupList",
+    "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+    "required": [
+     "groups"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groups": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIGroup"
+      },
+      "description": "groups is a list of APIGroup."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/federation/apis/swagger-spec/extensions.json
+++ b/federation/apis/swagger-spec/extensions.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/federation/apis/swagger-spec/extensions_v1beta1.json
+++ b/federation/apis/swagger-spec/extensions_v1beta1.json
@@ -108,7 +108,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.DaemonSet",
+        "type": "extensions.v1beta1.DaemonSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -390,7 +390,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.DaemonSet",
+        "type": "extensions.v1beta1.DaemonSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -445,7 +445,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -879,7 +879,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.DaemonSet",
+        "type": "extensions.v1beta1.DaemonSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -934,7 +934,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1078,7 +1078,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Deployment",
+        "type": "extensions.v1beta1.Deployment",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1360,7 +1360,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Deployment",
+        "type": "extensions.v1beta1.Deployment",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1415,7 +1415,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1802,7 +1802,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.DeploymentRollback",
+        "type": "extensions.v1beta1.DeploymentRollback",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1910,7 +1910,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Scale",
+        "type": "extensions.v1beta1.Scale",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1965,7 +1965,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2075,7 +2075,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Deployment",
+        "type": "extensions.v1beta1.Deployment",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2130,7 +2130,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2274,7 +2274,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Ingress",
+        "type": "extensions.v1beta1.Ingress",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2556,7 +2556,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Ingress",
+        "type": "extensions.v1beta1.Ingress",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2611,7 +2611,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3045,7 +3045,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Ingress",
+        "type": "extensions.v1beta1.Ingress",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3100,7 +3100,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3244,7 +3244,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.ReplicaSet",
+        "type": "extensions.v1beta1.ReplicaSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3526,7 +3526,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.ReplicaSet",
+        "type": "extensions.v1beta1.ReplicaSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3581,7 +3581,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4015,7 +4015,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Scale",
+        "type": "extensions.v1beta1.Scale",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4070,7 +4070,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4180,7 +4180,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.ReplicaSet",
+        "type": "extensions.v1beta1.ReplicaSet",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4235,7 +4235,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4306,7 +4306,7 @@
   "models": {
    "v1beta1.DaemonSetList": {
     "id": "v1beta1.DaemonSetList",
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "DaemonSetList is a collection of daemon sets.\n\nDEPRECATED: Use 'extensions.v1beta1.DaemonSetList' instead.",
     "required": [
      "items"
     ],
@@ -4334,7 +4334,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -4348,7 +4348,7 @@
    },
    "v1beta1.DaemonSet": {
     "id": "v1beta1.DaemonSet",
-    "description": "DaemonSet represents the configuration of a daemon set.",
+    "description": "DaemonSet represents the configuration of a daemon set.\n\nDEPRECATED: Use 'extensions.v1beta1.DaemonSet' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -4448,7 +4448,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -4480,7 +4480,7 @@
    },
    "v1beta1.DaemonSetSpec": {
     "id": "v1beta1.DaemonSetSpec",
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "DaemonSetSpec is the specification of a daemon set.\n\nDEPRECATED: Use 'extensions.v1beta1.DaemonSetSpec' instead.",
     "required": [
      "template"
     ],
@@ -4497,7 +4497,7 @@
    },
    "v1.LabelSelector": {
     "id": "v1.LabelSelector",
-    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelector' instead.",
     "properties": {
      "matchLabels": {
       "type": "object",
@@ -4514,7 +4514,7 @@
    },
    "v1.LabelSelectorRequirement": {
     "id": "v1.LabelSelectorRequirement",
-    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.\n\nDEPRECATED: Use 'io.k8s.meta.v1.LabelSelectorRequirement' instead.",
     "required": [
      "key",
      "operator"
@@ -5361,7 +5361,7 @@
       "description": "The URI the data disk in the blob storage"
      },
      "cachingMode": {
-      "$ref": "v1.AzureDataDiskCachingMode",
+      "$ref": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
       "description": "Host Caching mode: None, Read Only, Read Write."
      },
      "fsType": {
@@ -5374,8 +5374,8 @@
      }
     }
    },
-   "v1.AzureDataDiskCachingMode": {
-    "id": "v1.AzureDataDiskCachingMode",
+   "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.AzureDataDiskCachingMode",
     "properties": {}
    },
    "v1.PhotonPersistentDiskVolumeSource": {
@@ -5434,6 +5434,13 @@
        "$ref": "v1.ContainerPort"
       },
       "description": "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated."
+     },
+     "envFrom": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.EnvFromSource"
+      },
+      "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. An invalid key will prevent the container from starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated."
      },
      "env": {
       "type": "array",
@@ -5519,6 +5526,30 @@
      "hostIP": {
       "type": "string",
       "description": "What host IP to bind the external port to."
+     }
+    }
+   },
+   "v1.EnvFromSource": {
+    "id": "v1.EnvFromSource",
+    "description": "EnvFromSource represents the source of a set of ConfigMaps",
+    "properties": {
+     "prefix": {
+      "type": "string",
+      "description": "An optional identifer to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER."
+     },
+     "configMapRef": {
+      "$ref": "v1.ConfigMapEnvSource",
+      "description": "The ConfigMap to select from"
+     }
+    }
+   },
+   "v1.ConfigMapEnvSource": {
+    "id": "v1.ConfigMapEnvSource",
+    "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
      }
     }
    },
@@ -5828,21 +5859,21 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.Capability"
       },
       "description": "Removed capabilities"
      }
     }
    },
-   "v1.Capability": {
-    "id": "v1.Capability",
+   "io.k8s.kubernetes.pkg.api.v1.Capability": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.Capability",
     "properties": {}
    },
    "v1.SELinuxOptions": {
@@ -6094,7 +6125,7 @@
    },
    "v1beta1.DaemonSetStatus": {
     "id": "v1beta1.DaemonSetStatus",
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "DaemonSetStatus represents the current status of a daemon set.\n\nDEPRECATED: Use 'extensions.v1beta1.DaemonSetStatus' instead.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -6121,12 +6152,17 @@
       "type": "integer",
       "format": "int32",
       "description": "NumberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready."
+     },
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "ObservedGeneration is the most recent generation observed by the daemon set controller."
      }
     }
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -6165,7 +6201,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -6195,7 +6231,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -6213,6 +6249,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -6228,7 +6265,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -6263,18 +6300,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1beta1.DeploymentList": {
     "id": "v1beta1.DeploymentList",
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "DeploymentList is a list of Deployments.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentList' instead.",
     "required": [
      "items"
     ],
@@ -6302,7 +6339,7 @@
    },
    "v1beta1.Deployment": {
     "id": "v1beta1.Deployment",
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "Deployment enables declarative updates for Pods and ReplicaSets.\n\nDEPRECATED: Use 'extensions.v1beta1.Deployment' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -6328,7 +6365,7 @@
    },
    "v1beta1.DeploymentSpec": {
     "id": "v1beta1.DeploymentSpec",
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentSpec' instead.",
     "required": [
      "template"
     ],
@@ -6377,7 +6414,7 @@
    },
    "v1beta1.DeploymentStrategy": {
     "id": "v1beta1.DeploymentStrategy",
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DeploymentStrategy describes how to replace existing pods with new ones.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentStrategy' instead.",
     "properties": {
      "type": {
       "type": "string",
@@ -6391,7 +6428,7 @@
    },
    "v1beta1.RollingUpdateDeployment": {
     "id": "v1beta1.RollingUpdateDeployment",
-    "description": "Spec to control the desired behavior of rolling update.",
+    "description": "Spec to control the desired behavior of rolling update.\n\nDEPRECATED: Use 'extensions.v1beta1.RollingUpdateDeployment' instead.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -6405,6 +6442,7 @@
    },
    "v1beta1.RollbackConfig": {
     "id": "v1beta1.RollbackConfig",
+    "description": "\n\nDEPRECATED: Use 'extensions.v1beta1.RollbackConfig' instead.",
     "properties": {
      "revision": {
       "type": "integer",
@@ -6415,7 +6453,7 @@
    },
    "v1beta1.DeploymentStatus": {
     "id": "v1beta1.DeploymentStatus",
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DeploymentStatus is the most recently observed status of the Deployment.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentStatus' instead.",
     "properties": {
      "observedGeneration": {
       "type": "integer",
@@ -6431,6 +6469,11 @@
       "type": "integer",
       "format": "int32",
       "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec."
+     },
+     "readyReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of ready pods targeted by this deployment."
      },
      "availableReplicas": {
       "type": "integer",
@@ -6453,7 +6496,7 @@
    },
    "v1beta1.DeploymentCondition": {
     "id": "v1beta1.DeploymentCondition",
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DeploymentCondition describes the state of a deployment at a certain point.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentCondition' instead.",
     "required": [
      "type",
      "status"
@@ -6487,7 +6530,7 @@
    },
    "v1beta1.DeploymentRollback": {
     "id": "v1beta1.DeploymentRollback",
-    "description": "DeploymentRollback stores the information required to rollback a deployment.",
+    "description": "DeploymentRollback stores the information required to rollback a deployment.\n\nDEPRECATED: Use 'extensions.v1beta1.DeploymentRollback' instead.",
     "required": [
      "name",
      "rollbackTo"
@@ -6517,7 +6560,7 @@
    },
    "v1beta1.Scale": {
     "id": "v1beta1.Scale",
-    "description": "represents a scaling request for a resource.",
+    "description": "represents a scaling request for a resource.\n\nDEPRECATED: Use 'extensions.v1beta1.Scale' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -6543,7 +6586,7 @@
    },
    "v1beta1.ScaleSpec": {
     "id": "v1beta1.ScaleSpec",
-    "description": "describes the attributes of a scale subresource",
+    "description": "describes the attributes of a scale subresource\n\nDEPRECATED: Use 'extensions.v1beta1.ScaleSpec' instead.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -6554,7 +6597,7 @@
    },
    "v1beta1.ScaleStatus": {
     "id": "v1beta1.ScaleStatus",
-    "description": "represents the current status of a scale subresource.",
+    "description": "represents the current status of a scale subresource.\n\nDEPRECATED: Use 'extensions.v1beta1.ScaleStatus' instead.",
     "required": [
      "replicas"
     ],
@@ -6576,7 +6619,7 @@
    },
    "v1beta1.IngressList": {
     "id": "v1beta1.IngressList",
-    "description": "IngressList is a collection of Ingress.",
+    "description": "IngressList is a collection of Ingress.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressList' instead.",
     "required": [
      "items"
     ],
@@ -6604,7 +6647,7 @@
    },
    "v1beta1.Ingress": {
     "id": "v1beta1.Ingress",
-    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.\n\nDEPRECATED: Use 'extensions.v1beta1.Ingress' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -6630,7 +6673,7 @@
    },
    "v1beta1.IngressSpec": {
     "id": "v1beta1.IngressSpec",
-    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "description": "IngressSpec describes the Ingress the user wishes to exist.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressSpec' instead.",
     "properties": {
      "backend": {
       "$ref": "v1beta1.IngressBackend",
@@ -6654,7 +6697,7 @@
    },
    "v1beta1.IngressBackend": {
     "id": "v1beta1.IngressBackend",
-    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "description": "IngressBackend describes all endpoints for a given service and port.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressBackend' instead.",
     "required": [
      "serviceName",
      "servicePort"
@@ -6672,7 +6715,7 @@
    },
    "v1beta1.IngressTLS": {
     "id": "v1beta1.IngressTLS",
-    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "description": "IngressTLS describes the transport layer security associated with an Ingress.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressTLS' instead.",
     "properties": {
      "hosts": {
       "type": "array",
@@ -6689,7 +6732,7 @@
    },
    "v1beta1.IngressRule": {
     "id": "v1beta1.IngressRule",
-    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressRule' instead.",
     "properties": {
      "host": {
       "type": "string",
@@ -6702,7 +6745,7 @@
    },
    "v1beta1.HTTPIngressRuleValue": {
     "id": "v1beta1.HTTPIngressRuleValue",
-    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.\n\nDEPRECATED: Use 'extensions.v1beta1.HTTPIngressRuleValue' instead.",
     "required": [
      "paths"
     ],
@@ -6718,7 +6761,7 @@
    },
    "v1beta1.HTTPIngressPath": {
     "id": "v1beta1.HTTPIngressPath",
-    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.\n\nDEPRECATED: Use 'extensions.v1beta1.HTTPIngressPath' instead.",
     "required": [
      "backend"
     ],
@@ -6735,7 +6778,7 @@
    },
    "v1beta1.IngressStatus": {
     "id": "v1beta1.IngressStatus",
-    "description": "IngressStatus describe the current state of the Ingress.",
+    "description": "IngressStatus describe the current state of the Ingress.\n\nDEPRECATED: Use 'extensions.v1beta1.IngressStatus' instead.",
     "properties": {
      "loadBalancer": {
       "$ref": "v1.LoadBalancerStatus",
@@ -6772,7 +6815,7 @@
    },
    "v1beta1.ReplicaSetList": {
     "id": "v1beta1.ReplicaSetList",
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "ReplicaSetList is a collection of ReplicaSets.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSetList' instead.",
     "required": [
      "items"
     ],
@@ -6800,7 +6843,7 @@
    },
    "v1beta1.ReplicaSet": {
     "id": "v1beta1.ReplicaSet",
-    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "description": "ReplicaSet represents the configuration of a ReplicaSet.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSet' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -6826,7 +6869,7 @@
    },
    "v1beta1.ReplicaSetSpec": {
     "id": "v1beta1.ReplicaSetSpec",
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "ReplicaSetSpec is the specification of a ReplicaSet.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSetSpec' instead.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -6850,7 +6893,7 @@
    },
    "v1beta1.ReplicaSetStatus": {
     "id": "v1beta1.ReplicaSetStatus",
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSetStatus' instead.",
     "required": [
      "replicas"
     ],
@@ -6891,7 +6934,7 @@
    },
    "v1beta1.ReplicaSetCondition": {
     "id": "v1beta1.ReplicaSetCondition",
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.\n\nDEPRECATED: Use 'extensions.v1beta1.ReplicaSetCondition' instead.",
     "required": [
      "type",
      "status"
@@ -6921,7 +6964,7 @@
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -6950,6 +6993,994 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetList": {
+    "id": "extensions.v1beta1.DaemonSetList",
+    "description": "DaemonSetList is a collection of daemon sets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.DaemonSet"
+      },
+      "description": "Items is a list of daemon sets."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSet": {
+    "id": "extensions.v1beta1.DaemonSet",
+    "description": "DaemonSet represents the configuration of a daemon set.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.DaemonSetSpec",
+      "description": "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "status": {
+      "$ref": "v1beta1.DaemonSetStatus",
+      "description": "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetSpec": {
+    "id": "extensions.v1beta1.DaemonSetSpec",
+    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     },
+     "template": {
+      "$ref": "v1.PodTemplateSpec",
+      "description": "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template"
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelector": {
+    "id": "io.k8s.meta.v1.LabelSelector",
+    "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "properties": {
+     "matchLabels": {
+      "type": "object",
+      "description": "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed."
+     },
+     "matchExpressions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.LabelSelectorRequirement"
+      },
+      "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed."
+     }
+    }
+   },
+   "io.k8s.meta.v1.LabelSelectorRequirement": {
+    "id": "io.k8s.meta.v1.LabelSelectorRequirement",
+    "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "required": [
+     "key",
+     "operator"
+    ],
+    "properties": {
+     "key": {
+      "type": "string",
+      "description": "key is the label key that the selector applies to."
+     },
+     "operator": {
+      "type": "string",
+      "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist."
+     },
+     "values": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch."
+     }
+    }
+   },
+   "extensions.v1beta1.DaemonSetStatus": {
+    "id": "extensions.v1beta1.DaemonSetStatus",
+    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "required": [
+     "currentNumberScheduled",
+     "numberMisscheduled",
+     "desiredNumberScheduled",
+     "numberReady"
+    ],
+    "properties": {
+     "currentNumberScheduled": {
+      "type": "integer",
+      "format": "int32",
+      "description": "CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+     },
+     "numberMisscheduled": {
+      "type": "integer",
+      "format": "int32",
+      "description": "NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+     },
+     "desiredNumberScheduled": {
+      "type": "integer",
+      "format": "int32",
+      "description": "DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md"
+     },
+     "numberReady": {
+      "type": "integer",
+      "format": "int32",
+      "description": "NumberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready."
+     },
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "ObservedGeneration is the most recent generation observed by the daemon set controller."
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "extensions.v1beta1.DeploymentList": {
+    "id": "extensions.v1beta1.DeploymentList",
+    "description": "DeploymentList is a list of Deployments.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata."
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.Deployment"
+      },
+      "description": "Items is the list of Deployments."
+     }
+    }
+   },
+   "extensions.v1beta1.Deployment": {
+    "id": "extensions.v1beta1.Deployment",
+    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata."
+     },
+     "spec": {
+      "$ref": "v1beta1.DeploymentSpec",
+      "description": "Specification of the desired behavior of the Deployment."
+     },
+     "status": {
+      "$ref": "v1beta1.DeploymentStatus",
+      "description": "Most recently observed status of the Deployment."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentSpec": {
+    "id": "extensions.v1beta1.DeploymentSpec",
+    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "required": [
+     "template"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1."
+     },
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment."
+     },
+     "template": {
+      "$ref": "v1.PodTemplateSpec",
+      "description": "Template describes the pods that will be created."
+     },
+     "strategy": {
+      "$ref": "v1beta1.DeploymentStrategy",
+      "description": "The deployment strategy to use to replace existing pods with new ones."
+     },
+     "minReadySeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)"
+     },
+     "revisionHistoryLimit": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified."
+     },
+     "paused": {
+      "type": "boolean",
+      "description": "Indicates that the deployment is paused and will not be processed by the deployment controller."
+     },
+     "rollbackTo": {
+      "$ref": "v1beta1.RollbackConfig",
+      "description": "The config this deployment is rolling back to. Will be cleared after rollback is done."
+     },
+     "progressDeadlineSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. This is not set by default."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentStrategy": {
+    "id": "extensions.v1beta1.DeploymentStrategy",
+    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate."
+     },
+     "rollingUpdate": {
+      "$ref": "v1beta1.RollingUpdateDeployment",
+      "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate."
+     }
+    }
+   },
+   "extensions.v1beta1.RollingUpdateDeployment": {
+    "id": "extensions.v1beta1.RollingUpdateDeployment",
+    "description": "Spec to control the desired behavior of rolling update.",
+    "properties": {
+     "maxUnavailable": {
+      "type": "string",
+      "description": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods."
+     },
+     "maxSurge": {
+      "type": "string",
+      "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods."
+     }
+    }
+   },
+   "extensions.v1beta1.RollbackConfig": {
+    "id": "extensions.v1beta1.RollbackConfig",
+    "properties": {
+     "revision": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The revision to rollback to. If set to 0, rollbck to the last revision."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentStatus": {
+    "id": "extensions.v1beta1.DeploymentStatus",
+    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "properties": {
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The generation observed by the deployment controller."
+     },
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of non-terminated pods targeted by this deployment (their labels match the selector)."
+     },
+     "updatedReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of non-terminated pods targeted by this deployment that have the desired template spec."
+     },
+     "readyReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of ready pods targeted by this deployment."
+     },
+     "availableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment."
+     },
+     "unavailableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Total number of unavailable pods targeted by this deployment."
+     },
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.DeploymentCondition"
+      },
+      "description": "Represents the latest available observations of a deployment's current state."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentCondition": {
+    "id": "extensions.v1beta1.DeploymentCondition",
+    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of deployment condition."
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the condition, one of True, False, Unknown."
+     },
+     "lastUpdateTime": {
+      "type": "string",
+      "description": "The last time this condition was updated."
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "description": "Last time the condition transitioned from one status to another."
+     },
+     "reason": {
+      "type": "string",
+      "description": "The reason for the condition's last transition."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human readable message indicating details about the transition."
+     }
+    }
+   },
+   "extensions.v1beta1.DeploymentRollback": {
+    "id": "extensions.v1beta1.DeploymentRollback",
+    "description": "DeploymentRollback stores the information required to rollback a deployment.",
+    "required": [
+     "name",
+     "rollbackTo"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "Required: This must match the Name of a deployment."
+     },
+     "updatedAnnotations": {
+      "type": "object",
+      "description": "The annotations to be updated to a deployment"
+     },
+     "rollbackTo": {
+      "$ref": "v1beta1.RollbackConfig",
+      "description": "The config of this deployment rollback."
+     }
+    }
+   },
+   "extensions.v1beta1.Scale": {
+    "id": "extensions.v1beta1.Scale",
+    "description": "represents a scaling request for a resource.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata."
+     },
+     "spec": {
+      "$ref": "v1beta1.ScaleSpec",
+      "description": "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status."
+     },
+     "status": {
+      "$ref": "v1beta1.ScaleStatus",
+      "description": "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only."
+     }
+    }
+   },
+   "extensions.v1beta1.ScaleSpec": {
+    "id": "extensions.v1beta1.ScaleSpec",
+    "description": "describes the attributes of a scale subresource",
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "desired number of instances for the scaled object."
+     }
+    }
+   },
+   "extensions.v1beta1.ScaleStatus": {
+    "id": "extensions.v1beta1.ScaleStatus",
+    "description": "represents the current status of a scale subresource.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "actual number of observed instances of the scaled object."
+     },
+     "selector": {
+      "type": "object",
+      "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     },
+     "targetSelector": {
+      "type": "string",
+      "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     }
+    }
+   },
+   "extensions.v1beta1.IngressList": {
+    "id": "extensions.v1beta1.IngressList",
+    "description": "IngressList is a collection of Ingress.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.Ingress"
+      },
+      "description": "Items is the list of Ingress."
+     }
+    }
+   },
+   "extensions.v1beta1.Ingress": {
+    "id": "extensions.v1beta1.Ingress",
+    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.IngressSpec",
+      "description": "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "status": {
+      "$ref": "v1beta1.IngressStatus",
+      "description": "Status is the current state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     }
+    }
+   },
+   "extensions.v1beta1.IngressSpec": {
+    "id": "extensions.v1beta1.IngressSpec",
+    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "properties": {
+     "backend": {
+      "$ref": "v1beta1.IngressBackend",
+      "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default."
+     },
+     "tls": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.IngressTLS"
+      },
+      "description": "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI."
+     },
+     "rules": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.IngressRule"
+      },
+      "description": "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressBackend": {
+    "id": "extensions.v1beta1.IngressBackend",
+    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "required": [
+     "serviceName",
+     "servicePort"
+    ],
+    "properties": {
+     "serviceName": {
+      "type": "string",
+      "description": "Specifies the name of the referenced service."
+     },
+     "servicePort": {
+      "type": "string",
+      "description": "Specifies the port of the referenced service."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressTLS": {
+    "id": "extensions.v1beta1.IngressTLS",
+    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "properties": {
+     "hosts": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified."
+     },
+     "secretName": {
+      "type": "string",
+      "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressRule": {
+    "id": "extensions.v1beta1.IngressRule",
+    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "properties": {
+     "host": {
+      "type": "string",
+      "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue."
+     },
+     "http": {
+      "$ref": "v1beta1.HTTPIngressRuleValue"
+     }
+    }
+   },
+   "extensions.v1beta1.HTTPIngressRuleValue": {
+    "id": "extensions.v1beta1.HTTPIngressRuleValue",
+    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "required": [
+     "paths"
+    ],
+    "properties": {
+     "paths": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.HTTPIngressPath"
+      },
+      "description": "A collection of paths that map requests to backends."
+     }
+    }
+   },
+   "extensions.v1beta1.HTTPIngressPath": {
+    "id": "extensions.v1beta1.HTTPIngressPath",
+    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "required": [
+     "backend"
+    ],
+    "properties": {
+     "path": {
+      "type": "string",
+      "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend."
+     },
+     "backend": {
+      "$ref": "v1beta1.IngressBackend",
+      "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to."
+     }
+    }
+   },
+   "extensions.v1beta1.IngressStatus": {
+    "id": "extensions.v1beta1.IngressStatus",
+    "description": "IngressStatus describe the current state of the Ingress.",
+    "properties": {
+     "loadBalancer": {
+      "$ref": "v1.LoadBalancerStatus",
+      "description": "LoadBalancer contains the current status of the load-balancer."
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetList": {
+    "id": "extensions.v1beta1.ReplicaSetList",
+    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.ReplicaSet"
+      },
+      "description": "List of ReplicaSets. More info: http://kubernetes.io/docs/user-guide/replication-controller"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSet": {
+    "id": "extensions.v1beta1.ReplicaSet",
+    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.ReplicaSetSpec",
+      "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "status": {
+      "$ref": "v1beta1.ReplicaSetStatus",
+      "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetSpec": {
+    "id": "extensions.v1beta1.ReplicaSetSpec",
+    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller"
+     },
+     "minReadySeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)"
+     },
+     "selector": {
+      "$ref": "v1.LabelSelector",
+      "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+     },
+     "template": {
+      "$ref": "v1.PodTemplateSpec",
+      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template"
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetStatus": {
+    "id": "extensions.v1beta1.ReplicaSetStatus",
+    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "required": [
+     "replicas"
+    ],
+    "properties": {
+     "replicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Replicas is the most recently oberved number of replicas. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller"
+     },
+     "fullyLabeledReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of pods that have labels matching the labels of the pod template of the replicaset."
+     },
+     "readyReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of ready replicas for this replica set."
+     },
+     "availableReplicas": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of available replicas (ready for at least minReadySeconds) for this replica set."
+     },
+     "observedGeneration": {
+      "type": "integer",
+      "format": "int64",
+      "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet."
+     },
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.ReplicaSetCondition"
+      },
+      "description": "Represents the latest available observations of a replica set's current state."
+     }
+    }
+   },
+   "extensions.v1beta1.ReplicaSetCondition": {
+    "id": "extensions.v1beta1.ReplicaSetCondition",
+    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of replica set condition."
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the condition, one of True, False, Unknown."
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "description": "The last time the condition transitioned from one status to another."
+     },
+     "reason": {
+      "type": "string",
+      "description": "The reason for the condition's last transition."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human readable message indicating details about the transition."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/federation/apis/swagger-spec/federation.json
+++ b/federation/apis/swagger-spec/federation.json
@@ -35,7 +35,7 @@
   "models": {
    "v1.APIGroup": {
     "id": "v1.APIGroup",
-    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIGroup' instead.",
     "required": [
      "name",
      "versions",
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.\n\nDEPRECATED: Use 'io.k8s.meta.v1.GroupVersionForDiscovery' instead.",
     "required": [
      "groupVersion",
      "version"
@@ -94,6 +94,83 @@
    },
    "v1.ServerAddressByClientCIDR": {
     "id": "v1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ServerAddressByClientCIDR' instead.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIGroup": {
+    "id": "io.k8s.meta.v1.APIGroup",
+    "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "required": [
+     "name",
+     "versions",
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "name": {
+      "type": "string",
+      "description": "name is the name of the group."
+     },
+     "versions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.GroupVersionForDiscovery"
+      },
+      "description": "versions are the versions supported in this group."
+     },
+     "preferredVersion": {
+      "$ref": "v1.GroupVersionForDiscovery",
+      "description": "preferredVersion is the version preferred by the API server, which probably is the storage version."
+     },
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.ServerAddressByClientCIDR"
+      },
+      "description": "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP."
+     }
+    }
+   },
+   "io.k8s.meta.v1.GroupVersionForDiscovery": {
+    "id": "io.k8s.meta.v1.GroupVersionForDiscovery",
+    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "required": [
+     "groupVersion",
+     "version"
+    ],
+    "properties": {
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion specifies the API group and version in the form \"group/version\""
+     },
+     "version": {
+      "type": "string",
+      "description": "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ServerAddressByClientCIDR": {
+    "id": "io.k8s.meta.v1.ServerAddressByClientCIDR",
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
     "required": [
      "clientCIDR",

--- a/federation/apis/swagger-spec/federation_v1beta1.json
+++ b/federation/apis/swagger-spec/federation_v1beta1.json
@@ -100,7 +100,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Cluster",
+        "type": "federation.v1beta1.Cluster",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -350,7 +350,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Cluster",
+        "type": "federation.v1beta1.Cluster",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -397,7 +397,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -602,7 +602,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1beta1.Cluster",
+        "type": "federation.v1beta1.Cluster",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -663,7 +663,7 @@
   "models": {
    "v1beta1.ClusterList": {
     "id": "v1beta1.ClusterList",
-    "description": "A list of all the kubernetes clusters registered to the federation",
+    "description": "A list of all the kubernetes clusters registered to the federation\n\nDEPRECATED: Use 'federation.v1beta1.ClusterList' instead.",
     "required": [
      "items"
     ],
@@ -691,7 +691,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -705,7 +705,7 @@
    },
    "v1beta1.Cluster": {
     "id": "v1beta1.Cluster",
-    "description": "Information about a registered cluster in a federated kubernetes setup. Clusters are not namespaced and have unique names in the federation.",
+    "description": "Information about a registered cluster in a federated kubernetes setup. Clusters are not namespaced and have unique names in the federation.\n\nDEPRECATED: Use 'federation.v1beta1.Cluster' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -805,7 +805,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -837,7 +837,7 @@
    },
    "v1beta1.ClusterSpec": {
     "id": "v1beta1.ClusterSpec",
-    "description": "ClusterSpec describes the attributes of a kubernetes cluster.",
+    "description": "ClusterSpec describes the attributes of a kubernetes cluster.\n\nDEPRECATED: Use 'federation.v1beta1.ClusterSpec' instead.",
     "required": [
      "serverAddressByClientCIDRs"
     ],
@@ -857,7 +857,7 @@
    },
    "v1beta1.ServerAddressByClientCIDR": {
     "id": "v1beta1.ServerAddressByClientCIDR",
-    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.\n\nDEPRECATED: Use 'federation.v1beta1.ServerAddressByClientCIDR' instead.",
     "required": [
      "clientCIDR",
      "serverAddress"
@@ -885,7 +885,7 @@
    },
    "v1beta1.ClusterStatus": {
     "id": "v1beta1.ClusterStatus",
-    "description": "ClusterStatus is information about the current status of a cluster updated by cluster controller peridocally.",
+    "description": "ClusterStatus is information about the current status of a cluster updated by cluster controller peridocally.\n\nDEPRECATED: Use 'federation.v1beta1.ClusterStatus' instead.",
     "properties": {
      "conditions": {
       "type": "array",
@@ -909,7 +909,7 @@
    },
    "v1beta1.ClusterCondition": {
     "id": "v1beta1.ClusterCondition",
-    "description": "ClusterCondition describes current state of a cluster.",
+    "description": "ClusterCondition describes current state of a cluster.\n\nDEPRECATED: Use 'federation.v1beta1.ClusterCondition' instead.",
     "required": [
      "type",
      "status"
@@ -943,7 +943,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -982,7 +982,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -1012,7 +1012,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -1030,6 +1030,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -1045,7 +1046,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -1080,18 +1081,18 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -1120,6 +1121,369 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "federation.v1beta1.ClusterList": {
+    "id": "federation.v1beta1.ClusterList",
+    "description": "A list of all the kubernetes clusters registered to the federation",
+    "required": [
+     "items"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "items": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.Cluster"
+      },
+      "description": "List of Cluster objects."
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "federation.v1beta1.Cluster": {
+    "id": "federation.v1beta1.Cluster",
+    "description": "Information about a registered cluster in a federated kubernetes setup. Clusters are not namespaced and have unique names in the federation.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ObjectMeta",
+      "description": "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata"
+     },
+     "spec": {
+      "$ref": "v1beta1.ClusterSpec",
+      "description": "Spec defines the behavior of the Cluster."
+     },
+     "status": {
+      "$ref": "v1beta1.ClusterStatus",
+      "description": "Status describes the current status of a Cluster"
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "federation.v1beta1.ClusterSpec": {
+    "id": "federation.v1beta1.ClusterSpec",
+    "description": "ClusterSpec describes the attributes of a kubernetes cluster.",
+    "required": [
+     "serverAddressByClientCIDRs"
+    ],
+    "properties": {
+     "serverAddressByClientCIDRs": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.ServerAddressByClientCIDR"
+      },
+      "description": "A map of client CIDR to server address. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR."
+     },
+     "secretRef": {
+      "$ref": "v1.LocalObjectReference",
+      "description": "Name of the secret containing kubeconfig to access this cluster. The secret is read from the kubernetes cluster that is hosting federation control plane. Admin needs to ensure that the required secret exists. Secret should be in the same namespace where federation control plane is hosted and it should have kubeconfig in its data with key \"kubeconfig\". This will later be changed to a reference to secret in federation control plane when the federation control plane supports secrets. This can be left empty if the cluster allows insecure access."
+     }
+    }
+   },
+   "federation.v1beta1.ServerAddressByClientCIDR": {
+    "id": "federation.v1beta1.ServerAddressByClientCIDR",
+    "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+    "required": [
+     "clientCIDR",
+     "serverAddress"
+    ],
+    "properties": {
+     "clientCIDR": {
+      "type": "string",
+      "description": "The CIDR with which clients can match their IP to figure out the server address that they should use."
+     },
+     "serverAddress": {
+      "type": "string",
+      "description": "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port."
+     }
+    }
+   },
+   "federation.v1beta1.ClusterStatus": {
+    "id": "federation.v1beta1.ClusterStatus",
+    "description": "ClusterStatus is information about the current status of a cluster updated by cluster controller peridocally.",
+    "properties": {
+     "conditions": {
+      "type": "array",
+      "items": {
+       "$ref": "v1beta1.ClusterCondition"
+      },
+      "description": "Conditions is an array of current cluster conditions."
+     },
+     "zones": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "Zones is the list of availability zones in which the nodes of the cluster exist, e.g. 'us-east1-a'. These will always be in the same region."
+     },
+     "region": {
+      "type": "string",
+      "description": "Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'."
+     }
+    }
+   },
+   "federation.v1beta1.ClusterCondition": {
+    "id": "federation.v1beta1.ClusterCondition",
+    "description": "ClusterCondition describes current state of a cluster.",
+    "required": [
+     "type",
+     "status"
+    ],
+    "properties": {
+     "type": {
+      "type": "string",
+      "description": "Type of cluster condition, Complete or Failed."
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the condition, one of True, False, Unknown."
+     },
+     "lastProbeTime": {
+      "type": "string",
+      "description": "Last time the condition was checked."
+     },
+     "lastTransitionTime": {
+      "type": "string",
+      "description": "Last time the condition transit from one status to another."
+     },
+     "reason": {
+      "type": "string",
+      "description": "(brief) reason for the condition's last transition."
+     },
+     "message": {
+      "type": "string",
+      "description": "Human readable message indicating details about last transition."
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/federation/apis/swagger-spec/resourceListing.json
+++ b/federation/apis/swagger-spec/resourceListing.json
@@ -36,6 +36,18 @@
    {
     "path": "/apis/extensions",
     "description": "get information of a group"
+   },
+   {
+    "path": "/apis/batch/v1",
+    "description": "API at /apis/batch/v1"
+   },
+   {
+    "path": "/apis/batch/v2alpha1",
+    "description": "API at /apis/batch/v2alpha1"
+   },
+   {
+    "path": "/apis/batch",
+    "description": "get information of a group"
    }
   ],
   "apiVersion": "",

--- a/federation/apis/swagger-spec/v1.json
+++ b/federation/apis/swagger-spec/v1.json
@@ -445,7 +445,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -1250,7 +1250,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2007,7 +2007,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2351,7 +2351,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -2824,7 +2824,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -3629,7 +3629,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4118,7 +4118,7 @@
         "allowMultiple": false
        },
        {
-        "type": "v1.Patch",
+        "type": "io.k8s.meta.v1.Patch",
         "paramType": "body",
         "name": "body",
         "description": "",
@@ -4217,7 +4217,7 @@
    },
    "v1.ListMeta": {
     "id": "v1.ListMeta",
-    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.\n\nDEPRECATED: Use 'io.k8s.meta.v1.ListMeta' instead.",
     "properties": {
      "selfLink": {
       "type": "string",
@@ -4327,7 +4327,7 @@
    },
    "v1.OwnerReference": {
     "id": "v1.OwnerReference",
-    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.\n\nDEPRECATED: Use 'io.k8s.meta.v1.OwnerReference' instead.",
     "required": [
      "apiVersion",
      "kind",
@@ -4359,7 +4359,7 @@
    },
    "v1.Status": {
     "id": "v1.Status",
-    "description": "Status is a return value for calls that don't return other objects.",
+    "description": "Status is a return value for calls that don't return other objects.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Status' instead.",
     "properties": {
      "kind": {
       "type": "string",
@@ -4398,7 +4398,7 @@
    },
    "v1.StatusDetails": {
     "id": "v1.StatusDetails",
-    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusDetails' instead.",
     "properties": {
      "name": {
       "type": "string",
@@ -4428,7 +4428,7 @@
    },
    "v1.StatusCause": {
     "id": "v1.StatusCause",
-    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.\n\nDEPRECATED: Use 'io.k8s.meta.v1.StatusCause' instead.",
     "properties": {
      "reason": {
       "type": "string",
@@ -4446,6 +4446,7 @@
    },
    "versioned.Event": {
     "id": "versioned.Event",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.watch.versioned.Event' instead.",
     "required": [
      "type",
      "object"
@@ -4461,7 +4462,7 @@
    },
    "v1.Patch": {
     "id": "v1.Patch",
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.\n\nDEPRECATED: Use 'io.k8s.meta.v1.Patch' instead.",
     "properties": {}
    },
    "v1.DeleteOptions": {
@@ -4496,13 +4497,13 @@
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
     "properties": {
      "uid": {
-      "$ref": "types.UID",
+      "$ref": "io.k8s.kubernetes.pkg.types.UID",
       "description": "Specifies the target UID."
      }
     }
    },
-   "types.UID": {
-    "id": "types.UID",
+   "io.k8s.kubernetes.pkg.types.UID": {
+    "id": "io.k8s.kubernetes.pkg.types.UID",
     "properties": {}
    },
    "v1.EventList": {
@@ -4697,14 +4698,14 @@
      "finalizers": {
       "type": "array",
       "items": {
-       "$ref": "v1.FinalizerName"
+       "$ref": "io.k8s.kubernetes.pkg.api.v1.FinalizerName"
       },
       "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: http://releases.k8s.io/HEAD/docs/design/namespaces.md#finalizers"
      }
     }
    },
-   "v1.FinalizerName": {
-    "id": "v1.FinalizerName",
+   "io.k8s.kubernetes.pkg.api.v1.FinalizerName": {
+    "id": "io.k8s.kubernetes.pkg.api.v1.FinalizerName",
     "properties": {}
    },
    "v1.NamespaceStatus": {
@@ -4957,7 +4958,7 @@
    },
    "v1.APIResourceList": {
     "id": "v1.APIResourceList",
-    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResourceList' instead.",
     "required": [
      "groupVersion",
      "resources"
@@ -4986,6 +4987,219 @@
    },
    "v1.APIResource": {
     "id": "v1.APIResource",
+    "description": "APIResource specifies the name of a resource and whether it is namespaced.\n\nDEPRECATED: Use 'io.k8s.meta.v1.APIResource' instead.",
+    "required": [
+     "name",
+     "namespaced",
+     "kind",
+     "verbs"
+    ],
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "name is the name of the resource."
+     },
+     "namespaced": {
+      "type": "boolean",
+      "description": "namespaced indicates if a resource is namespaced or not."
+     },
+     "kind": {
+      "type": "string",
+      "description": "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')"
+     },
+     "verbs": {
+      "type": "array",
+      "items": {
+       "type": "string"
+      },
+      "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     }
+    }
+   },
+   "io.k8s.meta.v1.ListMeta": {
+    "id": "io.k8s.meta.v1.ListMeta",
+    "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "properties": {
+     "selfLink": {
+      "type": "string",
+      "description": "SelfLink is a URL representing this object. Populated by the system. Read-only."
+     },
+     "resourceVersion": {
+      "type": "string",
+      "description": "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency"
+     }
+    }
+   },
+   "io.k8s.meta.v1.OwnerReference": {
+    "id": "io.k8s.meta.v1.OwnerReference",
+    "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "required": [
+     "apiVersion",
+     "kind",
+     "name",
+     "uid"
+    ],
+    "properties": {
+     "apiVersion": {
+      "type": "string",
+      "description": "API version of the referent."
+     },
+     "kind": {
+      "type": "string",
+      "description": "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "name": {
+      "type": "string",
+      "description": "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names"
+     },
+     "uid": {
+      "type": "string",
+      "description": "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids"
+     },
+     "controller": {
+      "type": "boolean",
+      "description": "If true, this reference points to the managing controller."
+     }
+    }
+   },
+   "io.k8s.meta.v1.Status": {
+    "id": "io.k8s.meta.v1.Status",
+    "description": "Status is a return value for calls that don't return other objects.",
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "metadata": {
+      "$ref": "v1.ListMeta",
+      "description": "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "status": {
+      "type": "string",
+      "description": "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status"
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the status of this operation."
+     },
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it."
+     },
+     "details": {
+      "$ref": "v1.StatusDetails",
+      "description": "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type."
+     },
+     "code": {
+      "type": "integer",
+      "format": "int32",
+      "description": "Suggested HTTP return code for this status, 0 if not set."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusDetails": {
+    "id": "io.k8s.meta.v1.StatusDetails",
+    "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "properties": {
+     "name": {
+      "type": "string",
+      "description": "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described)."
+     },
+     "group": {
+      "type": "string",
+      "description": "The group attribute of the resource associated with the status StatusReason."
+     },
+     "kind": {
+      "type": "string",
+      "description": "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "causes": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.StatusCause"
+      },
+      "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes."
+     },
+     "retryAfterSeconds": {
+      "type": "integer",
+      "format": "int32",
+      "description": "If specified, the time in seconds before the operation should be retried."
+     }
+    }
+   },
+   "io.k8s.meta.v1.StatusCause": {
+    "id": "io.k8s.meta.v1.StatusCause",
+    "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "properties": {
+     "reason": {
+      "type": "string",
+      "description": "A machine-readable description of the cause of the error. If this value is empty there is no information available."
+     },
+     "message": {
+      "type": "string",
+      "description": "A human-readable description of the cause of the error.  This field may be presented as-is to a reader."
+     },
+     "field": {
+      "type": "string",
+      "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\""
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.watch.versioned.Event": {
+    "id": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+    "required": [
+     "type",
+     "object"
+    ],
+    "properties": {
+     "type": {
+      "type": "string"
+     },
+     "object": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.meta.v1.Patch": {
+    "id": "io.k8s.meta.v1.Patch",
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "properties": {}
+   },
+   "io.k8s.meta.v1.APIResourceList": {
+    "id": "io.k8s.meta.v1.APIResourceList",
+    "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "required": [
+     "groupVersion",
+     "resources"
+    ],
+    "properties": {
+     "kind": {
+      "type": "string",
+      "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds"
+     },
+     "apiVersion": {
+      "type": "string",
+      "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources"
+     },
+     "groupVersion": {
+      "type": "string",
+      "description": "groupVersion is the group and version this APIResourceList is for."
+     },
+     "resources": {
+      "type": "array",
+      "items": {
+       "$ref": "v1.APIResource"
+      },
+      "description": "resources contains the name of the resources and if they are namespaced."
+     }
+    }
+   },
+   "io.k8s.meta.v1.APIResource": {
+    "id": "io.k8s.meta.v1.APIResource",
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
     "required": [
      "name",

--- a/federation/apis/swagger-spec/version.json
+++ b/federation/apis/swagger-spec/version.json
@@ -31,6 +31,50 @@
   "models": {
    "version.Info": {
     "id": "version.Info",
+    "description": "\n\nDEPRECATED: Use 'io.k8s.kubernetes.pkg.version.Info' instead.",
+    "required": [
+     "major",
+     "minor",
+     "gitVersion",
+     "gitCommit",
+     "gitTreeState",
+     "buildDate",
+     "goVersion",
+     "compiler",
+     "platform"
+    ],
+    "properties": {
+     "major": {
+      "type": "string"
+     },
+     "minor": {
+      "type": "string"
+     },
+     "gitVersion": {
+      "type": "string"
+     },
+     "gitCommit": {
+      "type": "string"
+     },
+     "gitTreeState": {
+      "type": "string"
+     },
+     "buildDate": {
+      "type": "string"
+     },
+     "goVersion": {
+      "type": "string"
+     },
+     "compiler": {
+      "type": "string"
+     },
+     "platform": {
+      "type": "string"
+     }
+    }
+   },
+   "io.k8s.kubernetes.pkg.version.Info": {
+    "id": "io.k8s.kubernetes.pkg.version.Info",
     "required": [
      "major",
      "minor",

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -171,7 +171,7 @@ func Run(s *options.ServerRunOptions) error {
 	genericConfig.AdmissionControl = admissionController
 	genericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapi.OpenAPIDefinitions)
 	genericConfig.OpenAPIConfig.SecurityDefinitions = securityDefinitions
-	genericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
+	genericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig(openapi.OpenAPIDefinitions)
 	genericConfig.LongRunningFunc = filters.BasicLongRunningRequestCheck(
 		sets.NewString("watch", "proxy"),
 		sets.NewString("attach", "exec", "proxy", "log", "portforward"),

--- a/hack/update-federation-swagger-spec.sh
+++ b/hack/update-federation-swagger-spec.sh
@@ -65,8 +65,7 @@ kube::log::status "Starting federation-apiserver"
   --insecure-port="${API_PORT}" \
   --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --advertise-address="10.10.10.10" \
-  --cert-dir="${TMP_DIR}/certs" \
-  --service-cluster-ip-range="10.0.0.0/24" >/tmp/swagger-federation-api-server.log 2>&1 &
+  --cert-dir="${TMP_DIR}/certs" >/tmp/swagger-federation-api-server.log 2>&1 &
 APISERVER_PID=$!
 
 kube::util::wait_for_url "${API_HOST}:${API_PORT}/" "apiserver: "

--- a/pkg/api/resource/amount.go
+++ b/pkg/api/resource/amount.go
@@ -55,6 +55,7 @@ var (
 // int64Amount represents a fixed precision numerator and arbitrary scale exponent. It is faster
 // than operations on inf.Dec for values that can be represented as int64.
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 type int64Amount struct {
 	value int64
 	scale Scale

--- a/pkg/api/resource/quantity.go
+++ b/pkg/api/resource/quantity.go
@@ -94,6 +94,7 @@ import (
 // +protobuf.options.marshal=false
 // +protobuf.options.(gogoproto.goproto_stringer)=false
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 type Quantity struct {
 	// i is the quantity in int64 scaled form, if d.Dec == nil
 	i int64Amount

--- a/pkg/api/v1/doc.go
+++ b/pkg/api/v1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/api
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 // +groupName=
 

--- a/pkg/api/v1/doc.go
+++ b/pkg/api/v1/doc.go
@@ -18,6 +18,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/api
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
+// +groupName=
 
 // Package v1 is the v1 version of the API.
 package v1 // import "k8s.io/kubernetes/pkg/api/v1"

--- a/pkg/api/validation/schema.go
+++ b/pkg/api/validation/schema.go
@@ -424,17 +424,8 @@ func (s *SwaggerSchema) validateField(value interface{}, fieldName, fieldType st
 	if reflect.TypeOf(value) == nil {
 		return append(allErrs, fmt.Errorf("unexpected nil value for field %v", fieldName))
 	}
-	// TODO: caesarxuchao: because we have multiple group/versions and objects
-	// may reference objects in other group, the commented out way of checking
-	// if a filedType is a type defined by us is outdated. We use a hacky way
-	// for now.
-	// TODO: the type name in the swagger spec is something like "v1.Binding",
-	// and the "v1" is generated from the package name, not the groupVersion of
-	// the type. We need to fix go-restful to embed the group name in the type
-	// name, otherwise we couldn't handle identically named types in different
-	// groups correctly.
+	// the versionRegexp is unnecessary, but preserved here in case clients outside of Kube were depending on it.
 	if _, ok := s.api.Models.At(fieldType); ok || versionRegexp.MatchString(fieldType) {
-		// if strings.HasPrefix(fieldType, apiVersion) {
 		return s.ValidateObject(value, fieldName, fieldType)
 	}
 	switch fieldType {

--- a/pkg/apis/abac/v0/types.go
+++ b/pkg/apis/abac/v0/types.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 package v0
 
 import (

--- a/pkg/apis/abac/v1beta1/doc.go
+++ b/pkg/apis/abac/v1beta1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/abac
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=abac.authorization.kubernetes.io

--- a/pkg/apis/abac/v1beta1/types.go
+++ b/pkg/apis/abac/v1beta1/types.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 package v1beta1
 
 import (

--- a/pkg/apis/apps/v1beta1/doc.go
+++ b/pkg/apis/apps/v1beta1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/apps
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/apps/v1beta1"

--- a/pkg/apis/authentication/v1beta1/doc.go
+++ b/pkg/apis/authentication/v1beta1/doc.go
@@ -18,5 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/authentication
 // +groupName=authentication.k8s.io
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/authentication/v1beta1"

--- a/pkg/apis/authorization/v1beta1/doc.go
+++ b/pkg/apis/authorization/v1beta1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/authorization
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=authorization.k8s.io

--- a/pkg/apis/autoscaling/v1/doc.go
+++ b/pkg/apis/autoscaling/v1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/autoscaling/v1"

--- a/pkg/apis/batch/v1/doc.go
+++ b/pkg/apis/batch/v1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 package v1 // import "k8s.io/kubernetes/pkg/apis/batch/v1"

--- a/pkg/apis/batch/v2alpha1/doc.go
+++ b/pkg/apis/batch/v2alpha1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 package v2alpha1 // import "k8s.io/kubernetes/pkg/apis/batch/v2alpha1"

--- a/pkg/apis/certificates/v1alpha1/doc.go
+++ b/pkg/apis/certificates/v1alpha1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/certificates
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=certificates.k8s.io

--- a/pkg/apis/componentconfig/v1alpha1/doc.go
+++ b/pkg/apis/componentconfig/v1alpha1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/componentconfig
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 package v1alpha1 // import "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1"

--- a/pkg/apis/extensions/v1beta1/doc.go
+++ b/pkg/apis/extensions/v1beta1/doc.go
@@ -19,6 +19,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -53,6 +53,7 @@ type ScaleStatus struct {
 // +noMethods=true
 
 // represents a scaling request for a resource.
+// +k8s:openapi-gen=legacy-name
 type Scale struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.
@@ -158,6 +159,7 @@ type HorizontalPodAutoscalerStatus struct {
 }
 
 // configuration of a horizontal pod autoscaler.
+// +k8s:openapi-gen=legacy-name
 type HorizontalPodAutoscaler struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
@@ -174,6 +176,7 @@ type HorizontalPodAutoscaler struct {
 }
 
 // list of horizontal pod autoscaler objects.
+// +k8s:openapi-gen=legacy-name
 type HorizontalPodAutoscalerList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -189,6 +192,7 @@ type HorizontalPodAutoscalerList struct {
 
 // A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource
 // types to the API.  It consists of one or more Versions of the api.
+// +k8s:openapi-gen=legacy-name
 type ThirdPartyResource struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -206,6 +210,7 @@ type ThirdPartyResource struct {
 }
 
 // ThirdPartyResourceList is a list of ThirdPartyResources.
+// +k8s:openapi-gen=legacy-name
 type ThirdPartyResourceList struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -225,6 +230,7 @@ type APIVersion struct {
 }
 
 // An internal object, used for versioned storage in etcd.  Not exposed to the end user.
+// +k8s:openapi-gen=legacy-name
 type ThirdPartyResourceData struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -239,6 +245,7 @@ type ThirdPartyResourceData struct {
 // +genclient=true
 
 // Deployment enables declarative updates for Pods and ReplicaSets.
+// +k8s:openapi-gen=legacy-name
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -304,6 +311,7 @@ type DeploymentSpec struct {
 }
 
 // DeploymentRollback stores the information required to rollback a deployment.
+// +k8s:openapi-gen=legacy-name
 type DeploymentRollback struct {
 	metav1.TypeMeta `json:",inline"`
 	// Required: This must match the Name of a deployment.
@@ -447,6 +455,7 @@ type DeploymentCondition struct {
 }
 
 // DeploymentList is a list of Deployments.
+// +k8s:openapi-gen=legacy-name
 type DeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -577,6 +586,7 @@ type DaemonSetStatus struct {
 // +genclient=true
 
 // DaemonSet represents the configuration of a daemon set.
+// +k8s:openapi-gen=legacy-name
 type DaemonSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -599,6 +609,7 @@ type DaemonSet struct {
 }
 
 // DaemonSetList is a collection of daemon sets.
+// +k8s:openapi-gen=legacy-name
 type DaemonSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -611,6 +622,7 @@ type DaemonSetList struct {
 }
 
 // ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.
+// +k8s:openapi-gen=legacy-name
 type ThirdPartyResourceDataList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
@@ -628,6 +640,7 @@ type ThirdPartyResourceDataList struct {
 // endpoints defined by a backend. An Ingress can be configured to give services
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
+// +k8s:openapi-gen=legacy-name
 type Ingress struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -647,6 +660,7 @@ type Ingress struct {
 }
 
 // IngressList is a collection of Ingress.
+// +k8s:openapi-gen=legacy-name
 type IngressList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -791,6 +805,7 @@ type IngressBackend struct {
 // +genclient=true
 
 // ReplicaSet represents the configuration of a ReplicaSet.
+// +k8s:openapi-gen=legacy-name
 type ReplicaSet struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -815,6 +830,7 @@ type ReplicaSet struct {
 }
 
 // ReplicaSetList is a collection of ReplicaSets.
+// +k8s:openapi-gen=legacy-name
 type ReplicaSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -915,6 +931,7 @@ type ReplicaSetCondition struct {
 
 // Pod Security Policy governs the ability to make requests that affect the Security Context
 // that will be applied to a pod and container.
+// +k8s:openapi-gen=legacy-name
 type PodSecurityPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -1112,6 +1129,7 @@ const (
 )
 
 // Pod Security Policy List is a list of PodSecurityPolicy objects.
+// +k8s:openapi-gen=legacy-name
 type PodSecurityPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -1123,6 +1141,7 @@ type PodSecurityPolicyList struct {
 	Items []PodSecurityPolicy `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
+// +k8s:openapi-gen=legacy-name
 type NetworkPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -1213,6 +1232,7 @@ type NetworkPolicyPeer struct {
 }
 
 // Network Policy List is a list of NetworkPolicy objects.
+// +k8s:openapi-gen=legacy-name
 type NetworkPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.

--- a/pkg/apis/imagepolicy/v1alpha1/doc.go
+++ b/pkg/apis/imagepolicy/v1alpha1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/imagepolicy
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=imagepolicy.k8s.io

--- a/pkg/apis/meta/v1/doc.go
+++ b/pkg/apis/meta/v1/doc.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=meta.k8s.io

--- a/pkg/apis/policy/v1beta1/doc.go
+++ b/pkg/apis/policy/v1beta1/doc.go
@@ -21,4 +21,5 @@ limitations under the License.
 // they aren't all here, are PodDisruptionBudget, PodSecurityPolicy,
 // NetworkPolicy, etc.
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/policy/v1beta1"

--- a/pkg/apis/rbac/v1alpha1/doc.go
+++ b/pkg/apis/rbac/v1alpha1/doc.go
@@ -17,6 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/rbac
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 
 // +groupName=rbac.authorization.k8s.io

--- a/pkg/apis/storage/v1beta1/doc.go
+++ b/pkg/apis/storage/v1beta1/doc.go
@@ -18,5 +18,6 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/storage
 // +groupName=storage.k8s.io
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 // +k8s:defaulter-gen=TypeMeta
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/storage/v1beta1"

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -29,7 +29,11 @@ import (
 )
 
 var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
-	"intstr.IntOrString": intstr.IntOrString{}.OpenAPIDefinition(), "resource.Quantity": resource.Quantity{}.OpenAPIDefinition(), "resource.int64Amount": {
+	"io.k8s.kubernetes.pkg.util.intstr.IntOrString": intstr.IntOrString{}.OpenAPIDefinition(),
+	"intstr.IntOrString":                            intstr.IntOrString{}.OpenAPIDefinition(),
+	"io.k8s.kubernetes.pkg.api.resource.Quantity":   resource.Quantity{}.OpenAPIDefinition(),
+	"resource.Quantity":                             resource.Quantity{}.OpenAPIDefinition(),
+	"io.k8s.kubernetes.pkg.api.resource.int64Amount": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "int64Amount represents a fixed precision numerator and arbitrary scale exponent. It is faster than operations on inf.Dec for values that can be represented as int64.",
@@ -49,6 +53,63 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"value", "scale"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/resource.int64Amount",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"resource.int64Amount": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "int64Amount represents a fixed precision numerator and arbitrary scale exponent. It is faster than operations on inf.Dec for values that can be represented as int64.",
+				Properties: map[string]spec.Schema{
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
+					"scale": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
+				},
+				Required: []string{"value", "scale"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/api/resource.int64Amount",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.kubernetes.pkg.api.resource.int64Amount",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.kubernetes.pkg.runtime.RawExtension": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
+				Properties: map[string]spec.Schema{
+					"Raw": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Raw is the underlying serialization of this object.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
+				},
+				Required: []string{"Raw"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/runtime.RawExtension",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -66,6 +127,39 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"Raw"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/runtime.RawExtension",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.kubernetes.pkg.runtime.RawExtension",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.kubernetes.pkg.runtime.TypeMeta": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "TypeMeta is shared by all top level objects. The proper way to use it is to inline it in your type, like this: type MyAwesomeAPIObject struct {\n     runtime.TypeMeta    `json:\",inline\"`\n     ... // other fields\n} func (obj *MyAwesomeAPIObject) SetGroupVersionKind(gvk *metav1.GroupVersionKind) { metav1.UpdateTypeMeta(obj,gvk) }; GroupVersionKind() *GroupVersionKind\n\nTypeMeta is provided here for convenience. You may use it directly from this package or define your own with the same fields.",
+				Properties: map[string]spec.Schema{
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/runtime.TypeMeta",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -87,6 +181,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format: "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/runtime.TypeMeta",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.kubernetes.pkg.runtime.TypeMeta",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.kubernetes.pkg.runtime.Unknown": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Unknown allows api objects with unknown types to be passed-through. This can be used to deal with the API objects from a plug-in. Unknown objects still have functioning TypeMeta features-- kind, version, etc. metadata and field mutatation.",
+				Properties: map[string]spec.Schema{
+					"Raw": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Raw will hold the complete serialized object which couldn't be matched with a registered type. Most likely, nothing should be done with this except for passing it through the system.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
+					"ContentEncoding": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ContentEncoding is encoding used to encode 'Raw' data. Unspecified means no encoding.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"ContentType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ContentType  is serialization method used to serialize 'Raw'. Unspecified means ContentTypeJSON.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"Raw", "ContentEncoding", "ContentType"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/runtime.Unknown",
 				},
 			},
 		},
@@ -121,8 +258,70 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"Raw", "ContentEncoding", "ContentType"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/runtime.Unknown",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.kubernetes.pkg.runtime.Unknown",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.APIGroup": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "name is the name of the group.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"versions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "versions are the versions supported in this group.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.GroupVersionForDiscovery"),
+									},
+								},
+							},
+						},
+					},
+					"preferredVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "preferredVersion is the version preferred by the API server, which probably is the storage version.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.GroupVersionForDiscovery"),
+						},
+					},
+					"serverAddressByClientCIDRs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ServerAddressByClientCIDR"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"name", "versions", "serverAddressByClientCIDRs"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.APIGroup",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.GroupVersionForDiscovery", "io.k8s.meta.v1.ServerAddressByClientCIDR"},
 	},
 	"v1.APIGroup": {
 		Schema: spec.Schema{
@@ -143,7 +342,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.GroupVersionForDiscovery"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.GroupVersionForDiscovery"),
 									},
 								},
 							},
@@ -152,7 +351,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"preferredVersion": {
 						SchemaProps: spec.SchemaProps{
 							Description: "preferredVersion is the version preferred by the API server, which probably is the storage version.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.GroupVersionForDiscovery"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.GroupVersionForDiscovery"),
 						},
 					},
 					"serverAddressByClientCIDRs": {
@@ -162,7 +361,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.ServerAddressByClientCIDR"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ServerAddressByClientCIDR"),
 									},
 								},
 							},
@@ -171,9 +370,45 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"name", "versions", "serverAddressByClientCIDRs"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.APIGroup",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.APIGroup",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.GroupVersionForDiscovery", "v1.ServerAddressByClientCIDR"},
+			"io.k8s.meta.v1.GroupVersionForDiscovery", "io.k8s.meta.v1.ServerAddressByClientCIDR"},
+	},
+	"io.k8s.meta.v1.APIGroupList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+				Properties: map[string]spec.Schema{
+					"groups": {
+						SchemaProps: spec.SchemaProps{
+							Description: "groups is a list of APIGroup.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.APIGroup"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"groups"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.APIGroupList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.APIGroup"},
 	},
 	"v1.APIGroupList": {
 		Schema: spec.Schema{
@@ -187,7 +422,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.APIGroup"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.APIGroup"),
 									},
 								},
 							},
@@ -196,9 +431,66 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"groups"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.APIGroupList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.APIGroupList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.APIGroup"},
+			"io.k8s.meta.v1.APIGroup"},
+	},
+	"io.k8s.meta.v1.APIResource": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "APIResource specifies the name of a resource and whether it is namespaced.",
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "name is the name of the resource.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"namespaced": {
+						SchemaProps: spec.SchemaProps{
+							Description: "namespaced indicates if a resource is namespaced or not.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"verbs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"name", "namespaced", "kind", "verbs"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.APIResource",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.APIResource": {
 		Schema: spec.Schema{
@@ -243,8 +535,51 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"name", "namespaced", "kind", "verbs"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.APIResource",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.APIResource",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.APIResourceList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+				Properties: map[string]spec.Schema{
+					"groupVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "groupVersion is the group and version this APIResourceList is for.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "resources contains the name of the resources and if they are namespaced.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.APIResource"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"groupVersion", "resources"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.APIResourceList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.APIResource"},
 	},
 	"v1.APIResourceList": {
 		Schema: spec.Schema{
@@ -265,7 +600,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.APIResource"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.APIResource"),
 									},
 								},
 							},
@@ -274,9 +609,59 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"groupVersion", "resources"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.APIResourceList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.APIResourceList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.APIResource"},
+			"io.k8s.meta.v1.APIResource"},
+	},
+	"io.k8s.meta.v1.APIVersions": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
+				Properties: map[string]spec.Schema{
+					"versions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "versions are the api versions that are available.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"serverAddressByClientCIDRs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "a map of client CIDR to server address that is serving this group. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR. The server returns only those CIDRs that it thinks that the client can match. For example: the master will return an internal IP CIDR only, if the client reaches the server using an internal IP. Server looks at X-Forwarded-For header or X-Real-Ip header or request.RemoteAddr (in that order) to get the client IP.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ServerAddressByClientCIDR"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"versions", "serverAddressByClientCIDRs"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.APIVersions",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.ServerAddressByClientCIDR"},
 	},
 	"v1.APIVersions": {
 		Schema: spec.Schema{
@@ -304,7 +689,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.ServerAddressByClientCIDR"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ServerAddressByClientCIDR"),
 									},
 								},
 							},
@@ -313,9 +698,15 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"versions", "serverAddressByClientCIDRs"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.APIVersions",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.APIVersions",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ServerAddressByClientCIDR"},
+			"io.k8s.meta.v1.ServerAddressByClientCIDR"},
 	},
 	"v1.AWSElasticBlockStoreVolumeSource": {
 		Schema: spec.Schema{
@@ -353,6 +744,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"volumeID"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.AWSElasticBlockStoreVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -381,6 +777,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Affinity",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.NodeAffinity", "v1.PodAffinity", "v1.PodAntiAffinity"},
@@ -407,6 +808,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"name", "devicePath"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.AttachedVolume",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -428,6 +834,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							},
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.AvoidPods",
 				},
 			},
 		},
@@ -477,6 +888,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"diskName", "diskURI"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.AzureDiskVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -509,6 +925,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"secretName", "shareName"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.AzureFileVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -531,6 +952,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"target"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Binding",
+				},
 			},
 		},
 		Dependencies: []string{
@@ -569,6 +995,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							},
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Capabilities",
 				},
 			},
 		},
@@ -630,6 +1061,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"monitors"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.CephFSVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LocalObjectReference"},
@@ -662,6 +1098,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"volumeID"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.CinderVolumeSource",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -702,6 +1143,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ComponentCondition",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -731,6 +1177,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ComponentStatus",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ComponentCondition", "v1.ObjectMeta"},
@@ -743,7 +1194,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -762,9 +1213,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ComponentStatusList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ComponentStatus", "v1.ListMeta"},
+			"io.k8s.meta.v1.ListMeta", "v1.ComponentStatus"},
 	},
 	"v1.ConfigMap": {
 		Schema: spec.Schema{
@@ -793,6 +1249,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ConfigMap",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta"},
@@ -802,6 +1263,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 			SchemaProps: spec.SchemaProps{
 				Description: "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
 				Properties:  map[string]spec.Schema{},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ConfigMapEnvSource",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -821,6 +1287,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"key"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ConfigMapKeySelector",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -832,7 +1303,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -851,9 +1322,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ConfigMapList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ConfigMap", "v1.ListMeta"},
+			"io.k8s.meta.v1.ListMeta", "v1.ConfigMap"},
 	},
 	"v1.ConfigMapVolumeSource": {
 		Schema: spec.Schema{
@@ -880,6 +1356,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "int32",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ConfigMapVolumeSource",
 				},
 			},
 		},
@@ -1060,6 +1541,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"name"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Container",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ContainerPort", "v1.EnvFromSource", "v1.EnvVar", "v1.Lifecycle", "v1.Probe", "v1.ResourceRequirements", "v1.SecurityContext", "v1.VolumeMount"},
@@ -1092,6 +1578,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"names"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ContainerImage",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -1139,6 +1630,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"containerPort"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ContainerPort",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -1167,6 +1663,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ContainerState",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ContainerStateRunning", "v1.ContainerStateTerminated", "v1.ContainerStateWaiting"},
@@ -1179,14 +1680,19 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"startedAt": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which the container was last (re-)started",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ContainerStateRunning",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1.ContainerStateTerminated": {
 		Schema: spec.Schema{
@@ -1224,13 +1730,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"startedAt": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which previous execution of the container started",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"finishedAt": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which the container last terminated",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"containerID": {
@@ -1243,9 +1749,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"exitCode"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ContainerStateTerminated",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1.ContainerStateWaiting": {
 		Schema: spec.Schema{
@@ -1266,6 +1777,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ContainerStateWaiting",
 				},
 			},
 		},
@@ -1333,9 +1849,51 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"name", "ready", "restartCount", "image", "imageID"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ContainerStatus",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ContainerState"},
+	},
+	"autoscaling.v1.CrossVersionObjectReference": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds\"",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "API version of the referent",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"kind", "name"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/autoscaling/v1.CrossVersionObjectReference",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.CrossVersionObjectReference": {
 		Schema: spec.Schema{
@@ -1366,6 +1924,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"kind", "name"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/autoscaling/v1.CrossVersionObjectReference",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "autoscaling.v1.CrossVersionObjectReference",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -1383,6 +1947,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"Port"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.DaemonEndpoint",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -1412,6 +1981,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.DeleteOptions",
 				},
 			},
 		},
@@ -1452,6 +2026,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"path"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.DownwardAPIVolumeFile",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectFieldSelector", "v1.ResourceFieldSelector"},
@@ -1483,9 +2062,36 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.DownwardAPIVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.DownwardAPIVolumeFile"},
+	},
+	"io.k8s.meta.v1.Duration": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Duration is a wrapper around time.Duration which supports correct marshaling to YAML and JSON. In particular, it marshals into strings, which can be used as map keys in json.",
+				Properties: map[string]spec.Schema{
+					"Duration": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int64",
+						},
+					},
+				},
+				Required: []string{"Duration"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.Duration",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.Duration": {
 		Schema: spec.Schema{
@@ -1500,6 +2106,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"Duration"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.Duration",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.Duration",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -1516,6 +2128,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EmptyDirVolumeSource",
 				},
 			},
 		},
@@ -1556,6 +2173,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"ip"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EndpointAddress",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectReference"},
@@ -1588,6 +2210,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"port"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EndpointPort",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -1638,6 +2265,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EndpointSubset",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.EndpointAddress", "v1.EndpointPort"},
@@ -1669,6 +2301,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"subsets"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Endpoints",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.EndpointSubset", "v1.ObjectMeta"},
@@ -1681,7 +2318,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1700,9 +2337,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EndpointsList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Endpoints", "v1.ListMeta"},
+			"io.k8s.meta.v1.ListMeta", "v1.Endpoints"},
 	},
 	"v1.EnvFromSource": {
 		Schema: spec.Schema{
@@ -1722,6 +2364,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Ref:         spec.MustCreateRef("#/definitions/v1.ConfigMapEnvSource"),
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EnvFromSource",
 				},
 			},
 		},
@@ -1756,6 +2403,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"name"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EnvVar",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.EnvVarSource"},
@@ -1789,6 +2441,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Ref:         spec.MustCreateRef("#/definitions/v1.SecretKeySelector"),
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EnvVarSource",
 				},
 			},
 		},
@@ -1835,13 +2492,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"firstTimestamp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The time at which the event was first recorded. (Time of server receipt is in TypeMeta.)",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"lastTimestamp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The time at which the most recent occurrence of this event was recorded.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"count": {
@@ -1861,9 +2518,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"metadata", "involvedObject"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Event",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.EventSource", "v1.ObjectMeta", "v1.ObjectReference", "v1.Time"},
+			"io.k8s.meta.v1.Time", "v1.EventSource", "v1.ObjectMeta", "v1.ObjectReference"},
 	},
 	"v1.EventList": {
 		Schema: spec.Schema{
@@ -1873,7 +2535,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -1892,9 +2554,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EventList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Event", "v1.ListMeta"},
+			"io.k8s.meta.v1.ListMeta", "v1.Event"},
 	},
 	"v1.EventSource": {
 		Schema: spec.Schema{
@@ -1915,6 +2582,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.EventSource",
 				},
 			},
 		},
@@ -1941,6 +2613,41 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ExecAction",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.ExportOptions": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ExportOptions is the query options to the standard REST get call.",
+				Properties: map[string]spec.Schema{
+					"export": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Should this value be exported.  Export strips fields that a user can not specify.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"exact": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Should the export be exact.  Exact export maintains cluster-specific fields like 'Namespace'.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"export", "exact"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.ExportOptions",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -1965,6 +2672,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"export", "exact"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.ExportOptions",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.ExportOptions",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -2011,6 +2724,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"targetWWNs", "lun"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.FCVolumeSource",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -2064,6 +2782,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"driver"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.FlexVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LocalObjectReference"},
@@ -2087,6 +2810,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.FlockerVolumeSource",
 				},
 			},
 		},
@@ -2128,6 +2856,33 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"pdName"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.GCEPersistentDiskVolumeSource",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.GetOptions": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "GetOptions is the standard query options to the standard REST get call.",
+				Properties: map[string]spec.Schema{
+					"resourceVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "When specified: - if unset, then the result is returned from remote storage based on quorum-read flag; - if it's 0, then we simply return what we currently have in cache, no guarantee; - if set to non zero, then the result is at least as fresh as given rv.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.GetOptions",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -2143,6 +2898,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.GetOptions",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.GetOptions",
 				},
 			},
 		},
@@ -2177,6 +2938,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"repository"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.GitRepoVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -2209,6 +2975,39 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"endpoints", "path"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.GlusterfsVolumeSource",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.GroupKind": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "GroupKind specifies a Group and a Kind, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types",
+				Properties: map[string]spec.Schema{
+					"Group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"Kind": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"Group", "Kind"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.GroupKind",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -2231,6 +3030,40 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"Group", "Kind"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.GroupKind",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.GroupKind",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.GroupResource": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "GroupResource specifies a Group and a Resource, but does not force a version.  This is useful for identifying concepts during lookup stages without having partially valid types",
+				Properties: map[string]spec.Schema{
+					"Group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"Resource": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"Group", "Resource"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.GroupResource",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -2255,6 +3088,40 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"Group", "Resource"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.GroupResource",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.GroupResource",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.GroupVersion": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "GroupVersion contains the \"group\" and the \"version\", which uniquely identifies the API.",
+				Properties: map[string]spec.Schema{
+					"Group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"Version": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"Group", "Version"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.GroupVersion",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -2277,6 +3144,42 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"Group", "Version"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.GroupVersion",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.GroupVersion",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.GroupVersionForDiscovery": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+				Properties: map[string]spec.Schema{
+					"groupVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "groupVersion specifies the API group and version in the form \"group/version\"",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"version": {
+						SchemaProps: spec.SchemaProps{
+							Description: "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"groupVersion", "version"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.GroupVersionForDiscovery",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -2302,6 +3205,46 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"groupVersion", "version"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.GroupVersionForDiscovery",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.GroupVersionForDiscovery",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.GroupVersionKind": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "GroupVersionKind unambiguously identifies a kind.  It doesn't anonymously include GroupVersion to avoid automatic coersion.  It doesn't use a GroupVersion to avoid custom marshalling",
+				Properties: map[string]spec.Schema{
+					"Group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"Version": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"Kind": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"Group", "Version", "Kind"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.GroupVersionKind",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -2332,6 +3275,46 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"Group", "Version", "Kind"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.GroupVersionKind",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.GroupVersionKind",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.GroupVersionResource": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "GroupVersionResource unambiguously identifies a resource.  It doesn't anonymously include GroupVersion to avoid automatic coersion.  It doesn't use a GroupVersion to avoid custom marshalling",
+				Properties: map[string]spec.Schema{
+					"Group": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"Version": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"Resource": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"Group", "Version", "Resource"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.GroupVersionResource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -2361,6 +3344,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"Group", "Version", "Resource"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.GroupVersionResource",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.GroupVersionResource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -2379,7 +3368,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-							Ref:         spec.MustCreateRef("#/definitions/intstr.IntOrString"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
 						},
 					},
 					"host": {
@@ -2412,9 +3401,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"port"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.HTTPGetAction",
+				},
+			},
 		},
 		Dependencies: []string{
-			"intstr.IntOrString", "v1.HTTPHeader"},
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString", "v1.HTTPHeader"},
 	},
 	"v1.HTTPHeader": {
 		Schema: spec.Schema{
@@ -2437,6 +3431,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"name", "value"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.HTTPHeader",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -2466,9 +3465,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Handler",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ExecAction", "v1.HTTPGetAction", "v1.TCPSocketAction"},
+	},
+	"autoscaling.v1.HorizontalPodAutoscaler": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "configuration of a horizontal pod autoscaler.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.HorizontalPodAutoscalerSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current information about the autoscaler.",
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.HorizontalPodAutoscalerStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/autoscaling/v1.HorizontalPodAutoscaler",
+				},
+			},
+		},
+		Dependencies: []string{
+			"autoscaling.v1.HorizontalPodAutoscalerSpec", "autoscaling.v1.HorizontalPodAutoscalerStatus", "v1.ObjectMeta"},
 	},
 	"v1.HorizontalPodAutoscaler": {
 		Schema: spec.Schema{
@@ -2484,22 +3522,28 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.HorizontalPodAutoscalerSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.HorizontalPodAutoscalerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "current information about the autoscaler.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.HorizontalPodAutoscalerStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.HorizontalPodAutoscalerStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/autoscaling/v1.HorizontalPodAutoscaler",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "autoscaling.v1.HorizontalPodAutoscaler",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.HorizontalPodAutoscalerSpec", "v1.HorizontalPodAutoscalerStatus", "v1.ObjectMeta"},
+			"autoscaling.v1.HorizontalPodAutoscalerSpec", "autoscaling.v1.HorizontalPodAutoscalerStatus", "v1.ObjectMeta"},
 	},
-	"v1.HorizontalPodAutoscalerList": {
+	"autoscaling.v1.HorizontalPodAutoscalerList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "list of horizontal pod autoscaler objects.",
@@ -2507,7 +3551,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2517,7 +3561,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.HorizontalPodAutoscaler"),
+										Ref: spec.MustCreateRef("#/definitions/autoscaling.v1.HorizontalPodAutoscaler"),
 									},
 								},
 							},
@@ -2526,11 +3570,53 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/autoscaling/v1.HorizontalPodAutoscalerList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.HorizontalPodAutoscaler", "v1.ListMeta"},
+			"autoscaling.v1.HorizontalPodAutoscaler", "io.k8s.meta.v1.ListMeta"},
 	},
-	"v1.HorizontalPodAutoscalerSpec": {
+	"v1.HorizontalPodAutoscalerList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "list of horizontal pod autoscaler objects.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "list of horizontal pod autoscaler objects.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/autoscaling.v1.HorizontalPodAutoscaler"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/autoscaling/v1.HorizontalPodAutoscalerList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "autoscaling.v1.HorizontalPodAutoscalerList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"autoscaling.v1.HorizontalPodAutoscaler", "io.k8s.meta.v1.ListMeta"},
+	},
+	"autoscaling.v1.HorizontalPodAutoscalerSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "specification of a horizontal pod autoscaler.",
@@ -2538,7 +3624,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"scaleTargetRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.CrossVersionObjectReference"),
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.CrossVersionObjectReference"),
 						},
 					},
 					"minReplicas": {
@@ -2565,11 +3651,61 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"scaleTargetRef", "maxReplicas"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/autoscaling/v1.HorizontalPodAutoscalerSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.CrossVersionObjectReference"},
+			"autoscaling.v1.CrossVersionObjectReference"},
 	},
-	"v1.HorizontalPodAutoscalerStatus": {
+	"v1.HorizontalPodAutoscalerSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "specification of a horizontal pod autoscaler.",
+				Properties: map[string]spec.Schema{
+					"scaleTargetRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "reference to scaled resource; horizontal pod autoscaler will learn the current resource consumption and will set the desired number of pods by using its Scale subresource.",
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.CrossVersionObjectReference"),
+						},
+					},
+					"minReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "lower limit for the number of pods that can be set by the autoscaler, default 1.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"maxReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"targetCPUUtilizationPercentage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified the default autoscaling policy will be used.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"scaleTargetRef", "maxReplicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/autoscaling/v1.HorizontalPodAutoscalerSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "autoscaling.v1.HorizontalPodAutoscalerSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"autoscaling.v1.CrossVersionObjectReference"},
+	},
+	"autoscaling.v1.HorizontalPodAutoscalerStatus": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "current status of a horizontal pod autoscaler",
@@ -2584,7 +3720,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastScaleTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"currentReplicas": {
@@ -2611,9 +3747,66 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"currentReplicas", "desiredReplicas"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/autoscaling/v1.HorizontalPodAutoscalerStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
+	},
+	"v1.HorizontalPodAutoscalerStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "current status of a horizontal pod autoscaler",
+				Properties: map[string]spec.Schema{
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "most recent generation observed by this autoscaler.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"lastScaleTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"currentReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current number of replicas of pods managed by this autoscaler.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"desiredReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "desired number of replicas of pods managed by this autoscaler.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"currentCPUUtilizationPercentage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"currentReplicas", "desiredReplicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/autoscaling/v1.HorizontalPodAutoscalerStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "autoscaling.v1.HorizontalPodAutoscalerStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1.HostPathVolumeSource": {
 		Schema: spec.Schema{
@@ -2629,6 +3822,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"path"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.HostPathVolumeSource",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -2683,8 +3881,47 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"targetPortal", "iqn", "lun"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ISCSIVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"batch.v1.Job": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Job represents the configuration of a single job.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v1.JobSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v1.JobStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v1.Job",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v1.JobSpec", "batch.v1.JobStatus", "v1.ObjectMeta"},
 	},
 	"v1.Job": {
 		Schema: spec.Schema{
@@ -2700,20 +3937,83 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v1.JobSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v1.JobSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v1.JobStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v1.JobStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v1.Job",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v1.Job",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.JobSpec", "v1.JobStatus", "v1.ObjectMeta"},
+			"batch.v1.JobSpec", "batch.v1.JobStatus", "v1.ObjectMeta"},
+	},
+	"batch.v1.JobCondition": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobCondition describes current state of a job.",
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type of job condition, Complete or Failed.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the condition, one of True, False, Unknown.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"lastProbeTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition was checked.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"lastTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition transit from one status to another.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "(brief) reason for the condition's last transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Human readable message indicating details about last transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"type", "status"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v1.JobCondition",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1.JobCondition": {
 		Schema: spec.Schema{
@@ -2737,13 +4037,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastProbeTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition was checked.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transit from one status to another.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -2763,11 +4063,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v1.JobCondition",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v1.JobCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
-	"v1.JobList": {
+	"batch.v1.JobList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JobList is a collection of jobs.",
@@ -2775,7 +4081,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -2785,7 +4091,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.Job"),
+										Ref: spec.MustCreateRef("#/definitions/batch.v1.Job"),
 									},
 								},
 							},
@@ -2794,9 +4100,108 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v1.JobList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Job", "v1.ListMeta"},
+			"batch.v1.Job", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1.JobList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobList is a collection of jobs.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is the list of Job.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/batch.v1.Job"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v1.JobList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v1.JobList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v1.Job", "io.k8s.meta.v1.ListMeta"},
+	},
+	"batch.v1.JobSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobSpec describes how the job execution will look like.",
+				Properties: map[string]spec.Schema{
+					"parallelism": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"completions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"activeDeadlineSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+					"manualSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ManualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"template": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Ref:         spec.MustCreateRef("#/definitions/v1.PodTemplateSpec"),
+						},
+					},
+				},
+				Required: []string{"template"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v1.JobSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
 	},
 	"v1.JobSpec": {
 		Schema: spec.Schema{
@@ -2827,7 +4232,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"manualSelector": {
@@ -2846,11 +4251,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"template"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v1.JobSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v1.JobSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector", "v1.PodTemplateSpec"},
+			"io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
 	},
-	"v1.JobStatus": {
+	"batch.v1.JobStatus": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JobStatus represents the current state of a Job.",
@@ -2862,7 +4273,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.JobCondition"),
+										Ref: spec.MustCreateRef("#/definitions/batch.v1.JobCondition"),
 									},
 								},
 							},
@@ -2871,13 +4282,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"startTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"completionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"active": {
@@ -2903,9 +4314,77 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v1.JobStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.JobCondition", "v1.Time"},
+			"batch.v1.JobCondition", "io.k8s.meta.v1.Time"},
+	},
+	"v1.JobStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobStatus represents the current state of a Job.",
+				Properties: map[string]spec.Schema{
+					"conditions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/batch.v1.JobCondition"),
+									},
+								},
+							},
+						},
+					},
+					"startTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"completionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"active": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Active is the number of actively running pods.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"succeeded": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Succeeded is the number of pods which reached Phase Succeeded.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"failed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Failed is the number of pods which reached Phase Failed.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v1.JobStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v1.JobStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v1.JobCondition", "io.k8s.meta.v1.Time"},
 	},
 	"v1.KeyToPath": {
 		Schema: spec.Schema{
@@ -2936,8 +4415,56 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"key", "path"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.KeyToPath",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.LabelSelector": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+				Properties: map[string]spec.Schema{
+					"matchLabels": {
+						SchemaProps: spec.SchemaProps{
+							Description: "matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is \"key\", the operator is \"In\", and the values array contains only \"value\". The requirements are ANDed.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"matchExpressions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelectorRequirement"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.LabelSelector",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.LabelSelectorRequirement"},
 	},
 	"v1.LabelSelector": {
 		Schema: spec.Schema{
@@ -2965,7 +4492,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.LabelSelectorRequirement"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelectorRequirement"),
 									},
 								},
 							},
@@ -2973,9 +4500,59 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.LabelSelector",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.LabelSelector",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelectorRequirement"},
+			"io.k8s.meta.v1.LabelSelectorRequirement"},
+	},
+	"io.k8s.meta.v1.LabelSelectorRequirement": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+				Properties: map[string]spec.Schema{
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Description: "key is the label key that the selector applies to.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"operator": {
+						SchemaProps: spec.SchemaProps{
+							Description: "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"values": {
+						SchemaProps: spec.SchemaProps{
+							Description: "values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"key", "operator"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.LabelSelectorRequirement",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.LabelSelectorRequirement": {
 		Schema: spec.Schema{
@@ -3013,6 +4590,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"key", "operator"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.LabelSelectorRequirement",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.LabelSelectorRequirement",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -3033,6 +4616,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Ref:         spec.MustCreateRef("#/definitions/v1.Handler"),
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Lifecycle",
 				},
 			},
 		},
@@ -3058,6 +4646,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.LimitRange",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LimitRangeSpec", "v1.ObjectMeta"},
@@ -3081,7 +4674,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -3094,7 +4687,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -3107,7 +4700,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -3120,7 +4713,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -3133,7 +4726,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -3141,9 +4734,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.LimitRangeItem",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
 	},
 	"v1.LimitRangeList": {
 		Schema: spec.Schema{
@@ -3153,7 +4751,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3172,9 +4770,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.LimitRangeList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LimitRange", "v1.ListMeta"},
+			"io.k8s.meta.v1.ListMeta", "v1.LimitRange"},
 	},
 	"v1.LimitRangeSpec": {
 		Schema: spec.Schema{
@@ -3197,6 +4800,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"limits"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.LimitRangeSpec",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LimitRangeItem"},
@@ -3209,7 +4817,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3219,7 +4827,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/runtime.RawExtension"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.runtime.RawExtension"),
 									},
 								},
 							},
@@ -3228,9 +4836,43 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.List",
+				},
+			},
 		},
 		Dependencies: []string{
-			"runtime.RawExtension", "v1.ListMeta"},
+			"io.k8s.kubernetes.pkg.runtime.RawExtension", "io.k8s.meta.v1.ListMeta"},
+	},
+	"io.k8s.meta.v1.ListMeta": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+				Properties: map[string]spec.Schema{
+					"selfLink": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SelfLink is a URL representing this object. Populated by the system. Read-only.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resourceVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "String that identifies the server's internal version of this object that can be used by clients to determine when objects have changed. Value must be treated as opaque by clients and passed unmodified back to the server. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.ListMeta",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.ListMeta": {
 		Schema: spec.Schema{
@@ -3251,6 +4893,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.ListMeta",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.ListMeta",
 				},
 			},
 		},
@@ -3298,6 +4946,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ListOptions",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -3320,6 +4973,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.LoadBalancerIngress",
 				},
 			},
 		},
@@ -3345,6 +5003,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.LoadBalancerStatus",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LoadBalancerIngress"},
@@ -3361,6 +5024,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.LocalObjectReference",
 				},
 			},
 		},
@@ -3395,6 +5063,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"server", "path"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NFSVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -3423,6 +5096,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Namespace",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.NamespaceSpec", "v1.NamespaceStatus", "v1.ObjectMeta"},
@@ -3435,7 +5113,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3454,9 +5132,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NamespaceList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.Namespace"},
+			"io.k8s.meta.v1.ListMeta", "v1.Namespace"},
 	},
 	"v1.NamespaceSpec": {
 		Schema: spec.Schema{
@@ -3479,6 +5162,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NamespaceSpec",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -3494,6 +5182,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NamespaceStatus",
 				},
 			},
 		},
@@ -3524,6 +5217,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Node",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.NodeSpec", "v1.NodeStatus", "v1.ObjectMeta"},
@@ -3549,6 +5247,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"type", "address"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeAddress",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -3579,6 +5282,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeAffinity",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.NodeSelector", "v1.PreferredSchedulingTerm"},
@@ -3605,13 +5313,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastHeartbeatTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time we got an update on a given condition.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transit from one status to another.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -3631,9 +5339,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1.NodeDaemonEndpoints": {
 		Schema: spec.Schema{
@@ -3648,6 +5361,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeDaemonEndpoints",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.DaemonEndpoint"},
@@ -3660,7 +5378,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -3679,9 +5397,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.Node"},
+			"io.k8s.meta.v1.ListMeta", "v1.Node"},
 	},
 	"v1.NodeProxyOptions": {
 		Schema: spec.Schema{
@@ -3695,6 +5418,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeProxyOptions",
 				},
 			},
 		},
@@ -3712,7 +5440,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -3721,9 +5449,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"Capacity"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeResources",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
 	},
 	"v1.NodeSelector": {
 		Schema: spec.Schema{
@@ -3745,6 +5478,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"nodeSelectorTerms"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeSelector",
+				},
 			},
 		},
 		Dependencies: []string{
@@ -3786,6 +5524,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"key", "operator"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeSelectorRequirement",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -3809,6 +5552,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"matchExpressions"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeSelectorTerm",
+				},
 			},
 		},
 		Dependencies: []string{
@@ -3849,6 +5597,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeSpec",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -3864,7 +5617,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -3877,7 +5630,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -3970,9 +5723,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity", "v1.AttachedVolume", "v1.ContainerImage", "v1.NodeAddress", "v1.NodeCondition", "v1.NodeDaemonEndpoints", "v1.NodeSystemInfo"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity", "v1.AttachedVolume", "v1.ContainerImage", "v1.NodeAddress", "v1.NodeCondition", "v1.NodeDaemonEndpoints", "v1.NodeSystemInfo"},
 	},
 	"v1.NodeSystemInfo": {
 		Schema: spec.Schema{
@@ -4052,6 +5810,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"machineID", "systemUUID", "bootID", "kernelVersion", "osImage", "containerRuntimeVersion", "kubeletVersion", "kubeProxyVersion", "operatingSystem", "architecture"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.NodeSystemInfo",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -4076,6 +5839,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"fieldPath"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ObjectFieldSelector",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -4137,13 +5905,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"creationTimestamp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.\n\nPopulated by the system. Read-only. Null for lists. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"deletionTimestamp": {
 						SchemaProps: spec.SchemaProps{
 							Description: "DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field. Once set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.\n\nPopulated by the system when a graceful deletion is requested. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"deletionGracePeriodSeconds": {
@@ -4188,7 +5956,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.OwnerReference"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.OwnerReference"),
 									},
 								},
 							},
@@ -4217,9 +5985,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ObjectMeta",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.OwnerReference", "v1.Time"},
+			"io.k8s.meta.v1.OwnerReference", "io.k8s.meta.v1.Time"},
 	},
 	"v1.ObjectReference": {
 		Schema: spec.Schema{
@@ -4277,6 +6050,62 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ObjectReference",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.OwnerReference": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+				Properties: map[string]spec.Schema{
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "API version of the referent.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind of the referent. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"uid": {
+						SchemaProps: spec.SchemaProps{
+							Description: "UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"controller": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If true, this reference points to the managing controller.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"apiVersion", "kind", "name", "uid"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.OwnerReference",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -4323,6 +6152,26 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"apiVersion", "kind", "name", "uid"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.OwnerReference",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.OwnerReference",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.Patch": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+				Properties:  map[string]spec.Schema{},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.Patch",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -4331,6 +6180,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 			SchemaProps: spec.SchemaProps{
 				Description: "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
 				Properties:  map[string]spec.Schema{},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.Patch",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.Patch",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -4358,6 +6213,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Ref:         spec.MustCreateRef("#/definitions/v1.PersistentVolumeStatus"),
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolume",
 				},
 			},
 		},
@@ -4389,6 +6249,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeClaim",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta", "v1.PersistentVolumeClaimSpec", "v1.PersistentVolumeClaimStatus"},
@@ -4401,7 +6266,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -4420,9 +6285,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeClaimList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.PersistentVolumeClaim"},
+			"io.k8s.meta.v1.ListMeta", "v1.PersistentVolumeClaim"},
 	},
 	"v1.PersistentVolumeClaimSpec": {
 		Schema: spec.Schema{
@@ -4446,7 +6316,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A label query over volumes to consider for binding.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"resources": {
@@ -4464,9 +6334,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeClaimSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector", "v1.ResourceRequirements"},
+			"io.k8s.meta.v1.LabelSelector", "v1.ResourceRequirements"},
 	},
 	"v1.PersistentVolumeClaimStatus": {
 		Schema: spec.Schema{
@@ -4501,7 +6376,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -4509,9 +6384,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeClaimStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
 	},
 	"v1.PersistentVolumeClaimVolumeSource": {
 		Schema: spec.Schema{
@@ -4535,6 +6415,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"claimName"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeClaimVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -4546,7 +6431,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -4565,9 +6450,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.PersistentVolume"},
+			"io.k8s.meta.v1.ListMeta", "v1.PersistentVolume"},
 	},
 	"v1.PersistentVolumeSource": {
 		Schema: spec.Schema{
@@ -4678,6 +6568,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.AWSElasticBlockStoreVolumeSource", "v1.AzureDiskVolumeSource", "v1.AzureFileVolumeSource", "v1.CephFSVolumeSource", "v1.CinderVolumeSource", "v1.FCVolumeSource", "v1.FlexVolumeSource", "v1.FlockerVolumeSource", "v1.GCEPersistentDiskVolumeSource", "v1.GlusterfsVolumeSource", "v1.HostPathVolumeSource", "v1.ISCSIVolumeSource", "v1.NFSVolumeSource", "v1.PhotonPersistentDiskVolumeSource", "v1.QuobyteVolumeSource", "v1.RBDVolumeSource", "v1.VsphereVirtualDiskVolumeSource"},
@@ -4694,7 +6589,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -4729,9 +6624,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity", "v1.ObjectReference"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity", "v1.ObjectReference"},
 	},
 	"v1.PersistentVolumeStatus": {
 		Schema: spec.Schema{
@@ -4761,6 +6661,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PersistentVolumeStatus",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -4785,6 +6690,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"pdID"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PhotonPersistentDiskVolumeSource",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -4812,6 +6722,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Ref:         spec.MustCreateRef("#/definitions/v1.PodStatus"),
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Pod",
 				},
 			},
 		},
@@ -4851,6 +6766,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodAffinity",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.PodAffinityTerm", "v1.WeightedPodAffinityTerm"},
@@ -4863,7 +6783,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"labelSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A label query over a set of resources, in this case pods.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"namespaces": {
@@ -4890,9 +6810,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"namespaces"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodAffinityTerm",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector"},
+			"io.k8s.meta.v1.LabelSelector"},
 	},
 	"v1.PodAntiAffinity": {
 		Schema: spec.Schema{
@@ -4925,6 +6850,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							},
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodAntiAffinity",
 				},
 			},
 		},
@@ -4973,6 +6903,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodAttachOptions",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -4998,13 +6933,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastProbeTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time we probed the condition.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transitioned from one status to another.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -5024,9 +6959,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1.PodExecOptions": {
 		Schema: spec.Schema{
@@ -5085,6 +7025,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"command"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodExecOptions",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -5096,7 +7041,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -5115,9 +7060,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.Pod"},
+			"io.k8s.meta.v1.ListMeta", "v1.Pod"},
 	},
 	"v1.PodLogOptions": {
 		Schema: spec.Schema{
@@ -5155,7 +7105,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"sinceTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "An RFC3339 timestamp from which to show logs. If this value precedes the time a pod was started, only logs since the pod start will be returned. If this value is in the future, no logs will be returned. Only one of sinceSeconds or sinceTime may be specified.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"timestamps": {
@@ -5181,9 +7131,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodLogOptions",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1.PodProxyOptions": {
 		Schema: spec.Schema{
@@ -5197,6 +7152,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodProxyOptions",
 				},
 			},
 		},
@@ -5250,6 +7210,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodSecurityContext",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.SELinuxOptions"},
@@ -5262,14 +7227,19 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"podController": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Reference to controller whose pods should avoid this node.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.OwnerReference"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.OwnerReference"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodSignature",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.OwnerReference"},
+			"io.k8s.meta.v1.OwnerReference"},
 	},
 	"v1.PodSpec": {
 		Schema: spec.Schema{
@@ -5428,6 +7398,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"containers"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodSpec",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.Affinity", "v1.Container", "v1.LocalObjectReference", "v1.PodSecurityContext", "v1.Volume"},
@@ -5488,7 +7463,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"startTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RFC 3339 date and time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"containerStatuses": {
@@ -5513,9 +7488,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ContainerStatus", "v1.PodCondition", "v1.Time"},
+			"io.k8s.meta.v1.Time", "v1.ContainerStatus", "v1.PodCondition"},
 	},
 	"v1.PodStatusResult": {
 		Schema: spec.Schema{
@@ -5534,6 +7514,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Ref:         spec.MustCreateRef("#/definitions/v1.PodStatus"),
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodStatusResult",
 				},
 			},
 		},
@@ -5559,6 +7544,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodTemplate",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta", "v1.PodTemplateSpec"},
@@ -5571,7 +7561,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -5590,9 +7580,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodTemplateList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.PodTemplate"},
+			"io.k8s.meta.v1.ListMeta", "v1.PodTemplate"},
 	},
 	"v1.PodTemplateSpec": {
 		Schema: spec.Schema{
@@ -5613,6 +7608,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PodTemplateSpec",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta", "v1.PodSpec"},
@@ -5629,6 +7629,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Preconditions",
 				},
 			},
 		},
@@ -5648,7 +7653,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"evictionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Time at which this entry was added to the list.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -5668,9 +7673,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"podSignature"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PreferAvoidPodsEntry",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.PodSignature", "v1.Time"},
+			"io.k8s.meta.v1.Time", "v1.PodSignature"},
 	},
 	"v1.PreferredSchedulingTerm": {
 		Schema: spec.Schema{
@@ -5692,6 +7702,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"weight", "preference"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.PreferredSchedulingTerm",
+				},
 			},
 		},
 		Dependencies: []string{
@@ -5739,6 +7754,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Probe",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -5784,6 +7804,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"registry", "volume"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.QuobyteVolumeSource",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -5858,6 +7883,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"monitors", "image"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.RBDVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LocalObjectReference"},
@@ -5890,6 +7920,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"range", "data"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.RangeAllocation",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta"},
@@ -5919,6 +7954,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ReplicationController",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta", "v1.ReplicationControllerSpec", "v1.ReplicationControllerStatus"},
@@ -5945,7 +7985,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The last time the condition transitioned from one status to another.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -5965,9 +8005,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ReplicationControllerCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1.ReplicationControllerList": {
 		Schema: spec.Schema{
@@ -5977,7 +8022,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -5996,9 +8041,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ReplicationControllerList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.ReplicationController"},
+			"io.k8s.meta.v1.ListMeta", "v1.ReplicationController"},
 	},
 	"v1.ReplicationControllerSpec": {
 		Schema: spec.Schema{
@@ -6039,6 +8089,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Ref:         spec.MustCreateRef("#/definitions/v1.PodTemplateSpec"),
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ReplicationControllerSpec",
 				},
 			},
 		},
@@ -6101,6 +8156,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"replicas"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ReplicationControllerStatus",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ReplicationControllerCondition"},
@@ -6127,15 +8187,20 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"divisor": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies the output format of the exposed resources, defaults to \"1\"",
-							Ref:         spec.MustCreateRef("#/definitions/resource.Quantity"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 						},
 					},
 				},
 				Required: []string{"resource"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ResourceFieldSelector",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
 	},
 	"v1.ResourceQuota": {
 		Schema: spec.Schema{
@@ -6162,6 +8227,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ResourceQuota",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta", "v1.ResourceQuotaSpec", "v1.ResourceQuotaStatus"},
@@ -6174,7 +8244,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -6193,9 +8263,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ResourceQuotaList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.ResourceQuota"},
+			"io.k8s.meta.v1.ListMeta", "v1.ResourceQuota"},
 	},
 	"v1.ResourceQuotaSpec": {
 		Schema: spec.Schema{
@@ -6209,7 +8284,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -6231,9 +8306,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ResourceQuotaSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
 	},
 	"v1.ResourceQuotaStatus": {
 		Schema: spec.Schema{
@@ -6247,7 +8327,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -6260,7 +8340,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -6268,9 +8348,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ResourceQuotaStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
 	},
 	"v1.ResourceRequirements": {
 		Schema: spec.Schema{
@@ -6284,7 +8369,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -6297,7 +8382,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/resource.Quantity"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 									},
 								},
 							},
@@ -6305,9 +8390,44 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ResourceRequirements",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
+	},
+	"io.k8s.meta.v1.RootPaths": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RootPaths lists the paths available at root. For example: \"/healthz\", \"/apis\".",
+				Properties: map[string]spec.Schema{
+					"paths": {
+						SchemaProps: spec.SchemaProps{
+							Description: "paths are the paths available at root.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"paths"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.RootPaths",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.RootPaths": {
 		Schema: spec.Schema{
@@ -6330,6 +8450,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"paths"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.RootPaths",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.RootPaths",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -6369,8 +8495,47 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.SELinuxOptions",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"autoscaling.v1.Scale": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Scale represents a scaling request for a resource.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.ScaleSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.ScaleStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/autoscaling/v1.Scale",
+				},
+			},
+		},
+		Dependencies: []string{
+			"autoscaling.v1.ScaleSpec", "autoscaling.v1.ScaleStatus", "v1.ObjectMeta"},
 	},
 	"v1.Scale": {
 		Schema: spec.Schema{
@@ -6386,20 +8551,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ScaleSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.ScaleSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ScaleStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/autoscaling.v1.ScaleStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/autoscaling/v1.Scale",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "autoscaling.v1.Scale",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1.ScaleSpec", "v1.ScaleStatus"},
+			"autoscaling.v1.ScaleSpec", "autoscaling.v1.ScaleStatus", "v1.ObjectMeta"},
+	},
+	"autoscaling.v1.ScaleSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ScaleSpec describes the attributes of a scale subresource.",
+				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "desired number of instances for the scaled object.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/autoscaling/v1.ScaleSpec",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.ScaleSpec": {
 		Schema: spec.Schema{
@@ -6413,6 +8606,42 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "int32",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/autoscaling/v1.ScaleSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "autoscaling.v1.ScaleSpec",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"autoscaling.v1.ScaleStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ScaleStatus represents the current status of a scale subresource.",
+				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "actual number of observed instances of the scaled object.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "label query over pods that should match the replicas count. This is same as the label selector but in the string format to avoid introspection by clients. The string will be in the same format as the query-param syntax. More info about label selectors: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"replicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/autoscaling/v1.ScaleStatus",
 				},
 			},
 		},
@@ -6439,6 +8668,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"replicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/autoscaling/v1.ScaleStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "autoscaling.v1.ScaleStatus",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -6491,6 +8726,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Secret",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta"},
@@ -6510,6 +8750,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"key"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.SecretKeySelector",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -6521,7 +8766,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -6540,9 +8785,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.SecretList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.Secret"},
+			"io.k8s.meta.v1.ListMeta", "v1.Secret"},
 	},
 	"v1.SecretVolumeSource": {
 		Schema: spec.Schema{
@@ -6576,6 +8826,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "int32",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.SecretVolumeSource",
 				},
 			},
 		},
@@ -6629,6 +8884,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.SecurityContext",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.Capabilities", "v1.SELinuxOptions"},
@@ -6646,9 +8906,44 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.SerializedReference",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectReference"},
+	},
+	"io.k8s.meta.v1.ServerAddressByClientCIDR": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+				Properties: map[string]spec.Schema{
+					"clientCIDR": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"serverAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"clientCIDR", "serverAddress"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.ServerAddressByClientCIDR",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.ServerAddressByClientCIDR": {
 		Schema: spec.Schema{
@@ -6671,6 +8966,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"clientCIDR", "serverAddress"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.ServerAddressByClientCIDR",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.ServerAddressByClientCIDR",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -6698,6 +8999,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Ref:         spec.MustCreateRef("#/definitions/v1.ServiceStatus"),
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Service",
 				},
 			},
 		},
@@ -6743,6 +9049,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ServiceAccount",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LocalObjectReference", "v1.ObjectMeta", "v1.ObjectReference"},
@@ -6755,7 +9066,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -6774,9 +9085,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ServiceAccountList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.ServiceAccount"},
+			"io.k8s.meta.v1.ListMeta", "v1.ServiceAccount"},
 	},
 	"v1.ServiceList": {
 		Schema: spec.Schema{
@@ -6786,7 +9102,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -6805,9 +9121,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ServiceList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.Service"},
+			"io.k8s.meta.v1.ListMeta", "v1.Service"},
 	},
 	"v1.ServicePort": {
 		Schema: spec.Schema{
@@ -6838,7 +9159,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"targetPort": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Number or name of the port to access on the pods targeted by the service. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME. If this is a string, it will be looked up as a named port in the target Pod's container ports. If this is not specified, the value of the 'port' field is used (an identity map). This field is ignored for services with clusterIP=None, and should be omitted or set equal to the 'port' field. More info: http://kubernetes.io/docs/user-guide/services#defining-a-service",
-							Ref:         spec.MustCreateRef("#/definitions/intstr.IntOrString"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
 						},
 					},
 					"nodePort": {
@@ -6851,9 +9172,14 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"port"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ServicePort",
+				},
+			},
 		},
 		Dependencies: []string{
-			"intstr.IntOrString"},
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString"},
 	},
 	"v1.ServiceProxyOptions": {
 		Schema: spec.Schema{
@@ -6867,6 +9193,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ServiceProxyOptions",
 				},
 			},
 		},
@@ -6983,6 +9314,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ServiceSpec",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ServicePort"},
@@ -7000,11 +9336,16 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.ServiceStatus",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LoadBalancerStatus"},
 	},
-	"v1.Status": {
+	"io.k8s.meta.v1.Status": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Status is a return value for calls that don't return other objects.",
@@ -7012,7 +9353,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"status": {
@@ -7039,7 +9380,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"details": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.StatusDetails"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.StatusDetails"),
 						},
 					},
 					"code": {
@@ -7051,9 +9392,107 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.Status",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.StatusDetails"},
+			"io.k8s.meta.v1.ListMeta", "io.k8s.meta.v1.StatusDetails"},
+	},
+	"v1.Status": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Status is a return value for calls that don't return other objects.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the operation. One of: \"Success\" or \"Failure\". More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A human-readable description of the status of this operation.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A machine-readable description of why this operation is in the \"Failure\" status. If this value is empty there is no information available. A Reason clarifies an HTTP status code but does not override it.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"details": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Extended data associated with the reason.  Each reason may define its own extended details. This field is optional and the data returned is not guaranteed to conform to any schema except that defined by the reason type.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.StatusDetails"),
+						},
+					},
+					"code": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Suggested HTTP return code for this status, 0 if not set.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.Status",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.Status",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.ListMeta", "io.k8s.meta.v1.StatusDetails"},
+	},
+	"io.k8s.meta.v1.StatusCause": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+				Properties: map[string]spec.Schema{
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A machine-readable description of the cause of the error. If this value is empty there is no information available.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A human-readable description of the cause of the error.  This field may be presented as-is to a reader.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"field": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.StatusCause",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.StatusCause": {
 		Schema: spec.Schema{
@@ -7083,8 +9522,71 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.StatusCause",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.StatusCause",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.StatusDetails": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name attribute of the resource associated with the status StatusReason (when there is a single name which can be described).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The group attribute of the resource associated with the status StatusReason.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The kind attribute of the resource associated with the status StatusReason. On some operations may differ from the requested resource Kind. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"causes": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.StatusCause"),
+									},
+								},
+							},
+						},
+					},
+					"retryAfterSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, the time in seconds before the operation should be retried.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.StatusDetails",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.StatusCause"},
 	},
 	"v1.StatusDetails": {
 		Schema: spec.Schema{
@@ -7119,7 +9621,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.StatusCause"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.StatusCause"),
 									},
 								},
 							},
@@ -7134,9 +9636,15 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.StatusDetails",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.StatusDetails",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.StatusCause"},
+			"io.k8s.meta.v1.StatusCause"},
 	},
 	"v1.Sysctl": {
 		Schema: spec.Schema{
@@ -7157,6 +9665,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"Name", "Value"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Sysctl",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -7168,15 +9681,20 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.",
-							Ref:         spec.MustCreateRef("#/definitions/intstr.IntOrString"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
 						},
 					},
 				},
 				Required: []string{"port"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.TCPSocketAction",
+				},
+			},
 		},
 		Dependencies: []string{
-			"intstr.IntOrString"},
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString"},
 	},
 	"v1.Taint": {
 		Schema: spec.Schema{
@@ -7207,8 +9725,33 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"key", "effect"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Taint",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.testgroup.v1.TestType": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.testgroup.v1.TestTypeStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1.TestType",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.testgroup.v1.TestTypeStatus"},
 	},
 	"v1.TestType": {
 		Schema: spec.Schema{
@@ -7216,22 +9759,28 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				Properties: map[string]spec.Schema{
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("#/definitions/v1.TestTypeStatus"),
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.testgroup.v1.TestTypeStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1.TestType",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.testgroup.v1.TestType",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.TestTypeStatus"},
+			"io.k8s.testgroup.v1.TestTypeStatus"},
 	},
-	"v1.TestTypeList": {
+	"io.k8s.testgroup.v1.TestTypeList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -7240,7 +9789,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.TestType"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.testgroup.v1.TestType"),
 									},
 								},
 							},
@@ -7249,9 +9798,69 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1.TestTypeList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1.TestType"},
+			"io.k8s.meta.v1.ListMeta", "io.k8s.testgroup.v1.TestType"},
+	},
+	"v1.TestTypeList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.testgroup.v1.TestType"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1.TestTypeList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.testgroup.v1.TestTypeList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.ListMeta", "io.k8s.testgroup.v1.TestType"},
+	},
+	"io.k8s.testgroup.v1.TestTypeStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"Blah": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"Blah"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1.TestTypeStatus",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1.TestTypeStatus": {
 		Schema: spec.Schema{
@@ -7266,10 +9875,18 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"Blah"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1.TestTypeStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.testgroup.v1.TestTypeStatus",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
-	"v1.Time": v1.Time{}.OpenAPIDefinition(), "v1.Timestamp": {
+	"io.k8s.meta.v1.Time": v1.Time{}.OpenAPIDefinition(),
+	"v1.Time":             v1.Time{}.OpenAPIDefinition(),
+	"io.k8s.meta.v1.Timestamp": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Timestamp is a struct that is equivalent to Time, but intended for protobuf marshalling/unmarshalling. It is generated into a serialization that matches Time. Do not use in Go structs.",
@@ -7290,6 +9907,42 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"seconds", "nanos"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.Timestamp",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"v1.Timestamp": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Timestamp is a struct that is equivalent to Time, but intended for protobuf marshalling/unmarshalling. It is generated into a serialization that matches Time. Do not use in Go structs.",
+				Properties: map[string]spec.Schema{
+					"seconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Represents seconds of UTC time since Unix epoch 1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59Z inclusive.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"nanos": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Non-negative fractions of a second at nanosecond resolution. Negative second values with fractions must still have non-negative nanos values that count forward in time. Must be from 0 to 999,999,999 inclusive. This field may be limited in precision depending on context.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"seconds", "nanos"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.Timestamp",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.Timestamp",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -7329,6 +9982,40 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Toleration",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.meta.v1.TypeMeta": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "TypeMeta describes an individual object in an API response or request with strings representing the type of the object and its API schema version. Structures that are versioned or persisted should inline TypeMeta.",
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/meta/v1.TypeMeta",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -7353,6 +10040,12 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/meta/v1.TypeMeta",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.meta.v1.TypeMeta",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -7370,6 +10063,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"name"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.Volume",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -7409,6 +10107,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"name", "mountPath"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.VolumeMount",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -7558,6 +10261,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.VolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.AWSElasticBlockStoreVolumeSource", "v1.AzureDiskVolumeSource", "v1.AzureFileVolumeSource", "v1.CephFSVolumeSource", "v1.CinderVolumeSource", "v1.ConfigMapVolumeSource", "v1.DownwardAPIVolumeSource", "v1.EmptyDirVolumeSource", "v1.FCVolumeSource", "v1.FlexVolumeSource", "v1.FlockerVolumeSource", "v1.GCEPersistentDiskVolumeSource", "v1.GitRepoVolumeSource", "v1.GlusterfsVolumeSource", "v1.HostPathVolumeSource", "v1.ISCSIVolumeSource", "v1.NFSVolumeSource", "v1.PersistentVolumeClaimVolumeSource", "v1.PhotonPersistentDiskVolumeSource", "v1.QuobyteVolumeSource", "v1.RBDVolumeSource", "v1.SecretVolumeSource", "v1.VsphereVirtualDiskVolumeSource"},
@@ -7584,6 +10292,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"volumePath"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.VsphereVirtualDiskVolumeSource",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -7608,6 +10321,11 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"weight", "podAffinityTerm"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.WeightedPodAffinityTerm",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.PodAffinityTerm"},
@@ -7618,8 +10336,46 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				Description: "simpleNameGenerator generates random names.",
 				Properties:  map[string]spec.Schema{},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/api/v1.simpleNameGenerator",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.certificates.v1alpha1.CertificateSigningRequest": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Describes a certificate signing request",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The certificate request itself and any additional information.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Derived information about the request.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequest",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec", "io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus", "v1.ObjectMeta"},
 	},
 	"v1alpha1.CertificateSigningRequest": {
 		Schema: spec.Schema{
@@ -7634,20 +10390,69 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The certificate request itself and any additional information.",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.CertificateSigningRequestSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Derived information about the request.",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.CertificateSigningRequestStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequest",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.certificates.v1alpha1.CertificateSigningRequest",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1alpha1.CertificateSigningRequestSpec", "v1alpha1.CertificateSigningRequestStatus"},
+			"io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec", "io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus", "v1.ObjectMeta"},
+	},
+	"io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "request approval state, currently Approved or Denied.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "brief reason for the request state",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "human readable message with details about the request state",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"lastUpdateTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "timestamp for the last update to this condition",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+				},
+				Required: []string{"type"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequestCondition",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1alpha1.CertificateSigningRequestCondition": {
 		Schema: spec.Schema{
@@ -7677,23 +10482,29 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastUpdateTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "timestamp for the last update to this condition",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 				},
 				Required: []string{"type"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequestCondition",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
-	"v1alpha1.CertificateSigningRequestList": {
+	"io.k8s.certificates.v1alpha1.CertificateSigningRequestList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -7702,7 +10513,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.CertificateSigningRequest"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"),
 									},
 								},
 							},
@@ -7711,9 +10522,97 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequestList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1alpha1.CertificateSigningRequest"},
+			"io.k8s.certificates.v1alpha1.CertificateSigningRequest", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1alpha1.CertificateSigningRequestList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequest"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequestList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.certificates.v1alpha1.CertificateSigningRequestList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.certificates.v1alpha1.CertificateSigningRequest", "io.k8s.meta.v1.ListMeta"},
+	},
+	"io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "This information is immutable after the request is created. Only the Request and ExtraInfo fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.",
+				Properties: map[string]spec.Schema{
+					"request": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Base64-encoded PKCS#10 CSR data",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
+					"username": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Information about the requesting user (if relevant) See user.Info interface for details",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"uid": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"groups": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"request"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequestSpec",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1alpha1.CertificateSigningRequestSpec": {
 		Schema: spec.Schema{
@@ -7756,10 +10655,16 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"request"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequestSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.certificates.v1alpha1.CertificateSigningRequestSpec",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
-	"v1alpha1.CertificateSigningRequestStatus": {
+	"io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Properties: map[string]spec.Schema{
@@ -7770,7 +10675,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.CertificateSigningRequestCondition"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition"),
 									},
 								},
 							},
@@ -7785,9 +10690,86 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequestStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1alpha1.CertificateSigningRequestCondition"},
+			"io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition"},
+	},
+	"v1alpha1.CertificateSigningRequestStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"conditions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Conditions applied to the request, such as approval or denial.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition"),
+									},
+								},
+							},
+						},
+					},
+					"certificate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If request was approved, the controller will place the issued certificate here.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1.CertificateSigningRequestStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.certificates.v1alpha1.CertificateSigningRequestStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.certificates.v1alpha1.CertificateSigningRequestCondition"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.ClusterRole": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"rules": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Rules holds all the PolicyRules for this ClusterRole",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.PolicyRule"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"rules"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRole",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.PolicyRule", "v1.ObjectMeta"},
 	},
 	"v1alpha1.ClusterRole": {
 		Schema: spec.Schema{
@@ -7807,7 +10789,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.PolicyRule"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.PolicyRule"),
 									},
 								},
 							},
@@ -7816,9 +10798,57 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"rules"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRole",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.ClusterRole",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1alpha1.PolicyRule"},
+			"io.k8s.authorization.rbac.v1alpha1.PolicyRule", "v1.ObjectMeta"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"subjects": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Subjects holds references to the objects the role applies to.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.Subject"),
+									},
+								},
+							},
+						},
+					},
+					"roleRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleRef"),
+						},
+					},
+				},
+				Required: []string{"subjects", "roleRef"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRoleBinding",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.RoleRef", "io.k8s.authorization.rbac.v1alpha1.Subject", "v1.ObjectMeta"},
 	},
 	"v1alpha1.ClusterRoleBinding": {
 		Schema: spec.Schema{
@@ -7838,7 +10868,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.Subject"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.Subject"),
 									},
 								},
 							},
@@ -7847,15 +10877,43 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"roleRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RoleRef can only reference a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.RoleRef"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleRef"),
 						},
 					},
 				},
 				Required: []string{"subjects", "roleRef"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRoleBinding",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1alpha1.RoleRef", "v1alpha1.Subject"},
+			"io.k8s.authorization.rbac.v1alpha1.RoleRef", "io.k8s.authorization.rbac.v1alpha1.Subject", "v1.ObjectMeta"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingBuilder": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterRoleBindingBuilder let's us attach methods.  A no-no for API types. We use it to construct bindings in code.  It's more compact than trying to write them out in a literal.",
+				Properties: map[string]spec.Schema{
+					"ClusterRoleBinding": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"),
+						},
+					},
+				},
+				Required: []string{"ClusterRoleBinding"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRoleBindingBuilder",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"},
 	},
 	"v1alpha1.ClusterRoleBindingBuilder": {
 		Schema: spec.Schema{
@@ -7864,17 +10922,23 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				Properties: map[string]spec.Schema{
 					"ClusterRoleBinding": {
 						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("#/definitions/v1alpha1.ClusterRoleBinding"),
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"),
 						},
 					},
 				},
 				Required: []string{"ClusterRoleBinding"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRoleBindingBuilder",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingBuilder",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1alpha1.ClusterRoleBinding"},
+			"io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"},
 	},
-	"v1alpha1.ClusterRoleBindingList": {
+	"io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ClusterRoleBindingList is a collection of ClusterRoleBindings",
@@ -7882,7 +10946,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -7892,7 +10956,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.ClusterRoleBinding"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"),
 									},
 								},
 							},
@@ -7901,11 +10965,53 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRoleBindingList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1alpha1.ClusterRoleBinding"},
+			"io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding", "io.k8s.meta.v1.ListMeta"},
 	},
-	"v1alpha1.ClusterRoleList": {
+	"v1alpha1.ClusterRoleBindingList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is a list of ClusterRoleBindings",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRoleBindingList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleBindingList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.ClusterRoleBinding", "io.k8s.meta.v1.ListMeta"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.ClusterRoleList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ClusterRoleList is a collection of ClusterRoles",
@@ -7913,7 +11019,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -7923,7 +11029,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.ClusterRole"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"),
 									},
 								},
 							},
@@ -7932,9 +11038,85 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRoleList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1alpha1.ClusterRole"},
+			"io.k8s.authorization.rbac.v1alpha1.ClusterRole", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1alpha1.ClusterRoleList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterRoleList is a collection of ClusterRoles",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is a list of ClusterRoles",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.ClusterRole"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.ClusterRoleList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.ClusterRoleList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.ClusterRole", "io.k8s.meta.v1.ListMeta"},
+	},
+	"io.k8s.imagepolicy.v1alpha1.ImageReview": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ImageReview checks if the set of images in a pod are allowed.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec holds information about the pod being evaluated",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.imagepolicy.v1alpha1.ImageReviewSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is filled in by the backend and indicates whether the pod should be allowed.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.imagepolicy.v1alpha1.ImageReviewStatus"),
+						},
+					},
+				},
+				Required: []string{"spec"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1.ImageReview",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.imagepolicy.v1alpha1.ImageReviewSpec", "io.k8s.imagepolicy.v1alpha1.ImageReviewStatus", "v1.ObjectMeta"},
 	},
 	"v1alpha1.ImageReview": {
 		Schema: spec.Schema{
@@ -7949,21 +11131,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds information about the pod being evaluated",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.ImageReviewSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.imagepolicy.v1alpha1.ImageReviewSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is filled in by the backend and indicates whether the pod should be allowed.",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.ImageReviewStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.imagepolicy.v1alpha1.ImageReviewStatus"),
 						},
 					},
 				},
 				Required: []string{"spec"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1.ImageReview",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.imagepolicy.v1alpha1.ImageReview",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1alpha1.ImageReviewSpec", "v1alpha1.ImageReviewStatus"},
+			"io.k8s.imagepolicy.v1alpha1.ImageReviewSpec", "io.k8s.imagepolicy.v1alpha1.ImageReviewStatus", "v1.ObjectMeta"},
+	},
+	"io.k8s.imagepolicy.v1alpha1.ImageReviewContainerSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ImageReviewContainerSpec is a description of a container within the pod creation request.",
+				Properties: map[string]spec.Schema{
+					"image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "This can be in the form image:tag or image@SHA:012345679abcdef.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1.ImageReviewContainerSpec",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1alpha1.ImageReviewContainerSpec": {
 		Schema: spec.Schema{
@@ -7979,10 +11189,16 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1.ImageReviewContainerSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.imagepolicy.v1alpha1.ImageReviewContainerSpec",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
-	"v1alpha1.ImageReviewSpec": {
+	"io.k8s.imagepolicy.v1alpha1.ImageReviewSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ImageReviewSpec is a description of the pod creation request.",
@@ -7994,7 +11210,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.ImageReviewContainerSpec"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.imagepolicy.v1alpha1.ImageReviewContainerSpec"),
 									},
 								},
 							},
@@ -8023,9 +11239,95 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1.ImageReviewSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1alpha1.ImageReviewContainerSpec"},
+			"io.k8s.imagepolicy.v1alpha1.ImageReviewContainerSpec"},
+	},
+	"v1alpha1.ImageReviewSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ImageReviewSpec is a description of the pod creation request.",
+				Properties: map[string]spec.Schema{
+					"containers": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Containers is a list of a subset of the information in each container of the Pod being created.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.imagepolicy.v1alpha1.ImageReviewContainerSpec"),
+									},
+								},
+							},
+						},
+					},
+					"annotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Annotations is a list of key-value pairs extracted from the Pod's annotations. It only includes keys which match the pattern `*.image-policy.k8s.io/*`. It is up to each webhook backend to determine how to interpret these annotations, if at all.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace is the namespace the pod is being created in.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1.ImageReviewSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.imagepolicy.v1alpha1.ImageReviewSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.imagepolicy.v1alpha1.ImageReviewContainerSpec"},
+	},
+	"io.k8s.imagepolicy.v1alpha1.ImageReviewStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ImageReviewStatus is the result of the token authentication request.",
+				Properties: map[string]spec.Schema{
+					"allowed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Allowed indicates that all images were allowed to be run.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Reason should be empty unless Allowed is false in which case it may contain a short description of what is wrong.  Kubernetes may truncate excessively long errors when displaying to the user.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"allowed"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1.ImageReviewStatus",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1alpha1.ImageReviewStatus": {
 		Schema: spec.Schema{
@@ -8049,10 +11351,16 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"allowed"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1.ImageReviewStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.imagepolicy.v1alpha1.ImageReviewStatus",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
-	"v1alpha1.KubeProxyConfiguration": {
+	"componentconfig.v1alpha1.KubeProxyConfiguration": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Properties: map[string]spec.Schema{
@@ -8101,13 +11409,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"iptablesSyncPeriodSeconds": {
 						SchemaProps: spec.SchemaProps{
 							Description: "iptablesSyncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"iptablesMinSyncPeriodSeconds": {
 						SchemaProps: spec.SchemaProps{
 							Description: "iptablesMinSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m', '2h22m').",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"kubeconfigPath": {
@@ -8162,7 +11470,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"udpTimeoutMilliseconds": {
 						SchemaProps: spec.SchemaProps{
 							Description: "udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s'). Must be greater than 0. Only applicable for proxyMode=userspace.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"conntrackMax": {
@@ -8189,21 +11497,291 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"conntrackTCPEstablishedTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "conntrackTCPEstablishedTimeout is how long an idle TCP connection will be kept open (e.g. '2s').  Must be greater than 0.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"conntrackTCPCloseWaitTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "conntrackTCPCloseWaitTimeout is how long an idle conntrack entry in CLOSE_WAIT state will remain in the conntrack table. (e.g. '60s'). Must be greater than 0 to set.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 				},
 				Required: []string{"bindAddress", "clusterCIDR", "healthzBindAddress", "healthzPort", "hostnameOverride", "iptablesMasqueradeBit", "iptablesSyncPeriodSeconds", "iptablesMinSyncPeriodSeconds", "kubeconfigPath", "masqueradeAll", "master", "oomScoreAdj", "mode", "portRange", "resourceContainer", "udpTimeoutMilliseconds", "conntrackMax", "conntrackMaxPerCore", "conntrackMin", "conntrackTCPEstablishedTimeout", "conntrackTCPCloseWaitTimeout"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeProxyConfiguration",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Duration"},
+			"io.k8s.meta.v1.Duration"},
+	},
+	"v1alpha1.KubeProxyConfiguration": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"bindAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0 for all interfaces)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"clusterCIDR": {
+						SchemaProps: spec.SchemaProps{
+							Description: "clusterCIDR is the CIDR range of the pods in the cluster. It is used to bridge traffic coming from outside of the cluster. If not provided, no off-cluster bridging will be performed.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"healthzBindAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "healthzBindAddress is the IP address for the health check server to serve on, defaulting to 127.0.0.1 (set to 0.0.0.0 for all interfaces)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"healthzPort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "healthzPort is the port to bind the health check server. Use 0 to disable.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"hostnameOverride": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"iptablesMasqueradeBit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "iptablesMasqueradeBit is the bit of the iptables fwmark space to use for SNAT if using the pure iptables proxy mode. Values must be within the range [0, 31].",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"iptablesSyncPeriodSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "iptablesSyncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m', '2h22m').  Must be greater than 0.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"iptablesMinSyncPeriodSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "iptablesMinSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m', '2h22m').",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"kubeconfigPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "kubeconfigPath is the path to the kubeconfig file with authorization information (the master location is set by the master flag).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"masqueradeAll": {
+						SchemaProps: spec.SchemaProps{
+							Description: "masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"master": {
+						SchemaProps: spec.SchemaProps{
+							Description: "master is the address of the Kubernetes API server (overrides any value in kubeconfig)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"oomScoreAdj": {
+						SchemaProps: spec.SchemaProps{
+							Description: "oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within the range [-1000, 1000]",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "mode specifies which proxy mode to use.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"portRange": {
+						SchemaProps: spec.SchemaProps{
+							Description: "portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resourceContainer": {
+						SchemaProps: spec.SchemaProps{
+							Description: "resourceContainer is the bsolute name of the resource-only container to create and run the Kube-proxy in (Default: /kube-proxy).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"udpTimeoutMilliseconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s'). Must be greater than 0. Only applicable for proxyMode=userspace.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"conntrackMax": {
+						SchemaProps: spec.SchemaProps{
+							Description: "conntrackMax is the maximum number of NAT connections to track (0 to leave as-is).  This takes precedence over conntrackMaxPerCore and conntrackMin.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"conntrackMaxPerCore": {
+						SchemaProps: spec.SchemaProps{
+							Description: "conntrackMaxPerCore is the maximum number of NAT connections to track per CPU core (0 to leave the limit as-is and ignore conntrackMin).",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"conntrackMin": {
+						SchemaProps: spec.SchemaProps{
+							Description: "conntrackMin is the minimum value of connect-tracking records to allocate, regardless of conntrackMaxPerCore (set conntrackMaxPerCore=0 to leave the limit as-is).",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"conntrackTCPEstablishedTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "conntrackTCPEstablishedTimeout is how long an idle TCP connection will be kept open (e.g. '2s').  Must be greater than 0.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"conntrackTCPCloseWaitTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "conntrackTCPCloseWaitTimeout is how long an idle conntrack entry in CLOSE_WAIT state will remain in the conntrack table. (e.g. '60s'). Must be greater than 0 to set.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+				},
+				Required: []string{"bindAddress", "clusterCIDR", "healthzBindAddress", "healthzPort", "hostnameOverride", "iptablesMasqueradeBit", "iptablesSyncPeriodSeconds", "iptablesMinSyncPeriodSeconds", "kubeconfigPath", "masqueradeAll", "master", "oomScoreAdj", "mode", "portRange", "resourceContainer", "udpTimeoutMilliseconds", "conntrackMax", "conntrackMaxPerCore", "conntrackMin", "conntrackTCPEstablishedTimeout", "conntrackTCPCloseWaitTimeout"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeProxyConfiguration",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeProxyConfiguration",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Duration"},
+	},
+	"componentconfig.v1alpha1.KubeSchedulerConfiguration": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"port": {
+						SchemaProps: spec.SchemaProps{
+							Description: "port is the port that the scheduler's http service runs on.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"address": {
+						SchemaProps: spec.SchemaProps{
+							Description: "address is the IP address to serve on.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"algorithmProvider": {
+						SchemaProps: spec.SchemaProps{
+							Description: "algorithmProvider is the scheduling algorithm provider to use.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"policyConfigFile": {
+						SchemaProps: spec.SchemaProps{
+							Description: "policyConfigFile is the filepath to the scheduler policy configuration.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"enableProfiling": {
+						SchemaProps: spec.SchemaProps{
+							Description: "enableProfiling enables profiling via web interface.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"enableContentionProfiling": {
+						SchemaProps: spec.SchemaProps{
+							Description: "enableContentionProfiling enables lock contention profiling, if enableProfiling is true.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"contentType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "contentType is contentType of requests sent to apiserver.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"kubeAPIQPS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.",
+							Type:        []string{"number"},
+							Format:      "float",
+						},
+					},
+					"kubeAPIBurst": {
+						SchemaProps: spec.SchemaProps{
+							Description: "kubeAPIBurst is the QPS burst to use while talking with kubernetes apiserver.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"schedulerName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "schedulerName is name of the scheduler, used to select which pods will be processed by this scheduler, based on pod's annotation with key 'scheduler.alpha.kubernetes.io/name'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"hardPodAffinitySymmetricWeight": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule corresponding to every RequiredDuringScheduling affinity rule. HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"failureDomains": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Indicate the \"all topologies\" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"leaderElection": {
+						SchemaProps: spec.SchemaProps{
+							Description: "leaderElection defines the configuration of leader election client.",
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.LeaderElectionConfiguration"),
+						},
+					},
+				},
+				Required: []string{"port", "address", "algorithmProvider", "policyConfigFile", "enableProfiling", "enableContentionProfiling", "contentType", "kubeAPIQPS", "kubeAPIBurst", "schedulerName", "hardPodAffinitySymmetricWeight", "failureDomains", "leaderElection"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeSchedulerConfiguration",
+				},
+			},
+		},
+		Dependencies: []string{
+			"componentconfig.v1alpha1.LeaderElectionConfiguration"},
 	},
 	"v1alpha1.KubeSchedulerConfiguration": {
 		Schema: spec.Schema{
@@ -8296,15 +11874,43 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"leaderElection": {
 						SchemaProps: spec.SchemaProps{
 							Description: "leaderElection defines the configuration of leader election client.",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.LeaderElectionConfiguration"),
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.LeaderElectionConfiguration"),
 						},
 					},
 				},
 				Required: []string{"port", "address", "algorithmProvider", "policyConfigFile", "enableProfiling", "enableContentionProfiling", "contentType", "kubeAPIQPS", "kubeAPIBurst", "schedulerName", "hardPodAffinitySymmetricWeight", "failureDomains", "leaderElection"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeSchedulerConfiguration",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeSchedulerConfiguration",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1alpha1.LeaderElectionConfiguration"},
+			"componentconfig.v1alpha1.LeaderElectionConfiguration"},
+	},
+	"componentconfig.v1alpha1.KubeletAnonymousAuthentication": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"enabled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "enabled allows anonymous requests to the kubelet server. Requests that are not rejected by another authentication method are treated as anonymous requests. Anonymous requests have a username of system:anonymous, and a group name of system:unauthenticated.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"enabled"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletAnonymousAuthentication",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1alpha1.KubeletAnonymousAuthentication": {
 		Schema: spec.Schema{
@@ -8320,8 +11926,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"enabled"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletAnonymousAuthentication",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeletAnonymousAuthentication",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"componentconfig.v1alpha1.KubeletAuthentication": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"x509": {
+						SchemaProps: spec.SchemaProps{
+							Description: "x509 contains settings related to x509 client certificate authentication",
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletX509Authentication"),
+						},
+					},
+					"webhook": {
+						SchemaProps: spec.SchemaProps{
+							Description: "webhook contains settings related to webhook bearer token authentication",
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletWebhookAuthentication"),
+						},
+					},
+					"anonymous": {
+						SchemaProps: spec.SchemaProps{
+							Description: "anonymous contains settings related to anonymous authentication",
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletAnonymousAuthentication"),
+						},
+					},
+				},
+				Required: []string{"x509", "webhook", "anonymous"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletAuthentication",
+				},
+			},
+		},
+		Dependencies: []string{
+			"componentconfig.v1alpha1.KubeletAnonymousAuthentication", "componentconfig.v1alpha1.KubeletWebhookAuthentication", "componentconfig.v1alpha1.KubeletX509Authentication"},
 	},
 	"v1alpha1.KubeletAuthentication": {
 		Schema: spec.Schema{
@@ -8330,27 +11976,62 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"x509": {
 						SchemaProps: spec.SchemaProps{
 							Description: "x509 contains settings related to x509 client certificate authentication",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.KubeletX509Authentication"),
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletX509Authentication"),
 						},
 					},
 					"webhook": {
 						SchemaProps: spec.SchemaProps{
 							Description: "webhook contains settings related to webhook bearer token authentication",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.KubeletWebhookAuthentication"),
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletWebhookAuthentication"),
 						},
 					},
 					"anonymous": {
 						SchemaProps: spec.SchemaProps{
 							Description: "anonymous contains settings related to anonymous authentication",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.KubeletAnonymousAuthentication"),
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletAnonymousAuthentication"),
 						},
 					},
 				},
 				Required: []string{"x509", "webhook", "anonymous"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletAuthentication",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeletAuthentication",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1alpha1.KubeletAnonymousAuthentication", "v1alpha1.KubeletWebhookAuthentication", "v1alpha1.KubeletX509Authentication"},
+			"componentconfig.v1alpha1.KubeletAnonymousAuthentication", "componentconfig.v1alpha1.KubeletWebhookAuthentication", "componentconfig.v1alpha1.KubeletX509Authentication"},
+	},
+	"componentconfig.v1alpha1.KubeletAuthorization": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"mode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "mode is the authorization mode to apply to requests to the kubelet server. Valid values are AlwaysAllow and Webhook. Webhook mode uses the SubjectAccessReview API to determine authorization.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"webhook": {
+						SchemaProps: spec.SchemaProps{
+							Description: "webhook contains settings related to Webhook authorization.",
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletWebhookAuthorization"),
+						},
+					},
+				},
+				Required: []string{"mode", "webhook"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletAuthorization",
+				},
+			},
+		},
+		Dependencies: []string{
+			"componentconfig.v1alpha1.KubeletWebhookAuthorization"},
 	},
 	"v1alpha1.KubeletAuthorization": {
 		Schema: spec.Schema{
@@ -8366,17 +12047,23 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"webhook": {
 						SchemaProps: spec.SchemaProps{
 							Description: "webhook contains settings related to Webhook authorization.",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.KubeletWebhookAuthorization"),
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletWebhookAuthorization"),
 						},
 					},
 				},
 				Required: []string{"mode", "webhook"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletAuthorization",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeletAuthorization",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1alpha1.KubeletWebhookAuthorization"},
+			"componentconfig.v1alpha1.KubeletWebhookAuthorization"},
 	},
-	"v1alpha1.KubeletConfiguration": {
+	"componentconfig.v1alpha1.KubeletConfiguration": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Properties: map[string]spec.Schema{
@@ -8390,19 +12077,19 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"syncFrequency": {
 						SchemaProps: spec.SchemaProps{
 							Description: "syncFrequency is the max period between synchronizing running containers and config",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"fileCheckFrequency": {
 						SchemaProps: spec.SchemaProps{
 							Description: "fileCheckFrequency is the duration between checking config files for new data",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"httpCheckFrequency": {
 						SchemaProps: spec.SchemaProps{
 							Description: "httpCheckFrequency is the duration between checking http for new data",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"manifestURL": {
@@ -8471,13 +12158,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"authentication": {
 						SchemaProps: spec.SchemaProps{
 							Description: "authentication specifies how requests to the Kubelet's server are authenticated",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.KubeletAuthentication"),
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletAuthentication"),
 						},
 					},
 					"authorization": {
 						SchemaProps: spec.SchemaProps{
 							Description: "authorization specifies how requests to the Kubelet's server are authorized",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.KubeletAuthorization"),
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletAuthorization"),
 						},
 					},
 					"hostnameOverride": {
@@ -8602,7 +12289,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"minimumGCAge": {
 						SchemaProps: spec.SchemaProps{
 							Description: "minimumGCAge is the minimum age for a finished container before it is garbage collected.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"maxPerPodContainerCount": {
@@ -8678,19 +12365,19 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"streamingConnectionIdleTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "streamingConnectionIdleTimeout is the maximum time a streaming connection can be idle before the connection is automatically closed.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"nodeStatusUpdateFrequency": {
 						SchemaProps: spec.SchemaProps{
 							Description: "nodeStatusUpdateFrequency is the frequency that kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"imageMinimumGCAge": {
 						SchemaProps: spec.SchemaProps{
 							Description: "imageMinimumGCAge is the minimum age for an unused image before it is garbage collected.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"imageGCHighThresholdPercent": {
@@ -8717,7 +12404,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"volumeStatsAggPeriod": {
 						SchemaProps: spec.SchemaProps{
 							Description: "How frequently to calculate and cache volume disk usage for all pods",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"networkPluginName": {
@@ -8842,13 +12529,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"runtimeRequestTimeout": {
 						SchemaProps: spec.SchemaProps{
 							Description: "runtimeRequestTimeout is the timeout for all runtime requests except long running requests - pull, logs, exec and attach.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"imagePullProgressDeadline": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If no pulling progress is made before the deadline imagePullProgressDeadline, the image pulling will be cancelled. Defaults to 1m0s.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"rktPath": {
@@ -9014,7 +12701,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"outOfDiskTransitionFrequency": {
 						SchemaProps: spec.SchemaProps{
 							Description: "outOfDiskTransitionFrequency is duration for which the kubelet has to wait before transitioning out of out-of-disk node condition status.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"nodeIP": {
@@ -9076,7 +12763,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"evictionPressureTransitionPeriod": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"evictionMaxPodGracePeriod": {
@@ -9215,9 +12902,892 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"podManifestPath", "syncFrequency", "fileCheckFrequency", "httpCheckFrequency", "manifestURL", "manifestURLHeader", "enableServer", "address", "port", "readOnlyPort", "tlsCertFile", "tlsPrivateKeyFile", "certDirectory", "authentication", "authorization", "hostnameOverride", "podInfraContainerImage", "dockerEndpoint", "rootDirectory", "seccompProfileRoot", "allowPrivileged", "hostNetworkSources", "hostPIDSources", "hostIPCSources", "registryPullQPS", "registryBurst", "eventRecordQPS", "eventBurst", "enableDebuggingHandlers", "minimumGCAge", "maxPerPodContainerCount", "maxContainerCount", "cAdvisorPort", "healthzPort", "healthzBindAddress", "oomScoreAdj", "registerNode", "clusterDomain", "masterServiceNamespace", "clusterDNS", "streamingConnectionIdleTimeout", "nodeStatusUpdateFrequency", "imageMinimumGCAge", "imageGCHighThresholdPercent", "imageGCLowThresholdPercent", "lowDiskSpaceThresholdMB", "volumeStatsAggPeriod", "networkPluginName", "networkPluginDir", "cniConfDir", "cniBinDir", "networkPluginMTU", "volumePluginDir", "cloudProvider", "cloudConfigFile", "kubeletCgroups", "runtimeCgroups", "systemCgroups", "cgroupRoot", "containerRuntime", "remoteRuntimeEndpoint", "remoteImageEndpoint", "runtimeRequestTimeout", "rktPath", "rktAPIEndpoint", "rktStage1Image", "lockFilePath", "exitOnLockContention", "hairpinMode", "babysitDaemons", "maxPods", "nvidiaGPUs", "dockerExecHandlerName", "podCIDR", "resolvConf", "cpuCFSQuota", "containerized", "maxOpenFiles", "registerSchedulable", "registerWithTaints", "contentType", "kubeAPIQPS", "kubeAPIBurst", "serializeImagePulls", "outOfDiskTransitionFrequency", "nodeIP", "nodeLabels", "nonMasqueradeCIDR", "enableCustomMetrics", "evictionHard", "evictionSoft", "evictionSoftGracePeriod", "evictionPressureTransitionPeriod", "evictionMaxPodGracePeriod", "evictionMinimumReclaim", "experimentalKernelMemcgNotification", "podsPerCore", "enableControllerAttachDetach", "systemReserved", "kubeReserved", "protectKernelDefaults", "makeIPTablesUtilChains", "iptablesMasqueradeBit", "iptablesDropBit"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletConfiguration",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Duration", "v1.Taint", "v1alpha1.KubeletAuthentication", "v1alpha1.KubeletAuthorization"},
+			"componentconfig.v1alpha1.KubeletAuthentication", "componentconfig.v1alpha1.KubeletAuthorization", "io.k8s.meta.v1.Duration", "v1.Taint"},
+	},
+	"v1alpha1.KubeletConfiguration": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"podManifestPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "podManifestPath is the path to the directory containing pod manifests to run, or the path to a single manifest file",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"syncFrequency": {
+						SchemaProps: spec.SchemaProps{
+							Description: "syncFrequency is the max period between synchronizing running containers and config",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"fileCheckFrequency": {
+						SchemaProps: spec.SchemaProps{
+							Description: "fileCheckFrequency is the duration between checking config files for new data",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"httpCheckFrequency": {
+						SchemaProps: spec.SchemaProps{
+							Description: "httpCheckFrequency is the duration between checking http for new data",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"manifestURL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "manifestURL is the URL for accessing the container manifest",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"manifestURLHeader": {
+						SchemaProps: spec.SchemaProps{
+							Description: "manifestURLHeader is the HTTP header to use when accessing the manifest URL, with the key separated from the value with a ':', as in 'key:value'",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"enableServer": {
+						SchemaProps: spec.SchemaProps{
+							Description: "enableServer enables the Kubelet's server",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"address": {
+						SchemaProps: spec.SchemaProps{
+							Description: "address is the IP address for the Kubelet to serve on (set to 0.0.0.0 for all interfaces)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"port": {
+						SchemaProps: spec.SchemaProps{
+							Description: "port is the port for the Kubelet to serve on.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"readOnlyPort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "readOnlyPort is the read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"tlsCertFile": {
+						SchemaProps: spec.SchemaProps{
+							Description: "tlsCertFile is the file containing x509 Certificate for HTTPS.  (CA cert, if any, concatenated after server cert). If tlsCertFile and tlsPrivateKeyFile are not provided, a self-signed certificate and key are generated for the public address and saved to the directory passed to certDir.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"tlsPrivateKeyFile": {
+						SchemaProps: spec.SchemaProps{
+							Description: "tlsPrivateKeyFile is the ile containing x509 private key matching tlsCertFile.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"certDirectory": {
+						SchemaProps: spec.SchemaProps{
+							Description: "certDirectory is the directory where the TLS certs are located (by default /var/run/kubernetes). If tlsCertFile and tlsPrivateKeyFile are provided, this flag will be ignored.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"authentication": {
+						SchemaProps: spec.SchemaProps{
+							Description: "authentication specifies how requests to the Kubelet's server are authenticated",
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletAuthentication"),
+						},
+					},
+					"authorization": {
+						SchemaProps: spec.SchemaProps{
+							Description: "authorization specifies how requests to the Kubelet's server are authorized",
+							Ref:         spec.MustCreateRef("#/definitions/componentconfig.v1alpha1.KubeletAuthorization"),
+						},
+					},
+					"hostnameOverride": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"podInfraContainerImage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "podInfraContainerImage is the image whose network/ipc namespaces containers in each pod will use.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"dockerEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Description: "dockerEndpoint is the path to the docker endpoint to communicate with.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"rootDirectory": {
+						SchemaProps: spec.SchemaProps{
+							Description: "rootDirectory is the directory path to place kubelet files (volume mounts,etc).",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"seccompProfileRoot": {
+						SchemaProps: spec.SchemaProps{
+							Description: "seccompProfileRoot is the directory path for seccomp profiles.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"allowPrivileged": {
+						SchemaProps: spec.SchemaProps{
+							Description: "allowPrivileged enables containers to request privileged mode. Defaults to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"hostNetworkSources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostNetworkSources is a comma-separated list of sources from which the Kubelet allows pods to use of host network. Defaults to \"*\". Valid options are \"file\", \"http\", \"api\", and \"*\" (all sources).",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"hostPIDSources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostPIDSources is a comma-separated list of sources from which the Kubelet allows pods to use the host pid namespace. Defaults to \"*\".",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"hostIPCSources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostIPCSources is a comma-separated list of sources from which the Kubelet allows pods to use the host ipc namespace. Defaults to \"*\".",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"registryPullQPS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "registryPullQPS is the limit of registry pulls per second. If 0, unlimited. Set to 0 for no limit. Defaults to 5.0.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"registryBurst": {
+						SchemaProps: spec.SchemaProps{
+							Description: "registryBurst is the maximum size of a bursty pulls, temporarily allows pulls to burst to this number, while still not exceeding registryQps. Only used if registryQPS > 0.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"eventRecordQPS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "eventRecordQPS is the maximum event creations per second. If 0, there is no limit enforced.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"eventBurst": {
+						SchemaProps: spec.SchemaProps{
+							Description: "eventBurst is the maximum size of a bursty event records, temporarily allows event records to burst to this number, while still not exceeding event-qps. Only used if eventQps > 0",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"enableDebuggingHandlers": {
+						SchemaProps: spec.SchemaProps{
+							Description: "enableDebuggingHandlers enables server endpoints for log collection and local running of containers and commands",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"minimumGCAge": {
+						SchemaProps: spec.SchemaProps{
+							Description: "minimumGCAge is the minimum age for a finished container before it is garbage collected.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"maxPerPodContainerCount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "maxPerPodContainerCount is the maximum number of old instances to retain per container. Each container takes up some disk space.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"maxContainerCount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "maxContainerCount is the maximum number of old instances of containers to retain globally. Each container takes up some disk space.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"cAdvisorPort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cAdvisorPort is the port of the localhost cAdvisor endpoint",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"healthzPort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "healthzPort is the port of the localhost healthz endpoint",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"healthzBindAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "healthzBindAddress is the IP address for the healthz server to serve on.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"oomScoreAdj": {
+						SchemaProps: spec.SchemaProps{
+							Description: "oomScoreAdj is The oom-score-adj value for kubelet process. Values must be within the range [-1000, 1000].",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"registerNode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "registerNode enables automatic registration with the apiserver.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"clusterDomain": {
+						SchemaProps: spec.SchemaProps{
+							Description: "clusterDomain is the DNS domain for this cluster. If set, kubelet will configure all containers to search this domain in addition to the host's search domains.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"masterServiceNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "masterServiceNamespace is The namespace from which the kubernetes master services should be injected into pods.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"clusterDNS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "clusterDNS is the IP address for a cluster DNS server.  If set, kubelet will configure all containers to use this for DNS resolution in addition to the host's DNS servers",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"streamingConnectionIdleTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "streamingConnectionIdleTimeout is the maximum time a streaming connection can be idle before the connection is automatically closed.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"nodeStatusUpdateFrequency": {
+						SchemaProps: spec.SchemaProps{
+							Description: "nodeStatusUpdateFrequency is the frequency that kubelet posts node status to master. Note: be cautious when changing the constant, it must work with nodeMonitorGracePeriod in nodecontroller.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"imageMinimumGCAge": {
+						SchemaProps: spec.SchemaProps{
+							Description: "imageMinimumGCAge is the minimum age for an unused image before it is garbage collected.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"imageGCHighThresholdPercent": {
+						SchemaProps: spec.SchemaProps{
+							Description: "imageGCHighThresholdPercent is the percent of disk usage after which image garbage collection is always run. The percent is calculated as this field value out of 100.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"imageGCLowThresholdPercent": {
+						SchemaProps: spec.SchemaProps{
+							Description: "imageGCLowThresholdPercent is the percent of disk usage before which image garbage collection is never run. Lowest disk usage to garbage collect to. The percent is calculated as this field value out of 100.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"lowDiskSpaceThresholdMB": {
+						SchemaProps: spec.SchemaProps{
+							Description: "lowDiskSpaceThresholdMB is the absolute free disk space, in MB, to maintain. When disk space falls below this threshold, new pods would be rejected.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"volumeStatsAggPeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "How frequently to calculate and cache volume disk usage for all pods",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"networkPluginName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "networkPluginName is the name of the network plugin to be invoked for various events in kubelet/pod lifecycle",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"networkPluginDir": {
+						SchemaProps: spec.SchemaProps{
+							Description: "networkPluginDir is the full path of the directory in which to search for network plugins (and, for backwards-compat, CNI config files)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"cniConfDir": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CNIConfDir is the full path of the directory in which to search for CNI config files",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"cniBinDir": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CNIBinDir is the full path of the directory in which to search for CNI plugin binaries",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"networkPluginMTU": {
+						SchemaProps: spec.SchemaProps{
+							Description: "networkPluginMTU is the MTU to be passed to the network plugin, and overrides the default MTU for cases where it cannot be automatically computed (such as IPSEC).",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"volumePluginDir": {
+						SchemaProps: spec.SchemaProps{
+							Description: "volumePluginDir is the full path of the directory in which to search for additional third party volume plugins",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"cloudProvider": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cloudProvider is the provider for cloud services.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"cloudConfigFile": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cloudConfigFile is the path to the cloud provider configuration file.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"kubeletCgroups": {
+						SchemaProps: spec.SchemaProps{
+							Description: "kubeletCgroups is the absolute name of cgroups to isolate the kubelet in.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"runtimeCgroups": {
+						SchemaProps: spec.SchemaProps{
+							Description: "runtimeCgroups are cgroups that container runtime is expected to be isolated in.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"systemCgroups": {
+						SchemaProps: spec.SchemaProps{
+							Description: "systemCgroups is absolute name of cgroups in which to place all non-kernel processes that are not already in a container. Empty for no container. Rolling back the flag requires a reboot.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"cgroupRoot": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cgroupRoot is the root cgroup to use for pods. This is handled by the container runtime on a best effort basis.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"experimentalCgroupsPerQOS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enable QoS based Cgroup hierarchy: top level cgroups for QoS Classes And all Burstable and BestEffort pods are brought up under their specific top level QoS cgroup.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"cgroupDriver": {
+						SchemaProps: spec.SchemaProps{
+							Description: "driver that the kubelet uses to manipulate cgroups on the host (cgroupfs or systemd)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"containerRuntime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "containerRuntime is the container runtime to use.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"remoteRuntimeEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Description: "remoteRuntimeEndpoint is the endpoint of remote runtime service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"remoteImageEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Description: "remoteImageEndpoint is the endpoint of remote image service",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"runtimeRequestTimeout": {
+						SchemaProps: spec.SchemaProps{
+							Description: "runtimeRequestTimeout is the timeout for all runtime requests except long running requests - pull, logs, exec and attach.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"imagePullProgressDeadline": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If no pulling progress is made before the deadline imagePullProgressDeadline, the image pulling will be cancelled. Defaults to 1m0s.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"rktPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "rktPath is the  path of rkt binary. Leave empty to use the first rkt in $PATH.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"experimentalMounterPath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "experimentalMounterPath is the path to mounter binary. If not set, kubelet will attempt to use mount binary that is available via $PATH,",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"rktAPIEndpoint": {
+						SchemaProps: spec.SchemaProps{
+							Description: "rktApiEndpoint is the endpoint of the rkt API service to communicate with.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"rktStage1Image": {
+						SchemaProps: spec.SchemaProps{
+							Description: "rktStage1Image is the image to use as stage1. Local paths and http/https URLs are supported.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"lockFilePath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "lockFilePath is the path that kubelet will use to as a lock file. It uses this file as a lock to synchronize with other kubelet processes that may be running.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"exitOnLockContention": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ExitOnLockContention is a flag that signifies to the kubelet that it is running in \"bootstrap\" mode. This requires that 'LockFilePath' has been set. This will cause the kubelet to listen to inotify events on the lock file, releasing it and exiting when another process tries to open that file.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"hairpinMode": {
+						SchemaProps: spec.SchemaProps{
+							Description: "How should the kubelet configure the container bridge for hairpin packets. Setting this flag allows endpoints in a Service to loadbalance back to themselves if they should try to access their own Service. Values:\n  \"promiscuous-bridge\": make the container bridge promiscuous.\n  \"hairpin-veth\":       set the hairpin flag on container veth interfaces.\n  \"none\":               do nothing.\nGenerally, one must set --hairpin-mode=veth-flag to achieve hairpin NAT, because promiscous-bridge assumes the existence of a container bridge named cbr0.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"babysitDaemons": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The node has babysitter process monitoring docker and kubelet.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"maxPods": {
+						SchemaProps: spec.SchemaProps{
+							Description: "maxPods is the number of pods that can run on this Kubelet.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"nvidiaGPUs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "nvidiaGPUs is the number of NVIDIA GPU devices on this node.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"dockerExecHandlerName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "dockerExecHandlerName is the handler to use when executing a command in a container. Valid values are 'native' and 'nsenter'. Defaults to 'native'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"podCIDR": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The CIDR to use for pod IP addresses, only used in standalone mode. In cluster mode, this is obtained from the master.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resolvConf": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ResolverConfig is the resolver configuration file used as the basis for the container DNS resolution configuration.\"), []",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"cpuCFSQuota": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cpuCFSQuota is Enable CPU CFS quota enforcement for containers that specify CPU limits",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"containerized": {
+						SchemaProps: spec.SchemaProps{
+							Description: "containerized should be set to true if kubelet is running in a container.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"maxOpenFiles": {
+						SchemaProps: spec.SchemaProps{
+							Description: "maxOpenFiles is Number of files that can be opened by Kubelet process.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"registerSchedulable": {
+						SchemaProps: spec.SchemaProps{
+							Description: "registerSchedulable tells the kubelet to register the node as schedulable. Won't have any effect if register-node is false. DEPRECATED: use registerWithTaints instead",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"registerWithTaints": {
+						SchemaProps: spec.SchemaProps{
+							Description: "registerWithTaints are an array of taints to add to a node object when the kubelet registers itself. This only takes effect when registerNode is true and upon the initial registration of the node.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/v1.Taint"),
+									},
+								},
+							},
+						},
+					},
+					"contentType": {
+						SchemaProps: spec.SchemaProps{
+							Description: "contentType is contentType of requests sent to apiserver.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"kubeAPIQPS": {
+						SchemaProps: spec.SchemaProps{
+							Description: "kubeAPIQPS is the QPS to use while talking with kubernetes apiserver",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"kubeAPIBurst": {
+						SchemaProps: spec.SchemaProps{
+							Description: "kubeAPIBurst is the burst to allow while talking with kubernetes apiserver",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"serializeImagePulls": {
+						SchemaProps: spec.SchemaProps{
+							Description: "serializeImagePulls when enabled, tells the Kubelet to pull images one at a time. We recommend *not* changing the default value on nodes that run docker daemon with version  < 1.9 or an Aufs storage backend. Issue #10959 has more details.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"outOfDiskTransitionFrequency": {
+						SchemaProps: spec.SchemaProps{
+							Description: "outOfDiskTransitionFrequency is duration for which the kubelet has to wait before transitioning out of out-of-disk node condition status.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"nodeIP": {
+						SchemaProps: spec.SchemaProps{
+							Description: "nodeIP is IP address of the node. If set, kubelet will use this IP address for the node.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"nodeLabels": {
+						SchemaProps: spec.SchemaProps{
+							Description: "nodeLabels to add when registering the node in the cluster.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"nonMasqueradeCIDR": {
+						SchemaProps: spec.SchemaProps{
+							Description: "nonMasqueradeCIDR configures masquerading: traffic to IPs outside this range will use IP masquerade.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"enableCustomMetrics": {
+						SchemaProps: spec.SchemaProps{
+							Description: "enable gathering custom metrics.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"evictionHard": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"evictionSoft": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"evictionSoftGracePeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Comma-delimeted list of grace periods for each soft eviction signal.  For example, 'memory.available=30s'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"evictionPressureTransitionPeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Duration for which the kubelet has to wait before transitioning out of an eviction pressure condition.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"evictionMaxPodGracePeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Maximum allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"evictionMinimumReclaim": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Comma-delimited list of minimum reclaims (e.g. imagefs.available=2Gi) that describes the minimum amount of resource the kubelet will reclaim when performing a pod eviction if that resource is under pressure.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"experimentalKernelMemcgNotification": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If enabled, the kubelet will integrate with the kernel memcg notification to determine if memory eviction thresholds are crossed rather than polling.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"podsPerCore": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Maximum number of pods per core. Cannot exceed MaxPods",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"enableControllerAttachDetach": {
+						SchemaProps: spec.SchemaProps{
+							Description: "enableControllerAttachDetach enables the Attach/Detach controller to manage attachment/detachment of volumes scheduled to this node, and disables kubelet from executing any attach/detach operations",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"systemReserved": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs that describe resources reserved for non-kubernetes components. Currently only cpu and memory are supported. [default=none] See http://kubernetes.io/docs/user-guide/compute-resources for more detail.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"kubeReserved": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A set of ResourceName=ResourceQuantity (e.g. cpu=200m,memory=150G) pairs that describe resources reserved for kubernetes system components. Currently only cpu and memory are supported. [default=none] See http://kubernetes.io/docs/user-guide/compute-resources for more detail.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"protectKernelDefaults": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Default behaviour for kernel tuning",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"makeIPTablesUtilChains": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If true, Kubelet ensures a set of iptables rules are present on host. These rules will serve as utility rules for various components, e.g. KubeProxy. The rules will be created based on IPTablesMasqueradeBit and IPTablesDropBit.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"iptablesMasqueradeBit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "iptablesMasqueradeBit is the bit of the iptables fwmark space to mark for SNAT Values must be within the range [0, 31]. Must be different from other mark bits. Warning: Please match the value of corresponding parameter in kube-proxy",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"iptablesDropBit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "iptablesDropBit is the bit of the iptables fwmark space to mark for dropping packets. Values must be within the range [0, 31]. Must be different from other mark bits.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"allowedUnsafeSysctls": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whitelist of unsafe sysctls or sysctl patterns (ending in *). Use these at your own risk. Resource isolation might be lacking and pod might influence each other on the same node.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"featureGates": {
+						SchemaProps: spec.SchemaProps{
+							Description: "featureGates is a string of comma-separated key=value pairs that describe feature gates for alpha/experimental features.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"enableCRI": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Enable Container Runtime Interface (CRI) integration.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"experimentalFailSwapOn": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Tells the Kubelet to fail to start if swap is enabled on the node.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"experimentalCheckNodeCapabilitiesBeforeMount": {
+						SchemaProps: spec.SchemaProps{
+							Description: "This flag, if set, enables a check prior to mount operations to verify that the required components (binaries, etc.) to mount the volume are available on the underlying node. If the check is enabled and fails the mount operation fails.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"podManifestPath", "syncFrequency", "fileCheckFrequency", "httpCheckFrequency", "manifestURL", "manifestURLHeader", "enableServer", "address", "port", "readOnlyPort", "tlsCertFile", "tlsPrivateKeyFile", "certDirectory", "authentication", "authorization", "hostnameOverride", "podInfraContainerImage", "dockerEndpoint", "rootDirectory", "seccompProfileRoot", "allowPrivileged", "hostNetworkSources", "hostPIDSources", "hostIPCSources", "registryPullQPS", "registryBurst", "eventRecordQPS", "eventBurst", "enableDebuggingHandlers", "minimumGCAge", "maxPerPodContainerCount", "maxContainerCount", "cAdvisorPort", "healthzPort", "healthzBindAddress", "oomScoreAdj", "registerNode", "clusterDomain", "masterServiceNamespace", "clusterDNS", "streamingConnectionIdleTimeout", "nodeStatusUpdateFrequency", "imageMinimumGCAge", "imageGCHighThresholdPercent", "imageGCLowThresholdPercent", "lowDiskSpaceThresholdMB", "volumeStatsAggPeriod", "networkPluginName", "networkPluginDir", "cniConfDir", "cniBinDir", "networkPluginMTU", "volumePluginDir", "cloudProvider", "cloudConfigFile", "kubeletCgroups", "runtimeCgroups", "systemCgroups", "cgroupRoot", "containerRuntime", "remoteRuntimeEndpoint", "remoteImageEndpoint", "runtimeRequestTimeout", "rktPath", "rktAPIEndpoint", "rktStage1Image", "lockFilePath", "exitOnLockContention", "hairpinMode", "babysitDaemons", "maxPods", "nvidiaGPUs", "dockerExecHandlerName", "podCIDR", "resolvConf", "cpuCFSQuota", "containerized", "maxOpenFiles", "registerSchedulable", "registerWithTaints", "contentType", "kubeAPIQPS", "kubeAPIBurst", "serializeImagePulls", "outOfDiskTransitionFrequency", "nodeIP", "nodeLabels", "nonMasqueradeCIDR", "enableCustomMetrics", "evictionHard", "evictionSoft", "evictionSoftGracePeriod", "evictionPressureTransitionPeriod", "evictionMaxPodGracePeriod", "evictionMinimumReclaim", "experimentalKernelMemcgNotification", "podsPerCore", "enableControllerAttachDetach", "systemReserved", "kubeReserved", "protectKernelDefaults", "makeIPTablesUtilChains", "iptablesMasqueradeBit", "iptablesDropBit"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletConfiguration",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeletConfiguration",
+				},
+			},
+		},
+		Dependencies: []string{
+			"componentconfig.v1alpha1.KubeletAuthentication", "componentconfig.v1alpha1.KubeletAuthorization", "io.k8s.meta.v1.Duration", "v1.Taint"},
+	},
+	"componentconfig.v1alpha1.KubeletWebhookAuthentication": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"enabled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "enabled allows bearer token authentication backed by the tokenreviews.authentication.k8s.io API",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"cacheTTL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cacheTTL enables caching of authentication results",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+				},
+				Required: []string{"enabled", "cacheTTL"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletWebhookAuthentication",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Duration"},
 	},
 	"v1alpha1.KubeletWebhookAuthentication": {
 		Schema: spec.Schema{
@@ -9233,15 +13803,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"cacheTTL": {
 						SchemaProps: spec.SchemaProps{
 							Description: "cacheTTL enables caching of authentication results",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 				},
 				Required: []string{"enabled", "cacheTTL"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletWebhookAuthentication",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeletWebhookAuthentication",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Duration"},
+			"io.k8s.meta.v1.Duration"},
+	},
+	"componentconfig.v1alpha1.KubeletWebhookAuthorization": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"cacheAuthorizedTTL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cacheAuthorizedTTL is the duration to cache 'authorized' responses from the webhook authorizer.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"cacheUnauthorizedTTL": {
+						SchemaProps: spec.SchemaProps{
+							Description: "cacheUnauthorizedTTL is the duration to cache 'unauthorized' responses from the webhook authorizer.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+				},
+				Required: []string{"cacheAuthorizedTTL", "cacheUnauthorizedTTL"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletWebhookAuthorization",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Duration"},
 	},
 	"v1alpha1.KubeletWebhookAuthorization": {
 		Schema: spec.Schema{
@@ -9250,21 +13854,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"cacheAuthorizedTTL": {
 						SchemaProps: spec.SchemaProps{
 							Description: "cacheAuthorizedTTL is the duration to cache 'authorized' responses from the webhook authorizer.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"cacheUnauthorizedTTL": {
 						SchemaProps: spec.SchemaProps{
 							Description: "cacheUnauthorizedTTL is the duration to cache 'unauthorized' responses from the webhook authorizer.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 				},
 				Required: []string{"cacheAuthorizedTTL", "cacheUnauthorizedTTL"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletWebhookAuthorization",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeletWebhookAuthorization",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Duration"},
+			"io.k8s.meta.v1.Duration"},
+	},
+	"componentconfig.v1alpha1.KubeletX509Authentication": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"clientCAFile": {
+						SchemaProps: spec.SchemaProps{
+							Description: "clientCAFile is the path to a PEM-encoded certificate bundle. If set, any request presenting a client certificate signed by one of the authorities in the bundle is authenticated with a username corresponding to the CommonName, and groups corresponding to the Organization in the client certificate.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"clientCAFile"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletX509Authentication",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1alpha1.KubeletX509Authentication": {
 		Schema: spec.Schema{
@@ -9280,8 +13912,56 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"clientCAFile"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.KubeletX509Authentication",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.KubeletX509Authentication",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"componentconfig.v1alpha1.LeaderElectionConfiguration": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "LeaderElectionConfiguration defines the configuration of leader election clients for components that can run with leader election enabled.",
+				Properties: map[string]spec.Schema{
+					"leaderElect": {
+						SchemaProps: spec.SchemaProps{
+							Description: "leaderElect enables a leader election client to gain leadership before executing the main loop. Enable this when running replicated components for high availability.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"leaseDuration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "leaseDuration is the duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"renewDeadline": {
+						SchemaProps: spec.SchemaProps{
+							Description: "renewDeadline is the interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+					"retryPeriod": {
+						SchemaProps: spec.SchemaProps{
+							Description: "retryPeriod is the duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
+						},
+					},
+				},
+				Required: []string{"leaderElect", "leaseDuration", "renewDeadline", "retryPeriod"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.LeaderElectionConfiguration",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Duration"},
 	},
 	"v1alpha1.LeaderElectionConfiguration": {
 		Schema: spec.Schema{
@@ -9298,29 +13978,35 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"leaseDuration": {
 						SchemaProps: spec.SchemaProps{
 							Description: "leaseDuration is the duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"renewDeadline": {
 						SchemaProps: spec.SchemaProps{
 							Description: "renewDeadline is the interval between attempts by the acting master to renew a leadership slot before it stops leading. This must be less than or equal to the lease duration. This is only applicable if leader election is enabled.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 					"retryPeriod": {
 						SchemaProps: spec.SchemaProps{
 							Description: "retryPeriod is the duration the clients should wait between attempting acquisition and renewal of a leadership. This is only applicable if leader election is enabled.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Duration"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Duration"),
 						},
 					},
 				},
 				Required: []string{"leaderElect", "leaseDuration", "renewDeadline", "retryPeriod"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1.LeaderElectionConfiguration",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "componentconfig.v1alpha1.LeaderElectionConfiguration",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Duration"},
+			"io.k8s.meta.v1.Duration"},
 	},
-	"v1alpha1.PolicyRule": {
+	"io.k8s.authorization.rbac.v1alpha1.PolicyRule": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
@@ -9342,7 +14028,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"attributeRestrictions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports. If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.",
-							Ref:         spec.MustCreateRef("#/definitions/runtime.RawExtension"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.runtime.RawExtension"),
 						},
 					},
 					"apiGroups": {
@@ -9404,9 +14090,130 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"verbs"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.PolicyRule",
+				},
+			},
 		},
 		Dependencies: []string{
-			"runtime.RawExtension"},
+			"io.k8s.kubernetes.pkg.runtime.RawExtension"},
+	},
+	"v1alpha1.PolicyRule": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+				Properties: map[string]spec.Schema{
+					"verbs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verbs is a list of Verbs that apply to ALL the ResourceKinds and AttributeRestrictions contained in this rule.  VerbAll represents all kinds.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"attributeRestrictions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AttributeRestrictions will vary depending on what the Authorizer/AuthorizationAttributeBuilder pair supports. If the Authorizer does not recognize how to handle the AttributeRestrictions, the Authorizer should report an error.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.runtime.RawExtension"),
+						},
+					},
+					"apiGroups": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of the enumerated resources in any API group will be allowed.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"resources": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resources is a list of resources this rule applies to.  ResourceAll represents all resources.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"resourceNames": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"nonResourceURLs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path This name is intentionally different than the internal type so that the DefaultConvert works nicely and because the ordering may be different. Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding. Rules can either apply to API resources (such as \"pods\" or \"secrets\") or non-resource URL paths (such as \"/api\"),  but not both.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"verbs"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.PolicyRule",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.PolicyRule",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.kubernetes.pkg.runtime.RawExtension"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.PolicyRuleBuilder": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "PolicyRuleBuilder let's us attach methods.  A no-no for API types. We use it to construct rules in code.  It's more compact than trying to write them out in a literal and allows us to perform some basic checking during construction",
+				Properties: map[string]spec.Schema{
+					"PolicyRule": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.PolicyRule"),
+						},
+					},
+				},
+				Required: []string{"PolicyRule"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.PolicyRuleBuilder",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.PolicyRule"},
 	},
 	"v1alpha1.PolicyRuleBuilder": {
 		Schema: spec.Schema{
@@ -9415,15 +14222,57 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				Properties: map[string]spec.Schema{
 					"PolicyRule": {
 						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("#/definitions/v1alpha1.PolicyRule"),
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.PolicyRule"),
 						},
 					},
 				},
 				Required: []string{"PolicyRule"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.PolicyRuleBuilder",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.PolicyRuleBuilder",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1alpha1.PolicyRule"},
+			"io.k8s.authorization.rbac.v1alpha1.PolicyRule"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.Role": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"rules": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Rules holds all the PolicyRules for this Role",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.PolicyRule"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"rules"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.Role",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.PolicyRule", "v1.ObjectMeta"},
 	},
 	"v1alpha1.Role": {
 		Schema: spec.Schema{
@@ -9443,7 +14292,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.PolicyRule"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.PolicyRule"),
 									},
 								},
 							},
@@ -9452,9 +14301,57 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"rules"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.Role",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.Role",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1alpha1.PolicyRule"},
+			"io.k8s.authorization.rbac.v1alpha1.PolicyRule", "v1.ObjectMeta"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.RoleBinding": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"subjects": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Subjects holds references to the objects the role applies to.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.Subject"),
+									},
+								},
+							},
+						},
+					},
+					"roleRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleRef"),
+						},
+					},
+				},
+				Required: []string{"subjects", "roleRef"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.RoleBinding",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.RoleRef", "io.k8s.authorization.rbac.v1alpha1.Subject", "v1.ObjectMeta"},
 	},
 	"v1alpha1.RoleBinding": {
 		Schema: spec.Schema{
@@ -9474,7 +14371,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.Subject"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.Subject"),
 									},
 								},
 							},
@@ -9483,17 +14380,23 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"roleRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "RoleRef can reference a Role in the current namespace or a ClusterRole in the global namespace. If the RoleRef cannot be resolved, the Authorizer must return an error.",
-							Ref:         spec.MustCreateRef("#/definitions/v1alpha1.RoleRef"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleRef"),
 						},
 					},
 				},
 				Required: []string{"subjects", "roleRef"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.RoleBinding",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.RoleBinding",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1alpha1.RoleRef", "v1alpha1.Subject"},
+			"io.k8s.authorization.rbac.v1alpha1.RoleRef", "io.k8s.authorization.rbac.v1alpha1.Subject", "v1.ObjectMeta"},
 	},
-	"v1alpha1.RoleBindingList": {
+	"io.k8s.authorization.rbac.v1alpha1.RoleBindingList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RoleBindingList is a collection of RoleBindings",
@@ -9501,7 +14404,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -9511,7 +14414,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.RoleBinding"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"),
 									},
 								},
 							},
@@ -9520,11 +14423,53 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.RoleBindingList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1alpha1.RoleBinding"},
+			"io.k8s.authorization.rbac.v1alpha1.RoleBinding", "io.k8s.meta.v1.ListMeta"},
 	},
-	"v1alpha1.RoleList": {
+	"v1alpha1.RoleBindingList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RoleBindingList is a collection of RoleBindings",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is a list of RoleBindings",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.RoleBinding"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.RoleBindingList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.RoleBindingList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.RoleBinding", "io.k8s.meta.v1.ListMeta"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.RoleList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "RoleList is a collection of Roles",
@@ -9532,7 +14477,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -9542,7 +14487,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1alpha1.Role"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"),
 									},
 								},
 							},
@@ -9551,9 +14496,88 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.RoleList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1alpha1.Role"},
+			"io.k8s.authorization.rbac.v1alpha1.Role", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1alpha1.RoleList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RoleList is a collection of Roles",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is a list of Roles",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.authorization.rbac.v1alpha1.Role"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.RoleList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.RoleList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.rbac.v1alpha1.Role", "io.k8s.meta.v1.ListMeta"},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.RoleRef": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "RoleRef contains information that points to the role being used",
+				Properties: map[string]spec.Schema{
+					"apiGroup": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIGroup is the group for the resource being referenced",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is the type of resource being referenced",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name is the name of resource being referenced",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"apiGroup", "kind", "name"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.RoleRef",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1alpha1.RoleRef": {
 		Schema: spec.Schema{
@@ -9583,6 +14607,56 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"apiGroup", "kind", "name"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.RoleRef",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.RoleRef",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.authorization.rbac.v1alpha1.Subject": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind of object being referenced. Values defined by this API group are \"User\", \"Group\", and \"ServiceAccount\". If the Authorizer does not recognized the kind value, the Authorizer should report an error.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion holds the API group and version of the referenced object.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the object being referenced.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace of the referenced object.  If the object kind is non-namespace, such as \"User\" or \"Group\", and this value is not empty the Authorizer should report an error.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"kind", "name"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.Subject",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -9623,6 +14697,34 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"kind", "name"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1.Subject",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.rbac.v1alpha1.Subject",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"extensions.v1beta1.APIVersion": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "An APIVersion represents a single concrete version of an object model.",
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of this version (e.g. 'v1').",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.APIVersion",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -9638,6 +14740,34 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.APIVersion",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.APIVersion",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"extensions.v1beta1.CPUTargetUtilization": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"targetPercentage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "fraction of the requested CPU that should be utilized/used, e.g. 70 means that 70% of the requested CPU should be in use.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"targetPercentage"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CPUTargetUtilization",
 				},
 			},
 		},
@@ -9657,8 +14787,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"targetPercentage"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CPUTargetUtilization",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.CPUTargetUtilization",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"federation.v1beta1.Cluster": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Information about a registered cluster in a federated kubernetes setup. Clusters are not namespaced and have unique names in the federation.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec defines the behavior of the Cluster.",
+							Ref:         spec.MustCreateRef("#/definitions/federation.v1beta1.ClusterSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status describes the current status of a Cluster",
+							Ref:         spec.MustCreateRef("#/definitions/federation.v1beta1.ClusterStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/federation/apis/federation/v1beta1.Cluster",
+				},
+			},
+		},
+		Dependencies: []string{
+			"federation.v1beta1.ClusterSpec", "federation.v1beta1.ClusterStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.Cluster": {
 		Schema: spec.Schema{
@@ -9674,20 +14844,83 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the behavior of the Cluster.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.ClusterSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/federation.v1beta1.ClusterSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status describes the current status of a Cluster",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.ClusterStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/federation.v1beta1.ClusterStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/federation/apis/federation/v1beta1.Cluster",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "federation.v1beta1.Cluster",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.ClusterSpec", "v1beta1.ClusterStatus"},
+			"federation.v1beta1.ClusterSpec", "federation.v1beta1.ClusterStatus", "v1.ObjectMeta"},
+	},
+	"federation.v1beta1.ClusterCondition": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterCondition describes current state of a cluster.",
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type of cluster condition, Complete or Failed.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the condition, one of True, False, Unknown.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"lastProbeTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition was checked.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"lastTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition transit from one status to another.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "(brief) reason for the condition's last transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Human readable message indicating details about last transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"type", "status"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/federation/apis/federation/v1beta1.ClusterCondition",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1beta1.ClusterCondition": {
 		Schema: spec.Schema{
@@ -9711,13 +14944,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastProbeTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition was checked.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transit from one status to another.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -9737,11 +14970,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/federation/apis/federation/v1beta1.ClusterCondition",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "federation.v1beta1.ClusterCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
-	"v1beta1.ClusterList": {
+	"federation.v1beta1.ClusterList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "A list of all the kubernetes clusters registered to the federation",
@@ -9749,7 +14988,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -9759,7 +14998,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.Cluster"),
+										Ref: spec.MustCreateRef("#/definitions/federation.v1beta1.Cluster"),
 									},
 								},
 							},
@@ -9768,11 +15007,53 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/federation/apis/federation/v1beta1.ClusterList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.Cluster"},
+			"federation.v1beta1.Cluster", "io.k8s.meta.v1.ListMeta"},
 	},
-	"v1beta1.ClusterSpec": {
+	"v1beta1.ClusterList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "A list of all the kubernetes clusters registered to the federation",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "List of Cluster objects.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/federation.v1beta1.Cluster"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/federation/apis/federation/v1beta1.ClusterList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "federation.v1beta1.ClusterList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"federation.v1beta1.Cluster", "io.k8s.meta.v1.ListMeta"},
+	},
+	"federation.v1beta1.ClusterSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ClusterSpec describes the attributes of a kubernetes cluster.",
@@ -9784,7 +15065,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.ServerAddressByClientCIDR"),
+										Ref: spec.MustCreateRef("#/definitions/federation.v1beta1.ServerAddressByClientCIDR"),
 									},
 								},
 							},
@@ -9799,11 +15080,53 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"serverAddressByClientCIDRs"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/federation/apis/federation/v1beta1.ClusterSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LocalObjectReference", "v1beta1.ServerAddressByClientCIDR"},
+			"federation.v1beta1.ServerAddressByClientCIDR", "v1.LocalObjectReference"},
 	},
-	"v1beta1.ClusterStatus": {
+	"v1beta1.ClusterSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterSpec describes the attributes of a kubernetes cluster.",
+				Properties: map[string]spec.Schema{
+					"serverAddressByClientCIDRs": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A map of client CIDR to server address. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/federation.v1beta1.ServerAddressByClientCIDR"),
+									},
+								},
+							},
+						},
+					},
+					"secretRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the secret containing kubeconfig to access this cluster. The secret is read from the kubernetes cluster that is hosting federation control plane. Admin needs to ensure that the required secret exists. Secret should be in the same namespace where federation control plane is hosted and it should have kubeconfig in its data with key \"kubeconfig\". This will later be changed to a reference to secret in federation control plane when the federation control plane supports secrets. This can be left empty if the cluster allows insecure access.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.LocalObjectReference"),
+						},
+					},
+				},
+				Required: []string{"serverAddressByClientCIDRs"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/federation/apis/federation/v1beta1.ClusterSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "federation.v1beta1.ClusterSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"federation.v1beta1.ServerAddressByClientCIDR", "v1.LocalObjectReference"},
+	},
+	"federation.v1beta1.ClusterStatus": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ClusterStatus is information about the current status of a cluster updated by cluster controller periodically.",
@@ -9815,7 +15138,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.ClusterCondition"),
+										Ref: spec.MustCreateRef("#/definitions/federation.v1beta1.ClusterCondition"),
 									},
 								},
 							},
@@ -9844,9 +15167,94 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/federation/apis/federation/v1beta1.ClusterStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.ClusterCondition"},
+			"federation.v1beta1.ClusterCondition"},
+	},
+	"v1beta1.ClusterStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ClusterStatus is information about the current status of a cluster updated by cluster controller periodically.",
+				Properties: map[string]spec.Schema{
+					"conditions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Conditions is an array of current cluster conditions.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/federation.v1beta1.ClusterCondition"),
+									},
+								},
+							},
+						},
+					},
+					"zones": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Zones is the list of availability zones in which the nodes of the cluster exist, e.g. 'us-east1-a'. These will always be in the same region.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"region": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/federation/apis/federation/v1beta1.ClusterStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "federation.v1beta1.ClusterStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"federation.v1beta1.ClusterCondition"},
+	},
+	"extensions.v1beta1.CustomMetricCurrentStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom Metric name.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom Metric value (average).",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
+						},
+					},
+				},
+				Required: []string{"name", "value"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CustomMetricCurrentStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
 	},
 	"v1beta1.CustomMetricCurrentStatus": {
 		Schema: spec.Schema{
@@ -9862,15 +15270,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"value": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Custom Metric value (average).",
-							Ref:         spec.MustCreateRef("#/definitions/resource.Quantity"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 						},
 					},
 				},
 				Required: []string{"name", "value"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CustomMetricCurrentStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.CustomMetricCurrentStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
+	},
+	"extensions.v1beta1.CustomMetricCurrentStatusList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.CustomMetricCurrentStatus"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CustomMetricCurrentStatusList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.CustomMetricCurrentStatus"},
 	},
 	"v1beta1.CustomMetricCurrentStatusList": {
 		Schema: spec.Schema{
@@ -9882,7 +15324,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.CustomMetricCurrentStatus"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.CustomMetricCurrentStatus"),
 									},
 								},
 							},
@@ -9891,9 +15333,45 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CustomMetricCurrentStatusList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.CustomMetricCurrentStatusList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.CustomMetricCurrentStatus"},
+			"extensions.v1beta1.CustomMetricCurrentStatus"},
+	},
+	"extensions.v1beta1.CustomMetricTarget": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Alpha-level support for Custom Metrics in HPA (as annotations).",
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom Metric name.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"value": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Custom Metric value (average).",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
+						},
+					},
+				},
+				Required: []string{"name", "value"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CustomMetricTarget",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
 	},
 	"v1beta1.CustomMetricTarget": {
 		Schema: spec.Schema{
@@ -9910,15 +15388,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"value": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Custom Metric value (average).",
-							Ref:         spec.MustCreateRef("#/definitions/resource.Quantity"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.api.resource.Quantity"),
 						},
 					},
 				},
 				Required: []string{"name", "value"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CustomMetricTarget",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.CustomMetricTarget",
+				},
+			},
 		},
 		Dependencies: []string{
-			"resource.Quantity"},
+			"io.k8s.kubernetes.pkg.api.resource.Quantity"},
+	},
+	"extensions.v1beta1.CustomMetricTargetList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.CustomMetricTarget"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CustomMetricTargetList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.CustomMetricTarget"},
 	},
 	"v1beta1.CustomMetricTargetList": {
 		Schema: spec.Schema{
@@ -9930,7 +15442,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.CustomMetricTarget"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.CustomMetricTarget"),
 									},
 								},
 							},
@@ -9939,9 +15451,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.CustomMetricTargetList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.CustomMetricTargetList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.CustomMetricTarget"},
+			"extensions.v1beta1.CustomMetricTarget"},
+	},
+	"extensions.v1beta1.DaemonSet": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DaemonSet represents the configuration of a daemon set.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DaemonSetSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DaemonSetStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DaemonSet",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.DaemonSetSpec", "extensions.v1beta1.DaemonSetStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.DaemonSet": {
 		Schema: spec.Schema{
@@ -9957,22 +15509,28 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the desired behavior of this daemon set. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.DaemonSetSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DaemonSetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is the current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.DaemonSetStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DaemonSetStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DaemonSet",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DaemonSet",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.DaemonSetSpec", "v1beta1.DaemonSetStatus"},
+			"extensions.v1beta1.DaemonSetSpec", "extensions.v1beta1.DaemonSetStatus", "v1.ObjectMeta"},
 	},
-	"v1beta1.DaemonSetList": {
+	"extensions.v1beta1.DaemonSetList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "DaemonSetList is a collection of daemon sets.",
@@ -9980,7 +15538,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -9990,7 +15548,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.DaemonSet"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.DaemonSet"),
 									},
 								},
 							},
@@ -9999,11 +15557,53 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DaemonSetList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.DaemonSet"},
+			"extensions.v1beta1.DaemonSet", "io.k8s.meta.v1.ListMeta"},
 	},
-	"v1beta1.DaemonSetSpec": {
+	"v1beta1.DaemonSetList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DaemonSetList is a collection of daemon sets.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is a list of daemon sets.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.DaemonSet"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DaemonSetList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DaemonSetList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.DaemonSet", "io.k8s.meta.v1.ListMeta"},
+	},
+	"extensions.v1beta1.DaemonSetSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "DaemonSetSpec is the specification of a daemon set.",
@@ -10011,7 +15611,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"template": {
@@ -10023,9 +15623,95 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"template"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DaemonSetSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector", "v1.PodTemplateSpec"},
+			"io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
+	},
+	"v1beta1.DaemonSetSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DaemonSetSpec is the specification of a daemon set.",
+				Properties: map[string]spec.Schema{
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Selector is a label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+					"template": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Template is the object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template",
+							Ref:         spec.MustCreateRef("#/definitions/v1.PodTemplateSpec"),
+						},
+					},
+				},
+				Required: []string{"template"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DaemonSetSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DaemonSetSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
+	},
+	"extensions.v1beta1.DaemonSetStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DaemonSetStatus represents the current status of a daemon set.",
+				Properties: map[string]spec.Schema{
+					"currentNumberScheduled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CurrentNumberScheduled is the number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"numberMisscheduled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NumberMisscheduled is the number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"desiredNumberScheduled": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DesiredNumberScheduled is the total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: http://releases.k8s.io/HEAD/docs/admin/daemons.md",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"numberReady": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NumberReady is the number of nodes that should be running the daemon pod and have one or more of the daemon pod running and ready.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration is the most recent generation observed by the daemon set controller.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+				},
+				Required: []string{"currentNumberScheduled", "numberMisscheduled", "desiredNumberScheduled", "numberReady"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DaemonSetStatus",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.DaemonSetStatus": {
 		Schema: spec.Schema{
@@ -10070,8 +15756,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"currentNumberScheduled", "numberMisscheduled", "desiredNumberScheduled", "numberReady"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DaemonSetStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DaemonSetStatus",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"extensions.v1beta1.Deployment": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Deployment enables declarative updates for Pods and ReplicaSets.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specification of the desired behavior of the Deployment.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DeploymentSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Most recently observed status of the Deployment.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DeploymentStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.Deployment",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.DeploymentSpec", "extensions.v1beta1.DeploymentStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.Deployment": {
 		Schema: spec.Schema{
@@ -10087,20 +15813,83 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the Deployment.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.DeploymentSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DeploymentSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the Deployment.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.DeploymentStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DeploymentStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.Deployment",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.Deployment",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.DeploymentSpec", "v1beta1.DeploymentStatus"},
+			"extensions.v1beta1.DeploymentSpec", "extensions.v1beta1.DeploymentStatus", "v1.ObjectMeta"},
+	},
+	"extensions.v1beta1.DeploymentCondition": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DeploymentCondition describes the state of a deployment at a certain point.",
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type of deployment condition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the condition, one of True, False, Unknown.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"lastUpdateTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The last time this condition was updated.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"lastTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition transitioned from one status to another.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The reason for the condition's last transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A human readable message indicating details about the transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"type", "status"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentCondition",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1beta1.DeploymentCondition": {
 		Schema: spec.Schema{
@@ -10124,13 +15913,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastUpdateTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The last time this condition was updated.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transitioned from one status to another.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -10150,11 +15939,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentCondition",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DeploymentCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
-	"v1beta1.DeploymentList": {
+	"extensions.v1beta1.DeploymentList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "DeploymentList is a list of Deployments.",
@@ -10162,7 +15957,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -10172,7 +15967,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.Deployment"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.Deployment"),
 									},
 								},
 							},
@@ -10181,9 +15976,95 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.Deployment"},
+			"extensions.v1beta1.Deployment", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1beta1.DeploymentList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DeploymentList is a list of Deployments.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is the list of Deployments.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.Deployment"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DeploymentList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.Deployment", "io.k8s.meta.v1.ListMeta"},
+	},
+	"extensions.v1beta1.DeploymentRollback": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DeploymentRollback stores the information required to rollback a deployment.",
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Required: This must match the Name of a deployment.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"updatedAnnotations": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The annotations to be updated to a deployment",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"rollbackTo": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The config of this deployment rollback.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.RollbackConfig"),
+						},
+					},
+				},
+				Required: []string{"name", "rollbackTo"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentRollback",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.RollbackConfig"},
 	},
 	"v1beta1.DeploymentRollback": {
 		Schema: spec.Schema{
@@ -10214,17 +16095,23 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"rollbackTo": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The config of this deployment rollback.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.RollbackConfig"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.RollbackConfig"),
 						},
 					},
 				},
 				Required: []string{"name", "rollbackTo"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentRollback",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DeploymentRollback",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.RollbackConfig"},
+			"extensions.v1beta1.RollbackConfig"},
 	},
-	"v1beta1.DeploymentSpec": {
+	"extensions.v1beta1.DeploymentSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "DeploymentSpec is the specification of the desired behavior of the Deployment.",
@@ -10239,7 +16126,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"template": {
@@ -10251,7 +16138,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"strategy": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The deployment strategy to use to replace existing pods with new ones.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.DeploymentStrategy"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DeploymentStrategy"),
 						},
 					},
 					"minReadySeconds": {
@@ -10278,7 +16165,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"rollbackTo": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The config this deployment is rolling back to. Will be cleared after rollback is done.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.RollbackConfig"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.RollbackConfig"),
 						},
 					},
 					"progressDeadlineSeconds": {
@@ -10291,9 +16178,162 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"template"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector", "v1.PodTemplateSpec", "v1beta1.DeploymentStrategy", "v1beta1.RollbackConfig"},
+			"extensions.v1beta1.DeploymentStrategy", "extensions.v1beta1.RollbackConfig", "io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
+	},
+	"v1beta1.DeploymentSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+					"template": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Template describes the pods that will be created.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.PodTemplateSpec"),
+						},
+					},
+					"strategy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The deployment strategy to use to replace existing pods with new ones.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.DeploymentStrategy"),
+						},
+					},
+					"minReadySeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"revisionHistoryLimit": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"paused": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Indicates that the deployment is paused and will not be processed by the deployment controller.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"rollbackTo": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The config this deployment is rolling back to. Will be cleared after rollback is done.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.RollbackConfig"),
+						},
+					},
+					"progressDeadlineSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The maximum time in seconds for a deployment to make progress before it is considered to be failed. The deployment controller will continue to process failed deployments and a condition with a ProgressDeadlineExceeded reason will be surfaced in the deployment status. Once autoRollback is implemented, the deployment controller will automatically rollback failed deployments. Note that progress will not be estimated during the time a deployment is paused. This is not set by default.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"template"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DeploymentSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.DeploymentStrategy", "extensions.v1beta1.RollbackConfig", "io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
+	},
+	"extensions.v1beta1.DeploymentStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DeploymentStatus is the most recently observed status of the Deployment.",
+				Properties: map[string]spec.Schema{
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The generation observed by the deployment controller.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"updatedReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"readyReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Total number of ready pods targeted by this deployment.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"availableReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"unavailableReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Total number of unavailable pods targeted by this deployment.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"conditions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Represents the latest available observations of a deployment's current state.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.DeploymentCondition"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.DeploymentCondition"},
 	},
 	"v1beta1.DeploymentStatus": {
 		Schema: spec.Schema{
@@ -10349,7 +16389,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.DeploymentCondition"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.DeploymentCondition"),
 									},
 								},
 							},
@@ -10357,9 +16397,44 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DeploymentStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.DeploymentCondition"},
+			"extensions.v1beta1.DeploymentCondition"},
+	},
+	"extensions.v1beta1.DeploymentStrategy": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "DeploymentStrategy describes how to replace existing pods with new ones.",
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"rollingUpdate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.RollingUpdateDeployment"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentStrategy",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.RollingUpdateDeployment"},
 	},
 	"v1beta1.DeploymentStrategy": {
 		Schema: spec.Schema{
@@ -10376,14 +16451,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"rollingUpdate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.RollingUpdateDeployment"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.RollingUpdateDeployment"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.DeploymentStrategy",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.DeploymentStrategy",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.RollingUpdateDeployment"},
+			"extensions.v1beta1.RollingUpdateDeployment"},
+	},
+	"policy.v1beta1.Eviction": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/<pod name>/evictions.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObjectMeta describes the pod that is being evicted.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"deleteOptions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DeleteOptions may be provided",
+							Ref:         spec.MustCreateRef("#/definitions/v1.DeleteOptions"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/policy/v1beta1.Eviction",
+				},
+			},
+		},
+		Dependencies: []string{
+			"v1.DeleteOptions", "v1.ObjectMeta"},
 	},
 	"v1beta1.Eviction": {
 		Schema: spec.Schema{
@@ -10404,9 +16513,51 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/policy/v1beta1.Eviction",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "policy.v1beta1.Eviction",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.DeleteOptions", "v1.ObjectMeta"},
+	},
+	"extensions.v1beta1.FSGroupStrategyOptions": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
+				Properties: map[string]spec.Schema{
+					"rule": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Rule is the strategy that will dictate what FSGroup is used in the SecurityContext.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"ranges": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IDRange"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.FSGroupStrategyOptions",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.IDRange"},
 	},
 	"v1beta1.FSGroupStrategyOptions": {
 		Schema: spec.Schema{
@@ -10427,7 +16578,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.IDRange"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IDRange"),
 									},
 								},
 							},
@@ -10435,9 +16586,45 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.FSGroupStrategyOptions",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.FSGroupStrategyOptions",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.IDRange"},
+			"extensions.v1beta1.IDRange"},
+	},
+	"extensions.v1beta1.HTTPIngressPath": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+				Properties: map[string]spec.Schema{
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"backend": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Backend defines the referenced service endpoint to which the traffic will be forwarded to.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressBackend"),
+						},
+					},
+				},
+				Required: []string{"backend"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HTTPIngressPath",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.IngressBackend"},
 	},
 	"v1beta1.HTTPIngressPath": {
 		Schema: spec.Schema{
@@ -10454,15 +16641,51 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"backend": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Backend defines the referenced service endpoint to which the traffic will be forwarded to.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.IngressBackend"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressBackend"),
 						},
 					},
 				},
 				Required: []string{"backend"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HTTPIngressPath",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.HTTPIngressPath",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.IngressBackend"},
+			"extensions.v1beta1.IngressBackend"},
+	},
+	"extensions.v1beta1.HTTPIngressRuleValue": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+				Properties: map[string]spec.Schema{
+					"paths": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A collection of paths that map requests to backends.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.HTTPIngressPath"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"paths"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HTTPIngressRuleValue",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.HTTPIngressPath"},
 	},
 	"v1beta1.HTTPIngressRuleValue": {
 		Schema: spec.Schema{
@@ -10476,7 +16699,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.HTTPIngressPath"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.HTTPIngressPath"),
 									},
 								},
 							},
@@ -10485,9 +16708,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"paths"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HTTPIngressRuleValue",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.HTTPIngressRuleValue",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.HTTPIngressPath"},
+			"extensions.v1beta1.HTTPIngressPath"},
+	},
+	"extensions.v1beta1.HorizontalPodAutoscaler": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "configuration of a horizontal pod autoscaler.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.HorizontalPodAutoscalerSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current information about the autoscaler.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.HorizontalPodAutoscalerStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscaler",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.HorizontalPodAutoscalerSpec", "extensions.v1beta1.HorizontalPodAutoscalerStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.HorizontalPodAutoscaler": {
 		Schema: spec.Schema{
@@ -10503,22 +16766,28 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "behaviour of autoscaler. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.HorizontalPodAutoscalerSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.HorizontalPodAutoscalerSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "current information about the autoscaler.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.HorizontalPodAutoscalerStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.HorizontalPodAutoscalerStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscaler",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.HorizontalPodAutoscaler",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.HorizontalPodAutoscalerSpec", "v1beta1.HorizontalPodAutoscalerStatus"},
+			"extensions.v1beta1.HorizontalPodAutoscalerSpec", "extensions.v1beta1.HorizontalPodAutoscalerStatus", "v1.ObjectMeta"},
 	},
-	"v1beta1.HorizontalPodAutoscalerList": {
+	"extensions.v1beta1.HorizontalPodAutoscalerList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "list of horizontal pod autoscaler objects.",
@@ -10526,7 +16795,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -10536,7 +16805,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.HorizontalPodAutoscaler"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"),
 									},
 								},
 							},
@@ -10545,11 +16814,53 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscalerList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.HorizontalPodAutoscaler"},
+			"extensions.v1beta1.HorizontalPodAutoscaler", "io.k8s.meta.v1.ListMeta"},
 	},
-	"v1beta1.HorizontalPodAutoscalerSpec": {
+	"v1beta1.HorizontalPodAutoscalerList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "list of horizontal pod autoscaler objects.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "list of horizontal pod autoscaler objects.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.HorizontalPodAutoscaler"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscalerList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.HorizontalPodAutoscalerList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.HorizontalPodAutoscaler", "io.k8s.meta.v1.ListMeta"},
+	},
+	"extensions.v1beta1.HorizontalPodAutoscalerSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "specification of a horizontal pod autoscaler.",
@@ -10557,7 +16868,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"scaleRef": {
 						SchemaProps: spec.SchemaProps{
 							Description: "reference to Scale subresource; horizontal pod autoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modifying its spec.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SubresourceReference"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.SubresourceReference"),
 						},
 					},
 					"minReplicas": {
@@ -10577,17 +16888,66 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"cpuUtilization": {
 						SchemaProps: spec.SchemaProps{
 							Description: "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified it defaults to the target CPU utilization at 80% of the requested resources.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.CPUTargetUtilization"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.CPUTargetUtilization"),
 						},
 					},
 				},
 				Required: []string{"scaleRef", "maxReplicas"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscalerSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.CPUTargetUtilization", "v1beta1.SubresourceReference"},
+			"extensions.v1beta1.CPUTargetUtilization", "extensions.v1beta1.SubresourceReference"},
 	},
-	"v1beta1.HorizontalPodAutoscalerStatus": {
+	"v1beta1.HorizontalPodAutoscalerSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "specification of a horizontal pod autoscaler.",
+				Properties: map[string]spec.Schema{
+					"scaleRef": {
+						SchemaProps: spec.SchemaProps{
+							Description: "reference to Scale subresource; horizontal pod autoscaler will learn the current resource consumption from its status, and will set the desired number of pods by modifying its spec.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.SubresourceReference"),
+						},
+					},
+					"minReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "lower limit for the number of pods that can be set by the autoscaler, default 1.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"maxReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "upper limit for the number of pods that can be set by the autoscaler; cannot be smaller than MinReplicas.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"cpuUtilization": {
+						SchemaProps: spec.SchemaProps{
+							Description: "target average CPU utilization (represented as a percentage of requested CPU) over all the pods; if not specified it defaults to the target CPU utilization at 80% of the requested resources.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.CPUTargetUtilization"),
+						},
+					},
+				},
+				Required: []string{"scaleRef", "maxReplicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscalerSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.HorizontalPodAutoscalerSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.CPUTargetUtilization", "extensions.v1beta1.SubresourceReference"},
+	},
+	"extensions.v1beta1.HorizontalPodAutoscalerStatus": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "current status of a horizontal pod autoscaler",
@@ -10602,7 +16962,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastScaleTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"currentReplicas": {
@@ -10629,9 +16989,96 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"currentReplicas", "desiredReplicas"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscalerStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
+	},
+	"v1beta1.HorizontalPodAutoscalerStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "current status of a horizontal pod autoscaler",
+				Properties: map[string]spec.Schema{
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "most recent generation observed by this autoscaler.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"lastScaleTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "last time the HorizontalPodAutoscaler scaled the number of pods; used by the autoscaler to control how often the number of pods is changed.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"currentReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current number of replicas of pods managed by this autoscaler.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"desiredReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "desired number of replicas of pods managed by this autoscaler.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"currentCPUUtilizationPercentage": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current average CPU utilization over all pods, represented as a percentage of requested CPU, e.g. 70 means that an average pod is using now 70% of its requested CPU.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"currentReplicas", "desiredReplicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HorizontalPodAutoscalerStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.HorizontalPodAutoscalerStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
+	},
+	"extensions.v1beta1.HostPortRange": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Host Port Range defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+				Properties: map[string]spec.Schema{
+					"min": {
+						SchemaProps: spec.SchemaProps{
+							Description: "min is the start of the range, inclusive.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"max": {
+						SchemaProps: spec.SchemaProps{
+							Description: "max is the end of the range, inclusive.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"min", "max"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HostPortRange",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.HostPortRange": {
 		Schema: spec.Schema{
@@ -10654,6 +17101,42 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"min", "max"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.HostPortRange",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.HostPortRange",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"extensions.v1beta1.IDRange": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ID Range provides a min/max of an allowed range of IDs.",
+				Properties: map[string]spec.Schema{
+					"min": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Min is the start of the range, inclusive.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"max": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Max is the end of the range, inclusive.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+				},
+				Required: []string{"min", "max"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IDRange",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -10680,8 +17163,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"min", "max"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IDRange",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.IDRange",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"extensions.v1beta1.Ingress": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is the current state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.Ingress",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.IngressSpec", "extensions.v1beta1.IngressStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.Ingress": {
 		Schema: spec.Schema{
@@ -10697,20 +17220,56 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec is the desired state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.IngressSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is the current state of the Ingress. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.IngressStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.Ingress",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.Ingress",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.IngressSpec", "v1beta1.IngressStatus"},
+			"extensions.v1beta1.IngressSpec", "extensions.v1beta1.IngressStatus", "v1.ObjectMeta"},
+	},
+	"extensions.v1beta1.IngressBackend": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "IngressBackend describes all endpoints for a given service and port.",
+				Properties: map[string]spec.Schema{
+					"serviceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies the name of the referenced service.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"servicePort": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specifies the port of the referenced service.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
+						},
+					},
+				},
+				Required: []string{"serviceName", "servicePort"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressBackend",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString"},
 	},
 	"v1beta1.IngressBackend": {
 		Schema: spec.Schema{
@@ -10727,17 +17286,23 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"servicePort": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specifies the port of the referenced service.",
-							Ref:         spec.MustCreateRef("#/definitions/intstr.IntOrString"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
 						},
 					},
 				},
 				Required: []string{"serviceName", "servicePort"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressBackend",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.IngressBackend",
+				},
+			},
 		},
 		Dependencies: []string{
-			"intstr.IntOrString"},
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString"},
 	},
-	"v1beta1.IngressList": {
+	"extensions.v1beta1.IngressList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "IngressList is a collection of Ingress.",
@@ -10745,7 +17310,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -10755,7 +17320,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.Ingress"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.Ingress"),
 									},
 								},
 							},
@@ -10764,9 +17329,73 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.Ingress"},
+			"extensions.v1beta1.Ingress", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1beta1.IngressList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "IngressList is a collection of Ingress.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is the list of Ingress.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.Ingress"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.IngressList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.Ingress", "io.k8s.meta.v1.ListMeta"},
+	},
+	"extensions.v1beta1.IngressRule": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+				Properties: map[string]spec.Schema{
+					"host": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressRule",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.IngressRule": {
 		Schema: spec.Schema{
@@ -10782,8 +17411,35 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressRule",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.IngressRule",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"extensions.v1beta1.IngressRuleValue": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "IngressRuleValue represents a rule to apply against incoming requests. If the rule is satisfied, the request is routed to the specified backend. Currently mixing different types of rules in a single Ingress is disallowed, so exactly one of the following must be set.",
+				Properties: map[string]spec.Schema{
+					"http": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.HTTPIngressRuleValue"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressRuleValue",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.HTTPIngressRuleValue"},
 	},
 	"v1beta1.IngressRuleValue": {
 		Schema: spec.Schema{
@@ -10792,16 +17448,22 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				Properties: map[string]spec.Schema{
 					"http": {
 						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("#/definitions/v1beta1.HTTPIngressRuleValue"),
+							Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.HTTPIngressRuleValue"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressRuleValue",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.IngressRuleValue",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.HTTPIngressRuleValue"},
+			"extensions.v1beta1.HTTPIngressRuleValue"},
 	},
-	"v1beta1.IngressSpec": {
+	"extensions.v1beta1.IngressSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "IngressSpec describes the Ingress the user wishes to exist.",
@@ -10809,7 +17471,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"backend": {
 						SchemaProps: spec.SchemaProps{
 							Description: "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.IngressBackend"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressBackend"),
 						},
 					},
 					"tls": {
@@ -10819,7 +17481,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.IngressTLS"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressTLS"),
 									},
 								},
 							},
@@ -10832,7 +17494,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.IngressRule"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressRule"),
 									},
 								},
 							},
@@ -10840,9 +17502,85 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.IngressBackend", "v1beta1.IngressRule", "v1beta1.IngressTLS"},
+			"extensions.v1beta1.IngressBackend", "extensions.v1beta1.IngressRule", "extensions.v1beta1.IngressTLS"},
+	},
+	"v1beta1.IngressSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "IngressSpec describes the Ingress the user wishes to exist.",
+				Properties: map[string]spec.Schema{
+					"backend": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressBackend"),
+						},
+					},
+					"tls": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressTLS"),
+									},
+								},
+							},
+						},
+					},
+					"rules": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IngressRule"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.IngressSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.IngressBackend", "extensions.v1beta1.IngressRule", "extensions.v1beta1.IngressTLS"},
+	},
+	"extensions.v1beta1.IngressStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "IngressStatus describe the current state of the Ingress.",
+				Properties: map[string]spec.Schema{
+					"loadBalancer": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LoadBalancer contains the current status of the load-balancer.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.LoadBalancerStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"v1.LoadBalancerStatus"},
 	},
 	"v1beta1.IngressStatus": {
 		Schema: spec.Schema{
@@ -10857,9 +17595,51 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.IngressStatus",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.LoadBalancerStatus"},
+	},
+	"extensions.v1beta1.IngressTLS": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "IngressTLS describes the transport layer security associated with an Ingress.",
+				Properties: map[string]spec.Schema{
+					"hosts": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"secretName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressTLS",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.IngressTLS": {
 		Schema: spec.Schema{
@@ -10889,8 +17669,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.IngressTLS",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.IngressTLS",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.authorization.v1beta1.LocalSubjectAccessReview": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is filled in by the server and indicates whether the request is allowed or not",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"),
+						},
+					},
+				},
+				Required: []string{"spec"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.LocalSubjectAccessReview",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.v1beta1.SubjectAccessReviewSpec", "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.LocalSubjectAccessReview": {
 		Schema: spec.Schema{
@@ -10905,21 +17725,54 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds information about the request being evaluated.  spec.namespace must be equal to the namespace you made the request against.  If empty, it is defaulted.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SubjectAccessReviewSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is filled in by the server and indicates whether the request is allowed or not",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SubjectAccessReviewStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"),
 						},
 					},
 				},
 				Required: []string{"spec"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.LocalSubjectAccessReview",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.v1beta1.LocalSubjectAccessReview",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.SubjectAccessReviewSpec", "v1beta1.SubjectAccessReviewStatus"},
+			"io.k8s.authorization.v1beta1.SubjectAccessReviewSpec", "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus", "v1.ObjectMeta"},
+	},
+	"extensions.v1beta1.NetworkPolicy": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specification of the desired behavior for this NetworkPolicy.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicySpec"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicy",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.NetworkPolicySpec", "v1.ObjectMeta"},
 	},
 	"v1beta1.NetworkPolicy": {
 		Schema: spec.Schema{
@@ -10934,14 +17787,62 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior for this NetworkPolicy.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.NetworkPolicySpec"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicySpec"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicy",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.NetworkPolicy",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.NetworkPolicySpec"},
+			"extensions.v1beta1.NetworkPolicySpec", "v1.ObjectMeta"},
+	},
+	"extensions.v1beta1.NetworkPolicyIngressRule": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+				Properties: map[string]spec.Schema{
+					"ports": {
+						SchemaProps: spec.SchemaProps{
+							Description: "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is not provided, this rule matches all ports (traffic not restricted by port). If this field is empty, this rule matches no ports (no traffic matches). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicyPort"),
+									},
+								},
+							},
+						},
+					},
+					"from": {
+						SchemaProps: spec.SchemaProps{
+							Description: "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is not provided, this rule matches all sources (traffic not restricted by source). If this field is empty, this rule matches no sources (no traffic matches). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicyPeer"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicyIngressRule",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.NetworkPolicyPeer", "extensions.v1beta1.NetworkPolicyPort"},
 	},
 	"v1beta1.NetworkPolicyIngressRule": {
 		Schema: spec.Schema{
@@ -10955,7 +17856,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.NetworkPolicyPort"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicyPort"),
 									},
 								},
 							},
@@ -10968,7 +17869,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.NetworkPolicyPeer"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicyPeer"),
 									},
 								},
 							},
@@ -10976,11 +17877,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicyIngressRule",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.NetworkPolicyIngressRule",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.NetworkPolicyPeer", "v1beta1.NetworkPolicyPort"},
+			"extensions.v1beta1.NetworkPolicyPeer", "extensions.v1beta1.NetworkPolicyPort"},
 	},
-	"v1beta1.NetworkPolicyList": {
+	"extensions.v1beta1.NetworkPolicyList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Network Policy List is a list of NetworkPolicy objects.",
@@ -10988,7 +17895,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -10998,7 +17905,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.NetworkPolicy"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicy"),
 									},
 								},
 							},
@@ -11007,9 +17914,78 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicyList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.NetworkPolicy"},
+			"extensions.v1beta1.NetworkPolicy", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1beta1.NetworkPolicyList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Network Policy List is a list of NetworkPolicy objects.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is a list of schema objects.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicy"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicyList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.NetworkPolicyList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.NetworkPolicy", "io.k8s.meta.v1.ListMeta"},
+	},
+	"extensions.v1beta1.NetworkPolicyPeer": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"podSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If not provided, this selector selects no pods. If present but empty, this selector selects all pods in this namespace.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+					"namespaceSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If omitted, this selector selects no namespaces. If present but empty, this selector selects all namespaces.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicyPeer",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.LabelSelector"},
 	},
 	"v1beta1.NetworkPolicyPeer": {
 		Schema: spec.Schema{
@@ -11018,20 +17994,54 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"podSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If not provided, this selector selects no pods. If present but empty, this selector selects all pods in this namespace.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"namespaceSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If omitted, this selector selects no namespaces. If present but empty, this selector selects all namespaces.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicyPeer",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.NetworkPolicyPeer",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector"},
+			"io.k8s.meta.v1.LabelSelector"},
+	},
+	"extensions.v1beta1.NetworkPolicyPort": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"protocol": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional.  The protocol (TCP or UDP) which traffic must match. If not specified, this field defaults to TCP.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"port": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicyPort",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString"},
 	},
 	"v1beta1.NetworkPolicyPort": {
 		Schema: spec.Schema{
@@ -11047,23 +18057,29 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"port": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.",
-							Ref:         spec.MustCreateRef("#/definitions/intstr.IntOrString"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicyPort",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.NetworkPolicyPort",
+				},
+			},
 		},
 		Dependencies: []string{
-			"intstr.IntOrString"},
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString"},
 	},
-	"v1beta1.NetworkPolicySpec": {
+	"extensions.v1beta1.NetworkPolicySpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Properties: map[string]spec.Schema{
 					"podSelector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"ingress": {
@@ -11073,7 +18089,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.NetworkPolicyIngressRule"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicyIngressRule"),
 									},
 								},
 							},
@@ -11082,9 +18098,79 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"podSelector"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicySpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector", "v1beta1.NetworkPolicyIngressRule"},
+			"extensions.v1beta1.NetworkPolicyIngressRule", "io.k8s.meta.v1.LabelSelector"},
+	},
+	"v1beta1.NetworkPolicySpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"podSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Selects the pods to which this NetworkPolicy object applies.  The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods.  In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+					"ingress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if namespace.networkPolicy.ingress.isolation is undefined and cluster policy allows it, OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not affect ingress isolation. If this field is present and contains at least one rule, this policy allows any traffic which matches at least one of the ingress rules in this list.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.NetworkPolicyIngressRule"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"podSelector"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.NetworkPolicySpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.NetworkPolicySpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.NetworkPolicyIngressRule", "io.k8s.meta.v1.LabelSelector"},
+	},
+	"io.k8s.authorization.v1beta1.NonResourceAttributes": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+				Properties: map[string]spec.Schema{
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Path is the URL path of the request",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"verb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verb is the standard HTTP verb",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.NonResourceAttributes",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.NonResourceAttributes": {
 		Schema: spec.Schema{
@@ -11107,8 +18193,47 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.NonResourceAttributes",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.v1beta1.NonResourceAttributes",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"policy.v1beta1.PodDisruptionBudget": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specification of the desired behavior of the PodDisruptionBudget.",
+							Ref:         spec.MustCreateRef("#/definitions/policy.v1beta1.PodDisruptionBudgetSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Most recently observed status of the PodDisruptionBudget.",
+							Ref:         spec.MustCreateRef("#/definitions/policy.v1beta1.PodDisruptionBudgetStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/policy/v1beta1.PodDisruptionBudget",
+				},
+			},
+		},
+		Dependencies: []string{
+			"policy.v1beta1.PodDisruptionBudgetSpec", "policy.v1beta1.PodDisruptionBudgetStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.PodDisruptionBudget": {
 		Schema: spec.Schema{
@@ -11123,29 +18248,35 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the PodDisruptionBudget.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.PodDisruptionBudgetSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/policy.v1beta1.PodDisruptionBudgetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Most recently observed status of the PodDisruptionBudget.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.PodDisruptionBudgetStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/policy.v1beta1.PodDisruptionBudgetStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/policy/v1beta1.PodDisruptionBudget",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "policy.v1beta1.PodDisruptionBudget",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.PodDisruptionBudgetSpec", "v1beta1.PodDisruptionBudgetStatus"},
+			"policy.v1beta1.PodDisruptionBudgetSpec", "policy.v1beta1.PodDisruptionBudgetStatus", "v1.ObjectMeta"},
 	},
-	"v1beta1.PodDisruptionBudgetList": {
+	"policy.v1beta1.PodDisruptionBudgetList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.",
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -11154,7 +18285,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.PodDisruptionBudget"),
+										Ref: spec.MustCreateRef("#/definitions/policy.v1beta1.PodDisruptionBudget"),
 									},
 								},
 							},
@@ -11163,9 +18294,77 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/policy/v1beta1.PodDisruptionBudgetList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.PodDisruptionBudget"},
+			"io.k8s.meta.v1.ListMeta", "policy.v1beta1.PodDisruptionBudget"},
+	},
+	"v1beta1.PodDisruptionBudgetList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/policy.v1beta1.PodDisruptionBudget"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/policy/v1beta1.PodDisruptionBudgetList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "policy.v1beta1.PodDisruptionBudgetList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.ListMeta", "policy.v1beta1.PodDisruptionBudget"},
+	},
+	"policy.v1beta1.PodDisruptionBudgetSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
+				Properties: map[string]spec.Schema{
+					"minAvailable": {
+						SchemaProps: spec.SchemaProps{
+							Description: "An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\".",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
+						},
+					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Label query over pods whose evictions are managed by the disruption budget.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/policy/v1beta1.PodDisruptionBudgetSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString", "io.k8s.meta.v1.LabelSelector"},
 	},
 	"v1beta1.PodDisruptionBudgetSpec": {
 		Schema: spec.Schema{
@@ -11175,22 +18374,28 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"minAvailable": {
 						SchemaProps: spec.SchemaProps{
 							Description: "An eviction is allowed if at least \"minAvailable\" pods selected by \"selector\" will still be available after the eviction, i.e. even in the absence of the evicted pod.  So for example you can prevent all voluntary evictions by specifying \"100%\".",
-							Ref:         spec.MustCreateRef("#/definitions/intstr.IntOrString"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
 						},
 					},
 					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Label query over pods whose evictions are managed by the disruption budget.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/policy/v1beta1.PodDisruptionBudgetSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "policy.v1beta1.PodDisruptionBudgetSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"intstr.IntOrString", "v1.LabelSelector"},
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString", "io.k8s.meta.v1.LabelSelector"},
 	},
-	"v1beta1.PodDisruptionBudgetStatus": {
+	"policy.v1beta1.PodDisruptionBudgetStatus": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
@@ -11209,7 +18414,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							AdditionalProperties: &spec.SchemaOrBool{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1.Time"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 									},
 								},
 							},
@@ -11246,9 +18451,108 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"disruptedPods", "disruptionsAllowed", "currentHealthy", "desiredHealthy", "expectedPods"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/policy/v1beta1.PodDisruptionBudgetStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
+	},
+	"v1beta1.PodDisruptionBudgetStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
+				Properties: map[string]spec.Schema{
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Most recent generation observed when updating this PDB status. PodDisruptionsAllowed and other status informatio is valid only if observedGeneration equals to PDB's object generation.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"disruptedPods": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DisruptedPods contains information about pods whose eviction was processed by the API server eviction subresource handler but has not yet been observed by the PodDisruptionBudget controller. A pod will be in this map from the time when the API server processed the eviction request to the time when the pod is seen by PDB controller as having been marked for deletion (or after a timeout). The key in the map is the name of the pod and the value is the time when the API server processed the eviction request. If the deletion didn't occur and a pod is still there it will be removed from the list automatically by PodDisruptionBudget controller after some time. If everything goes smooth this map should be empty for the most of the time. Large number of entries in the map may indicate problems with pod deletions.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+									},
+								},
+							},
+						},
+					},
+					"disruptionsAllowed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Number of pod disruptions that are currently allowed.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"currentHealthy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current number of healthy pods",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"desiredHealthy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "minimum desired number of healthy pods",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"expectedPods": {
+						SchemaProps: spec.SchemaProps{
+							Description: "total number of pods counted by this disruption budget",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"disruptedPods", "disruptionsAllowed", "currentHealthy", "desiredHealthy", "expectedPods"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/policy/v1beta1.PodDisruptionBudgetStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "policy.v1beta1.PodDisruptionBudgetStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
+	},
+	"extensions.v1beta1.PodSecurityPolicy": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Pod Security Policy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "spec defines the policy enforced.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.PodSecurityPolicySpec"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.PodSecurityPolicy",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.PodSecurityPolicySpec", "v1.ObjectMeta"},
 	},
 	"v1beta1.PodSecurityPolicy": {
 		Schema: spec.Schema{
@@ -11264,16 +18568,22 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "spec defines the policy enforced.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.PodSecurityPolicySpec"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.PodSecurityPolicySpec"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.PodSecurityPolicy",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.PodSecurityPolicy",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.PodSecurityPolicySpec"},
+			"extensions.v1beta1.PodSecurityPolicySpec", "v1.ObjectMeta"},
 	},
-	"v1beta1.PodSecurityPolicyList": {
+	"extensions.v1beta1.PodSecurityPolicyList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Pod Security Policy List is a list of PodSecurityPolicy objects.",
@@ -11281,7 +18591,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -11291,7 +18601,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.PodSecurityPolicy"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.PodSecurityPolicy"),
 									},
 								},
 							},
@@ -11300,9 +18610,196 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.PodSecurityPolicyList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.PodSecurityPolicy"},
+			"extensions.v1beta1.PodSecurityPolicy", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1beta1.PodSecurityPolicyList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Pod Security Policy List is a list of PodSecurityPolicy objects.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is a list of schema objects.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.PodSecurityPolicy"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.PodSecurityPolicyList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.PodSecurityPolicyList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.PodSecurityPolicy", "io.k8s.meta.v1.ListMeta"},
+	},
+	"extensions.v1beta1.PodSecurityPolicySpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Pod Security Policy Spec defines the policy enforced.",
+				Properties: map[string]spec.Schema{
+					"privileged": {
+						SchemaProps: spec.SchemaProps{
+							Description: "privileged determines if a pod can request to be run as privileged.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"defaultAddCapabilities": {
+						SchemaProps: spec.SchemaProps{
+							Description: "DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"requiredDropCapabilities": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"allowedCapabilities": {
+						SchemaProps: spec.SchemaProps{
+							Description: "AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"volumes": {
+						SchemaProps: spec.SchemaProps{
+							Description: "volumes is a white list of allowed volume plugins.  Empty indicates that all plugins may be used.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"hostNetwork": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"hostPorts": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostPorts determines which host port ranges are allowed to be exposed.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.HostPortRange"),
+									},
+								},
+							},
+						},
+					},
+					"hostPID": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostPID determines if the policy allows the use of HostPID in the pod spec.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"hostIPC": {
+						SchemaProps: spec.SchemaProps{
+							Description: "hostIPC determines if the policy allows the use of HostIPC in the pod spec.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"seLinux": {
+						SchemaProps: spec.SchemaProps{
+							Description: "seLinux is the strategy that will dictate the allowable labels that may be set.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.SELinuxStrategyOptions"),
+						},
+					},
+					"runAsUser": {
+						SchemaProps: spec.SchemaProps{
+							Description: "runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.RunAsUserStrategyOptions"),
+						},
+					},
+					"supplementalGroups": {
+						SchemaProps: spec.SchemaProps{
+							Description: "SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.SupplementalGroupsStrategyOptions"),
+						},
+					},
+					"fsGroup": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.FSGroupStrategyOptions"),
+						},
+					},
+					"readOnlyRootFilesystem": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"seLinux", "runAsUser", "supplementalGroups", "fsGroup"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.PodSecurityPolicySpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.FSGroupStrategyOptions", "extensions.v1beta1.HostPortRange", "extensions.v1beta1.RunAsUserStrategyOptions", "extensions.v1beta1.SELinuxStrategyOptions", "extensions.v1beta1.SupplementalGroupsStrategyOptions"},
 	},
 	"v1beta1.PodSecurityPolicySpec": {
 		Schema: spec.Schema{
@@ -11386,7 +18883,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.HostPortRange"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.HostPortRange"),
 									},
 								},
 							},
@@ -11409,25 +18906,25 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"seLinux": {
 						SchemaProps: spec.SchemaProps{
 							Description: "seLinux is the strategy that will dictate the allowable labels that may be set.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SELinuxStrategyOptions"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.SELinuxStrategyOptions"),
 						},
 					},
 					"runAsUser": {
 						SchemaProps: spec.SchemaProps{
 							Description: "runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.RunAsUserStrategyOptions"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.RunAsUserStrategyOptions"),
 						},
 					},
 					"supplementalGroups": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SupplementalGroupsStrategyOptions"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.SupplementalGroupsStrategyOptions"),
 						},
 					},
 					"fsGroup": {
 						SchemaProps: spec.SchemaProps{
 							Description: "FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.FSGroupStrategyOptions"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.FSGroupStrategyOptions"),
 						},
 					},
 					"readOnlyRootFilesystem": {
@@ -11440,9 +18937,38 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"seLinux", "runAsUser", "supplementalGroups", "fsGroup"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.PodSecurityPolicySpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.PodSecurityPolicySpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.FSGroupStrategyOptions", "v1beta1.HostPortRange", "v1beta1.RunAsUserStrategyOptions", "v1beta1.SELinuxStrategyOptions", "v1beta1.SupplementalGroupsStrategyOptions"},
+			"extensions.v1beta1.FSGroupStrategyOptions", "extensions.v1beta1.HostPortRange", "extensions.v1beta1.RunAsUserStrategyOptions", "extensions.v1beta1.SELinuxStrategyOptions", "extensions.v1beta1.SupplementalGroupsStrategyOptions"},
+	},
+	"io.kubernetes.authorization.abac.v1beta1.Policy": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Policy contains a single ABAC policy rule",
+				Properties: map[string]spec.Schema{
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec describes the policy rule",
+							Ref:         spec.MustCreateRef("#/definitions/io.kubernetes.authorization.abac.v1beta1.PolicySpec"),
+						},
+					},
+				},
+				Required: []string{"spec"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/abac/v1beta1.Policy",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.kubernetes.authorization.abac.v1beta1.PolicySpec"},
 	},
 	"v1beta1.Policy": {
 		Schema: spec.Schema{
@@ -11452,15 +18978,85 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec describes the policy rule",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.PolicySpec"),
+							Ref:         spec.MustCreateRef("#/definitions/io.kubernetes.authorization.abac.v1beta1.PolicySpec"),
 						},
 					},
 				},
 				Required: []string{"spec"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/abac/v1beta1.Policy",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.kubernetes.authorization.abac.v1beta1.Policy",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.PolicySpec"},
+			"io.kubernetes.authorization.abac.v1beta1.PolicySpec"},
+	},
+	"io.kubernetes.authorization.abac.v1beta1.PolicySpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "PolicySpec contains the attributes for a policy rule",
+				Properties: map[string]spec.Schema{
+					"user": {
+						SchemaProps: spec.SchemaProps{
+							Description: "User is the username this rule applies to. Either user or group is required to match the request. \"*\" matches all users.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Group is the group this rule applies to. Either user or group is required to match the request. \"*\" matches all groups.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"readonly": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Readonly matches readonly requests when true, and all requests when false",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"apiGroup": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIGroup is the name of an API group. APIGroup, Resource, and Namespace are required to match resource requests. \"*\" matches all API groups",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resource is the name of a resource. APIGroup, Resource, and Namespace are required to match resource requests. \"*\" matches all resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace is the name of a namespace. APIGroup, Resource, and Namespace are required to match resource requests. \"*\" matches all namespaces (including unnamespaced requests)",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"nonResourcePath": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NonResourcePath matches non-resource request paths. \"*\" matches all paths \"/foo/*\" matches all subpaths of foo",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/abac/v1beta1.PolicySpec",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.PolicySpec": {
 		Schema: spec.Schema{
@@ -11518,8 +19114,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/abac/v1beta1.PolicySpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.kubernetes.authorization.abac.v1beta1.PolicySpec",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"extensions.v1beta1.ReplicaSet": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ReplicaSet represents the configuration of a ReplicaSet.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec defines the specification of the desired behavior of the ReplicaSet. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.ReplicaSetSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.ReplicaSetStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSet",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.ReplicaSetSpec", "extensions.v1beta1.ReplicaSetStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.ReplicaSet": {
 		Schema: spec.Schema{
@@ -11535,20 +19171,77 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the specification of the desired behavior of the ReplicaSet. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.ReplicaSetSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.ReplicaSetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.ReplicaSetStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.ReplicaSetStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSet",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ReplicaSet",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.ReplicaSetSpec", "v1beta1.ReplicaSetStatus"},
+			"extensions.v1beta1.ReplicaSetSpec", "extensions.v1beta1.ReplicaSetStatus", "v1.ObjectMeta"},
+	},
+	"extensions.v1beta1.ReplicaSetCondition": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ReplicaSetCondition describes the state of a replica set at a certain point.",
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type of replica set condition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the condition, one of True, False, Unknown.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"lastTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The last time the condition transitioned from one status to another.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The reason for the condition's last transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A human readable message indicating details about the transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"type", "status"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSetCondition",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
 	},
 	"v1beta1.ReplicaSetCondition": {
 		Schema: spec.Schema{
@@ -11572,7 +19265,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The last time the condition transitioned from one status to another.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -11592,11 +19285,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSetCondition",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ReplicaSetCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
-	"v1beta1.ReplicaSetList": {
+	"extensions.v1beta1.ReplicaSetList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ReplicaSetList is a collection of ReplicaSets.",
@@ -11604,7 +19303,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -11614,7 +19313,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.ReplicaSet"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.ReplicaSet"),
 									},
 								},
 							},
@@ -11623,9 +19322,93 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSetList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.ReplicaSet"},
+			"extensions.v1beta1.ReplicaSet", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1beta1.ReplicaSetList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ReplicaSetList is a collection of ReplicaSets.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "List of ReplicaSets. More info: http://kubernetes.io/docs/user-guide/replication-controller",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.ReplicaSet"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSetList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ReplicaSetList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.ReplicaSet", "io.k8s.meta.v1.ListMeta"},
+	},
+	"extensions.v1beta1.ReplicaSetSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ReplicaSetSpec is the specification of a ReplicaSet.",
+				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"minReadySeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+					"template": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: http://kubernetes.io/docs/user-guide/replication-controller#pod-template",
+							Ref:         spec.MustCreateRef("#/definitions/v1.PodTemplateSpec"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSetSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
 	},
 	"v1beta1.ReplicaSetSpec": {
 		Schema: spec.Schema{
@@ -11649,7 +19432,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"template": {
@@ -11660,9 +19443,80 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSetSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ReplicaSetSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector", "v1.PodTemplateSpec"},
+			"io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
+	},
+	"extensions.v1beta1.ReplicaSetStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ReplicaSetStatus represents the current status of a ReplicaSet.",
+				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Replicas is the most recently oberved number of replicas. More info: http://kubernetes.io/docs/user-guide/replication-controller#what-is-a-replication-controller",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"fullyLabeledReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The number of pods that have labels matching the labels of the pod template of the replicaset.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"readyReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The number of ready replicas for this replica set.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"availableReplicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The number of available replicas (ready for at least minReadySeconds) for this replica set.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"conditions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Represents the latest available observations of a replica set's current state.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.ReplicaSetCondition"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"replicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSetStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.ReplicaSetCondition"},
 	},
 	"v1beta1.ReplicaSetStatus": {
 		Schema: spec.Schema{
@@ -11711,7 +19565,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.ReplicaSetCondition"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.ReplicaSetCondition"),
 									},
 								},
 							},
@@ -11720,15 +19574,105 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"replicas"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicaSetStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ReplicaSetStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.ReplicaSetCondition"},
+			"extensions.v1beta1.ReplicaSetCondition"},
+	},
+	"extensions.v1beta1.ReplicationControllerDummy": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Dummy definition",
+				Properties:  map[string]spec.Schema{},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicationControllerDummy",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.ReplicationControllerDummy": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "Dummy definition",
 				Properties:  map[string]spec.Schema{},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ReplicationControllerDummy",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ReplicationControllerDummy",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"io.k8s.authorization.v1beta1.ResourceAttributes": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+				Properties: map[string]spec.Schema{
+					"namespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Namespace is the namespace of the action being requested.  Currently, there is no distinction between no namespace and all namespaces \"\" (empty) is defaulted for LocalSubjectAccessReviews \"\" (empty) is empty for cluster-scoped resources \"\" (empty) means \"all\" for namespace scoped resources from a SubjectAccessReview or SelfSubjectAccessReview",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"verb": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Verb is a kubernetes resource API verb, like: get, list, watch, create, update, delete, proxy.  \"*\" means all.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Group is the API Group of the Resource.  \"*\" means all.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"version": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Version is the API Version of the Resource.  \"*\" means all.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"resource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Resource is one of the existing resource types.  \"*\" means all.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"subresource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Subresource is one of the existing resource types.  \"\" means none.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name is the name of the resource being requested for a \"get\" or deleted for a \"delete\". \"\" (empty) means all.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.ResourceAttributes",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -11789,6 +19733,33 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.ResourceAttributes",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.v1beta1.ResourceAttributes",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"extensions.v1beta1.RollbackConfig": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Properties: map[string]spec.Schema{
+					"revision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The revision to rollback to. If set to 0, rollbck to the last revision.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.RollbackConfig",
+				},
+			},
 		},
 		Dependencies: []string{},
 	},
@@ -11805,8 +19776,42 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.RollbackConfig",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.RollbackConfig",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"extensions.v1beta1.RollingUpdateDeployment": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Spec to control the desired behavior of rolling update.",
+				Properties: map[string]spec.Schema{
+					"maxUnavailable": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
+						},
+					},
+					"maxSurge": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.RollingUpdateDeployment",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString"},
 	},
 	"v1beta1.RollingUpdateDeployment": {
 		Schema: spec.Schema{
@@ -11816,20 +19821,63 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"maxUnavailable": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
-							Ref:         spec.MustCreateRef("#/definitions/intstr.IntOrString"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
 						},
 					},
 					"maxSurge": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
-							Ref:         spec.MustCreateRef("#/definitions/intstr.IntOrString"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.util.intstr.IntOrString"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.RollingUpdateDeployment",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.RollingUpdateDeployment",
+				},
+			},
 		},
 		Dependencies: []string{
-			"intstr.IntOrString"},
+			"io.k8s.kubernetes.pkg.util.intstr.IntOrString"},
+	},
+	"extensions.v1beta1.RunAsUserStrategyOptions": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Run A sUser Strategy Options defines the strategy type and any options used to create the strategy.",
+				Properties: map[string]spec.Schema{
+					"rule": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Rule is the strategy that will dictate the allowable RunAsUser values that may be set.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"ranges": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ranges are the allowed ranges of uids that may be used.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IDRange"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"rule"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.RunAsUserStrategyOptions",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.IDRange"},
 	},
 	"v1beta1.RunAsUserStrategyOptions": {
 		Schema: spec.Schema{
@@ -11850,7 +19898,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.IDRange"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IDRange"),
 									},
 								},
 							},
@@ -11859,9 +19907,45 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"rule"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.RunAsUserStrategyOptions",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.RunAsUserStrategyOptions",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.IDRange"},
+			"extensions.v1beta1.IDRange"},
+	},
+	"extensions.v1beta1.SELinuxStrategyOptions": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SELinux  Strategy Options defines the strategy type and any options used to create the strategy.",
+				Properties: map[string]spec.Schema{
+					"rule": {
+						SchemaProps: spec.SchemaProps{
+							Description: "type is the strategy that will dictate the allowable labels that may be set.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"seLinuxOptions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "seLinuxOptions required to run as; required for MustRunAs More info: http://releases.k8s.io/HEAD/docs/design/security_context.md#security-context",
+							Ref:         spec.MustCreateRef("#/definitions/v1.SELinuxOptions"),
+						},
+					},
+				},
+				Required: []string{"rule"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.SELinuxStrategyOptions",
+				},
+			},
+		},
+		Dependencies: []string{
+			"v1.SELinuxOptions"},
 	},
 	"v1beta1.SELinuxStrategyOptions": {
 		Schema: spec.Schema{
@@ -11884,9 +19968,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"rule"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.SELinuxStrategyOptions",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.SELinuxStrategyOptions",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.SELinuxOptions"},
+	},
+	"extensions.v1beta1.Scale": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "represents a scaling request for a resource.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object metadata; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.ScaleSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.ScaleStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.Scale",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.ScaleSpec", "extensions.v1beta1.ScaleStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.Scale": {
 		Schema: spec.Schema{
@@ -11902,20 +20026,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "defines the behavior of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.ScaleSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.ScaleSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "current status of the scale. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status. Read-only.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.ScaleStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/extensions.v1beta1.ScaleStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.Scale",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.Scale",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.ScaleSpec", "v1beta1.ScaleStatus"},
+			"extensions.v1beta1.ScaleSpec", "extensions.v1beta1.ScaleStatus", "v1.ObjectMeta"},
+	},
+	"extensions.v1beta1.ScaleSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "describes the attributes of a scale subresource",
+				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "desired number of instances for the scaled object.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ScaleSpec",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.ScaleSpec": {
 		Schema: spec.Schema{
@@ -11929,6 +20081,56 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Format:      "int32",
 						},
 					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ScaleSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ScaleSpec",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"extensions.v1beta1.ScaleStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "represents the current status of a scale subresource.",
+				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "actual number of observed instances of the scaled object.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"targetSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"replicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ScaleStatus",
 				},
 			},
 		},
@@ -11970,8 +20172,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"replicas"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ScaleStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ScaleStatus",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.authorization.v1beta1.SelfSubjectAccessReview": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec holds information about the request being evaluated.  user and groups must be empty",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is filled in by the server and indicates whether the request is allowed or not",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"),
+						},
+					},
+				},
+				Required: []string{"spec"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SelfSubjectAccessReview",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec", "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.SelfSubjectAccessReview": {
 		Schema: spec.Schema{
@@ -11986,21 +20228,55 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds information about the request being evaluated.  user and groups must be empty",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SelfSubjectAccessReviewSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is filled in by the server and indicates whether the request is allowed or not",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SubjectAccessReviewStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"),
 						},
 					},
 				},
 				Required: []string{"spec"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SelfSubjectAccessReview",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.v1beta1.SelfSubjectAccessReview",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.SelfSubjectAccessReviewSpec", "v1beta1.SubjectAccessReviewStatus"},
+			"io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec", "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus", "v1.ObjectMeta"},
+	},
+	"io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+				Properties: map[string]spec.Schema{
+					"resourceAttributes": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ResourceAuthorizationAttributes describes information for a resource access request",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.ResourceAttributes"),
+						},
+					},
+					"nonResourceAttributes": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NonResourceAttributes describes information for a non-resource access request",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.NonResourceAttributes"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SelfSubjectAccessReviewSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.v1beta1.NonResourceAttributes", "io.k8s.authorization.v1beta1.ResourceAttributes"},
 	},
 	"v1beta1.SelfSubjectAccessReviewSpec": {
 		Schema: spec.Schema{
@@ -12010,20 +20286,56 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"resourceAttributes": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ResourceAuthorizationAttributes describes information for a resource access request",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.ResourceAttributes"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.ResourceAttributes"),
 						},
 					},
 					"nonResourceAttributes": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NonResourceAttributes describes information for a non-resource access request",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.NonResourceAttributes"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.NonResourceAttributes"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SelfSubjectAccessReviewSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.v1beta1.SelfSubjectAccessReviewSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.NonResourceAttributes", "v1beta1.ResourceAttributes"},
+			"io.k8s.authorization.v1beta1.NonResourceAttributes", "io.k8s.authorization.v1beta1.ResourceAttributes"},
+	},
+	"federation.v1beta1.ServerAddressByClientCIDR": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+				Properties: map[string]spec.Schema{
+					"clientCIDR": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The CIDR with which clients can match their IP to figure out the server address that they should use.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"serverAddress": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Address of this server, suitable for a client that matches the above CIDR. This can be a hostname, hostname:port, IP or IP:port.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"clientCIDR", "serverAddress"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/federation/apis/federation/v1beta1.ServerAddressByClientCIDR",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.ServerAddressByClientCIDR": {
 		Schema: spec.Schema{
@@ -12047,8 +20359,47 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"clientCIDR", "serverAddress"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/federation/apis/federation/v1beta1.ServerAddressByClientCIDR",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "federation.v1beta1.ServerAddressByClientCIDR",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"apps.v1beta1.StatefulSet": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec defines the desired identities of pods in this set.",
+							Ref:         spec.MustCreateRef("#/definitions/apps.v1beta1.StatefulSetSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
+							Ref:         spec.MustCreateRef("#/definitions/apps.v1beta1.StatefulSetStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/apps/v1beta1.StatefulSet",
+				},
+			},
+		},
+		Dependencies: []string{
+			"apps.v1beta1.StatefulSetSpec", "apps.v1beta1.StatefulSetStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.StatefulSet": {
 		Schema: spec.Schema{
@@ -12063,29 +20414,35 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec defines the desired identities of pods in this set.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.StatefulSetSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/apps.v1beta1.StatefulSetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.StatefulSetStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/apps.v1beta1.StatefulSetStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/apps/v1beta1.StatefulSet",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "apps.v1beta1.StatefulSet",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.StatefulSetSpec", "v1beta1.StatefulSetStatus"},
+			"apps.v1beta1.StatefulSetSpec", "apps.v1beta1.StatefulSetStatus", "v1.ObjectMeta"},
 	},
-	"v1beta1.StatefulSetList": {
+	"apps.v1beta1.StatefulSetList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "StatefulSetList is a collection of StatefulSets.",
 				Properties: map[string]spec.Schema{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
-							Ref: spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -12094,7 +20451,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.StatefulSet"),
+										Ref: spec.MustCreateRef("#/definitions/apps.v1beta1.StatefulSet"),
 									},
 								},
 							},
@@ -12103,11 +20460,51 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/apps/v1beta1.StatefulSetList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.StatefulSet"},
+			"apps.v1beta1.StatefulSet", "io.k8s.meta.v1.ListMeta"},
 	},
-	"v1beta1.StatefulSetSpec": {
+	"v1beta1.StatefulSetList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StatefulSetList is a collection of StatefulSets.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/apps.v1beta1.StatefulSet"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/apps/v1beta1.StatefulSetList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "apps.v1beta1.StatefulSetList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"apps.v1beta1.StatefulSet", "io.k8s.meta.v1.ListMeta"},
+	},
+	"apps.v1beta1.StatefulSetSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "A StatefulSetSpec is the specification of a StatefulSet.",
@@ -12122,7 +20519,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"template": {
@@ -12154,9 +20551,101 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"template", "serviceName"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/apps/v1beta1.StatefulSetSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector", "v1.PersistentVolumeClaim", "v1.PodTemplateSpec"},
+			"io.k8s.meta.v1.LabelSelector", "v1.PersistentVolumeClaim", "v1.PodTemplateSpec"},
+	},
+	"v1beta1.StatefulSetSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "A StatefulSetSpec is the specification of a StatefulSet.",
+				Properties: map[string]spec.Schema{
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+					"template": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.PodTemplateSpec"),
+						},
+					},
+					"volumeClaimTemplates": {
+						SchemaProps: spec.SchemaProps{
+							Description: "VolumeClaimTemplates is a list of claims that pods are allowed to reference. The StatefulSet controller is responsible for mapping network identities to claims in a way that maintains the identity of a pod. Every claim in this list must have at least one matching (by name) volumeMount in one container in the template. A claim in this list takes precedence over any volumes in the template, with the same name.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/v1.PersistentVolumeClaim"),
+									},
+								},
+							},
+						},
+					},
+					"serviceName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ServiceName is the name of the service that governs this StatefulSet. This service must exist before the StatefulSet, and is responsible for the network identity of the set. Pods get DNS/hostnames that follow the pattern: pod-specific-string.serviceName.default.svc.cluster.local where \"pod-specific-string\" is managed by the StatefulSet controller.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"template", "serviceName"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/apps/v1beta1.StatefulSetSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "apps.v1beta1.StatefulSetSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.LabelSelector", "v1.PersistentVolumeClaim", "v1.PodTemplateSpec"},
+	},
+	"apps.v1beta1.StatefulSetStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StatefulSetStatus represents the current state of a StatefulSet.",
+				Properties: map[string]spec.Schema{
+					"observedGeneration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "most recent generation observed by this StatefulSet.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"replicas": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Replicas is the number of actual replicas.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+				Required: []string{"replicas"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/apps/v1beta1.StatefulSetStatus",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.StatefulSetStatus": {
 		Schema: spec.Schema{
@@ -12180,8 +20669,58 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"replicas"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/apps/v1beta1.StatefulSetStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "apps.v1beta1.StatefulSetStatus",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.storage.v1beta1.StorageClass": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"provisioner": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Provisioner indicates the type of the provisioner.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"parameters": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Parameters holds the parameters for the provisioner that should create volumes of this storage class.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"provisioner"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/storage/v1beta1.StorageClass",
+				},
+			},
+		},
+		Dependencies: []string{
+			"v1.ObjectMeta"},
 	},
 	"v1beta1.StorageClass": {
 		Schema: spec.Schema{
@@ -12218,11 +20757,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"provisioner"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/storage/v1beta1.StorageClass",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.storage.v1beta1.StorageClass",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta"},
 	},
-	"v1beta1.StorageClassList": {
+	"io.k8s.storage.v1beta1.StorageClassList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "StorageClassList is a collection of storage classes.",
@@ -12230,7 +20775,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -12240,7 +20785,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.StorageClass"),
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.storage.v1beta1.StorageClass"),
 									},
 								},
 							},
@@ -12249,9 +20794,85 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/storage/v1beta1.StorageClassList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.StorageClass"},
+			"io.k8s.meta.v1.ListMeta", "io.k8s.storage.v1beta1.StorageClass"},
+	},
+	"v1beta1.StorageClassList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageClassList is a collection of storage classes.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is the list of StorageClasses",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/io.k8s.storage.v1beta1.StorageClass"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/storage/v1beta1.StorageClassList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.storage.v1beta1.StorageClassList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.ListMeta", "io.k8s.storage.v1beta1.StorageClass"},
+	},
+	"io.k8s.authorization.v1beta1.SubjectAccessReview": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SubjectAccessReview checks whether or not a user or group can perform an action.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec holds information about the request being evaluated",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is filled in by the server and indicates whether the request is allowed or not",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"),
+						},
+					},
+				},
+				Required: []string{"spec"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SubjectAccessReview",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.v1beta1.SubjectAccessReviewSpec", "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.SubjectAccessReview": {
 		Schema: spec.Schema{
@@ -12266,23 +20887,29 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds information about the request being evaluated",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SubjectAccessReviewSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is filled in by the server and indicates whether the request is allowed or not",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.SubjectAccessReviewStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.SubjectAccessReviewStatus"),
 						},
 					},
 				},
 				Required: []string{"spec"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SubjectAccessReview",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.v1beta1.SubjectAccessReview",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.SubjectAccessReviewSpec", "v1beta1.SubjectAccessReviewStatus"},
+			"io.k8s.authorization.v1beta1.SubjectAccessReviewSpec", "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus", "v1.ObjectMeta"},
 	},
-	"v1beta1.SubjectAccessReviewSpec": {
+	"io.k8s.authorization.v1beta1.SubjectAccessReviewSpec": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
@@ -12290,13 +20917,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"resourceAttributes": {
 						SchemaProps: spec.SchemaProps{
 							Description: "ResourceAuthorizationAttributes describes information for a resource access request",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.ResourceAttributes"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.ResourceAttributes"),
 						},
 					},
 					"nonResourceAttributes": {
 						SchemaProps: spec.SchemaProps{
 							Description: "NonResourceAttributes describes information for a non-resource access request",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.NonResourceAttributes"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.NonResourceAttributes"),
 						},
 					},
 					"user": {
@@ -12343,9 +20970,122 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SubjectAccessReviewSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.NonResourceAttributes", "v1beta1.ResourceAttributes"},
+			"io.k8s.authorization.v1beta1.NonResourceAttributes", "io.k8s.authorization.v1beta1.ResourceAttributes"},
+	},
+	"v1beta1.SubjectAccessReviewSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+				Properties: map[string]spec.Schema{
+					"resourceAttributes": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ResourceAuthorizationAttributes describes information for a resource access request",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.ResourceAttributes"),
+						},
+					},
+					"nonResourceAttributes": {
+						SchemaProps: spec.SchemaProps{
+							Description: "NonResourceAttributes describes information for a non-resource access request",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authorization.v1beta1.NonResourceAttributes"),
+						},
+					},
+					"user": {
+						SchemaProps: spec.SchemaProps{
+							Description: "User is the user you're testing for. If you specify \"User\" but not \"Group\", then is it interpreted as \"What if User were not a member of any groups",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Groups is the groups you're testing for.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"extra": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type:   []string{"string"},
+													Format: "",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SubjectAccessReviewSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.v1beta1.SubjectAccessReviewSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authorization.v1beta1.NonResourceAttributes", "io.k8s.authorization.v1beta1.ResourceAttributes"},
+	},
+	"io.k8s.authorization.v1beta1.SubjectAccessReviewStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SubjectAccessReviewStatus",
+				Properties: map[string]spec.Schema{
+					"allowed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Allowed is required.  True if the action would be allowed, false otherwise.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Reason is optional.  It indicates why a request was allowed or denied.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"evaluationError": {
+						SchemaProps: spec.SchemaProps{
+							Description: "EvaluationError is an indication that some error occurred during the authorization check. It is entirely possible to get an error and be able to continue determine authorization status in spite of it. For instance, RBAC can be missing a role, but enough roles are still present and bound to reason about the request.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"allowed"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SubjectAccessReviewStatus",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.SubjectAccessReviewStatus": {
 		Schema: spec.Schema{
@@ -12375,6 +21115,55 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 				Required: []string{"allowed"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authorization/v1beta1.SubjectAccessReviewStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authorization.v1beta1.SubjectAccessReviewStatus",
+				},
+			},
+		},
+		Dependencies: []string{},
+	},
+	"extensions.v1beta1.SubresourceReference": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SubresourceReference contains enough information to let you inspect or modify the referred subresource.",
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind of the referent; More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "API version of the referent",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"subresource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Subresource name of the referent",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.SubresourceReference",
+				},
 			},
 		},
 		Dependencies: []string{},
@@ -12414,8 +21203,50 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.SubresourceReference",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.SubresourceReference",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"extensions.v1beta1.SupplementalGroupsStrategyOptions": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
+				Properties: map[string]spec.Schema{
+					"rule": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"ranges": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IDRange"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.SupplementalGroupsStrategyOptions",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.IDRange"},
 	},
 	"v1beta1.SupplementalGroupsStrategyOptions": {
 		Schema: spec.Schema{
@@ -12436,7 +21267,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.IDRange"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.IDRange"),
 									},
 								},
 							},
@@ -12444,9 +21275,57 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.SupplementalGroupsStrategyOptions",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.SupplementalGroupsStrategyOptions",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.IDRange"},
+			"extensions.v1beta1.IDRange"},
+	},
+	"extensions.v1beta1.ThirdPartyResource": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"description": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Description is the description of this object.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"versions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Versions are versions for this third party object",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.APIVersion"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ThirdPartyResource",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.APIVersion", "v1.ObjectMeta"},
 	},
 	"v1beta1.ThirdPartyResource": {
 		Schema: spec.Schema{
@@ -12473,7 +21352,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.APIVersion"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.APIVersion"),
 									},
 								},
 							},
@@ -12481,9 +21360,44 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ThirdPartyResource",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ThirdPartyResource",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.APIVersion"},
+			"extensions.v1beta1.APIVersion", "v1.ObjectMeta"},
+	},
+	"extensions.v1beta1.ThirdPartyResourceData": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "An internal object, used for versioned storage in etcd.  Not exposed to the end user.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"data": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Data is the raw JSON data for this data.",
+							Type:        []string{"string"},
+							Format:      "byte",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ThirdPartyResourceData",
+				},
+			},
+		},
+		Dependencies: []string{
+			"v1.ObjectMeta"},
 	},
 	"v1beta1.ThirdPartyResourceData": {
 		Schema: spec.Schema{
@@ -12505,11 +21419,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ThirdPartyResourceData",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ThirdPartyResourceData",
+				},
+			},
 		},
 		Dependencies: []string{
 			"v1.ObjectMeta"},
 	},
-	"v1beta1.ThirdPartyResourceDataList": {
+	"extensions.v1beta1.ThirdPartyResourceDataList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.",
@@ -12517,7 +21437,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -12527,7 +21447,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.ThirdPartyResourceData"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.ThirdPartyResourceData"),
 									},
 								},
 							},
@@ -12536,11 +21456,53 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ThirdPartyResourceDataList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.ThirdPartyResourceData"},
+			"extensions.v1beta1.ThirdPartyResourceData", "io.k8s.meta.v1.ListMeta"},
 	},
-	"v1beta1.ThirdPartyResourceList": {
+	"v1beta1.ThirdPartyResourceDataList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is the list of ThirdpartyResourceData.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.ThirdPartyResourceData"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ThirdPartyResourceDataList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ThirdPartyResourceDataList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.ThirdPartyResourceData", "io.k8s.meta.v1.ListMeta"},
+	},
+	"extensions.v1beta1.ThirdPartyResourceList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "ThirdPartyResourceList is a list of ThirdPartyResources.",
@@ -12548,7 +21510,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -12558,7 +21520,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v1beta1.ThirdPartyResource"),
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.ThirdPartyResource"),
 									},
 								},
 							},
@@ -12567,9 +21529,85 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ThirdPartyResourceList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v1beta1.ThirdPartyResource"},
+			"extensions.v1beta1.ThirdPartyResource", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v1beta1.ThirdPartyResourceList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "ThirdPartyResourceList is a list of ThirdPartyResources.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is the list of ThirdPartyResources.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/extensions.v1beta1.ThirdPartyResource"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/extensions/v1beta1.ThirdPartyResourceList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "extensions.v1beta1.ThirdPartyResourceList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"extensions.v1beta1.ThirdPartyResource", "io.k8s.meta.v1.ListMeta"},
+	},
+	"io.k8s.authentication.v1beta1.TokenReview": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec holds information about the request being evaluated",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authentication.v1beta1.TokenReviewSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is filled in by the server and indicates whether the request can be authenticated.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authentication.v1beta1.TokenReviewStatus"),
+						},
+					},
+				},
+				Required: []string{"spec"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authentication/v1beta1.TokenReview",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authentication.v1beta1.TokenReviewSpec", "io.k8s.authentication.v1beta1.TokenReviewStatus", "v1.ObjectMeta"},
 	},
 	"v1beta1.TokenReview": {
 		Schema: spec.Schema{
@@ -12584,21 +21622,49 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec holds information about the request being evaluated",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.TokenReviewSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authentication.v1beta1.TokenReviewSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is filled in by the server and indicates whether the request can be authenticated.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.TokenReviewStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authentication.v1beta1.TokenReviewStatus"),
 						},
 					},
 				},
 				Required: []string{"spec"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authentication/v1beta1.TokenReview",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authentication.v1beta1.TokenReview",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v1beta1.TokenReviewSpec", "v1beta1.TokenReviewStatus"},
+			"io.k8s.authentication.v1beta1.TokenReviewSpec", "io.k8s.authentication.v1beta1.TokenReviewStatus", "v1.ObjectMeta"},
+	},
+	"io.k8s.authentication.v1beta1.TokenReviewSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "TokenReviewSpec is a description of the token authentication request.",
+				Properties: map[string]spec.Schema{
+					"token": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Token is the opaque bearer token.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authentication/v1beta1.TokenReviewSpec",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.TokenReviewSpec": {
 		Schema: spec.Schema{
@@ -12614,8 +21680,50 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authentication/v1beta1.TokenReviewSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authentication.v1beta1.TokenReviewSpec",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.authentication.v1beta1.TokenReviewStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "TokenReviewStatus is the result of the token authentication request.",
+				Properties: map[string]spec.Schema{
+					"authenticated": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Authenticated indicates that the token was associated with a known user.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"user": {
+						SchemaProps: spec.SchemaProps{
+							Description: "User is the UserInfo associated with the provided token.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authentication.v1beta1.UserInfo"),
+						},
+					},
+					"error": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Error indicates that the token couldn't be checked",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authentication/v1beta1.TokenReviewStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.authentication.v1beta1.UserInfo"},
 	},
 	"v1beta1.TokenReviewStatus": {
 		Schema: spec.Schema{
@@ -12632,7 +21740,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"user": {
 						SchemaProps: spec.SchemaProps{
 							Description: "User is the UserInfo associated with the provided token.",
-							Ref:         spec.MustCreateRef("#/definitions/v1beta1.UserInfo"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.authentication.v1beta1.UserInfo"),
 						},
 					},
 					"error": {
@@ -12644,9 +21752,79 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authentication/v1beta1.TokenReviewStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authentication.v1beta1.TokenReviewStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1beta1.UserInfo"},
+			"io.k8s.authentication.v1beta1.UserInfo"},
+	},
+	"io.k8s.authentication.v1beta1.UserInfo": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "UserInfo holds the information about the user needed to implement the user.Info interface.",
+				Properties: map[string]spec.Schema{
+					"username": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The name that uniquely identifies this user among all active users.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"uid": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A unique value that identifies this user across time. If this user is deleted and another user by the same name is added, they will have different UIDs.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"groups": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The names of groups this user is a part of.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type:   []string{"string"},
+										Format: "",
+									},
+								},
+							},
+						},
+					},
+					"extra": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Any additional information provided by the authenticator.",
+							Type:        []string{"object"},
+							AdditionalProperties: &spec.SchemaOrBool{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Type: []string{"array"},
+										Items: &spec.SchemaOrArray{
+											Schema: &spec.Schema{
+												SchemaProps: spec.SchemaProps{
+													Type:   []string{"string"},
+													Format: "",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/authentication/v1beta1.UserInfo",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"v1beta1.UserInfo": {
 		Schema: spec.Schema{
@@ -12704,8 +21882,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/authentication/v1beta1.UserInfo",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.authentication.v1beta1.UserInfo",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"batch.v2alpha1.CronJob": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "CronJob represents the configuration of a single cron job.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec is a structure defining the expected behavior of a job, including the schedule. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.CronJobSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.CronJobStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.CronJob",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v2alpha1.CronJobSpec", "batch.v2alpha1.CronJobStatus", "v1.ObjectMeta"},
 	},
 	"v2alpha1.CronJob": {
 		Schema: spec.Schema{
@@ -12721,22 +21939,28 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec is a structure defining the expected behavior of a job, including the schedule. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v2alpha1.CronJobSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.CronJobSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v2alpha1.CronJobStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.CronJobStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.CronJob",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.CronJob",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v2alpha1.CronJobSpec", "v2alpha1.CronJobStatus"},
+			"batch.v2alpha1.CronJobSpec", "batch.v2alpha1.CronJobStatus", "v1.ObjectMeta"},
 	},
-	"v2alpha1.CronJobList": {
+	"batch.v2alpha1.CronJobList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "CronJobList is a collection of cron jobs.",
@@ -12744,7 +21968,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -12754,7 +21978,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v2alpha1.CronJob"),
+										Ref: spec.MustCreateRef("#/definitions/batch.v2alpha1.CronJob"),
 									},
 								},
 							},
@@ -12763,9 +21987,102 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.CronJobList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v2alpha1.CronJob"},
+			"batch.v2alpha1.CronJob", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v2alpha1.CronJobList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "CronJobList is a collection of cron jobs.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is the list of CronJob.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/batch.v2alpha1.CronJob"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.CronJobList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.CronJobList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v2alpha1.CronJob", "io.k8s.meta.v1.ListMeta"},
+	},
+	"batch.v2alpha1.CronJobSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "CronJobSpec describes how the job execution will look like and when it will actually run.",
+				Properties: map[string]spec.Schema{
+					"schedule": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Schedule contains the schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"startingDeadlineSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"concurrencyPolicy": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ConcurrencyPolicy specifies how to treat concurrent executions of a Job.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"suspend": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Suspend flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"jobTemplate": {
+						SchemaProps: spec.SchemaProps{
+							Description: "JobTemplate is the object that describes the job that will be created when executing a CronJob.",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobTemplateSpec"),
+						},
+					},
+				},
+				Required: []string{"schedule", "jobTemplate"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.CronJobSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v2alpha1.JobTemplateSpec"},
 	},
 	"v2alpha1.CronJobSpec": {
 		Schema: spec.Schema{
@@ -12803,15 +22120,56 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"jobTemplate": {
 						SchemaProps: spec.SchemaProps{
 							Description: "JobTemplate is the object that describes the job that will be created when executing a CronJob.",
-							Ref:         spec.MustCreateRef("#/definitions/v2alpha1.JobTemplateSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobTemplateSpec"),
 						},
 					},
 				},
 				Required: []string{"schedule", "jobTemplate"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.CronJobSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.CronJobSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v2alpha1.JobTemplateSpec"},
+			"batch.v2alpha1.JobTemplateSpec"},
+	},
+	"batch.v2alpha1.CronJobStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "CronJobStatus represents the current state of a cron job.",
+				Properties: map[string]spec.Schema{
+					"active": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Active holds pointers to currently running jobs.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/v1.ObjectReference"),
+									},
+								},
+							},
+						},
+					},
+					"lastScheduleTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.CronJobStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time", "v1.ObjectReference"},
 	},
 	"v2alpha1.CronJobStatus": {
 		Schema: spec.Schema{
@@ -12834,14 +22192,54 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastScheduleTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "LastScheduleTime keeps information of when was the last time the job was successfully scheduled.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.CronJobStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.CronJobStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectReference", "v1.Time"},
+			"io.k8s.meta.v1.Time", "v1.ObjectReference"},
+	},
+	"batch.v2alpha1.Job": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Job represents the configuration of a single job.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobStatus"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.Job",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v2alpha1.JobSpec", "batch.v2alpha1.JobStatus", "v1.ObjectMeta"},
 	},
 	"v2alpha1.Job": {
 		Schema: spec.Schema{
@@ -12857,20 +22255,83 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Spec is a structure defining the expected behavior of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v2alpha1.JobSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Status is a structure describing current status of a job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v2alpha1.JobStatus"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobStatus"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.Job",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.Job",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v2alpha1.JobSpec", "v2alpha1.JobStatus"},
+			"batch.v2alpha1.JobSpec", "batch.v2alpha1.JobStatus", "v1.ObjectMeta"},
+	},
+	"batch.v2alpha1.JobCondition": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobCondition describes current state of a job.",
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Type of job condition, Complete or Failed.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Status of the condition, one of True, False, Unknown.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"lastProbeTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition was checked.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"lastTransitionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Last time the condition transit from one status to another.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"reason": {
+						SchemaProps: spec.SchemaProps{
+							Description: "(brief) reason for the condition's last transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Human readable message indicating details about last transition.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"type", "status"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobCondition",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.Time"},
 	},
 	"v2alpha1.JobCondition": {
 		Schema: spec.Schema{
@@ -12894,13 +22355,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"lastProbeTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition was checked.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"lastTransitionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Last time the condition transit from one status to another.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"reason": {
@@ -12920,11 +22381,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"type", "status"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobCondition",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.JobCondition",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time"},
+			"io.k8s.meta.v1.Time"},
 	},
-	"v2alpha1.JobList": {
+	"batch.v2alpha1.JobList": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JobList is a collection of jobs.",
@@ -12932,7 +22399,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"metadata": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
-							Ref:         spec.MustCreateRef("#/definitions/v1.ListMeta"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
 						},
 					},
 					"items": {
@@ -12942,7 +22409,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v2alpha1.Job"),
+										Ref: spec.MustCreateRef("#/definitions/batch.v2alpha1.Job"),
 									},
 								},
 							},
@@ -12951,9 +22418,108 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"items"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobList",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ListMeta", "v2alpha1.Job"},
+			"batch.v2alpha1.Job", "io.k8s.meta.v1.ListMeta"},
+	},
+	"v2alpha1.JobList": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobList is a collection of jobs.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard list metadata More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.ListMeta"),
+						},
+					},
+					"items": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Items is the list of Job.",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/batch.v2alpha1.Job"),
+									},
+								},
+							},
+						},
+					},
+				},
+				Required: []string{"items"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobList",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.JobList",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v2alpha1.Job", "io.k8s.meta.v1.ListMeta"},
+	},
+	"batch.v2alpha1.JobSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobSpec describes how the job execution will look like.",
+				Properties: map[string]spec.Schema{
+					"parallelism": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Parallelism specifies the maximum desired number of pods the job should run at any given time. The actual number of pods running in steady state will be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism), i.e. when the work left to do is less than max parallelism. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"completions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"activeDeadlineSeconds": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
+					"selector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
+						},
+					},
+					"manualSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "ManualSelector controls generation of pod labels and pod selectors. Leave `manualSelector` unset unless you are certain what you are doing. When false or unset, the system pick labels unique to this job and appends those labels to the pod template.  When true, the user is responsible for picking unique labels and specifying the selector.  Failure to pick a unique label may cause this and other jobs to not function correctly.  However, You may see `manualSelector=true` in jobs that were created with the old `extensions/v1beta1` API. More info: http://releases.k8s.io/HEAD/docs/design/selector-generation.md",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"template": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Template is the object that describes the pod that will be created when executing a job. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Ref:         spec.MustCreateRef("#/definitions/v1.PodTemplateSpec"),
+						},
+					},
+				},
+				Required: []string{"template"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
 	},
 	"v2alpha1.JobSpec": {
 		Schema: spec.Schema{
@@ -12984,7 +22550,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"selector": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Selector is a label query over pods that should match the pod count. Normally, the system sets this field for you. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-							Ref:         spec.MustCreateRef("#/definitions/v1.LabelSelector"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.LabelSelector"),
 						},
 					},
 					"manualSelector": {
@@ -13003,11 +22569,17 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"template"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.JobSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.LabelSelector", "v1.PodTemplateSpec"},
+			"io.k8s.meta.v1.LabelSelector", "v1.PodTemplateSpec"},
 	},
-	"v2alpha1.JobStatus": {
+	"batch.v2alpha1.JobStatus": {
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
 				Description: "JobStatus represents the current state of a Job.",
@@ -13019,7 +22591,7 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: spec.MustCreateRef("#/definitions/v2alpha1.JobCondition"),
+										Ref: spec.MustCreateRef("#/definitions/batch.v2alpha1.JobCondition"),
 									},
 								},
 							},
@@ -13028,13 +22600,13 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"startTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"completionTime": {
 						SchemaProps: spec.SchemaProps{
 							Description: "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
-							Ref:         spec.MustCreateRef("#/definitions/v1.Time"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
 						},
 					},
 					"active": {
@@ -13060,9 +22632,105 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobStatus",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.Time", "v2alpha1.JobCondition"},
+			"batch.v2alpha1.JobCondition", "io.k8s.meta.v1.Time"},
+	},
+	"v2alpha1.JobStatus": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobStatus represents the current state of a Job.",
+				Properties: map[string]spec.Schema{
+					"conditions": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Ref: spec.MustCreateRef("#/definitions/batch.v2alpha1.JobCondition"),
+									},
+								},
+							},
+						},
+					},
+					"startTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "StartTime represents time when the job was acknowledged by the Job Manager. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"completionTime": {
+						SchemaProps: spec.SchemaProps{
+							Description: "CompletionTime represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.meta.v1.Time"),
+						},
+					},
+					"active": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Active is the number of actively running pods.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"succeeded": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Succeeded is the number of pods which reached Phase Succeeded.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"failed": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Failed is the number of pods which reached Phase Failed.",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobStatus",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.JobStatus",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v2alpha1.JobCondition", "io.k8s.meta.v1.Time"},
+	},
+	"batch.v2alpha1.JobTemplate": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobTemplate describes a template for creating copies of a predefined pod.",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"template": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Template defines jobs that will be created from this template http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobTemplateSpec"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobTemplate",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v2alpha1.JobTemplateSpec", "v1.ObjectMeta"},
 	},
 	"v2alpha1.JobTemplate": {
 		Schema: spec.Schema{
@@ -13078,14 +22746,48 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"template": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Template defines jobs that will be created from this template http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v2alpha1.JobTemplateSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobTemplateSpec"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobTemplate",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.JobTemplate",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v2alpha1.JobTemplateSpec"},
+			"batch.v2alpha1.JobTemplateSpec", "v1.ObjectMeta"},
+	},
+	"batch.v2alpha1.JobTemplateSpec": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "JobTemplateSpec describes the data a Job should have when created from a template",
+				Properties: map[string]spec.Schema{
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Standard object's metadata of the jobs created from this template. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata",
+							Ref:         spec.MustCreateRef("#/definitions/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Specification of the desired behavior of the job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobSpec"),
+						},
+					},
+				},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobTemplateSpec",
+				},
+			},
+		},
+		Dependencies: []string{
+			"batch.v2alpha1.JobSpec", "v1.ObjectMeta"},
 	},
 	"v2alpha1.JobTemplateSpec": {
 		Schema: spec.Schema{
@@ -13101,14 +22803,90 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"spec": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Specification of the desired behavior of the job. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status",
-							Ref:         spec.MustCreateRef("#/definitions/v2alpha1.JobSpec"),
+							Ref:         spec.MustCreateRef("#/definitions/batch.v2alpha1.JobSpec"),
 						},
 					},
 				},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/apis/batch/v2alpha1.JobTemplateSpec",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "batch.v2alpha1.JobTemplateSpec",
+				},
+			},
 		},
 		Dependencies: []string{
-			"v1.ObjectMeta", "v2alpha1.JobSpec"},
+			"batch.v2alpha1.JobSpec", "v1.ObjectMeta"},
+	},
+	"io.k8s.kubernetes.pkg.version.Info": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Info contains versioning information. how we'll want to distribute that information.",
+				Properties: map[string]spec.Schema{
+					"major": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"minor": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"gitVersion": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"gitCommit": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"gitTreeState": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"buildDate": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"goVersion": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"compiler": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"platform": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+				Required: []string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/version.Info",
+				},
+			},
+		},
+		Dependencies: []string{},
 	},
 	"version.Info": {
 		Schema: spec.Schema{
@@ -13172,8 +22950,43 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 				},
 				Required: []string{"major", "minor", "gitVersion", "gitCommit", "gitTreeState", "buildDate", "goVersion", "compiler", "platform"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/version.Info",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.kubernetes.pkg.version.Info",
+				},
+			},
 		},
 		Dependencies: []string{},
+	},
+	"io.k8s.kubernetes.pkg.watch.versioned.Event": {
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Event represents a single event to a watched resource.",
+				Properties: map[string]spec.Schema{
+					"type": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"object": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *api.Status is recommended; other types may make sense\n   depending on context.",
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.runtime.RawExtension"),
+						},
+					},
+				},
+				Required: []string{"type", "object"},
+			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang": "k8s.io/kubernetes/pkg/watch/versioned.Event",
+				},
+			},
+		},
+		Dependencies: []string{
+			"io.k8s.kubernetes.pkg.runtime.RawExtension"},
 	},
 	"versioned.Event": {
 		Schema: spec.Schema{
@@ -13189,14 +23002,20 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 					"object": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *api.Status is recommended; other types may make sense\n   depending on context.",
-							Ref:         spec.MustCreateRef("#/definitions/runtime.RawExtension"),
+							Ref:         spec.MustCreateRef("#/definitions/io.k8s.kubernetes.pkg.runtime.RawExtension"),
 						},
 					},
 				},
 				Required: []string{"type", "object"},
 			},
+			VendorExtensible: spec.VendorExtensible{
+				Extensions: spec.Extensions{
+					"io.k8s.kubernetes.openapi.type.golang":         "k8s.io/kubernetes/pkg/watch/versioned.Event",
+					"io.k8s.kubernetes.openapi.type.deprecated.use": "io.k8s.kubernetes.pkg.watch.versioned.Event",
+				},
+			},
 		},
 		Dependencies: []string{
-			"runtime.RawExtension"},
+			"io.k8s.kubernetes.pkg.runtime.RawExtension"},
 	},
 }

--- a/pkg/genericapiserver/api/groupversion.go
+++ b/pkg/genericapiserver/api/groupversion.go
@@ -81,6 +81,9 @@ type APIGroupVersion struct {
 	// ResourceLister is an interface that knows how to list resources
 	// for this API Group.
 	ResourceLister handlers.APIResourceLister
+
+	// ModelNamerFunc turns an object into it's Swagger/OpenAPI compatible name.
+	ModelNamerFunc func(interface{}) string
 }
 
 // InstallREST registers the REST handlers (storage, watch, proxy and redirect) into a restful Container.

--- a/pkg/genericapiserver/api/installer.go
+++ b/pkg/genericapiserver/api/installer.go
@@ -116,7 +116,7 @@ func (a *APIInstaller) Install(ws *restful.WebService) (apiResources []metav1.AP
 
 // NewWebService creates a new restful webservice with the api installer's prefix and version.
 func (a *APIInstaller) NewWebService() *restful.WebService {
-	ws := new(restful.WebService)
+	ws := new(restful.WebService).TypeNameHandler(a.group.ModelNamerFunc)
 	ws.Path(a.prefix)
 	// a.prefix contains "prefix/group/version"
 	ws.Doc("API at " + a.prefix)

--- a/pkg/genericapiserver/genericapiserver.go
+++ b/pkg/genericapiserver/genericapiserver.go
@@ -163,6 +163,12 @@ func (s *GenericAPIServer) MinRequestTimeout() time.Duration {
 	return s.minRequestTimeout
 }
 
+// OpenAPIConfig is exposed so that third party swagger definitions can be generated with the appropriate
+// model names.
+func (s *GenericAPIServer) OpenAPIConfig() *openapicommon.Config {
+	return s.openAPIConfig
+}
+
 type preparedGenericAPIServer struct {
 	*GenericAPIServer
 }
@@ -170,7 +176,9 @@ type preparedGenericAPIServer struct {
 // PrepareRun does post API installation setup steps.
 func (s *GenericAPIServer) PrepareRun() preparedGenericAPIServer {
 	if s.swaggerConfig != nil {
-		routes.Swagger{Config: s.swaggerConfig}.Install(s.HandlerContainer)
+		routes.Swagger{
+			Config: s.swaggerConfig,
+		}.Install(s.HandlerContainer)
 	}
 	if s.openAPIConfig != nil {
 		routes.OpenAPI{
@@ -338,6 +346,8 @@ func (s *GenericAPIServer) newAPIGroupVersion(apiGroupInfo *APIGroupInfo, groupV
 		Admit:             s.admissionControl,
 		Context:           s.RequestContextMapper(),
 		MinRequestTimeout: s.minRequestTimeout,
+
+		ModelNamerFunc: s.openAPIConfig.ObjectTypeNameFunction(),
 	}
 }
 

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -66,7 +66,7 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 			Version: "unversioned",
 		},
 	}
-	config.SwaggerConfig = DefaultSwaggerConfig()
+	config.SwaggerConfig = DefaultSwaggerConfig(openapigen.OpenAPIDefinitions)
 
 	return etcdServer, *config, assert.New(t)
 }
@@ -370,7 +370,7 @@ func TestNotRestRoutesHaveAuth(t *testing.T) {
 	config.EnableSwaggerUI = true
 	config.EnableIndex = true
 	config.EnableProfiling = true
-	config.SwaggerConfig = DefaultSwaggerConfig()
+	config.SwaggerConfig = DefaultSwaggerConfig(nil)
 
 	kubeVersion := version.Get()
 	config.Version = &kubeVersion

--- a/pkg/genericapiserver/openapi/BUILD
+++ b/pkg/genericapiserver/openapi/BUILD
@@ -33,6 +33,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//pkg/genericapiserver/openapi/common:go_default_library",
+        "//pkg/util/diff:go_default_library",
         "//vendor:github.com/emicklei/go-restful",
         "//vendor:github.com/go-openapi/spec",
         "//vendor:github.com/stretchr/testify/assert",

--- a/pkg/genericapiserver/openapi/common/common.go
+++ b/pkg/genericapiserver/openapi/common/common.go
@@ -145,15 +145,61 @@ func GetOpenAPITypeFormat(typeName string) (string, string) {
 	return mapped[0], mapped[1]
 }
 
-// golangTypeNameOpenAPIVendorExtension is an OpenAPI vendor extension that identifies the Golang
-// type name of a given OpenAPI struct.
-const golangTypeNameOpenAPIVendorExtension = "io.k8s.kubernetes.openapi.type.golang"
+const (
+	// golangTypeNameOpenAPIVendorExtension is an OpenAPI vendor extension that identifies the Golang
+	// type name of a given OpenAPI struct.
+	golangTypeNameOpenAPIVendorExtension = "io.k8s.kubernetes.openapi.type.golang"
+	// deprecatedUseOpenAPIVendorExtension is an OpenAPI vendor extension that identifies this model
+	// type is deprecated and the value of the extension indicatse the model name that should be used
+	// instead.
+	deprecatedUseOpenAPIVendorExtension = "io.k8s.kubernetes.openapi.type.deprecated.use"
+)
 
 // TypeNameFunction returns a function that can map a given Go type to an OpenAPI name.
 func (c *Config) TypeNameFunction() func(t reflect.Type) string {
 	typesToDefinitions := make(typeMapper)
 	if c != nil && c.Definitions != nil {
+		// insert deprecated types first
 		for name, definition := range *c.Definitions {
+			if _, ok := definition.Schema.VendorExtensible.Extensions.GetString(deprecatedUseOpenAPIVendorExtension); !ok {
+				continue
+			}
+			if t, ok := definition.Schema.VendorExtensible.Extensions.GetString(golangTypeNameOpenAPIVendorExtension); ok {
+				typesToDefinitions[t] = name
+			}
+		}
+		// for all non-deprecated types, insert
+		for name, definition := range *c.Definitions {
+			if _, ok := definition.Schema.VendorExtensible.Extensions.GetString(deprecatedUseOpenAPIVendorExtension); ok {
+				continue
+			}
+			if t, ok := definition.Schema.VendorExtensible.Extensions.GetString(golangTypeNameOpenAPIVendorExtension); ok {
+				typesToDefinitions[t] = name
+			}
+		}
+	}
+	return typesToDefinitions.Name
+}
+
+// LegacyTypeNameFunction returns a function that can map a given Go type to an OpenAPI name, and prefers the
+// legacy version of a name (deprecated ones) over future names.
+func (c *Config) LegacyTypeNameFunction() func(t reflect.Type) string {
+	typesToDefinitions := make(typeMapper)
+	if c != nil && c.Definitions != nil {
+		// for all non-deprecated types, insert
+		for name, definition := range *c.Definitions {
+			if _, ok := definition.Schema.VendorExtensible.Extensions.GetString(deprecatedUseOpenAPIVendorExtension); ok {
+				continue
+			}
+			if t, ok := definition.Schema.VendorExtensible.Extensions.GetString(golangTypeNameOpenAPIVendorExtension); ok {
+				typesToDefinitions[t] = name
+			}
+		}
+		// allow types marked as deprecated to override non-deprecated names
+		for name, definition := range *c.Definitions {
+			if _, ok := definition.Schema.VendorExtensible.Extensions.GetString(deprecatedUseOpenAPIVendorExtension); !ok {
+				continue
+			}
 			if t, ok := definition.Schema.VendorExtensible.Extensions.GetString(golangTypeNameOpenAPIVendorExtension); ok {
 				typesToDefinitions[t] = name
 			}
@@ -166,6 +212,22 @@ func (c *Config) TypeNameFunction() func(t reflect.Type) string {
 func (c *Config) ObjectTypeNameFunction() func(obj interface{}) string {
 	fn := c.TypeNameFunction()
 	return func(obj interface{}) string { return fn(reflect.TypeOf(obj)) }
+}
+
+// DeprecatedDefinitions returns a map of names that are deprecated to their replacement type name.
+func (c *Config) DeprecatedDefinitions() map[string]string {
+	if c == nil || c.Definitions == nil {
+		return nil
+	}
+	deprecated := make(map[string]string)
+	for name, definition := range *c.Definitions {
+		instead, ok := definition.Schema.VendorExtensible.Extensions.GetString(deprecatedUseOpenAPIVendorExtension)
+		if !ok {
+			continue
+		}
+		deprecated[name] = instead
+	}
+	return deprecated
 }
 
 // typeMapper is a map of Go types names to OpenAPI definition names.

--- a/pkg/genericapiserver/routes/swagger.go
+++ b/pkg/genericapiserver/routes/swagger.go
@@ -17,9 +17,9 @@ limitations under the License.
 package routes
 
 import (
-	"k8s.io/kubernetes/pkg/genericapiserver/mux"
-
 	"github.com/emicklei/go-restful/swagger"
+
+	"k8s.io/kubernetes/pkg/genericapiserver/mux"
 )
 
 // Swagger installs the /swaggerapi/ endpoint to allow schema discovery

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -323,7 +323,7 @@ func TestValidOpenAPISpec(t *testing.T) {
 			Version: "unversioned",
 		},
 	}
-	config.GenericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
+	config.GenericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig(openapigen.OpenAPIDefinitions)
 
 	master, err := config.Complete().New()
 	if err != nil {

--- a/pkg/master/thirdparty/thirdparty.go
+++ b/pkg/master/thirdparty/thirdparty.go
@@ -329,5 +329,7 @@ func (m *ThirdPartyResourceServer) thirdpartyapi(group, kind, version, pluralRes
 		MinRequestTimeout: m.genericAPIServer.MinRequestTimeout(),
 
 		ResourceLister: dynamicLister{m, extensionsrest.MakeThirdPartyPath(group)},
+
+		ModelNamerFunc: m.genericAPIServer.OpenAPIConfig().ObjectTypeNameFunction(),
 	}
 }

--- a/pkg/runtime/types.go
+++ b/pkg/runtime/types.go
@@ -33,6 +33,7 @@ package runtime
 // +k8s:deepcopy-gen=true
 // +protobuf=true
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 type TypeMeta struct {
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty" yaml:"apiVersion,omitempty" protobuf:"bytes,1,opt,name=apiVersion"`
@@ -89,6 +90,7 @@ const (
 // +k8s:deepcopy-gen=true
 // +protobuf=true
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 type RawExtension struct {
 	// Raw is the underlying serialization of this object.
 	//
@@ -108,6 +110,7 @@ type RawExtension struct {
 // +k8s:deepcopy-gen=true
 // +protobuf=true
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 type Unknown struct {
 	TypeMeta `json:",inline" protobuf:"bytes,1,opt,name=typeMeta"`
 	// Raw will hold the complete serialized object which couldn't be matched

--- a/pkg/util/intstr/intstr.go
+++ b/pkg/util/intstr/intstr.go
@@ -40,6 +40,7 @@ import (
 // +protobuf=true
 // +protobuf.options.(gogoproto.goproto_stringer)=false
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 type IntOrString struct {
 	Type   Type   `protobuf:"varint,1,opt,name=type,casttype=Type"`
 	IntVal int32  `protobuf:"varint,2,opt,name=intVal"`

--- a/pkg/version/doc.go
+++ b/pkg/version/doc.go
@@ -16,5 +16,4 @@ limitations under the License.
 
 // Package version supplies version information collected at build time to
 // kubernetes components.
-// +k8s:openapi-gen=true
 package version // import "k8s.io/kubernetes/pkg/version"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -25,6 +25,7 @@ import (
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 type Info struct {
 	Major        string `json:"major"`
 	Minor        string `json:"minor"`

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -24,6 +24,7 @@ import (
 // Info contains versioning information.
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
+// +k8s:openapi-gen=true
 type Info struct {
 	Major        string `json:"major"`
 	Minor        string `json:"minor"`

--- a/pkg/watch/versioned/types.go
+++ b/pkg/watch/versioned/types.go
@@ -26,6 +26,7 @@ import (
 //
 // +protobuf=true
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen=legacy-name
 type Event struct {
 	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
 

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -197,7 +197,7 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 			},
 		}
 		masterConfig.GenericConfig.OpenAPIConfig.Definitions = openapi.OpenAPIDefinitions
-		masterConfig.GenericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
+		masterConfig.GenericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig(openapi.OpenAPIDefinitions)
 	}
 
 	// set the loopback client config

--- a/vendor/github.com/emicklei/go-restful/CHANGES.md
+++ b/vendor/github.com/emicklei/go-restful/CHANGES.md
@@ -1,5 +1,8 @@
 Change history of go-restful
 =
+2016-12-22
+- (API change) Remove code related to caching request content. Removes SetCacheReadEntity(doCache bool)
+
 2016-11-26
 - Default change! now use CurlyRouter (was RouterJSR311)
 - Default change! no more caching of request content

--- a/vendor/github.com/emicklei/go-restful/README.md
+++ b/vendor/github.com/emicklei/go-restful/README.md
@@ -1,7 +1,12 @@
 go-restful
 ==========
 
+[![Build Status](https://drone.io/github.com/emicklei/go-restful/status.png)](https://drone.io/github.com/emicklei/go-restful/latest)
+
 package for building REST-style Web Services using Google Go
+
+- [Documentation on godoc.org](http://godoc.org/github.com/emicklei/go-restful)
+- [Code examples](https://github.com/emicklei/go-restful/tree/master/examples)
 
 REST asks developers to use HTTP methods explicitly and in a way that's consistent with the protocol definition. This basic REST design principle establishes a one-to-one mapping between create, read, update, and delete (CRUD) operations and HTTP methods. According to this mapping:
 
@@ -40,8 +45,8 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 
 - Routes for request &#8594; function mapping with path parameter (e.g. {id}) support
 - Configurable router:
-	- Routing algorithm after [JSR311](http://jsr311.java.net/nonav/releases/1.1/spec/spec.html) that is implemented using (but does **not** accept) regular expressions (See RouterJSR311 which is used by default)
-	- Fast routing algorithm that allows static elements, regular expressions and dynamic parameters in the URL path (e.g. /meetings/{id} or /static/{subpath:*}, See CurlyRouter)
+	- (default) Fast routing algorithm that allows static elements, regular expressions and dynamic parameters in the URL path (e.g. /meetings/{id} or /static/{subpath:*}
+	- Routing algorithm after [JSR311](http://jsr311.java.net/nonav/releases/1.1/spec/spec.html) that is implemented using (but does **not** accept) regular expressions
 - Request API for reading structs from JSON/XML and accesing parameters (path,query,header)
 - Response API for writing structs to JSON/XML and setting headers
 - Filters for intercepting the request &#8594; response flow on Service or Route level
@@ -59,16 +64,11 @@ func (u UserResource) findUser(request *restful.Request, response *restful.Respo
 	
 ### Resources
 
-- [Documentation on godoc.org](http://godoc.org/github.com/emicklei/go-restful)
-- [Code examples](https://github.com/emicklei/go-restful/tree/master/examples)
 - [Example posted on blog](http://ernestmicklei.com/2012/11/go-restful-first-working-example/)
 - [Design explained on blog](http://ernestmicklei.com/2012/11/go-restful-api-design/)
 - [sourcegraph](https://sourcegraph.com/github.com/emicklei/go-restful)
-- [gopkg.in](https://gopkg.in/emicklei/go-restful.v1)
 - [showcase: Mora - MongoDB REST Api server](https://github.com/emicklei/mora)
 
-[![Build Status](https://drone.io/github.com/emicklei/go-restful/status.png)](https://drone.io/github.com/emicklei/go-restful/latest)
-
-(c) 2012 - 2015, http://ernestmicklei.com. MIT License
+(c) 2012 - 2016, http://ernestmicklei.com. MIT License
 
 Type ```git shortlog -s``` for a full list of contributors.

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
@@ -226,6 +226,9 @@ func (sws SwaggerService) composeDeclaration(ws *restful.WebService, pathPrefix 
 	pathToRoutes := newOrderedRouteMap()
 	for _, other := range ws.Routes() {
 		if strings.HasPrefix(other.Path, pathPrefix) {
+			if len(pathPrefix) > 1 && len(other.Path) > len(pathPrefix) && other.Path[len(pathPrefix)] != '/' {
+				continue
+			}
 			pathToRoutes.Add(other.Path, other)
 		}
 	}

--- a/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
+++ b/vendor/github.com/emicklei/go-restful/swagger/swagger_webservice.go
@@ -293,7 +293,7 @@ func composeResponseMessages(route restful.Route, decl *ApiDeclaration, config *
 		if each.Model != nil {
 			st := reflect.TypeOf(each.Model)
 			isCollection, st := detectCollectionType(st)
-			modelName := modelBuilder{}.keyFrom(st)
+			modelName := modelBuilder{Config: config}.keyFrom(st)
 			if isCollection {
 				modelName = "array[" + modelName + "]"
 			}
@@ -418,7 +418,7 @@ func asDataType(any interface{}, config *Config) (*string, *Item) {
 	// If it's not a collection, return the suggested model name
 	st := reflect.TypeOf(any)
 	isCollection, st := detectCollectionType(st)
-	modelName := modelBuilder{}.keyFrom(st)
+	modelName := modelBuilder{Config: config}.keyFrom(st)
 	// if it's not a collection we are done
 	if !isCollection {
 		return &modelName, nil

--- a/vendor/github.com/emicklei/go-restful/web_service.go
+++ b/vendor/github.com/emicklei/go-restful/web_service.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"errors"
 	"os"
+	"reflect"
 	"sync"
 
 	"github.com/emicklei/go-restful/log"
@@ -24,6 +25,8 @@ type WebService struct {
 	documentation  string
 	apiVersion     string
 
+	typeNameHandleFunc TypeNameHandleFunction
+
 	dynamicRoutes bool
 
 	// protects 'routes' if dynamic routes are enabled
@@ -32,6 +35,25 @@ type WebService struct {
 
 func (w *WebService) SetDynamicRoutes(enable bool) {
 	w.dynamicRoutes = enable
+}
+
+// TypeNameHandleFunction declares functions that can handle translating the name of a sample object
+// into the restful documentation for the service.
+type TypeNameHandleFunction func(sample interface{}) string
+
+// TypeNameHandler sets the function that will convert types to strings in the parameter
+// and model definitions. If not set, the web service will invoke
+// reflect.TypeOf(object).String().
+func (w *WebService) TypeNameHandler(handler TypeNameHandleFunction) *WebService {
+	w.typeNameHandleFunc = handler
+	return w
+}
+
+// reflectTypeName is the default TypeNameHandleFunction and for a given object
+// returns the name that Go identifies it with (e.g. "string" or "v1.Object") via
+// the reflection API.
+func reflectTypeName(sample interface{}) string {
+	return reflect.TypeOf(sample).String()
 }
 
 // compilePathExpression ensures that the path is compiled into a RegEx for those routers that need it.
@@ -174,7 +196,7 @@ func (w *WebService) RemoveRoute(path, method string) error {
 
 // Method creates a new RouteBuilder and initialize its http method
 func (w *WebService) Method(httpMethod string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method(httpMethod)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method(httpMethod)
 }
 
 // Produces specifies that this WebService can produce one or more MIME types.
@@ -239,30 +261,30 @@ func (w *WebService) Documentation() string {
 
 // HEAD is a shortcut for .Method("HEAD").Path(subPath)
 func (w *WebService) HEAD(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("HEAD").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("HEAD").Path(subPath)
 }
 
 // GET is a shortcut for .Method("GET").Path(subPath)
 func (w *WebService) GET(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("GET").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("GET").Path(subPath)
 }
 
 // POST is a shortcut for .Method("POST").Path(subPath)
 func (w *WebService) POST(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("POST").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("POST").Path(subPath)
 }
 
 // PUT is a shortcut for .Method("PUT").Path(subPath)
 func (w *WebService) PUT(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("PUT").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("PUT").Path(subPath)
 }
 
 // PATCH is a shortcut for .Method("PATCH").Path(subPath)
 func (w *WebService) PATCH(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("PATCH").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("PATCH").Path(subPath)
 }
 
 // DELETE is a shortcut for .Method("DELETE").Path(subPath)
 func (w *WebService) DELETE(subPath string) *RouteBuilder {
-	return new(RouteBuilder).servicePath(w.rootPath).Method("DELETE").Path(subPath)
+	return new(RouteBuilder).typeNameHandler(w.typeNameHandleFunc).servicePath(w.rootPath).Method("DELETE").Path(subPath)
 }


### PR DESCRIPTION
There can be more than one type with a given name in a given version, but in different groups. For example, `pkg/apis/batch/v1#Foo` could also be in `pkg/api/v1#Foo`, and OpenAPI would generate the same name `v1.Foo`, which causes a conflict (duplicate name).

Instead, we should assign names that include group + version as a prefix. This PR uses the default algorithm in gengo for assigning package shortnames (`parentpackage_package.Type`).

This will impact any caller that generates from OpenAPI, but they were already broken.

Found during #37530