### PR TITLE
Cherry-pick of #38463: fix in HPA e2e tests

### DIFF
--- a/test/e2e/autoscaling_utils.go
+++ b/test/e2e/autoscaling_utils.go
@@ -394,7 +394,7 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, ns, name, k
 	}
 	framework.ExpectNoError(framework.RunRC(controllerRcConfig))
 
-	// Make sure endpoints are propagated.
-	// TODO(piosz): replace sleep with endpoints watch.
-	time.Sleep(10 * time.Second)
+	// Wait for endpoints to propagate for the controller service.
+	framework.ExpectNoError(framework.WaitForServiceEndpointsNum(
+		c, ns, controllerName, 1, startServiceInterval, startServiceTimeout))
 }


### PR DESCRIPTION
HPA e2e tests: fixed waiting for service creation. Fixes #38549.