### PR TITLE
[WIP] add stream-timeout option to `kubectl exec`

### DIFF
--- a/pkg/client/unversioned/remotecommand/remotecommand.go
+++ b/pkg/client/unversioned/remotecommand/remotecommand.go
@@ -177,24 +177,5 @@ func (e *streamExecutor) Stream(options StreamOptions) error {
 		streamer = newStreamProtocolV1(options)
 	}
 
-	streamChan := make(chan error)
-	go func() {
-		streamChan <- streamer.stream(conn)
-	}()
-
-	if options.StreamTimeout == 0 {
-		select {
-		case err, _ := <-streamChan:
-			return err
-		}
-	} else {
-		select {
-		case err, _ := <-streamChan:
-			return err
-		case <-time.After(options.StreamTimeout):
-			return fmt.Errorf("Timeout exceeded for this operation.")
-		}
-	}
-
-	return nil
+	return streamer.stream(conn)
 }

--- a/pkg/client/unversioned/remotecommand/v4.go
+++ b/pkg/client/unversioned/remotecommand/v4.go
@@ -20,12 +20,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strconv"
 	"sync"
+	"time"
+
+	"bufio"
 
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
 	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/runtime"
 )
 
 // streamProtocolV4 implements version 4 of the streaming protocol for attach
@@ -33,6 +38,8 @@ import (
 // the use of metav1.Status instead of plain text messages.
 type streamProtocolV4 struct {
 	*streamProtocolV3
+
+	keepAliveChan chan int
 }
 
 var _ streamProtocolHandler = &streamProtocolV4{}
@@ -40,6 +47,7 @@ var _ streamProtocolHandler = &streamProtocolV4{}
 func newStreamProtocolV4(options StreamOptions) streamProtocolHandler {
 	return &streamProtocolV4{
 		streamProtocolV3: newStreamProtocolV3(options).(*streamProtocolV3),
+		keepAliveChan:    make(chan int),
 	}
 }
 
@@ -51,6 +59,41 @@ func (p *streamProtocolV4) handleResizes() {
 	p.streamProtocolV3.handleResizes()
 }
 
+// copy bytes from p.remoteStdout to p.Stdout without using io.Copy, in order to
+// reuse the stream to notify p.keepAliveChan of ongoing activity in the remote shell
+func (p *streamProtocolV4) copyStdout(wg *sync.WaitGroup) {
+	if p.Stdout == nil {
+		return
+	}
+
+	wg.Add(1)
+	go func() {
+		defer runtime.HandleCrash()
+		defer wg.Done()
+		defer close(p.keepAliveChan)
+
+		chunkReader := bufio.NewReader(p.remoteStdout)
+		buffer := make([]byte, 32*1024)
+		for {
+			n, err := chunkReader.Read(buffer)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				runtime.HandleError(err)
+				break
+			}
+
+			p.Stdout.Write(buffer[0:n])
+
+			// send amount of bytes written to keepAliveChan
+			// in order to notify it of ongoing activity in
+			// the remote shell.
+			p.keepAliveChan <- n
+		}
+	}()
+}
+
 func (p *streamProtocolV4) stream(conn streamCreator) error {
 	if err := p.createStreams(conn); err != nil {
 		return err
@@ -59,20 +102,61 @@ func (p *streamProtocolV4) stream(conn streamCreator) error {
 	// now that all the streams have been created, proceed with reading & copying
 
 	errorChan := watchErrorStream(p.errorStream, &errorDecoderV4{})
+	waitChan := make(chan bool)
 
-	p.handleResizes()
+	go func() {
+		defer runtime.HandleCrash()
 
-	p.copyStdin()
+		// now that all the streams have been created, proceed with reading & copying
 
-	var wg sync.WaitGroup
-	p.copyStdout(&wg)
-	p.copyStderr(&wg)
+		p.handleResizes()
+		p.copyStdin()
 
-	// we're waiting for stdout/stderr to finish copying
-	wg.Wait()
+		var wg sync.WaitGroup
+		p.copyStdout(&wg)
+		p.copyStderr(&wg)
 
-	// waits for errorStream to finish reading with an error or nil
-	return <-errorChan
+		// we're waiting for stdout/stderr to finish copying
+		wg.Wait()
+
+		close(waitChan)
+	}()
+
+	if p.StreamTimeout == 0 {
+		for {
+			select {
+			case <-waitChan:
+				return <-errorChan
+			case <-p.keepAliveChan:
+				// noop - keep reading from this channel to prevent
+				// blocking the stdout stream copy.
+			}
+		}
+	} else {
+		totalIdleTime := p.StreamTimeout.Seconds()
+		tickDuration := 1 * time.Second
+
+		// if tickDuration is >= user-specified idle timeout,
+		// make the ticker count equal to the user-defined timeout
+		if p.StreamTimeout < tickDuration {
+			tickDuration = p.StreamTimeout
+		}
+
+		for {
+			select {
+			case <-waitChan:
+				return <-errorChan
+			case <-p.keepAliveChan:
+				totalIdleTime = p.StreamTimeout.Seconds()
+			case <-time.After(tickDuration):
+				totalIdleTime--
+				if totalIdleTime <= 0 {
+					return fmt.Errorf("Timeout exceeded for this operation.")
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // errorDecoderV4 interprets the json-marshaled metav1.Status on the error channel

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -416,6 +416,10 @@ func AddGeneratorFlags(cmd *cobra.Command, defaultGenerator string) {
 	AddDryRunFlag(cmd)
 }
 
+func AddRemoteStreamFlags(cmd *cobra.Command) {
+	cmd.Flags().Duration("stream-timeout", 0, "Maximum amount of time to keep remote shell open. If 0, shell will remain open until an EOF is received. Defaults to 0.")
+}
+
 func ReadConfigDataFromReader(reader io.Reader, source string) ([]byte, error) {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -417,7 +417,7 @@ func AddGeneratorFlags(cmd *cobra.Command, defaultGenerator string) {
 }
 
 func AddRemoteStreamFlags(cmd *cobra.Command) {
-	cmd.Flags().Duration("stream-timeout", 0, "Maximum amount of time to keep remote shell open. If 0, shell will remain open until an EOF is received. Defaults to 0.")
+	cmd.Flags().Duration("stream-timeout", 0, "Maximum amount of time to keep remote shell open without any activity. If 0, shell will remain open indefinitely. Defaults to 0.")
 }
 
 func ReadConfigDataFromReader(reader io.Reader, source string) ([]byte, error) {


### PR DESCRIPTION
**Release note**:
```release-note
adds a --stream-timeout option to "kubectl exec" in order to timeout once inside of a remote shell
```

This patch implements a timeout option for remote streams. This allows a
maximum time to be specified for a remote shell to remain open. If a
`--stream-timeout` value `> 0` is provided, the stream executor will not
wait for the `stdout` and `stderr` streams of a remote shell to finish
copying, but will rather close the stream and exit with error `Timeout
exceeded for this operation`.

Although `kubectl exec` already supports the global
`request-timeout` option as well as the local `--timeout` option, the
former is only for making ther inital request with a `restclient`, and
the latter is the amount of time to wait before a pod is retrieved.
Therefore, it was necessary to introduce a third timeout option for
specifically timing out the command once inside of a remote shell.

**Example**
```
$ kubectl exec -- /bin/sh -c "while true; do echo test; sleep 1s; done"
Defaulting container name to mypodcontainer.
Use 'kubectl describe pod/mypod' to see all of the containers in this pod.
test
test
test
...
^C

$ kubectl exec --stream-timeout=5s mypod -- /bin/sh -c "while true; do echo test; sleep 1s; done"
Defaulting container name to mypodcontainer.
Use 'kubectl describe pod/mypod' to see all of the containers in this pod.
test
test
test
test
test
error: Timeout exceeded for this operation.
```

@kubernetes/cli-review @fabianofranz 