### PR TITLE
remove rbac super user

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -100,7 +100,6 @@ func Run(s *options.ServerRunOptions) error {
 								ApplyOptions(s.GenericServerRunOptions). // apply the options selected
 								ApplyInsecureServingOptions(s.InsecureServing).
 								ApplyAuthenticationOptions(s.Authentication).
-								ApplyRBACSuperUser(s.Authorization.RBACSuperUser).
 								ApplySecureServingOptions(s.SecureServing)
 	if err != nil {
 		return fmt.Errorf("failed to configure https: %s", err)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -82,7 +82,6 @@ func Run(s *options.ServerRunOptions) error {
 								ApplyOptions(s.GenericServerRunOptions). // apply the options selected
 								ApplyInsecureServingOptions(s.InsecureServing).
 								ApplyAuthenticationOptions(s.Authentication).
-								ApplyRBACSuperUser(s.Authorization.RBACSuperUser).
 								ApplySecureServingOptions(s.SecureServing)
 	if err != nil {
 		return fmt.Errorf("failed to configure https: %s", err)

--- a/pkg/genericapiserver/authorizer/builtin.go
+++ b/pkg/genericapiserver/authorizer/builtin.go
@@ -173,7 +173,6 @@ func NewAuthorizerFromAuthorizationConfig(config AuthorizationConfig) (authorize
 				config.InformerFactory.RoleBindings().Lister(),
 				config.InformerFactory.ClusterRoles().Lister(),
 				config.InformerFactory.ClusterRoleBindings().Lister(),
-				config.RBACSuperUser,
 			)
 			authorizers = append(authorizers, rbacAuthorizer)
 		default:

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -100,8 +100,6 @@ type Config struct {
 	SupportsBasicAuth bool
 	Authorizer        authorizer.Authorizer
 	AdmissionControl  admission.Interface
-	// TODO(ericchiang): Determine if policy escalation checks should be an admission controller.
-	AuthorizerRBACSuperUser string
 
 	// LoopbackClientConfig is a config for a privileged loopback connection to the API server
 	LoopbackClientConfig *restclient.Config
@@ -308,11 +306,6 @@ func (c *Config) ApplyAuthenticationOptions(o *options.BuiltInAuthenticationOpti
 	}
 
 	c.SupportsBasicAuth = len(o.PasswordFile.BasicAuthFile) > 0
-	return c
-}
-
-func (c *Config) ApplyRBACSuperUser(rbacSuperUser string) *Config {
-	c.AuthorizerRBACSuperUser = rbacSuperUser
 	return c
 }
 

--- a/pkg/genericapiserver/options/authorization.go
+++ b/pkg/genericapiserver/options/authorization.go
@@ -36,7 +36,6 @@ type BuiltInAuthorizationOptions struct {
 	WebhookConfigFile           string
 	WebhookCacheAuthorizedTTL   time.Duration
 	WebhookCacheUnauthorizedTTL time.Duration
-	RBACSuperUser               string
 }
 
 func NewBuiltInAuthorizationOptions() *BuiltInAuthorizationOptions {
@@ -72,9 +71,10 @@ func (s *BuiltInAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 		"authorization-webhook-cache-unauthorized-ttl", s.WebhookCacheUnauthorizedTTL,
 		"The duration to cache 'unauthorized' responses from the webhook authorizer. Default is 30s.")
 
-	fs.StringVar(&s.RBACSuperUser, "authorization-rbac-super-user", s.RBACSuperUser, ""+
+	fs.String("authorization-rbac-super-user", "", ""+
 		"If specified, a username which avoids RBAC authorization checks and role binding "+
 		"privilege escalation checks, to be used with --authorization-mode=RBAC.")
+	fs.MarkDeprecated("authorization-rbac-super-user", "Removed during alpha to beta.  The 'system:masters' group has privileged access.")
 
 }
 
@@ -90,7 +90,6 @@ func (s *BuiltInAuthorizationOptions) ToAuthorizationConfig(informerFactory info
 		WebhookConfigFile:           s.WebhookConfigFile,
 		WebhookCacheAuthorizedTTL:   s.WebhookCacheAuthorizedTTL,
 		WebhookCacheUnauthorizedTTL: s.WebhookCacheUnauthorizedTTL,
-		RBACSuperUser:               s.RBACSuperUser,
 		InformerFactory:             informerFactory,
 	}
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -253,7 +253,7 @@ func (c completedConfig) New() (*Master, error) {
 		certificatesrest.RESTStorageProvider{},
 		extensionsrest.RESTStorageProvider{ResourceInterface: thirdparty.NewThirdPartyResourceServer(s, c.StorageFactory)},
 		policyrest.RESTStorageProvider{},
-		rbacrest.RESTStorageProvider{AuthorizerRBACSuperUser: c.GenericConfig.AuthorizerRBACSuperUser},
+		rbacrest.RESTStorageProvider{},
 		storagerest.RESTStorageProvider{},
 	}
 	m.InstallAPIs(c.Config.GenericConfig.APIResourceConfigSource, restOptionsFactory.NewFor, restStorageProviders...)

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -33,17 +33,14 @@ type Storage struct {
 	rest.StandardStorage
 
 	ruleResolver validation.AuthorizationRuleResolver
-
-	// user which skips privilege escalation checks
-	superUser string
 }
 
-func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver, superUser string) *Storage {
-	return &Storage{s, ruleResolver, superUser}
+func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver) *Storage {
+	return &Storage{s, ruleResolver}
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Create(ctx, obj)
 	}
 
@@ -56,7 +53,7 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 }
 
 func (s *Storage) Update(ctx api.Context, name string, obj rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Update(ctx, name, obj)
 	}
 

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -33,17 +33,14 @@ type Storage struct {
 	rest.StandardStorage
 
 	ruleResolver validation.AuthorizationRuleResolver
-
-	// user which skips privilege escalation checks
-	superUser string
 }
 
-func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver, superUser string) *Storage {
-	return &Storage{s, ruleResolver, superUser}
+func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver) *Storage {
+	return &Storage{s, ruleResolver}
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Create(ctx, obj)
 	}
 
@@ -59,7 +56,7 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 }
 
 func (s *Storage) Update(ctx api.Context, name string, obj rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Update(ctx, name, obj)
 	}
 

--- a/pkg/registry/rbac/escalation_check.go
+++ b/pkg/registry/rbac/escalation_check.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/auth/user"
 )
 
