### PR TITLE
drop duplicate judgement

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -436,8 +436,8 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.KubeletDeps) (err error) {
 	}
 
 	if kubeDeps.ContainerManager == nil {
-		if s.SystemCgroups != "" && s.CgroupRoot == "" {
-			return fmt.Errorf("invalid configuration: system container was specified and cgroup root was not specified")
+		if s.SystemCgroups != "" {
+			return fmt.Errorf("invalid configuration: system container was specified ")
 		}
 		kubeDeps.ContainerManager, err = cm.NewContainerManager(
 			kubeDeps.Mounter,


### PR DESCRIPTION

the Cgroup-Root was checked in function NewContainerManager(),we do not need to judge twice.