### PR TITLE
Set --anonymous-auth to false on v1.5 clusters to preserve the locked-down v1.4 behaviour

### DIFF
--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -447,6 +447,7 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--allow-privileged",
 				"--advertise-address=foo",
 				"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+				"--anonymous-auth=false",
 				"--etcd-servers=http://127.0.0.1:2379",
 			},
 		},


### PR DESCRIPTION
From discussions with sig-auth-people.

Without this patch, anyone can do basically anything, because the apiserver in v1.5 mode is unprotected due to that kubeadm doesn't have any ABAC/RBAC-authorizers.

@mikedanese @justinsb @deads2k @kubernetes/sig-cluster-lifecycle 