### PR TITLE
cluster/images/hyperkube: add jq for some volume plugins

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -28,6 +28,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     util-linux \
     socat \
     git \
+    jq \
     nfs-common \
     glusterfs-client \
     cifs-utils \


### PR DESCRIPTION
**What this PR does / why we need it**:

Some flexvolume plugins use jq. See also https://github.com/coreos/bugs/issues/1706

It weighs in at about 400kb, so seems sane to include.

**Release note**:
```release-note
NONE
```

cc @luxas @pbx0 