### PR TITLE
WIP: Kubeadm self-hosted deployment type

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"time"
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
@@ -49,6 +50,9 @@ var (
 
 		kubeadm join --discovery %s
 		`)
+	deploymentStaticPod  = "static-pods"
+	deploymentSelfHosted = "self-hosted"
+	deploymentTypes      = []string{deploymentStaticPod, deploymentSelfHosted}
 )
 
 // NewCmdInit returns "kubeadm init" command.
@@ -60,11 +64,12 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 
 	var cfgPath string
 	var skipPreFlight bool
+	var deploymentType string // static pods, self-hosted, etc.
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Run this in order to set up the Kubernetes master",
 		Run: func(cmd *cobra.Command, args []string) {
-			i, err := NewInit(cfgPath, &cfg, skipPreFlight)
+			i, err := NewInit(cfgPath, &cfg, skipPreFlight, deploymentType)
 			kubeadmutil.CheckErr(err)
 			kubeadmutil.CheckErr(i.Validate())
 			kubeadmutil.CheckErr(i.Run(out))
@@ -136,16 +141,20 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().Var(
 		discovery.NewDiscoveryValue(&cfg.Discovery), "discovery",
 		"The discovery method kubeadm will use for connecting nodes to the master",
+
+	cmd.PersistentFlags().StringVar(
+		&deploymentType, "deployment", deploymentType,
+		fmt.Sprintf("specify a deployment type from %v", deploymentTypes),
 	)
 
+	cmd.PersistentFlags().Int32Var(
+		&cfg.API.BindPort, "api-port", cfg.API.BindPort,
+		"Port for API to bind to",
+	)
 	return cmd
 }
 
-type Init struct {
-	cfg *kubeadmapi.MasterConfiguration
-}
-
-func NewInit(cfgPath string, cfg *kubeadmapi.MasterConfiguration, skipPreFlight bool) (*Init, error) {
+func NewInit(cfgPath string, cfg *kubeadmapi.MasterConfiguration, skipPreFlight bool, deploymentType string) (Init, error) {
 
 	fmt.Println("[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.")
 
@@ -205,15 +214,45 @@ func NewInit(cfgPath string, cfg *kubeadmapi.MasterConfiguration, skipPreFlight 
 		fmt.Println("\t(/etc/systemd/system/kubelet.service.d/10-kubeadm.conf should be edited for this purpose)")
 	}
 
-	return &Init{cfg: cfg}, nil
+	var deploymentTypeValid bool
+	for _, supportedDT := range deploymentTypes {
+		if deploymentType == supportedDT {
+			deploymentTypeValid = true
+		}
+	}
+	if !deploymentTypeValid {
+		return nil, fmt.Errorf("%s is not a valid deployment type, you can use any of %v or leave unset to accept the default", deploymentType, deploymentTypes)
+	}
+	if deploymentType == deploymentSelfHosted {
+		fmt.Println("[init] Creating self-hosted Kubernetes deployment...")
+		return &SelfHostedInit{cfg: cfg}, nil
+	}
+
+	fmt.Println("[init] Creating static pod Kubernetes deployment...")
+	return &StaticPodInit{cfg: cfg}, nil
 }
 
 func (i *Init) Validate() error {
 	return validation.ValidateMasterConfiguration(i.cfg).ToAggregate()
 }
 
+// Init structs define implementations of the cluster setup for each supported
+// delpoyment type.
+type Init interface {
+	Cfg() *kubeadmapi.MasterConfiguration
+	Run(out io.Writer) error
+}
+
+type StaticPodInit struct {
+	cfg *kubeadmapi.MasterConfiguration
+}
+
+func (spi *StaticPodInit) Cfg() *kubeadmapi.MasterConfiguration {
+	return spi.cfg
+}
+
 // Run executes master node provisioning, including certificates, needed static pod manifests, etc.
-func (i *Init) Run(out io.Writer) error {
+func (i *StaticPodInit) Run(out io.Writer) error {
 
 	if i.cfg.Discovery.Token != nil {
 		if err := kubemaster.PrepareTokenDiscovery(i.cfg.Discovery.Token); err != nil {
@@ -273,6 +312,99 @@ func (i *Init) Run(out io.Writer) error {
 	}
 
 	fmt.Fprintf(out, initDoneMsgf, generateJoinArgs(i.cfg))
+	return nil
+}
+
+// SelfHostedInit initializes a self-hosted cluster.
+type SelfHostedInit struct {
+	cfg *kubeadmapi.MasterConfiguration
+}
+
+func (spi *SelfHostedInit) Cfg() *kubeadmapi.MasterConfiguration {
+	return spi.cfg
+}
+
+// Run executes master node provisioning, including certificates, needed pod manifests, etc.
+func (i *SelfHostedInit) Run(out io.Writer) error {
+	if err := kubemaster.CreateTokenAuthFile(&i.cfg.Secrets); err != nil {
+		return err
+	}
+
+	if err := kubemaster.WriteStaticPodManifests(i.cfg); err != nil {
+		return err
+	}
+
+	caKey, caCert, err := kubemaster.CreatePKIAssets(i.cfg)
+	if err != nil {
+		return err
+	}
+
+	kubeconfigs, err := kubemaster.CreateCertsAndConfigForClients(i.cfg.API, []string{"kubelet", "admin"}, caKey, caCert)
+	if err != nil {
+		return err
+	}
+
+	// kubeadm is responsible for writing the following kubeconfig file, which
+	// kubelet should be waiting for. Help user avoid foot-shooting by refusing to
+	// write a file that has already been written (the kubelet will be up and
+	// running in that case - they'd need to stop the kubelet, remove the file, and
+	// start it again in that case).
+	// TODO(phase1+) this is no longer the right place to guard agains foo-shooting,
+	// we need to decide how to handle existing files (it may be handy to support
+	// importing existing files, may be we could even make our command idempotant,
+	// or at least allow for external PKI and stuff)
+	for name, kubeconfig := range kubeconfigs {
+		if err := kubeadmutil.WriteKubeconfigIfNotExists(name, kubeconfig); err != nil {
+			return err
+		}
+	}
+
+	client, err := kubemaster.CreateClientAndWaitForAPI(kubeconfigs["admin"])
+	if err != nil {
+		return err
+	}
+
+	schedulePodsOnMaster := false
+	if err := kubemaster.UpdateMasterRoleLabelsAndTaints(client, schedulePodsOnMaster); err != nil {
+		return err
+	}
+
+	// Temporary control plane is up, now we create our self hosted control
+	// plane components and remove the static manifests:
+	fmt.Println("[init] Creating self-hosted control plane...")
+	if err := kubemaster.CreateSelfHostedControlPlane(i.cfg, client); err != nil {
+		return err
+	}
+	// At this point the API server is running but cannot get the port it wants
+	// because of our temporary API server.
+
+	// TODO: Make sure the self hosted apiserver is up before we proceed here:
+	time.Sleep(20 * time.Second)
+
+	// Now we can remove the static pod manifests written earlier and let the
+	// self-hosted components take over:
+	fmt.Println("[init] Removing static pod manifests to transition to self-hosted control plane...")
+	if err := kubemaster.DeleteStaticManifests(); err != nil {
+		return err
+	}
+
+	// TODO: Let kubelet restart and come back up:
+	time.Sleep(20 * time.Second)
+
+	if err := kubemaster.CreateDiscoveryDeploymentAndSecret(i.cfg, client, caCert); err != nil {
+		return err
+	}
+
+	if err := kubemaster.CreateEssentialAddons(i.cfg, client); err != nil {
+		return err
+	}
+
+	data := joinArgsData{i.cfg, kubeadmapiext.DefaultAPIBindPort, kubeadmapiext.DefaultDiscoveryBindPort}
+	if joinArgs, err := generateJoinArgs(data); err != nil {
+		return err
+	} else {
+		fmt.Fprintf(out, initDoneMsgf, joinArgs)
+	}
 	return nil
 }
 

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"time"
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
@@ -377,21 +376,6 @@ func (i *SelfHostedInit) Run(out io.Writer) error {
 	if err := kubemaster.CreateSelfHostedControlPlane(i.cfg, client); err != nil {
 		return err
 	}
-	// At this point the API server is running but cannot get the port it wants
-	// because of our temporary API server.
-
-	// TODO: Make sure the self hosted apiserver is up before we proceed here:
-	time.Sleep(20 * time.Second)
-
-	// Now we can remove the static pod manifests written earlier and let the
-	// self-hosted components take over:
-	fmt.Println("[init] Removing static pod manifests to transition to self-hosted control plane...")
-	if err := kubemaster.DeleteStaticManifests(); err != nil {
-		return err
-	}
-
-	// TODO: Let kubelet restart and come back up:
-	time.Sleep(20 * time.Second)
 
 	if i.cfg.Discovery.Token != nil {
 		if err := kubemaster.CreateDiscoveryDeploymentAndSecret(i.cfg, client, caCert); err != nil {

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -148,6 +148,15 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 	return nil
 }
 
+func DeleteStaticManifests() error {
+	apiServerStaticManifestPath := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir,
+		"manifests", kubeAPIServer+".json")
+	if err := os.Remove(apiServerStaticManifestPath); err != nil {
+		return fmt.Errorf("unable to delete temporary API server manifest [%v]", err)
+	}
+	return nil
+}
+
 // etcdVolume exposes a path on the host in order to guarantee data survival during reboot.
 func etcdVolume(cfg *kubeadmapi.MasterConfiguration) api.Volume {
 	return api.Volume{

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -154,6 +154,12 @@ func DeleteStaticManifests() error {
 	if err := os.Remove(apiServerStaticManifestPath); err != nil {
 		return fmt.Errorf("unable to delete temporary API server manifest [%v]", err)
 	}
+
+	ctrlMgrStaticManifestPath := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir,
+		"manifests", kubeControllerManager+".json")
+	if err := os.Remove(ctrlMgrStaticManifestPath); err != nil {
+		return fmt.Errorf("unable to delete temporary controller manager manifest [%v]", err)
+	}
 	return nil
 }
 

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -160,6 +160,12 @@ func DeleteStaticManifests() error {
 	if err := os.Remove(ctrlMgrStaticManifestPath); err != nil {
 		return fmt.Errorf("unable to delete temporary controller manager manifest [%v]", err)
 	}
+
+	schedulerStaticManifestPath := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir,
+		"manifests", kubeScheduler+".json")
+	if err := os.Remove(schedulerStaticManifestPath); err != nil {
+		return fmt.Errorf("unable to delete temporary scheduler manifest [%v]", err)
+	}
 	return nil
 }
 

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -96,10 +96,12 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 			Env:           getProxyEnvVars(),
 		}, volumes...),
 		kubeScheduler: componentPod(api.Container{
-			Name:          kubeScheduler,
-			Image:         images.GetCoreImage(images.KubeSchedulerImage, cfg, kubeadmapi.GlobalEnvParams.HyperkubeImage),
-			Command:       getSchedulerCommand(cfg),
-			LivenessProbe: componentProbe(10251, "/healthz"),
+			Name:  kubeScheduler,
+			Image: images.GetCoreImage(images.KubeSchedulerImage, cfg, kubeadmapi.GlobalEnvParams.HyperkubeImage),
+			// TODO: Using non-standard port here so self-hosted scheduler can come up:
+			// Use the regular port if this is not going to be a self-hosted deployment.
+			Command:       getSchedulerCommand(cfg, 10260),
+			LivenessProbe: componentProbe(10260, "/healthz"),
 			Resources:     componentResources("100m"),
 			Env:           getProxyEnvVars(),
 		}),
@@ -398,11 +400,12 @@ func getControllerManagerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 	return command
 }
 
-func getSchedulerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
+func getSchedulerCommand(cfg *kubeadmapi.MasterConfiguration, schedulerPort int) []string {
 	return append(getComponentBaseCommand(scheduler),
 		"--address=127.0.0.1",
 		"--leader-elect",
 		"--master=127.0.0.1:8080",
+		fmt.Sprintf("--port=%d", schedulerPort),
 	)
 }
 

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -150,27 +150,6 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 	return nil
 }
 
-func DeleteStaticManifests() error {
-	apiServerStaticManifestPath := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir,
-		"manifests", kubeAPIServer+".json")
-	if err := os.Remove(apiServerStaticManifestPath); err != nil {
-		return fmt.Errorf("unable to delete temporary API server manifest [%v]", err)
-	}
-
-	ctrlMgrStaticManifestPath := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir,
-		"manifests", kubeControllerManager+".json")
-	if err := os.Remove(ctrlMgrStaticManifestPath); err != nil {
-		return fmt.Errorf("unable to delete temporary controller manager manifest [%v]", err)
-	}
-
-	schedulerStaticManifestPath := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir,
-		"manifests", kubeScheduler+".json")
-	if err := os.Remove(schedulerStaticManifestPath); err != nil {
-		return fmt.Errorf("unable to delete temporary scheduler manifest [%v]", err)
-	}
-	return nil
-}
-
 // etcdVolume exposes a path on the host in order to guarantee data survival during reboot.
 func etcdVolume(cfg *kubeadmapi.MasterConfiguration) api.Volume {
 	return api.Volume{

--- a/cmd/kubeadm/app/master/selfhosted.go
+++ b/cmd/kubeadm/app/master/selfhosted.go
@@ -1,0 +1,92 @@
+package master
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	ext "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+)
+
+// Sources from bootkube templates.go
+func getAPIServerDS(cfg *kubeadmapi.MasterConfiguration) ext.DaemonSet {
+
+	volumes := []v1.Volume{k8sVolume(cfg)}
+	volumeMounts := []v1.VolumeMount{k8sVolumeMount()}
+
+	if isCertsVolumeMountNeeded() {
+		volumes = append(volumes, certsVolume(cfg))
+		volumeMounts = append(volumeMounts, certsVolumeMount())
+	}
+
+	if isPkiVolumeMountNeeded() {
+		volumes = append(volumes, pkiVolume(cfg))
+		volumeMounts = append(volumeMounts, pkiVolumeMount())
+	}
+
+	ds := ext.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "extensions/v1beta1",
+			Kind:       "DaemonSet",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name:      kubeAPIServer,
+			Namespace: "kube-system",
+			// TODO: label from bootkube, not sure if necessary
+			Labels: map[string]string{"k8s-app": "kube-apiserver"},
+		},
+		Spec: ext.DaemonSetSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{
+						"k8s-app":   "kube-apiserver", // # TODO: from bootkube, not sure if necessary
+						"tier":      "control-plane",
+						"component": kubeAPIServer,
+					},
+				},
+				Spec: v1.PodSpec{
+					// TODO: Make sure masters get this label
+					NodeSelector: map[string]string{metav1.NodeLabelKubeadmAlphaRole: metav1.NodeLabelRoleMaster},
+					HostNetwork:  true,
+					Volumes:      volumes,
+
+					Containers: []v1.Container{
+						v1.Container{
+							Name:    kubeAPIServer,
+							Image:   images.GetCoreImage(images.KubeAPIServerImage, cfg, kubeadmapi.GlobalEnvParams.HyperkubeImage),
+							Command: getAPIServerCommand(cfg),
+							Env: []v1.EnvVar{
+								v1.EnvVar{
+									Name: "MY_POD_IP",
+									ValueFrom: &v1.EnvVarSource{
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "status.podIP",
+										},
+									},
+								},
+							},
+							VolumeMounts:  volumeMounts,
+							LivenessProbe: componentProbe(8080, "/healthz"),
+							Resources:     componentResources("250m"),
+						},
+					},
+				},
+			},
+		},
+	}
+	return ds
+}
+
+func CreateSelfHostedControlPlane(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
+	ds := getAPIServerDS(cfg)
+	fmt.Printf("%+v\n", ds)
+	if _, err := client.Extensions().DaemonSets(api.NamespaceSystem).Create(&ds); err != nil {
+		return fmt.Errorf("failed to create self-hosted %q DaemonSet [%v]", kubeAPIServer, err)
+	}
+	return nil
+}

--- a/cmd/kubeadm/app/master/selfhosted.go
+++ b/cmd/kubeadm/app/master/selfhosted.go
@@ -29,7 +29,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	ext "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
 
 func CreateSelfHostedControlPlane(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {

--- a/cmd/kubeadm/app/master/selfhosted.go
+++ b/cmd/kubeadm/app/master/selfhosted.go
@@ -114,7 +114,9 @@ func WaitForSelfHostedControlPlane(client *clientset.Clientset) error {
 	start := time.Now()
 	// TODO: Break this up into multiple wait's so we don't re-do every step:
 	wait.PollInfinite(apiCallRetryInterval, func() (bool, error) {
-		apiDS, err := client.DaemonSets(api.NamespaceSystem).Get(kubeAPIServer)
+		// TODO: This might be pointless, checking the pods is probably enough.
+		apiDS, err := client.DaemonSets(api.NamespaceSystem).Get(kubeAPIServer,
+			metav1.GetOptions{})
 		if err != nil {
 			fmt.Println("[debug] error getting apiserver DaemonSet:", err)
 			return false, nil
@@ -128,6 +130,7 @@ func WaitForSelfHostedControlPlane(client *clientset.Clientset) error {
 		}
 
 		// Check that all API Server pods are running:
+		// TODO: Do we need a stronger label link than this?
 		listOpts := v1.ListOptions{LabelSelector: "k8s-app=kube-apiserver"}
 		apiPods, err := client.Pods(api.NamespaceSystem).List(listOpts)
 		if err != nil {

--- a/cmd/kubeadm/app/master/selfhosted.go
+++ b/cmd/kubeadm/app/master/selfhosted.go
@@ -184,6 +184,7 @@ func getControllerManagerDeployment(cfg *kubeadmapi.MasterConfiguration,
 				Spec: v1.PodSpec{
 					// TODO: Make sure masters get this label
 					NodeSelector: map[string]string{metav1.NodeLabelKubeadmAlphaRole: metav1.NodeLabelRoleMaster},
+					HostNetwork:  true,
 					Volumes:      volumes,
 
 					Containers: []v1.Container{
@@ -242,12 +243,13 @@ func getSchedulerDeployment(cfg *kubeadmapi.MasterConfiguration) ext.Deployment 
 				},
 				Spec: v1.PodSpec{
 					NodeSelector: map[string]string{metav1.NodeLabelKubeadmAlphaRole: metav1.NodeLabelRoleMaster},
+					HostNetwork:  true,
 
 					Containers: []v1.Container{
 						v1.Container{
 							Name:          kubeScheduler,
 							Image:         images.GetCoreImage(images.KubeSchedulerImage, cfg, kubeadmapi.GlobalEnvParams.HyperkubeImage),
-							Command:       getSchedulerCommand(cfg),
+							Command:       getSchedulerCommand(cfg, 10251),
 							LivenessProbe: componentProbe(10251, "/healthz"),
 							Resources:     componentResources("100m"),
 							Env:           getProxyEnvVars(),


### PR DESCRIPTION
Just an initial rough cut of getting something working. Right now this is only the apiserver. Adds a hacky --deployment option (temporary until we refactor API) to trigger a self-hosted install.

Creates a daemonset for our apiserver, then pauses for it to start running on the master. At that point it's trying to grab it's port which is already in use and just waiting. We then remove the static pod manifest triggering a kubelet restart. Another pause waiting for kubelet to come back and we proceed with creating discovery service etc.

I fear it's only working because the apiserver container remains running while kubelet restarts. This is presumably where we need a checkpoint pod running?

@aaronlevy if you get a chance could use your feedback on how this looks so far. 

cc @luxas @mikedanese @lukemarsden @errordeveloper @jbeda 