### PR TITLE
pkg/volume: RenameDirectory updates for go 1.8

### DIFF
--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -321,15 +321,7 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 }
 
 func (ed *emptyDir) teardownDefault(dir string) error {
-	tmpDir, err := volume.RenameDirectory(dir, ed.volName+".deleting~")
-	if err != nil {
-		return err
-	}
-	err = os.RemoveAll(tmpDir)
-	if err != nil {
-		return err
-	}
-	return nil
+	return volume.RenameWithFallback(dir, ed.volName+".deleting~")
 }
 
 func (ed *emptyDir) teardownTmpfs(dir string) error {


### PR DESCRIPTION
`os.Rename()` changed in go1.8 to work the same on unix as on Windows.
see https://beta.golang.org/doc/go1.8#os

This updates the `RenameDirectory` function to take that into account in
preparation for go1.8.

updates #38228