### PR TITLE
Don't put licence template in godeps licences file

### DIFF
--- a/hack/update-godep-licenses.sh
+++ b/hack/update-godep-licenses.sh
@@ -134,17 +134,6 @@ TMP_LICENSE_FILE="/tmp/Godeps.LICENSES.$$"
 DEPS_DIR="vendor"
 declare -Ag CONTENT
 
-# Put the K8S LICENSE on top
-(
-echo "================================================================================"
-echo "= Kubernetes licensed under: ="
-echo
-cat ${LICENSE_ROOT}/LICENSE
-echo
-echo "= LICENSE $(cat ${LICENSE_ROOT}/LICENSE | md5sum)"
-echo "================================================================================"
-) > ${TMP_LICENSE_FILE}
-
 # Loop through every package in Godeps.json
 for PACKAGE in $(cat Godeps/Godeps.json | \
                  jq -r ".Deps[].ImportPath" | \


### PR DESCRIPTION
As described in https://github.com/kubernetes/kubernetes-template-project/issues/3 LICENCE file in the root of the repo is not a Kubernetes licence, so it shouldn't be used as such.

Bit of overview: https://github.com/kubernetes/kubernetes/pull/37305 change

CC @jbeda @mikedanese @david-mcmahon 


