### PR TITLE
Node E2E: Remove setup-node option

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -128,7 +128,7 @@ if [ $remote = true ] ; then
     --zone="$zone" --project="$project" --gubernator="$gubernator" \
     --hosts="$hosts" --images="$images" --cleanup="$cleanup" \
     --results-dir="$artifacts" --ginkgo-flags="$ginkgoflags" \
-    --image-project="$image_project" --instance-name-prefix="$instance_prefix" --setup-node="true" \
+    --image-project="$image_project" --instance-name-prefix="$instance_prefix" \
     --delete-instances="$delete_instances" --test_args="$test_args" --instance-metadata="$metadata" \
     2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -545,7 +545,6 @@ service-node-ports
 service-overrides
 service-sync-period
 session-affinity
-setup-node
 show-all
 show-events
 show-kind

--- a/test/e2e_node/jenkins/benchmark/jenkins-benchmark.properties
+++ b/test/e2e_node/jenkins/benchmark/jenkins-benchmark.properties
@@ -4,7 +4,6 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]"'
-SETUP_NODE=false
 TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
 KUBELET_ARGS='--experimental-cgroups-per-qos=true --cgroup-root=/'
 PARALLELISM=1

--- a/test/e2e_node/jenkins/cri_validation/jenkins-benchmark.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-benchmark.properties
@@ -4,7 +4,6 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]"'
-SETUP_NODE=false
 TEST_ARGS='--feature-gates=DynamicKubeletConfig=true,StreamingProxyRedirects=true'
 KUBELET_ARGS='--experimental-cri=true'
 PARALLELISM=1

--- a/test/e2e_node/jenkins/cri_validation/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-pull.properties
@@ -4,6 +4,5 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-pr-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2'
-SETUP_NODE=false
 TEST_ARGS='--feature-gates=StreamingProxyRedirects=true'
 KUBELET_ARGS='--experimental-cri=true'

--- a/test/e2e_node/jenkins/cri_validation/jenkins-serial.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-serial.properties
@@ -4,7 +4,6 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]"'
-SETUP_NODE=false
 TEST_ARGS='--feature-gates=DynamicKubeletConfig=true,StreamingProxyRedirects=true'
 KUBELET_ARGS='--experimental-cri=true'
 PARALLELISM=1

--- a/test/e2e_node/jenkins/cri_validation/jenkins-validation.properties
+++ b/test/e2e_node/jenkins/cri_validation/jenkins-validation.properties
@@ -4,7 +4,6 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
-SETUP_NODE=false
 TEST_ARGS='--feature-gates=StreamingProxyRedirects=true'
 KUBELET_ARGS='--experimental-cri=true'
 TIMEOUT=1h

--- a/test/e2e_node/jenkins/docker_validation/jenkins-perf.properties
+++ b/test/e2e_node/jenkins/docker_validation/jenkins-perf.properties
@@ -18,5 +18,4 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]"'
-SETUP_NODE=true
 PARALLELISM=1

--- a/test/e2e_node/jenkins/docker_validation/jenkins-validation.properties
+++ b/test/e2e_node/jenkins/docker_validation/jenkins-validation.properties
@@ -14,5 +14,4 @@ GCE_PROJECT=k8s-jkns-ci-node-e2e
 GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION}"
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
-SETUP_NODE=true
 TIMEOUT=1h

--- a/test/e2e_node/jenkins/e2e-node-jenkins.sh
+++ b/test/e2e_node/jenkins/e2e-node-jenkins.sh
@@ -46,5 +46,5 @@ go run test/e2e_node/runner/remote/run_remote.go  --logtostderr --vmodule=*=4 --
   --images="$GCE_IMAGES" --image-project="$GCE_IMAGE_PROJECT" \
   --image-config-file="$GCE_IMAGE_CONFIG_PATH" --cleanup="$CLEANUP" \
   --results-dir="$ARTIFACTS" --ginkgo-flags="--nodes=$PARALLELISM $GINKGO_FLAGS" \
