### PR TITLE
genericapiserver: turn APIContainer.SecretRoutes into a real ServeMux

### DIFF
--- a/cmd/kubernetes-discovery/pkg/apiserver/apiserver.go
+++ b/cmd/kubernetes-discovery/pkg/apiserver/apiserver.go
@@ -227,8 +227,8 @@ func (s *APIDiscoveryServer) AddAPIService(apiService *apiregistration.APIServic
 		lister:    s.lister,
 	}
 	// discovery is protected
-	s.GenericAPIServer.HandlerContainer.SecretRoutes.Handle(groupPath, groupDiscoveryHandler)
-	s.GenericAPIServer.HandlerContainer.SecretRoutes.Handle(groupPath+"/", groupDiscoveryHandler)
+	s.GenericAPIServer.HandlerContainer.UnlistedRoutes.Handle(groupPath, groupDiscoveryHandler)
+	s.GenericAPIServer.HandlerContainer.UnlistedRoutes.Handle(groupPath+"/", groupDiscoveryHandler)
 
 }
 

--- a/pkg/genericapiserver/genericapiserver_test.go
+++ b/pkg/genericapiserver/genericapiserver_test.go
@@ -323,7 +323,7 @@ func TestCustomHandlerChain(t *testing.T) {
 	}
 
 	s.HandlerContainer.NonSwaggerRoutes.Handle("/nonswagger", handler)
-	s.HandlerContainer.SecretRoutes.Handle("/secret", handler)
+	s.HandlerContainer.UnlistedRoutes.Handle("/secret", handler)
 
 	type Test struct {
 		handler   http.Handler

--- a/pkg/genericapiserver/mux/container.go
+++ b/pkg/genericapiserver/mux/container.go
@@ -33,8 +33,8 @@ type APIContainer struct {
 	// NonSwaggerRoutes are recorded and are visible at /, but do not show up in Swagger.
 	NonSwaggerRoutes PathRecorderMux
 
-	// SecretRoutes are not recorded, are not visible at / and do not show up in Swagger.
-	SecretRoutes *http.ServeMux
+	// UnlistedRoutes are not recorded, therefore not visible at / and do not show up in Swagger.
+	UnlistedRoutes *http.ServeMux
 }
 
 // NewAPIContainer constructs a new container for APIs
@@ -44,7 +44,7 @@ func NewAPIContainer(mux *http.ServeMux, s runtime.NegotiatedSerializer) *APICon
 		NonSwaggerRoutes: PathRecorderMux{
 			mux: mux,
 		},
-		SecretRoutes: mux,
+		UnlistedRoutes: mux,
 	}
 	c.Container.ServeMux = mux
 	c.Container.Router(restful.CurlyRouter{}) // e.g. for proxy/{kind}/{name}/{*}

--- a/pkg/genericapiserver/mux/container.go
+++ b/pkg/genericapiserver/mux/container.go
@@ -29,8 +29,12 @@ import (
 // handlers that do not show up in swagger or in /
 type APIContainer struct {
 	*restful.Container
+
+	// NonSwaggerRoutes are recorded and are visible at /, but do not show up in Swagger.
 	NonSwaggerRoutes PathRecorderMux
-	SecretRoutes     Mux
+
+	// SecretRoutes are not recorded, are not visible at / and do not show up in Swagger.
+	SecretRoutes *http.ServeMux
 }
 
 // NewAPIContainer constructs a new container for APIs

--- a/pkg/genericapiserver/mux/container_test.go
+++ b/pkg/genericapiserver/mux/container_test.go
@@ -26,14 +26,14 @@ import (
 func TestNewAPIContainer(t *testing.T) {
 	mux := http.NewServeMux()
 	c := NewAPIContainer(mux, nil)
-	assert.Equal(t, mux, c.SecretRoutes, "SecretRoutes ServeMux's do not match")
+	assert.Equal(t, mux, c.UnlistedRoutes, "UnlistedRoutes ServeMux's do not match")
 	assert.Equal(t, mux, c.Container.ServeMux, "Container ServeMux's do not match")
 }
 
 func TestSecretHandlers(t *testing.T) {
 	mux := http.NewServeMux()
 	c := NewAPIContainer(mux, nil)
-	c.SecretRoutes.HandleFunc("/secret", func(http.ResponseWriter, *http.Request) {})
+	c.UnlistedRoutes.HandleFunc("/secret", func(http.ResponseWriter, *http.Request) {})
 	c.NonSwaggerRoutes.HandleFunc("/nonswagger", func(http.ResponseWriter, *http.Request) {})
 	assert.NotContains(t, c.NonSwaggerRoutes.HandledPaths(), "/secret")
 	assert.Contains(t, c.NonSwaggerRoutes.HandledPaths(), "/nonswagger")

--- a/pkg/genericapiserver/mux/container_test.go
+++ b/pkg/genericapiserver/mux/container_test.go
@@ -26,7 +26,7 @@ import (
 func TestNewAPIContainer(t *testing.T) {
 	mux := http.NewServeMux()
 	c := NewAPIContainer(mux, nil)
-	assert.Equal(t, mux, c.SecretRoutes.(*http.ServeMux), "SecretRoutes ServeMux's do not match")
+	assert.Equal(t, mux, c.SecretRoutes, "SecretRoutes ServeMux's do not match")
 	assert.Equal(t, mux, c.Container.ServeMux, "Container ServeMux's do not match")
 }
 

--- a/pkg/genericapiserver/openapi/openapi.go
+++ b/pkg/genericapiserver/openapi/openapi.go
@@ -62,7 +62,7 @@ func RegisterOpenAPIService(servePath string, webServices []*restful.WebService,
 		return err
 	}
 
-	container.SecretRoutes.HandleFunc(servePath, func(w http.ResponseWriter, r *http.Request) {
+	container.UnlistedRoutes.HandleFunc(servePath, func(w http.ResponseWriter, r *http.Request) {
 		resp := restful.NewResponse(w)
 		if r.URL.Path != servePath {
 			resp.WriteErrorString(http.StatusNotFound, "Path not found!")

--- a/pkg/genericapiserver/routes/index.go
+++ b/pkg/genericapiserver/routes/index.go
@@ -30,7 +30,7 @@ type Index struct{}
 
 // Install adds the Index webservice to the given mux.
 func (i Index) Install(c *mux.APIContainer) {
-	c.SecretRoutes.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	c.UnlistedRoutes.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		status := http.StatusOK
 		if r.URL.Path != "/" && r.URL.Path != "/index.html" {
 			// Since "/" matches all paths, handleIndex is called for all paths for which there is no handler registered.

--- a/pkg/genericapiserver/routes/profiling.go
+++ b/pkg/genericapiserver/routes/profiling.go
@@ -27,7 +27,7 @@ type Profiling struct{}
 
 // Install adds the Profiling webservice to the given mux.
 func (d Profiling) Install(c *mux.APIContainer) {
-	c.SecretRoutes.HandleFunc("/debug/pprof/", pprof.Index)
-	c.SecretRoutes.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	c.SecretRoutes.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	c.UnlistedRoutes.HandleFunc("/debug/pprof/", pprof.Index)
+	c.UnlistedRoutes.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	c.UnlistedRoutes.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 }


### PR DESCRIPTION
The secret routes `Mux` is actually a `http.ServeMux` and we are type-casting to it. For downstream we want to wrap it into a restful container which also needs a real `http.ServeMux`.