### PR TITLE
path.Clean paths in GlobalEnvParams and remove unnecessary path.Join

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/env.go
+++ b/cmd/kubeadm/app/apis/kubeadm/env.go
@@ -19,6 +19,7 @@ package kubeadm
 import (
 	"fmt"
 	"os"
+	"path"
 	"runtime"
 	"strings"
 )
@@ -46,9 +47,9 @@ func SetEnvParams() *EnvParams {
 	}
 
 	return &EnvParams{
-		KubernetesDir:    envParams["kubernetes_dir"],
-		HostPKIPath:      envParams["host_pki_path"],
-		HostEtcdPath:     envParams["host_etcd_path"],
+		KubernetesDir:    path.Clean(envParams["kubernetes_dir"]),
+		HostPKIPath:      path.Clean(envParams["host_pki_path"]),
+		HostEtcdPath:     path.Clean(envParams["host_etcd_path"]),
 		HyperkubeImage:   envParams["hyperkube_image"],
 		RepositoryPrefix: envParams["repo_prefix"],
 		DiscoveryImage:   envParams["discovery_image"],

--- a/cmd/kubeadm/app/master/discovery.go
+++ b/cmd/kubeadm/app/master/discovery.go
@@ -66,7 +66,7 @@ func encodeKubeDiscoverySecretData(cfg *kubeadmapi.MasterConfiguration, caCert *
 func newKubeDiscoveryPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.PodSpec {
 	return v1.PodSpec{
 		// We have to use host network namespace, as `HostPort`/`HostIP` are Docker's
-		// buisness and CNI support isn't quite there yet (except for kubenet)
+		// business and CNI support isn't quite there yet (except for kubenet)
 		// (see https://github.com/kubernetes/kubernetes/issues/31307)
 		// TODO update this when #31307 is resolved
 		HostNetwork:     true,

--- a/cmd/kubeadm/app/master/pki.go
+++ b/cmd/kubeadm/app/master/pki.go
@@ -158,7 +158,7 @@ func CreatePKIAssets(cfg *kubeadmapi.MasterConfiguration) (*rsa.PrivateKey, *x50
 	}
 	altNames.DNSNames = append(altNames.DNSNames, cfg.API.ExternalDNSNames...)
 
-	pkiPath := path.Join(kubeadmapi.GlobalEnvParams.HostPKIPath)
+	pkiPath := kubeadmapi.GlobalEnvParams.HostPKIPath
 
 	caKey, caCert, err := newCertificateAuthority()
 	if err != nil {

--- a/cmd/kubeadm/app/node/bootstrap.go
+++ b/cmd/kubeadm/app/node/bootstrap.go
@@ -126,7 +126,7 @@ func createClients(caCert []byte, endpoint, token string, nodeName types.NodeNam
 	return clientSet, nil
 }
 
-// check to see if there are other nodes in the cluster with identical node names.
+// CheckForNodeNameDuplicates checks whether there are other nodes in the cluster with identical node names.
 func CheckForNodeNameDuplicates(connection *ConnectionDetails) error {
 	hostName, err := os.Hostname()
 	if err != nil {

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -28,7 +28,7 @@ func TestEmptyVersion(t *testing.T) {
 
 	ver, err := KubernetesReleaseVersion("")
 	if err == nil {
-		t.Error("KubernetesReleaseVersion returned succesfully, but error expected")
+		t.Error("KubernetesReleaseVersion returned successfully, but error expected")
 	}
 	if ver != "" {
 		t.Error("KubernetesReleaseVersion returned value, expected only error")


### PR DESCRIPTION
**What this PR does / why we need it**:

1. clean all paths in `GlobalEnvParams`
1. remove unnecessary path.Join call in `pki.go`
2. fix some typos and comment errors

Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>