### PR TITLE
hack/cherry_pick_pull.sh: cleanup patch files

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -173,9 +173,13 @@ for pull in "${PULLS[@]}"; do
       exit 1
     fi
   }
+
   # set the subject
   subject=$(grep -m 1 "^Subject" "/tmp/${pull}.patch" | sed -e 's/Subject: \[PATCH//g' | sed 's/.*] //')
   SUBJECTS+=("#${pull}: ${subject}")
+
+  # remove the patch file from /tmp
+  rm -f "/tmp/${pull}.patch"
 done
 gitamcleanup=false
 


### PR DESCRIPTION
this was driving me nuts.
it will now remove the patch files from /tmp