### PR TITLE
Prevent SIGPIPE errors causing the version check line to fail

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -32,7 +32,7 @@ kube::etcd::start() {
     exit 1
   fi
 
-  version=$(etcd --version | head -n 1 | cut -d " " -f 3)
+  version=$(etcd --version | tail -n +1 | head -n 1 | cut -d " " -f 3)
   if [[ "${version}" < "${ETCD_VERSION}" ]]; then
    kube::log::usage "etcd version ${ETCD_VERSION} or greater required."
    kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."


### PR DESCRIPTION
The way we use pipe in hack/lib/etcd.sh when processing the version command can lead to
141 failues on some systems. Using a prefix of tail can prevent this.

Fixes #38109