### PR TITLE
Fix code coverage in build script on OS X.

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -245,25 +245,28 @@ runTests() {
   # `go test` does not install the things it builds. `go test -i` installs
   # the build artifacts but doesn't run the tests.  The two together provide
   # a large speedup for tests that do not need to be rebuilt.
-  printf "%s\n" "${@}" | grep -Ev $cover_ignore_dirs | xargs -I{} -n1 -P${KUBE_COVERPROCS} \
-    bash -c "set -o pipefail; _pkg=\"{}\"; _pkg_out=\${_pkg//\//_}; \
-        go test -i ${goflags[@]:+${goflags[@]}} \
-          ${KUBE_RACE} \
-          ${KUBE_TIMEOUT} \
-          -cover -covermode=\"${KUBE_COVERMODE}\" \
-          -coverprofile=\"${cover_report_dir}/\${_pkg}/${cover_profile}\" \
-          \"${KUBE_GO_PACKAGE}/\${_pkg}\" \
-          ${testargs[@]:+${testargs[@]}}
-        go test ${goflags[@]:+${goflags[@]}} \
-          ${KUBE_RACE} \
-          ${KUBE_TIMEOUT} \
-          -cover -covermode=\"${KUBE_COVERMODE}\" \
-          -coverprofile=\"${cover_report_dir}/\${_pkg}/${cover_profile}\" \
-          \"${KUBE_GO_PACKAGE}/\${_pkg}\" \
-          ${testargs[@]:+${testargs[@]}} \
-        | tee ${junit_filename_prefix:+\"${junit_filename_prefix}-\$_pkg_out.stdout\"} \
-        | grep \"${go_test_grep_pattern}\"" \
-      && test_result=$? || test_result=$?
+  printf "%s\n" "${@}" \
+    | grep -Ev $cover_ignore_dirs \
+    | xargs -I{} -n 1 -P ${KUBE_COVERPROCS} \
+    bash -c "set -o pipefail; _pkg=\"\$0\"; _pkg_out=\${_pkg//\//_}; \
+      go test -i ${goflags[@]:+${goflags[@]}} \
+        ${KUBE_RACE} \
+        ${KUBE_TIMEOUT} \
+        -cover -covermode=\"${KUBE_COVERMODE}\" \
+        -coverprofile=\"${cover_report_dir}/\${_pkg}/${cover_profile}\" \
+        \"${KUBE_GO_PACKAGE}/\${_pkg}\" \
+        ${testargs[@]:+${testargs[@]}}
+      go test ${goflags[@]:+${goflags[@]}} \
+        ${KUBE_RACE} \
+        ${KUBE_TIMEOUT} \
+        -cover -covermode=\"${KUBE_COVERMODE}\" \
+        -coverprofile=\"${cover_report_dir}/\${_pkg}/${cover_profile}\" \
+        \"${KUBE_GO_PACKAGE}/\${_pkg}\" \
+        ${testargs[@]:+${testargs[@]}} \
+      | tee ${junit_filename_prefix:+\"${junit_filename_prefix}-\$_pkg_out.stdout\"} \
+      | grep \"${go_test_grep_pattern}\"" \
+    {} \
+    && test_result=$? || test_result=$?
 
   produceJUnitXMLReport "${junit_filename_prefix}"
 


### PR DESCRIPTION
Fixes #20223

- Fixes code coverage in build script on BSD systems (including OS X).
- Supersedes #38536.

Successfully tested on two platforms:

```
Darwin <hostname> 16.1.0 Darwin Kernel Version 16.1.0: Thu Oct 13 21:26:57 PDT 2016; root:xnu-3789.21.3~60/RELEASE_X86_64 x86_64
```

```
Linux <hostname> 4.4.14-040414-generic #201606241434 SMP Fri Jun 24 18:36:45 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux
```

cc @ixdy @mfanjie @balajismaniam @smarterclayton @soltysh

**Release note**:
```release-note
```