### PR TITLE
Don't check nodeport for nginx ingress

### DIFF
--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -114,7 +114,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7", func() {
 				By(t.entryLog)
 				t.execute()
 				By(t.exitLog)
-				jig.waitForIngress()
+				jig.waitForIngress(true)
 			}
 		})
 
@@ -196,7 +196,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7", func() {
 				By(t.entryLog)
 				t.execute()
 				By(t.exitLog)
-				jig.waitForIngress()
+				jig.waitForIngress(false)
 			}
 		})
 	})


### PR DESCRIPTION
Services behind a standard nginx ingress don't need nodeport, so don't check that. 