### PR TITLE
HPA e2e tests: fixed waiting for service creation.

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -396,7 +396,7 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, internalCli
 	}
 	framework.ExpectNoError(framework.RunRC(controllerRcConfig))
 
-	// Make sure endpoints are propagated.
-	// TODO(piosz): replace sleep with endpoints watch.
-	time.Sleep(10 * time.Second)
+	// Wait for endpoints to propagate for the controller service.
+	framework.ExpectNoError(framework.WaitForServiceEndpointsNum(
+		c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
 }


### PR DESCRIPTION
HPA e2e tests: fixed waiting for service creation. Fixes #32512.