### PR TITLE
Automatically download missing kube binaries in kube-up/kube-down.

### DIFF
--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -46,7 +46,7 @@ KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://storage.googleapis.com
 function detect_kube_release() {
   if [[ ! -e "${KUBE_ROOT}/version" ]]; then
     echo "Can't determine Kubernetes release." >&2
-    echo "This script should only be run from a prebuilt Kubernetes release." >&2
+    echo "${BASH_SOURCE} should only be run from a prebuilt Kubernetes release." >&2
     echo "Did you mean to use get-kube.sh instead?" >&2
     exit 1
   fi
@@ -162,8 +162,8 @@ detect_client_info
 CLIENT_TAR="kubernetes-client-${CLIENT_PLATFORM}-${CLIENT_ARCH}.tar.gz"
 
 echo "Kubernetes release: ${KUBERNETES_RELEASE}"
-echo "Server: ${SERVER_PLATFORM}/${SERVER_ARCH}"
-echo "Client: ${CLIENT_PLATFORM}/${CLIENT_ARCH}"
+echo "Server: ${SERVER_PLATFORM}/${SERVER_ARCH}  (to override, set KUBERNETES_SERVER_ARCH)"
+echo "Client: ${CLIENT_PLATFORM}/${CLIENT_ARCH}  (autodetected)"
 echo
 
 # TODO: remove this check and default to true when we stop shipping server
@@ -201,7 +201,7 @@ if [[ -z "${KUBERNETES_SKIP_CONFIRM-}" ]]; then
   read confirm
   if [[ "${confirm}" =~ ^[nN]$ ]]; then
     echo "Aborting."
-    exit 0
+    exit 1
   fi
 fi
 

--- a/cluster/kube-down.sh
+++ b/cluster/kube-down.sh
@@ -31,6 +31,7 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 echo "Bringing down cluster using provider: $KUBERNETES_PROVIDER"
 
 verify-prereqs
+verify-kube-binaries
 kube-down
 
 echo "Done"

--- a/cluster/kube-push.sh
+++ b/cluster/kube-push.sh
@@ -69,6 +69,7 @@ if [[ "${push_to_master}" == "true" ]] && [[ "${push_to_node}" == "true" ]]; the
 fi
 
 verify-prereqs
+verify-kube-binaries
 KUBE_VERSION=${1-}
 
 if [[ "${push_to_master}" == "false" ]] && [[ "${push_to_node}" == "false" ]]; then

--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -41,6 +41,8 @@ fi
 
 echo "... calling verify-prereqs" >&2
 verify-prereqs
+echo "... calling verify-kube-binaries" >&2
+verify-kube-binaries
 
 if [[ "${KUBE_STAGE_IMAGES:-}" == "true" ]]; then
   echo "... staging images" >&2


### PR DESCRIPTION
**What this PR does / why we need it**: some users extract `kubernetes.tar.gz` and then immediately call `cluster/kube-up.sh` without first calling the new `cluster/get-kube-binaries.sh` script. As a result, the cluster fails to start, but it's not immediately clear why binaries are missing.

This PR streamlines this workflow by detecting this condition and prompting the user to download necessary binaries (using `cluster/get-kube-binaries.sh`).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #38725

**Release note**:
```release-note
Since `kubernetes.tar.gz` no longer includes client or server binaries, `cluster/kube-{up,down,push}.sh` now automatically download released binaries if they are missing.
```

cc @arun-gupta @christian-posta 
