### PR TITLE
Update client status generator to not use json tags

### DIFF
--- a/cmd/kubernetes-discovery/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
+++ b/cmd/kubernetes-discovery/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
@@ -33,6 +33,7 @@ type APIServicesGetter interface {
 type APIServiceInterface interface {
 	Create(*apiregistration.APIService) (*apiregistration.APIService, error)
 	Update(*apiregistration.APIService) (*apiregistration.APIService, error)
+	UpdateStatus(*apiregistration.APIService) (*apiregistration.APIService, error)
 	Delete(name string, options *api.DeleteOptions) error
 	DeleteCollection(options *api.DeleteOptions, listOptions api.ListOptions) error
 	Get(name string) (*apiregistration.APIService, error)
@@ -71,6 +72,21 @@ func (c *aPIServices) Update(aPIService *apiregistration.APIService) (result *ap
 	err = c.client.Put().
 		Resource("apiservices").
 		Name(aPIService.Name).
+		Body(aPIService).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
+func (c *aPIServices) UpdateStatus(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
+	result = &apiregistration.APIService{}
+	err = c.client.Put().
+		Resource("apiservices").
+		Name(aPIService.Name).
+		SubResource("status").
 		Body(aPIService).
 		Do().
 		Into(result)

--- a/cmd/kubernetes-discovery/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/fake/fake_apiservice.go
+++ b/cmd/kubernetes-discovery/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/fake/fake_apiservice.go
@@ -50,6 +50,15 @@ func (c *FakeAPIServices) Update(aPIService *apiregistration.APIService) (result
 	return obj.(*apiregistration.APIService), err
 }
 
+func (c *FakeAPIServices) UpdateStatus(aPIService *apiregistration.APIService) (*apiregistration.APIService, error) {
+	obj, err := c.Fake.
+		Invokes(core.NewRootUpdateSubresourceAction(apiservicesResource, "status", aPIService), &apiregistration.APIService{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apiregistration.APIService), err
+}
+
 func (c *FakeAPIServices) Delete(name string, options *api.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(core.NewRootDeleteAction(apiservicesResource, name), &apiregistration.APIService{})

--- a/cmd/kubernetes-discovery/pkg/client/clientset_generated/release_1_5/typed/apiregistration/v1alpha1/apiservice.go
+++ b/cmd/kubernetes-discovery/pkg/client/clientset_generated/release_1_5/typed/apiregistration/v1alpha1/apiservice.go
@@ -79,6 +79,9 @@ func (c *aPIServices) Update(aPIService *v1alpha1.APIService) (result *v1alpha1.
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *aPIServices) UpdateStatus(aPIService *v1alpha1.APIService) (result *v1alpha1.APIService, err error) {
 	result = &v1alpha1.APIService{}
 	err = c.client.Put().

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_type.go
@@ -17,9 +17,9 @@ limitations under the License.
 package generators
 
 import (
+	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -51,16 +51,25 @@ func (g *genClientForType) Imports(c *generator.Context) (imports []string) {
 	return g.imports.ImportLines()
 }
 
-// Ideally, we'd like hasStatus to return true if there is a subresource path
+// Ideally, we'd like genStatus to return true if there is a subresource path
 // registered for "status" in the API server, but we do not have that
-// information, so hasStatus returns true if the type has a status field.
-func hasStatus(t *types.Type) bool {
+// information, so genStatus returns true if the type has a status field.
+func genStatus(t *types.Type) bool {
+	// Default to true if we have a Status member
+	hasStatus := false
 	for _, m := range t.Members {
-		if m.Name == "Status" && strings.Contains(m.Tags, `json:"status`) {
-			return true
+		if m.Name == "Status" {
+			hasStatus = true
+			break
 		}
 	}
-	return false
+
+	// Allow overriding via a comment on the type
+	genStatus, err := types.ExtractSingleBoolCommentTag("+", "genclientstatus", hasStatus, t.SecondClosestCommentLines)
+	if err != nil {
+		fmt.Printf("error looking up +genclientstatus: %v\n", err)
+	}
+	return genStatus
 }
 
 // GenerateType makes the body of a file implementing the individual typed client for type t.
@@ -101,7 +110,7 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 	if !noMethods {
 		sw.Do(interfaceTemplate2, m)
 		// Include the UpdateStatus method if the type has a status
-		if hasStatus(t) {
+		if genStatus(t) {
 			sw.Do(interfaceUpdateStatusTemplate, m)
 		}
 		sw.Do(interfaceTemplate3, m)
@@ -120,7 +129,7 @@ func (g *genClientForType) GenerateType(c *generator.Context, t *types.Type, w i
 		sw.Do(createTemplate, m)
 		sw.Do(updateTemplate, m)
 		// Generate the UpdateStatus method if the type has a status
-		if hasStatus(t) {
+		if genStatus(t) {
 			sw.Do(updateStatusTemplate, m)
 		}
 		sw.Do(deleteTemplate, m)
@@ -296,6 +305,9 @@ func (c *$.type|privatePlural$) Update($.type|private$ *$.type|raw$) (result *$.
 `
 
 var updateStatusTemplate = `
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *$.type|privatePlural$) UpdateStatus($.type|private$ *$.type|raw$) (result *$.type|raw$, err error) {
 	result = &$.type|raw${}
 	err = c.client.Put().

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/testtype.go
@@ -82,6 +82,9 @@ func (c *testTypes) Update(testType *testgroup.TestType) (result *testgroup.Test
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *testTypes) UpdateStatus(testType *testgroup.TestType) (result *testgroup.TestType, err error) {
 	result = &testgroup.TestType{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/namespace.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/namespace.go
@@ -77,6 +77,9 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *namespaces) UpdateStatus(namespace *api.Namespace) (result *api.Namespace, err error) {
 	result = &api.Namespace{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/service.go
@@ -81,6 +81,9 @@ func (c *services) Update(service *api.Service) (result *api.Service, err error)
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *services) UpdateStatus(service *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/daemonset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/daemonset.go
@@ -82,6 +82,9 @@ func (c *daemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *daemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/deployment.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/deployment.go
@@ -82,6 +82,9 @@ func (c *deployments) Update(deployment *extensions.Deployment) (result *extensi
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *deployments) UpdateStatus(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/ingress.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/ingress.go
@@ -82,6 +82,9 @@ func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingr
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/replicaset.go
@@ -82,6 +82,9 @@ func (c *replicaSets) Update(replicaSet *extensions.ReplicaSet) (result *extensi
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *replicaSets) UpdateStatus(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
 	result = &extensions.ReplicaSet{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/cluster.go
@@ -78,6 +78,9 @@ func (c *clusters) Update(cluster *federation.Cluster) (result *federation.Clust
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *clusters) UpdateStatus(cluster *federation.Cluster) (result *federation.Cluster, err error) {
 	result = &federation.Cluster{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/namespace.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/namespace.go
@@ -78,6 +78,9 @@ func (c *namespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err 
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *namespaces) UpdateStatus(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/service.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/core/v1/service.go
@@ -82,6 +82,9 @@ func (c *services) Update(service *v1.Service) (result *v1.Service, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *services) UpdateStatus(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/daemonset.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/daemonset.go
@@ -83,6 +83,9 @@ func (c *daemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.Daemo
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *daemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/deployment.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/deployment.go
@@ -83,6 +83,9 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/ingress.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/ingress.go
@@ -83,6 +83,9 @@ func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *ingresses) UpdateStatus(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/replicaset.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/extensions/v1beta1/replicaset.go
@@ -83,6 +83,9 @@ func (c *replicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.Re
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *replicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Put().

--- a/federation/client/clientset_generated/federation_release_1_5/typed/federation/v1beta1/cluster.go
+++ b/federation/client/clientset_generated/federation_release_1_5/typed/federation/v1beta1/cluster.go
@@ -79,6 +79,9 @@ func (c *clusters) Update(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, er
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *clusters) UpdateStatus(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, err error) {
 	result = &v1beta1.Cluster{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
@@ -82,6 +82,9 @@ func (c *statefulSets) Update(statefulSet *apps.StatefulSet) (result *apps.State
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *statefulSets) UpdateStatus(statefulSet *apps.StatefulSet) (result *apps.StatefulSet, err error) {
 	result = &apps.StatefulSet{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
@@ -82,6 +82,9 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling.H
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	result = &autoscaling.HorizontalPodAutoscaler{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/cronjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/cronjob.go
@@ -82,6 +82,9 @@ func (c *cronJobs) Update(cronJob *batch.CronJob) (result *batch.CronJob, err er
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *cronJobs) UpdateStatus(cronJob *batch.CronJob) (result *batch.CronJob, err error) {
 	result = &batch.CronJob{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/job.go
@@ -82,6 +82,9 @@ func (c *jobs) Update(job *batch.Job) (result *batch.Job, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *jobs) UpdateStatus(job *batch.Job) (result *batch.Job, err error) {
 	result = &batch.Job{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/certificatesigningrequest.go
@@ -78,6 +78,9 @@ func (c *certificateSigningRequests) Update(certificateSigningRequest *certifica
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *certificateSigningRequests) UpdateStatus(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
 	result = &certificates.CertificateSigningRequest{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/namespace.go
@@ -77,6 +77,9 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *namespaces) UpdateStatus(namespace *api.Namespace) (result *api.Namespace, err error) {
 	result = &api.Namespace{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/node.go
@@ -77,6 +77,9 @@ func (c *nodes) Update(node *api.Node) (result *api.Node, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *nodes) UpdateStatus(node *api.Node) (result *api.Node, err error) {
 	result = &api.Node{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolume.go
@@ -77,6 +77,9 @@ func (c *persistentVolumes) Update(persistentVolume *api.PersistentVolume) (resu
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *persistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolumeclaim.go
@@ -81,6 +81,9 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVol
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
 	result = &api.PersistentVolumeClaim{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/pod.go
@@ -81,6 +81,9 @@ func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *pods) UpdateStatus(pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/replicationcontroller.go
@@ -81,6 +81,9 @@ func (c *replicationControllers) Update(replicationController *api.ReplicationCo
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *replicationControllers) UpdateStatus(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/resourcequota.go
@@ -81,6 +81,9 @@ func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.R
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
 	result = &api.ResourceQuota{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/service.go
@@ -81,6 +81,9 @@ func (c *services) Update(service *api.Service) (result *api.Service, err error)
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *services) UpdateStatus(service *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/daemonset.go
@@ -82,6 +82,9 @@ func (c *daemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *daemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
@@ -82,6 +82,9 @@ func (c *deployments) Update(deployment *extensions.Deployment) (result *extensi
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *deployments) UpdateStatus(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/ingress.go
@@ -82,6 +82,9 @@ func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingr
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
@@ -82,6 +82,9 @@ func (c *replicaSets) Update(replicaSet *extensions.ReplicaSet) (result *extensi
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *replicaSets) UpdateStatus(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
 	result = &extensions.ReplicaSet{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/poddisruptionbudget.go
@@ -82,6 +82,9 @@ func (c *podDisruptionBudgets) Update(podDisruptionBudget *policy.PodDisruptionB
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *podDisruptionBudgets) UpdateStatus(podDisruptionBudget *policy.PodDisruptionBudget) (result *policy.PodDisruptionBudget, err error) {
 	result = &policy.PodDisruptionBudget{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/apps/v1beta1/statefulset.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/apps/v1beta1/statefulset.go
@@ -83,6 +83,9 @@ func (c *statefulSets) Update(statefulSet *v1beta1.StatefulSet) (result *v1beta1
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *statefulSets) UpdateStatus(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	result = &v1beta1.StatefulSet{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -83,6 +83,9 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v1.Horizontal
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/batch/v1/job.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/batch/v1/job.go
@@ -83,6 +83,9 @@ func (c *jobs) Update(job *v1.Job) (result *v1.Job, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *jobs) UpdateStatus(job *v1.Job) (result *v1.Job, err error) {
 	result = &v1.Job{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/batch/v2alpha1/cronjob.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/batch/v2alpha1/cronjob.go
@@ -83,6 +83,9 @@ func (c *cronJobs) Update(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, 
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *cronJobs) UpdateStatus(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	result = &v2alpha1.CronJob{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/batch/v2alpha1/job.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/batch/v2alpha1/job.go
@@ -83,6 +83,9 @@ func (c *jobs) Update(job *v2alpha1.Job) (result *v2alpha1.Job, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *jobs) UpdateStatus(job *v2alpha1.Job) (result *v2alpha1.Job, err error) {
 	result = &v2alpha1.Job{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/certificates/v1alpha1/certificatesigningrequest.go
@@ -79,6 +79,9 @@ func (c *certificateSigningRequests) Update(certificateSigningRequest *v1alpha1.
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *certificateSigningRequests) UpdateStatus(certificateSigningRequest *v1alpha1.CertificateSigningRequest) (result *v1alpha1.CertificateSigningRequest, err error) {
 	result = &v1alpha1.CertificateSigningRequest{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/namespace.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/namespace.go
@@ -78,6 +78,9 @@ func (c *namespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err 
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *namespaces) UpdateStatus(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/node.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/node.go
@@ -78,6 +78,9 @@ func (c *nodes) Update(node *v1.Node) (result *v1.Node, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *nodes) UpdateStatus(node *v1.Node) (result *v1.Node, err error) {
 	result = &v1.Node{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/persistentvolume.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/persistentvolume.go
@@ -78,6 +78,9 @@ func (c *persistentVolumes) Update(persistentVolume *v1.PersistentVolume) (resul
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *persistentVolumes) UpdateStatus(persistentVolume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/persistentvolumeclaim.go
@@ -82,6 +82,9 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *v1.PersistentVolu
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
 	result = &v1.PersistentVolumeClaim{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/pod.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/pod.go
@@ -82,6 +82,9 @@ func (c *pods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *pods) UpdateStatus(pod *v1.Pod) (result *v1.Pod, err error) {
 	result = &v1.Pod{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/replicationcontroller.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/replicationcontroller.go
@@ -82,6 +82,9 @@ func (c *replicationControllers) Update(replicationController *v1.ReplicationCon
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *replicationControllers) UpdateStatus(replicationController *v1.ReplicationController) (result *v1.ReplicationController, err error) {
 	result = &v1.ReplicationController{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/resourcequota.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/resourcequota.go
@@ -82,6 +82,9 @@ func (c *resourceQuotas) Update(resourceQuota *v1.ResourceQuota) (result *v1.Res
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *resourceQuotas) UpdateStatus(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
 	result = &v1.ResourceQuota{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/core/v1/service.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/core/v1/service.go
@@ -82,6 +82,9 @@ func (c *services) Update(service *v1.Service) (result *v1.Service, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *services) UpdateStatus(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/daemonset.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/daemonset.go
@@ -83,6 +83,9 @@ func (c *daemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.Daemo
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *daemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/deployment.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/deployment.go
@@ -83,6 +83,9 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/ingress.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/ingress.go
@@ -83,6 +83,9 @@ func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *ingresses) UpdateStatus(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/job.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/job.go
@@ -83,6 +83,9 @@ func (c *jobs) Update(job *v1beta1.Job) (result *v1beta1.Job, err error) {
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *jobs) UpdateStatus(job *v1beta1.Job) (result *v1beta1.Job, err error) {
 	result = &v1beta1.Job{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/replicaset.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/extensions/v1beta1/replicaset.go
@@ -83,6 +83,9 @@ func (c *replicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.Re
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *replicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
 	err = c.client.Put().

--- a/pkg/client/clientset_generated/release_1_5/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/release_1_5/typed/policy/v1beta1/poddisruptionbudget.go
@@ -83,6 +83,9 @@ func (c *podDisruptionBudgets) Update(podDisruptionBudget *v1beta1.PodDisruption
 	return
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+
 func (c *podDisruptionBudgets) UpdateStatus(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	result = &v1beta1.PodDisruptionBudget{}
 	err = c.client.Put().


### PR DESCRIPTION
fixes dependence on json tags in internal versions and drives the generation of UpdateStatus based on type comments

caught a type we were missing an UpdateStatus for