### PR TITLE
remove the create-external-load-balancer flag in cmd/expose.go

### DIFF
--- a/examples/selenium/README.md
+++ b/examples/selenium/README.md
@@ -59,7 +59,7 @@ curl http://localhost:4444
 If you are using Google Container Engine, you can expose your hub via the internet. This is a bad idea for many reasons, but you can do it as follows:
 
 ```console
-kubectl expose rc selenium-hub --name=selenium-hub-external --labels="app=selenium-hub,external=true" --create-external-load-balancer=true
+kubectl expose rc selenium-hub --name=selenium-hub-external --labels="app=selenium-hub,external=true" --type=LoadBalancer
 ```
 
 Then wait a few minutes, eventually your new `selenium-hub-external` service will be assigned a load balanced IP from gcloud. Once `kubectl get svc selenium-hub-external` shows two IPs, run this snippet.

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -115,7 +115,6 @@ controller-start-interval
 cors-allowed-origins
 cpu-cfs-quota
 cpu-percent
-create-external-load-balancer
 current-release-pr
 current-replicas
 daemonset-lookup-cache-size

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -99,9 +99,6 @@ func NewCmdExposeService(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("protocol", "", "The network protocol for the service to be created. Default is 'TCP'.")
 	cmd.Flags().String("port", "", "The port that the service should serve on. Copied from the resource being exposed, if unspecified")
 	cmd.Flags().String("type", "", "Type for this service: ClusterIP, NodePort, or LoadBalancer. Default is 'ClusterIP'.")
-	// TODO: remove create-external-load-balancer in code on or after Aug 25, 2016.
-	cmd.Flags().Bool("create-external-load-balancer", false, "If true, create an external load balancer for this service (trumped by --type). Implementation is cloud provider dependent. Default is 'false'.")
-	cmd.Flags().MarkDeprecated("create-external-load-balancer", "use --type=\"LoadBalancer\" instead")
 	cmd.Flags().String("load-balancer-ip", "", "IP to assign to the Load Balancer. If empty, an ephemeral IP will be created and used (cloud-provider specific).")
 	cmd.Flags().String("selector", "", "A label selector to use for this service. Only equality-based selector requirements are supported. If empty (the default) infer the selector from the replication controller or replica set.")
 	cmd.Flags().StringP("labels", "l", "", "Labels to apply to the service created by this call.")

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -61,7 +61,6 @@ func paramNames() []GeneratorParam {
 		{"ports", false},
 		{"labels", false},
 		{"external-ip", false},
-		{"create-external-load-balancer", false},
 		{"load-balancer-ip", false},
 		{"type", false},
 		{"protocol", false},
@@ -203,9 +202,6 @@ func generate(genericParams map[string]interface{}) (runtime.Object, error) {
 			port := service.Spec.Ports[i].Port
 			service.Spec.Ports[i].TargetPort = intstr.FromInt(int(port))
 		}
-	}
-	if params["create-external-load-balancer"] == "true" {
-		service.Spec.Type = api.ServiceTypeLoadBalancer
 	}
 	if len(params["external-ip"]) > 0 {
 		service.Spec.ExternalIPs = []string{params["external-ip"]}

--- a/pkg/kubectl/service_test.go
+++ b/pkg/kubectl/service_test.go
@@ -159,7 +159,7 @@ func TestGenerateService(t *testing.T) {
 				"protocol":                      "UDP",
 				"container-port":                "foobar",
 				"external-ip":                   "1.2.3.4",
-				"create-external-load-balancer": "true",
+				"type":                          "LoadBalancer",
 			},
 			expected: api.Service{
 				ObjectMeta: api.ObjectMeta{

--- a/pkg/kubectl/service_test.go
+++ b/pkg/kubectl/service_test.go
@@ -153,13 +153,13 @@ func TestGenerateService(t *testing.T) {
 		{
 			generator: ServiceGeneratorV2{},
 			params: map[string]interface{}{
-				"selector":                      "foo=bar,baz=blah",
-				"name":                          "test",
-				"port":                          "80",
-				"protocol":                      "UDP",
-				"container-port":                "foobar",
-				"external-ip":                   "1.2.3.4",
-				"type":                          "LoadBalancer",
+				"selector":       "foo=bar,baz=blah",
+				"name":           "test",
+				"port":           "80",
+				"protocol":       "UDP",
+				"container-port": "foobar",
+				"external-ip":    "1.2.3.4",
+				"type":           "LoadBalancer",
 			},
 			expected: api.Service{
 				ObjectMeta: api.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
In cmd/expose.go there is a todo "remove create-external-load-balancer in code on or after Aug 25, 2016.", and now it's been a long time past. So I remove this flag and modify the test cases. 
Please check for this, thanks!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
remove the deprecated flag "create-external-load-balancer" and use --type="LoadBalancer" instead.
```