### PR TITLE
improve the forbidden message

### DIFF
--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -308,7 +308,8 @@ func NewGenericServerResponse(code int, verb string, qualifiedResource schema.Gr
 		message = "the server has asked for the client to provide credentials"
 	case http.StatusForbidden:
 		reason = metav1.StatusReasonForbidden
-		message = "the server does not allow access to the requested resource"
+		// the server message has details about who is trying to perform what action.  Keep its message.
+		message = serverMessage
 	case http.StatusMethodNotAllowed:
 		reason = metav1.StatusReasonMethodNotAllowed
 		message = "the server does not allow this method on the requested resource"

--- a/pkg/apiserver/filters/authorization.go
+++ b/pkg/apiserver/filters/authorization.go
@@ -40,12 +40,12 @@ func WithAuthorization(handler http.Handler, requestContextMapper api.RequestCon
 			return
 		}
 
-		attrs, err := GetAuthorizerAttributes(ctx)
+		attributes, err := GetAuthorizerAttributes(ctx)
 		if err != nil {
 			internalError(w, req, err)
 			return
 		}
-		authorized, reason, err := a.Authorize(attrs)
+		authorized, reason, err := a.Authorize(attributes)
 		if authorized {
 			handler.ServeHTTP(w, req)
 			return
@@ -55,8 +55,8 @@ func WithAuthorization(handler http.Handler, requestContextMapper api.RequestCon
 			return
 		}
 
-		glog.V(4).Infof("Forbidden: %#v, Reason: %s", req.RequestURI, reason)
-		forbidden(w, req)
+		glog.V(4).Infof("Forbidden: %#v, Reason: %q", req.RequestURI, reason)
+		forbidden(attributes, w, req, reason)
 	})
 }
 

--- a/pkg/apiserver/filters/impersonation_test.go
+++ b/pkg/apiserver/filters/impersonation_test.go
@@ -118,7 +118,7 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name: "tester",
 			},
-			expectedCode: http.StatusForbidden,
+			expectedCode: http.StatusInternalServerError,
 		},
 		{
 			name: "impersonating-extra-without-user",
@@ -129,7 +129,7 @@ func TestImpersonationFilter(t *testing.T) {
 			expectedUser: &user.DefaultInfo{
 				Name: "tester",
 			},
-			expectedCode: http.StatusForbidden,
+			expectedCode: http.StatusInternalServerError,
 		},
 		{
 			name: "disallowed-group",


### PR DESCRIPTION
Improves the forbidden message to include more details about what was denied.

`User "foo" cannot list replicasets.extensions in the namespace "default". `
`User "foo" cannot list replicasets.extensions at the cluster scope. `

@xilabao looks like you looking in a similar area, but focused on errors.
@sttts a lot of usual reviewers are out.