### PR TITLE
GC changes for synchronous GC supports

### DIFF
--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -111,7 +111,7 @@ func (m *PodControllerRefManager) AdoptPod(pod *v1.Pod) error {
 			strings.Join([]string{pod.Namespace, pod.Name, string(pod.UID)}, "_"))
 	}
 	addControllerPatch := fmt.Sprintf(
-		`{"metadata":{"ownerReferences":[{"apiVersion":"%s","kind":"%s","name":"%s","uid":"%s","controller":true}],"uid":"%s"}}`,
+		`{"metadata":{"ownerReferences":[{"apiVersion":"%s","kind":"%s","name":"%s","uid":"%s","controller":true,"blockOwnerDeletion":true}],"uid":"%s"}}`,
 		m.controllerKind.GroupVersion(), m.controllerKind.Kind,
 		m.controllerObject.Name, m.controllerObject.UID, pod.UID)
 	return m.podControl.PatchPod(pod.Namespace, pod.Name, []byte(addControllerPatch))

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -449,6 +449,9 @@ func (r RealPodControl) CreatePodsWithControllerRef(namespace string, template *
 	if controllerRef.Controller == nil || *controllerRef.Controller != true {
 		return fmt.Errorf("controllerRef.Controller is not set")
 	}
+	if controllerRef.BlockOwnerDeletion == nil || *controllerRef.BlockOwnerDeletion != true {
+		return fmt.Errorf("controllerRef.BlockOwnerDeletion is not set")
+	}
 	return r.createPods("", namespace, template, controllerObject, controllerRef)
 }
 

