### PR TITLE
cleanup genericapiserver authentication options

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -96,14 +96,14 @@ func Run(s *options.ServerRunOptions) error {
 
 	genericapiserver.DefaultAndValidateRunOptions(s.GenericServerRunOptions)
 
-	genericConfig, err := genericapiserver.NewConfig(). // create the new config
-								ApplyOptions(s.GenericServerRunOptions). // apply the options selected
-								ApplyInsecureServingOptions(s.InsecureServing).
-								ApplyAuthenticationOptions(s.Authentication).
-								ApplySecureServingOptions(s.SecureServing)
-	if err != nil {
+	genericConfig := genericapiserver.NewConfig(). // create the new config
+							ApplyOptions(s.GenericServerRunOptions). // apply the options selected
+							ApplyInsecureServingOptions(s.InsecureServing)
+
+	if _, err := genericConfig.ApplySecureServingOptions(s.SecureServing); err != nil {
 		return fmt.Errorf("failed to configure https: %s", err)
 	}
+	genericConfig.ApplyAuthenticationOptions(s.Authentication)
 
 	capabilities.Initialize(capabilities.Capabilities{
 		AllowPrivileged: s.AllowPrivileged,

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -219,7 +219,7 @@ func Run(s *options.ServerRunOptions) error {
 		}
 	}
 
-	authenticatorConfig := s.Authentication.ToAuthenticationConfig(s.SecureServing.ClientCA)
+	authenticatorConfig := s.Authentication.ToAuthenticationConfig()
 	if s.Authentication.ServiceAccounts.Lookup {
 		// If we need to look up service accounts and tokens,
 		// go directly to etcd to avoid recursive auth insanity

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -99,14 +99,14 @@ func (serverOptions *ServerRunOptions) Run(stopCh <-chan struct{}) error {
 		glog.Fatalf("Error creating self-signed certificates: %v", err)
 	}
 
-	config, err := genericapiserver.NewConfig().
+	config := genericapiserver.NewConfig().
 		ApplyOptions(serverOptions.GenericServerRunOptions).
-		ApplyInsecureServingOptions(serverOptions.InsecureServing).
-		ApplyAuthenticationOptions(serverOptions.Authentication).
-		ApplySecureServingOptions(serverOptions.SecureServing)
-	if err != nil {
+		ApplyInsecureServingOptions(serverOptions.InsecureServing)
+
+	if _, err := config.ApplySecureServingOptions(serverOptions.SecureServing); err != nil {
 		return fmt.Errorf("failed to configure https: %s", err)
 	}
+	config.ApplyAuthenticationOptions(serverOptions.Authentication)
 
 	config.Authorizer = authorizer.NewAlwaysAllowAuthorizer()
 	s, err := config.Complete().New()

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -126,7 +126,7 @@ func Run(s *options.ServerRunOptions) error {
 		storageFactory.SetEtcdLocation(groupResource, servers)
 	}
 
-	apiAuthenticator, securityDefinitions, err := authenticator.New(s.Authentication.ToAuthenticationConfig(s.SecureServing.ClientCA))
+	apiAuthenticator, securityDefinitions, err := authenticator.New(s.Authentication.ToAuthenticationConfig())
 	if err != nil {
 		glog.Fatalf("Invalid Authentication Config: %v", err)
 	}

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -78,14 +78,14 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	genericapiserver.DefaultAndValidateRunOptions(s.GenericServerRunOptions)
-	genericConfig, err := genericapiserver.NewConfig(). // create the new config
-								ApplyOptions(s.GenericServerRunOptions). // apply the options selected
-								ApplyInsecureServingOptions(s.InsecureServing).
-								ApplyAuthenticationOptions(s.Authentication).
-								ApplySecureServingOptions(s.SecureServing)
-	if err != nil {
+	genericConfig := genericapiserver.NewConfig(). // create the new config
+							ApplyOptions(s.GenericServerRunOptions). // apply the options selected
+							ApplyInsecureServingOptions(s.InsecureServing)
+
+	if _, err := genericConfig.ApplySecureServingOptions(s.SecureServing); err != nil {
 		return fmt.Errorf("failed to configure https: %s", err)
 	}
+	genericConfig.ApplyAuthenticationOptions(s.Authentication)
 
 	// TODO: register cluster federation resources here.
 	resourceConfig := genericapiserver.NewResourceConfig()

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -232,7 +232,6 @@ func (c *Config) ApplySecureServingOptions(secureServing *options.SecureServingO
 		ServingInfo: ServingInfo{
 			BindAddress: net.JoinHostPort(secureServing.ServingOptions.BindAddress.String(), strconv.Itoa(secureServing.ServingOptions.BindPort)),
 		},
-		ClientCA: secureServing.ClientCA,
 	}
 
 	serverCertFile, serverKeyFile := secureServing.ServerCert.CertKey.CertFile, secureServing.ServerCert.CertKey.KeyFile
@@ -303,6 +302,10 @@ func (c *Config) ApplyInsecureServingOptions(insecureServing *options.ServingOpt
 func (c *Config) ApplyAuthenticationOptions(o *options.BuiltInAuthenticationOptions) *Config {
 	if o == nil || o.PasswordFile == nil {
 		return c
+	}
+
+	if o.ClientCert != nil && c.SecureServingInfo != nil {
+		c.SecureServingInfo.ClientCA = o.ClientCert.ClientCA
 	}
 
 	c.SupportsBasicAuth = len(o.PasswordFile.BasicAuthFile) > 0

--- a/pkg/genericapiserver/options/serving.go
+++ b/pkg/genericapiserver/options/serving.go
@@ -41,8 +41,6 @@ type SecureServingOptions struct {
 	ServerCert GeneratableKeyCert
 	// SNICertKeys are named CertKeys for serving secure traffic with SNI support.
 	SNICertKeys []config.NamedCertKey
-	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates
-	ClientCA string
 }
 
 type CertKey struct {
@@ -124,11 +122,6 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 		"trump over extracted names. For multiple key/certificate pairs, use the "+
 		"--tls-sni-cert-key multiple times. "+
 		"Examples: \"example.key,example.crt\" or \"*.foo.com,foo.com:foo.key,foo.crt\".")
-
-	fs.StringVar(&s.ClientCA, "client-ca-file", s.ClientCA, ""+
-		"If set, any request presenting a client certificate signed by one of "+
-		"the authorities in the client-ca-file is authenticated with an identity "+
-		"corresponding to the CommonName of the client certificate.")
 }
 
 func (s *SecureServingOptions) AddDeprecatedFlags(fs *pflag.FlagSet) {


### PR DESCRIPTION
Moves client certificate CA to the authentication structs and adds front proxy for the delegation case.

@liggitt part of what you requested in the options pull.