### PR TITLE
use in-cluster kubeconfig for genericapiserver

### DIFF
--- a/cmd/kubernetes-discovery/artifacts/local-cluster-up/kubernetes-discover-pod.yaml
+++ b/cmd/kubernetes-discovery/artifacts/local-cluster-up/kubernetes-discover-pod.yaml
@@ -24,8 +24,6 @@ spec:
         - "--tls-private-key-file=/var/run/serving-cert/tls.key"
         - "--tls-ca-file=/var/run/serving-ca/ca.crt"
         - "--client-ca-file=/var/run/client-ca/ca.crt"
-        - "--authentication-kubeconfig=/var/run/auth-kubeconfig/kubeconfig"
-        - "--authorization-kubeconfig=/var/run/auth-kubeconfig/kubeconfig"
         - "--requestheader-username-headers=X-Remote-User"
         - "--requestheader-group-headers=X-Remote-Group"
         - "--requestheader-extra-headers-prefix=X-Remote-Extra-"
@@ -43,8 +41,6 @@ spec:
           name: volume-client-ca
         - mountPath: /var/run/auth-proxy-client
           name: volume-auth-proxy-client
-        - mountPath: /var/run/auth-kubeconfig
-          name: volume-auth-kubeconfig
         - mountPath: /var/run/etcd-client-cert
           name: volume-etcd-client-cert
         - mountPath: /var/run/serving-ca
@@ -53,6 +49,7 @@ spec:
           name: volume-serving-cert
         - mountPath: /var/run/etcd-ca
           name: volume-etcd-ca
+      serviceAccountName: kubernetes-discovery
       volumes:
       - configMap:
           defaultMode: 420
@@ -66,10 +63,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: auth-proxy-client
-      - name: volume-auth-kubeconfig
-        secret:
-          defaultMode: 420
-          secretName: discovery-auth-kubeconfig
       - name: volume-etcd-client-cert
         secret:
           defaultMode: 420

--- a/cmd/kubernetes-discovery/artifacts/local-cluster-up/kubernetes-discovery-sa.yaml
+++ b/cmd/kubernetes-discovery/artifacts/local-cluster-up/kubernetes-discovery-sa.yaml
@@ -1,0 +1,4 @@
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: kubernetes-discovery

