### PR TITLE
Increase Kibana e2e test timeout

### DIFF
--- a/test/e2e/kibana_logging.go
+++ b/test/e2e/kibana_logging.go
@@ -51,7 +51,7 @@ const (
 // ClusterLevelLoggingWithKibana is an end to end test that checks to see if Kibana is alive.
 func ClusterLevelLoggingWithKibana(f *framework.Framework) {
 	// graceTime is how long to keep retrying requests for status information.
-	const graceTime = 10 * time.Minute
+	const graceTime = 20 * time.Minute
 
 	// Check for the existence of the Kibana service.
 	By("Checking the Kibana service exists.")


### PR DESCRIPTION
10 minutes is not always enough to start kibana instance, most probably increasing the timeout will fix https://github.com/kubernetes/kubernetes/issues/36809

Follow-up of https://github.com/kubernetes/kubernetes/pull/36192

CC @piosz 