### PR TITLE
Disable kubernetes-discovery in local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -802,7 +802,7 @@ if [[ "${START_MODE}" != "kubeletonly" ]]; then
   start_etcd
   set_service_accounts
   start_apiserver
-  start_discovery
+  # start_discovery
   start_controller_manager
   start_kubeproxy
   start_kubedns


### PR DESCRIPTION
fix #38257

Fixes local-up-cluster until kubernetes-discovery flags are hooked up