### PR TITLE
etcd2: watching from 0 returns all initial states as ADDED events

### DIFF
--- a/pkg/storage/etcd/etcd_watcher.go
+++ b/pkg/storage/etcd/etcd_watcher.go
@@ -359,9 +359,6 @@ func (w *etcdWatcher) sendAdd(res *etcd.Response) {
 		return
 	}
 	action := watch.Added
-	if res.Node.ModifiedIndex != res.Node.CreatedIndex {
-		action = watch.Modified
-	}
 	w.emit(watch.Event{
 		Type:   action,
 		Object: obj,
@@ -454,6 +451,8 @@ func (w *etcdWatcher) sendDelete(res *etcd.Response) {
 func (w *etcdWatcher) sendResult(res *etcd.Response) {
 	switch res.Action {
 	case EtcdCreate, EtcdGet:
+		// "Get" will only happen in watch 0 case, where we explicitly want ADDED event
+		// for initial state.
 		w.sendAdd(res)
 	case EtcdSet, EtcdCAS:
 		w.sendModify(res)

--- a/pkg/storage/interfaces.go
+++ b/pkg/storage/interfaces.go
@@ -112,6 +112,8 @@ type Interface interface {
 	// resourceVersion may be used to specify what version to begin watching,
 	// which should be the current resourceVersion, and no longer rv+1
 	// (e.g. reconnecting without missing any updates).
+	// If resource version is "0", this interface will get current object at given key
+	// and send it in an "ADDED" event, before watch starts.
 	Watch(ctx context.Context, key string, resourceVersion string, p SelectionPredicate) (watch.Interface, error)
 
 	// WatchList begins watching the specified key's items. Items are decoded into API
@@ -119,6 +121,8 @@ type Interface interface {
 	// resourceVersion may be used to specify what version to begin watching,
 	// which should be the current resourceVersion, and no longer rv+1
 	// (e.g. reconnecting without missing any updates).
+	// If resource version is "0", this interface will list current objects directory defined by key
+	// and send them in "ADDED" events, before watch starts.
 	WatchList(ctx context.Context, key string, resourceVersion string, p SelectionPredicate) (watch.Interface, error)
 
 	// Get unmarshals json found at key into objPtr. On a not found error, will either


### PR DESCRIPTION
ref:
https://github.com/kubernetes/kubernetes/pull/36797
https://github.com/kubernetes/kubernetes/issues/36545
https://github.com/kubernetes/kubernetes/pull/36561
https://github.com/kubernetes/kubernetes/issues/13969

Since we have made consensus and fixed the behavior in etcd3, we would also change etcd2 to make this uniform and consistent. The end goal is that we would have it explicit on interface docs.

**release note**:
```
etcd2: watching from 0 returns all initial states as ADDED events
```