### PR TITLE
The String() value of Nothing() should be in the grammar

### DIFF
--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -71,11 +71,11 @@ func (ls Set) AsSelectorPreValidated() Selector {
 	return SelectorFromValidatedSet(ls)
 }
 
-// FormatLables convert label map into plain string
+// FormatLabels convert label map into plain string
 func FormatLabels(labelMap map[string]string) string {
 	l := Set(labelMap).String()
 	if l == "" {
-		l = "<none>"
+		l = Nothing().String()
 	}
 	return l
 }

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -229,3 +229,27 @@ func TestLabelSelectorParse(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatLabels(t *testing.T) {
+	tests := []struct {
+		expected string
+		labels   map[string]string
+	}{
+		{
+			labels:   map[string]string{"a": "a"},
+			expected: "a=a",
+		},
+
+		{
+			labels:   map[string]string{},
+			expected: "0 != 0",
+		},
+	}
+
+	for _, test := range tests {
+		result := FormatLabels(test.labels)
+		if result != test.expected {
+			t.Errorf("result: %s, expected: %s did not match", result, test.expected)
+		}
+	}
+}

--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -62,7 +62,7 @@ type nothingSelector struct{}
 
 func (n nothingSelector) Matches(_ Labels) bool              { return false }
 func (n nothingSelector) Empty() bool                        { return false }
-func (n nothingSelector) String() string                     { return "<null>" }
+func (n nothingSelector) String() string                     { return "0 != 0" }
 func (n nothingSelector) Add(_ ...Requirement) Selector      { return n }
 func (n nothingSelector) Requirements() (Requirements, bool) { return nil, false }
 

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -511,6 +511,7 @@ func TestSetSelectorParser(t *testing.T) {
 		{"a notin(", nil, true, false},        // bad formed
 		{"a (", nil, false, false},            // cpar
 		{"(", nil, false, false},              // opar
+		{Nothing().String(), nil, false, true},
 	}
 
 	for _, ssp := range setSelectorParserTests {


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the string representation of the Nothing() selector so that it may parse. 
Serializing Labels as strings is a supported operation, so it is imperative that
deserialization work also.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #38718

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
labels.Nothing().String() representation changed to something syntactically valid.
```
