### PR TITLE
Fix local up cluster dns with RBAC

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -401,6 +401,14 @@ contexts:
     name: local-up-cluster
 current-context: local-up-cluster
 EOF
+
+    # flatten the kubeconfig files to make them self contained
+    username=$(whoami)
+    ${CONTROLPLANE_SUDO} /bin/bash -e <<EOF
+    ${GO_OUT}/kubectl --kubeconfig="${CERT_DIR}/$1.kubeconfig" config view --minify --flatten > "/tmp/$1.kubeconfig"
+    mv -f "/tmp/$1.kubeconfig" "${CERT_DIR}/$1.kubeconfig"
+    chown ${username} "${CERT_DIR}/$1.kubeconfig"
+EOF
 }
 
 function start_apiserver {
@@ -724,7 +732,6 @@ function start_kubeproxy {
 }
 
 function start_kubedns {
-
     if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
         echo "Creating kube-system namespace"
         sed -e "s/{{ pillar\['dns_replicas'\] }}/${DNS_REPLICAS}/g;s/{{ pillar\['dns_domain'\] }}/${DNS_DOMAIN}/g;" "${KUBE_ROOT}/cluster/addons/dns/skydns-rc.yaml.in" >| skydns-rc.yaml
@@ -742,18 +749,15 @@ function start_kubedns {
           sed -i -e "/{{ pillar\['federations_domain_map'\] }}/d" skydns-rc.yaml
         fi
         sed -e "s/{{ pillar\['dns_server'\] }}/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/addons/dns/skydns-svc.yaml.in" >| skydns-svc.yaml
-        export KUBERNETES_PROVIDER=local
-        ${KUBECTL} config set-cluster local --server=https://${API_HOST}:${API_SECURE_PORT} --certificate-authority=${ROOT_CA_FILE}
-        ${KUBECTL} config set-credentials myself --username=admin --password=admin
-        ${KUBECTL} config set-context local --cluster=local --user=myself
-        ${KUBECTL} config use-context local
-
+        
+        # TODO update to dns role once we have one.
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" create clusterrolebinding system:kube-dns --clusterrole=cluster-admin --serviceaccount=kube-system:default
         # use kubectl to create skydns rc and service
-        ${KUBECTL} --namespace=kube-system create -f skydns-rc.yaml
-        ${KUBECTL} --namespace=kube-system create -f skydns-svc.yaml
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system create -f skydns-rc.yaml
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system create -f skydns-svc.yaml
         echo "Kube-dns rc and service successfully deployed."
+        rm  skydns-rc.yaml skydns-svc.yaml
     fi
-
 }
 
 function print_success {

--- a/pkg/kubectl/clusterrolebinding.go
+++ b/pkg/kubectl/clusterrolebinding.go
@@ -19,6 +19,8 @@ package kubectl
 import (
 	"fmt"
 
+	"strings"
+
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/runtime"
 )
@@ -33,6 +35,8 @@ type ClusterRoleBindingGeneratorV1 struct {
 	Users []string
 	// Groups to derive the clusterRoleBinding from (optional)
 	Groups []string
+	// ServiceAccounts to derive the clusterRoleBinding from in namespace:name format(optional)
+	ServiceAccounts []string
 }
 
 // Ensure it supports the generator pattern that uses parameter injection.
@@ -66,6 +70,15 @@ func (s ClusterRoleBindingGeneratorV1) Generate(genericParams map[string]interfa
 		delegate.Groups = fromLiteralArray
 		delete(genericParams, "group")
 	}
+	fromSAStrings, found := genericParams["serviceaccount"]
+	if found {
+		fromLiteralArray, isArray := fromSAStrings.([]string)
+		if !isArray {
+			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+		}
+		delegate.ServiceAccounts = fromLiteralArray
+		delete(genericParams, "serviceaccounts")
+	}
 	params := map[string]string{}
 	for key, value := range genericParams {
 		strVal, isString := value.(string)
@@ -86,6 +99,7 @@ func (s ClusterRoleBindingGeneratorV1) ParamNames() []GeneratorParam {
 		{"clusterrole", false},
 		{"user", false},
 		{"group", false},
+		{"serviceaccount", false},
 		{"force", false},
 	}
 }
@@ -109,11 +123,15 @@ func (s ClusterRoleBindingGeneratorV1) StructuredGenerate() (runtime.Object, err
 			Name:       user,
 		})
 	}
-	for _, group := range s.Groups {
+	for _, sa := range s.ServiceAccounts {
+		tokens := strings.Split(sa, ":")
+		if len(tokens) != 2 {
+			return nil, fmt.Errorf("serviceaccount must be <namespace>:<name>")
+		}
 		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbac.Subject{
-			Kind:       rbac.GroupKind,
-			APIVersion: "rbac/v1alpha1",
-			Name:       group,
+			Kind:      rbac.ServiceAccountKind,
+			Namespace: tokens[0],
+			Name:      tokens[1],
 		})
 	}
 

--- a/pkg/kubectl/cmd/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding.go
@@ -55,6 +55,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.
 	cmd.Flags().String("clusterrole", "", "ClusterRole this ClusterRoleBinding should reference")
 	cmd.Flags().StringSlice("user", []string{}, "usernames to bind to the role")
 	cmd.Flags().StringSlice("group", []string{}, "groups to bind to the role")
+	cmd.Flags().StringSlice("serviceaccount", []string{}, "service accounts to bind to the role")
 	return cmd
 }
 
@@ -68,10 +69,11 @@ func CreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Co
 	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
 	case cmdutil.ClusterRoleBindingV1GeneratorName:
 		generator = &kubectl.ClusterRoleBindingGeneratorV1{
-			Name:        name,
-			ClusterRole: cmdutil.GetFlagString(cmd, "clusterrole"),
-			Users:       cmdutil.GetFlagStringSlice(cmd, "user"),
-			Groups:      cmdutil.GetFlagStringSlice(cmd, "group"),
+			Name:            name,
+			ClusterRole:     cmdutil.GetFlagString(cmd, "clusterrole"),
+			Users:           cmdutil.GetFlagStringSlice(cmd, "user"),
+			Groups:          cmdutil.GetFlagStringSlice(cmd, "group"),
+			ServiceAccounts: cmdutil.GetFlagStringSlice(cmd, "serviceaccount"),
 		}
 	default:
 		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator: %s not supported.", generatorName))


### PR DESCRIPTION
The DNS server needs permissions to run using RBAC.  This does it with a big hammer before we sort out tight permissions.

@fabianofranz for the CLI change
@xilabao for the local-up-cluster change