### PR TITLE
Add json,yaml output format support to kubectl create, kubectl apply

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -130,6 +130,7 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 	}
 
 	dryRun := cmdutil.GetFlagBool(cmd, "dry-run")
+	output := cmdutil.GetFlagString(cmd, "output")
 
 	count := 0
 	err = r.Visit(func(info *resource.Info, err error) error {
@@ -153,7 +154,11 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 		}
 
 		count++
-		shortOutput := cmdutil.GetFlagString(cmd, "output") == "name"
+
+		shortOutput := output == "name"
+		if len(output) > 0 && !shortOutput {
+			return cmdutil.PrintResourceInfoForCommand(cmd, info, f, out)
+		}
 		if !shortOutput {
 			f.PrintObjectSpecificMessage(info.Object, out)
 		}

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/runtime/schema"
 
 	"github.com/spf13/cobra"
@@ -131,6 +132,24 @@ func PrinterForCommand(cmd *cobra.Command) (kubectl.ResourcePrinter, bool, error
 	}
 
 	return maybeWrapSortingPrinter(cmd, printer), generic, nil
+}
+
+// PrintResourceInfoForCommand receives a *cobra.Command and a *resource.Info and
+// attempts to print an info object based on the specified output format. If the
+// object passed is non-generic, it attempts to print the object using a HumanReadablePrinter.
+// Requires that printer flags have been added to cmd (see AddPrinterFlags).
+func PrintResourceInfoForCommand(cmd *cobra.Command, info *resource.Info, f Factory, out io.Writer) error {
+	printer, generic, err := PrinterForCommand(cmd)
+	if err != nil {
+		return err
+	}
+	if !generic || printer == nil {
+		printer, err = f.PrinterForMapping(cmd, nil, false)
+		if err != nil {
+			return err
+		}
+	}
+	return printer.PrintObj(info.Object, out)
 }
 
 func maybeWrapSortingPrinter(cmd *cobra.Command, printer kubectl.ResourcePrinter) kubectl.ResourcePrinter {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/37390

**Release note**:
```release-note
Added support for printing in all supported `--output` formats to `kubectl create ...` and `kubectl apply ...`
```

This patch adds the ability to specify an output format other than
"name" to `kubectl create ...`. It can be used in conjunction with the
`--dry-run` option. Converts unstructured objects into known types in
order to support all `--output` values.

The patch prints `*resource.Info`s returned by the server. If a resource does not yet exist (and the `--dry-run` option is not set), the resource is created and printed in the specified format.

@kubernetes/cli-review @fabianofranz 