### PR TITLE
Node Conformance Test: Fix report prefix for node conformance test.

### DIFF
--- a/test/e2e_node/remote/node_conformance.go
+++ b/test/e2e_node/remote/node_conformance.go
@@ -287,8 +287,8 @@ func (c *ConformanceRemote) RunTest(host, workspace, results, junitFilePrefix, t
 	// Run the tests
 	glog.V(2).Infof("Starting tests on %q", host)
 	podManifestPath := getPodManifestPath(workspace)
-	cmd := fmt.Sprintf("'timeout -k 30s %fs docker run --rm --privileged=true --net=host -v /:/rootfs -v %s:%s -v %s:/var/result %s'",
-		timeout.Seconds(), podManifestPath, podManifestPath, results, getConformanceImageRepo())
+	cmd := fmt.Sprintf("'timeout -k 30s %fs docker run --rm --privileged=true --net=host -v /:/rootfs -v %s:%s -v %s:/var/result -e TEST_ARGS=--report-prefix=%s %s'",
+		timeout.Seconds(), podManifestPath, podManifestPath, results, junitFilePrefix, getConformanceImageRepo())
 	testOutput, err := SSH(host, "sh", "-c", cmd)
 	if err != nil {
 		return testOutput, err


### PR DESCRIPTION
The node conformance CI is running now.

The only problem is that junit files overwrite each other because of the lack of junit prefix. http://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-conformance/42/artifacts/

This PR fixes this. I've verified in my environment, it works well.

@timstclair 