### PR TITLE
Bump default kubernetes version when no internet is present to v1.5

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -24,7 +24,7 @@ const (
 	DefaultServiceDNSDomain          = "cluster.local"
 	DefaultServicesSubnet            = "10.96.0.0/12"
 	DefaultKubernetesVersion         = "stable"
-	DefaultKubernetesFallbackVersion = "v1.4.6"
+	DefaultKubernetesFallbackVersion = "v1.5.0"
 	DefaultAPIBindPort               = 6443
 	DefaultDiscoveryBindPort         = 9898
 )


### PR DESCRIPTION
@mikedanese Please lgtm as soon as possible
It's a noop, when no internet is present so the latest version can't be determined, this version is used.