### PR TITLE
exported function StartControllers should have comment

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -220,6 +220,9 @@ func Run(s *options.CMServer) error {
 	panic("unreachable")
 }
 
+// StartControllers is start controller (replication controller,node controller,resourceQuota controller,
+// namespace controller,serviceAccount controller,token controller,server controller,
+// endpoint controller) in Controller manager
 func StartControllers(s *options.CMServer, kubeconfig *restclient.Config, rootClientBuilder, clientBuilder controller.ControllerClientBuilder, stop <-chan struct{}, recorder record.EventRecorder) error {
 	client := func(serviceAccountName string) clientset.Interface {
 		return rootClientBuilder.ClientOrDie(serviceAccountName)

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -25,7 +25,7 @@ import (
 
 	// Cloud providers
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+
 
 	// Volume plugins
 	"github.com/golang/glog"

--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -34,6 +34,7 @@ import (
 // and credentialprovider.
 var AWSRegions = [...]string{
 	"us-east-1",
+	"us-east-2",
 	"us-west-1",
 	"us-west-2",
 	"eu-west-1",


### PR DESCRIPTION
**What this PR does / why we need it**:
exported function StartControllers should have comment

 "k8s.io/kubernetes/pkg/cloudprovider/providers"  alias _ is not used, suggest to delete

