### PR TITLE
Remove https check from keystone authentication since this is not essential

### DIFF
--- a/plugin/pkg/auth/authenticator/password/keystone/keystone.go
+++ b/plugin/pkg/auth/authenticator/password/keystone/keystone.go
@@ -73,7 +73,7 @@ func (keystoneAuthenticator *KeystoneAuthenticator) AuthenticatedClient(options 
 // NewKeystoneAuthenticator returns a password authenticator that validates credentials using openstack keystone
 func NewKeystoneAuthenticator(authURL string, caFile string) (*KeystoneAuthenticator, error) {
 	if !strings.HasPrefix(authURL, "https") {
-		return nil, errors.New("Auth URL should be secure and start with https")
+		glog.Info("Authenticating with keystone through plain http")
 	}
 	if authURL == "" {
 		return nil, errors.New("Auth URL is empty")


### PR DESCRIPTION
Since secure keystone authentication(by CA file) is an enhanced and optional feature, we should not force keystone  `authURL`  to start with https. In some circumstances we prefer not to verify the keystone server, because keystone itself is an authentication approach anyway. 

By default, keystone is recommended to install and configure with http.

ref: 
[Install and configure Keystone](http://docs.openstack.org/newton/install-guide-rdo/keystone-install.html)
[#11798](https://github.com/kubernetes/kubernetes/pull/11798)
[#35488](https://github.com/kubernetes/kubernetes/pull/35488)
