### PR TITLE
apply sandbox network mode based on network plugin

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -294,7 +294,7 @@ func (ds *dockerService) applySandboxLinuxOptions(hc *dockercontainer.HostConfig
 	// TODO: Check if this works with per-pod cgroups.
 	hc.CgroupParent = lc.GetCgroupParent()
 	// Apply security context.
-	applySandboxSecurityContext(lc, createConfig.Config, hc)
+	applySandboxSecurityContext(lc, createConfig.Config, hc, ds.networkPlugin)
 
 	return nil
 }


### PR DESCRIPTION
This allows CRI to use docker's network bridge. Can be combined with noop network plugin. This allows to use docker0 with no further configuration. Good for tools like minikube/hyperkube.