### PR TITLE
make local-up-cluster.sh match "normal" launch without anonymous access

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -410,7 +410,7 @@ EOF
 
     # Wait for kube-apiserver to come up before launching the rest of the components.
     echo "Waiting for apiserver to come up"
-    kube::util::wait_for_url "https://${API_HOST}:${API_SECURE_PORT}/version" "apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} || exit 1
+    kube::util::wait_for_url "http://${API_HOST}:${API_PORT}/version" "apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} || exit 1
 }
 
 function start_controller_manager {


### PR DESCRIPTION
Ref #38847

This changes the readiness detection, but keeps the defaults matching the "normal" launch without anonymous auth.  

```release-note
Fixes an issue where `hack/local-up-cluster.sh` would fail on the API server start with

!!! [1215 15:42:56] Timed out waiting for apiserver:  to answer at https://localhost:6443/version; tried 10 waiting 1 between each
```

@janetkuo @saad-ali 