### PR TITLE
Remove dead code in `pkg/registry/generic/registry/store.go`

### DIFF
--- a/pkg/registry/generic/registry/store.go
+++ b/pkg/registry/generic/registry/store.go
@@ -879,9 +879,6 @@ func (e *Store) Watch(ctx api.Context, options *api.ListOptions) (watch.Interfac
 func (e *Store) WatchPredicate(ctx api.Context, p storage.SelectionPredicate, resourceVersion string) (watch.Interface, error) {
 	if name, ok := p.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
-			if err != nil {
-				return nil, err
-			}
 			w, err := e.Storage.Watch(ctx, key, resourceVersion, p)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Fixes #38822

Depending on the intent of the original code, the correct fix may instead be:

```go
if name, ok := p.MatchesSingle(); ok {
	key, err := e.KeyFunc(ctx, name)
	if err != nil {
		return nil, err
	}
	w, err := e.Storage.Watch(ctx, key, resourceVersion, p)
	if err != nil {
		return nil, err
	}
	if e.Decorator != nil {
		return newDecoratedWatcher(w, e.Decorator), nil
	}
	return w, nil
	// if we cannot extract a key based on the current context, the optimization is skipped
}
```

Signed-off-by: Monis Khan <mkhan@redhat.com>

cc @deads2k 