### PR TITLE
Add DNS-schema Specification

### DIFF
--- a/cmd/kube-dns/SPEC.md
+++ b/cmd/kube-dns/SPEC.md
@@ -1,6 +1,6 @@
 # Kubernetes DNS-Based Service Discovery
 
-## About This Document
+## 0 - About This Document
 
 This document is a specification for DNS-based Kubernetes service
 discovery. While service discovery in Kubernetes may be provided via
@@ -9,40 +9,40 @@ highly recommended add-on. The actual DNS service itself need not
 be provided by the default Kube-DNS implementation. This document
 is intended to provide a baseline for commonality between implementations.
 
-## Schema Version
+## 1 - Schema Version
 
 This document describes version 1.0.0 of the schema.
 
-## Resource Records
+## 2 - Resource Records
 
-Any DNS-based service discovery solution for Kubernetes must provide the
+Any DNS-based service discovery solution for Kubernetes must provide the
 resource records (RRs) described below to be considered compliant with this
 specification.
 
-### Definitions
+### 2.1 - Definitions
 
 In the RR descriptions below, values not in angle brackets, `< >`,
 are literals. The meaning of the values in angle brackets are defined
 below or in the description of the specific record.
 
-- `<zone>` = configured cluster domain, e.g. cluster.local
-- `<ns>` = a Namespace
-- `<ttl>` = the standard DNS time-to-live value for the record
+- `<zone>` = configured cluster domain, e.g. cluster.local
+- `<ns>` = a Namespace
+- `<ttl>` = the standard DNS time-to-live value for the record
 
 In the RR descriptions below, the following definitions should be used for
 words in _italics_.
 
 _hostname_
   - In order of precedence, the _hostname_ of an endpoint is:
-    - The value of the endpoint’s `hostname` field.
+    - The value of the endpoint's `hostname` field.
     - A unique, system-assigned identifier for the endpoint. The exact format and source of this identifier is not prescribed by this specification. However, it must be possible to use this to identify a specific endpoint in the context of a Service. This is used in the event no explicit endpoint hostname is defined.
 
 _ready_
-  - An endpoint is considered _ready_ if its address is in the `addresses` field of the EndpointSubset object, or the corresponding service has the `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation set to `true`.
+  - An endpoint is considered _ready_ if its address is in the `addresses` field of the EndpointSubset object, or the corresponding service has the `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation set to `true`.
 
 All comparisons between query data and data in Kubernetes is **case-insensitive**.
 