--- a/hack/local-up-discovery.sh
+++ b/hack/local-up-discovery.sh
@@ -53,22 +53,16 @@ function start_discovery {
 	# etcd doesn't seem to have separate signers for serving and client trust
 	kube::util::create_client_certkey "${sudo}" "${CERT_DIR}" "etcd-ca" discovery-etcd discovery-etcd
 
-	# create credentials for running delegated authn/authz checks
-	# "client-ca" is created when you start the apiserver
-	kube::util::create_client_certkey "${sudo}" "${CERT_DIR}" "client-ca" discovery-auth system:discovery-auth
-	kube::util::write_client_kubeconfig "${sudo}" "${CERT_DIR}" "${ROOT_CA_FILE}" "kubernetes.default.svc" 443 discovery-auth
-	# ${kubectl} config set-cluster local-up-cluster --kubeconfig="${CERT_DIR}/discovery-auth.kubeconfig" --insecure-skip-tls-verify
-
 	# don't fail if the namespace already exists or something
 	# If this fails for some reason, the script will fail during creation of other resources
 	kubectl_core create namespace kube-public || true
 
 	# grant permission to run delegated authentication and authorization checks
 	kubectl_core delete clusterrolebinding discovery:system:auth-delegator > /dev/null 2>&1 || true
-	kubectl_core create clusterrolebinding discovery:system:auth-delegator --clusterrole=system:auth-delegator --user=system:discovery-auth
+	kubectl_core create clusterrolebinding discovery:system:auth-delegator --clusterrole=system:auth-delegator --serviceaccount=kube-public:kubernetes-discovery
 
 	# make sure the resources we're about to create don't exist
-	kubectl_core -n kube-public delete secret auth-proxy-client serving-etcd serving-discovery discovery-etcd discovery-auth-kubeconfig > /dev/null 2>&1 || true
+	kubectl_core -n kube-public delete secret auth-proxy-client serving-etcd serving-discovery discovery-etcd > /dev/null 2>&1 || true
 	kubectl_core -n kube-public delete configmap etcd-ca discovery-ca client-ca request-header-ca > /dev/null 2>&1 || true
 	kubectl_core -n kube-public delete -f "${KUBE_ROOT}/cmd/kubernetes-discovery/artifacts/local-cluster-up" > /dev/null 2>&1 || true
 
@@ -76,7 +70,6 @@ function start_discovery {
 	sudo_kubectl_core -n kube-public create secret tls serving-etcd --cert="${CERT_DIR}/serving-etcd.crt" --key="${CERT_DIR}/serving-etcd.key"
 	sudo_kubectl_core -n kube-public create secret tls serving-discovery --cert="${CERT_DIR}/serving-discovery.crt" --key="${CERT_DIR}/serving-discovery.key"
 	sudo_kubectl_core -n kube-public create secret tls discovery-etcd --cert="${CERT_DIR}/client-discovery-etcd.crt" --key="${CERT_DIR}/client-discovery-etcd.key"
-	kubectl_core -n kube-public create secret generic discovery-auth-kubeconfig --from-file="kubeconfig=${CERT_DIR}/discovery-auth.kubeconfig"
 	kubectl_core -n kube-public create configmap etcd-ca --from-file="ca.crt=${CERT_DIR}/etcd-ca.crt" || true
 	kubectl_core -n kube-public create configmap discovery-ca --from-file="ca.crt=${CERT_DIR}/discovery-ca.crt" || true
 	kubectl_core -n kube-public create configmap client-ca --from-file="ca.crt=${CERT_DIR}/client-ca.crt" || true
@@ -87,7 +80,7 @@ function start_discovery {
 	kubectl_core -n kube-public create -f "${KUBE_ROOT}/cmd/kubernetes-discovery/artifacts/local-cluster-up"
 
 	${sudo} cp "${CERT_DIR}/admin.kubeconfig" "${CERT_DIR}/admin-discovery.kubeconfig"
-	${sudo} chown ${username} "${CERT_DIR}/admin-discovery.kubeconfig"
+	${sudo} chown ${USER} "${CERT_DIR}/admin-discovery.kubeconfig"
 	${kubectl} config set-cluster local-up-cluster --kubeconfig="${CERT_DIR}/admin-discovery.kubeconfig" --certificate-authority="${CERT_DIR}/discovery-ca.crt" --embed-certs --server="https://${API_HOST_IP}:${DISCOVERY_SECURE_PORT}"
 
 	# Wait for kubernetes-discovery to come up before launching the rest of the components.

--- a/pkg/genericapiserver/config.go
+++ b/pkg/genericapiserver/config.go
@@ -399,7 +399,9 @@ func (c *Config) ApplyDelegatingAuthenticationOptions(o *options.DelegatingAuthe
 	}
 
 	c.Authenticator = authenticator
-	c.OpenAPIConfig.SecurityDefinitions = securityDefinitions
+	if c.OpenAPIConfig != nil {
+		c.OpenAPIConfig.SecurityDefinitions = securityDefinitions
+	}
 	c.SupportsBasicAuth = false
 
 	return c, nil

--- a/pkg/genericapiserver/options/BUILD
+++ b/pkg/genericapiserver/options/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//pkg/apiserver/authenticator:go_default_library",
         "//pkg/client/clientset_generated/clientset/typed/authentication/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset/typed/authorization/v1beta1:go_default_library",
+        "//pkg/client/restclient:go_default_library",
         "//pkg/client/unversioned/clientcmd:go_default_library",
         "//pkg/controller/informers:go_default_library",
         "//pkg/genericapiserver/authorizer:go_default_library",


### PR DESCRIPTION
Allow the use of the in-cluster config to communicate with the core API server for delegated authn/authz for an addon API server.

@kubernetes/sig-api-machinery @sttts 