### PR TITLE
Re-add /healthz/ping handler in genericapiserver

### DIFF
--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -287,6 +287,14 @@ func TestPrepareRun(t *testing.T) {
 	resp, err = http.Get(server.URL + "/swaggerapi/")
 	assert.NoError(err)
 	assert.Equal(http.StatusOK, resp.StatusCode)
+
+	// healthz checks are installed in PrepareRun
+	resp, err = http.Get(server.URL + "/healthz")
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
+	resp, err = http.Get(server.URL + "/healthz/ping")
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
 }
 
 // TestCustomHandlerChain verifies the handler chain with custom handler chain builder functions.


### PR DESCRIPTION
The ping handler was removed through https://github.com/kubernetes/kubernetes/commit/f56cbfa8d58488fc67ffab902cc2e0df0b5e29e5#diff-c47934bf31679532191ed2b519d74399L233 (in case `c.Tunneler` was disabled).