### PR TITLE
Make StrategicPatch delete all matching maps in a merging list

### DIFF
--- a/pkg/util/strategicpatch/patch.go
+++ b/pkg/util/strategicpatch/patch.go
@@ -656,12 +656,16 @@ func mergeSlice(original, patch []interface{}, elemType reflect.Type, mergeKey s
 			if patchType == deleteDirective {
 				mergeValue, ok := typedV[mergeKey]
 				if ok {
-					_, originalKey, found, err := findMapInSliceBasedOnKeyValue(original, mergeKey, mergeValue)
-					if err != nil {
-						return nil, err
-					}
+					// delete all matching entries (based on merge key) from a merging list
+					for {
+						_, originalKey, found, err := findMapInSliceBasedOnKeyValue(original, mergeKey, mergeValue)
+						if err != nil {
+							return nil, err
+						}
 
-					if found {
+						if !found {
+							break
+						}
 						// Delete the element at originalKey.
 						original = append(original[:originalKey], original[originalKey+1:]...)
 					}

--- a/pkg/util/strategicpatch/patch_test.go
+++ b/pkg/util/strategicpatch/patch_test.go
@@ -308,6 +308,25 @@ testCases:
       $patch: replace
     modified:
       other: a
+  - description: delete all duplicate entries in a merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 1
+        - name: 2
+          value: a
+        - name: 3
+        - name: 3
+    twoWay:
+      mergingList:
+        - name: 1
+          $patch: delete
+        - name: 3
+          $patch: delete
+    modified:
+      mergingList:
+        - name: 2
+          value: a
 `)
 
 func TestCustomStrategicMergePatch(t *testing.T) {


### PR DESCRIPTION
fixes #38332

```release-note
NONE
```

cc: @lavalamp @pwittrock 