### PR TITLE
add authentication/authorization to kubernetes-discovery

### DIFF
--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -343,6 +343,46 @@ func (c *Config) ApplyAuthenticationOptions(o *options.BuiltInAuthenticationOpti
 	return c, nil
 }
 
+func (c *Config) ApplyDelegatingAuthenticationOptions(o *options.DelegatingAuthenticationOptions) (*Config, error) {
+	if o == nil {
+		return c, nil
+	}
+
+	cfg, err := o.ToAuthenticationConfig()
+	if err != nil {
+		return nil, err
+	}
+	authenticator, securityDefinitions, err := cfg.New()
+	if err != nil {
+		return nil, err
+	}
+
+	c.Authenticator = authenticator
+	c.OpenAPIConfig.SecurityDefinitions = securityDefinitions
+	c.SupportsBasicAuth = false
+
+	return c, nil
+}
+
+func (c *Config) ApplyDelegatingAuthorizationOptions(o *options.DelegatingAuthorizationOptions) (*Config, error) {
+	if o == nil {
+		return c, nil
+	}
+
+	cfg, err := o.ToAuthorizationConfig()
+	if err != nil {
+		return nil, err
+	}
+	authorizer, err := cfg.New()
+	if err != nil {
+		return nil, err
+	}
+
+	c.Authorizer = authorizer
+
+	return c, nil
+}
+
 // ApplyOptions applies the run options to the method receiver and returns self
 func (c *Config) ApplyOptions(options *options.ServerRunOptions) *Config {
 	if len(options.AuditLogPath) != 0 {

--- a/pkg/genericapiserver/options/authorization.go
+++ b/pkg/genericapiserver/options/authorization.go
@@ -111,8 +111,9 @@ type DelegatingAuthorizationOptions struct {
 
 func NewDelegatingAuthorizationOptions() *DelegatingAuthorizationOptions {
 	return &DelegatingAuthorizationOptions{
-		AllowCacheTTL: 5 * time.Minute,
-		DenyCacheTTL:  30 * time.Second,
+		// very low for responsiveness, but high enough to handle storms
+		AllowCacheTTL: 10 * time.Second,
+		DenyCacheTTL:  10 * time.Second,
 	}
 }
 
@@ -125,6 +126,14 @@ func (s *DelegatingAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.RemoteKubeConfigFile, "authorization-kubeconfig", s.RemoteKubeConfigFile, ""+
 		"kubeconfig file pointing at the 'core' kubernetes server with enough rights to create "+
 		" subjectaccessreviews.authorization.k8s.io.")
+
+	fs.DurationVar(&s.AllowCacheTTL, "authorization-webhook-cache-authorized-ttl",
+		s.AllowCacheTTL,
+		"The duration to cache 'authorized' responses from the webhook authorizer.")
+
+	fs.DurationVar(&s.DenyCacheTTL,
+		"authorization-webhook-cache-unauthorized-ttl", s.DenyCacheTTL,
+		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
 }
 
 func (s *DelegatingAuthorizationOptions) ToAuthorizationConfig() (authorizer.DelegatingAuthorizerConfig, error) {


### PR DESCRIPTION
Wires authentication and authorization into `kubernetes-discovery` and re-enables the `local-up-cluster.sh` along with proper permission granting for RBAC cases.

@sttts @liggitt 