### PR TITLE
Fix kubectl Factory extensibility

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -221,6 +221,10 @@ func (f *FakeFactory) RESTClient() (*restclient.RESTClient, error) {
 	return nil, nil
 }
 
+func (f *FakeFactory) ClientCache() cmdutil.ClientCache {
+	return nil
+}
+
 func (f *FakeFactory) ClientSet() (*internalclientset.Clientset, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Fix kubectl Factory extensibility by avoiding any calls to other Factory methods
and instead use exposed package-level helper functions that take in subdivided
interfaces so downstream integrators can reuse Kubernetes's default
implementations but pass in a different Factory implementation.

cc @smarterclayton @fabianofranz @AdoHe @kubernetes/kubectl @kubernetes/rh-ux @kubernetes/sig-cli 