### PR TITLE
add health check for mysql-galera

### DIFF
--- a/examples/storage/mysql-galera/image/Dockerfile
+++ b/examples/storage/mysql-galera/image/Dockerfile
@@ -50,6 +50,7 @@ COPY my.cnf /etc/mysql/my.cnf
 COPY cluster.cnf /etc/mysql/conf.d/cluster.cnf
 
 COPY docker-entrypoint.sh /entrypoint.sh
+COPY healthz /usr/local/bin/healthz
 ENTRYPOINT ["/entrypoint.sh"]
 
 EXPOSE 3306 4444 4567 4568

--- a/examples/storage/mysql-galera/image/healthz
+++ b/examples/storage/mysql-galera/image/healthz
@@ -1,0 +1,2 @@
+#!/bin/bash
+mysql -u$MYSQL_USER -p$MYSQL_PASSWORD -e 'select version();' &>/dev/null

--- a/examples/storage/mysql-galera/pxc-node1.yaml
+++ b/examples/storage/mysql-galera/pxc-node1.yaml
@@ -35,6 +35,11 @@ spec:
               cpu: 0.3
           image: capttofu/percona_xtradb_cluster_5_6:beta
           name: pxc-node1
+          readinessProbe:
+            exec:
+              command: ["healthz"]
+            initialDelaySeconds: 20
+            timeoutSeconds: 5
           ports:
             - containerPort: 3306
             - containerPort: 4444

--- a/examples/storage/mysql-galera/pxc-node2.yaml
+++ b/examples/storage/mysql-galera/pxc-node2.yaml
@@ -36,6 +36,11 @@ spec:
               cpu: 0.3
           image: capttofu/percona_xtradb_cluster_5_6:beta
           name: pxc-node2
+          readinessProbe:
+            exec:
+              command: ["healthz"]
+            initialDelaySeconds: 20
+            timeoutSeconds: 5
           ports:
             - containerPort: 3306
             - containerPort: 4444

--- a/examples/storage/mysql-galera/pxc-node3.yaml
+++ b/examples/storage/mysql-galera/pxc-node3.yaml
@@ -36,6 +36,11 @@ spec:
               cpu: 0.3
           image: capttofu/percona_xtradb_cluster_5_6:beta
           name: pxc-node3
+          readinessProbe:
+            exec:
+              command: ["healthz"]
+            initialDelaySeconds: 20
+            timeoutSeconds: 5
           ports:
             - containerPort: 3306
             - containerPort: 4444


### PR DESCRIPTION
**What this PR does / why we need it**:
  add health check for mysql-galera to avoid connection errors when some of the pods restart.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```

