### PR TITLE
ShortcutExpander has been extended in a way that it will examine the …

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -32309,7 +32309,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "kind": {
@@ -32323,6 +32324,10 @@
      "namespaced": {
       "description": "namespaced indicates if a resource is namespaced or not.",
       "type": "boolean"
+     },
+     "shortName": {
+      "description": "shortName is the suggested short name of the resource.",
+      "type": "string"
      },
      "verbs": {
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -2886,7 +2886,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -2907,6 +2908,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/authentication.k8s.io_v1beta1.json
+++ b/api/swagger-spec/authentication.k8s.io_v1beta1.json
@@ -301,7 +301,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -322,6 +323,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/authorization.k8s.io_v1beta1.json
+++ b/api/swagger-spec/authorization.k8s.io_v1beta1.json
@@ -514,7 +514,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -535,6 +536,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/autoscaling_v1.json
+++ b/api/swagger-spec/autoscaling_v1.json
@@ -1446,7 +1446,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -1467,6 +1468,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -2866,7 +2866,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -2887,6 +2888,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/batch_v2alpha1.json
+++ b/api/swagger-spec/batch_v2alpha1.json
@@ -69,7 +69,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -90,6 +91,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/certificates.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/certificates.k8s.io_v1alpha1.json
@@ -1134,7 +1134,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -1155,6 +1156,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -10738,7 +10738,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -10759,6 +10760,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/policy_v1beta1.json
+++ b/api/swagger-spec/policy_v1beta1.json
@@ -1456,7 +1456,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -1477,6 +1478,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io_v1alpha1.json
@@ -3364,7 +3364,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -3385,6 +3386,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/storage.k8s.io_v1beta1.json
+++ b/api/swagger-spec/storage.k8s.io_v1beta1.json
@@ -969,7 +969,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -990,6 +991,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -19984,7 +19984,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "name": {
@@ -20005,6 +20006,10 @@
        "type": "string"
       },
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)"
+     },
+     "shortName": {
+      "type": "string",
+      "description": "shortName is the suggested short name of the resource."
      }
     }
    }

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -8556,7 +8556,8 @@
      "name",
      "namespaced",
      "kind",
-     "verbs"
+     "verbs",
+     "shortName"
     ],
     "properties": {
      "kind": {
@@ -8570,6 +8571,10 @@
      "namespaced": {
       "description": "namespaced indicates if a resource is namespaced or not.",
       "type": "boolean"
+     },
+     "shortName": {
+      "description": "shortName is the suggested short name of the resource.",
+      "type": "string"
      },
      "verbs": {
       "description": "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",

--- a/pkg/apis/meta/v1/types.go
+++ b/pkg/apis/meta/v1/types.go
@@ -433,6 +433,8 @@ type APIResource struct {
 	// verbs is a list of supported kube verbs (this includes get, list, watch, create,
 	// update, patch, delete, deletecollection, and proxy)
 	Verbs Verbs `json:"verbs" protobuf:"bytes,4,opt,name=verbs"`
+	// shortName is the suggested short name of the resource.
+	ShortName string `json:"shortName" protobuf:"bytes,5,opt,name=shortName"`
 }
 
 // Verbs masks the value so protobuf can generate

--- a/pkg/apis/meta/v1/types_swagger_doc_generated.go
+++ b/pkg/apis/meta/v1/types_swagger_doc_generated.go
@@ -54,6 +54,7 @@ var map_APIResource = map[string]string{
 	"namespaced": "namespaced indicates if a resource is namespaced or not.",
 	"kind":       "kind is the kind for the resource (e.g. 'Foo' is the kind for a resource 'foo')",
 	"verbs":      "verbs is a list of supported kube verbs (this includes get, list, watch, create, update, patch, delete, deletecollection, and proxy)",
+	"shortName":  "shortName is the suggested short name of the resource.",
 }
 
 func (APIResource) SwaggerDoc() map[string]string {

--- a/pkg/apis/meta/v1/types_test.go
+++ b/pkg/apis/meta/v1/types_test.go
@@ -29,9 +29,9 @@ func TestVerbsMarshalJSON(t *testing.T) {
 		input  APIResource
 		result string
 	}{
-		{APIResource{}, `{"name":"","namespaced":false,"kind":"","verbs":null}`},
-		{APIResource{Verbs: Verbs([]string{})}, `{"name":"","namespaced":false,"kind":"","verbs":[]}`},
-		{APIResource{Verbs: Verbs([]string{"delete"})}, `{"name":"","namespaced":false,"kind":"","verbs":["delete"]}`},
+		{APIResource{}, `{"name":"","namespaced":false,"kind":"","verbs":null,"shortName":""}`},
+		{APIResource{Verbs: Verbs([]string{})}, `{"name":"","namespaced":false,"kind":"","verbs":[],"shortName":""}`},
+		{APIResource{Verbs: Verbs([]string{"delete"})}, `{"name":"","namespaced":false,"kind":"","verbs":["delete"],"shortName":""}`},
 	}
 
 	for i, c := range cases {

--- a/pkg/apis/meta/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/meta/v1/zz_generated.deepcopy.go
@@ -88,6 +88,7 @@ func DeepCopy_v1_APIResource(in interface{}, out interface{}, c *conversion.Clon
 		} else {
 			out.Verbs = nil
 		}
+		out.ShortName = in.ShortName
 		return nil
 	}
 }

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -240,8 +240,15 @@ var OpenAPIDefinitions *common.OpenAPIDefinitions = &common.OpenAPIDefinitions{
 							},
 						},
 					},
+					"shortName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "shortName is the suggested short name of the resource.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
-				Required: []string{"name", "namespaced", "kind", "verbs"},
+				Required: []string{"name", "namespaced", "kind", "verbs", "shortName"},
 			},
 		},
 		Dependencies: []string{},

