### PR TITLE
typo found with controller comment for framework_test.

### DIFF
--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -888,7 +888,7 @@ func wrapTestWithInjectedOperation(toWrap testCall, injectBeforeOperation func(c
 			atomic.StoreInt32(&testFinished, 1)
 		}()
 
-		// Wait for the controler to finish the test function.
+		// Wait for the controller to finish the test function.
 		for atomic.LoadInt32(&testFinished) == 0 {
 			time.Sleep(time.Millisecond * 10)
 		}


### PR DESCRIPTION


**What this PR does / why we need it**: fix test comment typo


**Release note**:
`NONE`

