### PR TITLE
Fix panic in vSphere cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -128,30 +128,15 @@ func TestVSphereLogin(t *testing.T) {
 func TestZones(t *testing.T) {
 	cfg := VSphereConfig{}
 	cfg.Global.Datacenter = "myDatacenter"
-	failureZone := "myCluster"
 
 	// Create vSphere configuration object
 	vs := VSphere{
-		cfg:         &cfg,
-		clusterName: failureZone,
+		cfg: &cfg,
 	}
 
-	z, ok := vs.Zones()
-	if !ok {
-		t.Fatalf("Zones() returned false")
-	}
-
-	zone, err := z.GetZone()
-	if err != nil {
-		t.Fatalf("GetZone() returned error: %s", err)
-	}
-
-	if zone.Region != vs.cfg.Global.Datacenter {
-		t.Fatalf("GetZone() returned wrong region (%s)", zone.Region)
-	}
-
-	if zone.FailureDomain != failureZone {
-		t.Fatalf("GetZone() returned wrong Failure Zone (%s)", zone.FailureDomain)
+	_, ok := vs.Zones()
+	if ok {
+		t.Fatalf("Zones() returned true")
 	}
 }
 


### PR DESCRIPTION
Currently vSphere Cloud Provider triggers panic in controller-manager pod kubernetes. This is because it queries for the cluster name from the VC. We have eliminated that code from the vSphere cloud provider. 

Fixes #36295 