### PR TITLE
Priority REST Mapper: Actually honor user choice

### DIFF
--- a/pkg/api/meta/priority.go
+++ b/pkg/api/meta/priority.go
@@ -163,9 +163,9 @@ func (m PriorityRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string)
 	if len(versions) > 0 {
 		priorities = make([]schema.GroupVersionKind, 0, len(m.KindPriority)+len(versions))
 		for _, version := range versions {
-			gv, err := schema.ParseGroupVersion(version)
-			if err != nil {
-				return nil, err
+			gv := schema.GroupVersion{
+				Version: version,
+				Group:   gk.Group,
 			}
 			priorities = append(priorities, gv.WithKind(AnyKind))
 		}


### PR DESCRIPTION
```release-note
Fixes bug in resolving client-requested API versions
```

RESTMapping takes a desired GroupKind, and a set of versions, and
returns a rest mapper for the first matching version.  It also has a
list of built-in discovered prioritized versions, to which it appends
the user versions.

However, when it goes to parse the versions, it parses them as
GroupVersions.  Since only a version was passed, the group will be the
empty group (""), which will only match rest mappings for the empty
group, ergo, none of the user's versions will match if they are
attempting a match for a non-emtpy-group GroupKind.

This fixes that by taking the parsed GroupVersion, and overriding the
Group with the Group from the passed-in GroupKind.