### PR TITLE
cluster: bindmount more cert paths

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -53,6 +53,9 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+            - name: usr-ca-certs
+              mountPath: /usr/share/ca-certificates
+              readOnly: true
         - image: gcr.io/google_containers/heapster:v1.2.0
           name: eventer
           command:
@@ -62,6 +65,9 @@ spec:
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
+              readOnly: true
+            - name: usr-ca-certs
+              mountPath: /usr/share/ca-certificates
               readOnly: true
         - image: gcr.io/google_containers/addon-resizer:1.6
           name: heapster-nanny
@@ -125,3 +131,6 @@ spec:
         - name: ssl-certs
           hostPath:
             path: "/etc/ssl/certs"
+        - name: usr-ca-certs
+          hostPath:
+            path: "/usr/share/ca-certificates"

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -54,6 +54,9 @@ spec:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
               readOnly: true
+            - name: usr-ca-certs
+              mountPath: /usr/share/ca-certificates
+              readOnly: true
         - image: gcr.io/google_containers/heapster:v1.2.0
           name: eventer
           command:
@@ -63,6 +66,9 @@ spec:
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
+              readOnly: true
+            - name: usr-ca-certs
+              mountPath: /usr/share/ca-certificates
               readOnly: true
         - image: gcr.io/google_containers/addon-resizer:1.6
           name: heapster-nanny
@@ -126,3 +132,6 @@ spec:
         - name: ssl-certs
           hostPath:
             path: "/etc/ssl/certs"
+        - name: usr-ca-certs
+          hostPath:
+            path: "/usr/share/ca-certificates"

--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -46,6 +46,11 @@
                         "mountPath": "/etc/ssl/certs"
                     },
                     {
+                        "name": "usrsharecacerts",
+                        "readOnly": true,
+                        "mountPath": "/usr/share/ca-certificates"
+                    },
+                    {
                         "name": "logfile",
                         "mountPath": "/var/log/cluster-autoscaler.log",
                         "readOnly": false
@@ -61,6 +66,12 @@
                 "name": "ssl-certs",
                 "hostPath": {
                     "path": "/etc/ssl/certs"
+                }
+            },
+            {
+                "name": "usrsharecacerts",
+                "hostPath": {
+                    "path": "/usr/share/ca-certificates"
                 }
             },
             {

--- a/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
+++ b/cluster/saltbase/salt/kube-apiserver/kube-apiserver.manifest
@@ -236,6 +236,9 @@
         { "name": "etcssl",
         "mountPath": "/etc/ssl",
         "readOnly": true},
+        { "name": "usrsharecacerts",
+        "mountPath": "/usr/share/ca-certificates",
+        "readOnly": true},
         { "name": "varssl",
         "mountPath": "/var/ssl",
         "readOnly": true},
@@ -269,6 +272,10 @@
   { "name": "etcssl",
     "hostPath": {
         "path": "/etc/ssl"}
+  },
+  { "name": "usrsharecacerts",
+    "hostPath": {
+        "path": "/usr/share/ca-certificates"}
   },
   { "name": "varssl",
     "hostPath": {

--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -134,6 +134,9 @@
         { "name": "etcssl",
         "mountPath": "/etc/ssl",
         "readOnly": true},
+        { "name": "usrsharecacerts",
+        "mountPath": "/usr/share/ca-certificates",
+        "readOnly": true},
         { "name": "varssl",
         "mountPath": "/var/ssl",
         "readOnly": true},
@@ -160,6 +163,10 @@
   { "name": "etcssl",
     "hostPath": {
         "path": "/etc/ssl"}
+  },
+  { "name": "usrsharecacerts",
+    "hostPath": {
+        "path": "/usr/share/ca-certificates"}
   },
   { "name": "varssl",
     "hostPath": {

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -57,7 +57,10 @@ spec:
       privileged: true
     volumeMounts:
     - mountPath: /etc/ssl/certs
-      name: ssl-certs-host
+      name: etc-ssl-certs
+      readOnly: true
+    - mountPath: /usr/share/ca-certificates
+      name: usr-ca-certs
       readOnly: true
     - mountPath: /var/log
       name: varlog
@@ -68,7 +71,10 @@ spec:
   volumes:
   - hostPath:
       path: /usr/share/ca-certificates
-    name: ssl-certs-host
+    name: usr-ca-certs
+  - hostPath:
+      path: /etc/ssl/certs
+    name: etc-ssl-certs
   - hostPath:
       path: /var/lib/kube-proxy/kubeconfig
     name: kubeconfig


### PR DESCRIPTION
**What this PR does / why we need it**:

/etc/ssl/certs is currently mounted through in a number of places.
However, on Gentoo and CoreOS (and probably others), the files in
/etc/ssl/certs are just symlinks to files in /usr/share/ca-certificates.

For these components to correclty work, the target of the symlinks needs
to be available as well.

This is especially important for kube-controller-manager, where this
issue was noticed.



**Special notes for your reviewer**:

This change was originally part of #33965, but was split out for ease of
review.

**Release note**:

```release-note
NONE
```