### PR TITLE
conversion-gen: add --skip-unsafe flag

### DIFF
--- a/cmd/libs/go2idl/conversion-gen/main.go
+++ b/cmd/libs/go2idl/conversion-gen/main.go
@@ -64,6 +64,8 @@ func main() {
 	}
 	pflag.CommandLine.StringSliceVar(&customArgs.ExtraPeerDirs, "extra-peer-dirs", customArgs.ExtraPeerDirs,
 		"Comma-separated list of import paths which are considered, after tag-specified peers, for conversions.")
+	pflag.CommandLine.BoolVar(&customArgs.SkipUnsafe, "skip-unsafe", customArgs.SkipUnsafe,
+		"If true, will not generate code using unsafe pointer conversions; resulting code may be slower.")
 	arguments.CustomArgs = customArgs
 
 	// Run it.

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -561,6 +561,7 @@ since-time
 skip-generated-rewrite
 skip-munges
 skip-preflight-checks
+skip-unsafe
 sort-by
 source-file
 ssh-env


### PR DESCRIPTION
We should expose the SkipUnsafe option, for legacy compatability, so
that conversion-go can be used in other projects, and for platforms
where unsafe is not available.

Make unsafe code generation the default though, and have the help text
hint that the resulting code is sub-optimal.