### PR TITLE
Remove needless env var in OpenStack provider

### DIFF
--- a/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
@@ -32,7 +32,7 @@ write_files:
       username=$OS_USERNAME
       password=$OS_PASSWORD
       region=$OS_REGION_NAME
-      tenant-id=$OS_TENANT_ID
+      tenant-name=$OS_TENANT_NAME
       [LoadBalancer]
       lb-version=$LBAAS_VERSION
       subnet-id=$SUBNET_ID

--- a/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
@@ -106,9 +106,9 @@ parameters:
     description: OpenStack Region Name
     default: false
 
-  os_tenant_id:
+  os_tenant_name:
     type: string
-    description: OpenStack Tenant ID
+    description: OpenStack Tenant Name
     default: false
 
   enable_proxy:
@@ -296,7 +296,7 @@ resources:
             "$OS_USERNAME": {get_param: os_username}
             "$OS_PASSWORD": {get_param: os_password}
             "$OS_REGION_NAME": {get_param: os_region_name}
-            "$OS_TENANT_ID": {get_param: os_tenant_id}
+            "$OS_TENANT_NAME": {get_param: os_tenant_name}
             "$LBAAS_VERSION": {get_param: lbaas_version}
             "$SUBNET_ID": {get_resource: fixed_subnet}
             "$FLOATING_NETWORK_ID": {get_attr: [kube_master_floating, floating_network_id]}
@@ -401,7 +401,7 @@ resources:
           os_username: {get_param: os_username}
           os_password: {get_param: os_password}
           os_region_name: {get_param: os_region_name}
-          os_tenant_id: {get_param: os_tenant_id}
+          os_tenant_name: {get_param: os_tenant_name}
           enable_proxy: {get_param: enable_proxy }
           ftp_proxy: {get_param: ftp_proxy }
           http_proxy: {get_param: http_proxy }

--- a/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
@@ -61,9 +61,9 @@ parameters:
     description: OpenStack Region Name
     default: false
 
-  os_tenant_id:
+  os_tenant_name:
     type: string
-    description: OpenStack Tenant ID
+    description: OpenStack Tenant Name
     default: false
 
   enable_proxy:
@@ -213,7 +213,7 @@ resources:
             "$OS_USERNAME": {get_param: os_username}
             "$OS_PASSWORD": {get_param: os_password}
             "$OS_REGION_NAME": {get_param: os_region_name}
-            "$OS_TENANT_ID": {get_param: os_tenant_id}
+            "$OS_TENANT_NAME": {get_param: os_tenant_name}
             "$role": "kubernetes-pool"
 
   run_salt:

--- a/cluster/openstack-heat/openrc-default.sh
+++ b/cluster/openstack-heat/openrc-default.sh
@@ -22,5 +22,4 @@ export OS_USERNAME=${OS_USERNAME:-admin}
 export OS_PASSWORD=${OS_PASSWORD:-secretsecret}
 export OS_AUTH_URL=${OS_AUTH_URL:-http://192.168.123.100:5000/v2.0}
 export OS_TENANT_NAME=${OS_TENANT_NAME:-admin}
-export OS_TENANT_ID=${OS_TENANT_ID:-ed51b98b40944d89a449592eb67431eb}
 export OS_REGION_NAME=${OS_REGION_NAME:-RegionOne}

--- a/cluster/openstack-heat/openrc-swift.sh
+++ b/cluster/openstack-heat/openrc-swift.sh
@@ -23,5 +23,4 @@ export OS_USERNAME=${OS_USERNAME:-admin}
 export OS_PASSWORD=${OS_PASSWORD:-secretsecret}
 export OS_AUTH_URL=${OS_AUTH_URL:-http://192.168.123.100:5000/v2.0}
 export OS_TENANT_NAME=${OS_TENANT_NAME:-admin}
-export OS_TENANT_ID=${OS_TENANT_ID:-ed51b98b40944d89a449592eb67431eb}
 export OS_REGION_NAME=${OS_REGION_NAME:-RegionOne}

--- a/cluster/openstack-heat/util.sh
+++ b/cluster/openstack-heat/util.sh
@@ -217,7 +217,7 @@ function run-heat-script() {
       --parameter os_username=${OS_USERNAME} \
       --parameter os_password=${OS_PASSWORD} \
       --parameter os_region_name=${OS_REGION_NAME} \
-      --parameter os_tenant_id=${OS_TENANT_ID} \
+      --parameter os_tenant_name=${OS_TENANT_NAME} \
       --parameter enable_proxy=${ENABLE_PROXY} \
       --parameter ftp_proxy="${FTP_PROXY}" \
       --parameter http_proxy="${HTTP_PROXY}" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

If we use openstack provider to set up k8s cluster using kube-up script,
`TENANT_ID` environment variable is needed.
But to configure `TENANT_ID` is very annoying because this value is not static by each env.
This patch uses `TENANT_NAME` instead of `TENANT_ID`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

Since `TENANT_NAME` is unique if we use keystone v2 api,
so `TENANT_ID` is not needed if `TENANT_NAME` is provided
to configure OpenStack provider.
And also to set `TENANT_ID` is annoying to develop, because
`TENANT_ID` is not static by each environment.
This patch remove dependency of `TENANT_ID` and simply use
`TENANT_NAME`.