### PR TITLE
Fix 1.3 e2e test to add an additional wait for 1.5 behavior

### DIFF
--- a/test/e2e/resize_nodes.go
+++ b/test/e2e/resize_nodes.go
@@ -447,6 +447,9 @@ var _ = framework.KubeDescribe("Nodes [Disruptive]", func() {
 			err = framework.WaitForClusterSize(c, int(replicas-1), 10*time.Minute)
 			Expect(err).NotTo(HaveOccurred())
 
+			By("waiting 1 minute for the pods to get cleaned up and recreated")
+			time.Sleep(time.Minute)
+
 			By("verifying whether the pods from the removed node are recreated")
 			err = framework.VerifyPods(c, ns, name, true, replicas)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Prequel: https://github.com/kubernetes/kubernetes/pull/38324

**This fix is for the 1.3 branch**. 
Fixes https://github.com/kubernetes/kubernetes/issues/38247

This makes the 1.5 upgrade tests green while being **a NOP on 
the older 1.3 tests**. 

* pre-1.5 behavior is that the NC cleans up pods as soon as node is unreachable for a specified timeout.
* 1.5 behavior is to let the podGC clean up the pods after node deletion by NC.

Due to the fact that the deletion responsibility is now (as of 1.5) split
between the NC and podGC, we need an additional sleep to ensure that
things get cleaned up. 

This was changed in https://github.com/kubernetes/kubernetes/pull/35235

