### PR TITLE
dnsprovider: Expose route53 constructor

### DIFF
--- a/federation/pkg/dnsprovider/providers/aws/route53/interface.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/interface.go
@@ -28,9 +28,9 @@ type Interface struct {
 	service stubs.Route53API
 }
 
-// newInterfaceWithStub facilitates stubbing out the underlying AWS Route53
-// library for testing purposes.  It returns an provider-independent interface.
-func newInterfaceWithStub(service stubs.Route53API) *Interface {
+// New builds an Interface, with a specified Route53API implementation.
+// This is useful for testing purposes, but also if we want an instance with with custom AWS options.
+func New(service stubs.Route53API) *Interface {
 	return &Interface{service}
 }
 

--- a/federation/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -40,5 +40,5 @@ func init() {
 func newRoute53(config io.Reader) (*Interface, error) {
 	// Connect to AWS Route53 - TODO: Do more sophisticated auth
 	svc := route53.New(session.New())
-	return newInterfaceWithStub(svc), nil
+	return New(svc), nil
 }

--- a/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
@@ -40,7 +40,7 @@ func newTestInterface() (dnsprovider.Interface, error) {
 func newFakeInterface() (dnsprovider.Interface, error) {
 	var service route53testing.Route53API
 	service = route53testing.NewRoute53APIStub()
-	iface := newInterfaceWithStub(service)
+	iface := New(service)
 	// Add a fake zone to test against.
 	params := &route53.CreateHostedZoneInput{
 		CallerReference: aws.String("Nonce"),       // Required


### PR DESCRIPTION
This enables testing when the dnsprovider is used externally (with a
mock Route53 API, as we do in kops), and also might be useful for
constructing with a particular client instance with extra options.