### PR TITLE
Better deal with failures under golang 1.8beta1

### DIFF
--- a/pkg/client/restclient/url_utils.go
+++ b/pkg/client/restclient/url_utils.go
@@ -33,10 +33,7 @@ func DefaultServerURL(host, apiPath string, groupVersion schema.GroupVersion, de
 	}
 	base := host
 	hostURL, err := url.Parse(base)
-	if err != nil {
-		return nil, "", err
-	}
-	if hostURL.Scheme == "" || hostURL.Host == "" {
+	if err != nil || hostURL.Scheme == "" || hostURL.Host == "" {
 		scheme := "http://"
 		if defaultTLS {
 			scheme = "https://"


### PR DESCRIPTION
If there is any error in the initial parsing then we should just
try adding the scheme.

url.Parse(base) has changed in 1.8. Please see the following change
https://github.com/golang/go/commit/c5ccbdd22bdbdc43d541b7e7d4ed66ceb559030e

Fixes #38380