### PR TITLE
Only create the symlink when container log path exists

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -32,6 +32,10 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 )
 
+const (
+	dockerDefaultLoggingDriver = "json-file"
+)
+
 // ListContainers lists all containers matching the filter.
 func (ds *dockerService) ListContainers(filter *runtimeapi.ContainerFilter) ([]*runtimeapi.Container, error) {
 	opts := dockertypes.ContainerListOptions{All: true}
@@ -217,13 +221,35 @@ func (ds *dockerService) createContainerLogSymlink(containerID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get container %q log path: %v", containerID, err)
 	}
-	if path != "" && realPath != "" {
-		// Only create the symlink when container log path is specified.
+
+	if path == "" {
+		glog.V(5).Infof("Container %s log path isn't specified, will not create the symlink", containerID)
+		return nil
+	}
+
+	if realPath != "" {
+		// Only create the symlink when container log path is specified and log file exists.
 		if err = ds.os.Symlink(realPath, path); err != nil {
 			return fmt.Errorf("failed to create symbolic link %q to the container log file %q for container %q: %v",
 				path, realPath, containerID, err)
 		}
+	} else {
+		dockerLoggingDriver := ""
+		dockerInfo, err := ds.client.Info()
+		if err != nil {
+			glog.Errorf("Failed to execute Info() call to the Docker client: %v", err)
+		} else {
+			dockerLoggingDriver = dockerInfo.LoggingDriver
+			glog.V(10).Infof("Docker logging driver is %s", dockerLoggingDriver)
+		}
+
+		if dockerLoggingDriver == dockerDefaultLoggingDriver {
+			glog.Errorf("Cannot create symbolic link because container log file doesn't exist!")
+		} else {
+			glog.V(5).Infof("Unsupported logging driver: %s", dockerLoggingDriver)
+		}
 	}
+
 	return nil
 }
 

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -78,7 +78,8 @@ import (
 )
 
 const (
-	DockerType = "docker"
+	DockerType                 = "docker"
+	dockerDefaultLoggingDriver = "json-file"
 
 	// https://docs.docker.com/engine/reference/api/docker_remote_api/
 	// docker version should be at least 1.9.x
@@ -1793,14 +1794,31 @@ func (dm *DockerManager) runContainerInPod(pod *v1.Pod, container *v1.Container,
 		return kubecontainer.ContainerID{}, fmt.Errorf("InspectContainer: %v", err)
 	}
 
-	// Create a symbolic link to the Docker container log file using a name which captures the
-	// full pod name, the container name and the Docker container ID. Cluster level logging will
-	// capture these symbolic filenames which can be used for search terms in Elasticsearch or for
-	// labels for Cloud Logging.
 	containerLogFile := containerInfo.LogPath
-	symlinkFile := LogSymlink(dm.containerLogsDir, kubecontainer.GetPodFullName(pod), container.Name, id.ID)
-	if err = dm.os.Symlink(containerLogFile, symlinkFile); err != nil {
-		glog.Errorf("Failed to create symbolic link to the log file of pod %q container %q: %v", format.Pod(pod), container.Name, err)
+	if containerLogFile != "" {
+		// Create a symbolic link to the Docker container log file using a name which captures the
+		// full pod name, the container name and the Docker container ID. Cluster level logging will
+		// capture these symbolic filenames which can be used for search terms in Elasticsearch or for
+		// labels for Cloud Logging.
+		symlinkFile := LogSymlink(dm.containerLogsDir, kubecontainer.GetPodFullName(pod), container.Name, id.ID)
+		if err = dm.os.Symlink(containerLogFile, symlinkFile); err != nil {
+			glog.Errorf("Failed to create symbolic link to the log file of pod %q container %q: %v", format.Pod(pod), container.Name, err)
+		}
+	} else {
+		dockerLoggingDriver := ""
+		dockerInfo, err := dm.client.Info()
+		if err != nil {
+			glog.Errorf("Failed to execute Info() call to the Docker client: %v", err)
+		} else {
+			dockerLoggingDriver = dockerInfo.LoggingDriver
+			glog.V(10).Infof("Docker logging driver is %s", dockerLoggingDriver)
+		}
+
+		if dockerLoggingDriver == dockerDefaultLoggingDriver {
+			glog.Errorf("Cannot create symbolic link because container log file doesn't exist!")
+		} else {
+			glog.V(5).Infof("Unsupported logging driver: %s", dockerLoggingDriver)
+		}
 	}
 
 	// Check if current docker version is higher than 1.10. Otherwise, we have to apply OOMScoreAdj instead of using docker API.


### PR DESCRIPTION
When using `syslog` logging driver instead of `json-file`, there will not be container log files such as `<containerID-json.log>`. We should not create symlink in this case.