### PR TITLE
Node E2E: `make test-e2e-node` runs the same test with pr builder by default.

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -18,7 +18,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 focus=${FOCUS:-""}
-skip=${SKIP:-""}
+skip=${SKIP-"\[Flaky\]|\[Slow\]|\[Serial\]"}
 # The number of tests that can run in parallel depends on what tests
 # are running and on the size of the node. Too many, and tests will
 # fail due to resource contention. 8 is a reasonable default for a

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -317,7 +317,11 @@ func getTestArtifacts(host, testDir string) error {
 // in the runner. This is used to collect serial console log.
 // TODO(random-liu): Use the log-dump script in cluster e2e.
 func WriteLog(host, filename, content string) error {
-	f, err := os.Create(filepath.Join(*resultsDir, host, filename))
+	logPath := filepath.Join(*resultsDir, host)
+	if err := os.MkdirAll(logPath, 0755); err != nil {
+		return fmt.Errorf("failed to create log directory %q: %v", logPath, err)
+	}
+	f, err := os.Create(filepath.Join(logPath, filename))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR makes `make test-e2e-node` run non-serial, non-flaky, non-slow test by default.
This will make it easier to use.

/cc @timstclair 