### PR TITLE
genericapiserver: simplfy EtcdOptions.Validate()

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -36,7 +36,6 @@ go_library(
         "//pkg/master:go_default_library",
         "//pkg/registry/cachesize:go_default_library",
         "//pkg/runtime/schema:go_default_library",
-        "//pkg/util/errors:go_default_library",
         "//pkg/util/net:go_default_library",
         "//pkg/util/sets:go_default_library",
         "//pkg/util/wait:go_default_library",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -55,7 +55,6 @@ import (
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/runtime/schema"
-	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -81,8 +80,8 @@ cluster's shared state through which all other components interact.`,
 
 // Run runs the specified APIServer.  This should never exit.
 func Run(s *options.ServerRunOptions) error {
-	if errs := s.Etcd.Validate(); len(errs) > 0 {
-		return utilerrors.NewAggregate(errs)
+	if err := s.Etcd.Validate(); err != nil {
+		return err
 	}
 	if err := s.GenericServerRunOptions.DefaultExternalAddress(s.SecureServing, s.InsecureServing); err != nil {
 		return err

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -86,8 +86,8 @@ func (serverOptions *ServerRunOptions) Run(stopCh <-chan struct{}) error {
 	serverOptions.Etcd.StorageConfig.ServerList = []string{"http://127.0.0.1:2379"}
 
 	genericvalidation.ValidateRunOptions(serverOptions.GenericServerRunOptions)
-	if errs := serverOptions.Etcd.Validate(); len(errs) > 0 {
-		return utilerrors.NewAggregate(errs)
+	if err := serverOptions.Etcd.Validate(); err != nil {
+		return err
 	}
 	if errs := serverOptions.SecureServing.Validate(); len(errs) > 0 {
 		return utilerrors.NewAggregate(errs)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -44,7 +44,6 @@ import (
 	genericregistry "k8s.io/kubernetes/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/routes"
 	"k8s.io/kubernetes/pkg/runtime/schema"
-	utilerrors "k8s.io/kubernetes/pkg/util/errors"
 	"k8s.io/kubernetes/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/version"
@@ -68,8 +67,8 @@ cluster's shared state through which all other components interact.`,
 
 // Run runs the specified APIServer.  This should never exit.
 func Run(s *options.ServerRunOptions) error {
-	if errs := s.Etcd.Validate(); len(errs) > 0 {
-		utilerrors.NewAggregate(errs)
+	if err := s.Etcd.Validate(); err != nil {
+		return err
 	}
 	if err := s.GenericServerRunOptions.DefaultExternalAddress(s.SecureServing, s.InsecureServing); err != nil {
 		return err

--- a/pkg/genericapiserver/options/etcd.go
+++ b/pkg/genericapiserver/options/etcd.go
@@ -45,13 +45,12 @@ func NewEtcdOptions() *EtcdOptions {
 	}
 }
 
-func (s *EtcdOptions) Validate() []error {
-	allErrors := []error{}
+func (s *EtcdOptions) Validate() error {
 	if len(s.StorageConfig.ServerList) == 0 {
-		allErrors = append(allErrors, fmt.Errorf("--etcd-servers must be specified"))
+		return fmt.Errorf("--etcd-servers must be specified")
 	}
 
-	return allErrors
+	return nil
 }
 
 // AddEtcdFlags adds flags related to etcd storage for a specific APIServer to the specified FlagSet


### PR DESCRIPTION

Validate() only needs to return single error.
No need to complicate it with error slice.