### PR TITLE
etcd2: remove unnecessary PrevValue in SetOption

### DIFF
--- a/pkg/storage/etcd/etcd_helper.go
+++ b/pkg/storage/etcd/etcd_helper.go
@@ -525,7 +525,6 @@ func (h *etcdHelper) GuaranteedUpdate(
 		startTime := time.Now()
 		// Swap origBody with data, if origBody is the latest etcd data.
 		opts := etcd.SetOptions{
-			PrevValue: origBody,
 			PrevIndex: index,
 			TTL:       time.Duration(ttl) * time.Second,
 		}


### PR DESCRIPTION
ref: https://github.com/kubernetes/kubernetes/issues/37994

Summary:
- PrevValue is set in HTTP header, and large value (>1MB) could exceed check limit
- We don't need PrevValue indeed since we already use PrevIndex in SetOptions and each PrevIndex corresponds to each PrevValue.

I don't really think we need extra tests for this. There is already test for GuaranteedUpdate covering its use cases.