### PR TITLE
Fix GCI mounter issue

### DIFF
--- a/cluster/gce/gci/mounter/mounter
+++ b/cluster/gce/gci/mounter/mounter
@@ -31,7 +31,7 @@ function gc {
     # Rkt pods end up creating new copies of mounts on the host. Hence it is ideal to clean them up right away.
     attempt=0
     until [ $attempt -ge 5 ]; do
-	${RKT_BINARY} gc --grace-period=0s &> /dev/null && break
+	${RKT_BINARY} gc --grace-period=0s &> /dev/null
 	attempt=$[$attempt+1]
 	sleep 1
     done

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -130,13 +130,21 @@ func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
 		}
 	}
 
+	// TODO: this is a workaround for the unmount device issue caused by gci mounter.
+	// In GCI cluster, if gci mounter is used for mounting, the container started by mounter
+	// script will cause additional mounts created in the container. Since these mounts are
+	// irrelavant to the original mounts, they should be not considered when checking the
+	// mount references. Current solution is to filter out those mount paths that contain
+	// the string of original mount path.
+	// Plan to work on better approach to solve this issue.
+
 	// Find all references to the device.
 	var refs []string
 	if deviceName == "" {
 		glog.Warningf("could not determine device for path: %q", mountPath)
 	} else {
 		for i := range mps {
-			if mps[i].Device == deviceName && mps[i].Path != slTarget {
+			if mps[i].Device == deviceName && !strings.Contains(mps[i].Path, slTarget) {
 				refs = append(refs, mps[i].Path)
 			}
 		}

--- a/pkg/util/mount/mount_linux_test.go
+++ b/pkg/util/mount/mount_linux_test.go
@@ -98,7 +98,7 @@ func TestGetMountRefs(t *testing.T) {
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd"},
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd-in-pod"},
 			{Device: "/dev/sdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd2"},
-			{Device: "/dev/sdc", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod"},
+			{Device: "/dev/sdc", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod1"},
 			{Device: "/dev/sdc", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod2"},
 		},
 	}
@@ -114,7 +114,7 @@ func TestGetMountRefs(t *testing.T) {
 			},
 		},
 		{
-			"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod",
+			"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod1",
 			[]string{
 				"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod2",
 				"/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd2",

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -94,7 +94,7 @@ func UnmountPath(mountPath string, mounter mount.Interface) error {
 		return err
 	}
 	if notMnt {
-		glog.V(4).Info("%q is unmounted, deleting the directory", mountPath)
+		glog.V(4).Infof("%q is unmounted, deleting the directory", mountPath)
 		return os.Remove(mountPath)
 	}
 	return nil


### PR DESCRIPTION
Two fixes in this PR

1. Remove break in the mounter script to make sure gc run multiple times
To make sure existed container created by mounter script gets garbage collected, we make rkt gc run multiple times

2. Fix unmount issue cased by GlusterFS mounter 
When GlusterFS volume is mounted on GCI image cluster, the GCI mounter script will create a container and then execute mount in the container. Because mount for GlusterFS will run a glusterfs daemon, the container created by the mounter will continue be in running state and rkt garbage collection will not collect it. Because of the shared mount propagation setting, any mounts on the host will be reflected to the container which might cause a large mount table. Also, in current umount device logic, we check the mount references before issuing the operations. In this case, unmount device will fail because of the extra mount points in the container. The following gives an example of original mount path and the shared mount point created in container.

a. original mount 
/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/nfs-disk rw,relatime shared:133 - ext4 /dev/sdb rw,data=ordered
b. shared mount in container
/var/lib/rkt/pods/run/3496eadc-74d9-4349-9370-db7636f5f963/stage1/rootfs/opt/stage2/gci mounter/rootfs/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/nfs-disk rw,relatime shared:133 - ext4 /dev/sdb rw,data=ordered

The current workaround for this issue is: since these shared mounts are irrelevant to the original mounts, they should be not considered when checking the mount references. By comparing the mount paths, the shared mount path contains the full original mount path so they should be filtered out.