### PR TITLE
Fix zsh completion: unknown file attribute error

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -271,6 +271,7 @@ fi
 __kubectl_convert_bash_to_zsh() {
 	sed \
 	-e 's/declare -F/whence -w/' \
+	-e 's/_get_comp_words_by_ref "\$@"/_get_comp_words_by_ref "\$*"/' \
 	-e 's/local \([a-zA-Z0-9_]*\)=/local \1; \1=/' \
 	-e 's/flags+=("\(--.*\)=")/flags+=("\1"); two_word_flags+=("\1")/' \
 	-e 's/must_have_one_flag+=("\(--.*\)=")/must_have_one_flag+=("\1")/' \


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes zsh completion.

Sourcing the file with `zsh` > 4 resulted in an `unknown file attribute`.
More details at http://stackoverflow.com/questions/37220495/zsh-unknown-file-attribute