-  --test-timeout="$TIMEOUT" --setup-node="$SETUP_NODE" --test_args="$TEST_ARGS --kubelet-flags=\"$KUBELET_ARGS\"" \
+  --test-timeout="$TIMEOUT" --test_args="$TEST_ARGS --kubelet-flags=\"$KUBELET_ARGS\"" \
   --instance-metadata="$GCE_INSTANCE_METADATA"

--- a/test/e2e_node/jenkins/jenkins-ci.properties
+++ b/test/e2e_node/jenkins/jenkins-ci.properties
@@ -4,6 +4,5 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
-SETUP_NODE=false
 KUBELET_ARGS='--experimental-cgroups-per-qos=true --cgroup-root=/'
 TIMEOUT=1h

--- a/test/e2e_node/jenkins/jenkins-flaky.properties
+++ b/test/e2e_node/jenkins/jenkins-flaky.properties
@@ -4,5 +4,4 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--focus="\[Flaky\]"'
-SETUP_NODE=false
 KUBELET_ARGS='--experimental-cgroups-per-qos=true --cgroup-root=/'

--- a/test/e2e_node/jenkins/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/jenkins-pull.properties
@@ -4,6 +4,5 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-pr-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2'
-SETUP_NODE=false
 KUBELET_ARGS='--experimental-cgroups-per-qos=true --cgroup-root=/'
 

--- a/test/e2e_node/jenkins/jenkins-serial.properties
+++ b/test/e2e_node/jenkins/jenkins-serial.properties
@@ -4,7 +4,6 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]"'
-SETUP_NODE=false
 TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
 KUBELET_ARGS='--experimental-cgroups-per-qos=true --cgroup-root=/'
 PARALLELISM=1

--- a/test/e2e_node/jenkins/template.properties
+++ b/test/e2e_node/jenkins/template.properties
@@ -15,8 +15,6 @@ GCE_PROJECT=
 GCE_IMAGE_PROJECT=
 # If true, delete instances created from GCE_IMAGES/GCE_IMAGE_CONFIG_PATH and files copied to GCE_HOSTS
 CLEANUP=true
-# If true, current user will be added to the docker group on test node
-SETUP_NODE=false
 # KUBELET_ARGS are the arguments passed to kubelet. The args will override corresponding default kubelet
 # setting in the test framework and --kubelet-flags in TEST_ARGS.
 # If true QoS Cgroup Hierarchy is created and tests specifc to the cgroup hierarchy run

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -152,18 +152,7 @@ func CreateTestArchive() (string, error) {
 }
 
 // Returns the command output, whether the exit was ok, and any errors
-func RunRemote(archive string, host string, cleanup bool, junitFilePrefix string, setupNode bool, testArgs string, ginkgoFlags string) (string, bool, error) {
-	if setupNode {
-		uname, err := user.Current()
-		if err != nil {
-			return "", false, fmt.Errorf("could not find username: %v", err)
-		}
-		output, err := SSH(host, "usermod", "-a", "-G", "docker", uname.Username)
-		if err != nil {
-			return "", false, fmt.Errorf("instance %s not running docker daemon - Command failed: %s", host, output)
-		}
-	}
-
+func RunRemote(archive string, host string, cleanup bool, junitFilePrefix string, testArgs string, ginkgoFlags string) (string, bool, error) {
 	// Create the temp staging directory
 	glog.Infof("Staging test binaries on %s", host)
 	workspace := fmt.Sprintf("/tmp/node-e2e-%s", getTimestamp())


### PR DESCRIPTION
This PR removes `setup-node` option, because:
* It is misleading. `setup-node` doesn't really setup the node, test framework will only put current user into docker user group when it is specified.
* It is not necessary anymore. Because we always run node e2e test as root now, we don't need to do this anymore.

This is a minor cleanup preparing for my test framework refactoring work. Will send out the refactor PR later.

/cc @kubernetes/sig-node 