--- a/pkg/controller/garbagecollector/garbage_collector.go
+++ b/pkg/controller/garbagecollector/garbage_collector.go
@@ -296,6 +296,9 @@ func (gc *GarbageCollector) classifyReferences(item *node, latestReferences []me
 		if err != nil {
 			return solid, dangling, waiting, err
 		}
+		// TODO: It's only necessary to talk to the API server if the owner node
+		// is a "virtual" node. The local graph could lag behind the real
+		// status, but in practice, the difference is small.
 		owner, err := client.Resource(resource, item.identity.Namespace).Get(reference.Name)
 		if err != nil {
 			if !errors.IsNotFound(err) {
@@ -350,7 +353,9 @@ func (gc *GarbageCollector) processItem(item *node) error {
 		glog.V(5).Infof("processing item %s returned at once", item.identity)
 		return nil
 	}
-	// Get the latest item from the API server
+	// TODO: It's only necessary to talk to the API server if this is a
+	// "virtual" node. The local graph could lag behind the real status, but in
+	// practice, the difference is small.
 	latest, err := gc.getObject(item.identity)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/controller/garbagecollector/garbage_collector.go
+++ b/pkg/controller/garbagecollector/garbage_collector.go
@@ -109,15 +109,13 @@ func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 	defer gc.dependencyGraphBuilder.graphChanges.ShutDown()
 
 	glog.Infof("Garbage Collector: Initializing")
-	gc.dependencyGraphBuilder.startMonitors(stopCh)
-	if !cache.WaitForCacheSync(stopCh, gc.dependencyGraphBuilder.MonitorsSynced) {
+	gc.dependencyGraphBuilder.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, gc.dependencyGraphBuilder.HasSynced) {
 		return
 	}
 	glog.Infof("Garbage Collector: All resource monitors have synced. Proceeding to collect garbage")
 
-	// worker
-	go wait.Until(gc.dependencyGraphBuilder.runProcessGraphChanges, 1*time.Second, stopCh)
-
+	// gc workers
 	for i := 0; i < workers; i++ {
 		go wait.Until(gc.runAttemptToDeleteWorker, 1*time.Second, stopCh)
 		go wait.Until(gc.runAttemptToOrphanWorker, 1*time.Second, stopCh)
@@ -167,13 +165,13 @@ func objectReferenceToMetadataOnlyObject(ref objectReference) *metaonly.Metadata
 }
 
 // classify the latestReferences to three categories:
-// solid: the owner exists, and is not "waiting"
+// solid: the owner exists, and is not "waitingForDependentsDeletion"
 // dangling: the owner does not exist
-// waiting: the owner exists, its deletionTimestamp is non-nil, and it has
+// waitingForDependentsDeletion: the owner exists, its deletionTimestamp is non-nil, and it has
 // FinalizerDeletingDependents
 // This function communicates with the server.
 func (gc *GarbageCollector) classifyReferences(item *node, latestReferences []metav1.OwnerReference) (
-	solid, dangling, waiting []metav1.OwnerReference, err error) {
+	solid, dangling, waitingForDependentsDeletion []metav1.OwnerReference, err error) {
 	for _, reference := range latestReferences {
 		if gc.absentOwnerCache.Has(reference.UID) {
 			glog.V(5).Infof("according to the absentOwnerCache, object %s's owner %s/%s, %s does not exist", item.identity.UID, reference.APIVersion, reference.Kind, reference.Name)
@@ -189,11 +187,11 @@ func (gc *GarbageCollector) classifyReferences(item *node, latestReferences []me
 		fqKind := schema.FromAPIVersionAndKind(reference.APIVersion, reference.Kind)
 		client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
 		if err != nil {
-			return solid, dangling, waiting, err
+			return nil, nil, nil, err
 		}
 		resource, err := gc.apiResource(reference.APIVersion, reference.Kind, len(item.identity.Namespace) != 0)
 		if err != nil {
-			return solid, dangling, waiting, err
+			return nil, nil, nil, err
 		}
 		// TODO: It's only necessary to talk to the API server if the owner node
 		// is a "virtual" node. The local graph could lag behind the real
@@ -201,7 +199,7 @@ func (gc *GarbageCollector) classifyReferences(item *node, latestReferences []me
 		owner, err := client.Resource(resource, item.identity.Namespace).Get(reference.Name)
 		if err != nil {
 			if !errors.IsNotFound(err) {
-				return solid, dangling, waiting, err
+				return nil, nil, nil, err
 			}
 			gc.absentOwnerCache.Add(reference.UID)
 			glog.V(5).Infof("object %s's owner %s/%s, %s is not found", item.identity.UID, reference.APIVersion, reference.Kind, reference.Name)
@@ -217,15 +215,15 @@ func (gc *GarbageCollector) classifyReferences(item *node, latestReferences []me
 
 		ownerAccessor, err := meta.Accessor(owner)
 		if err != nil {
-			return solid, dangling, waiting, err
+			return nil, nil, nil, err
 		}
 		if ownerAccessor.GetDeletionTimestamp() != nil && hasDeleteDependentsFinalizer(ownerAccessor) {
-			waiting = append(waiting, reference)
+			waitingForDependentsDeletion = append(waitingForDependentsDeletion, reference)
 		} else {
 			solid = append(solid, reference)
 		}
 	}
-	return solid, dangling, waiting, nil
+	return solid, dangling, waitingForDependentsDeletion, nil
 }
 
 func (gc *GarbageCollector) generateVirtualDeleteEvent(identity objectReference) {
@@ -256,15 +254,15 @@ func (gc *GarbageCollector) attempToDeleteItem(item *node) error {
 	// "virtual" node. The local graph could lag behind the real status, but in
 	// practice, the difference is small.
 	latest, err := gc.getObject(item.identity)
+	if err != nil && errors.IsNotFound(err) {
+		// the GraphBuilder can add "virtual" node for an owner that doesn't
+		// exist yet, so we need to enqueue a virtual Delete event to remove
+		// the virtual node from GraphBuilder.uidToNode.
+		glog.V(5).Infof("item %v not found, generating a virtual delete event", item.identity)
+		gc.generateVirtualDeleteEvent(item.identity)
+		return nil
+	}
 	if err != nil {
-		if errors.IsNotFound(err) {
-			// the GraphBuilder can add "virtual" node for an owner that doesn't
-			// exist yet, so we need to enqueue a virtual Delete event to remove
-			// the virtual node from GraphBuilder.uidToNode.
-			glog.V(5).Infof("item %v not found, generating a virtual delete event", item.identity)
-			gc.generateVirtualDeleteEvent(item.identity)
-			return nil
-		}
 		return err
 	}
 	if latest.GetUID() != item.identity.UID {
@@ -286,22 +284,22 @@ func (gc *GarbageCollector) attempToDeleteItem(item *node) error {
 		return nil
 	}
 
-	solid, dangling, waiting, err := gc.classifyReferences(item, ownerReferences)
+	solid, dangling, waitingForDependentsDeletion, err := gc.classifyReferences(item, ownerReferences)
 	if err != nil {
 		return err
 	}
-	glog.V(5).Infof("classify references of %s.\nsolid: %#v\ndangling: %#v\nwaiting: %#v\n", item.identity, solid, dangling, waiting)
+	glog.V(5).Infof("classify references of %s.\nsolid: %#v\ndangling: %#v\nwaitingForDependentsDeletion: %#v\n", item.identity, solid, dangling, waitingForDependentsDeletion)
 
 	switch {
 	case len(solid) != 0:
 		glog.V(2).Infof("object %s has at least one existing owner, will not garbage collect", item.identity)
-		if len(dangling) != 0 || len(waiting) != 0 {
-			glog.V(2).Infof("remove dangling references %#v and waiting references %#v for object %s", dangling, waiting, item.identity)
+		if len(dangling) != 0 || len(waitingForDependentsDeletion) != 0 {
+			glog.V(2).Infof("remove dangling references %#v and waiting references %#v for object %s", dangling, waitingForDependentsDeletion, item.identity)
 		}
-		patch := deleteOwnerRefPatch(item.identity.UID, append(ownerRefsToUIDs(dangling), ownerRefsToUIDs(waiting)...)...)
+		patch := deleteOwnerRefPatch(item.identity.UID, append(ownerRefsToUIDs(dangling), ownerRefsToUIDs(waitingForDependentsDeletion)...)...)
 		_, err = gc.patchObject(item.identity, patch)
 		return err
-	case len(waiting) != 0 && len(item.dependents) != 0:
+	case len(waitingForDependentsDeletion) != 0 && len(item.dependents) != 0:
 		for dep := range item.dependents {
 			if dep.isDeletingDependents() {
 				// this circle detection has false positives, we need to

--- a/pkg/controller/garbagecollector/garbage_collector.go
+++ b/pkg/controller/garbagecollector/garbage_collector.go
@@ -116,7 +116,7 @@ func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 	glog.Infof("Garbage Collector: All resource monitors have synced. Proceeding to collect garbage")
 
 	// worker
-	go wait.Until(gc.dependencyGraphBuilder.runProcessEvent, 1*time.Second, stopCh)
+	go wait.Until(gc.dependencyGraphBuilder.runProcessGraphChanges, 1*time.Second, stopCh)
 
 	for i := 0; i < workers; i++ {
 		go wait.Until(gc.runAttemptToDeleteWorker, 1*time.Second, stopCh)

--- a/pkg/controller/garbagecollector/garbage_collector.go
+++ b/pkg/controller/garbagecollector/garbage_collector.go
@@ -63,10 +63,16 @@ type GarbageCollector struct {
 	// garbage collector attempts to delete the items in attemptToDelete queue when the time is ripe.
 	attemptToDelete workqueue.RateLimitingInterface
 	// garbage collector attempts to orphan the dependents of the items in the attemptToOrphan queue, then deletes the items.
-	attemptToOrphan                     workqueue.RateLimitingInterface
-	monitors                            []*cache.Controller
-	dependencyGraphBuilder              *GraphBuilder
-	registeredRateLimiter               *RegisteredRateLimiter
+	attemptToOrphan workqueue.RateLimitingInterface
+	// each monitor list/watches a resource, the results are funneled to the
+	// dependencyGraphBuilder
+	monitors               []*cache.Controller
+	dependencyGraphBuilder *GraphBuilder
+	// used to register exactly once the rate limiter of the dynamic client
+	// used by the garbage collector controller.
+	registeredRateLimiter *RegisteredRateLimiter
+	// used to register exactly once the rate limiters of the clients used by
+	// the `monitors`.
 	registeredRateLimiterForControllers *RegisteredRateLimiter
 	// GC caches the owners that do not exist according to the API server.
 	absentOwnerCache *UIDCache

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -23,12 +23,10 @@ import (
 
 	"github.com/golang/glog"
 
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/v1"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/apis/meta/v1/unstructured"
 	"k8s.io/kubernetes/pkg/client/cache"
 	"k8s.io/kubernetes/pkg/client/typed/dynamic"
 	"k8s.io/kubernetes/pkg/controller/garbagecollector/metaonly"
@@ -38,7 +36,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/clock"
 	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
-	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/util/workqueue"
 	"k8s.io/kubernetes/pkg/watch"
@@ -49,382 +46,6 @@ const ResourceResyncTime time.Duration = 0
 type monitor struct {
 	store      cache.Store
 	controller *cache.Controller
-}
-
-type objectReference struct {
-	metav1.OwnerReference
-	// This is needed by the dynamic client
-	Namespace string
-}
-
-func (s objectReference) String() string {
-	return fmt.Sprintf("[%s/%s, namespace: %s, name: %s, uid: %s]", s.APIVersion, s.Kind, s.Namespace, s.Name, s.UID)
-}
-
-// node does not require a lock to protect. The single-threaded
-// Propagator.processEvent() is the sole writer of the nodes. The multi-threaded
-// GarbageCollector.processItem() reads the nodes, but it only reads the fields
-// that never get changed by Propagator.processEvent().
-type node struct {
-	identity objectReference
-	// dependents will be read by the orphan() routine, we need to protect it with a lock.
-	dependentsLock sync.RWMutex
-	dependents     map[*node]struct{}
-	// When processing an Update event, we need to compare the updated
-	// ownerReferences with the owners recorded in the graph.
-	owners []metav1.OwnerReference
-}
-
-func (ownerNode *node) addDependent(dependent *node) {
-	ownerNode.dependentsLock.Lock()
-	defer ownerNode.dependentsLock.Unlock()
-	ownerNode.dependents[dependent] = struct{}{}
-}
-
-func (ownerNode *node) deleteDependent(dependent *node) {
-	ownerNode.dependentsLock.Lock()
-	defer ownerNode.dependentsLock.Unlock()
-	delete(ownerNode.dependents, dependent)
-}
-
-type eventType int
-
-const (
-	addEvent eventType = iota
-	updateEvent
-	deleteEvent
-)
-
-type event struct {
-	eventType eventType
-	obj       interface{}
-	// the update event comes with an old object, but it's not used by the garbage collector.
-	oldObj interface{}
-}
-
-type concurrentUIDToNode struct {
-	*sync.RWMutex
-	uidToNode map[types.UID]*node
-}
-
-func (m *concurrentUIDToNode) Write(node *node) {
-	m.Lock()
-	defer m.Unlock()
-	m.uidToNode[node.identity.UID] = node
-}
-
-func (m *concurrentUIDToNode) Read(uid types.UID) (*node, bool) {
-	m.RLock()
-	defer m.RUnlock()
-	n, ok := m.uidToNode[uid]
-	return n, ok
-}
-
-func (m *concurrentUIDToNode) Delete(uid types.UID) {
-	m.Lock()
-	defer m.Unlock()
-	delete(m.uidToNode, uid)
-}
-
-type Propagator struct {
-	eventQueue *workqueue.TimedWorkQueue
-	// uidToNode doesn't require a lock to protect, because only the
-	// single-threaded Propagator.processEvent() reads/writes it.
-	uidToNode *concurrentUIDToNode
-	gc        *GarbageCollector
-}
-
-// addDependentToOwners adds n to owners' dependents list. If the owner does not
-// exist in the p.uidToNode yet, a "virtual" node will be created to represent
-// the owner. The "virtual" node will be enqueued to the dirtyQueue, so that
-// processItem() will verify if the owner exists according to the API server.
-func (p *Propagator) addDependentToOwners(n *node, owners []metav1.OwnerReference) {
-	for _, owner := range owners {
-		ownerNode, ok := p.uidToNode.Read(owner.UID)
-		if !ok {
-			// Create a "virtual" node in the graph for the owner if it doesn't
-			// exist in the graph yet. Then enqueue the virtual node into the
-			// dirtyQueue. The garbage processor will enqueue a virtual delete
-			// event to delete it from the graph if API server confirms this
-			// owner doesn't exist.
-			ownerNode = &node{
-				identity: objectReference{
-					OwnerReference: owner,
-					Namespace:      n.identity.Namespace,
-				},
-				dependents: make(map[*node]struct{}),
-			}
-			glog.V(6).Infof("add virtual node.identity: %s\n\n", ownerNode.identity)
-			p.uidToNode.Write(ownerNode)
-			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: ownerNode})
-		}
-		ownerNode.addDependent(n)
-	}
-}
-
-// insertNode insert the node to p.uidToNode; then it finds all owners as listed
-// in n.owners, and adds the node to their dependents list.
-func (p *Propagator) insertNode(n *node) {
-	p.uidToNode.Write(n)
-	p.addDependentToOwners(n, n.owners)
-}
-
-// removeDependentFromOwners remove n from owners' dependents list.
-func (p *Propagator) removeDependentFromOwners(n *node, owners []metav1.OwnerReference) {
-	for _, owner := range owners {
-		ownerNode, ok := p.uidToNode.Read(owner.UID)
-		if !ok {
-			continue
-		}
-		ownerNode.deleteDependent(n)
-	}
-}
-
-// removeNode removes the node from p.uidToNode, then finds all
-// owners as listed in n.owners, and removes n from their dependents list.
-func (p *Propagator) removeNode(n *node) {
-	p.uidToNode.Delete(n.identity.UID)
-	p.removeDependentFromOwners(n, n.owners)
-}
-
-// TODO: profile this function to see if a naive N^2 algorithm performs better
-// when the number of references is small.
-func referencesDiffs(old []metav1.OwnerReference, new []metav1.OwnerReference) (added []metav1.OwnerReference, removed []metav1.OwnerReference) {
-	oldUIDToRef := make(map[string]metav1.OwnerReference)
-	for i := 0; i < len(old); i++ {
-		oldUIDToRef[string(old[i].UID)] = old[i]
-	}
-	oldUIDSet := sets.StringKeySet(oldUIDToRef)
-	newUIDToRef := make(map[string]metav1.OwnerReference)
-	for i := 0; i < len(new); i++ {
-		newUIDToRef[string(new[i].UID)] = new[i]
-	}
-	newUIDSet := sets.StringKeySet(newUIDToRef)
-
-	addedUID := newUIDSet.Difference(oldUIDSet)
-	removedUID := oldUIDSet.Difference(newUIDSet)
-
-	for uid := range addedUID {
-		added = append(added, newUIDToRef[uid])
-	}
-	for uid := range removedUID {
-		removed = append(removed, oldUIDToRef[uid])
-	}
-	return added, removed
-}
-
-func shouldOrphanDependents(e *event, accessor meta.Object) bool {
-	// The delta_fifo may combine the creation and update of the object into one
-	// event, so we need to check AddEvent as well.
-	if e.oldObj == nil {
-		if accessor.GetDeletionTimestamp() == nil {
-			return false
-		}
-	} else {
-		oldAccessor, err := meta.Accessor(e.oldObj)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("cannot access oldObj: %v", err))
-			return false
-		}
-		// ignore the event if it's not updating DeletionTimestamp from non-nil to nil.
-		if accessor.GetDeletionTimestamp() == nil || oldAccessor.GetDeletionTimestamp() != nil {
-			return false
-		}
-	}
-	finalizers := accessor.GetFinalizers()
-	for _, finalizer := range finalizers {
-		if finalizer == v1.FinalizerOrphan {
-			return true
-		}
-	}
-	return false
-}
-
-// dependents are copies of pointers to the owner's dependents, they don't need to be locked.
-func (gc *GarbageCollector) orhpanDependents(owner objectReference, dependents []*node) error {
-	var failedDependents []objectReference
-	var errorsSlice []error
-	for _, dependent := range dependents {
-		// the dependent.identity.UID is used as precondition
-		deleteOwnerRefPatch := fmt.Sprintf(`{"metadata":{"ownerReferences":[{"$patch":"delete","uid":"%s"}],"uid":"%s"}}`, owner.UID, dependent.identity.UID)
-		_, err := gc.patchObject(dependent.identity, []byte(deleteOwnerRefPatch))
-		// note that if the target ownerReference doesn't exist in the
-		// dependent, strategic merge patch will NOT return an error.
-		if err != nil && !errors.IsNotFound(err) {
-			errorsSlice = append(errorsSlice, fmt.Errorf("orphaning %s failed with %v", dependent.identity, err))
-		}
-	}
-	if len(failedDependents) != 0 {
-		return fmt.Errorf("failed to orphan dependents of owner %s, got errors: %s", owner, utilerrors.NewAggregate(errorsSlice).Error())
-	}
-	glog.V(6).Infof("successfully updated all dependents")
-	return nil
-}
-
-// TODO: Using Patch when strategicmerge supports deleting an entry from a
-// slice of a base type.
-func (gc *GarbageCollector) removeOrphanFinalizer(owner *node) error {
-	const retries = 5
-	for count := 0; count < retries; count++ {
-		ownerObject, err := gc.getObject(owner.identity)
-		if err != nil {
-			return fmt.Errorf("cannot finalize owner %s, because cannot get it. The garbage collector will retry later.", owner.identity)
-		}
-		accessor, err := meta.Accessor(ownerObject)
-		if err != nil {
-			return fmt.Errorf("cannot access the owner object: %v. The garbage collector will retry later.", err)
-		}
-		finalizers := accessor.GetFinalizers()
-		var newFinalizers []string
-		found := false
-		for _, f := range finalizers {
-			if f == v1.FinalizerOrphan {
-				found = true
-				break
-			} else {
-				newFinalizers = append(newFinalizers, f)
-			}
-		}
-		if !found {
-			glog.V(6).Infof("the orphan finalizer is already removed from object %s", owner.identity)
-			return nil
-		}
-		// remove the owner from dependent's OwnerReferences
-		ownerObject.SetFinalizers(newFinalizers)
-		_, err = gc.updateObject(owner.identity, ownerObject)
-		if err == nil {
-			return nil
-		}
-		if err != nil && !errors.IsConflict(err) {
-			return fmt.Errorf("cannot update the finalizers of owner %s, with error: %v, tried %d times", owner.identity, err, count+1)
-		}
-		// retry if it's a conflict
-		glog.V(6).Infof("got conflict updating the owner object %s, tried %d times", owner.identity, count+1)
-	}
-	return fmt.Errorf("updateMaxRetries(%d) has reached. The garbage collector will retry later for owner %v.", retries, owner.identity)
-}
-
-// orphanFinalizer dequeues a node from the orphanQueue, then finds its dependents
-// based on the graph maintained by the GC, then removes it from the
-// OwnerReferences of its dependents, and finally updates the owner to remove
-// the "Orphan" finalizer. The node is add back into the orphanQueue if any of
-// these steps fail.
-func (gc *GarbageCollector) orphanFinalizer() {
-	timedItem, quit := gc.orphanQueue.Get()
-	if quit {
-		return
-	}
-	defer gc.orphanQueue.Done(timedItem)
-	owner, ok := timedItem.Object.(*node)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("expect *node, got %#v", timedItem.Object))
-	}
-	// we don't need to lock each element, because they never get updated
-	owner.dependentsLock.RLock()
-	dependents := make([]*node, 0, len(owner.dependents))
-	for dependent := range owner.dependents {
-		dependents = append(dependents, dependent)
-	}
-	owner.dependentsLock.RUnlock()
-
-	err := gc.orhpanDependents(owner.identity, dependents)
-	if err != nil {
-		glog.V(6).Infof("orphanDependents for %s failed with %v", owner.identity, err)
-		gc.orphanQueue.Add(timedItem)
-		return
-	}
-	// update the owner, remove "orphaningFinalizer" from its finalizers list
-	err = gc.removeOrphanFinalizer(owner)
-	if err != nil {
-		glog.V(6).Infof("removeOrphanFinalizer for %s failed with %v", owner.identity, err)
-		gc.orphanQueue.Add(timedItem)
-	}
-	OrphanProcessingLatency.Observe(sinceInMicroseconds(gc.clock, timedItem.StartTime))
-}
-
-// Dequeueing an event from eventQueue, updating graph, populating dirty_queue.
-func (p *Propagator) processEvent() {
-	timedItem, quit := p.eventQueue.Get()
-	if quit {
-		return
-	}
-	defer p.eventQueue.Done(timedItem)
-	event, ok := timedItem.Object.(*event)
-	if !ok {
-		utilruntime.HandleError(fmt.Errorf("expect a *event, got %v", timedItem.Object))
-		return
-	}
-	obj := event.obj
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("cannot access obj: %v", err))
-		return
-	}
-	typeAccessor, err := meta.TypeAccessor(obj)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("cannot access obj: %v", err))
-		return
-	}
-	glog.V(6).Infof("Propagator process object: %s/%s, namespace %s, name %s, event type %s", typeAccessor.GetAPIVersion(), typeAccessor.GetKind(), accessor.GetNamespace(), accessor.GetName(), event.eventType)
-	// Check if the node already exsits
-	existingNode, found := p.uidToNode.Read(accessor.GetUID())
-	switch {
-	case (event.eventType == addEvent || event.eventType == updateEvent) && !found:
-		newNode := &node{
-			identity: objectReference{
-				OwnerReference: metav1.OwnerReference{
-					APIVersion: typeAccessor.GetAPIVersion(),
-					Kind:       typeAccessor.GetKind(),
-					UID:        accessor.GetUID(),
-					Name:       accessor.GetName(),
-				},
-				Namespace: accessor.GetNamespace(),
-			},
-			dependents: make(map[*node]struct{}),
-			owners:     accessor.GetOwnerReferences(),
-		}
-		p.insertNode(newNode)
-		// the underlying delta_fifo may combine a creation and deletion into one event
-		if shouldOrphanDependents(event, accessor) {
-			glog.V(6).Infof("add %s to the orphanQueue", newNode.identity)
-			p.gc.orphanQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: newNode})
-		}
-	case (event.eventType == addEvent || event.eventType == updateEvent) && found:
-		// caveat: if GC observes the creation of the dependents later than the
-		// deletion of the owner, then the orphaning finalizer won't be effective.
-		if shouldOrphanDependents(event, accessor) {
-			glog.V(6).Infof("add %s to the orphanQueue", existingNode.identity)
-			p.gc.orphanQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: existingNode})
-		}
-		// add/remove owner refs
-		added, removed := referencesDiffs(existingNode.owners, accessor.GetOwnerReferences())
-		if len(added) == 0 && len(removed) == 0 {
-			glog.V(6).Infof("The updateEvent %#v doesn't change node references, ignore", event)
-			return
-		}
-		// update the node itself
-		existingNode.owners = accessor.GetOwnerReferences()
-		// Add the node to its new owners' dependent lists.
-		p.addDependentToOwners(existingNode, added)
-		// remove the node from the dependent list of node that are no long in
-		// the node's owners list.
-		p.removeDependentFromOwners(existingNode, removed)
-	case event.eventType == deleteEvent:
-		if !found {
-			glog.V(6).Infof("%v doesn't exist in the graph, this shouldn't happen", accessor.GetUID())
-			return
-		}
-		p.removeNode(existingNode)
-		existingNode.dependentsLock.RLock()
-		defer existingNode.dependentsLock.RUnlock()
-		if len(existingNode.dependents) > 0 {
-			p.gc.absentOwnerCache.Add(accessor.GetUID())
-		}
-		for dep := range existingNode.dependents {
-			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: dep})
-		}
-	}
-	EventProcessingLatency.Observe(sinceInMicroseconds(p.gc.clock, timedItem.StartTime))
 }
 
 // GarbageCollector is responsible for carrying out cascading deletion, and
@@ -575,186 +196,6 @@ func NewGarbageCollector(metaOnlyClientPool dynamic.ClientPool, clientPool dynam
 	return gc, nil
 }
 
-func (gc *GarbageCollector) worker() {
-	timedItem, quit := gc.dirtyQueue.Get()
-	if quit {
-		return
-	}
-	defer gc.dirtyQueue.Done(timedItem)
-	err := gc.processItem(timedItem.Object.(*node))
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error syncing item %#v: %v", timedItem.Object, err))
-		// retry if garbage collection of an object failed.
-		gc.dirtyQueue.Add(timedItem)
-		return
-	}
-	DirtyProcessingLatency.Observe(sinceInMicroseconds(gc.clock, timedItem.StartTime))
-}
-
-// apiResource consults the REST mapper to translate an <apiVersion, kind,
-// namespace> tuple to a metav1.APIResource struct.
-func (gc *GarbageCollector) apiResource(apiVersion, kind string, namespaced bool) (*metav1.APIResource, error) {
-	fqKind := schema.FromAPIVersionAndKind(apiVersion, kind)
-	mapping, err := gc.restMapper.RESTMapping(fqKind.GroupKind(), apiVersion)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get REST mapping for kind: %s, version: %s", kind, apiVersion)
-	}
-	glog.V(6).Infof("map kind %s, version %s to resource %s", kind, apiVersion, mapping.Resource)
-	resource := metav1.APIResource{
-		Name:       mapping.Resource,
-		Namespaced: namespaced,
-		Kind:       kind,
-	}
-	return &resource, nil
-}
-
-func (gc *GarbageCollector) deleteObject(item objectReference) error {
-	fqKind := schema.FromAPIVersionAndKind(item.APIVersion, item.Kind)
-	client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
-	gc.registeredRateLimiter.registerIfNotPresent(fqKind.GroupVersion(), client, "garbage_collector_operation")
-	resource, err := gc.apiResource(item.APIVersion, item.Kind, len(item.Namespace) != 0)
-	if err != nil {
-		return err
-	}
-	uid := item.UID
-	preconditions := v1.Preconditions{UID: &uid}
-	deleteOptions := v1.DeleteOptions{Preconditions: &preconditions}
-	return client.Resource(resource, item.Namespace).Delete(item.Name, &deleteOptions)
-}
-
-func (gc *GarbageCollector) getObject(item objectReference) (*unstructured.Unstructured, error) {
-	fqKind := schema.FromAPIVersionAndKind(item.APIVersion, item.Kind)
-	client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
-	gc.registeredRateLimiter.registerIfNotPresent(fqKind.GroupVersion(), client, "garbage_collector_operation")
-	resource, err := gc.apiResource(item.APIVersion, item.Kind, len(item.Namespace) != 0)
-	if err != nil {
-		return nil, err
-	}
-	return client.Resource(resource, item.Namespace).Get(item.Name)
-}
-
-func (gc *GarbageCollector) updateObject(item objectReference, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	fqKind := schema.FromAPIVersionAndKind(item.APIVersion, item.Kind)
-	client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
-	gc.registeredRateLimiter.registerIfNotPresent(fqKind.GroupVersion(), client, "garbage_collector_operation")
-	resource, err := gc.apiResource(item.APIVersion, item.Kind, len(item.Namespace) != 0)
-	if err != nil {
-		return nil, err
-	}
-	return client.Resource(resource, item.Namespace).Update(obj)
-}
-
-func (gc *GarbageCollector) patchObject(item objectReference, patch []byte) (*unstructured.Unstructured, error) {
-	fqKind := schema.FromAPIVersionAndKind(item.APIVersion, item.Kind)
-	client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
-	gc.registeredRateLimiter.registerIfNotPresent(fqKind.GroupVersion(), client, "garbage_collector_operation")
-	resource, err := gc.apiResource(item.APIVersion, item.Kind, len(item.Namespace) != 0)
-	if err != nil {
-		return nil, err
-	}
-	return client.Resource(resource, item.Namespace).Patch(item.Name, api.StrategicMergePatchType, patch)
-}
-
-func objectReferenceToUnstructured(ref objectReference) *unstructured.Unstructured {
-	ret := &unstructured.Unstructured{}
-	ret.SetKind(ref.Kind)
-	ret.SetAPIVersion(ref.APIVersion)
-	ret.SetUID(ref.UID)
-	ret.SetNamespace(ref.Namespace)
-	ret.SetName(ref.Name)
-	return ret
-}
-
-func objectReferenceToMetadataOnlyObject(ref objectReference) *metaonly.MetadataOnlyObject {
-	return &metaonly.MetadataOnlyObject{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: ref.APIVersion,
-			Kind:       ref.Kind,
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Namespace: ref.Namespace,
-			UID:       ref.UID,
-			Name:      ref.Name,
-		},
-	}
-}
-
-func (gc *GarbageCollector) processItem(item *node) error {
-	// Get the latest item from the API server
-	latest, err := gc.getObject(item.identity)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// the Propagator can add "virtual" node for an owner that doesn't
-			// exist yet, so we need to enqueue a virtual Delete event to remove
-			// the virtual node from Propagator.uidToNode.
-			glog.V(6).Infof("item %v not found, generating a virtual delete event", item.identity)
-			event := &event{
-				eventType: deleteEvent,
-				obj:       objectReferenceToMetadataOnlyObject(item.identity),
-			}
-			glog.V(6).Infof("generating virtual delete event for %s\n\n", event.obj)
-			gc.propagator.eventQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: gc.clock.Now(), Object: event})
-			return nil
-		}
-		return err
-	}
-	if latest.GetUID() != item.identity.UID {
-		glog.V(6).Infof("UID doesn't match, item %v not found, generating a virtual delete event", item.identity)
-		event := &event{
-			eventType: deleteEvent,
-			obj:       objectReferenceToMetadataOnlyObject(item.identity),
-		}
-		glog.V(6).Infof("generating virtual delete event for %s\n\n", event.obj)
-		gc.propagator.eventQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: gc.clock.Now(), Object: event})
-		return nil
-	}
-	ownerReferences := latest.GetOwnerReferences()
-	if len(ownerReferences) == 0 {
-		glog.V(6).Infof("object %s's doesn't have an owner, continue on next item", item.identity)
-		return nil
-	}
-	// TODO: we need to remove dangling references if the object is not to be
-	// deleted.
-	for _, reference := range ownerReferences {
-		if gc.absentOwnerCache.Has(reference.UID) {
-			glog.V(6).Infof("according to the absentOwnerCache, object %s's owner %s/%s, %s does not exist", item.identity.UID, reference.APIVersion, reference.Kind, reference.Name)
-			continue
-		}
-		// TODO: we need to verify the reference resource is supported by the
-		// system. If it's not a valid resource, the garbage collector should i)
-		// ignore the reference when decide if the object should be deleted, and
-		// ii) should update the object to remove such references. This is to
-		// prevent objects having references to an old resource from being
-		// deleted during a cluster upgrade.
-		fqKind := schema.FromAPIVersionAndKind(reference.APIVersion, reference.Kind)
-		client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
-		if err != nil {
-			return err
-		}
-		resource, err := gc.apiResource(reference.APIVersion, reference.Kind, len(item.identity.Namespace) != 0)
-		if err != nil {
-			return err
-		}
-		owner, err := client.Resource(resource, item.identity.Namespace).Get(reference.Name)
-		if err == nil {
-			if owner.GetUID() != reference.UID {
-				glog.V(6).Infof("object %s's owner %s/%s, %s is not found, UID mismatch", item.identity.UID, reference.APIVersion, reference.Kind, reference.Name)
-				gc.absentOwnerCache.Add(reference.UID)
-				continue
-			}
-			glog.V(6).Infof("object %s has at least an existing owner, will not garbage collect", item.identity.UID)
-			return nil
-		} else if errors.IsNotFound(err) {
-			gc.absentOwnerCache.Add(reference.UID)
-			glog.V(6).Infof("object %s's owner %s/%s, %s is not found", item.identity.UID, reference.APIVersion, reference.Kind, reference.Name)
-		} else {
-			return err
-		}
-	}
-	glog.V(2).Infof("none of object %s's owners exist any more, will garbage collect it", item.identity)
-	return gc.deleteObject(item.identity)
-}
-
 func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 	glog.Infof("Garbage Collector: Initializing")
 	for _, monitor := range gc.monitors {
@@ -785,6 +226,271 @@ func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 	gc.dirtyQueue.ShutDown()
 	gc.orphanQueue.ShutDown()
 	gc.propagator.eventQueue.ShutDown()
+}
+
+func (gc *GarbageCollector) worker() {
+	timedItem, quit := gc.dirtyQueue.Get()
+	if quit {
+		return
+	}
+	defer gc.dirtyQueue.Done(timedItem)
+	err := gc.processItem(timedItem.Object.(*node))
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Error syncing item %#v: %v", timedItem.Object, err))
+		// retry if garbage collection of an object failed.
+		gc.dirtyQueue.Add(timedItem)
+		return
+	}
+	DirtyProcessingLatency.Observe(sinceInMicroseconds(gc.clock, timedItem.StartTime))
+}
+
+func objectReferenceToMetadataOnlyObject(ref objectReference) *metaonly.MetadataOnlyObject {
+	return &metaonly.MetadataOnlyObject{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ref.APIVersion,
+			Kind:       ref.Kind,
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: ref.Namespace,
+			UID:       ref.UID,
+			Name:      ref.Name,
+		},
+	}
+}
+
+// classify the latestReferences to three categories:
+// solid: the owner exists, and is not "waiting"
+// dangling: the owner does not exist
+// waiting: the owner exists, its deletionTimestamp is non-nil, and it has
+// FianlizerDeletingDependents
+// This function communicates with the server.
+func (gc *GarbageCollector) classifyReferences(item *node, latestReferences []metav1.OwnerReference) (
+	solid []metav1.OwnerReference,
+	dangling []metav1.OwnerReference,
+	waiting []metav1.OwnerReference,
+	err error,
+) {
+	for _, reference := range latestReferences {
+		if gc.absentOwnerCache.Has(reference.UID) {
+			glog.V(6).Infof("according to the absentOwnerCache, object %s's owner %s/%s, %s does not exist", item.identity.UID, reference.APIVersion, reference.Kind, reference.Name)
+			dangling = append(dangling, reference)
+			continue
+		}
+		// TODO: we need to verify the reference resource is supported by the
+		// system. If it's not a valid resource, the garbage collector should i)
+		// ignore the reference when decide if the object should be deleted, and
+		// ii) should update the object to remove such references. This is to
+		// prevent objects having references to an old resource from being
+		// deleted during a cluster upgrade.
+		fqKind := schema.FromAPIVersionAndKind(reference.APIVersion, reference.Kind)
+		client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
+		if err != nil {
+			return solid, dangling, waiting, err
+		}
+		resource, err := gc.apiResource(reference.APIVersion, reference.Kind, len(item.identity.Namespace) != 0)
+		if err != nil {
+			return solid, dangling, waiting, err
+		}
+		owner, err := client.Resource(resource, item.identity.Namespace).Get(reference.Name)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				gc.absentOwnerCache.Add(reference.UID)
+				glog.V(6).Infof("object %s's owner %s/%s, %s is not found", item.identity.UID, reference.APIVersion, reference.Kind, reference.Name)
+				dangling = append(dangling, reference)
+			} else {
+				return solid, dangling, waiting, err
+			}
+		}
+
+		if owner.GetUID() != reference.UID {
+			glog.V(6).Infof("object %s's owner %s/%s, %s is not found, UID mismatch", item.identity.UID, reference.APIVersion, reference.Kind, reference.Name)
+			gc.absentOwnerCache.Add(reference.UID)
+			dangling = append(dangling, reference)
+			continue
+		}
+
+		ownerAccessor, err := meta.Accessor(owner)
+		if err != nil {
+			return solid, dangling, waiting, err
+		}
+		if ownerAccessor.GetDeletionTimestamp() != nil && hasDeleteDependentsFinalizer(ownerAccessor) {
+			waiting = append(waiting, reference)
+		} else {
+			solid = append(solid, reference)
+		}
+	}
+	return solid, dangling, waiting, nil
+}
+
+func (gc *GarbageCollector) generateVirtualDeleteEvent(identity objectReference) {
+	event := &event{
+		eventType: deleteEvent,
+		obj:       objectReferenceToMetadataOnlyObject(identity),
+	}
+	glog.V(6).Infof("generating virtual delete event for %s\n\n", event.obj)
+	gc.propagator.eventQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: gc.clock.Now(), Object: event})
+}
+
+func ownerRefsToUIDs(refs []metav1.OwnerReference) []types.UID {
+	var ret []types.UID
+	for _, ref := range refs {
+		ret = append(ret, ref.UID)
+	}
+	return ret
+}
+
+func (gc *GarbageCollector) processItem(item *node) error {
+	glog.V(2).Infof("processing item %s", item.identity)
+	// "being deleted" is an one-way trip to the final deletion. We'll just wait for the final deletion, and then process the object's dependents.
+	if item.beingDeleted && !item.deletingDependents {
+		glog.V(6).Infof("processing item %s returned at once", item.identity)
+		return nil
+	}
+	// Get the latest item from the API server
+	latest, err := gc.getObject(item.identity)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// the Propagator can add "virtual" node for an owner that doesn't
+			// exist yet, so we need to enqueue a virtual Delete event to remove
+			// the virtual node from Propagator.uidToNode.
+			glog.V(6).Infof("item %v not found, generating a virtual delete event", item.identity)
+			gc.generateVirtualDeleteEvent(item.identity)
+			return nil
+		}
+		return err
+	}
+	if latest.GetUID() != item.identity.UID {
+		glog.V(6).Infof("UID doesn't match, item %v not found, generating a virtual delete event", item.identity)
+		gc.generateVirtualDeleteEvent(item.identity)
+		return nil
+	}
+
+	// TODO: orphanFinalizer() routine is similar. Consider merging orphanFinalizer() into processItem() as well.
+	if item.deletingDependents {
+		return gc.processDeletingDependentsItem(item)
+	}
+
+	// compute if we should delete the item
+	ownerReferences := latest.GetOwnerReferences()
+	if len(ownerReferences) == 0 {
+		glog.V(2).Infof("object %s's doesn't have an owner, continue on next item", item.identity)
+		return nil
+	}
+
+	solid, dangling, waiting, err := gc.classifyReferences(item, ownerReferences)
+	if err != nil {
+		return err
+	}
+	glog.V(6).Infof("classify references of %s.\nsolid: %#v\ndangling: %#v\nwaiting: %#v\n", item.identity, solid, dangling, waiting)
+
+	switch {
+	case len(solid) != 0:
+		glog.V(2).Infof("object %s has at least one existing owner, will not garbage collect", item.identity)
+		if len(dangling) != 0 || len(waiting) != 0 {
+			glog.V(2).Infof("remove dangling references %#v and waiting references %#v for object %s", dangling, waiting, item.identity)
+		}
+		patch := deleteOwnerRefPatch(item.identity.UID, append(ownerRefsToUIDs(dangling), ownerRefsToUIDs(waiting)...)...)
+		_, err = gc.patchObject(item.identity, patch)
+		return err
+	case len(waiting) != 0 && len(item.dependents) != 0:
+		for dep := range item.dependents {
+			if dep.deletingDependents {
+				// this circle detection has false positives, we need to
+				// apply a more rigorous detection if this turns out to be a
+				// problem.
+				glog.V(2).Infof("processing object %s, some of its owners and its dependent [%s] have FianlizerDeletingDependents, to prevent potential cycle, its ownerReferences are going to be modified to be non-blocking, then the object is going to be deleted with DeletePropagationForeground", item.identity, dep.identity)
+				patch, err := item.patchToUnblockOwnerReferences()
+				if err != nil {
+					return err
+				}
+				if _, err := gc.patchObject(item.identity, patch); err != nil {
+					return err
+				}
+				break
+			}
+		}
+		glog.V(2).Infof("at least one owner of object %s has FianlizerDeletingDependents, and the object itself has dependents, so it is going to be deleted with DeletePropagationForeground", item.identity)
+		return gc.deleteObject(item.identity, v1.DeletePropagationForeground)
+	default:
+		glog.V(2).Infof("delete object %s with DeletePropagationDefault", item.identity)
+		return gc.deleteObject(item.identity, v1.DeletePropagationDefault)
+	}
+}
+
+// process item that's waiting for its dependents to be deleted
+func (gc *GarbageCollector) processDeletingDependentsItem(item *node) error {
+	blockingDependents := item.blockingDependents()
+	if len(blockingDependents) == 0 {
+		glog.V(2).Infof("remove DeleteDependents finalizer for item %s", item.identity)
+		return gc.removeFinalizer(item, v1.FinalizerDeleteDependents)
+	} else {
+		for _, dep := range blockingDependents {
+			if !dep.deletingDependents {
+				glog.V(2).Infof("adding %s to dirtyQueue, because its owner %s is deletingDependents", dep.identity, item.identity)
+				gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: gc.clock.Now(), Object: dep})
+			}
+		}
+		return nil
+	}
+}
+
+// dependents are copies of pointers to the owner's dependents, they don't need to be locked.
+func (gc *GarbageCollector) orhpanDependents(owner objectReference, dependents []*node) error {
+	var failedDependents []objectReference
+	var errorsSlice []error
+	for _, dependent := range dependents {
+		// the dependent.identity.UID is used as precondition
+		patch := deleteOwnerRefPatch(dependent.identity.UID, owner.UID)
+		_, err := gc.patchObject(dependent.identity, patch)
+		// note that if the target ownerReference doesn't exist in the
+		// dependent, strategic merge patch will NOT return an error.
+		if err != nil && !errors.IsNotFound(err) {
+			errorsSlice = append(errorsSlice, fmt.Errorf("orphaning %s failed with %v", dependent.identity, err))
+		}
+	}
+	if len(failedDependents) != 0 {
+		return fmt.Errorf("failed to orphan dependents of owner %s, got errors: %s", owner, utilerrors.NewAggregate(errorsSlice).Error())
+	}
+	glog.V(6).Infof("successfully updated all dependents")
+	return nil
+}
+
+// orphanFinalizer dequeues a node from the orphanQueue, then finds its dependents
+// based on the graph maintained by the GC, then removes it from the
+// OwnerReferences of its dependents, and finally updates the owner to remove
+// the "Orphan" finalizer. The node is add back into the orphanQueue if any of
+// these steps fail.
+func (gc *GarbageCollector) orphanFinalizer() {
+	timedItem, quit := gc.orphanQueue.Get()
+	if quit {
+		return
+	}
+	defer gc.orphanQueue.Done(timedItem)
+	owner, ok := timedItem.Object.(*node)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expect *node, got %#v", timedItem.Object))
+	}
+	// we don't need to lock each element, because they never get updated
+	owner.dependentsLock.RLock()
+	dependents := make([]*node, 0, len(owner.dependents))
+	for dependent := range owner.dependents {
+		dependents = append(dependents, dependent)
+	}
+	owner.dependentsLock.RUnlock()
+
+	err := gc.orhpanDependents(owner.identity, dependents)
+	if err != nil {
+		glog.V(6).Infof("orphanDependents for %s failed with %v", owner.identity, err)
+		gc.orphanQueue.Add(timedItem)
+		return
+	}
+	// update the owner, remove "orphaningFinalizer" from its finalizers list
+	err = gc.removeFinalizer(owner, v1.FinalizerOrphanDependents)
+	if err != nil {
+		glog.V(6).Infof("removeOrphanFinalizer for %s failed with %v", owner.identity, err)
+		gc.orphanQueue.Add(timedItem)
+	}
+	OrphanProcessingLatency.Observe(sinceInMicroseconds(gc.clock, timedItem.StartTime))
 }
 
 // *FOR TEST USE ONLY* It's not safe to call this function when the GC is still

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -559,3 +559,16 @@ func TestUnblockOwnerReference(t *testing.T) {
 		}
 	}
 }
