### PR TITLE
Remove Azure Subnet RouteTable check

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_routes.go
+++ b/pkg/cloudprovider/providers/azure/azure_routes.go
@@ -87,27 +87,6 @@ func (az *Cloud) CreateRoute(clusterName string, nameHint string, kubeRoute *clo
 		}
 	}
 
-	// ensure the subnet is properly configured
-	subnet, err := az.SubnetsClient.Get(az.ResourceGroup, az.VnetName, az.SubnetName, "")
-	if err != nil {
-		// 404 is fatal here
-		return err
-	}
-	if subnet.RouteTable != nil {
-		if *subnet.RouteTable.ID != *routeTable.ID {
-			return fmt.Errorf("The subnet has a route table, but it was unrecognized. Refusing to modify it. active_routetable=%q expected_routetable=%q", *subnet.RouteTable.ID, *routeTable.ID)
-		}
-	} else {
-		subnet.RouteTable = &network.RouteTable{
-			ID: routeTable.ID,
-		}
-		glog.V(3).Info("create: updating subnet")
-		_, err := az.SubnetsClient.CreateOrUpdate(az.ResourceGroup, az.VnetName, az.SubnetName, subnet, nil)
-		if err != nil {
-			return err
-		}
-	}
-
 	targetIP, err := az.getIPForMachine(kubeRoute.TargetNode)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

PR Removes the subnet configuration check for Azure cloudprovider. The subnet check ensures that the subnet is associated with the Route Table. However if the VNET is in a different Azure Resource Group then the check fails, even if the subnet is already valid. This a stop gap fix, to allow Kubernetes to be deployed to Custom VNETs in Azure, that may reside in a different resource group to the cluster.

fixes #38134 

@colemickens 

