### PR TITLE
daemonset: bail out after we enqueue once

### DIFF
--- a/pkg/controller/daemon/daemoncontroller.go
+++ b/pkg/controller/daemon/daemoncontroller.go
@@ -385,6 +385,7 @@ func (dsc *DaemonSetsController) addNode(obj interface{}) {
 		shouldEnqueue := dsc.nodeShouldRunDaemonPod(node, ds)
 		if shouldEnqueue {
 			dsc.enqueueDaemonSet(ds)
+			return
 		}
 	}
 }
@@ -406,6 +407,7 @@ func (dsc *DaemonSetsController) updateNode(old, cur interface{}) {
 		shouldEnqueue := (dsc.nodeShouldRunDaemonPod(oldNode, ds) != dsc.nodeShouldRunDaemonPod(curNode, ds))
 		if shouldEnqueue {
 			dsc.enqueueDaemonSet(ds)
+			return
 		}
 	}
 	// TODO: it'd be nice to pass a hint with these enqueues, so that each ds would only examine the added node (unless it has other work to do, too).


### PR DESCRIPTION
This isn't terrible because we dedup in the queue but it's a waste of
cycles.