### PR TITLE
Enable lazy initialization of ext3/ext4 filesystems

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -68,7 +68,7 @@ function safe-format-and-mount() {
   # Format only if the disk is not already formatted.
   if ! tune2fs -l "${device}" ; then
     echo "Formatting '${device}'"
-    mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0,discard "${device}"
+    mkfs.ext4 -F "${device}"
   fi
 
   mkdir -p "${mountpoint}"

--- a/cluster/saltbase/salt/helpers/safe_format_and_mount
+++ b/cluster/saltbase/salt/helpers/safe_format_and_mount
@@ -22,12 +22,9 @@
 
 FSCK=fsck.ext4
 MOUNT_OPTIONS="discard,defaults"
-MKFS="mkfs.ext4 -E lazy_itable_init=0,lazy_journal_init=0 -F"
+MKFS="mkfs.ext4 -F"
 if [ -e /etc/redhat-release ]; then
-    if grep -q '6\..' /etc/redhat-release; then
-      # lazy_journal_init is not recognized in redhat 6
-      MKFS="mkfs.ext4 -E lazy_itable_init=0 -F"
-    elif grep -q '7\..' /etc/redhat-release; then
+    if grep -q '7\..' /etc/redhat-release; then
       FSCK=fsck.xfs
       MKFS=mkfs.xfs
     fi

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -359,7 +359,7 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 				fstype = "ext4"
 			}
 			if fstype == "ext4" || fstype == "ext3" {
-				args = []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", source}
+				args = []string{"-F", source}
 			}
 			glog.Infof("Disk %q appears to be unformatted, attempting to format as type: %q with options: %v", source, fstype, args)
 			cmd := mounter.Runner.Command("mkfs."+fstype, args...)

--- a/pkg/util/mount/safe_format_and_mount_test.go
+++ b/pkg/util/mount/safe_format_and_mount_test.go
@@ -109,7 +109,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			execScripts: []ExecArgs{
 				{"fsck", []string{"-a", "/dev/foo"}, "", nil},
 				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
-				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", fmt.Errorf("formatting failed")},
+				{"mkfs.ext4", []string{"-F", "/dev/foo"}, "", fmt.Errorf("formatting failed")},
 			},
 			expectedError: fmt.Errorf("formatting failed"),
 		},
@@ -120,7 +120,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			execScripts: []ExecArgs{
 				{"fsck", []string{"-a", "/dev/foo"}, "", nil},
 				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
-				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
+				{"mkfs.ext4", []string{"-F", "/dev/foo"}, "", nil},
 			},
 			expectedError: fmt.Errorf("Still cannot mount"),
 		},
@@ -131,7 +131,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			execScripts: []ExecArgs{
 				{"fsck", []string{"-a", "/dev/foo"}, "", nil},
 				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
-				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
+				{"mkfs.ext4", []string{"-F", "/dev/foo"}, "", nil},
 			},
 			expectedError: nil,
 		},
@@ -142,7 +142,7 @@ func TestSafeFormatAndMount(t *testing.T) {
 			execScripts: []ExecArgs{
 				{"fsck", []string{"-a", "/dev/foo"}, "", nil},
 				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
-				{"mkfs.ext3", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
+				{"mkfs.ext3", []string{"-F", "/dev/foo"}, "", nil},
 			},
 			expectedError: nil,
 		},

--- a/test/kubemark/resources/start-kubemark-master.sh
+++ b/test/kubemark/resources/start-kubemark-master.sh
@@ -71,7 +71,7 @@ function safe-format-and-mount() {
 	# Format only if the disk is not already formatted.
 	if ! tune2fs -l "${device}" ; then
 		echo "Formatting '${device}'"
-		mkfs.ext4 -F -E lazy_itable_init=0,lazy_journal_init=0,discard "${device}"
+		mkfs.ext4 -F "${device}"
 	fi
 
 	mkdir -p "${mountpoint}"


### PR DESCRIPTION
**What this PR does / why we need it**: It enables lazy inode table and journal initialization in ext3 and ext4.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #30752, fixes #30240

**Release note**:
```release-note
Enable lazy inode table and journal initialization for ext3 and ext4
```

**Special notes for your reviewer**:
This PR removes the extended options to mkfs.ext3/mkfs.ext4, so that the defaults (enabled) for lazy initialization are used.

These extended options come from a script that was historically located at */usr/share/google/safe_format_and_mount* and later ported to GO so this dependency to the script could be removed. After some search, I found the original script here: https://github.com/GoogleCloudPlatform/compute-image-packages/blob/legacy/google-startup-scripts/usr/share/google/safe_format_and_mount

Checking the history of this script, I found the commit [Disable lazy init of inode table and journal.](https://github.com/GoogleCloudPlatform/compute-image-packages/commit/4d7346f7f59cb88ec934c436bd853b74f4ebbaf5). This one introduces the extended flags with this description:
```
Now that discard with guaranteed zeroing is supported by PD,
initializing them is really fast and prevents perf from being affected
when the filesystem is first mounted.
```

The problem is, that this is not true for all cloud providers and all disk types, e.g. Azure and AWS. I only tested with magnetic disks on Azure and AWS, so maybe it's different for SSDs on these cloud providers. The result is that this performance optimization dramatically increases the time needed to format a disk in such cases.

When mkfs.ext4 is told to not lazily initialize the inode tables and the check for guaranteed zeroing on discard fails, it falls back to a very naive implementation that simply loops and writes zeroed buffers to the disk. Performance on this highly depends on free memory and also uses up all this free memory for write caching, reducing performance of everything else in the system. 

As of https://github.com/kubernetes/kubernetes/issues/30752, there is also something inside kubelet that somehow degrades performance of all this. It's however not exactly known what it is but I'd assume it has something to do with cgroups throttling IO or memory. 

I checked the kernel code for lazy inode table initialization. The nice thing is, that the kernel also does the guaranteed zeroing on discard check. If it is guaranteed, the kernel uses discard for the lazy initialization, which should finish in a just few seconds. If it is not guaranteed, it falls back to using *bio*s, which does not require the use of the write cache. The result is, that free memory is not required and not touched, thus performance is maxed and the system does not suffer.

As the original reason for disabling lazy init was a performance optimization and the kernel already does this optimization by default (and in a much better way), I'd suggest to completely remove these flags and rely on the kernel to do it in the best way.