### PR TITLE
ShortcutExpander has been extended in a way that it will examine a ha…

### DIFF
--- a/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
+++ b/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/runtime/schema"
 )
 
 func TestReplaceAliases(t *testing.T) {
@@ -44,6 +45,16 @@ func TestReplaceAliases(t *testing.T) {
 			arg:      "all,secrets",
 			expected: "pods,replicationcontrollers,services,statefulsets,horizontalpodautoscalers,jobs,deployments,replicasets,secrets",
 		},
+		{
+			name:     "sc-resolves-to-storageclasses",
+			arg:      "sc",
+			expected: "storageclasses",
+		},
+		{
+			name:     "storageclasses-no-replacement",
+			arg:      "storageclasses",
+			expected: "storageclasses",
+		},
 	}
 
 	mapper := NewShortcutExpander(testapi.Default.RESTMapper(), nil)
@@ -56,6 +67,33 @@ func TestReplaceAliases(t *testing.T) {
 		}
 		if strings.Join(resources, ",") != test.expected {
 			t.Errorf("%s: unexpected argument: expected %s, got %s", test.name, test.expected, resources)
+		}
+	}
+}
+func TestKindFor(t *testing.T) {
+	tests := []struct {
+		in       schema.GroupVersionResource
+		expected schema.GroupVersionKind
+	}{
+		{
+			in:       schema.GroupVersionResource{Group: "storage.k8s.io", Version: "", Resource: "sc"},
+			expected: schema.GroupVersionKind{Group: "storage.k8s.io", Version: "v1beta1", Kind: "StorageClass"},
+		},
+		{
+			in:       schema.GroupVersionResource{Group: "", Version: "", Resource: "sc"},
+			expected: schema.GroupVersionKind{Group: "storage.k8s.io", Version: "v1beta1", Kind: "StorageClass"},
+		},
+	}
+
+	mapper := NewShortcutExpander(testapi.Default.RESTMapper(), nil)
+
+	for i, test := range tests {
+		ret, err := mapper.KindFor(test.in)
+		if err != nil {
+			t.Errorf("%d: unexpected error returned %s", i, err.Error())
+		}
+		if ret != test.expected {
+			t.Errorf("%d: unexpected data returned %#v, expected %#v", i, ret, test.expected)
 		}
 	}
 }

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -75,42 +75,121 @@ func (m OutputVersionMapper) RESTMapping(gk schema.GroupKind, versions ...string
 	return m.RESTMapper.RESTMapping(gk, versions...)
 }
 
-// ShortForms is the list of short names to their expanded names
-var ShortForms = map[string]string{
-	// Please keep this alphabetized
+// ResourceShortcuts represents a structure that holds the information how to
+// transition from resource's shortcut to its full name.
+type ResourceShortcuts struct {
+	ShortForm schema.GroupResource
+	LongForm  schema.GroupResource
+}
+
+// ResourcesShortcutStatic is the list of short names to their expanded names.
+// Note that the list is ordered by group.
+var ResourcesShortcutStatic = []ResourceShortcuts{
 	// If you add an entry here, please also take a look at pkg/kubectl/cmd/cmd.go
 	// and add an entry to valid_resources when appropriate.
-	"cm":     "configmaps",
-	"cs":     "componentstatuses",
-	"csr":    "certificatesigningrequests",
-	"deploy": "deployments",
-	"ds":     "daemonsets",
-	"ep":     "endpoints",
-	"ev":     "events",
-	"hpa":    "horizontalpodautoscalers",
-	"ing":    "ingresses",
-	"limits": "limitranges",
-	"no":     "nodes",
-	"ns":     "namespaces",
-	"pdb":    "poddisruptionbudgets",
-	"po":     "pods",
-	"psp":    "podSecurityPolicies",
-	"pvc":    "persistentvolumeclaims",
-	"pv":     "persistentvolumes",
-	"quota":  "resourcequotas",
-	"rc":     "replicationcontrollers",
-	"rs":     "replicasets",
-	"sa":     "serviceaccounts",
-	"svc":    "services",
+	{
+		ShortForm: schema.GroupResource{Resource: "cm"},
+		LongForm:  schema.GroupResource{Resource: "configmaps"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "cs"},
+		LongForm:  schema.GroupResource{Resource: "componentstatuses"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "ep"},
+		LongForm:  schema.GroupResource{Resource: "endpoints"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "ev"},
+		LongForm:  schema.GroupResource{Resource: "events"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "limits"},
+		LongForm:  schema.GroupResource{Resource: "limitranges"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "no"},
+		LongForm:  schema.GroupResource{Resource: "nodes"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "ns"},
+		LongForm:  schema.GroupResource{Resource: "namespaces"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "po"},
+		LongForm:  schema.GroupResource{Resource: "pods"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "pvc"},
+		LongForm:  schema.GroupResource{Resource: "persistentvolumeclaims"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "pv"},
+		LongForm:  schema.GroupResource{Resource: "persistentvolumes"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "quota"},
+		LongForm:  schema.GroupResource{Resource: "resourcequotas"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "rc"},
+		LongForm:  schema.GroupResource{Resource: "replicationcontrollers"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "rs"},
+		LongForm:  schema.GroupResource{Resource: "replicasets"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "sa"},
+		LongForm:  schema.GroupResource{Resource: "serviceaccounts"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "svc"},
+		LongForm:  schema.GroupResource{Resource: "services"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "autoscaling", Resource: "hpa"},
+		LongForm:  schema.GroupResource{Group: "autoscaling", Resource: "horizontalpodautoscalers"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "certificates.k8s.io", Resource: "csr"},
+		LongForm:  schema.GroupResource{Group: "certificates.k8s.io", Resource: "certificatesigningrequests"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "policy", Resource: "pdb"},
+		LongForm:  schema.GroupResource{Group: "policy", Resource: "poddisruptionbudgets"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "deploy"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "deployments"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "ds"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "daemonsets"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "hpa"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "horizontalpodautoscalers"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "ing"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "ingresses"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "psp"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "podSecurityPolicies"},
+	},
 }
 
 // ResourceShortFormFor looks up for a short form of resource names.
+// TODO: Change the signature of this function so that it can
+// make use of ResourceShortcuts.
 func ResourceShortFormFor(resource string) (string, bool) {
 	var alias string
 	exists := false
-	for k, val := range ShortForms {
-		if val == resource {
-			alias = k
+	for _, item := range ResourcesShortcutStatic {
+		if item.LongForm.Resource == resource {
+			alias = item.ShortForm.Resource
 			exists = true
 			break
 		}
@@ -139,9 +218,9 @@ func ResourceAliases(rs []string) []string {
 		plurals[plural] = struct{}{}
 	}
 
-	for sf, r := range ShortForms {
-		if _, found := plurals[r]; found {
-			as = append(as, sf)
+	for _, item := range ResourcesShortcutStatic {
+		if _, found := plurals[item.LongForm.Resource]; found {
+			as = append(as, item.ShortForm.Resource)
 		}
 	}
 	return as


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

ShortcutExpander has been extended in a way that it will examine a hardcoded list of tuples anticipated from the server when searching for an alternative name for the resource.

Note that the list is ordered and the first match will yield the extended resource's name.

One important thing to highlight is that the ShortcutExpander will fall back to PriorityRestMaper to determine the group for the resource.

Also this PR introduces a new shortcut namely sc which will resolve to storageclasses within storage.k8s.io group


**Special notes for your reviewer**: You might want to see https://github.com/kubernetes/kubernetes/pull/38755

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```