### PR TITLE
remove incorrect groupName comment for apps.k8s.io

### DIFF
--- a/pkg/apis/apps/doc.go
+++ b/pkg/apis/apps/doc.go
@@ -15,6 +15,5 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +groupName=apps.k8s.io
 
 package apps // import "k8s.io/kubernetes/pkg/apis/apps"

--- a/pkg/apis/apps/v1beta1/doc.go
+++ b/pkg/apis/apps/v1beta1/doc.go
@@ -18,6 +18,5 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/apps
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=apps.k8s.io
 
 package v1beta1 // import "k8s.io/kubernetes/pkg/apis/apps/v1beta1"


### PR DESCRIPTION
The group name is "apps", not "apps.k8s.io"

The comment didn't actually affect client generation because there was an extra space between it and the package declaration, but removing it to avoid confusion