### PR TITLE
Renames kube-dns configure files from skydns* to kubedns*

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -41,7 +41,7 @@ spec:
           - --namespace=kube-system
           - --configmap=kube-dns-autoscaler
           - --mode=linear
-          # Should keep target in sync with cluster/addons/dns/skydns-rc.yaml.base
+          # Should keep target in sync with cluster/addons/dns/kubedns-controller.yaml.base
           - --target=Deployment/kube-dns
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
           # If using small nodes, "nodesPerReplica" should dominate.

--- a/cluster/addons/dns/Makefile
+++ b/cluster/addons/dns/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Makefile for the skydns underscore templates to Salt/Pillar and other formats.
+# Makefile for the kubedns underscore templates to Salt/Pillar and other formats.
 
 # If you update the *.base templates, please run this Makefile before pushing.
 #
@@ -29,6 +29,6 @@ all: transform
 %.sed: %.base
 	sed -f transforms2sed.sed $<  | sed s/__SOURCE_FILENAME__/$</g > $@
 
-transform: skydns-rc.yaml.in skydns-svc.yaml.in skydns-rc.yaml.sed skydns-svc.yaml.sed
+transform: kubedns-controller.yaml.in kubedns-svc.yaml.in kubedns-controller.yaml.sed kubedns-svc.yaml.sed
 
 .PHONY: transform

--- a/cluster/addons/dns/README.md
+++ b/cluster/addons/dns/README.md
@@ -23,7 +23,7 @@ for reference.
 ## kube-dns Deployment and Service templates
 
 This directory contains the base UNDERSCORE templates that can be used
-to generate the skydns-rc.yaml.in and skydns.rc.yaml.in needed in Salt format.
+to generate the kubedns-controller.yaml.in and kubedns.controller.yaml.in needed in Salt format.
 
 Due to a varied preference in templating language choices, the transform
 Makefile in this directory should be enhanced to generate all required
@@ -34,7 +34,7 @@ update the various scripts that supply values for your new parameter.
 Here is one way you might find those scripts:
 ```
 cd kubernetes
-find [a-zA-Z0-9]* -type f -exec grep skydns-rc.yaml \{\} \; -print -exec echo \;
+find [a-zA-Z0-9]* -type f -exec grep kubedns-controller.yaml \{\} \; -print -exec echo \;
 ```
 
 ### Base Template files
@@ -42,17 +42,17 @@ find [a-zA-Z0-9]* -type f -exec grep skydns-rc.yaml \{\} \; -print -exec echo \;
 These are the authoritative base templates.
 Run 'make' to generate the Salt and Sed yaml templates from these.
 
-skydns-rc.yaml.base
-skydns-svc.yaml.base
+kubedns-controller.yaml.base
+kubedns-svc.yaml.base
 
 ### Generated Salt files
 
-skydns-rc.yaml.in
-skydns-svc.yaml.in
+kubedns-controller.yaml.in
+kubedns-svc.yaml.in
 
 ### Generated Sed files
 
-skydns-rc.yaml.sed
-skydns-svc.yaml.sed
+kubedns-controller.yaml.sed
+kubedns-svc.yaml.sed
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns/README.md?pixel)]()

--- a/cluster/addons/dns/kubedns-controller.yaml.base
+++ b/cluster/addons/dns/kubedns-controller.yaml.base
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 # Should keep target in cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
 # in sync with this file.
 
-# Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
+# __MACHINE_GENERATED_WARNING__
 
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -78,10 +77,11 @@ spec:
           initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
-        - --domain=$DNS_DOMAIN.
+        - --domain=__PILLAR__DNS__DOMAIN__.
         - --dns-port=10053
         - --config-map=kube-dns
         - --v=2
+        __PILLAR__FEDERATIONS__DOMAIN__MAP__
         env:
         - name: PROMETHEUS_PORT
           value: "10055"
@@ -157,9 +157,9 @@ spec:
             # net memory requested by the pod constant.
             memory: 50Mi
         args:
-        - --cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1 >/dev/null
+        - --cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1 >/dev/null
         - --url=/healthz-dnsmasq
-        - --cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1:10053 >/dev/null
+        - --cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1:10053 >/dev/null
         - --url=/healthz-kubedns
         - --port=8080
         - --quiet

