### PR TITLE
Add federation-openapi-spec to update-all targets

### DIFF
--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -59,7 +59,8 @@ BASH_TARGETS="
 	swagger-spec
 	openapi-spec
 	api-reference-docs
-	bazel"
+	bazel
+	federation-openapi-spec"
 # TODO: (caesarxuchao) uncomment after 1.5 code freeze.
 #	staging-client-go"
 


### PR DESCRIPTION
As `make verify` runs all `hack/verify-*` scripts (with some exceptions), `update-all.sh` should be in sync. It is missing all the federation targets right now, but `verify-federation-openapi-spec.sh` exists. Hence, we add that.

@nikhiljindal @mbohlool what about the other federation update scripts?