### PR TITLE
Fix wrong skipf parameter

### DIFF
--- a/test/e2e/ubernetes_lite.go
+++ b/test/e2e/ubernetes_lite.go
@@ -45,7 +45,8 @@ var _ = framework.KubeDescribe("Multi-AZ Clusters", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 		By(fmt.Sprintf("Checking for multi-zone cluster.  Zone count = %d", zoneCount))
-		framework.SkipUnlessAtLeast(zoneCount, 2, "Zone count is %d, only run for multi-zone clusters, skipping test")
+		msg := fmt.Sprintf("Zone count is %d, only run for multi-zone clusters, skipping test", zoneCount)
+		framework.SkipUnlessAtLeast(zoneCount, 2, msg)
 		// TODO: SkipUnlessDefaultScheduler() // Non-default schedulers might not spread
 	})
 	It("should spread the pods of a service across zones", func() {


### PR DESCRIPTION
**How to reproduce**

When run e2e test, it reports `%!!(MISSING)d(MISSING)`:
```
STEP: Checking for multi-zone cluster.  Zone count = 1
Dec  6 14:16:43.272: INFO: Zone count is %!!(MISSING)d(MISSING), only run for multi-zone clusters, skipping test
[AfterEach] [k8s.io] Multi-AZ Clusters
```

We need to pass a string parameter to `SkipUnlessAtLeast`

