### PR TITLE
hack/dev-build-*: Run dev build instead of release build

### DIFF
--- a/hack/dev-build-and-push.sh
+++ b/hack/dev-build-and-push.sh
@@ -22,8 +22,9 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-# Build a release
-"${KUBE_ROOT}/build/release.sh"
+# Build a dev release
+make -f ${KUBE_ROOT}/Makefile quick-release
+
 if [ "$?" != "0" ]; then
         echo "Building a release failed!"
         exit 1

--- a/hack/dev-build-and-up.sh
+++ b/hack/dev-build-and-up.sh
@@ -23,8 +23,9 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-# Then build a release
-"${KUBE_ROOT}/build/release.sh"
+# Build a dev release
+make -f ${KUBE_ROOT}/Makefile quick-release
+
 if [ "$?" != "0" ]; then
         echo "Building the release failed!"
         exit 1


### PR DESCRIPTION
The current dev-build-*.sh scripts do a full release build which means
running tests and also doing cross-platform builds.  This is unnecessary
and after discussing this in Slack it was suggested to either blow away
these files or fix them.  This should fix them.

/cc @ixdy, @mml, @thockin 