### PR TITLE
documentation string for DefaultExternalAddress

### DIFF
--- a/pkg/genericapiserver/options/server_run_options.go
+++ b/pkg/genericapiserver/options/server_run_options.go
@@ -85,6 +85,10 @@ func NewServerRunOptions() *ServerRunOptions {
 	}
 }
 
+// DefaultAdvertiseAddress sets the field AdvertiseAddress if
+// unset. The field will be set based on the SecureServingOptions. If
+// the SecureServingOptions is not present, DefaultExternalAddress
+// will fall back to the insecure ServingOptions.
 func (s *ServerRunOptions) DefaultAdvertiseAddress(secure *SecureServingOptions, insecure *ServingOptions) error {
 	if s.AdvertiseAddress == nil || s.AdvertiseAddress.IsUnspecified() {
 		switch {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
docs for a public function

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

I encountered this function that did not have a doc string. The function was easy to read, so I wrote a doc string for the function.