### PR TITLE
Added validation for API server's 'apiserver-count' flag.

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -116,7 +116,7 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 		"Currently only applies to long-running requests.")
 
 	fs.IntVar(&s.MasterCount, "apiserver-count", s.MasterCount,
-		"The number of apiservers running in the cluster.")
+		"The number of apiservers running in the cluster, must be a positive number.")
 
 	// See #14282 for details on how to test/try this option out.
 	// TODO: remove this comment once this option is tested in CI.

--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -63,5 +63,8 @@ func (options *ServerRunOptions) Validate() []error {
 	if errs := options.InsecureServing.Validate("insecure-port"); len(errs) > 0 {
 		errors = append(errors, errs...)
 	}
+	if options.MasterCount <= 0 {
+		errors = append(errors, fmt.Errorf("--apiserver-count should be a positive number, but value '%d' provided", options.MasterCount))
+	}
 	return errors
 }


### PR DESCRIPTION
Added validation for API server's 'apiserver-count' flag. The value of this flag should be a positive number, otherwise, will cause error while reconciling endpoints in MasterCountEndpointsReconciler. 

Fixed #38143 