### PR TITLE
Revert "Enable updates in unit test for federated daemonset controller"

### DIFF
--- a/federation/pkg/federation-controller/daemonset/BUILD
+++ b/federation/pkg/federation-controller/daemonset/BUILD
@@ -46,7 +46,6 @@ go_test(
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_release_1_5/fake:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
-        "//federation/pkg/federation-controller/util/deletionhelper:go_default_library",
         "//federation/pkg/federation-controller/util/test:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",

--- a/federation/pkg/federation-controller/daemonset/daemonset_controller_test.go
+++ b/federation/pkg/federation-controller/daemonset/daemonset_controller_test.go
@@ -25,7 +25,7 @@ import (
 	federationapi "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	fakefedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_release_1_5/fake"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
-	"k8s.io/kubernetes/federation/pkg/federation-controller/util/deletionhelper"
+	//"k8s.io/kubernetes/federation/pkg/federation-controller/util/deletionhelper"
 	. "k8s.io/kubernetes/federation/pkg/federation-controller/util/test"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 	extensionsv1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
@@ -46,14 +46,14 @@ func TestDaemonSetController(t *testing.T) {
 	RegisterFakeList("clusters", &fakeClient.Fake, &federationapi.ClusterList{Items: []federationapi.Cluster{*cluster1}})
 	RegisterFakeList("daemonsets", &fakeClient.Fake, &extensionsv1.DaemonSetList{Items: []extensionsv1.DaemonSet{}})
 	daemonsetWatch := RegisterFakeWatch("daemonsets", &fakeClient.Fake)
-	daemonsetUpdateChan := RegisterFakeCopyOnUpdate("daemonsets", &fakeClient.Fake, daemonsetWatch)
+	// daemonsetUpdateChan := RegisterFakeCopyOnUpdate("daemonsets", &fakeClient.Fake, daemonsetWatch)
 	clusterWatch := RegisterFakeWatch("clusters", &fakeClient.Fake)
 
 	cluster1Client := &fakekubeclientset.Clientset{}
 	cluster1Watch := RegisterFakeWatch("daemonsets", &cluster1Client.Fake)
 	RegisterFakeList("daemonsets", &cluster1Client.Fake, &extensionsv1.DaemonSetList{Items: []extensionsv1.DaemonSet{}})
 	cluster1CreateChan := RegisterFakeCopyOnCreate("daemonsets", &cluster1Client.Fake, cluster1Watch)
-	cluster1UpdateChan := RegisterFakeCopyOnUpdate("daemonsets", &cluster1Client.Fake, cluster1Watch)
+	// cluster1UpdateChan := RegisterFakeCopyOnUpdate("daemonsets", &cluster1Client.Fake, cluster1Watch)
 
 	cluster2Client := &fakekubeclientset.Clientset{}
 	cluster2Watch := RegisterFakeWatch("daemonsets", &cluster2Client.Fake)
@@ -96,14 +96,15 @@ func TestDaemonSetController(t *testing.T) {
 
 	// Test add federated daemonset.
 	daemonsetWatch.Add(&daemonset1)
-
-	// There should be 2 updates to add both the finalizers.
-	updatedDaemonSet := GetDaemonSetFromChan(daemonsetUpdateChan)
-	assert.True(t, daemonsetController.hasFinalizerFunc(updatedDaemonSet, deletionhelper.FinalizerDeleteFromUnderlyingClusters))
-	updatedDaemonSet = GetDaemonSetFromChan(daemonsetUpdateChan)
-	assert.True(t, daemonsetController.hasFinalizerFunc(updatedDaemonSet, apiv1.FinalizerOrphan))
-	daemonset1 = *updatedDaemonSet
-
+	/*
+		// TODO: Re-enable this when we have fixed these flaky tests: https://github.com/kubernetes/kubernetes/issues/36540.
+		// There should be 2 updates to add both the finalizers.
+		updatedDaemonSet := GetDaemonSetFromChan(daemonsetUpdateChan)
+		assert.True(t, daemonsetController.hasFinalizerFunc(updatedDaemonSet, deletionhelper.FinalizerDeleteFromUnderlyingClusters))
+		updatedDaemonSet = GetDaemonSetFromChan(daemonsetUpdateChan)
+		assert.True(t, daemonsetController.hasFinalizerFunc(updatedDaemonSet, apiv1.FinalizerOrphan))
+		daemonset1 = *updatedDaemonSet
+	*/
 	createdDaemonSet := GetDaemonSetFromChan(cluster1CreateChan)
 	assert.NotNil(t, createdDaemonSet)
 	assert.Equal(t, daemonset1.Namespace, createdDaemonSet.Namespace)
@@ -117,24 +118,30 @@ func TestDaemonSetController(t *testing.T) {
 		cluster1.Name, getDaemonSetKey(daemonset1.Namespace, daemonset1.Name), wait.ForeverTestTimeout)
 	assert.Nil(t, err, "daemonset should have appeared in the informer store")
 
-	// TODO: Re-enable this when we have fixed these flaky tests: https://github.com/kubernetes/kubernetes/issues/36540.
-	// Test update federated daemonset.
-	daemonset1.Annotations = map[string]string{
-		"A": "B",
-	}
-	daemonsetWatch.Modify(&daemonset1)
-	updatedDaemonSet = GetDaemonSetFromChan(cluster1UpdateChan)
-	assert.NotNil(t, updatedDaemonSet)
-	assert.Equal(t, daemonset1.Name, updatedDaemonSet.Name)
-	assert.Equal(t, daemonset1.Namespace, updatedDaemonSet.Namespace)
-	assert.True(t, daemonsetsEqual(daemonset1, *updatedDaemonSet),
-		fmt.Sprintf("expected: %v, actual: %v", daemonset1, *updatedDaemonSet))
+	/*
+		        // TODO: Re-enable this when we have fixed these flaky tests: https://github.com/kubernetes/kubernetes/issues/36540.
+			// Test update federated daemonset.
+			daemonset1.Annotations = map[string]string{
+				"A": "B",
+			}
+			daemonsetWatch.Modify(&daemonset1)
+			updatedDaemonSet = GetDaemonSetFromChan(cluster1UpdateChan)
+			assert.NotNil(t, updatedDaemonSet)
+			assert.Equal(t, daemonset1.Name, updatedDaemonSet.Name)
+			assert.Equal(t, daemonset1.Namespace, updatedDaemonSet.Namespace)
+			assert.True(t, daemonsetsEqual(daemonset1, *updatedDaemonSet),
+				fmt.Sprintf("expected: %v, actual: %v", daemonset1, *updatedDaemonSet))
 
-	// Test update federated daemonset.
-	daemonset1.Spec.Template.Name = "TEST"
-	daemonsetWatch.Modify(&daemonset1)
-	err = CheckObjectFromChan(cluster1UpdateChan, MetaAndSpecCheckingFunction(&daemonset1))
-	assert.NoError(t, err)
+			// Test update federated daemonset.
+			daemonset1.Spec.Template.Name = "TEST"
+			daemonsetWatch.Modify(&daemonset1)
+			updatedDaemonSet = GetDaemonSetFromChan(cluster1UpdateChan)
+			assert.NotNil(t, updatedDaemonSet)
+			assert.Equal(t, daemonset1.Name, updatedDaemonSet.Name)
+			assert.Equal(t, daemonset1.Namespace, updatedDaemonSet.Namespace)
+			assert.True(t, daemonsetsEqual(daemonset1, *updatedDaemonSet),
+				fmt.Sprintf("expected: %v, actual: %v", daemonset1, *updatedDaemonSet))
+	*/
 
 	// Test add cluster
 	clusterWatch.Add(cluster2)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#37291

The test flaked in https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/37659/pull-kubernetes-unit/8198/