-### Record for Schema Version
+### 2.2 - Record for Schema Version
 
 There must be a `TXT` record named `dns-version.<zone>.` that contains the
 [semantic version](http://semver.org) of the DNS schema in use in this cluster.
@@ -54,12 +54,12 @@ There must be a `TXT` record named `dns-version.<zone>.` that contains the
 - Answer Example:
   - `dns-version.cluster.local. 28800 IN TXT "1.0.0"`
 
-### Records for a Service with ClusterIP
+### 2.3 - Records for a Service with ClusterIP
 
 Given a Service named `<service>` in Namespace `<ns>` with ClusterIP
 `<cluster-ip>`, the following records must exist.
 
-#### `A` Record
+#### 2.3.1 - `A` Record
 - Record Format:
   - `<service>.<ns>.svc.<zone>. <ttl> IN A <cluster-ip>`
 - Question Example:
@@ -67,9 +67,9 @@ Given a Service named `<service>` in Namespace `<ns>` with ClusterIP
 - Answer Example:
   - `kubernetes.default.svc.cluster.local. 4 IN A 10.3.0.1`
 
-#### `SRV` Records
+#### 2.3.2 - `SRV` Records
 For each port in the Service with name `<port>` and number
-`<port-number>` using protocol `<proto>`, an `SRV` record of the following
+`<port-number>` using protocol `<proto>`, an `SRV` record of the following
 form must exist.
 - Record Format:
    - `_<port>._<proto>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <service>.<ns>.svc.<zone>.`
@@ -88,7 +88,7 @@ Unnamed ports do not have an `SRV` record.
 The Additional section of the response may include the Service `A` record
 referred to in the `SRV` record.
 
-#### `PTR` Record
+#### 2.3.3 - `PTR` Record
 Given Service ClusterIP `<a>.<b>.<c>.<d>`, a `PTR` record of the following
 form must exist.
 - Record Format:
@@ -98,12 +98,12 @@ form must exist.
 - Answer Example:
   - `1.0.3.10.in-addr.arpa. 14 IN PTR kubernetes.default.svc.cluster.local.`
 
-### Records for a Headless Service
+### 2.4 - Records for a Headless Service
 
 Given a headless Service `<service>` in Namespace `<ns>` (i.e., a Service with
 no ClusterIP), the following records must exist.
 
-#### `A` Records
+#### 2.4.1 - `A` Records
 There must be an `A` record for each _ready_ endpoint of the Service with IP
 address `<endpoint-ip>` as shown below. If there are no _ready_ endpoints,
 there must be no `A` records of this form; however, a query for them will have
@@ -131,9 +131,9 @@ must be one such `A` record returned for each IP.
 - Answer Example:
   - `my-pet.headless.default.svc.cluster.local. 4 IN A 10.3.0.100`
 
-#### `SRV` Records
+#### 2.4.2 - `SRV` Records
 For each combination of _ready_ endpoint with _hostname_ of `<hostname>`, and
-port in the Service with name `<port>` and number `<port-number>` using
+port in the Service with name `<port>` and number `<port-number>` using
 protocol `<proto>`, an `SRV` record of the following form must exist.
 - Record Format:
    - `_<port>._<proto>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <hostname>.<service>.<ns>.svc.<zone>.`
@@ -160,9 +160,9 @@ Unnamed ports do not have an `SRV` record.
 The Additional section of the response may include the `A` records
 referred to in the `SRV` records.
 
-#### `PTR` Records
+#### 2.4.3 - `PTR` Records
 
-Given a _ready_ endpoint with _hostname_ of `<hostname>` and IP address
+Given a _ready_ endpoint with _hostname_ of `<hostname>` and IP address
 `<a>.<b>.<c>.<d>`, a `PTR` record of the following form must exist.
 - Record Format:
   - `<d>.<c>.<b>.<a>.in-addr.arpa. <ttl> IN PTR <hostname>.<service>.<ns>.svc.<zone>.`
@@ -171,14 +171,15 @@ Given a _ready_ endpoint with _hostname_ of `<hostname>` and IP address
 - Answer Example:
   - `100.0.3.10.in-addr.arpa. 14 IN PTR my-pet.headless.default.svc.cluster.local.`
 
-### Deprecated Records
+### 2.5 - Deprecated Records
 Kube-DNS versions prior to implementation of this specification also replied
 with an `A` record of the form below for any values of `<a>`, `<b>`, `<c>`, and `<d>` between 0 and 254:
 - Record Format:
   - `<a>-<b>-<c>-<d>.<ns>.pod.<zone>. <ttl> IN A <a>.<b>.<c>.<d>`
 
-This behavior is deprecated and not required to satisfy this specification.
+This behavior is deprecated but is required to satisfy this specification. It
+will be removed from a future version of the specification.
 
-## Schema Extensions
+## 3 - Schema Extensions
 Specific implementations may choose to extend this schema, but the RRs in this
 document must be a subset of the RRs produced by the implementation.

--- a/cmd/kube-dns/SPEC.md
+++ b/cmd/kube-dns/SPEC.md
@@ -151,11 +151,11 @@ Unnamed ports do not have an `SRV` record.
 - Question Example:
   - `_https._tcp.headless.default.svc.cluster.local. IN SRV`
 - Answer Example:
-  ```
+```
         _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 my-pet.headless.default.svc.cluster.local.
         _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 my-pet-2.headless.default.svc.cluster.local.
         _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 438934893.headless.default.svc.cluster.local.
-  ```
+```
 
 The Additional section of the response may include the `A` records
 referred to in the `SRV` records.

--- a/cmd/kube-dns/SPEC.md
+++ b/cmd/kube-dns/SPEC.md
@@ -107,7 +107,7 @@ no ClusterIP), the following records must exist.
 There must be an `A` record for each _ready_ endpoint of the Service with IP
 address `<endpoint-ip>` as shown below. If there are no _ready_ endpoints,
 there must be no `A` records of this form; however, a query for them will have
-an empty result rather than `NXDOMAIN`, since the Service exists.
+an empty answer with `rcode` 0 rather than `NXDOMAIN`, since the Service exists.
 
 - Record Format:
   - `<service>.<ns>.svc.<zone>. <ttl> IN A <endpoint-ip>`

--- a/cmd/kube-dns/SPEC.md
+++ b/cmd/kube-dns/SPEC.md
@@ -2,139 +2,183 @@
 
 ## About This Document
 
-This document describes a DNS schema for DNS-based Kubernetes service
+This document is a specification for DNS-based Kubernetes service
 discovery. While service discovery in Kubernetes may be provided via
 other protocols and mechanisms, DNS is very commonly used and is a
-highly recommended add-on. The actual DNS service itself though need not
-be provided by the default Kube-DNS implementation, and so this document
-is intended to provide a baseline for commonality between
-implementations.
+highly recommended add-on. The actual DNS service itself need not
+be provided by the default Kube-DNS implementation. This document
+is intended to provide a baseline for commonality between implementations.
 
 ## Schema Version
 
 This document describes version 1.0.0 of the schema.
 
-## Query Responses
+## Resource Records
 
-Any DNS-based service discovery solution for Kubernetes must support the
-queries described below to be considered compliant with this specification.
+Any DNS-based service discovery solution for Kubernetes must provide the
+resource records (RRs) described below to be considered compliant with this
+specification.
 
-In the query names below, values not in angle brackets, `< >`,
+### Definitions
+
+In the RR descriptions below, values not in angle brackets, `< >`,
 are literals. The meaning of the values in angle brackets are defined
-below or in the description of the specific query response.
+below or in the description of the specific record.
 
