### PR TITLE
Cleanup firewalls, add nginx ingress to presubmit

### DIFF
--- a/test/e2e/federated-ingress.go
+++ b/test/e2e/federated-ingress.go
@@ -421,7 +421,7 @@ func (j *federationTestJig) waitForFederatedIngress() {
 		for _, p := range rules.IngressRuleValue.HTTP.Paths {
 			route := fmt.Sprintf("%v://%v%v", proto, address, p.Path)
 			framework.Logf("Testing route %v host %v with simple GET", route, rules.Host)
-			ExpectNoError(pollURL(route, rules.Host, lbPollTimeout, timeoutClient, false))
+			ExpectNoError(pollURL(route, rules.Host, lbPollTimeout, lbPollInterval, timeoutClient, false))
 		}
 	}
 }


### PR DESCRIPTION
Make the firewall cleanup code follow the same pattern as the other cleanup functions, and add the nginx ingress e2e to presubmit. 

Planning to watch the test for a bit, and if it works alright, I'll add the other Ingress e2e to post-submit merge blocker. 