### PR TITLE
prevent negotation on connections that dont' require it

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -230,6 +230,10 @@ func (f *FakeFactory) ClientConfig() (*restclient.Config, error) {
 	return f.tf.ClientConfig, f.tf.Err
 }
 
+func (f *FakeFactory) BareClientConfig() (*restclient.Config, error) {
+	return f.tf.ClientConfig, f.tf.Err
+}
+
 func (f *FakeFactory) ClientForMapping(*meta.RESTMapping) (resource.RESTClient, error) {
 	return f.tf.Client, f.tf.Err
 }

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -91,6 +91,9 @@ type ClientAccessFactory interface {
 	RESTClient() (*restclient.RESTClient, error)
 	// Returns a client.Config for accessing the Kubernetes server.
 	ClientConfig() (*restclient.Config, error)
+	// BareClientConfig returns a client.Config that has NOT been negotiated. It's
+	// just directions to the server. People use this to build RESTMappers on top of
+	BareClientConfig() (*restclient.Config, error)
 
 	// TODO this should probably be removed and collapsed into whatever we want to use long term
 	// probably returning a restclient for a version and leaving contruction up to someone else

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -179,6 +179,10 @@ func (f *ring0Factory) ClientSetForVersion(requiredVersion *schema.GroupVersion)
 func (f *ring0Factory) ClientConfig() (*restclient.Config, error) {
 	return f.clientCache.ClientConfigForVersion(nil)
 }
+func (f *ring0Factory) BareClientConfig() (*restclient.Config, error) {
+	return f.clientConfig.ClientConfig()
+}
+
 func (f *ring0Factory) ClientConfigForVersion(requiredVersion *schema.GroupVersion) (*restclient.Config, error) {
 	return f.clientCache.ClientConfigForVersion(nil)
 }

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -135,7 +135,7 @@ func (f *ring1Factory) ClientForMapping(mapping *meta.RESTMapping) (resource.RES
 }
 
 func (f *ring1Factory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (resource.RESTClient, error) {
-	cfg, err := f.clientAccessFactory.ClientConfig()
+	cfg, err := f.clientAccessFactory.BareClientConfig()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Not all clientconfigs require negotiation.  Before there was a patch (hardcoded to an instance variable) that allowed this.  This updates the code to allow the same as before.

@kubernetes/sig-cli @fabianofranz

@ncdc you'll want to pick