-`<zone>` = configured cluster domain, e.g. cluster.local
+- `<zone>` = configured cluster domain, e.g. cluster.local
+- `<ns>` = a Namespace
+- `<ttl>` = the standard DNS time-to-live value for the record
 
-`<ns>` = a Namespace
-
-All comparisons between query names and data in Kubernetes is **case-insensitive**.
-
-In the results column, the following definitions should be used for
+In the RR descriptions below, the following definitions should be used for
 words in _italics_.
 
-- _hostname_
-  - For endpoints, in order of precedence:
+_hostname_
+  - In order of precedence, the _hostname_ of an endpoint is:
     - The value of the endpoint’s `hostname` field.
-    - A unique, system-assigned identifier for the endpoint. The exact format and source of this identifier is not prescribed by this specification. However, it must be possible to use this to identify a specific endpoint in the context of a Service. This is used for SRV queries below in the event no explicit endpoint hostname is defined by the above methods.
+    - A unique, system-assigned identifier for the endpoint. The exact format and source of this identifier is not prescribed by this specification. However, it must be possible to use this to identify a specific endpoint in the context of a Service. This is used in the event no explicit endpoint hostname is defined.
 
-- _ready_
+_ready_
   - An endpoint is considered _ready_ if its address is in the `addresses` field of the EndpointSubset object, or the corresponding service has the `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation set to `true`.
 
-The supported queries and expected responses follow.
+All comparisons between query data and data in Kubernetes is **case-insensitive**.
 
-- **Question:** `<service>.<ns>.svc.<zone>. IN A`
-  - If no Service named `<service>` exists in `<ns>`, the result will be `NXDOMAIN`.
-  - If a Service named `<service>` exists in `<ns>` with a ClusterIP, then the result will be a single A record with the specified name and the ClusterIP of that Service.
-    - Answer Format:
-      - `<service>.<ns>.svc.<zone>. <ttl> IN A <cluster-ip>`
-    - Answer Example:
-      - `kubernetes.default.svc.cluster.local. 4 IN A 10.3.0.1`
-  - If a Service named `<service>` exists in `<ns>` without a ClusterIP (i.e., a headless service)  and there are no _ready_ endpoints for that Service, then the result will be empty (i.e., an empty Answer section).
-  - If a Service named `<service>` exists in `<ns>` without a ClusterIP and there are _ready_ endpoints for the Service, the result will be an A record with the specified name and IP for each _ready_ endpoint.
-    - Answer Format:
-      - `<service>.<ns>.svc.<zone>. <ttl> IN A <endpoint-ip>`
-    - Answer Example:
+### Record for Schema Version
+
+There must be a `TXT` record named `dns-version.<zone>.` that contains the
+[semantic version](http://semver.org) of the DNS schema in use in this cluster.
+
+- Record Format:
+  - `dns-version.<zone>. <ttl> IN TXT <schema-version>`
+- Question Example:
+  - `dns-version.cluster.local. IN TXT`
+- Answer Example:
+  - `dns-version.cluster.local. 28800 IN TXT "1.0.0"`
+
+### Records for a Service with ClusterIP
+
+Given a Service named `<service>` in Namespace `<ns>` with ClusterIP
+`<cluster-ip>`, the following records must exist.
+
+#### `A` Record
+- Record Format:
+  - `<service>.<ns>.svc.<zone>. <ttl> IN A <cluster-ip>`
+- Question Example:
+  - `kubernetes.default.svc.cluster.local. IN A`
+- Answer Example:
+  - `kubernetes.default.svc.cluster.local. 4 IN A 10.3.0.1`
+
+#### `SRV` Records
+For each port in the Service with name `<port>` and number
+`<port-number>` using protocol `<proto>`, an `SRV` record of the following
+form must exist.
+- Record Format:
+   - `_<port>._<proto>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <service>.<ns>.svc.<zone>.`
+
+The priority `<priority>` and weight `<weight>` are numbers as described
+in [RFC2782](https://tools.ietf.org/html/rfc2782) and whose values are not
+prescribed by this specification.
+
+Unnamed ports do not have an `SRV` record.
+
+- Question Example:
+  - `_https._tcp.kubernetes.default.svc.cluster.local. IN SRV`
+- Answer Example:
+  - `_https._tcp.kubernetes.default.svc.cluster.local. 30 IN SRV 10 100 443 kubernetes.default.svc.cluster.local.`
+
+The Additional section of the response may include the Service `A` record
+referred to in the `SRV` record.
+
+#### `PTR` Record
+Given Service ClusterIP `<a>.<b>.<c>.<d>`, a `PTR` record of the following
+form must exist.
+- Record Format:
+  - `<d>.<c>.<b>.<a>.in-addr.arpa. <ttl> IN PTR <service>.<ns>.svc.<zone>.`
+- Question Example:
+  - `1.0.3.10.in-addr.arpa. IN PTR`
+- Answer Example:
+  - `1.0.3.10.in-addr.arpa. 14 IN PTR kubernetes.default.svc.cluster.local.`
+
+### Records for a Headless Service
+
+Given a headless Service `<service>` in Namespace `<ns>` (i.e., a Service with
+no ClusterIP), the following records must exist.
+
+#### `A` Records
+There must be an `A` record for each _ready_ endpoint of the Service with IP
+address `<endpoint-ip>` as shown below. If there are no _ready_ endpoints,
+there must be no `A` records of this form; however, a query for them will have
+an empty result rather than `NXDOMAIN`, since the Service exists.
+
+- Record Format:
+  - `<service>.<ns>.svc.<zone>. <ttl> IN A <endpoint-ip>`
+- Question Example:
+  - `headless.default.svc.cluster.local. IN A`
+- Answer Example:
 ```
