### PR TITLE
Remove DockerLegacyService comment from kubelet

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -574,9 +574,6 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 					return nil, err
 				}
 			}
-			// Use DockerLegacyService directly to work around unimplemented
-			// functions in CRI.
-			// TODO: Remove this hack after CRI is fully implemented.
 			// TODO: Move the instrumented interface wrapping into kuberuntime.
 			runtimeService = kuberuntime.NewInstrumentedRuntimeService(rs)
 			imageService = is


### PR DESCRIPTION
The comment is obsolete as there's no more DockerLegacyService.