### PR TITLE
Avoid exporting fluentd-es own logs

### DIFF
--- a/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
+++ b/cluster/saltbase/salt/fluentd-es/fluentd-es.yaml
@@ -9,6 +9,10 @@ spec:
   containers:
   - name: fluentd-elasticsearch
     image: gcr.io/google_containers/fluentd-elasticsearch:1.20
+    command:
+      - '/bin/sh'
+      - '-c'
+      - '/usr/sbin/td-agent 2>&1 >>/var/log/fluentd.log'
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/38213 for fluentd-es version

CC @piosz 