### PR TITLE
Fix pods/log OpenAPI/Swagger spec to return string instead of v1.Pod

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3638,7 +3638,7 @@
       "200": {
        "description": "OK",
        "schema": {
-        "$ref": "#/definitions/v1.Pod"
+        "type": "string"
        }
       },
       "401": {

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -8980,7 +8980,7 @@
     "description": "API at /api/v1",
     "operations": [
      {
-      "type": "v1.Pod",
+      "type": "string",
       "method": "GET",
       "summary": "read log of the specified Pod",
       "nickname": "readNamespacedPodLog",
@@ -9070,7 +9070,7 @@
        {
         "code": 200,
         "message": "OK",
-        "responseModel": "v1.Pod"
+        "responseModel": "string"
        }
       ],
       "produces": [

--- a/docs/api-reference/v1/operations.html
+++ b/docs/api-reference/v1/operations.html
@@ -8971,7 +8971,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">success</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><a href="../definitions#_v1_pod">v1.Pod</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 </tr>
 </tbody>
 </table>
@@ -33308,7 +33308,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-12-05 07:38:49 UTC
+Last updated 2016-12-06 22:35:20 UTC
 </div>
 </div>
 </body>

--- a/pkg/api/rest/rest.go
+++ b/pkg/api/rest/rest.go
@@ -290,6 +290,10 @@ type StorageMetadata interface {
 	// ProducesMIMETypes returns a list of the MIME types the specified HTTP verb (GET, POST, DELETE,
 	// PATCH) can respond with.
 	ProducesMIMETypes(verb string) []string
+
+	// ProducesObject returns an object the specified HTTP verb respond with. It will overwrite storage object if
+	// it is not nil. Only the type of the return object matters, the value will be ignored.
+	ProducesObject(verb string) interface{}
 }
 
 // ConnectRequest is an object passed to admission control for Connect operations

--- a/pkg/apiserver/api_installer.go
+++ b/pkg/apiserver/api_installer.go
@@ -213,7 +213,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 	if err != nil {
 		return nil, err
 	}
-	versionedObject := indirectArbitraryPointer(versionedPtr)
+	defaultVersionedObject := indirectArbitraryPointer(versionedPtr)
 	kind := fqKindToRegister.Kind
 	hasSubresource := len(subresource) > 0
 
@@ -520,6 +520,10 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		Kind:        fqKindToRegister,
 	}
 	for _, action := range actions {
+		versionedObject := storageMeta.ProducesObject(action.Verb)
+		if versionedObject == nil {
+			versionedObject = defaultVersionedObject
+		}
 		reqScope.Namer = action.Namer
 		namespaced := ""
 		if apiResource.Namespaced {
@@ -1051,6 +1055,10 @@ type defaultStorageMetadata struct{}
 var _ rest.StorageMetadata = defaultStorageMetadata{}
 
 func (defaultStorageMetadata) ProducesMIMETypes(verb string) []string {
+	return nil
+}
+
+func (defaultStorageMetadata) ProducesObject(verb string) interface{} {
 	return nil
 }
 

--- a/pkg/apiserver/apiserver_test.go
+++ b/pkg/apiserver/apiserver_test.go
@@ -620,6 +620,10 @@ func (m *MetadataRESTStorage) ProducesMIMETypes(method string) []string {
 	return m.types
 }
 
+func (m *MetadataRESTStorage) ProducesObject(verb string) interface{} {
+	return nil
+}
+
 var _ rest.StorageMetadata = &MetadataRESTStorage{}
 
 type GetWithOptionsRESTStorage struct {

--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -55,6 +55,11 @@ func (r *LogREST) ProducesMIMETypes(verb string) []string {
 	}
 }
 
+// LogREST implements StorageMetadata, return string as the generating object
+func (r *LogREST) ProducesObject(verb string) interface{} {
+	return ""
+}
+
 // Get retrieves a runtime.Object that will stream the contents of the pod log
 func (r *LogREST) Get(ctx api.Context, name string, opts runtime.Object) (runtime.Object, error) {
 	logOpts, ok := opts.(*api.PodLogOptions)


### PR DESCRIPTION
log operation is part of pod and had the assumption of returning a v1.Pod. First I added the support for an operation to be able to customize its return object then added the support to "pods/log" operation to return an string as an object sample.

Fixes #37881
Cc @kubernetes/sig-api-machinery 