### PR TITLE
Prevent json decoder panic on invalid input

### DIFF
--- a/pkg/runtime/serializer/json/json.go
+++ b/pkg/runtime/serializer/json/json.go
@@ -194,7 +194,7 @@ func (s *Serializer) RecognizesData(peek io.Reader) (ok, unknown bool, err error
 		// we could potentially look for '---'
 		return false, true, nil
 	}
-	_, ok = utilyaml.GuessJSONStream(peek, 2048)
+	_, _, ok = utilyaml.GuessJSONStream(peek, 2048)
 	return ok, false, nil
 }
 

--- a/pkg/util/yaml/decoder_test.go
+++ b/pkg/util/yaml/decoder_test.go
@@ -65,7 +65,7 @@ func TestSplitYAMLDocument(t *testing.T) {
 }
 
 func TestGuessJSON(t *testing.T) {
-	if r, isJSON := GuessJSONStream(bytes.NewReader([]byte(" \n{}")), 100); !isJSON {
+	if r, _, isJSON := GuessJSONStream(bytes.NewReader([]byte(" \n{}")), 100); !isJSON {
 		t.Fatalf("expected stream to be JSON")
 	} else {
 		b := make([]byte, 30)


### PR DESCRIPTION
Related downstream issue: https://github.com/openshift/origin/issues/12132
```
# Can be replicated on kubectl with:
$ cat panic.json
{
  "kind": "Pod",
  "apiVersion": "v1",
  "metadata": {
    "name": "",
    "labels": {
      "name": ""
    },
    "generateName": "",
    "namespace": "",
    "annotations": []
  },
  "spec": {}
},

$ kubectl create -f panic.json --validate=false
```

**Release note**:
```release-note
release-note-none
```

This patch handles cases where `ioutil.ReadAll` will return a single
character output on an invalid json input, causing the `Decode` method
to panic when it tries to calculate the line number for the syntax
error. The example below would cause a panic due to the trailing comma
at the end:

```
{
  "kind": "Pod",
  "apiVersion": "v1",
  "metadata": {
    "name": "",
    "labels": {
      "name": ""
    },
    "generateName": "",
    "namespace": "",
    "annotations": []
  },
  "spec": {}
},
```

@kubernetes/cli-review @fabianofranz 