### PR TITLE
Bump Cluster Autoscaler to 0.4.0

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.4.0-beta1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.4.0",
                 "command": [
                     "/bin/sh",
                     "-c",


### PR DESCRIPTION
This is the  same binary as 0.4.0-beta1, that has been tested for the last couple weeks.

@saad-ali This should be cherry-picked to 1.5 release.

```release-note
Cluster Autoscaler in version 0.4.0
```

cc: @fgrzadkowski @piosz @jszczepkowski 