### PR TITLE
Significantly speed-up make

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -399,7 +399,7 @@ kube::golang::place_bins() {
     if [[ -d "${full_binpath_src}" ]]; then
       mkdir -p "${KUBE_OUTPUT_BINPATH}/${platform}"
       find "${full_binpath_src}" -maxdepth 1 -type f -exec \
-        rsync -ptc {} "${KUBE_OUTPUT_BINPATH}/${platform}" \;
+        rsync -pc {} "${KUBE_OUTPUT_BINPATH}/${platform}" \;
     fi
   done
 }

--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -60,9 +60,9 @@ fi
 mkdir -p $(dirname "${CACHE}")
 if $("${NEED_FIND}"); then
     kfind -type f -name \*.go  \
-        | xargs -n1 dirname    \
-        | LC_ALL=C sort -u     \
+        | sed 's|/[^/]*$||'    \
         | sed 's|^./||'        \
+        | LC_ALL=C sort -u     \
         > "${CACHE}"
 fi
 cat "${CACHE}"


### PR DESCRIPTION
- do not call `dirname` for every go file => gives **>8 seconds** on each make run
- do not preserve time during rsync from `_output/local/go/bin` to `_output/local/bin/<os>/<arch>`:
  
  We do a touch after our rebuild heuristic triggers.
  
  If in `_output/local/go/bin` you have an older binary and go decides that it's good enough, the following rsync will "preserve the timestamp" of the binary copy in `_output/local/bin/<os>/<arch>`. This reverts the effect of any previous `touch` (compare `Makefile.generated_files`).

  We do a complete rsync of binaries for each go target, not only the one which is rebuilt. This means that later go targets will overwrite the timestamps of freshly touched binaries. Hence, our rebuild heuristic will trigger again and again when running `make`.

  This PR remove the "preserve mtime" from the rsync call. Hence, the effect of touch is not reverted anymore by later rsyncs.