### PR TITLE
Fix unmountDevice issue caused by shared mount in GCI

### DIFF
--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -130,21 +130,13 @@ func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {
 		}
 	}
 
-	// TODO: this is a workaround for the unmount device issue caused by gci mounter.
-	// In GCI cluster, if gci mounter is used for mounting, the container started by mounter
-	// script will cause additional mounts created in the container. Since these mounts are
-	// irrelavant to the original mounts, they should be not considered when checking the
-	// mount references. Current solution is to filter out those mount paths that contain
-	// the string of original mount path.
-	// Plan to work on better approach to solve this issue.
-
 	// Find all references to the device.
 	var refs []string
 	if deviceName == "" {
 		glog.Warningf("could not determine device for path: %q", mountPath)
 	} else {
 		for i := range mps {
-			if mps[i].Device == deviceName && !strings.Contains(mps[i].Path, slTarget) {
+			if mps[i].Device == deviceName && mps[i].Path != slTarget {
 				refs = append(refs, mps[i].Path)
 			}
 		}

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -22,6 +22,7 @@ package operationexecutor
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -1053,7 +1054,8 @@ func (oe *operationExecutor) generateUnmountDeviceFunc(
 				err)
 		}
 		refs, err := attachableVolumePlugin.GetDeviceMountRefs(deviceMountPath)
-		if err != nil || len(refs) > 0 {
+
+		if err != nil || hasMountRefs(deviceMountPath, refs) {
 			if err == nil {
 				err = fmt.Errorf("The device mount path %q is still mounted by other references %v", deviceMountPath, refs)
 			}
@@ -1122,6 +1124,24 @@ func (oe *operationExecutor) generateUnmountDeviceFunc(
 
 		return nil
 	}, nil
+}
+
+// TODO: this is a workaround for the unmount device issue caused by gci mounter.
+// In GCI cluster, if gci mounter is used for mounting, the container started by mounter
+// script will cause additional mounts created in the container. Since these mounts are
+// irrelavant to the original mounts, they should be not considered when checking the
+// mount references. Current solution is to filter out those mount paths that contain
+// the string of original mount path.
+// Plan to work on better approach to solve this issue.
+
+func hasMountRefs(mountPath string, mountRefs []string) bool {
+	count := 0
+	for _, ref := range mountRefs {
+		if !strings.Contains(ref, mountPath) {
+			count = count + 1
+		}
+	}
+	return count > 0
 }
 
 func (oe *operationExecutor) generateVerifyControllerAttachedVolumeFunc(


### PR DESCRIPTION
This is a fix on top #38124. In this fix, we move the logic to filter
out shared mount references into operation_executor's UnmountDevice
function to avoid this part is being used by other types volumes such as
rdb, azure etc. This filter function should be only needed during
unmount device for GCI image.