### PR TITLE
Node E2E: Disable AU in node e2e test.

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -73,7 +73,7 @@ if [ $remote = true ] ; then
     gci_image=$(gcloud compute images list --project $image_project \
     --no-standard-images --regexp="gci-dev.*" --format="table[no-heading](name)")
     images=$gci_image
-    metadata="user-data<${KUBE_ROOT}/test/e2e_node/jenkins/gci-init.yaml"
+    metadata="user-data<${KUBE_ROOT}/test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
   fi
   instance_prefix=${INSTANCE_PREFIX:-"test"}
   cleanup=${CLEANUP:-"true"}

--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -52,21 +52,21 @@ images:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   gci-resource2:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   gci-resource3:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
   coreos-resource1:

--- a/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
@@ -4,55 +4,55 @@ images:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   gci-density2:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   gci-density2-qps60:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   gci-density3:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-2
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   gci-density4:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
   gci-resource1:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   gci-resource2:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   gci-resource3:
     image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'

--- a/test/e2e_node/jenkins/cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/image-config.yaml
@@ -5,4 +5,4 @@ images:
   gci-family:
     image_regex: gci-dev-56-8977-0-0
     project: google-containers
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"

--- a/test/e2e_node/jenkins/docker_validation/jenkins-perf.properties
+++ b/test/e2e_node/jenkins/docker_validation/jenkins-perf.properties
@@ -11,7 +11,7 @@ CONFIG_FILE=test/e2e_node/jenkins/docker_validation/perf-config.yaml
 cp $CONFIG_FILE $GCE_IMAGE_CONFIG_PATH
 sed -i -e "s@{{IMAGE}}@${GCI_IMAGE}@g" $GCE_IMAGE_CONFIG_PATH
 sed -i -e "s@{{IMAGE_PROJECT}}@${GCI_IMAGE_PROJECT}@g" $GCE_IMAGE_CONFIG_PATH
-sed -i -e "s@{{METADATA}}@user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION}@g" $GCE_IMAGE_CONFIG_PATH
+sed -i -e "s@{{METADATA}}@user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION},gci-update-strategy=update_disabled@g" $GCE_IMAGE_CONFIG_PATH
 
 GCE_HOSTS=
 GCE_ZONE=us-central1-f

--- a/test/e2e_node/jenkins/docker_validation/jenkins-validation.properties
+++ b/test/e2e_node/jenkins/docker_validation/jenkins-validation.properties
@@ -11,7 +11,7 @@ GCE_ZONE=us-central1-f
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 # user-data is the GCI cloud init config file.
 # gci-docker-version specifies docker version in GCI image.
-GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION}"
+GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION},gci-update-strategy=update_disabled"
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
 TIMEOUT=1h

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -15,4 +15,4 @@ images:
   gci-family:
     image_regex: gci-dev-56-8977-0-0
     project: google-containers
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
This PR disables auto upgrade in node e2e.

This helps reduce "broken pipe" flake.

/cc @kubernetes/goog-image 