### PR TITLE
Mark kube-proxy as critical

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -41,6 +41,9 @@ metadata:
   labels:
     tier: node
     component: kube-proxy
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+    scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
 spec:
   hostNetwork: true
   containers:


### PR DESCRIPTION
kube-proxy should not be evicted for resources, pretty much ever.

Probably want this in 1.5, but 1.5.1 is OK - @saad-ali 