### PR TITLE
prevent audit filter from panic-ing on missing user info

### DIFF
--- a/pkg/apiserver/filters/audit.go
+++ b/pkg/apiserver/filters/audit.go
@@ -115,8 +115,13 @@ func WithAudit(handler http.Handler, attributeGetter RequestAttributeGetter, out
 		}
 		id := uuid.NewRandom().String()
 
+		username := "<none>"
+		if attribs.GetUser() != nil {
+			username = attribs.GetUser().GetName()
+		}
+
 		line := fmt.Sprintf("%s AUDIT: id=%q ip=%q method=%q user=%q as=%q asgroups=%q namespace=%q uri=%q\n",
-			time.Now().Format(time.RFC3339Nano), id, utilnet.GetClientIP(req), req.Method, attribs.GetUser().GetName(), asuser, asgroups, namespace, req.URL)
+			time.Now().Format(time.RFC3339Nano), id, utilnet.GetClientIP(req), req.Method, username, asuser, asgroups, namespace, req.URL)
 		if _, err := fmt.Fprint(out, line); err != nil {
 			glog.Errorf("Unable to write audit log: %s, the error is: %v", line, err)
 		}

--- a/pkg/apiserver/filters/audit_test.go
+++ b/pkg/apiserver/filters/audit_test.go
@@ -124,3 +124,32 @@ func (m *fakeRequestContextMapper) Get(req *http.Request) (api.Context, bool) {
 func (*fakeRequestContextMapper) Update(req *http.Request, context api.Context) error {
 	return nil
 }
+
+func TestAuditNoPanicOnNilUser(t *testing.T) {
+	var buf bytes.Buffer
+
+	attributeGetter := NewRequestAttributeGetter(&fakeRequestContextMapper{})
+	handler := WithAudit(&fakeHTTPHandler{}, attributeGetter, &buf)
+
+	req, _ := http.NewRequest("GET", "/api/v1/namespaces/default/pods", nil)
+	req.RemoteAddr = "127.0.0.1"
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	line := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(line) != 2 {
+		t.Fatalf("Unexpected amount of lines in audit log: %d", len(line))
+	}
+	match, err := regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" ip="127.0.0.1" method="GET" user="<none>" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"`, line[0])
+	if err != nil {
+		t.Errorf("Unexpected error matching first line: %v", err)
+	}
+	if !match {
+		t.Errorf("Unexpected first line of audit: %s", line[0])
+	}
+	match, err = regexp.MatchString(`[\d\:\-\.\+TZ]+ AUDIT: id="[\w-]+" response="200"`, line[1])
+	if err != nil {
+		t.Errorf("Unexpected error matching second line: %v", err)
+	}
+	if !match {
+		t.Errorf("Unexpected second line of audit: %s", line[1])
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/38716.  That bug crashes the API server when audit is on and there's no user on the request.

This performs a nil check on the `GetUser()` before using it.


```release-note
Fixes issue where if the audit log is enabled and anonymous authentication is disabled, then an unauthenticated user request will cause a panic and crash the `kube-apiserver`.
```

@sleepbrett @saad-ali 