-      headless.default.svc.cluster.local. 4 IN A 10.3.0.1
-      headless.default.svc.cluster.local. 4 IN A 10.3.0.2
-      headless.default.svc.cluster.local. 4 IN A 10.3.0.3
+    headless.default.svc.cluster.local. 4 IN A 10.3.0.1
+    headless.default.svc.cluster.local. 4 IN A 10.3.0.2
+    headless.default.svc.cluster.local. 4 IN A 10.3.0.3
 ```
-- **Question:** `<hostname>.<service>.<ns>.svc.<zone>. IN A`
-  - If no Service named `<service>` exists in `<ns>`, the result will be `NXDOMAIN`.
-  - If a Service named `<service>` exists in `<ns>` and a _ready_ endpoint exists for that Service with _hostname_ of `<hostname>` the result will be a single A record with the IP address of that endpoint. If no such endpoint exists, the result will be `NXDOMAIN`.
-    - Answer Format:
-      - `<hostname>.<service>.<ns>.svc.<zone>. <ttl> IN A <endpoint-ip>`
-    - Answer Example:
-      - `my-pet.my-service.default.svc.cluster.local. 4 IN A 10.3.0.100`
-- **Question:** `<a>-<b>-<c>-<d>.<ns>.pod.<zone>. IN A`
-  - If a Pod exists with IP address `<a>.<b>.<c>.<d>`, the result will be an A record with the specified name and the IP address `<a>.<b>.<c>.<d>`.
-    - Answer Format:
-      - `<a>-<b>-<c>-<d>.<ns>.pod.<zone>. <ttl> IN A <a>.<b>.<c>.<d>`
-    - Answer Example:
-      - `10-11-12-13.default.pod.cluster.local. 4 IN A 10.11.12.13`
-  - If no such Pod exists, the result will be `NXDOMAIN`.
-- **Question:** `_<port>._<proto>.<service>.<ns>.svc.<zone>. IN SRV`
-  - If no Service named `<service>` exists in `<ns>`, the result will be `NXDOMAIN`.
-  - If a Service named `<service>` exists in `<ns>` with a ClusterIP, and the service has a port named `<port>` using protocol `<proto>`, the result in the Answer section will be a single SRV record with the port number of the selected port and the name of the A record for the service (`<service>.<ns>.svc.<zone>.`). Unnamed ports will not receive an SRV record. The priority and weight returned are not prescribed by this specification. The Additional section may contain the named A record.
-    - Answer Format:
-       - `_<port>._<proto>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <service>.<ns>.svc.<zone>.`
-    - Answer Example:
-       - `_https._tcp.kubernetes.default.svc.cluster.local. 30 IN SRV 10 100 443 kubernetes.default.svc.cluster.local.`
-  - If a Service named `<service>` exists in `<ns>` without a ClusterIP, and the Service has no ready endpoints, the result will be an empty Answer section.
-  - If a Service named `<service>` exists in `<ns>` without a ClusterIP and with _ready_ endpoints, the result in the Answer section will be one SRV record for each _ready_ endpoint. Each record will contain the specific port number for the selected port and the name of an A record `<hostname>.<service>.<ns>.svc.<zone>` where `<hostname>` is the endpoint _hostname_. As described above, this name will resolve to an A record with the IP address of the specific _ready_ endpoint (which may be included in the Additional section). The priority and weight are not prescribed by this specification.
-    - Answer Format:
-      - `_<port>._<proto>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <hostname>.<service>.<ns>.svc.<zone>.`
-    - Answer Example:
-```
-      _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 my-pet-1.headless.default.svc.cluster.local.
-      _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 my-pet-2.headless.default.svc.cluster.local.
-      _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 438934893.headless.default.svc.cluster.local.
-```
-- **Question:** `<service>.<ns>.svc.<zone>. IN SRV`
-  - If no Service named `<service>` exists in `<ns>`, the result will be `NXDOMAIN`.
-  - If a Service named `<service>` exists in `<ns>` with a ClusterIP, and the service has **N** ports named `<port-1>, <port-2>, …, <port-n>` using protocol `<proto-1>, <proto-2>, …, <proto-n>` the result will be **N** SRV record with names `_<port-1>._<proto-1>.<service>.<ns>.svc.<zone>`, etc., the port number of the specific port and the name of the A record `<service>.<ns>.svc.<zone>`. The priority and weight returned are not prescribed by this specification.
-    - Answer Format:
-      - `_<port-x>._<proto-x>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <service>.<ns>.svc.<zone>.`
-    - Answer Example:
-```
-      _https._tcp.my-service.default.svc.cluster.local.  4 IN SRV 10 100 443 my-service.default.svc.cluster.local.
-      _http._tcp.my-service.default.svc.cluster.local.   4 IN SRV 10 100 80  my-service.default.svc.cluster.local.
-      _syslog._udp.my-service.default.svc.cluster.local. 4 IN SRV 10 100 514 my-service.default.svc.cluster.local.
-```
-  - If a Service named `<service>` exists in `<ns>` without a ClusterIP and with _ready_ endpoints, the result in the Answer section will be one SRV record for each _ready_ endpoint and port combination. Thus, if there are **N** ports for the service and **M** _ready_ endpoints, there will be **N** :heavy_multiplication_x: **M** records in the Answer section. The name of each record will be `_<port>._<proto>.<service>.<ns>.svc.<zone>`. Here, `<port>` is the name of the port if it has one, and empty if it does not. `<proto>` is either “udp” or “tcp” depending on the port protocol. There will therefore be **M** records with the same name, one for each _ready_ endpoint. The records will contain the port number of the `<port>` and the name of an A record `<hostname>.<service>.<ns>.svc.<zone>` where `<hostname>` is the endpoint _hostname_. This name will resolve to an A record with the IP address of the specific _ready_ endpoint (which may be included in the Additional section). The priority and weight are not prescribed by this specification.
-    - Answer Format:
-      - `_<port-x>._<proto-x>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <service>.<ns>.svc.<zone>.`
-    - Answer Example:
-```
-      _https._tcp.headless.default.svc.cluster.local.  4 IN SRV 10 100 443 my-pet-1.headless.default.svc.cluster.local.
-      _http._tcp.headless.default.svc.cluster.local.   4 IN SRV 10 100 80  my-pet-1.headless.default.svc.cluster.local.
-      _syslog._udp.headless.default.svc.cluster.local. 4 IN SRV 10 100 514 my-pet-1.headless.default.svc.cluster.local.
-      _https._tcp.headless.default.svc.cluster.local.  4 IN SRV 10 100 443 my-pet-2.headless.default.svc.cluster.local.
-      _http._tcp.headless.default.svc.cluster.local.   4 IN SRV 10 100 80  my-pet-2.headless.default.svc.cluster.local.
-      _syslog._udp.headless.default.svc.cluster.local. 4 IN SRV 10 100 514 my-pet-2.headless.default.svc.cluster.local.
-      _https._tcp.headless.default.svc.cluster.local.  4 IN SRV 10 100 443 438934893.headless.default.svc.cluster.local.
-      _http._tcp.headless.default.svc.cluster.local.   4 IN SRV 10 100 80  438934893.headless.default.svc.cluster.local.
-      _syslog._udp.headless.default.svc.cluster.local. 4 IN SRV 10 100 514 438934893.headless.default.svc.cluster.local.
-```
-- **Question:** `<reverse-ip-name>. IN PTR`
-  - If a Service with ClusterIP equal to the IP of `<reverse-ip-name>` exists, a PTR record with `<service>.<ns>.svc.<zone>.` will be returned.
-    - Answer Format:
-      - `<reverse-ip-name>. <ttl> IN PTR <service>.<ns>.svc.<zone>.`
-    - Answer Example:
-      - `1.0.3.10.in-addr.arpa. 14 IN PTR kubernetes.default.svc.cluster.local.`
-  - If a _ready_ endpoint exists with IP equal to the IP of `<reverse-ip-name>` exists, and the endpoint has a non-empty _hostname_ with value `<hostname>`, then a PTR record with `<hostname>.<service>.<ns>.svc.<zone>` will be returned.
-    - Answer Format:
-      - `<reverse-ip-name>. <ttl> IN PTR <hostname>.<service>.<ns>.svc.<zone>.`
-    - Answer Example:
-      - `100.0.3.10.in-addr.arpa. 14 IN PTR my-pet.my-service.default.svc.cluster.local.`
-  - Otherwise, the result is `NXDOMAIN`.
-- **Question:** `dns-version.<zone>. IN TXT`
-  - Returns the semantic versioning of the DNS-schema in use in this cluster.
-    - Answer Format:
-      - `dns-version.<zone>. <ttl> IN TXT <schema-version>`
-    - Answer Example:
-      - `dns-version.cluster.local. 28800 IN TXT "1.0.0"`
+
+There must also be an `A` record of the following form for each _ready_
+endpoint with _hostname_ of `<hostname>` and IP address `<endpoint-ip>`.
+If there are multiple IP addresses for a given _hostname_, then there
+must be one such `A` record returned for each IP.
+- Record Format:
+  - `<hostname>.<service>.<ns>.svc.<zone>. <ttl> IN A <endpoint-ip>`
+- Question Example:
+  - `my-pet.headless.default.svc.cluster.local. IN A`
+- Answer Example:
+  - `my-pet.headless.default.svc.cluster.local. 4 IN A 10.3.0.100`
+
+#### `SRV` Records
+For each combination of _ready_ endpoint with _hostname_ of `<hostname>`, and
+port in the Service with name `<port>` and number `<port-number>` using
+protocol `<proto>`, an `SRV` record of the following form must exist.
+- Record Format:
+   - `_<port>._<proto>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <hostname>.<service>.<ns>.svc.<zone>.`
+
+This implies that if there are **N** _ready_ endpoints and the Service
+defines **M** named ports, there will be **N** :heavy_multiplication_x: **M**
+`SRV` RRs for the Service.
+
+The priority `<priority>` and weight `<weight>` are numbers as described
+in [RFC2782](https://tools.ietf.org/html/rfc2782) and whose values are not
+prescribed by this specification.
+
+Unnamed ports do not have an `SRV` record.
+
+- Question Example:
+  - `_https._tcp.headless.default.svc.cluster.local. IN SRV`
+- Answer Example:
+  ```
+        _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 my-pet.headless.default.svc.cluster.local.
+        _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 my-pet-2.headless.default.svc.cluster.local.
+        _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 438934893.headless.default.svc.cluster.local.
+  ```
+
+The Additional section of the response may include the `A` records
+referred to in the `SRV` records.
+
+#### `PTR` Records
+
+Given a _ready_ endpoint with _hostname_ of `<hostname>` and IP address
+`<a>.<b>.<c>.<d>`, a `PTR` record of the following form must exist.
+- Record Format:
+  - `<d>.<c>.<b>.<a>.in-addr.arpa. <ttl> IN PTR <hostname>.<service>.<ns>.svc.<zone>.`
+- Question Example:
+  - `100.0.3.10.in-addr.arpa. IN PTR`
+- Answer Example:
+  - `100.0.3.10.in-addr.arpa. 14 IN PTR my-pet.headless.default.svc.cluster.local.`
+
+### Deprecated Records
+Kube-DNS versions prior to implementation of this specification also replied
+with an `A` record of the form below for any values of `<a>`, `<b>`, `<c>`, and `<d>` between 0 and 254:
+- Record Format:
+  - `<a>-<b>-<c>-<d>.<ns>.pod.<zone>. <ttl> IN A <a>.<b>.<c>.<d>`
+
+This behavior is deprecated and not required to satisfy this specification.
 
 ## Schema Extensions
-
-Specific implementations may choose to extend this schema, but the queries and responses described here are expected from any Kubernetes DNS solution.
+Specific implementations may choose to extend this schema, but the RRs in this
+document must be a subset of the RRs produced by the implementation.

--- a/cmd/kube-dns/SPEC.md
+++ b/cmd/kube-dns/SPEC.md
@@ -1,0 +1,140 @@
+# Kubernetes DNS-Based Service Discovery
+
+## About This Document
+
+This document describes a DNS schema for DNS-based Kubernetes service
+discovery. While service discovery in Kubernetes may be provided via
+other protocols and mechanisms, DNS is very commonly used and is a
+highly recommended add-on. The actual DNS service itself though need not
+be provided by the default Kube-DNS implementation, and so this document
+is intended to provide a baseline for commonality between
+implementations.
+
+## Schema Version
+
+This document describes version 1.0.0 of the schema.
+
+## Query Responses
+
+Any DNS-based service discovery solution for Kubernetes must support the
+queries described below to be considered compliant with this specification.
+
+In the query names below, values not in angle brackets, `< >`,
+are literals. The meaning of the values in angle brackets are defined
+below or in the description of the specific query response.
+
+`<zone>` = configured cluster domain, e.g. cluster.local
+
+`<ns>` = a Namespace
+
+All comparisons between query names and data in Kubernetes is **case-insensitive**.
+
+In the results column, the following definitions should be used for
+words in _italics_.
+
+- _hostname_
+  - For endpoints, in order of precedence:
+    - The value of the endpoint’s `hostname` field.
+    - A unique, system-assigned identifier for the endpoint. The exact format and source of this identifier is not prescribed by this specification. However, it must be possible to use this to identify a specific endpoint in the context of a Service. This is used for SRV queries below in the event no explicit endpoint hostname is defined by the above methods.
+
+- _ready_
+  - An endpoint is considered _ready_ if its address is in the `addresses` field of the EndpointSubset object, or the corresponding service has the `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation set to `true`.
+
+The supported queries and expected responses follow.
+
+- **Question:** `<service>.<ns>.svc.<zone>. IN A`
+  - If no Service named `<service>` exists in `<ns>`, the result will be `NXDOMAIN`.
+  - If a Service named `<service>` exists in `<ns>` with a ClusterIP, then the result will be a single A record with the specified name and the ClusterIP of that Service.
+    - Answer Format:
+      - `<service>.<ns>.svc.<zone>. <ttl> IN A <cluster-ip>`
+    - Answer Example:
+      - `kubernetes.default.svc.cluster.local. 4 IN A 10.3.0.1`
+  - If a Service named `<service>` exists in `<ns>` without a ClusterIP (i.e., a headless service)  and there are no _ready_ endpoints for that Service, then the result will be empty (i.e., an empty Answer section).
+  - If a Service named `<service>` exists in `<ns>` without a ClusterIP and there are _ready_ endpoints for the Service, the result will be an A record with the specified name and IP for each _ready_ endpoint.
+    - Answer Format:
+      - `<service>.<ns>.svc.<zone>. <ttl> IN A <endpoint-ip>`
+    - Answer Example:
+```
+      headless.default.svc.cluster.local. 4 IN A 10.3.0.1
+      headless.default.svc.cluster.local. 4 IN A 10.3.0.2
+      headless.default.svc.cluster.local. 4 IN A 10.3.0.3
+```
+- **Question:** `<hostname>.<service>.<ns>.svc.<zone>. IN A`
+  - If no Service named `<service>` exists in `<ns>`, the result will be `NXDOMAIN`.
+  - If a Service named `<service>` exists in `<ns>` and a _ready_ endpoint exists for that Service with _hostname_ of `<hostname>` the result will be a single A record with the IP address of that endpoint. If no such endpoint exists, the result will be `NXDOMAIN`.
+    - Answer Format:
+      - `<hostname>.<service>.<ns>.svc.<zone>. <ttl> IN A <endpoint-ip>`
+    - Answer Example:
+      - `my-pet.my-service.default.svc.cluster.local. 4 IN A 10.3.0.100`
+- **Question:** `<a>-<b>-<c>-<d>.<ns>.pod.<zone>. IN A`
+  - If a Pod exists with IP address `<a>.<b>.<c>.<d>`, the result will be an A record with the specified name and the IP address `<a>.<b>.<c>.<d>`.
+    - Answer Format:
+      - `<a>-<b>-<c>-<d>.<ns>.pod.<zone>. <ttl> IN A <a>.<b>.<c>.<d>`
+    - Answer Example:
+      - `10-11-12-13.default.pod.cluster.local. 4 IN A 10.11.12.13`
+  - If no such Pod exists, the result will be `NXDOMAIN`.
+- **Question:** `_<port>._<proto>.<service>.<ns>.svc.<zone>. IN SRV`
+  - If no Service named `<service>` exists in `<ns>`, the result will be `NXDOMAIN`.
+  - If a Service named `<service>` exists in `<ns>` with a ClusterIP, and the service has a port named `<port>` using protocol `<proto>`, the result in the Answer section will be a single SRV record with the port number of the selected port and the name of the A record for the service (`<service>.<ns>.svc.<zone>.`). Unnamed ports will not receive an SRV record. The priority and weight returned are not prescribed by this specification. The Additional section may contain the named A record.
+    - Answer Format:
+       - `_<port>._<proto>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <service>.<ns>.svc.<zone>.`
+    - Answer Example:
+       - `_https._tcp.kubernetes.default.svc.cluster.local. 30 IN SRV 10 100 443 kubernetes.default.svc.cluster.local.`
+  - If a Service named `<service>` exists in `<ns>` without a ClusterIP, and the Service has no ready endpoints, the result will be an empty Answer section.
+  - If a Service named `<service>` exists in `<ns>` without a ClusterIP and with _ready_ endpoints, the result in the Answer section will be one SRV record for each _ready_ endpoint. Each record will contain the specific port number for the selected port and the name of an A record `<hostname>.<service>.<ns>.svc.<zone>` where `<hostname>` is the endpoint _hostname_. As described above, this name will resolve to an A record with the IP address of the specific _ready_ endpoint (which may be included in the Additional section). The priority and weight are not prescribed by this specification.
+    - Answer Format:
+      - `_<port>._<proto>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <hostname>.<service>.<ns>.svc.<zone>.`
+    - Answer Example:
+```
+      _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 my-pet-1.headless.default.svc.cluster.local.
+      _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 my-pet-2.headless.default.svc.cluster.local.
+      _https._tcp.headless.default.svc.cluster.local. 4 IN SRV 10 100 443 438934893.headless.default.svc.cluster.local.
+```
+- **Question:** `<service>.<ns>.svc.<zone>. IN SRV`
+  - If no Service named `<service>` exists in `<ns>`, the result will be `NXDOMAIN`.
+  - If a Service named `<service>` exists in `<ns>` with a ClusterIP, and the service has **N** ports named `<port-1>, <port-2>, …, <port-n>` using protocol `<proto-1>, <proto-2>, …, <proto-n>` the result will be **N** SRV record with names `_<port-1>._<proto-1>.<service>.<ns>.svc.<zone>`, etc., the port number of the specific port and the name of the A record `<service>.<ns>.svc.<zone>`. The priority and weight returned are not prescribed by this specification.
+    - Answer Format:
+      - `_<port-x>._<proto-x>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <service>.<ns>.svc.<zone>.`
+    - Answer Example:
+```
+      _https._tcp.my-service.default.svc.cluster.local.  4 IN SRV 10 100 443 my-service.default.svc.cluster.local.
+      _http._tcp.my-service.default.svc.cluster.local.   4 IN SRV 10 100 80  my-service.default.svc.cluster.local.
+      _syslog._udp.my-service.default.svc.cluster.local. 4 IN SRV 10 100 514 my-service.default.svc.cluster.local.
+```
+  - If a Service named `<service>` exists in `<ns>` without a ClusterIP and with _ready_ endpoints, the result in the Answer section will be one SRV record for each _ready_ endpoint and port combination. Thus, if there are **N** ports for the service and **M** _ready_ endpoints, there will be **N** :heavy_multiplication_x: **M** records in the Answer section. The name of each record will be `_<port>._<proto>.<service>.<ns>.svc.<zone>`. Here, `<port>` is the name of the port if it has one, and empty if it does not. `<proto>` is either “udp” or “tcp” depending on the port protocol. There will therefore be **M** records with the same name, one for each _ready_ endpoint. The records will contain the port number of the `<port>` and the name of an A record `<hostname>.<service>.<ns>.svc.<zone>` where `<hostname>` is the endpoint _hostname_. This name will resolve to an A record with the IP address of the specific _ready_ endpoint (which may be included in the Additional section). The priority and weight are not prescribed by this specification.
+    - Answer Format:
+      - `_<port-x>._<proto-x>.<service>.<ns>.svc.<zone>. <ttl> IN SRV <weight> <priority> <port-number> <service>.<ns>.svc.<zone>.`
+    - Answer Example:
+```
+      _https._tcp.headless.default.svc.cluster.local.  4 IN SRV 10 100 443 my-pet-1.headless.default.svc.cluster.local.
+      _http._tcp.headless.default.svc.cluster.local.   4 IN SRV 10 100 80  my-pet-1.headless.default.svc.cluster.local.
+      _syslog._udp.headless.default.svc.cluster.local. 4 IN SRV 10 100 514 my-pet-1.headless.default.svc.cluster.local.
+      _https._tcp.headless.default.svc.cluster.local.  4 IN SRV 10 100 443 my-pet-2.headless.default.svc.cluster.local.
+      _http._tcp.headless.default.svc.cluster.local.   4 IN SRV 10 100 80  my-pet-2.headless.default.svc.cluster.local.
+      _syslog._udp.headless.default.svc.cluster.local. 4 IN SRV 10 100 514 my-pet-2.headless.default.svc.cluster.local.
+      _https._tcp.headless.default.svc.cluster.local.  4 IN SRV 10 100 443 438934893.headless.default.svc.cluster.local.
+      _http._tcp.headless.default.svc.cluster.local.   4 IN SRV 10 100 80  438934893.headless.default.svc.cluster.local.
+      _syslog._udp.headless.default.svc.cluster.local. 4 IN SRV 10 100 514 438934893.headless.default.svc.cluster.local.
+```
+- **Question:** `<reverse-ip-name>. IN PTR`
+  - If a Service with ClusterIP equal to the IP of `<reverse-ip-name>` exists, a PTR record with `<service>.<ns>.svc.<zone>.` will be returned.
+    - Answer Format:
+      - `<reverse-ip-name>. <ttl> IN PTR <service>.<ns>.svc.<zone>.`
+    - Answer Example:
+      - `1.0.3.10.in-addr.arpa. 14 IN PTR kubernetes.default.svc.cluster.local.`
+  - If a _ready_ endpoint exists with IP equal to the IP of `<reverse-ip-name>` exists, and the endpoint has a non-empty _hostname_ with value `<hostname>`, then a PTR record with `<hostname>.<service>.<ns>.svc.<zone>` will be returned.
+    - Answer Format:
+      - `<reverse-ip-name>. <ttl> IN PTR <hostname>.<service>.<ns>.svc.<zone>.`
+    - Answer Example:
+      - `100.0.3.10.in-addr.arpa. 14 IN PTR my-pet.my-service.default.svc.cluster.local.`
+  - Otherwise, the result is `NXDOMAIN`.
+- **Question:** `dns-version.<zone>. IN TXT`
+  - Returns the semantic versioning of the DNS-schema in use in this cluster.
+    - Answer Format:
+      - `dns-version.<zone>. <ttl> IN TXT <schema-version>`
+    - Answer Example:
+      - `dns-version.cluster.local. 28800 IN TXT "1.0.0"`
+
+## Schema Extensions
+
+Specific implementations may choose to extend this schema, but the queries and responses described here are expected from any Kubernetes DNS solution.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR establishes an explicit baseline DNS schema for Kubernetes. Currently, this information is contained in a few places in the documentation. This PR gathers this into one place and adds additional, explicit detail to what the supported queries and expected responses are. The intention is to provide a common schema that different DNS service discovery implementations can implement.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: None

**Special notes for your reviewer**:
This started life here https://docs.google.com/document/d/1B4ZA1HwprWMzyT7nUZLAZ93Fjwcdt9qs0aXfifKxpTs/edit# but this PR is the result. Currently kube-dns does not support this schema 100%. There are a few items in here that are not yet in kube-dns. I will add comments to them on the PR. This makes the spec more aspirational than current. We may want to note that directly in the spec until kube-dns fully meets it (or change the spec, of course).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```