### PR TITLE
fix GetVolumeInUse() function

### DIFF
--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -297,8 +297,10 @@ func (vm *volumeManager) GetVolumesInUse() []v1.UniqueVolumeName {
 
 	for _, volume := range desiredVolumes {
 		if volume.PluginIsAttachable {
-			desiredVolumesMap[volume.VolumeName] = true
-			volumesToReportInUse = append(volumesToReportInUse, volume.VolumeName)
+			if _, exists := desiredVolumesMap[volume.VolumeName]; !exists {
+				desiredVolumesMap[volume.VolumeName] = true
+				volumesToReportInUse = append(volumesToReportInUse, volume.VolumeName)
+			}
 		}
 	}
 


### PR DESCRIPTION

Since we just want to get volume name info, each volume name just need to added once.  desiredStateOfWorld.GetVolumesToMount() will return volume and pod binding info,
if one volume is mounted to several pods, the volume name will be return several times. That is not what we want in this function.
We can add a new function to only get the volume name info  or judge whether the volume name is added to the desiredVolumesMap array.