### PR TITLE
cluster/gce/coreos: add OWNERS

### DIFF
--- a/cluster/gce/coreos/OWNERS
+++ b/cluster/gce/coreos/OWNERS
@@ -1,0 +1,4 @@
+assignees:
+  - euank
+  - yifan-gu
+  - ethernetdan


### PR DESCRIPTION
See #33965 for context.

The code in `cluster/gce/coreos` has mostly been written/maintained by @yifan-gu and myself thusfar, so I added our names to the owner list.

@ethernetdan has also volunteered as well (thanks!).

**Release note**:
```release-note
NONE
```

cc @roberthbailey 