### PR TITLE
AWS: Deprecate the bash deployment

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -36,6 +36,15 @@ source "${KUBE_ROOT}/cluster/aws/${KUBE_CONFIG_FILE-"config-default.sh"}"
 source "${KUBE_ROOT}/cluster/common.sh"
 source "${KUBE_ROOT}/cluster/lib/util.sh"
 
+if [[ -z "${KUBE_AWS_DEPRECATION_WARNED:-}" ]]; then
+  echo -e "${color_red}WARNING${color_norm}: The bash deployment for AWS is deprecated and will be removed in v1.7." >&2
+  echo "For a list of viable alternatives, see:" >&2
+  echo >&2
+  echo "  http://kubernetes.io/docs/getting-started-guides/aws/" >&2
+  echo >&2
+  export KUBE_AWS_DEPRECATION_WARNED=yes
+fi
+
 ALLOCATE_NODE_CIDRS=true
 
 NODE_INSTANCE_PREFIX="${INSTANCE_PREFIX}-minion"


### PR DESCRIPTION
**What this PR does / why we need it**:  Add a strong deprecation warning to the `kube-up.sh` AWS deployment.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
The bash AWS deployment via kube-up.sh has been deprecated. See http://kubernetes.io/docs/getting-started-guides/aws/ for alternatives.
```