### PR TITLE
hack/e2e.go / kops: Add --kops-admin-access to restrict API access

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -308,6 +308,7 @@ k8s-bin-dir
 k8s-build-output
 keep-gogoproto
 km-path
+kops-admin-access
 kops-cluster
 kops-kubernetes-version
 kops-nodes


### PR DESCRIPTION
**What this PR does / why we need it**: Allow `--admin-access` to be set in `kops`
**Release note**:
```release-note
NONE
```

