### PR TITLE
delete continue in monitorNodeStatus

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -517,7 +517,6 @@ func (nc *NodeController) monitorNodeStatus() error {
 							glog.Errorf("Unable to forcefully delete node %q: %v", nodeName, err)
 						}
 					}(node.Name)
-					continue
 				}
 			}
 		}


### PR DESCRIPTION

the continue will run at the end of the for loop, we do not need it