### PR TITLE
Automated cherry pick of #37103 #38260

### DIFF
--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/test/e2e/framework"
-	testutils "k8s.io/kubernetes/test/utils"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -100,15 +99,6 @@ func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string) *a
 			RestartPolicy: api.RestartPolicyNever,
 		},
 	}
-}
-
-func WaitForTerminatedContainer(f *framework.Framework, pod *api.Pod, containerName string) error {
-	return framework.WaitForPodCondition(f.ClientSet, f.Namespace.Name, pod.Name, "container terminated", framework.PodStartTimeout, func(pod *api.Pod) (bool, error) {
-		if len(testutils.TerminatedContainers(pod)[containerName]) > 0 {
-			return true, nil
-		}
-		return false, nil
-	})
 }
 
 type portForwardCommand struct {
@@ -231,7 +221,7 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 			conn.Close()
 
 			By("Waiting for the target pod to stop running")
-			if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+			if err := framework.WaitForTerminatedContainer(f.Client, pod, f.Namespace.Name, "portforwardtester"); err != nil {
 				framework.Failf("Container did not terminate: %v", err)
 			}
 
@@ -297,7 +287,7 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 			}
 
 			By("Waiting for the target pod to stop running")
-			if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+			if err := framework.WaitForTerminatedContainer(f.Client, pod, f.Namespace.Name, "portforwardtester"); err != nil {
 				framework.Failf("Container did not terminate: %v", err)
 			}
 
@@ -355,7 +345,7 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 			}
 
 			By("Waiting for the target pod to stop running")
-			if err := WaitForTerminatedContainer(f, pod, "portforwardtester"); err != nil {
+			if err := framework.WaitForTerminatedContainer(f.Client, pod, f.Namespace.Name, "portforwardtester"); err != nil {
 				framework.Failf("Container did not terminate: %v", err)
 			}
 

--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -56,8 +57,8 @@ func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string) *a
 			Containers: []api.Container{
 				{
 					Name:  "portforwardtester",
-					Image: "gcr.io/google_containers/portforwardtester:1.0",
-					Env: []api.EnvVar{
+					Image: "gcr.io/google_containers/portforwardtester:1.2",
+					Env: []v1.EnvVar{
 						{
 							Name:  "BIND_PORT",
 							Value: "80",

--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 1.0
+TAG = 1.2
 PREFIX = gcr.io/google_containers
 
 all: push

--- a/test/images/port-forward-tester/portforwardtester.go
+++ b/test/images/port-forward-tester/portforwardtester.go
@@ -47,20 +47,40 @@ func getEnvInt(name string) int {
 	return value
 }
 
+// taken from net/http/server.go:
+//
+// rstAvoidanceDelay is the amount of time we sleep after closing the
+// write side of a TCP connection before closing the entire socket.
+// By sleeping, we increase the chances that the client sees our FIN
+// and processes its final data before they process the subsequent RST
+// from closing a connection with known unread data.
+// This RST seems to occur mostly on BSD systems. (And Windows?)
+// This timeout is somewhat arbitrary (~latency around the planet).
+const rstAvoidanceDelay = 500 * time.Millisecond
+
 func main() {
+	bindAddress := os.Getenv("BIND_ADDRESS")
+	if bindAddress == "" {
+		bindAddress = "localhost"
+	}
 	bindPort := os.Getenv("BIND_PORT")
-	listener, err := net.Listen("tcp", fmt.Sprintf("localhost:%s", bindPort))
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(bindAddress, bindPort))
+	if err != nil {
+		fmt.Printf("Error resolving: %v\n", err)
+		os.Exit(1)
+	}
+	listener, err := net.ListenTCP("tcp", addr)
 	if err != nil {
 		fmt.Printf("Error listening: %v\n", err)
 		os.Exit(1)
 	}
 
-	conn, err := listener.Accept()
+	conn, err := listener.AcceptTCP()
 	if err != nil {
 		fmt.Printf("Error accepting connection: %v\n", err)
 		os.Exit(1)
 	}
-	defer conn.Close()
+
 	fmt.Println("Accepted client connection")
 
 	expectedClientData := os.Getenv("EXPECTED_CLIENT_DATA")
@@ -101,6 +121,21 @@ func main() {
 			time.Sleep(time.Duration(chunkInterval) * time.Millisecond)
 		}
 	}
+
+	fmt.Println("Shutting down connection")
+
+	// set linger timeout to flush buffers. This is the official way according to the go api docs. But
+	// there are controversial discussions whether this value has any impact on most platforms
+	// (compare https://codereview.appspot.com/95320043).
+	conn.SetLinger(-1)
+
+	// Flush the connection cleanly, following https://blog.netherlabs.nl/articles/2009/01/18/the-ultimate-so_linger-page-or-why-is-my-tcp-not-reliable:
+	// 1. close write half of connection which sends a FIN packet
+	// 2. give client some time to receive the FIN
+	// 3. close the complete connection
+	conn.CloseWrite()
+	time.Sleep(rstAvoidanceDelay)
+	conn.Close()
 
 	fmt.Println("Done")
 }


### PR DESCRIPTION
Cherry pick of #37103 #38260 on release-1.4.

#37103: portfordwardtester: avoid data loss during send+close+exit
#38260: Wait for the port to be ready before starting