### PR TITLE
 Added 'hollow'-node-problem-detector to hollow-nodes in kubemark

### DIFF
--- a/test/kubemark/resources/hollow-node_template.json
+++ b/test/kubemark/resources/hollow-node_template.json
@@ -27,9 +27,21 @@
 						}
 					},
 					{
+						"name": "npdconfig-volume",
+						"configMap": {
+							"name": "node-problem-detector-config"
+						}
+					},
+					{
 						"name": "logs-volume",
 						"hostPath": {
 							"path": "/var/logs"
+						}
+					},
+					{
+						"name": "kernellog-volume",
+						"hostPath": {
+							"path": "/var/log"
 						}
 					}
 				],
@@ -57,7 +69,7 @@
 							"valueFrom": {
 								"fieldRef": {
 									"fieldPath": "metadata.name"
-									}
+								}
 							}
 						}
 					],
@@ -105,7 +117,7 @@
 							"valueFrom": {
 								"fieldRef": {
 									"fieldPath": "metadata.name"
-									}
+								}
 							}
 						}
 					],
@@ -129,6 +141,41 @@
 							"cpu": "20m",
 							"memory": "100M"
 						}
+					}
+				},
+				{
+					"name": "hollow-node-problem-detector",
+					"image": "gcr.io/google_containers/node-problem-detector:v0.2",
+					"env": [
+						{
+							"name": "NODE_NAME",
+							"valueFrom": {
+								"fieldRef": {
+									"fieldPath": "spec.nodeName"
+								}
+							}
+						}
+					],
+					"volumeMounts": [
+						{
+							"name": "npdconfig-volume",
+							"mountPath": "/config",
+							"readOnly": true
+						},
+						{
+							"name": "kernellog-volume",
+							"mountPath": "/log",
+							"readOnly": true
+						}
+					],
+					"resources": {
+						"requests": {
+							"cpu": "20m",
+							"memory": "20Mi"
+						}
+					},
+					"securityContext": {
+						"privileged": true
 					}
 				}]
 			}

--- a/test/kubemark/resources/kernel-monitor.json
+++ b/test/kubemark/resources/kernel-monitor.json
@@ -1,0 +1,9 @@
+{
+	"logPath": "/log/faillog",
+	"lookback": "10m",
+	"startPattern": "Initializing cgroup subsys cpuset",
+	"bufferSize": 10,
+	"source": "kernel-monitor",
+	"conditions": [],
+	"rules": []
+}

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -264,6 +264,7 @@ sed -i'' -e "s/{{EVENTER_MEM}}/${eventer_mem}/g" "${RESOURCE_DIRECTORY}/addons/h
 "${KUBECTL}" create -f "${KUBECONFIG_SECRET}" --namespace="kubemark"
 "${KUBECTL}" create -f "${NODE_CONFIGMAP}" --namespace="kubemark"
 "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/addons" --namespace="kubemark"
+"${KUBECTL}" create configmap node-problem-detector-config --from-file="${RESOURCE_DIRECTORY}/kernel-monitor.json" --namespace="kubemark"
 "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/hollow-node.json" --namespace="kubemark"
 
 rm "${KUBECONFIG_SECRET}"


### PR DESCRIPTION
Added node-problem-detector container in kubemark hollow-nodes, which takes in a 'hollow' (having an empty list of rules and conditions) kernel monitor config.

cc @kubernetes/sig-scalability-misc @wojtek-t @gmarek 