### PR TITLE
fix start_discovery in local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -514,7 +514,17 @@ function start_discovery {
     write_client_kubeconfig discovery-auth
 
     # grant permission to run delegated authentication and authorization checks
-    kubectl create clusterrolebinding discovery:system:auth-delegator --clusterrole=system:auth-delegator --user=system:discovery-auth
+    if [[ "${ENABLE_RBAC}" = true ]]; then
+        ${KUBECTL} ${AUTH_ARGS} create clusterrolebinding discovery:system:auth-delegator --clusterrole=system:auth-delegator --user=system:discovery-auth
+    fi
+
+    curl --silent -k -g $API_HOST:$DISCOVERY_SECURE_PORT
+    if [ ! $? -eq 0 ]; then
+        echo "Kubernetes Discovery secure port is free, proceeding..."
+    else
+        echo "ERROR starting Kubernetes Discovery, exiting. Some process on $API_HOST is serving already on $DISCOVERY_SECURE_PORT"
+        return
+    fi
 
     DISCOVERY_SERVER_LOG=/tmp/kubernetes-discovery.log
     ${CONTROLPLANE_SUDO} "${GO_OUT}/kubernetes-discovery" \
@@ -749,6 +759,7 @@ Logs:
   ${CTLRMGR_LOG:-}
   ${PROXY_LOG:-}
   ${SCHEDULER_LOG:-}
+  ${DISCOVERY_SERVER_LOG:-}
 EOF
 fi
 


### PR DESCRIPTION
fix #38363 @deads2k

1.fix hack/local-up-cluster.sh: line 517: kubectl: command not found
2.check the use of $DISCOVERY_SECURE_PORT
3.add DISCOVERY_SERVER_LOG to prompt