--- a/cluster/addons/dns/kubedns-controller.yaml.in
+++ b/cluster/addons/dns/kubedns-controller.yaml.in
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
 # Should keep target in cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
 # in sync with this file.
 
-# Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
+# Warning: This is a file generated from the base underscore template file: kubedns-controller.yaml.base
 
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/cluster/addons/dns/kubedns-controller.yaml.sed
+++ b/cluster/addons/dns/kubedns-controller.yaml.sed
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Warning: This is a file generated from the base underscore template file: skydns-rc.yaml.base
+# Should keep target in cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+# in sync with this file.
+
+# Warning: This is a file generated from the base underscore template file: kubedns-controller.yaml.base
 
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -44,17 +47,17 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-{{ arch }}:1.9
+        image: gcr.io/google_containers/kubedns-amd64:1.9
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            memory: 200Mi
+            memory: 170Mi
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 70Mi
         livenessProbe:
           httpGet:
             path: /healthz-kubedns
@@ -74,16 +77,13 @@ spec:
           initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
-        # command = "/kube-dns"
-        - --domain={{ pillar['dns_domain'] }}.
+        - --domain=$DNS_DOMAIN.
         - --dns-port=10053
         - --config-map=kube-dns
         - --v=2
-        - --kube_master_url=http://{{ private_address }}:8080
-        {{ pillar['federations_domain_map'] }}
         env:
-          - name: PROMETHEUS_PORT
-            value: "10055"
+        - name: PROMETHEUS_PORT
+          value: "10055"
         ports:
         - containerPort: 10053
           name: dns-local
@@ -95,7 +95,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-{{ arch }}:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -117,6 +117,11 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
+        # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+        resources:
+          requests:
+            cpu: 150m
+            memory: 10Mi
       - name: dnsmasq-metrics
         image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
         livenessProbe:
@@ -139,7 +144,7 @@ spec:
           requests:
             memory: 10Mi
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-{{ arch }}:1.2
+        image: gcr.io/google_containers/exechealthz-amd64:1.2
         resources:
           limits:
             memory: 50Mi
@@ -151,9 +156,9 @@ spec:
             # net memory requested by the pod constant.
             memory: 50Mi
         args:
-        - --cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null
+        - --cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1 >/dev/null
         - --url=/healthz-dnsmasq
-        - --cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1:10053 >/dev/null
+        - --cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1:10053 >/dev/null
         - --url=/healthz-kubedns
         - --port=8080
         - --quiet

--- a/cluster/addons/dns/kubedns-svc.yaml.base
+++ b/cluster/addons/dns/kubedns-svc.yaml.base
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
-
-# Warning: This is a file generated from the base underscore template file: skydns-svc.yaml.base
+# __MACHINE_GENERATED_WARNING__
 
 apiVersion: v1
 kind: Service
@@ -28,7 +26,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: $DNS_SERVER_IP
+  clusterIP: __PILLAR__DNS__SERVER__
   ports:
   - name: dns
     port: 53

--- a/cluster/addons/dns/kubedns-svc.yaml.in
+++ b/cluster/addons/dns/kubedns-svc.yaml.in
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
-
-# Warning: This is a file generated from the base underscore template file: skydns-svc.yaml.base
+# Warning: This is a file generated from the base underscore template file: kubedns-svc.yaml.base
 
 apiVersion: v1
 kind: Service

--- a/cluster/addons/dns/kubedns-svc.yaml.sed
+++ b/cluster/addons/dns/kubedns-svc.yaml.sed
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
-
-# __MACHINE_GENERATED_WARNING__
+# Warning: This is a file generated from the base underscore template file: kubedns-svc.yaml.base
 
 apiVersion: v1
 kind: Service
