### PR TITLE
New ns param for NewClusterVerification

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -48,6 +48,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 	// Reusable cluster state function.  This won't be adversly affected by lazy initialization of framework.
 	clusterState := func(selectorKey string, selectorValue string) *framework.ClusterVerification {
 		return f.NewClusterVerification(
+			f.Namespace,
 			framework.PodStateVerification{
 				Selectors:   map[string]string{selectorKey: selectorValue},
 				ValidPhases: []v1.PodPhase{v1.PodRunning},

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -853,10 +853,10 @@ type ClusterVerification struct {
 	podState  PodStateVerification
 }
 
-func (f *Framework) NewClusterVerification(filter PodStateVerification) *ClusterVerification {
+func (f *Framework) NewClusterVerification(namespace *v1.Namespace, filter PodStateVerification) *ClusterVerification {
 	return &ClusterVerification{
 		f.ClientSet,
-		f.Namespace,
+		namespace,
 		filter,
 	}
 }

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -267,6 +267,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 	// Reustable cluster state function.  This won't be adversly affected by lazy initialization of framework.
 	clusterState := func() *framework.ClusterVerification {
 		return f.NewClusterVerification(
+			f.Namespace,
 			framework.PodStateVerification{
 				Selectors:   map[string]string{"app": "redis"},
 				ValidPhases: []v1.PodPhase{v1.PodRunning /*v1.PodPending*/},

--- a/test/e2e/logging_soak.go
+++ b/test/e2e/logging_soak.go
@@ -114,6 +114,7 @@ func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname 
 	)
 
 	logSoakVerification := f.NewClusterVerification(
+		f.Namespace,
 		framework.PodStateVerification{
 			Selectors:   podlables,
 			ValidPhases: []v1.PodPhase{v1.PodRunning, v1.PodSucceeded},

--- a/test/e2e/networking_perf.go
+++ b/test/e2e/networking_perf.go
@@ -119,6 +119,7 @@ var _ = framework.KubeDescribe("Networking IPerf [Experimental] [Slow] [Feature:
 		iperfResults := &IPerfResults{}
 
 		iperfClusterVerification := f.NewClusterVerification(
+			f.Namespace,
 			framework.PodStateVerification{
 				Selectors:   iperfClientPodLabels,
 				ValidPhases: []v1.PodPhase{v1.PodSucceeded},


### PR DESCRIPTION
**What this PR does / why we need it**: Allows the test to specify alternate namespaces to when waiting for pods to be in a specific state.

**Which issue this PR fixes**: fixes #38138

**Special notes for your reviewer**: Minor fix

**Release note**: None

