### PR TITLE
Remove the ReadyReplica version guard

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -500,8 +500,6 @@ func WaitForPodsSuccess(c clientset.Interface, ns string, successPodLabels map[s
 	return nil
 }
 
-var ReadyReplicaVersion = utilversion.MustParseSemantic("v1.4.0")
-
 // WaitForPodsRunningReady waits up to timeout to ensure that all pods in
 // namespace ns are either running and ready, or failed but controlled by a
 // controller. Also, it ensures that at least minPods are running and
@@ -517,12 +515,6 @@ var ReadyReplicaVersion = utilversion.MustParseSemantic("v1.4.0")
 // means "Ready" or not.
 // If skipSucceeded is true, any pods that are Succeeded are not counted.
 func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods int32, timeout time.Duration, ignoreLabels map[string]string, skipSucceeded bool) error {
-	// This can be removed when we no longer have 1.3 servers running with upgrade tests.
-	hasReadyReplicas, err := ServerVersionGTE(ReadyReplicaVersion, c.Discovery())
-	if err != nil {
-		Logf("Error getting the server version: %v", err)
-		return err
-	}
 
 	ignoreSelector := labels.SelectorFromSet(ignoreLabels)
 	start := time.Now()
@@ -545,26 +537,24 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods int32, ti
 		// checked.
 		replicas, replicaOk := int32(0), int32(0)
 
-		if hasReadyReplicas {
-			rcList, err := c.Core().ReplicationControllers(ns).List(v1.ListOptions{})
-			if err != nil {
-				Logf("Error getting replication controllers in namespace '%s': %v", ns, err)
-				return false, nil
-			}
-			for _, rc := range rcList.Items {
-				replicas += *rc.Spec.Replicas
-				replicaOk += rc.Status.ReadyReplicas
-			}
+		rcList, err := c.Core().ReplicationControllers(ns).List(v1.ListOptions{})
+		if err != nil {
+			Logf("Error getting replication controllers in namespace '%s': %v", ns, err)
+			return false, nil
+		}
+		for _, rc := range rcList.Items {
+			replicas += *rc.Spec.Replicas
+			replicaOk += rc.Status.ReadyReplicas
+		}
 
-			rsList, err := c.Extensions().ReplicaSets(ns).List(v1.ListOptions{})
-			if err != nil {
-				Logf("Error getting replication sets in namespace %q: %v", ns, err)
-				return false, nil
-			}
-			for _, rs := range rsList.Items {
-				replicas += *rs.Spec.Replicas
-				replicaOk += rs.Status.ReadyReplicas
-			}
+		rsList, err := c.Extensions().ReplicaSets(ns).List(v1.ListOptions{})
+		if err != nil {
+			Logf("Error getting replication sets in namespace %q: %v", ns, err)
+			return false, nil
+		}
+		for _, rs := range rsList.Items {
+			replicas += *rs.Spec.Replicas
+			replicaOk += rs.Status.ReadyReplicas
 		}
 
 		podList, err := c.Core().Pods(ns).List(v1.ListOptions{})
@@ -605,9 +595,7 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods int32, ti
 
 		Logf("%d / %d pods in namespace '%s' are running and ready (%d seconds elapsed)",
 			nOk, len(podList.Items), ns, int(time.Since(start).Seconds()))
-		if hasReadyReplicas {
-			Logf("expected %d pod replicas in namespace '%s', %d are Running and Ready.", replicas, ns, replicaOk)
-		}
+		Logf("expected %d pod replicas in namespace '%s', %d are Running and Ready.", replicas, ns, replicaOk)
 
 		if replicaOk == replicas && nOk >= minPods && len(badPods) == 0 {
 			return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**: Removes outlived version guards.

**Which issue this PR fixes**: fixes #37310

