### PR TITLE
API v1: do not require ports for all types of services

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -35069,9 +35069,6 @@
    },
    "v1.ServiceSpec": {
     "description": "ServiceSpec describes the attributes that a user creates on a service.",
-    "required": [
-     "ports"
-    ],
     "properties": {
      "clusterIP": {
       "description": "clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are \"None\", empty string (\"\"), or a valid IP address. \"None\" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -19821,9 +19821,6 @@
    "v1.ServiceSpec": {
     "id": "v1.ServiceSpec",
     "description": "ServiceSpec describes the attributes that a user creates on a service.",
-    "required": [
-     "ports"
-    ],
     "properties": {
      "ports": {
       "type": "array",

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -8328,7 +8328,7 @@ Examples:<br>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ports</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">The list of ports that are exposed by this service. More info: <a href="http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies">http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies</a></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_serviceport">v1.ServicePort</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -8620,7 +8620,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-12-05 09:52:00 UTC
+Last updated 2016-12-07 11:17:17 UTC
 </div>
 </div>
 </body>

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -9774,9 +9774,6 @@
    },
    "v1.ServiceSpec": {
     "description": "ServiceSpec describes the attributes that a user creates on a service.",
-    "required": [
-     "ports"
-    ],
     "properties": {
      "clusterIP": {
       "description": "clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are \"None\", empty string (\"\"), or a valid IP address. \"None\" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -33967,6 +33967,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			var yyq2588 [10]bool
 			_, _, _ = yysep2588, yyq2588, yy2arr2588
 			const yyr2588 bool = false
+			yyq2588[0] = len(x.Ports) != 0
 			yyq2588[1] = len(x.Selector) != 0
 			yyq2588[2] = x.ClusterIP != ""
 			yyq2588[3] = x.Type != ""
@@ -33980,7 +33981,7 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			if yyr2588 || yy2arr2588 {
 				r.EncodeArrayStart(10)
 			} else {
-				yynn2588 = 1
+				yynn2588 = 0
 				for _, b := range yyq2588 {
 					if b {
 						yynn2588++
@@ -33991,28 +33992,34 @@ func (x *ServiceSpec) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2588 || yy2arr2588 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.Ports == nil {
-					r.EncodeNil()
-				} else {
-					yym2590 := z.EncBinary()
-					_ = yym2590
-					if false {
+				if yyq2588[0] {
+					if x.Ports == nil {
+						r.EncodeNil()
 					} else {
-						h.encSliceServicePort(([]ServicePort)(x.Ports), e)
+						yym2590 := z.EncBinary()
+						_ = yym2590
+						if false {
+						} else {
+							h.encSliceServicePort(([]ServicePort)(x.Ports), e)
+						}
 					}
+				} else {
+					r.EncodeNil()
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("ports"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.Ports == nil {
-					r.EncodeNil()
-				} else {
-					yym2591 := z.EncBinary()
-					_ = yym2591
-					if false {
+				if yyq2588[0] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("ports"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Ports == nil {
+						r.EncodeNil()
 					} else {
-						h.encSliceServicePort(([]ServicePort)(x.Ports), e)
+						yym2591 := z.EncBinary()
+						_ = yym2591
+						if false {
+						} else {
+							h.encSliceServicePort(([]ServicePort)(x.Ports), e)
+						}
 					}
 				}
 			}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2491,7 +2491,7 @@ type LoadBalancerIngress struct {
 type ServiceSpec struct {
 	// The list of ports that are exposed by this service.
 	// More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
-	Ports []ServicePort `json:"ports" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
+	Ports []ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
 
 	// Route service traffic to pods with label keys and values matching this
 	// selector. If empty or not present, the service is assumed to have an

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -12678,7 +12678,6 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 						},
 					},
 				},
-				Required: []string{"ports"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
Ports values had to be specified for all types of services but object with service type "ExternalName" does't define ports. That's why we had to remove required condition.
Presence of ports in service types where ports are actually required is verified here: 
https://github.com/kubernetes/kubernetes/blob/master/pkg/api/validation/validation.go#L2439

For more information about ExternalName services see:
http://kubernetes.io/docs/user-guide/services/#services-without-selectors

Fixes https://github.com/kubernetes/kubernetes/issues/34394