### PR TITLE
Avoid exporting fluentd-gcp own logs

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -26,7 +26,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google_containers
-TAG = 1.29
+TAG = 1.30
 
 build:
 	docker build -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/run.sh
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/run.sh
@@ -26,4 +26,4 @@ fi
 LD_PRELOAD=/opt/td-agent/embedded/lib/libjemalloc.so
 RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0.9
 
-/usr/sbin/td-agent "$@"
+/usr/sbin/td-agent $@

--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -36,8 +36,8 @@ fi
 readonly master_ssh_supported_providers="gce aws kubemark"
 readonly node_ssh_supported_providers="gce gke aws"
 
-readonly master_logfiles="kube-apiserver kube-scheduler rescheduler kube-controller-manager etcd glbc cluster-autoscaler kube-addon-manager"
-readonly node_logfiles="kube-proxy"
+readonly master_logfiles="kube-apiserver kube-scheduler rescheduler kube-controller-manager etcd glbc cluster-autoscaler kube-addon-manager fluentd"
+readonly node_logfiles="kube-proxy fluentd"
 readonly aws_logfiles="cloud-init-output"
 readonly gce_logfiles="startupscript"
 readonly kern_logfile="kern"

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,16 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.29
+    image: gcr.io/google_containers/fluentd-gcp:1.30
+    # If fluentd consumes its own logs, the following situation may happen:
+    # fluentd fails to send a chunk to the server => writes it to the log =>
+    # tries to send this message to the server => fails to send a chunk and so on.
+    # Writing to a file, which is not exported to the back-end prevents it.
+    # It also allows to increase the fluentd verbosity by default.
+    command:
+      - '/bin/sh'
+      - '-c'
+      - '/run.sh $FLUENTD_ARGS 2>&1 >>/var/log/fluentd.log'
     resources:
       limits:
         memory: 200Mi
@@ -20,9 +29,6 @@ spec:
         # requests of other per-node add-ons (e.g. kube-proxy).
         cpu: 100m
         memory: 200Mi
-    env:
-    - name: FLUENTD_ARGS
-      value: -q
     volumeMounts:
     - name: varlog
       mountPath: /var/log


### PR DESCRIPTION
To prevent fluentd from exporting its own logs, redirect the output to a file. Ability to read fluentd logs remains, but because these logs will not be exported, we can increase the verbosity of these logs.

Same change should be made for fluentd-es image.

CC @piosz 