### PR TITLE
e2e: mark 3rd portforwarding test as flaky

### DIFF
--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -174,7 +174,7 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 	f := framework.NewDefaultFramework("port-forwarding")
 
 	framework.KubeDescribe("With a server that expects a client request", func() {
-		It("should support a client that connects, sends no data, and disconnects [Conformance]", func() {
+		It("should support a client that connects, sends no data, and disconnects [Conformance] [Flaky]", func() {
 			By("creating the target pod")
 			pod := pfPod("abc", "1", "1", "1")
 			if _, err := f.ClientSet.Core().Pods(f.Namespace.Name).Create(pod); err != nil {


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/38194 and https://github.com/kubernetes/kubernetes/issues/27680#issuecomment-265392033.

cc @kubernetes/sig-testing