### PR TITLE
fix connection upgrades through kuberentes-discovery

### DIFF
--- a/cmd/kubernetes-discovery/main.go
+++ b/cmd/kubernetes-discovery/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"os"
 	"runtime"
 
@@ -43,6 +44,7 @@ func main() {
 	}
 
 	cmd := server.NewCommandStartDiscoveryServer(os.Stdout, os.Stderr)
+	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {
 		cmdutil.CheckErr(err)
 	}


### PR DESCRIPTION
The initial upgrade through the proxy doesn't use the passed transport to handle the communication to the remote side.  Since we need auth proxy headers, this broke the upgrade for exec.

This sets those headers once if its an upgrade request (the transport stomps them if called anyway, so it won't shadow.).

@sttts I think this is the last required piece.  Then we start wiring in for e2e.