--- a/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
+++ b/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
@@ -17,17 +17,42 @@ limitations under the License.
 package util
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api/testapi"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/runtime/schema"
 )
 
 func TestReplaceAliases(t *testing.T) {
+	srvResDefault := []*metav1.APIResourceList{
+		{
+			GroupVersion: "catalog/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:      "servicecatalog",
+					ShortName: "sc",
+				},
+			},
+		},
+		{
+			GroupVersion: "storage.k8s.io/v1beta1",
+			APIResources: []metav1.APIResource{
+				{
+					Name:      "storageclass",
+					ShortName: "sc",
+				},
+			},
+		},
+	}
 	tests := []struct {
-		name     string
-		arg      string
-		expected string
+		name      string
+		arg       string
+		expected  string
+		srvRes    []*metav1.APIResourceList
+		srvResErr bool
 	}{
 		{
 			name:     "no-replacement",
@@ -44,11 +69,41 @@ func TestReplaceAliases(t *testing.T) {
 			arg:      "all,secrets",
 			expected: "pods,replicationcontrollers,services,statefulsets,horizontalpodautoscalers,jobs,deployments,replicasets,secrets",
 		},
+		{
+			name:      "sc-replacement-from-srv-resources",
+			arg:       "sc",
+			expected:  "servicecatalog",
+			srvRes:    srvResDefault,
+			srvResErr: false,
+		},
+		{
+			name:      "po-replacement-from-hardcoded-resources",
+			arg:       "po",
+			expected:  "pods",
+			srvRes:    srvResDefault,
+			srvResErr: false,
+		},
+		{
+			name:      "sc-untouched-srv-error",
+			arg:       "sc",
+			expected:  "sc",
+			srvRes:    srvResDefault,
+			srvResErr: true,
+		},
 	}
 
-	mapper := NewShortcutExpander(testapi.Default.RESTMapper(), nil)
+	c := NewFakeDiscoveryClient()
+	mapper := NewShortcutExpander(testapi.Default.RESTMapper(), c)
 
 	for _, test := range tests {
+		if test.srvRes != nil {
+			c.ServerResourcesHandler = func() ([]*metav1.APIResourceList, error) {
+				if test.srvResErr {
+					return nil, errors.New("Some nasty error")
+				}
+				return test.srvRes, nil
+			}
+		}
 		resources := []string{}
 		for _, arg := range strings.Split(test.arg, ",") {
 			curr, _ := mapper.AliasesForResource(arg)
@@ -57,5 +112,31 @@ func TestReplaceAliases(t *testing.T) {
 		if strings.Join(resources, ",") != test.expected {
 			t.Errorf("%s: unexpected argument: expected %s, got %s", test.name, test.expected, resources)
 		}
+	}
+}
+
+func TestKindFor(t *testing.T) {
+	dc := NewFakeDiscoveryClient()
+	target := NewShortcutExpander(testapi.Default.RESTMapper(), dc)
+	expectedGVK := schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "HorizontalPodAutoscaler"}
+
+	dc.ServerResourcesForGroupVersionHandler = func(groupVersion string) (*metav1.APIResourceList, error) {
+		return &metav1.APIResourceList{
+			GroupVersion: schema.GroupVersion{Group: "extensions", Version: "v1beta1"}.String(),
+			APIResources: []metav1.APIResource{
+				{
+					Name:      "horizontalpodautoscalers",
+					ShortName: "abc",
+				},
+			},
+		}, nil
+	}
+
+	ret, err := target.KindFor(schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "abc"})
+	if err != nil {
+		t.Errorf("unexpected error returned %s", err.Error())
+	}
+	if ret != expectedGVK {
+		t.Errorf("unexpected data returned %#v, expected %#v", ret, expectedGVK)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

ShortcutExpander has been extended in a way that it will examine the server resources in the first place when searching for an alternative name for the resource.

Note that the list returned from the server is ordered and the first match will yield the extended resource's name.

APIResource struct has been extended by the shorName field - at the moment will always be empty no server side logic fill this field.
