### PR TITLE
goflags must be after subcommand

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -662,7 +662,7 @@ kube::golang::build_binaries() {
       # Only try to generate bindata if the file exists, since in some cases
       # one-off builds of individual directories may exclude some files.
       if [[ -f "${KUBE_ROOT}/${bindata}" ]]; then
-        go "${goflags[@]:+${goflags[@]}}" generate "${KUBE_ROOT}/${bindata}"
+        go generate "${goflags[@]:+${goflags[@]}}" "${KUBE_ROOT}/${bindata}"
       fi
     done
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
if GOFLAGS is set when calling make, kubernetes will fail to build

as an example, I often have `GOFLAGS=-v` so I can have some idea of progress during compilation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
no known issue

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