@@ -28,7 +26,7 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-  clusterIP: __PILLAR__DNS__SERVER__
+  clusterIP: $DNS_SERVER_IP
   ports:
   - name: dns
     port: 53

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1064,12 +1064,12 @@ function start-kube-addons {
   fi
   if [[ "${ENABLE_CLUSTER_DNS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "dns"
-    local -r dns_rc_file="${dst_dir}/dns/skydns-rc.yaml"
-    local -r dns_svc_file="${dst_dir}/dns/skydns-svc.yaml"
-    mv "${dst_dir}/dns/skydns-rc.yaml.in" "${dns_rc_file}"
-    mv "${dst_dir}/dns/skydns-svc.yaml.in" "${dns_svc_file}"
+    local -r dns_controller_file="${dst_dir}/dns/kubedns-controller.yaml"
+    local -r dns_svc_file="${dst_dir}/dns/kubedns-svc.yaml"
+    mv "${dst_dir}/dns/kubedns-controller.yaml.in" "${dns_controller_file}"
+    mv "${dst_dir}/dns/kubedns-svc.yaml.in" "${dns_svc_file}"
     # Replace the salt configurations with variable values.
-    sed -i -e "s@{{ *pillar\['dns_domain'\] *}}@${DNS_DOMAIN}@g" "${dns_rc_file}"
+    sed -i -e "s@{{ *pillar\['dns_domain'\] *}}@${DNS_DOMAIN}@g" "${dns_controller_file}"
     sed -i -e "s@{{ *pillar\['dns_server'\] *}}@${DNS_SERVER_IP}@g" "${dns_svc_file}"
 
     if [[ "${ENABLE_DNS_HORIZONTAL_AUTOSCALER:-}" == "true" ]]; then
@@ -1082,12 +1082,12 @@ function start-kube-addons {
         federations_domain_map="${FEDERATION_NAME}=${DNS_ZONE_NAME}"
       fi
       if [[ -n "${federations_domain_map}" ]]; then
-        sed -i -e "s@{{ *pillar\['federations_domain_map'\] *}}@- --federations=${federations_domain_map}@g" "${dns_rc_file}"
+        sed -i -e "s@{{ *pillar\['federations_domain_map'\] *}}@- --federations=${federations_domain_map}@g" "${dns_controller_file}"
       else
-        sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_rc_file}"
+        sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_controller_file}"
       fi
     else
-      sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_rc_file}"
+      sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_controller_file}"
     fi
   fi
   if [[ "${ENABLE_CLUSTER_REGISTRY:-}" == "true" ]]; then

--- a/cluster/gce/trusty/configure-helper.sh
+++ b/cluster/gce/trusty/configure-helper.sh
@@ -891,12 +891,12 @@ start_kube_addons() {
   fi
   if [ "${ENABLE_CLUSTER_DNS:-}" = "true" ]; then
     setup_addon_manifests "addons" "dns"
-    dns_rc_file="${addon_dst_dir}/dns/skydns-rc.yaml"
-    dns_svc_file="${addon_dst_dir}/dns/skydns-svc.yaml"
-    mv "${addon_dst_dir}/dns/skydns-rc.yaml.in" "${dns_rc_file}"
-    mv "${addon_dst_dir}/dns/skydns-svc.yaml.in" "${dns_svc_file}"
+    dns_controller_file="${addon_dst_dir}/dns/kubedns-controller.yaml"
+    dns_svc_file="${addon_dst_dir}/dns/kubedns-svc.yaml"
+    mv "${addon_dst_dir}/dns/kubedns-controller.yaml.in" "${dns_controller_file}"
+    mv "${addon_dst_dir}/dns/kubedns-svc.yaml.in" "${dns_svc_file}"
     # Replace the salt configurations with variable values.
-    sed -i -e "s@{{ *pillar\['dns_domain'\] *}}@${DNS_DOMAIN}@g" "${dns_rc_file}"
+    sed -i -e "s@{{ *pillar\['dns_domain'\] *}}@${DNS_DOMAIN}@g" "${dns_controller_file}"
     sed -i -e "s@{{ *pillar\['dns_server'\] *}}@${DNS_SERVER_IP}@g" "${dns_svc_file}"
 
     if [[ "${ENABLE_DNS_HORIZONTAL_AUTOSCALER:-}" == "true" ]]; then
@@ -909,12 +909,12 @@ start_kube_addons() {
         FEDERATIONS_DOMAIN_MAP="${FEDERATION_NAME}=${DNS_ZONE_NAME}"
       fi
       if [[ -n "${FEDERATIONS_DOMAIN_MAP}" ]]; then
-        sed -i -e "s@{{ *pillar\['federations_domain_map'\] *}}@- --federations=${FEDERATIONS_DOMAIN_MAP}@g" "${dns_rc_file}"
+        sed -i -e "s@{{ *pillar\['federations_domain_map'\] *}}@- --federations=${FEDERATIONS_DOMAIN_MAP}@g" "${dns_controller_file}"
       else
-        sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_rc_file}"
+        sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_controller_file}"
       fi
     else
