### PR TITLE
Improve error message for name/label validation.

### DIFF
--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -638,7 +638,7 @@ func TestValidateDeployment(t *testing.T) {
 			MaxSurge: intstr.FromString("20Percent"),
 		},
 	}
-	errorCases["must match the regex"] = invalidMaxSurgeDeployment
+	errorCases["a valid percent string must be"] = invalidMaxSurgeDeployment
 
 	// MaxSurge and MaxUnavailable cannot both be zero.
 	invalidRollingUpdateDeployment := validDeployment()

--- a/pkg/apis/meta/v1/validation/validation_test.go
+++ b/pkg/apis/meta/v1/validation/validation_test.go
@@ -47,14 +47,19 @@ func TestValidateLabels(t *testing.T) {
 		}
 	}
 
+	namePartErrMsg := "name part must consist of"
+	nameErrMsg := "a qualified name must consist of"
+	labelErrMsg := "a valid label must be an empty string or consist of"
+	maxLengthErrMsg := "must be no more than"
+
 	labelNameErrorCases := []struct {
 		labels map[string]string
 		expect string
 	}{
-		{map[string]string{"nospecialchars^=@": "bar"}, "must match the regex"},
-		{map[string]string{"cantendwithadash-": "bar"}, "must match the regex"},
-		{map[string]string{"only/one/slash": "bar"}, "must match the regex"},
-		{map[string]string{strings.Repeat("a", 254): "bar"}, "must be no more than"},
+		{map[string]string{"nospecialchars^=@": "bar"}, namePartErrMsg},
+		{map[string]string{"cantendwithadash-": "bar"}, namePartErrMsg},
+		{map[string]string{"only/one/slash": "bar"}, nameErrMsg},
+		{map[string]string{strings.Repeat("a", 254): "bar"}, maxLengthErrMsg},
 	}
 	for i := range labelNameErrorCases {
 		errs := ValidateLabels(labelNameErrorCases[i].labels, field.NewPath("field"))
@@ -71,10 +76,10 @@ func TestValidateLabels(t *testing.T) {
 		labels map[string]string
 		expect string
 	}{
-		{map[string]string{"toolongvalue": strings.Repeat("a", 64)}, "must be no more than"},
-		{map[string]string{"backslashesinvalue": "some\\bad\\value"}, "must match the regex"},
-		{map[string]string{"nocommasallowed": "bad,value"}, "must match the regex"},
-		{map[string]string{"strangecharsinvalue": "?#$notsogood"}, "must match the regex"},
+		{map[string]string{"toolongvalue": strings.Repeat("a", 64)}, maxLengthErrMsg},
+		{map[string]string{"backslashesinvalue": "some\\bad\\value"}, labelErrMsg},
+		{map[string]string{"nocommasallowed": "bad,value"}, labelErrMsg},
+		{map[string]string{"strangecharsinvalue": "?#$notsogood"}, labelErrMsg},
 	}
 	for i := range labelValueErrorCases {
 		errs := ValidateLabels(labelValueErrorCases[i].labels, field.NewPath("field"))


### PR DESCRIPTION
Instead of just providing regex in name/label validation error output, we need to add the naming rules of the name/label, which is more end-user readable.

Fixed #37654