### PR TITLE
Adding correct secret type for Ceph RBD storageclass provisioner example

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -335,10 +335,10 @@ First we must identify the Ceph client admin key. This is usually found in `/etc
   caps osd = "allow *"
 ```
 
-From the key value, we will create a secret. We must create the Ceph admin Secret in the namespace defined in our `StorageClass`. In this example we set the namespace to `kube-system`.
+From the key value, we will create a secret. We must create the Ceph admin Secret in the namespace defined in our `StorageClass`. In this example we've set the namespace to `kube-system`.
 
 ```
-$ kubectl create secret generic ceph-secret-admin --from-literal=key='AQBfxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==' --namespace=kube-system
+$ kubectl create secret generic ceph-secret-admin --from-literal=key='AQBfxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx==' --namespace=kube-system --type=kubernetes.io/rbd
 ```
 
 Now modify `examples/experimental/persistent-volume-provisioning/rbd/rbd-storage-class.yaml` to reflect your environment, particularly the `monitors` field.  We are now ready to create our RBD Storage Class:
@@ -360,7 +360,7 @@ This key will be made into a secret, just like the admin secret. However this us
 
 ```
 kubectl create namespace myns
-kubectl create secret generic ceph-secret-user --from-literal=key='AQBQyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy==' --namespace=myns
+kubectl create secret generic ceph-secret-user --from-literal=key='AQBQyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy==' --namespace=myns --type=kubernetes.io/rbd
 ```
 
 You are now ready to provision and use RBD storage.

--- a/examples/experimental/persistent-volume-provisioning/rbd/ceph-secret-admin.yaml
+++ b/examples/experimental/persistent-volume-provisioning/rbd/ceph-secret-admin.yaml
@@ -4,5 +4,6 @@ metadata:
   name: ceph-secret-admin
 type: "kubernetes.io/rbd"
 data:
+#Please note this value is base64 encoded.
   key: QVFEQ1pMdFhPUnQrSmhBQUFYaERWNHJsZ3BsMmNjcDR6RFZST0E9PQ==
 type: kubernetes.io/rbd

--- a/examples/experimental/persistent-volume-provisioning/rbd/ceph-secret-user.yaml
+++ b/examples/experimental/persistent-volume-provisioning/rbd/ceph-secret-user.yaml
@@ -4,4 +4,5 @@ metadata:
   name: ceph-secret-user
 type: "kubernetes.io/rbd"  
 data:
+#Please note this value is base64 encoded.
   key: QVFBTWdYaFZ3QkNlRGhBQTlubFBhRnlmVVNhdEdENGRyRldEdlE9PQ==


### PR DESCRIPTION
StorageClass now requires provider-specific secret types, adding them to the RBD provisioning docs.