-func EscalationAllowed(ctx api.Context, superUser string) bool {
+func EscalationAllowed(ctx api.Context) bool {
 	u, ok := api.UserFrom(ctx)
 	if !ok {
 		// the only way to be without a user is to either have no authenticators by explicitly saying that's your preference
@@ -29,10 +29,6 @@ func EscalationAllowed(ctx api.Context, superUser string) bool {
 		return true
 	}
 
-	// check to see if this subject is allowed to escalate
-	if len(superUser) != 0 && u.GetName() == superUser {
-		return true
-	}
 	// system:masters is special because the API server uses it for privileged loopback connections
 	// therefore we know that a member of system:masters can always do anything
 	for _, group := range u.GetGroups() {

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -46,9 +46,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 )
 
-type RESTStorageProvider struct {
-	AuthorizerRBACSuperUser string
-}
+type RESTStorageProvider struct{}
 
 var _ genericapiserver.PostStartHookProvider = RESTStorageProvider{}
 
@@ -83,19 +81,19 @@ func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource genericapis
 	storage := map[string]rest.Storage{}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("roles")) {
 		rolesStorage := roleetcd.NewREST(restOptionsGetter(rbac.Resource("roles")))
-		storage["roles"] = rolepolicybased.NewStorage(rolesStorage, newRuleValidator(), p.AuthorizerRBACSuperUser)
+		storage["roles"] = rolepolicybased.NewStorage(rolesStorage, newRuleValidator())
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("rolebindings")) {
 		roleBindingsStorage := rolebindingetcd.NewREST(restOptionsGetter(rbac.Resource("rolebindings")))
-		storage["rolebindings"] = rolebindingpolicybased.NewStorage(roleBindingsStorage, newRuleValidator(), p.AuthorizerRBACSuperUser)
+		storage["rolebindings"] = rolebindingpolicybased.NewStorage(roleBindingsStorage, newRuleValidator())
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("clusterroles")) {
 		clusterRolesStorage := clusterroleetcd.NewREST(restOptionsGetter(rbac.Resource("clusterroles")))
-		storage["clusterroles"] = clusterrolepolicybased.NewStorage(clusterRolesStorage, newRuleValidator(), p.AuthorizerRBACSuperUser)
+		storage["clusterroles"] = clusterrolepolicybased.NewStorage(clusterRolesStorage, newRuleValidator())
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("clusterrolebindings")) {
 		clusterRoleBindingsStorage := clusterrolebindingetcd.NewREST(restOptionsGetter(rbac.Resource("clusterrolebindings")))
-		storage["clusterrolebindings"] = clusterrolebindingpolicybased.NewStorage(clusterRoleBindingsStorage, newRuleValidator(), p.AuthorizerRBACSuperUser)
+		storage["clusterrolebindings"] = clusterrolebindingpolicybased.NewStorage(clusterRoleBindingsStorage, newRuleValidator())
 	}
 	return storage
 }

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -33,17 +33,14 @@ type Storage struct {
 	rest.StandardStorage
 
 	ruleResolver validation.AuthorizationRuleResolver
-
-	// user which skips privilege escalation checks
-	superUser string
 }
 
-func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver, superUser string) *Storage {
-	return &Storage{s, ruleResolver, superUser}
+func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver) *Storage {
+	return &Storage{s, ruleResolver}
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Create(ctx, obj)
 	}
 
