### PR TITLE
trimspace on user specified env params

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/env.go
+++ b/cmd/kubeadm/app/apis/kubeadm/env.go
@@ -43,7 +43,7 @@ func SetEnvParams() *EnvParams {
 	}
 
 	for k := range envParams {
-		if v := os.Getenv(fmt.Sprintf("KUBE_%s", strings.ToUpper(k))); v != "" {
+		if v := strings.TrimSpace(os.Getenv(fmt.Sprintf("KUBE_%s", strings.ToUpper(k)))); v != "" {
 			envParams[k] = v
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
before this PR, for example, if user `export KUBE_REPO_PREFIX=" "`, kubeadm will get an absolutely invalid repo_prefix.
this PR trims all leading and trailing white spaces from user specified env params.

Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>