### PR TITLE
gitattributes for better reviews

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
 hack/verify-flags/known-flags.txt merge=union
 test/test_owners.csv merge=union
+
+**/zz_generated.*.go -diff
+**/types.generated.go -diff
+**/generated.pb.go -diff
+**/generated.proto -diff
+**/types_swagger_doc_generated.go -diff
+docs/api-reference/** -diff
+federation/docs/api-reference/** -diff


### PR DESCRIPTION
Reviewable will ignore files marked as -diff.
