### PR TITLE
prevent anonymous auth and allow all

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -97,6 +97,8 @@ func Run(s *options.ServerRunOptions) error {
 		return fmt.Errorf("error setting the external host value: %v", err)
 	}
 
+	s.Authentication.ApplyAuthorization(s.Authorization)
+
 	// validate options
 	if errs := s.Validate(); len(errs) != 0 {
 		return utilerrors.NewAggregate(errs)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -79,12 +79,13 @@ func Run(s *options.ServerRunOptions) error {
 		return fmt.Errorf("error setting the external host value: %v", err)
 	}
 
+	s.Authentication.ApplyAuthorization(s.Authorization)
+
 	// validate options
 	if errs := s.Validate(); len(errs) != 0 {
 		return utilerrors.NewAggregate(errs)
 	}
 
-	// create config from options
 	genericConfig := genericapiserver.NewConfig(). // create the new config
 							ApplyOptions(s.GenericServerRunOptions). // apply the options selected
 							ApplyInsecureServingOptions(s.InsecureServing)

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -417,7 +417,10 @@ function start_apiserver {
 
     # Wait for kube-apiserver to come up before launching the rest of the components.
     echo "Waiting for apiserver to come up"
-    kube::util::wait_for_url "https://${API_HOST}:${API_SECURE_PORT}/version" "apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} || exit 1
+    # this uses the API port because if you don't have any authenticator, you can't seem to use the secure port at all.
+    # this matches what happened with the combination in 1.4.
+    # TODO change this conditionally based on whether API_PORT is on or off
+    kube::util::wait_for_url "http://${API_HOST}:${API_PORT}/version" "apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} || exit 1
 
     # Create kubeconfigs for all components, using client certs
     kube::util::write_client_kubeconfig "${CONTROLPLANE_SUDO}" "${CERT_DIR}" "${ROOT_CA_FILE}" "${API_HOST}" "${API_SECURE_PORT}" admin

--- a/pkg/kubeapiserver/options/BUILD
+++ b/pkg/kubeapiserver/options/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//pkg/genericapiserver/options:go_default_library",
         "//pkg/kubeapiserver/authenticator:go_default_library",
         "//pkg/kubeapiserver/authorizer:go_default_library",
+        "//vendor:github.com/golang/glog",
         "//vendor:github.com/spf13/pflag",
     ],
 )

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -18,13 +18,16 @@ package options
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
 	"k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
+	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer"
 )
 
 type BuiltInAuthenticationOptions struct {
@@ -315,4 +318,27 @@ func (o *BuiltInAuthenticationOptions) Apply(c *genericapiserver.Config) error {
 
 	c.SupportsBasicAuth = len(o.PasswordFile.BasicAuthFile) > 0
 	return nil
+}
+
+// ApplyAuthorization will conditionally modify the authentication options based on the authorization options
+func (o *BuiltInAuthenticationOptions) ApplyAuthorization(authorization *BuiltInAuthorizationOptions) {
+	if o == nil || authorization == nil || o.Anonymous == nil {
+		return
+	}
+
+	// authorization ModeAlwaysAllow cannot be combined with AnonymousAuth.
+	// in such a case the AnonymousAuth is stomped to false and you get a message
+	if o.Anonymous.Allow {
+		found := false
+		for _, mode := range strings.Split(authorization.Mode, ",") {
+			if mode == authorizer.ModeAlwaysAllow {
+				found = true
+				break
+			}
+		}
+		if found {
+			glog.Warningf("AnonymousAuth is not allowed with the AllowAll authorizer.  Resetting AnonymousAuth to false. You should use a different authorizer")
+			o.Anonymous.Allow = false
+		}
+	}
 }


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/38696 for master

@kubernetes/sig-auth 

```release-note
Anonymous authentication is now automatically disabled if the API server is started with the AlwaysAllow authorizer.
```