### PR TITLE
Let DirectEncoder take a hint of what gvk to set during its construction

### DIFF
--- a/pkg/runtime/serializer/codec_factory.go
+++ b/pkg/runtime/serializer/codec_factory.go
@@ -220,9 +220,10 @@ type DirectCodecFactory struct {
 	CodecFactory
 }
 
-// EncoderForVersion returns an encoder that does not do conversion. gv is ignored.
-func (f DirectCodecFactory) EncoderForVersion(serializer runtime.Encoder, _ runtime.GroupVersioner) runtime.Encoder {
+// EncoderForVersion returns an encoder that does not do conversion.
+func (f DirectCodecFactory) EncoderForVersion(serializer runtime.Encoder, version runtime.GroupVersioner) runtime.Encoder {
 	return versioning.DirectEncoder{
+		Version:     version,
 		Encoder:     serializer,
 		ObjectTyper: f.CodecFactory.scheme,
 	}


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubeadm/issues/52.

The issue was that when the kubeadm binary executed `c.Extensions().Deployments().Delete(&v1.DeleteOptions{})`, the DeleteOptions.APIVersion is set as `kubeadm.k8s.io/v1alpha` in the serialized format. API server couldn't decode that.

With this PR, `DeleteOptions.APIVersion` will be set to `extensions.v1beta1` in the serialized format.

cc @mikedanese @luxas 

@kubernetes/sig-api-machinery 