### PR TITLE
glusterfs: Fix all gid types to int to prevent failures on 32bit systems

### DIFF
--- a/examples/experimental/persistent-volume-provisioning/README.md
+++ b/examples/experimental/persistent-volume-provisioning/README.md
@@ -94,7 +94,7 @@ When both `restuserkey` and `secretNamespace` + `secretName` is specified, the s
 
 Example of a secret can be found in [glusterfs-provisioning-secret.yaml](glusterfs-provisioning-secret.yaml).
 
-* `gidMin` + `gidMax` : The minimum and maximum value of GID range for the storage class. A unique value (GID) in this range ( gidMin-gidMax ) will be used for dynamically provisioned volumes. These are optional values. If not specified, the volume will be provisioned with a value between 2000-4294967295 which are defaults for gidMin and gidMax respectively.
+* `gidMin` + `gidMax` : The minimum and maximum value of GID range for the storage class. A unique value (GID) in this range ( gidMin-gidMax ) will be used for dynamically provisioned volumes. These are optional values. If not specified, the volume will be provisioned with a value between 2000-2147483647 which are defaults for gidMin and gidMax respectively.
 
 Reference : ([How to configure Heketi](https://github.com/heketi/heketi/wiki/Setting-up-the-topology))
 

--- a/pkg/volume/glusterfs/glusterfs_test.go
+++ b/pkg/volume/glusterfs/glusterfs_test.go
@@ -270,7 +270,7 @@ func TestParseClassParameters(t *testing.T) {
 				userKey:     "password",
 				secretValue: "password",
 				gidMin:      2000,
-				gidMax:      4294967295,
+				gidMax:      2147483647,
 			},
 		},
 		{
@@ -290,7 +290,7 @@ func TestParseClassParameters(t *testing.T) {
 				secretNamespace: "default",
 				secretValue:     "mypassword",
 				gidMin:          2000,
-				gidMax:          4294967295,
+				gidMax:          2147483647,
 			},
 		},
 		{
@@ -304,7 +304,7 @@ func TestParseClassParameters(t *testing.T) {
 			&provisioningConfig{
 				url:    "https://localhost:8080",
 				gidMin: 2000,
-				gidMax: 4294967295,
+				gidMax: 2147483647,
 			},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

The glusterfs dynamic provisioner with GID security has an issue on 32 bit systems.
This fixes that issue by forcing all gid types to int internally.
<!--
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fix the glusterfs dynamic provisioner for 32bit systems by limiting the gids to type int internally, and allowing 2147483647 as the highest GID.
```

This makes all types int until we hand the GID to heketi/gluster,
at which point it's converted to int64.

It also limits the maximum usable GID ti math.MaxInt32 = 2147483647.

Signed-off-by: Michael Adam <obnox@redhat.com>