### PR TITLE
Node E2E: Update CVM version to e2e-node-containervm-v20161208-image.

### DIFF
--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -1,49 +1,49 @@
 ---
 images:
   containervm-density1:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
     machine: n1-standard-1
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   containervm-density2:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   containervm-density2-qps60:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   containervm-density3:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
     machine: n1-standard-2
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   containervm-density4:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
   containervm-resource1:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   containervm-resource2:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   containervm-resource3:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
     machine: n1-standard-1
     tests:

--- a/test/e2e_node/jenkins/cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   containervm:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
   gci-family:
     image_regex: gci-dev-56-8977-0-0

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -10,7 +10,7 @@ images:
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   containervm:
-    image: e2e-node-containervm-v20160604-image
+    image: e2e-node-containervm-v20161208-image
     project: kubernetes-node-e2e-images
   gci-family:
     image_regex: gci-dev-56-8977-0-0


### PR DESCRIPTION
I built the new node e2e image from e2e-node-containervm-v20161208-image.

@timstclair 
/cc @kubernetes/sig-node 