-      sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_rc_file}"
+      sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_controller_file}"
     fi
   fi
   if [ "${ENABLE_CLUSTER_REGISTRY:-}" = "true" ]; then

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -58,8 +58,8 @@ endif
 	cp ../../saltbase/salt/generate-cert/make-ca-cert.sh ${TEMP_DIR}
 
 	# Singlenode addons
-	cp ../../addons/dns/skydns-rc.yaml.base ${TEMP_DIR}/addons/singlenode/skydns-rc.yaml
-	cp ../../addons/dns/skydns-svc.yaml.base ${TEMP_DIR}/addons/singlenode/skydns-svc.yaml
+	cp ../../addons/dns/kubedns-controller.yaml.base ${TEMP_DIR}/addons/singlenode/kubedns-controller.yaml
+	cp ../../addons/dns/kubedns-svc.yaml.base ${TEMP_DIR}/addons/singlenode/kubedns-svc.yaml
 	cp ../../addons/dashboard/dashboard-controller.yaml ${TEMP_DIR}/addons/singlenode/
 	cp ../../addons/dashboard/dashboard-service.yaml ${TEMP_DIR}/addons/singlenode/
 
@@ -76,8 +76,8 @@ endif
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 	cd ${TEMP_DIR} && sed -i.back "s|CACHEBUST|$(shell uuidgen)|g" Dockerfile
 	cd ${TEMP_DIR} && sed -i.back "s|-amd64|-${ARCH}|g" addons/singlenode/*.yaml addons/multinode/*.yaml
-	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__SERVER__|10.0.0.10|g" addons/singlenode/skydns*.yaml addons/multinode/skydns*.yaml
-	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__DOMAIN__|cluster.local|g;s|__PILLAR__FEDERATIONS__DOMAIN__MAP__||g;" addons/singlenode/skydns*.yaml addons/multinode/skydns*.yaml
+	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__SERVER__|10.0.0.10|g" addons/singlenode/kubedns*.yaml addons/multinode/kubedns*.yaml
+	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__DOMAIN__|cluster.local|g;s|__PILLAR__FEDERATIONS__DOMAIN__MAP__||g;" addons/singlenode/kubedns*.yaml addons/multinode/kubedns*.yaml
 	cd ${TEMP_DIR} && rm -f addons/singlenode/*.back addons/multinode/*.back static-pods/*.back
 
 	# Make scripts executable before they are copied into the Docker image. If we make them executable later, in another layer

--- a/cluster/juju/layers/kubernetes/config.yaml
+++ b/cluster/juju/layers/kubernetes/config.yaml
@@ -18,4 +18,4 @@ options:
     default: cluster.local
     description: |
       The domain name to use for the Kubernetes cluster by the
-      skydns service.
+      kubedns service.

--- a/cluster/juju/layers/kubernetes/reactive/k8s.py
+++ b/cluster/juju/layers/kubernetes/reactive/k8s.py
@@ -166,10 +166,10 @@ def launch_dns():
         # Create the kube-system namespace that is used by the kubedns files.
         check_call(split('kubectl create namespace kube-system'))
     # Check for the kubedns replication controller.
-    return_code = call(split('kubectl get -f files/manifests/kubedns-rc.yaml'))
+    return_code = call(split('kubectl get -f files/manifests/kubedns-controller.yaml'))
     if return_code != 0:
         # Create the kubedns replication controller from the rendered file.
-        check_call(split('kubectl create -f files/manifests/kubedns-rc.yaml'))
+        check_call(split('kubectl create -f files/manifests/kubedns-controller.yaml'))
     # Check for the kubedns service.
     return_code = call(split('kubectl get -f files/manifests/kubedns-svc.yaml'))
     if return_code != 0:
@@ -330,7 +330,7 @@ def gather_sdn_data():
     else:
         # There is no SDN cider fall back to the kubernetes config cidr option.
         pillar['dns_server'] = get_dns_ip(hookenv.config().get('cidr'))
-    # The pillar['dns_domain'] value is used in the kubedns-rc.yaml
+    # The pillar['dns_domain'] value is used in the kubedns-controller.yaml
     pillar['dns_domain'] = hookenv.config().get('dns_domain')
     # Use a 'pillar' dictionary so we can reuse the upstream kubedns templates.
     sdn_data['pillar'] = pillar
@@ -453,14 +453,14 @@ def render_files(reldata=None):
         # Render the files/manifests/master.json that contains parameters for
         # the apiserver, controller, and controller-manager
         render('master.json', target, context)
-        # Source: ...cluster/addons/dns/skydns-svc.yaml.in
+        # Source: ...cluster/addons/dns/kubedns-svc.yaml.in
         target = os.path.join(rendered_manifest_dir, 'kubedns-svc.yaml')
         # Render files/kubernetes/kubedns-svc.yaml for the DNS service.
         render('kubedns-svc.yaml', target, context)
-        # Source: ...cluster/addons/dns/skydns-rc.yaml.in
-        target = os.path.join(rendered_manifest_dir, 'kubedns-rc.yaml')
-        # Render files/kubernetes/kubedns-rc.yaml for the DNS pod.
-        render('kubedns-rc.yaml', target, context)
+        # Source: ...cluster/addons/dns/kubedns-controller.yaml.in
+        target = os.path.join(rendered_manifest_dir, 'kubedns-controller.yaml')
+        # Render files/kubernetes/kubedns-controller.yaml for the DNS pod.
+        render('kubedns-controller.yaml', target, context)
 
 
 def status_set(level, message):

--- a/cluster/juju/layers/kubernetes/templates/kubedns-controller.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-controller.yaml
@@ -12,11 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO - At some point, we need to rename all skydns-*.yaml.* files to kubedns-*.yaml.*
-# Should keep target in cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
-# in sync with this file.
+# This file should be kept in sync with cluster/addons/dns/kubedns-controller.yaml.base
 
-# __MACHINE_GENERATED_WARNING__
+# Warning: This is a file generated from the base underscore template file: kubedns-controller.yaml.base
 
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -48,17 +46,17 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-amd64:1.9
+        image: gcr.io/google_containers/kubedns-{{ arch }}:1.9
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
           # guaranteed class. Currently, this container falls into the
           # "burstable" category so the kubelet doesn't backoff from restarting it.
           limits:
-            memory: 170Mi
+            memory: 200Mi
           requests:
             cpu: 100m
-            memory: 70Mi
+            memory: 100Mi
         livenessProbe:
           httpGet:
             path: /healthz-kubedns
@@ -78,14 +76,16 @@ spec:
           initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
-        - --domain=__PILLAR__DNS__DOMAIN__.
+        # command = "/kube-dns"
+        - --domain={{ pillar['dns_domain'] }}.
         - --dns-port=10053
         - --config-map=kube-dns
         - --v=2
-        __PILLAR__FEDERATIONS__DOMAIN__MAP__
+        - --kube_master_url=http://{{ private_address }}:8080
+        {{ pillar['federations_domain_map'] }}
         env:
-        - name: PROMETHEUS_PORT
-          value: "10055"
+          - name: PROMETHEUS_PORT
+            value: "10055"
         ports:
         - containerPort: 10053
           name: dns-local
@@ -97,7 +97,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-{{ arch }}:1.4
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -119,11 +119,6 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
-        # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
-        resources:
-          requests:
-            cpu: 150m
-            memory: 10Mi
       - name: dnsmasq-metrics
         image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
         livenessProbe:
@@ -146,7 +141,7 @@ spec:
           requests:
             memory: 10Mi
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.2
+        image: gcr.io/google_containers/exechealthz-{{ arch }}:1.2
         resources:
           limits:
             memory: 50Mi
@@ -158,9 +153,9 @@ spec:
             # net memory requested by the pod constant.
             memory: 50Mi
         args:
-        - --cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1 >/dev/null
+        - --cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1 >/dev/null
         - --url=/healthz-dnsmasq
-        - --cmd=nslookup kubernetes.default.svc.__PILLAR__DNS__DOMAIN__ 127.0.0.1:10053 >/dev/null
+        - --cmd=nslookup kubernetes.default.svc.{{ pillar['dns_domain'] }} 127.0.0.1:10053 >/dev/null
         - --url=/healthz-kubedns
         - --port=8080
         - --quiet

--- a/cluster/juju/layers/kubernetes/templates/kubedns-svc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-svc.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file should be kept in sync with cluster/images/hyperkube/dns-svc.yaml
+# This file should be kept in sync with cluster/addons/dns/kubedns-svc.yaml.base
 
-# Warning: This is a file generated from the base underscore template file: skydns-svc.yaml.base
+# Warning: This is a file generated from the base underscore template file: kubedns-svc.yaml.base
 
 apiVersion: v1
 kind: Service

--- a/cluster/libvirt-coreos/config-default.sh
+++ b/cluster/libvirt-coreos/config-default.sh
@@ -62,5 +62,5 @@ DNS_DOMAIN="cluster.local"
 ENABLE_DNS_HORIZONTAL_AUTOSCALER="${KUBE_ENABLE_DNS_HORIZONTAL_AUTOSCALER:-false}"
 
 #Generate dns files
-sed -f "${KUBE_ROOT}/cluster/addons/dns/transforms2sed.sed" < "${KUBE_ROOT}/cluster/addons/dns/skydns-rc.yaml.base" | sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  > "${KUBE_ROOT}/cluster/libvirt-coreos/skydns-rc.yaml"
-sed -f "${KUBE_ROOT}/cluster/addons/dns/transforms2sed.sed" < "${KUBE_ROOT}/cluster/addons/dns/skydns-svc.yaml.base" | sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  > "${KUBE_ROOT}/cluster/libvirt-coreos/skydns-svc.yaml"
+sed -f "${KUBE_ROOT}/cluster/addons/dns/transforms2sed.sed" < "${KUBE_ROOT}/cluster/addons/dns/kubedns-controller.yaml.base" | sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  > "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-controller.yaml"
+sed -f "${KUBE_ROOT}/cluster/addons/dns/transforms2sed.sed" < "${KUBE_ROOT}/cluster/addons/dns/kubedns-svc.yaml.base" | sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  > "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-svc.yaml"

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -177,8 +177,8 @@ function initialize-pool {
   mkdir -p "$POOL_PATH/kubernetes/addons"
   if [[ "$ENABLE_CLUSTER_DNS" == "true" ]]; then
       render-template "$ROOT/namespace.yaml" > "$POOL_PATH/kubernetes/addons/namespace.yaml"
-      render-template "$ROOT/skydns-svc.yaml" > "$POOL_PATH/kubernetes/addons/skydns-svc.yaml"
-      render-template "$ROOT/skydns-rc.yaml"  > "$POOL_PATH/kubernetes/addons/skydns-rc.yaml"
+      render-template "$ROOT/kubedns-svc.yaml" > "$POOL_PATH/kubernetes/addons/kubedns-svc.yaml"
+      render-template "$ROOT/kubedns-controller.yaml"  > "$POOL_PATH/kubernetes/addons/kubedns-controller.yaml"
   fi
 
   virsh pool-refresh $POOL

--- a/cluster/mesos/docker/deploy-dns.sh
+++ b/cluster/mesos/docker/deploy-dns.sh
@@ -28,8 +28,8 @@ kubectl="${KUBE_ROOT}/cluster/kubectl.sh"
 workspace=$(pwd)
 
 # Process salt pillar templates manually
-sed -e "s/{{ pillar\['dns_domain'\] }}/${DNS_DOMAIN}/g" "${KUBE_ROOT}/cluster/addons/dns/skydns-rc.yaml.in" > "${workspace}/skydns-rc.yaml"
-sed -e "s/{{ pillar\['dns_server'\] }}/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/addons/dns/skydns-svc.yaml.in" > "${workspace}/skydns-svc.yaml"
+sed -e "s/{{ pillar\['dns_domain'\] }}/${DNS_DOMAIN}/g" "${KUBE_ROOT}/cluster/addons/dns/kubedns-controller.yaml.in" > "${workspace}/kubedns-controller.yaml"
+sed -e "s/{{ pillar\['dns_server'\] }}/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/addons/dns/kubedns-svc.yaml.in" > "${workspace}/kubedns-svc.yaml"
 
 # Federation specific values.
 if [[ "${FEDERATION:-}" == "true" ]]; then
@@ -38,14 +38,14 @@ if [[ "${FEDERATION:-}" == "true" ]]; then
     FEDERATIONS_DOMAIN_MAP="${FEDERATION_NAME}=${DNS_ZONE_NAME}"
   fi
   if [[ -n "${FEDERATIONS_DOMAIN_MAP}" ]]; then
-    sed -i -e "s/{{ pillar\['federations_domain_map'\] }}/- --federations=${FEDERATIONS_DOMAIN_MAP}/g" "${workspace}/skydns-rc.yaml"
+    sed -i -e "s/{{ pillar\['federations_domain_map'\] }}/- --federations=${FEDERATIONS_DOMAIN_MAP}/g" "${workspace}/kubedns-controller.yaml"
   else
-    sed -i -e "/{{ pillar\['federations_domain_map'\] }}/d" "${workspace}/skydns-rc.yaml"
+    sed -i -e "/{{ pillar\['federations_domain_map'\] }}/d" "${workspace}/kubedns-controller.yaml"
   fi
 else
-  sed -i -e "/{{ pillar\['federations_domain_map'\] }}/d" "${workspace}/skydns-rc.yaml"
+  sed -i -e "/{{ pillar\['federations_domain_map'\] }}/d" "${workspace}/kubedns-controller.yaml"
 fi
 
 # Use kubectl to create kube-dns controller and service
-"${kubectl}" create -f "${workspace}/skydns-rc.yaml"
-"${kubectl}" create -f "${workspace}/skydns-svc.yaml"
+"${kubectl}" create -f "${workspace}/kubedns-controller.yaml"
+"${kubectl}" create -f "${workspace}/kubedns-svc.yaml"

--- a/cluster/saltbase/salt/kube-addons/init.sls
+++ b/cluster/saltbase/salt/kube-addons/init.sls
@@ -73,17 +73,17 @@ addon-dir-create:
 {% endif %}
 
 {% if pillar.get('enable_cluster_dns', '').lower() == 'true' %}
-/etc/kubernetes/addons/dns/skydns-svc.yaml:
+/etc/kubernetes/addons/dns/kubedns-svc.yaml:
   file.managed:
-    - source: salt://kube-addons/dns/skydns-svc.yaml.in
+    - source: salt://kube-addons/dns/kubedns-svc.yaml.in
     - template: jinja
     - group: root
     - dir_mode: 755
     - makedirs: True
 
-/etc/kubernetes/addons/dns/skydns-rc.yaml:
+/etc/kubernetes/addons/dns/kubedns-controller.yaml:
   file.managed:
-    - source: salt://kube-addons/dns/skydns-rc.yaml.in
+    - source: salt://kube-addons/dns/kubedns-controller.yaml.in
     - template: jinja
     - group: root
     - dir_mode: 755

--- a/cluster/ubuntu/.gitignore
+++ b/cluster/ubuntu/.gitignore
@@ -1,2 +1,2 @@
 binaries
-skydns*
+kubedns*

--- a/cluster/ubuntu/deployAddons.sh
+++ b/cluster/ubuntu/deployAddons.sh
@@ -41,15 +41,15 @@ function init {
 
 function deploy_dns {
   echo "Deploying DNS on Kubernetes"
-  sed -e "s/\\\$DNS_DOMAIN/${DNS_DOMAIN}/g" "${KUBE_ROOT}/cluster/addons/dns/skydns-rc.yaml.sed" > skydns-rc.yaml
-  sed -e "s/\\\$DNS_SERVER_IP/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/addons/dns/skydns-svc.yaml.sed" > skydns-svc.yaml
+  sed -e "s/\\\$DNS_DOMAIN/${DNS_DOMAIN}/g" "${KUBE_ROOT}/cluster/addons/dns/kubedns-controller.yaml.sed" > kubedns-controller.yaml
+  sed -e "s/\\\$DNS_SERVER_IP/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/addons/dns/kubedns-svc.yaml.sed" > kubedns-svc.yaml
 
   KUBEDNS=`eval "${KUBECTL} get services --namespace=kube-system | grep kube-dns | cat"`
 
   if [ ! "$KUBEDNS" ]; then
-    # use kubectl to create skydns rc and service
-    ${KUBECTL} --namespace=kube-system create -f skydns-rc.yaml 
-    ${KUBECTL} --namespace=kube-system create -f skydns-svc.yaml
+    # use kubectl to create kubedns controller and service
+    ${KUBECTL} --namespace=kube-system create -f kubedns-controller.yaml 
+    ${KUBECTL} --namespace=kube-system create -f kubedns-svc.yaml
 
     echo "Kube-dns controller and service are successfully deployed."
   else


### PR DESCRIPTION
`skydns-` prefix and `-rc` suffix are confusing and misleading. Renaming it to `kubedns` in existing yaml files and scripts.

@bowei @thockin 