### PR TITLE
kubelet/get-pods-from-http: effective judgement for kubeCfg.ManifestURLHeader

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -226,15 +226,6 @@ type KubeletDeps struct {
 // makePodSourceConfig creates a config.PodConfig from the given
 // KubeletConfiguration or returns an error.
 func makePodSourceConfig(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *KubeletDeps, nodeName types.NodeName) (*config.PodConfig, error) {
-	manifestURLHeader := make(http.Header)
-	if kubeCfg.ManifestURLHeader != "" {
-		pieces := strings.Split(kubeCfg.ManifestURLHeader, ":")
-		if len(pieces) != 2 {
-			return nil, fmt.Errorf("manifest-url-header must have a single ':' key-value separator, got %q", kubeCfg.ManifestURLHeader)
-		}
-		manifestURLHeader.Set(pieces[0], pieces[1])
-	}
-
 	// source of all configuration
 	cfg := config.NewPodConfig(config.PodConfigNotificationIncremental, kubeDeps.Recorder)
 
@@ -246,6 +237,14 @@ func makePodSourceConfig(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps
 
 	// define url config source
 	if kubeCfg.ManifestURL != "" {
+		manifestURLHeader := make(http.Header)
+		if kubeCfg.ManifestURLHeader != "" {
+			pieces := strings.Split(kubeCfg.ManifestURLHeader, ":")
+			if len(pieces) != 2 {
+				return nil, fmt.Errorf("manifest-url-header must have a single ':' key-value separator, got %q", kubeCfg.ManifestURLHeader)
+			}
+			manifestURLHeader.Set(pieces[0], pieces[1])
+		}
 		glog.Infof("Adding manifest url %q with HTTP header %v", kubeCfg.ManifestURL, manifestURLHeader)
 		config.NewSourceURL(kubeCfg.ManifestURL, manifestURLHeader, nodeName, kubeCfg.HTTPCheckFrequency.Duration, cfg.Channel(kubetypes.HTTPSource))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow this description:
   ```
    --manifest-url string                                     URL for accessing the container manifest
    --manifest-url-header string                              HTTP header to use when accessing the manifest URL, with the key separated from the value with a ':', as in 'key:value'
```

In my opinion, the "--manifest-url-header" will to be used only when " --manifest-url" has been configured. But, from the current implementation:

1. "--manifest-url-header" will be parsed even if "--manifest-url" not be configured, and the object which has been parsed maybe never be use
2. if the "--manifest-url-header" is configured as an error value, but the "--manifest-url" does not configure any values, i.e:
        `KUBELET_OPTS=" --manifest-url-header=key01:t:est01 --v=0 --healthz-bind-address=0.0.0.0 --hostname-override=XXXX  --api-servers=http://XXXXX:8080  --logtostderr=true  --cluster-dns=192.168.3.10  --cluster-domain=cluster.local --allow-privileged=false "`       
     kubelet start will be failed: 
     `error: failed to run Kubelet: failed to create kubelet: manifest-url-header must have a single ':' key-value separator, got ["key01:t:est01"]`
     I think this error is unnessary under this case, so i changed position of judgement.