@@ -56,7 +53,7 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 }
 
 func (s *Storage) Update(ctx api.Context, name string, obj rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Update(ctx, name, obj)
 	}
 

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -33,17 +33,14 @@ type Storage struct {
 	rest.StandardStorage
 
 	ruleResolver validation.AuthorizationRuleResolver
-
-	// user which skips privilege escalation checks
-	superUser string
 }
 
-func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver, superUser string) *Storage {
-	return &Storage{s, ruleResolver, superUser}
+func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver) *Storage {
+	return &Storage{s, ruleResolver}
 }
 
 func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, error) {
-	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Create(ctx, obj)
 	}
 
@@ -59,7 +56,7 @@ func (s *Storage) Create(ctx api.Context, obj runtime.Object) (runtime.Object, e
 }
 
 func (s *Storage) Update(ctx api.Context, name string, obj rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
-	if rbacregistry.EscalationAllowed(ctx, s.superUser) {
+	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Update(ctx, name, obj)
 	}
 

--- a/plugin/pkg/auth/authorizer/rbac/rbac.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac.go
@@ -33,16 +33,10 @@ type RequestToRuleMapper interface {
 }
 
 type RBACAuthorizer struct {
-	superUser string
-
 	authorizationRuleResolver RequestToRuleMapper
 }
 
 func (r *RBACAuthorizer) Authorize(requestAttributes authorizer.Attributes) (bool, string, error) {
-	if r.superUser != "" && requestAttributes.GetUser() != nil && requestAttributes.GetUser().GetName() == r.superUser {
-		return true, "", nil
-	}
-
 	rules, ruleResolutionError := r.authorizationRuleResolver.RulesFor(requestAttributes.GetUser(), requestAttributes.GetNamespace())
 	if RulesAllow(requestAttributes, rules...) {
 		return true, "", nil
@@ -51,9 +45,8 @@ func (r *RBACAuthorizer) Authorize(requestAttributes authorizer.Attributes) (boo
 	return false, "", ruleResolutionError
 }
 
-func New(roles validation.RoleGetter, roleBindings validation.RoleBindingLister, clusterRoles validation.ClusterRoleGetter, clusterRoleBindings validation.ClusterRoleBindingLister, superUser string) *RBACAuthorizer {
+func New(roles validation.RoleGetter, roleBindings validation.RoleBindingLister, clusterRoles validation.ClusterRoleGetter, clusterRoleBindings validation.ClusterRoleBindingLister) *RBACAuthorizer {
 	authorizer := &RBACAuthorizer{
-		superUser: superUser,
 		authorizationRuleResolver: validation.NewDefaultRuleResolver(
 			roles, roleBindings, clusterRoles, clusterRoleBindings,
 		),

--- a/plugin/pkg/auth/authorizer/rbac/rbac_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac_test.go
@@ -122,8 +122,6 @@ func TestAuthorizer(t *testing.T) {
 		clusterRoles        []*rbac.ClusterRole
 		clusterRoleBindings []*rbac.ClusterRoleBinding
 
-		superUser string
-
 		shouldPass []authorizer.Attributes
 		shouldFail []authorizer.Attributes
 	}{
@@ -222,7 +220,7 @@ func TestAuthorizer(t *testing.T) {
 	}
 	for i, tt := range tests {
 		ruleResolver, _ := validation.NewTestRuleResolver(tt.roles, tt.roleBindings, tt.clusterRoles, tt.clusterRoleBindings)
-		a := RBACAuthorizer{tt.superUser, ruleResolver}
+		a := RBACAuthorizer{ruleResolver}
 		for _, attr := range tt.shouldPass {
 			if authorized, _, _ := a.Authorize(attr); !authorized {
 				t.Errorf("case %d: incorrectly restricted %s", i, attr)


### PR DESCRIPTION
Cleaning up cruft and duplicated capabilities as we transition from RBAC alpha to beta.  In 1.5, we added a secured loopback connection based on the `system:masters` group name.  `system:masters` have full power in the API, so the RBAC super user is superfluous.

The flag will stay in place so that the process can still launch, but it will be disconnected.

@kubernetes/sig-auth