### PR TITLE
Use the full path when running cfssl/cfssljson

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -372,7 +372,7 @@ function create_client_certkey {
     done
     ${CONTROLPLANE_SUDO} /bin/bash -e <<EOF
     cd ${CERT_DIR}
-    echo '{"CN":"${CN}","names":[${NAMES}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | cfssl gencert -ca=${CA}.crt -ca-key=${CA}.key -config=client-ca-config.json - | cfssljson -bare client-${ID}
+    echo '{"CN":"${CN}","names":[${NAMES}],"hosts":[""],"key":{"algo":"rsa","size":2048}}' | $(command -v cfssl) gencert -ca=${CA}.crt -ca-key=${CA}.key -config=client-ca-config.json - | $(command -v cfssljson) -bare client-${ID}
     mv "client-${ID}-key.pem" "client-${ID}.key"
     mv "client-${ID}.pem" "client-${ID}.crt"
     rm -f "client-${ID}.csr"


### PR DESCRIPTION
When we do run with sudo, the current PATH on which cfssl
and cfssljson were found is lost. So make sure we use the
same PATH in the sudo bash snippet as well.