### PR TITLE
[WIP] keep service cache in kubernetes-discovery

### DIFF
--- a/cmd/kubernetes-discovery/pkg/cmd/server/start.go
+++ b/cmd/kubernetes-discovery/pkg/cmd/server/start.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/kubernetes/cmd/kubernetes-discovery/pkg/apiserver"
 	"k8s.io/kubernetes/cmd/kubernetes-discovery/pkg/legacy"
 	"k8s.io/kubernetes/pkg/api"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/genericapiserver/filters"
 	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/options"
@@ -135,9 +137,15 @@ func (o DiscoveryServerOptions) RunDiscoveryServer() error {
 		return err
 	}
 
+	kubeconfig, err := restclient.InClusterConfig()
+	if err != nil {
+		return err
+	}
+
 	config := apiserver.Config{
-		GenericConfig:     genericAPIServerConfig,
-		RESTOptionsGetter: &restOptionsFactory{storageConfig: &o.Etcd.StorageConfig},
+		GenericConfig:       genericAPIServerConfig,
+		RESTOptionsGetter:   &restOptionsFactory{storageConfig: &o.Etcd.StorageConfig},
+		CoreAPIServerClient: kubeclientset.NewForConfigOrDie(kubeconfig),
 	}
 
 	config.ProxyClientCert, err = ioutil.ReadFile(o.ProxyClientCertFile)

--- a/hack/local-up-discovery.sh
+++ b/hack/local-up-discovery.sh
@@ -59,7 +59,9 @@ function start_discovery {
 
 	# grant permission to run delegated authentication and authorization checks
 	kubectl_core delete clusterrolebinding discovery:system:auth-delegator > /dev/null 2>&1 || true
+	kubectl_core delete clusterrolebinding discovery:system:kubernetes-discovery > /dev/null 2>&1 || true
 	kubectl_core create clusterrolebinding discovery:system:auth-delegator --clusterrole=system:auth-delegator --serviceaccount=kube-public:kubernetes-discovery
+	kubectl_core create clusterrolebinding discovery:system:kubernetes-discovery --clusterrole=system:kubernetes-discovery --serviceaccount=kube-public:kubernetes-discovery
 
 	# make sure the resources we're about to create don't exist
 	kubectl_core -n kube-public delete secret auth-proxy-client serving-etcd serving-discovery discovery-etcd > /dev/null 2>&1 || true

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -231,6 +231,14 @@ func ClusterRoles() []rbac.ClusterRole {
 			},
 		},
 		{
+			// a role to use for the API registry, summarization, and proxy handling
+			ObjectMeta: api.ObjectMeta{Name: "system:kubernetes-discovery"},
+			Rules: []rbac.PolicyRule{
+				// it needs to see all services so that it knows whether the ones it's point to exist or not
+				rbac.NewRule(Read...).Groups(legacyGroup).Resources("services").RuleOrDie(),
+			},
+		},
+		{
 			// a role to use for bootstrapping the kube-controller-manager so it can create the shared informers
 			// service accounts, and secrets that we need to create separate identities for other controllers
 			ObjectMeta: api.ObjectMeta{Name: "system:kube-controller-manager"},


### PR DESCRIPTION
If you have an API service that doesn't point to a service that actually exists, I thought I'd just let all the proxy calls fail, no problem right?  Somewhere down the proxy code this is producing a dial failure during discovery since we hit a proxied endpoint to get the resources
```
Error from server (InternalError): an error on the server ("Error: 'dial tcp 10.0.0.141:443: getsockopt: connection refused'\nTrying to reach: 'https://api.projects-openshift-io.svc/apis/projects.openshift.io/v1'") has prevented the request from succeeding
```

My first thought was to try to find that code, but I suspect its due to generic handling.  My next thought was to modify kubectl negotiation (not impossible).  My last thought was that I probably shouldn't be proxying to those locations at all.  This does that.  I'm looking for opinions or alternatives.

@kubernetes/sig-api-machinery-misc 
@sttts @ncdc @liggitt 