### PR TITLE
Adds docs for dns-horizontal-autoscaler and kube-dns

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/MAINTAINERS.md
+++ b/cluster/addons/dns-horizontal-autoscaler/MAINTAINERS.md
@@ -1,0 +1,6 @@
+# Maintainers
+
+Zihong Zheng <zihongz@google.com>
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns-horizontal-autoscaler/MAINTAINERS.md?pixel)]()

--- a/cluster/addons/dns-horizontal-autoscaler/README.md
+++ b/cluster/addons/dns-horizontal-autoscaler/README.md
@@ -1,0 +1,12 @@
+# DNS Horizontal Autoscaler
+
+DNS Horizontal Autoscaler enables horizontal autoscaling feature for DNS service
+in Kubernetes clusters. This autoscaler runs as a Deployment. It collects cluster
+status from the APIServer, horizontally scales the number of DNS backends based
+on demand. Autoscaling parameters could be tuned by modifying the `kube-dns-autoscaler`
+ConfigMap in `kube-system` namespace.
+
+Learn more at: https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns-horizontal-autoscaler/README.md?pixel)]()

--- a/cluster/addons/dns/README.md
+++ b/cluster/addons/dns/README.md
@@ -1,4 +1,26 @@
-# SkyDNS Replication Controllers and Service templates
+# kube-dns
+kube-dns schedules DNS Pods and Service on the cluster, other pods in cluster can
+use the DNS Service’s IP to resolve DNS names.
+
+More details on http://kubernetes.io/docs/admin/dns/.
+
+## Manually scale kube-dns Deployment
+kube-dns creates only one DNS Pod by default. If
+[dns-horizontal-autoscaler](../dns-horizontal-autoscaler/)
+is not enabled, you may need to manually scale kube-dns Deployment.
+
+Please use below `kubectl scale` command to scale:
+```
+kubectl --namespace=kube-system scale deployment kube-dns --replicas=<NUM_YOU_WANT>
+```
+
+Do not use `kubectl edit` to modify kube-dns Deployment object if it is controlled by
+[Addon Manager](../addon-manager/). Otherwise the modifications will be clobbered,
+in addition the replicas count for kube-dns Deployment will be reset to 1. See
+[Cluster add-ons README](../README.md) and [#36411](https://github.com/kubernetes/kubernetes/issues/36411)
+for reference.
+
+## kube-dns Deployment and Service templates
 
 This directory contains the base UNDERSCORE templates that can be used
 to generate the skydns-rc.yaml.in and skydns.rc.yaml.in needed in Salt format.
@@ -15,7 +37,7 @@ cd kubernetes
 find [a-zA-Z0-9]* -type f -exec grep skydns-rc.yaml \{\} \; -print -exec echo \;
 ```
 
-## Base Template files
+### Base Template files
 
 These are the authoritative base templates.
 Run 'make' to generate the Salt and Sed yaml templates from these.
@@ -23,12 +45,12 @@ Run 'make' to generate the Salt and Sed yaml templates from these.
 skydns-rc.yaml.base
 skydns-svc.yaml.base
 
-## Generated Salt files
+### Generated Salt files
 
 skydns-rc.yaml.in
 skydns-svc.yaml.in
 
-## Generated Sed files
+### Generated Sed files
 
 skydns-rc.yaml.sed
 skydns-svc.yaml.sed


### PR DESCRIPTION
Although we have separate docs on kubernetes.io, we should have a short description about the dns-horizontal-autoscaler addon in folder.

Also updates kube-dns README with example command to scale kube-dns Deployment. This is needed because Addon Manager v6 has stricter reconcile behavior.

@bowei @bprashanth @thockin 