+
+// *FOR TEST USE ONLY* It's not safe to call this function when the GC is still
+// busy.
+// GraphHasUID returns if the GraphBuilder has a particular UID store in its
+// uidToNode graph. It's useful for debugging.
+func (gc *GarbageCollector) GraphHasUID(UIDs []types.UID) bool {
+	for _, u := range UIDs {
+		if _, ok := gc.dependencyGraphBuilder.uidToNode.Read(u); ok {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/controller/garbagecollector/graph.go
+++ b/pkg/controller/garbagecollector/graph.go
@@ -34,7 +34,7 @@ func (s objectReference) String() string {
 	return fmt.Sprintf("[%s/%s, namespace: %s, name: %s, uid: %s]", s.APIVersion, s.Kind, s.Namespace, s.Name, s.UID)
 }
 
-// The single-threaded Propagator.processEvent() is the sole writer of the
+// The single-threaded GraphBuilder.processEvent() is the sole writer of the
 // nodes. The multi-threaded GarbageCollector.processItem() reads the nodes.
 type node struct {
 	identity objectReference

--- a/pkg/controller/garbagecollector/graph.go
+++ b/pkg/controller/garbagecollector/graph.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"fmt"
+	"sync"
+
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/types"
+)
+
+type objectReference struct {
+	metav1.OwnerReference
+	// This is needed by the dynamic client
+	Namespace string
+}
+
+func (s objectReference) String() string {
+	return fmt.Sprintf("[%s/%s, namespace: %s, name: %s, uid: %s]", s.APIVersion, s.Kind, s.Namespace, s.Name, s.UID)
+}
+
+// The single-threaded Propagator.processEvent() is the sole writer of the
+// nodes. The multi-threaded GarbageCollector.processItem() reads the nodes.
+type node struct {
+	identity objectReference
+	// dependents will be read by the orphan() routine, we need to protect it with a lock.
+	dependentsLock sync.RWMutex
+	dependents     map[*node]struct{}
+	// this is set by processEvent() if the object has non-nil DeletionTimestamp
+	// and has the FianlizerDeleteDependents.
+	deletingDependents bool
+	// this records if the object's deletionTimestamp is non-nil.
+	beingDeleted bool
+	// when processing an Update event, we need to compare the updated
+	// ownerReferences with the owners recorded in the graph.
+	owners []metav1.OwnerReference
+}
+
+func (ownerNode *node) addDependent(dependent *node) {
+	ownerNode.dependentsLock.Lock()
+	defer ownerNode.dependentsLock.Unlock()
+	ownerNode.dependents[dependent] = struct{}{}
+}
+
+func (ownerNode *node) deleteDependent(dependent *node) {
+	ownerNode.dependentsLock.Lock()
+	defer ownerNode.dependentsLock.Unlock()
+	delete(ownerNode.dependents, dependent)
+}
+
+// blockingDependents returns the dependents that are blocking the deletion of
+// n.
+func (n *node) blockingDependents() []*node {
+	var ret []*node
+	for dep := range n.dependents {
+		for _, owner := range dep.owners {
+			if owner.UID == n.identity.UID && owner.BlockOwnerDeletion != nil && *owner.BlockOwnerDeletion {
+				ret = append(ret, dep)
+			}
+		}
+	}
+	return ret
+}
+
+type concurrentUIDToNode struct {
+	*sync.RWMutex
+	uidToNode map[types.UID]*node
+}
+
+func (m *concurrentUIDToNode) Write(node *node) {
+	m.Lock()
+	defer m.Unlock()
+	m.uidToNode[node.identity.UID] = node
+}
+
+func (m *concurrentUIDToNode) Read(uid types.UID) (*node, bool) {
+	m.RLock()
+	defer m.RUnlock()
+	n, ok := m.uidToNode[uid]
+	return n, ok
+}
+
+func (m *concurrentUIDToNode) Delete(uid types.UID) {
+	m.Lock()
+	defer m.Unlock()
+	delete(m.uidToNode, uid)
+}

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -68,7 +68,7 @@ type GraphBuilder struct {
 	// the in-memory graph according to the changes.
 	graphChanges workqueue.RateLimitingInterface
 	// uidToNode doesn't require a lock to protect, because only the
-	// single-threaded GraphBuilder.processEvent() reads/writes it.
+	// single-threaded GraphBuilder.processGraphChanges() reads/writes it.
 	uidToNode *concurrentUIDToNode
 	// GraphBuilder is the producer of attemptToDelete and attemptToOrphan, GC is the consumer.
 	attemptToDelete workqueue.RateLimitingInterface
@@ -394,13 +394,13 @@ func (gb *GraphBuilder) processTransitions(oldObj interface{}, newAccessor meta.
 	}
 }
 
-func (gb *GraphBuilder) runProcessEvent() {
-	for gb.processEvent() {
+func (gb *GraphBuilder) runProcessGraphChanges() {
+	for gb.processGraphChanges() {
 	}
 }
 
 // Dequeueing an event from graphChanges, updating graph, populating dirty_queue.
-func (gb *GraphBuilder) processEvent() bool {
+func (gb *GraphBuilder) processGraphChanges() bool {
 	item, quit := gb.graphChanges.Get()
 	if quit {
 		return false

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -83,7 +83,7 @@ func (p *GraphBuilder) addDependentToOwners(n *node, owners []metav1.OwnerRefere
 				},
 				dependents: make(map[*node]struct{}),
 			}
-			glog.V(6).Infof("add virtual node.identity: %s\n\n", ownerNode.identity)
+			glog.V(5).Infof("add virtual node.identity: %s\n\n", ownerNode.identity)
 			p.uidToNode.Write(ownerNode)
 			p.attemptToDelete.Add(ownerNode)
 		}
@@ -225,7 +225,7 @@ func (p *GraphBuilder) addUnblockedOwnersToDirtyQueue(removed []metav1.OwnerRefe
 		if ref.BlockOwnerDeletion != nil && *ref.BlockOwnerDeletion {
 			node, found := p.uidToNode.Read(ref.UID)
 			if !found {
-				glog.V(6).Infof("cannot find %s in uidToNode", ref.UID)
+				glog.V(5).Infof("cannot find %s in uidToNode", ref.UID)
 				continue
 			}
 			p.attemptToDelete.Add(node)
@@ -236,7 +236,7 @@ func (p *GraphBuilder) addUnblockedOwnersToDirtyQueue(removed []metav1.OwnerRefe
 			c.new.BlockOwnerDeletion != nil && !*c.new.BlockOwnerDeletion {
 			node, found := p.uidToNode.Read(c.new.UID)
 			if !found {
-				glog.V(6).Infof("cannot find %s in uidToNode", c.new.UID)
+				glog.V(5).Infof("cannot find %s in uidToNode", c.new.UID)
 				continue
 			}
 			p.attemptToDelete.Add(node)
@@ -267,7 +267,7 @@ func (p *GraphBuilder) processEvent() {
 		utilruntime.HandleError(fmt.Errorf("cannot access obj: %v", err))
 		return
 	}
-	glog.V(6).Infof("GraphBuilder process object: %s/%s, namespace %s, name %s, event type %s", typeAccessor.GetAPIVersion(), typeAccessor.GetKind(), accessor.GetNamespace(), accessor.GetName(), event.eventType)
+	glog.V(5).Infof("GraphBuilder process object: %s/%s, namespace %s, name %s, event type %s", typeAccessor.GetAPIVersion(), typeAccessor.GetKind(), accessor.GetNamespace(), accessor.GetName(), event.eventType)
 	// Check if the node already exsits
 	existingNode, found := p.uidToNode.Read(accessor.GetUID())
 	switch {
@@ -290,7 +290,7 @@ func (p *GraphBuilder) processEvent() {
 		p.insertNode(newNode)
 		// the underlying delta_fifo may combine a creation and deletion into one event
 		if shouldOrphanDependents(event, accessor) {
-			glog.V(6).Infof("add %s to the attemptToOrphan", newNode.identity)
+			glog.V(5).Infof("add %s to the attemptToOrphan", newNode.identity)
 			p.attemptToOrphan.Add(newNode)
 		}
 		if startsWaitingForDependentsDeletion(event, accessor) {
@@ -304,7 +304,7 @@ func (p *GraphBuilder) processEvent() {
 		// caveat: if GC observes the creation of the dependents later than the
 		// deletion of the owner, then the orphaning finalizer won't be effective.
 		if shouldOrphanDependents(event, accessor) {
-			glog.V(6).Infof("add %s to the attemptToOrphan", existingNode.identity)
+			glog.V(5).Infof("add %s to the attemptToOrphan", existingNode.identity)
 			p.attemptToOrphan.Add(existingNode)
 		}
 		if beingDeleted(accessor) {
@@ -322,11 +322,11 @@ func (p *GraphBuilder) processEvent() {
 		// add/remove owner refs
 		added, removed, changed := referencesDiffs(existingNode.owners, accessor.GetOwnerReferences())
 		if len(added) == 0 && len(removed) == 0 && len(changed) == 0 {
-			glog.V(6).Infof("The updateEvent %#v doesn't change node references, ignore", event)
+			glog.V(5).Infof("The updateEvent %#v doesn't change node references, ignore", event)
 			return
 		}
 		if len(changed) != 0 {
-			glog.V(6).Infof("references %#v changed for object %s", changed, existingNode.identity)
+			glog.V(5).Infof("references %#v changed for object %s", changed, existingNode.identity)
 		}
 		p.addUnblockedOwnersToDirtyQueue(removed, changed)
 		// update the node itself
@@ -338,7 +338,7 @@ func (p *GraphBuilder) processEvent() {
 		p.removeDependentFromOwners(existingNode, removed)
 	case event.eventType == deleteEvent:
 		if !found {
-			glog.V(6).Infof("%v doesn't exist in the graph, this shouldn't happen", accessor.GetUID())
+			glog.V(5).Infof("%v doesn't exist in the graph, this shouldn't happen", accessor.GetUID())
 			return
 		}
 		p.removeNode(existingNode)

--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/v1"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/meta/v1/unstructured"
+	"k8s.io/kubernetes/pkg/runtime/schema"
+)
+
+// apiResource consults the REST mapper to translate an <apiVersion, kind,
+// namespace> tuple to a unversioned.APIResource struct.
+func (gc *GarbageCollector) apiResource(apiVersion, kind string, namespaced bool) (*metav1.APIResource, error) {
+	fqKind := schema.FromAPIVersionAndKind(apiVersion, kind)
+	mapping, err := gc.restMapper.RESTMapping(fqKind.GroupKind(), apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get REST mapping for kind: %s, version: %s", kind, apiVersion)
+	}
+	glog.V(6).Infof("map kind %s, version %s to resource %s", kind, apiVersion, mapping.Resource)
+	resource := metav1.APIResource{
+		Name:       mapping.Resource,
+		Namespaced: namespaced,
+		Kind:       kind,
+	}
+	return &resource, nil
+}
+
+func (gc *GarbageCollector) deleteObject(item objectReference, policy v1.DeletePropagationPolicy) error {
+	fqKind := schema.FromAPIVersionAndKind(item.APIVersion, item.Kind)
+	client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
+	gc.registeredRateLimiter.registerIfNotPresent(fqKind.GroupVersion(), client, "garbage_collector_operation")
+	resource, err := gc.apiResource(item.APIVersion, item.Kind, len(item.Namespace) != 0)
+	if err != nil {
+		return err
+	}
+	uid := item.UID
+	preconditions := v1.Preconditions{UID: &uid}
+	deleteOptions := v1.DeleteOptions{Preconditions: &preconditions, PropagationPolicy: &policy}
+	return client.Resource(resource, item.Namespace).Delete(item.Name, &deleteOptions)
+}
+
+func (gc *GarbageCollector) getObject(item objectReference) (*unstructured.Unstructured, error) {
+	fqKind := schema.FromAPIVersionAndKind(item.APIVersion, item.Kind)
+	client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
+	gc.registeredRateLimiter.registerIfNotPresent(fqKind.GroupVersion(), client, "garbage_collector_operation")
+	resource, err := gc.apiResource(item.APIVersion, item.Kind, len(item.Namespace) != 0)
+	if err != nil {
+		return nil, err
+	}
+	return client.Resource(resource, item.Namespace).Get(item.Name)
+}
+
+func (gc *GarbageCollector) updateObject(item objectReference, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	fqKind := schema.FromAPIVersionAndKind(item.APIVersion, item.Kind)
+	client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
+	gc.registeredRateLimiter.registerIfNotPresent(fqKind.GroupVersion(), client, "garbage_collector_operation")
+	resource, err := gc.apiResource(item.APIVersion, item.Kind, len(item.Namespace) != 0)
+	if err != nil {
+		return nil, err
+	}
+	return client.Resource(resource, item.Namespace).Update(obj)
+}
+
+func (gc *GarbageCollector) patchObject(item objectReference, patch []byte) (*unstructured.Unstructured, error) {
+	fqKind := schema.FromAPIVersionAndKind(item.APIVersion, item.Kind)
+	client, err := gc.clientPool.ClientForGroupVersionKind(fqKind)
+	gc.registeredRateLimiter.registerIfNotPresent(fqKind.GroupVersion(), client, "garbage_collector_operation")
+	resource, err := gc.apiResource(item.APIVersion, item.Kind, len(item.Namespace) != 0)
+	if err != nil {
+		return nil, err
+	}
+	return client.Resource(resource, item.Namespace).Patch(item.Name, api.StrategicMergePatchType, patch)
+}
+
+// TODO: Using Patch when strategicmerge supports deleting an entry from a
+// slice of a base type.
+func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string) error {
+	const retries = 5
+	for count := 0; count < retries; count++ {
+		ownerObject, err := gc.getObject(owner.identity)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("cannot finalize owner %s, because cannot get it. The garbage collector will retry later.", owner.identity)
+		}
+		accessor, err := meta.Accessor(ownerObject)
+		if err != nil {
+			return fmt.Errorf("cannot access the owner object: %v. The garbage collector will retry later.", err)
+		}
+		finalizers := accessor.GetFinalizers()
+		var newFinalizers []string
+		found := false
+		for _, f := range finalizers {
+			if f == targetFinalizer {
+				found = true
+				break
+			} else {
+				newFinalizers = append(newFinalizers, f)
+			}
+		}
+		if !found {
+			glog.V(6).Infof("the orphan finalizer is already removed from object %s", owner.identity)
+			return nil
+		}
+		// remove the owner from dependent's OwnerReferences
+		ownerObject.SetFinalizers(newFinalizers)
+		_, err = gc.updateObject(owner.identity, ownerObject)
+		if err == nil {
+			return nil
+		}
+		if err != nil && !errors.IsConflict(err) {
+			return fmt.Errorf("cannot update the finalizers of owner %s, with error: %v, tried %d times", owner.identity, err, count+1)
+		}
+		// retry if it's a conflict
+		glog.V(6).Infof("got conflict updating the owner object %s, tried %d times", owner.identity, count+1)
+	}
+	return fmt.Errorf("updateMaxRetries(%d) has reached. The garbage collector will retry later for owner %v.", retries, owner.identity)
+}

--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -38,7 +38,7 @@ func (gc *GarbageCollector) apiResource(apiVersion, kind string, namespaced bool
 	if err != nil {
 		return nil, fmt.Errorf("unable to get REST mapping for kind: %s, version: %s", kind, apiVersion)
 	}
-	glog.V(6).Infof("map kind %s, version %s to resource %s", kind, apiVersion, mapping.Resource)
+	glog.V(5).Infof("map kind %s, version %s to resource %s", kind, apiVersion, mapping.Resource)
 	resource := metav1.APIResource{
 		Name:       mapping.Resource,
 		Namespaced: namespaced,
@@ -122,7 +122,7 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 			}
 		}
 		if !found {
-			glog.V(6).Infof("the orphan finalizer is already removed from object %s", owner.identity)
+			glog.V(5).Infof("the orphan finalizer is already removed from object %s", owner.identity)
 			return nil
 		}
 		// remove the owner from dependent's OwnerReferences
@@ -135,7 +135,7 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 			return fmt.Errorf("cannot update the finalizers of owner %s, with error: %v, tried %d times", owner.identity, err, count+1)
 		}
 		// retry if it's a conflict
-		glog.V(6).Infof("got conflict updating the owner object %s, tried %d times", owner.identity, count+1)
+		glog.V(5).Infof("got conflict updating the owner object %s, tried %d times", owner.identity, count+1)
 	}
 	return fmt.Errorf("updateMaxRetries(%d) has reached. The garbage collector will retry later for owner %v.", retries, owner.identity)
 }

--- a/pkg/controller/garbagecollector/patch.go
+++ b/pkg/controller/garbagecollector/patch.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/controller/garbagecollector/metaonly"
+	"k8s.io/kubernetes/pkg/types"
+)
+
+func deleteOwnerRefPatch(dependentUID types.UID, ownerUIDs ...types.UID) []byte {
+	var pieces []string
+	for _, ownerUID := range ownerUIDs {
+		pieces = append(pieces, fmt.Sprintf(`{"$patch":"delete","uid":"%s"}`, ownerUID))
+	}
+	patch := fmt.Sprintf(`{"metadata":{"ownerReferences":[%s],"uid":"%s"}}`, strings.Join(pieces, ","), dependentUID)
+	return []byte(patch)
+}
+
+// generate a patch that unsets the BlockOwnerDeletion field of all
+// ownerReferences of node.
+func (n *node) patchToUnblockOwnerReferences() ([]byte, error) {
+	var dummy metaonly.MetadataOnlyObject
+	var blockingRefs []metav1.OwnerReference
+	falseVar := false
+	for _, owner := range n.owners {
+		if owner.BlockOwnerDeletion != nil && *owner.BlockOwnerDeletion {
+			ref := owner
+			ref.BlockOwnerDeletion = &falseVar
+			blockingRefs = append(blockingRefs, ref)
+		}
+	}
+	dummy.ObjectMeta.SetOwnerReferences(blockingRefs)
+	dummy.ObjectMeta.UID = n.identity.UID
+	return json.Marshal(dummy)
+}

--- a/pkg/controller/garbagecollector/propagator.go
+++ b/pkg/controller/garbagecollector/propagator.go
@@ -45,6 +45,9 @@ type event struct {
 	oldObj interface{}
 }
 
+// Propagator: based on the events supplied by the informers, Propagator updates
+// uidToNode, a graph that caches the dependencies as we know, and enqueues
+// items to the dirtyQueue and orphanQueue.
 type Propagator struct {
 	eventQueue *workqueue.TimedWorkQueue
 	// uidToNode doesn't require a lock to protect, because only the

--- a/pkg/controller/garbagecollector/propagator.go
+++ b/pkg/controller/garbagecollector/propagator.go
@@ -1,0 +1,353 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package garbagecollector
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/golang/glog"
+
+	"k8s.io/kubernetes/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/api/v1"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
+	"k8s.io/kubernetes/pkg/util/sets"
+	"k8s.io/kubernetes/pkg/util/workqueue"
+)
+
+type eventType int
+
+const (
+	addEvent eventType = iota
+	updateEvent
+	deleteEvent
+)
+
+type event struct {
+	eventType eventType
+	obj       interface{}
+	// the update event comes with an old object, but it's not used by the garbage collector.
+	oldObj interface{}
+}
+
+type Propagator struct {
+	eventQueue *workqueue.TimedWorkQueue
+	// uidToNode doesn't require a lock to protect, because only the
+	// single-threaded Propagator.processEvent() reads/writes it.
+	uidToNode *concurrentUIDToNode
+	gc        *GarbageCollector
+}
+
+// addDependentToOwners adds n to owners' dependents list. If the owner does not
+// exist in the p.uidToNode yet, a "virtual" node will be created to represent
+// the owner. The "virtual" node will be enqueued to the dirtyQueue, so that
+// processItem() will verify if the owner exists according to the API server.
+func (p *Propagator) addDependentToOwners(n *node, owners []metav1.OwnerReference) {
+	for _, owner := range owners {
+		ownerNode, ok := p.uidToNode.Read(owner.UID)
+		if !ok {
+			// Create a "virtual" node in the graph for the owner if it doesn't
+			// exist in the graph yet. Then enqueue the virtual node into the
+			// dirtyQueue. The garbage processor will enqueue a virtual delete
+			// event to delete it from the graph if API server confirms this
+			// owner doesn't exist.
+			ownerNode = &node{
+				identity: objectReference{
+					OwnerReference: owner,
+					Namespace:      n.identity.Namespace,
+				},
+				dependents: make(map[*node]struct{}),
+			}
+			glog.V(6).Infof("add virtual node.identity: %s\n\n", ownerNode.identity)
+			p.uidToNode.Write(ownerNode)
+			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: ownerNode})
+		}
+		ownerNode.addDependent(n)
+	}
+}
+
+// insertNode insert the node to p.uidToNode; then it finds all owners as listed
+// in n.owners, and adds the node to their dependents list.
+func (p *Propagator) insertNode(n *node) {
+	p.uidToNode.Write(n)
+	p.addDependentToOwners(n, n.owners)
+}
+
+// removeDependentFromOwners remove n from owners' dependents list.
+func (p *Propagator) removeDependentFromOwners(n *node, owners []metav1.OwnerReference) {
+	for _, owner := range owners {
+		ownerNode, ok := p.uidToNode.Read(owner.UID)
+		if !ok {
+			continue
+		}
+		ownerNode.deleteDependent(n)
+	}
+}
+
+// removeNode removes the node from p.uidToNode, then finds all
+// owners as listed in n.owners, and removes n from their dependents list.
+func (p *Propagator) removeNode(n *node) {
+	p.uidToNode.Delete(n.identity.UID)
+	p.removeDependentFromOwners(n, n.owners)
+}
+
+type ownerRefPair struct {
+	old metav1.OwnerReference
+	new metav1.OwnerReference
+}
+
+// TODO: profile this function to see if a naive N^2 algorithm performs better
+// when the number of references is small.
+func referencesDiffs(old []metav1.OwnerReference, new []metav1.OwnerReference) (added []metav1.OwnerReference, removed []metav1.OwnerReference, changed []ownerRefPair) {
+	oldUIDToRef := make(map[string]metav1.OwnerReference)
+	for i := 0; i < len(old); i++ {
+		oldUIDToRef[string(old[i].UID)] = old[i]
+	}
+	oldUIDSet := sets.StringKeySet(oldUIDToRef)
+	newUIDToRef := make(map[string]metav1.OwnerReference)
+	for i := 0; i < len(new); i++ {
+		newUIDToRef[string(new[i].UID)] = new[i]
+	}
+	newUIDSet := sets.StringKeySet(newUIDToRef)
+
+	addedUID := newUIDSet.Difference(oldUIDSet)
+	removedUID := oldUIDSet.Difference(newUIDSet)
+	intersection := oldUIDSet.Intersection(newUIDSet)
+
+	for uid := range addedUID {
+		added = append(added, newUIDToRef[uid])
+	}
+	for uid := range removedUID {
+		removed = append(removed, oldUIDToRef[uid])
+	}
+	for uid := range intersection {
+		if !reflect.DeepEqual(oldUIDToRef[uid], newUIDToRef[uid]) {
+			changed = append(changed, ownerRefPair{old: oldUIDToRef[uid], new: newUIDToRef[uid]})
+		}
+	}
+	return added, removed, changed
+}
+
+// returns if the object in the event just transitions to "being deleted".
+func deletionStarts(e *event, accessor meta.Object) bool {
+	// The delta_fifo may combine the creation and update of the object into one
+	// event, so if there is no e.oldObj, we just return if the e.obj is being deleted.
+	if e.oldObj == nil {
+		if accessor.GetDeletionTimestamp() == nil {
+			return false
+		}
+	} else {
+		oldAccessor, err := meta.Accessor(e.oldObj)
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("cannot access oldObj: %v", err))
+			return false
+		}
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("cannot access newObj: %v", err))
+			return false
+		}
+		if accessor.GetDeletionTimestamp() == nil || oldAccessor.GetDeletionTimestamp() != nil {
+			return false
+		}
+	}
+	return true
+}
+
+func beingDeleted(accessor meta.Object) bool {
+	return accessor.GetDeletionTimestamp() != nil
+}
+
+func hasDeleteDependentsFinalizer(accessor meta.Object) bool {
+	finalizers := accessor.GetFinalizers()
+	for _, finalizer := range finalizers {
+		if finalizer == v1.FinalizerDeleteDependents {
+			return true
+		}
+	}
+	return false
+}
+
+func hasOrphanFianlizer(accessor meta.Object) bool {
+	finalizers := accessor.GetFinalizers()
+	for _, finalizer := range finalizers {
+		if finalizer == v1.FinalizerOrphanDependents {
+			return true
+		}
+	}
+	return false
+}
+
+func startsWaitingForDependentsDeletion(e *event, accessor meta.Object) bool {
+	if !deletionStarts(e, accessor) {
+		// ignore the event if it's not about an object that starts being deleted.
+		return false
+	}
+	return hasDeleteDependentsFinalizer(accessor)
+}
+
+func shouldOrphanDependents(e *event, accessor meta.Object) bool {
+	if !deletionStarts(e, accessor) {
+		// ignore the event if it's not about an object that starts being deleted.
+		return false
+	}
+	return hasOrphanFianlizer(accessor)
+}
+
+// if an blocking ownerReference points to an object gets removed, or get set to
+// "BlockOwnerDeletion=false", add the object to the dirty queue.
+func (p *Propagator) addUnblockedOwnersToDirtyQueue(removed []metav1.OwnerReference, changed []ownerRefPair) {
+	for _, ref := range removed {
+		if ref.BlockOwnerDeletion != nil && *ref.BlockOwnerDeletion {
+			node, found := p.uidToNode.Read(ref.UID)
+			if !found {
+				glog.V(6).Infof("cannot find %s in uidToNode", ref.UID)
+				continue
+			}
+			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: node})
+		}
+	}
+	for _, c := range changed {
+		if c.old.BlockOwnerDeletion != nil && *c.old.BlockOwnerDeletion &&
+			c.new.BlockOwnerDeletion != nil && !*c.new.BlockOwnerDeletion {
+			node, found := p.uidToNode.Read(c.new.UID)
+			if !found {
+				glog.V(6).Infof("cannot find %s in uidToNode", c.new.UID)
+				continue
+			}
+			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: node})
+		}
+	}
+}
+
+// Dequeueing an event from eventQueue, updating graph, populating dirty_queue.
+func (p *Propagator) processEvent() {
+	timedItem, quit := p.eventQueue.Get()
+	if quit {
+		return
+	}
+	defer p.eventQueue.Done(timedItem)
+	event, ok := timedItem.Object.(*event)
+	if !ok {
+		utilruntime.HandleError(fmt.Errorf("expect a *event, got %v", timedItem.Object))
+		return
+	}
+	obj := event.obj
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("cannot access obj: %v", err))
+		return
+	}
+	typeAccessor, err := meta.TypeAccessor(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("cannot access obj: %v", err))
+		return
+	}
+	glog.V(6).Infof("Propagator process object: %s/%s, namespace %s, name %s, event type %s", typeAccessor.GetAPIVersion(), typeAccessor.GetKind(), accessor.GetNamespace(), accessor.GetName(), event.eventType)
+	// Check if the node already exsits
+	existingNode, found := p.uidToNode.Read(accessor.GetUID())
+	switch {
+	case (event.eventType == addEvent || event.eventType == updateEvent) && !found:
+		newNode := &node{
+			identity: objectReference{
+				OwnerReference: metav1.OwnerReference{
+					APIVersion: typeAccessor.GetAPIVersion(),
+					Kind:       typeAccessor.GetKind(),
+					UID:        accessor.GetUID(),
+					Name:       accessor.GetName(),
+				},
+				Namespace: accessor.GetNamespace(),
+			},
+			dependents:         make(map[*node]struct{}),
+			owners:             accessor.GetOwnerReferences(),
+			deletingDependents: beingDeleted(accessor) && hasDeleteDependentsFinalizer(accessor),
+			beingDeleted:       beingDeleted(accessor),
+		}
+		p.insertNode(newNode)
+		// the underlying delta_fifo may combine a creation and deletion into one event
+		if shouldOrphanDependents(event, accessor) {
+			glog.V(6).Infof("add %s to the orphanQueue", newNode.identity)
+			p.gc.orphanQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: newNode})
+		}
+		if startsWaitingForDependentsDeletion(event, accessor) {
+			glog.V(2).Infof("add %s to the dirtyQueue, because it's waiting for its dependents to be deleted", newNode.identity)
+			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: newNode})
+			for dep := range newNode.dependents {
+				p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: dep})
+			}
+		}
+	case (event.eventType == addEvent || event.eventType == updateEvent) && found:
+		// caveat: if GC observes the creation of the dependents later than the
+		// deletion of the owner, then the orphaning finalizer won't be effective.
+		if shouldOrphanDependents(event, accessor) {
+			glog.V(6).Infof("add %s to the orphanQueue", existingNode.identity)
+			p.gc.orphanQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: existingNode})
+		}
+		if beingDeleted(accessor) {
+			existingNode.beingDeleted = true
+		}
+		if startsWaitingForDependentsDeletion(event, accessor) {
+			glog.V(2).Infof("add %s to the dirtyQueue, because it's waiting for its dependents to be deleted", existingNode.identity)
+			// if the existingNode is added as a "virtual" node, its deletingDependents field is not properly set, so always set it here.
+			existingNode.deletingDependents = true
+			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: existingNode})
+			for dep := range existingNode.dependents {
+				p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: dep})
+			}
+		}
+		// add/remove owner refs
+		added, removed, changed := referencesDiffs(existingNode.owners, accessor.GetOwnerReferences())
+		if len(added) == 0 && len(removed) == 0 && len(changed) == 0 {
+			glog.V(6).Infof("The updateEvent %#v doesn't change node references, ignore", event)
+			return
+		}
+		if len(changed) != 0 {
+			glog.V(6).Infof("references %#v changed for object %s", changed, existingNode.identity)
+		}
+		p.addUnblockedOwnersToDirtyQueue(removed, changed)
+		// update the node itself
+		existingNode.owners = accessor.GetOwnerReferences()
+		// Add the node to its new owners' dependent lists.
+		p.addDependentToOwners(existingNode, added)
+		// remove the node from the dependent list of node that are no longer in
+		// the node's owners list.
+		p.removeDependentFromOwners(existingNode, removed)
+	case event.eventType == deleteEvent:
+		if !found {
+			glog.V(6).Infof("%v doesn't exist in the graph, this shouldn't happen", accessor.GetUID())
+			return
+		}
+		p.removeNode(existingNode)
+		existingNode.dependentsLock.RLock()
+		defer existingNode.dependentsLock.RUnlock()
+		if len(existingNode.dependents) > 0 {
+			p.gc.absentOwnerCache.Add(accessor.GetUID())
+		}
+		for dep := range existingNode.dependents {
+			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: dep})
+		}
+		for _, owner := range existingNode.owners {
+			ownerNode, found := p.uidToNode.Read(owner.UID)
+			if !found || !ownerNode.deletingDependents {
+				continue
+			}
+			// this is to let processItem check if all the owner's dependents are deleted.
+			p.gc.dirtyQueue.Add(&workqueue.TimedWorkQueueItem{StartTime: p.gc.clock.Now(), Object: ownerNode})
+		}
+	}
+	EventProcessingLatency.Observe(sinceInMicroseconds(p.gc.clock, timedItem.StartTime))
+}

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -487,11 +487,12 @@ func (rsc *ReplicaSetController) manageReplicas(filteredPods []*v1.Pod, rs *exte
 				if rsc.garbageCollectorEnabled {
 					var trueVar = true
 					controllerRef := &metav1.OwnerReference{
-						APIVersion: getRSKind().GroupVersion().String(),
-						Kind:       getRSKind().Kind,
-						Name:       rs.Name,
-						UID:        rs.UID,
-						Controller: &trueVar,
+						APIVersion:         getRSKind().GroupVersion().String(),
+						Kind:               getRSKind().Kind,
+						Name:               rs.Name,
+						UID:                rs.UID,
+						BlockOwnerDeletion: &trueVar,
+						Controller:         &trueVar,
 					}
 					err = rsc.podControl.CreatePodsWithControllerRef(rs.Namespace, &rs.Spec.Template, rs, controllerRef)
 				} else {

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -547,11 +547,12 @@ func (rm *ReplicationManager) manageReplicas(filteredPods []*v1.Pod, rc *v1.Repl
 				if rm.garbageCollectorEnabled {
 					var trueVar = true
 					controllerRef := &metav1.OwnerReference{
-						APIVersion: getRCKind().GroupVersion().String(),
-						Kind:       getRCKind().Kind,
-						Name:       rc.Name,
-						UID:        rc.UID,
-						Controller: &trueVar,
+						APIVersion:         getRCKind().GroupVersion().String(),
+						Kind:               getRCKind().Kind,
+						Name:               rc.Name,
+						UID:                rc.UID,
+						BlockOwnerDeletion: &trueVar,
+						Controller:         &trueVar,
 					}
 					err = rm.podControl.CreatePodsWithControllerRef(rc.Namespace, rc.Spec.Template, rc, controllerRef)
 				} else {

--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -117,9 +117,9 @@ var InterestingApiServerMetrics = []string{
 }
 
 var InterestingControllerManagerMetrics = []string{
-	"garbage_collector_event_processing_latency_microseconds",
-	"garbage_collector_dirty_processing_latency_microseconds",
-	"garbage_collector_orphan_processing_latency_microseconds",
+	"garbage_collector_event_queue_latency",
+	"garbage_collector_dirty_queue_latency",
+	"garbage_collector_orhan_queue_latency",
 }
 
 var InterestingKubeletMetrics = []string{

--- a/test/e2e/garbage_collector.go
+++ b/test/e2e/garbage_collector.go
@@ -20,15 +20,24 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/v1"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
 	"k8s.io/kubernetes/pkg/metrics"
+	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
+
+func getDeletePropagationForegroundOptions() *v1.DeleteOptions {
+	policy := v1.DeletePropagationForeground
+	return &v1.DeleteOptions{PropagationPolicy: &policy}
+}
 
 func getOrphanOptions() *v1.DeleteOptions {
 	var trueVar = true
@@ -40,9 +49,11 @@ func getNonOrphanOptions() *v1.DeleteOptions {
 	return &v1.DeleteOptions{OrphanDependents: &falseVar}
 }
 
-func newOwnerRC(f *framework.Framework, name string) *v1.ReplicationController {
-	var replicas int32
-	replicas = 2
+func getSelector() map[string]string {
+	return map[string]string{"app": "gc-test"}
+}
+
+func newOwnerRC(f *framework.Framework, name string, replicas int32) *v1.ReplicationController {
 	return &v1.ReplicationController{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ReplicationController",
@@ -54,18 +65,40 @@ func newOwnerRC(f *framework.Framework, name string) *v1.ReplicationController {
 		},
 		Spec: v1.ReplicationControllerSpec{
 			Replicas: &replicas,
-			Selector: map[string]string{"app": "gc-test"},
+			Selector: getSelector(),
 			Template: &v1.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
-					Labels: map[string]string{"app": "gc-test"},
+					Labels: getSelector(),
 				},
 				Spec: v1.PodSpec{
+					TerminationGracePeriodSeconds: func() *int64 { i := int64(0); return &i }(),
 					Containers: []v1.Container{
 						{
 							Name:  "nginx",
 							Image: "gcr.io/google_containers/nginx:1.7.9",
 						},
 					},
+				},
+			},
+		},
+	}
+}
+
+func newGCPod(name string) *v1.Pod {
+	return &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PodSpec{
+			TerminationGracePeriodSeconds: func() *int64 { i := int64(0); return &i }(),
+			Containers: []v1.Container{
+				{
+					Name:  "nginx",
+					Image: "gcr.io/google_containers/nginx:1.7.9",
 				},
 			},
 		},
@@ -121,7 +154,7 @@ var _ = framework.KubeDescribe("Garbage collector", func() {
 		rcClient := clientSet.Core().ReplicationControllers(f.Namespace.Name)
 		podClient := clientSet.Core().Pods(f.Namespace.Name)
 		rcName := "simpletest.rc"
-		rc := newOwnerRC(f, rcName)
+		rc := newOwnerRC(f, rcName, 2)
 		By("create the rc")
 		rc, err := rcClient.Create(rc)
 		if err != nil {
@@ -172,8 +205,8 @@ var _ = framework.KubeDescribe("Garbage collector", func() {
 		rcClient := clientSet.Core().ReplicationControllers(f.Namespace.Name)
 		podClient := clientSet.Core().Pods(f.Namespace.Name)
 		rcName := "simpletest.rc"
-		rc := newOwnerRC(f, rcName)
-		replicas := int32(100)
+		rc := newOwnerRC(f, rcName, 2)
+		replicas := int32(10)
 		rc.Spec.Replicas = &replicas
 		By("create the rc")
 		rc, err := rcClient.Create(rc)
@@ -210,7 +243,7 @@ var _ = framework.KubeDescribe("Garbage collector", func() {
 				return false, nil
 			}
 			return true, nil
-		}); err != nil && err != wait.ErrWaitTimeout {
+		}); err != nil {
 			framework.Failf("%v", err)
 		}
 		By("wait for 30 seconds to see if the garbage collector mistakenly deletes the pods")
@@ -234,7 +267,7 @@ var _ = framework.KubeDescribe("Garbage collector", func() {
 		rcClient := clientSet.Core().ReplicationControllers(f.Namespace.Name)
 		podClient := clientSet.Core().Pods(f.Namespace.Name)
 		rcName := "simpletest.rc"
-		rc := newOwnerRC(f, rcName)
+		rc := newOwnerRC(f, rcName, 2)
 		By("create the rc")
 		rc, err := rcClient.Create(rc)
 		if err != nil {
@@ -274,5 +307,241 @@ var _ = framework.KubeDescribe("Garbage collector", func() {
 			framework.Failf("%v", err)
 		}
 		gatherMetrics(f)
+	})
+
+	It("[Feature:GarbageCollector] should keep the rc around until all its pods are deleted if the deleteOptions says so", func() {
+		clientSet := f.ClientSet
+		rcClient := clientSet.Core().ReplicationControllers(f.Namespace.Name)
+		podClient := clientSet.Core().Pods(f.Namespace.Name)
+		rcName := "simpletest.rc"
+		rc := newOwnerRC(f, rcName, 2)
+		replicas := int32(100)
+		rc.Spec.Replicas = &replicas
+		By("create the rc")
+		rc, err := rcClient.Create(rc)
+		if err != nil {
+			framework.Failf("Failed to create replication controller: %v", err)
+		}
+		// wait for rc to create pods
+		if err := wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
+			rc, err := rcClient.Get(rc.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("Failed to get rc: %v", err)
+			}
+			if rc.Status.Replicas == *rc.Spec.Replicas {
+				return true, nil
+			} else {
+				return false, nil
+			}
+		}); err != nil {
+			framework.Failf("failed to wait for the rc.Status.Replicas to reach rc.Spec.Replicas: %v", err)
+		}
+		By("delete the rc")
+		deleteOptions := getDeletePropagationForegroundOptions()
+		deleteOptions.Preconditions = v1.NewUIDPreconditions(string(rc.UID))
+		if err := rcClient.Delete(rc.ObjectMeta.Name, deleteOptions); err != nil {
+			framework.Failf("failed to delete the rc: %v", err)
+		}
+		By("wait for the rc to be deleted")
+		// default client QPS is 20, deleting each pod requires 2 requests, so 30s should be enough
+		if err := wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
+			_, err := rcClient.Get(rc.Name, metav1.GetOptions{})
+			if err == nil {
+				pods, _ := podClient.List(v1.ListOptions{})
+				framework.Logf("%d pods remaining", len(pods.Items))
+				count := 0
+				for _, pod := range pods.Items {
+					if pod.ObjectMeta.DeletionTimestamp == nil {
+						count++
+					}
+				}
+				framework.Logf("%d pods has nil DeletionTimestamp", count)
+				framework.Logf("")
+				return false, nil
+			} else {
+				if errors.IsNotFound(err) {
+					return true, nil
+				} else {
+					return false, err
+				}
+			}
+		}); err != nil {
+			pods, err2 := podClient.List(v1.ListOptions{})
+			if err2 != nil {
+				framework.Failf("%v", err2)
+			}
+			framework.Logf("%d remaining pods are:", len(pods.Items))
+			framework.Logf("The ObjectMeta of the remaining pods are:")
+			for _, pod := range pods.Items {
+				framework.Logf("%#v", pod.ObjectMeta)
+			}
+			framework.Failf("failed to delete the rc: %v", err)
+		}
+		// There shouldn't be any pods
+		pods, err := podClient.List(v1.ListOptions{})
+		if err != nil {
+			framework.Failf("%v", err)
+		}
+		if len(pods.Items) != 0 {
+			framework.Failf("expected no pods, got %#v", pods)
+		}
+		gatherMetrics(f)
+	})
+
+	// TODO: this should be an integration test
+	It("[Feature:GarbageCollector] should not delete dependents that have both valid owner and owner that's waiting for dependents to be deleted", func() {
+		clientSet := f.ClientSet
+		rcClient := clientSet.Core().ReplicationControllers(f.Namespace.Name)
+		podClient := clientSet.Core().Pods(f.Namespace.Name)
+		rc1Name := "simpletest-rc-to-be-deleted"
+		replicas := int32(100)
+		halfReplicas := 50
+		rc1 := newOwnerRC(f, rc1Name, replicas)
+		By("create the rc1")
+		rc1, err := rcClient.Create(rc1)
+		if err != nil {
+			framework.Failf("Failed to create replication controller: %v", err)
+		}
+		rc2Name := "simpletest-rc-to-stay"
+		rc2 := newOwnerRC(f, rc2Name, 0)
+		rc2.Spec.Selector = nil
+		rc2.Spec.Template.ObjectMeta.Labels = map[string]string{"another.key": "another.value"}
+		By("create the rc2")
+		rc2, err = rcClient.Create(rc2)
+		if err != nil {
+			framework.Failf("Failed to create replication controller: %v", err)
+		}
+		// wait for rc1 to be stable
+		if err := wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
+			rc1, err := rcClient.Get(rc1.Name, metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("Failed to get rc: %v", err)
+			}
+			if rc1.Status.Replicas == *rc1.Spec.Replicas {
+				return true, nil
+			} else {
+				return false, nil
+			}
+		}); err != nil {
+			framework.Failf("failed to wait for the rc.Status.Replicas to reach rc.Spec.Replicas: %v", err)
+		}
+		By(fmt.Sprintf("set half of pods created by rc %s to have rc %s as owner as well", rc1Name, rc2Name))
+		pods, err := podClient.List(v1.ListOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		patch := fmt.Sprintf(`{"metadata":{"ownerReferences":[{"apiVersion":"v1","kind":"ReplicationController","name":"%s","uid":"%s"}]}}`, rc2.ObjectMeta.Name, rc2.ObjectMeta.UID)
+		for i := 0; i < halfReplicas; i++ {
+			pod := pods.Items[i]
+			_, err := podClient.Patch(pod.Name, api.StrategicMergePatchType, []byte(patch))
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		By(fmt.Sprintf("delete the rc %s", rc1Name))
+		deleteOptions := getDeletePropagationForegroundOptions()
+		deleteOptions.Preconditions = v1.NewUIDPreconditions(string(rc1.UID))
+		if err := rcClient.Delete(rc1.ObjectMeta.Name, deleteOptions); err != nil {
+			framework.Failf("failed to delete the rc: %v", err)
+		}
+		By("wait for the rc to be deleted")
+		// default client QPS is 20, deleting each pod requires 2 requests, so 30s should be enough
+		if err := wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
+			_, err := rcClient.Get(rc1.Name, metav1.GetOptions{})
+			if err == nil {
+				pods, _ := podClient.List(v1.ListOptions{})
+				framework.Logf("%d pods remaining", len(pods.Items))
+				count := 0
+				for _, pod := range pods.Items {
+					if pod.ObjectMeta.DeletionTimestamp == nil {
+						count++
+					}
+				}
+				framework.Logf("%d pods has nil DeletionTimestamp", count)
+				framework.Logf("")
+				return false, nil
+			} else {
+				if errors.IsNotFound(err) {
+					return true, nil
+				} else {
+					return false, err
+				}
+			}
+		}); err != nil {
+			pods, err2 := podClient.List(v1.ListOptions{})
+			if err2 != nil {
+				framework.Failf("%v", err2)
+			}
+			framework.Logf("%d remaining pods are:", len(pods.Items))
+			framework.Logf("ObjectMeta of remaining pods are:")
+			for _, pod := range pods.Items {
+				framework.Logf("%#v", pod.ObjectMeta)
+			}
+			framework.Failf("failed to delete rc %s, err: %v", rc1Name, err)
+		}
+		// half of the pods should still exist,
+		pods, err = podClient.List(v1.ListOptions{})
+		if err != nil {
+			framework.Failf("%v", err)
+		}
+		if len(pods.Items) != halfReplicas {
+			framework.Failf("expected %d pods, got %d", halfReplicas, len(pods.Items))
+		}
+		for _, pod := range pods.Items {
+			if pod.ObjectMeta.DeletionTimestamp != nil {
+				framework.Failf("expected pod DeletionTimestamp to be nil, got %#v", pod.ObjectMeta)
+			}
+			// they should only have 1 ownerReference left
+			if len(pod.ObjectMeta.OwnerReferences) != 1 {
+				framework.Failf("expected pod to only have 1 owner, got %#v", pod.ObjectMeta.OwnerReferences)
+			}
+		}
+		gatherMetrics(f)
+	})
+
+	// TODO: should be an integration test
+	It("[Feature:GarbageCollector] should not be blocked by dependency circle", func() {
+		clientSet := f.ClientSet
+		podClient := clientSet.Core().Pods(f.Namespace.Name)
+		pod1 := newGCPod("pod1")
+		pod1, err := podClient.Create(pod1)
+		Expect(err).NotTo(HaveOccurred())
+		pod2 := newGCPod("pod2")
+		pod2, err = podClient.Create(pod2)
+		Expect(err).NotTo(HaveOccurred())
+		pod3 := newGCPod("pod3")
+		pod3, err = podClient.Create(pod3)
+		Expect(err).NotTo(HaveOccurred())
+		// create circular dependency
+		addRefPatch := func(name string, uid types.UID) []byte {
+			return []byte(fmt.Sprintf(`{"metadata":{"ownerReferences":[{"apiVersion":"v1","kind":"Pod","name":"%s","uid":"%s","controller":true,"blockOwnerDeletion":true}]}}`, name, uid))
+		}
+		pod1, err = podClient.Patch(pod1.Name, api.StrategicMergePatchType, addRefPatch(pod3.Name, pod3.UID))
+		Expect(err).NotTo(HaveOccurred())
+		framework.Logf("pod1.ObjectMeta.OwnerReferences=%#v", pod1.ObjectMeta.OwnerReferences)
+		pod2, err = podClient.Patch(pod2.Name, api.StrategicMergePatchType, addRefPatch(pod1.Name, pod1.UID))
+		Expect(err).NotTo(HaveOccurred())
+		framework.Logf("pod2.ObjectMeta.OwnerReferences=%#v", pod2.ObjectMeta.OwnerReferences)
+		pod3, err = podClient.Patch(pod3.Name, api.StrategicMergePatchType, addRefPatch(pod2.Name, pod2.UID))
+		Expect(err).NotTo(HaveOccurred())
+		framework.Logf("pod3.ObjectMeta.OwnerReferences=%#v", pod3.ObjectMeta.OwnerReferences)
+		// delete one pod, should result in the deletion of all pods
+		deleteOptions := getDeletePropagationForegroundOptions()
+		deleteOptions.Preconditions = v1.NewUIDPreconditions(string(pod1.UID))
+		err = podClient.Delete(pod1.ObjectMeta.Name, deleteOptions)
+		Expect(err).NotTo(HaveOccurred())
+		var pods *v1.PodList
+		var err2 error
+		if err := wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
+			pods, err2 = podClient.List(v1.ListOptions{})
+			if err2 != nil {
+				return false, fmt.Errorf("Failed to list pods: %v", err)
+			}
+			if len(pods.Items) == 0 {
+				return true, nil
+			} else {
+				return false, nil
+			}
+		}); err != nil {
+			framework.Logf("pods are %#v", pods.Items)
+			framework.Failf("failed to wait for all pods to be deleted: %v", err)
+		}
 	})
 })

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	dto "github.com/prometheus/client_model/go"
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
@@ -403,19 +402,21 @@ func TestStressingCascadingDeletion(t *testing.T) {
 	if gc.GraphHasUID(uids) {
 		t.Errorf("Expect all nodes representing replication controllers are removed from the Propagator's graph")
 	}
-	metric := &dto.Metric{}
-	garbagecollector.EventProcessingLatency.Write(metric)
-	count := float64(metric.Summary.GetSampleCount())
-	sum := metric.Summary.GetSampleSum()
-	t.Logf("Average time spent in GC's eventQueue is %.1f microseconds", sum/count)
-	garbagecollector.DirtyProcessingLatency.Write(metric)
-	count = float64(metric.Summary.GetSampleCount())
-	sum = metric.Summary.GetSampleSum()
-	t.Logf("Average time spent in GC's dirtyQueue is %.1f microseconds", sum/count)
-	garbagecollector.OrphanProcessingLatency.Write(metric)
-	count = float64(metric.Summary.GetSampleCount())
-	sum = metric.Summary.GetSampleSum()
-	t.Logf("Average time spent in GC's orphanQueue is %.1f microseconds", sum/count)
+	// TODO: figure out how to retrieve the metrics without the global
+	// variables.
+	//	metric := &dto.Metric{}
+	//	garbagecollector.EventProcessingLatency.Write(metric)
+	//	count := float64(metric.Summary.GetSampleCount())
+	//	sum := metric.Summary.GetSampleSum()
+	//	t.Logf("Average time spent in GC's eventQueue is %.1f microseconds", sum/count)
+	//	garbagecollector.DirtyProcessingLatency.Write(metric)
+	//	count = float64(metric.Summary.GetSampleCount())
+	//	sum = metric.Summary.GetSampleSum()
+	//	t.Logf("Average time spent in GC's dirtyQueue is %.1f microseconds", sum/count)
+	//	garbagecollector.OrphanProcessingLatency.Write(metric)
+	//	count = float64(metric.Summary.GetSampleCount())
+	//	sum = metric.Summary.GetSampleSum()
+	//	t.Logf("Average time spent in GC's orphanQueue is %.1f microseconds", sum/count)
 }
 
 func TestOrphaning(t *testing.T) {

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -31,6 +31,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
@@ -46,6 +47,11 @@ import (
 	"k8s.io/kubernetes/test/integration"
 	"k8s.io/kubernetes/test/integration/framework"
 )
+
+func getDeletePropagationForegroundOptions() *v1.DeleteOptions {
+	policy := v1.DeletePropagationForeground
+	return &v1.DeleteOptions{PropagationPolicy: &policy}
+}
 
 func getOrphanOptions() *v1.DeleteOptions {
 	var trueVar = true
@@ -298,7 +304,7 @@ func setupRCsPods(t *testing.T, gc *garbagecollector.GarbageCollector, clientSet
 		}
 		podUIDs = append(podUIDs, pod.ObjectMeta.UID)
 	}
-	orphan := (options != nil && options.OrphanDependents != nil && *options.OrphanDependents) || (options == nil && len(initialFinalizers) != 0 && initialFinalizers[0] == api.FinalizerOrphan)
+	orphan := (options != nil && options.OrphanDependents != nil && *options.OrphanDependents) || (options == nil && len(initialFinalizers) != 0 && initialFinalizers[0] == api.FinalizerOrphanDependents)
 	// if we intend to orphan the pods, we need wait for the gc to observe the
 	// creation of the pods, otherwise if the deletion of RC is observed before
 	// the creation of the pods, the pods will not be orphaned.
@@ -357,9 +363,9 @@ func TestStressingCascadingDeletion(t *testing.T) {
 		// rc is created with empty finalizers, deleted with nil delete options, pods will remain.
 		go setupRCsPods(t, gc, clientSet, "collection1-"+strconv.Itoa(i), ns.Name, []string{}, nil, &wg, rcUIDs)
 		// rc is created with the orphan finalizer, deleted with nil options, pods will remain.
-		go setupRCsPods(t, gc, clientSet, "collection2-"+strconv.Itoa(i), ns.Name, []string{api.FinalizerOrphan}, nil, &wg, rcUIDs)
+		go setupRCsPods(t, gc, clientSet, "collection2-"+strconv.Itoa(i), ns.Name, []string{api.FinalizerOrphanDependents}, nil, &wg, rcUIDs)
 		// rc is created with the orphan finalizer, deleted with DeleteOptions.OrphanDependents=false, pods will be deleted.
-		go setupRCsPods(t, gc, clientSet, "collection3-"+strconv.Itoa(i), ns.Name, []string{api.FinalizerOrphan}, getNonOrphanOptions(), &wg, rcUIDs)
+		go setupRCsPods(t, gc, clientSet, "collection3-"+strconv.Itoa(i), ns.Name, []string{api.FinalizerOrphanDependents}, getNonOrphanOptions(), &wg, rcUIDs)
 		// rc is created with empty finalizers, deleted with DeleteOptions.OrphanDependents=true, pods will remain.
 		go setupRCsPods(t, gc, clientSet, "collection4-"+strconv.Itoa(i), ns.Name, []string{}, getOrphanOptions(), &wg, rcUIDs)
 	}
@@ -428,7 +434,7 @@ func TestOrphaning(t *testing.T) {
 		t.Fatalf("Failed to create replication controller: %v", err)
 	}
 
-	// these pods should be ophaned.
+	// these pods should be orphaned.
 	var podUIDs []types.UID
 	podsNum := 3
 	for i := 0; i < podsNum; i++ {
@@ -480,5 +486,185 @@ func TestOrphaning(t *testing.T) {
 		if len(pod.ObjectMeta.OwnerReferences) != 0 {
 			t.Errorf("pod %s still has non-empty OwnerRefereces: %v", pod.ObjectMeta.Name, pod.ObjectMeta.OwnerReferences)
 		}
+	}
+}
+
+func TestSolidOwnerDoesNotBlockWaitingOwner(t *testing.T) {
+	s, gc, clientSet := setup(t)
+	defer s.Close()
+
+	ns := framework.CreateTestingNamespace("gc-foreground1", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
+	podClient := clientSet.Core().Pods(ns.Name)
+	rcClient := clientSet.Core().ReplicationControllers(ns.Name)
+	// create the RC with the orphan finalizer set
+	toBeDeletedRC, err := rcClient.Create(newOwnerRC(toBeDeletedRCName, ns.Name))
+	if err != nil {
+		t.Fatalf("Failed to create replication controller: %v", err)
+	}
+	remainingRC, err := rcClient.Create(newOwnerRC(remainingRCName, ns.Name))
+	if err != nil {
+		t.Fatalf("Failed to create replication controller: %v", err)
+	}
+	trueVar := true
+	pod := newPod("pod", ns.Name, []metav1.OwnerReference{
+		{UID: toBeDeletedRC.ObjectMeta.UID, Name: toBeDeletedRC.Name, BlockOwnerDeletion: &trueVar},
+		{UID: remainingRC.ObjectMeta.UID, Name: remainingRC.Name},
+	})
+	_, err = podClient.Create(pod)
+	if err != nil {
+		t.Fatalf("Failed to create Pod: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	go gc.Run(5, stopCh)
+	defer close(stopCh)
+
+	err = rcClient.Delete(toBeDeletedRCName, getDeletePropagationForegroundOptions())
+	if err != nil {
+		t.Fatalf("Failed to delete the rc: %v", err)
+	}
+	// verify the toBeDeleteRC is deleted
+	if err := wait.PollImmediate(5*time.Second, 30*time.Second, func() (bool, error) {
+		_, err := rcClient.Get(toBeDeletedRC.Name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// verify pods don't have the toBeDeleteRC as an owner anymore
+	pod, err = podClient.Get("pod", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Failed to list pods: %v", err)
+	}
+	if len(pod.ObjectMeta.OwnerReferences) != 1 {
+		t.Errorf("expect pod to have only one ownerReference: got %#v", pod.ObjectMeta.OwnerReferences)
+	} else if pod.ObjectMeta.OwnerReferences[0].Name != remainingRC.Name {
+		t.Errorf("expect pod to have an ownerReference pointing to %s, got %#v", remainingRC.Name, pod.ObjectMeta.OwnerReferences)
+	}
+}
+
+func TestNonBlockingOwnerRefDoesNotBlock(t *testing.T) {
+	s, gc, clientSet := setup(t)
+	defer s.Close()
+
+	ns := framework.CreateTestingNamespace("gc-foreground2", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
+	podClient := clientSet.Core().Pods(ns.Name)
+	rcClient := clientSet.Core().ReplicationControllers(ns.Name)
+	// create the RC with the orphan finalizer set
+	toBeDeletedRC, err := rcClient.Create(newOwnerRC(toBeDeletedRCName, ns.Name))
+	if err != nil {
+		t.Fatalf("Failed to create replication controller: %v", err)
+	}
+	// BlockingOwnerDeletion is not set
+	pod1 := newPod("pod1", ns.Name, []metav1.OwnerReference{
+		{UID: toBeDeletedRC.ObjectMeta.UID, Name: toBeDeletedRC.Name},
+	})
+	// adding finalizer that no controller handles, so that the pod won't be deleted
+	pod1.ObjectMeta.Finalizers = []string{"x/y"}
+	// BlockingOwnerDeletion is false
+	falseVar := false
+	pod2 := newPod("pod2", ns.Name, []metav1.OwnerReference{
+		{UID: toBeDeletedRC.ObjectMeta.UID, Name: toBeDeletedRC.Name, BlockOwnerDeletion: &falseVar},
+	})
+	// adding finalizer that no controller handles, so that the pod won't be deleted
+	pod2.ObjectMeta.Finalizers = []string{"x/y"}
+	_, err = podClient.Create(pod1)
+	if err != nil {
+		t.Fatalf("Failed to create Pod: %v", err)
+	}
+	_, err = podClient.Create(pod2)
+	if err != nil {
+		t.Fatalf("Failed to create Pod: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	go gc.Run(5, stopCh)
+	defer close(stopCh)
+
+	err = rcClient.Delete(toBeDeletedRCName, getDeletePropagationForegroundOptions())
+	if err != nil {
+		t.Fatalf("Failed to delete the rc: %v", err)
+	}
+	// verify the toBeDeleteRC is deleted
+	if err := wait.PollImmediate(5*time.Second, 30*time.Second, func() (bool, error) {
+		_, err := rcClient.Get(toBeDeletedRC.Name, metav1.GetOptions{})
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return true, nil
+			}
+			return false, err
+		}
+		return false, nil
+	}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// verify pods are still there
+	pods, err := podClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to list pods: %v", err)
+	}
+	if len(pods.Items) != 2 {
+		t.Errorf("expect there to be 2 pods, got %#v", pods.Items)
+	}
+}
+
+func TestBlockingOwnerRefDoesBlock(t *testing.T) {
+	s, gc, clientSet := setup(t)
+	defer s.Close()
+
+	ns := framework.CreateTestingNamespace("gc-foreground2", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
+	podClient := clientSet.Core().Pods(ns.Name)
+	rcClient := clientSet.Core().ReplicationControllers(ns.Name)
+	// create the RC with the orphan finalizer set
+	toBeDeletedRC, err := rcClient.Create(newOwnerRC(toBeDeletedRCName, ns.Name))
+	if err != nil {
+		t.Fatalf("Failed to create replication controller: %v", err)
+	}
+	trueVar := true
+	pod := newPod("pod", ns.Name, []metav1.OwnerReference{
+		{UID: toBeDeletedRC.ObjectMeta.UID, Name: toBeDeletedRC.Name, BlockOwnerDeletion: &trueVar},
+	})
+	// adding finalizer that no controller handles, so that the pod won't be deleted
+	pod.ObjectMeta.Finalizers = []string{"x/y"}
+	_, err = podClient.Create(pod)
+	if err != nil {
+		t.Fatalf("Failed to create Pod: %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	go gc.Run(5, stopCh)
+	defer close(stopCh)
+
+	err = rcClient.Delete(toBeDeletedRCName, getDeletePropagationForegroundOptions())
+	if err != nil {
+		t.Fatalf("Failed to delete the rc: %v", err)
+	}
+	time.Sleep(30 * time.Second)
+	// verify the toBeDeleteRC is NOT deleted
+	_, err = rcClient.Get(toBeDeletedRC.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// verify pods are still there
+	pods, err := podClient.List(v1.ListOptions{})
+	if err != nil {
+		t.Fatalf("Failed to list pods: %v", err)
+	}
+	if len(pods.Items) != 1 {
+		t.Errorf("expect there to be 1 pods, got %#v", pods.Items)
 	}
 }


### PR DESCRIPTION
Split from #38676.
Design doc: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/synchronous-garbage-collection.md.

This PR won't compile. It's for review only.

Comments that will be addressed in follow-up PRs:
1. check if an update event changes DeletionTimestamp, OwnerReferences, or Finalizers, if not, don't send it via the graphChanges channel.
2. In attempToDelete, try to use the cache instead of communicating with the API server. One exception: We need to talk to the API server to check if the object represented by a "virtual" node exists.

TODO:
- [ ] split the unit tests garbagecollector_test.go according to the components tested.
- [ ] try if it's practically safe to use the cached object status in attempToDeleteItem(), after synchronous GC feature is stable. (Also see https://github.com/kubernetes/kubernetes/pull/38676#discussion_r103056971)
- [ ] add blockOwnerDeletion for rs adoption https://github.com/kubernetes/kubernetes/pull/38679#discussion_r93817284

cc @kubernetes/sig-api-machinery