### PR TITLE
Cherry-pick of #38617: fixed detection of master during.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -612,6 +612,7 @@ function kube-up() {
   set_num_migs
 
   if [[ ${KUBE_USE_EXISTING_MASTER:-} == "true" ]]; then
+    detect-master
     parse-master-env
     create-nodes
   elif [[ ${KUBE_REPLICATE_EXISTING_MASTER:-} == "true" ]]; then


### PR DESCRIPTION
```release-note
Fixed detection of master during creation of multizone nodes cluster by kube-up.
```

Fixed detection of master during creation of multizone nodes cluster by kube-up.