### PR TITLE
Remove all MAINTAINER statements in the codebase as they are deprecated

### DIFF
--- a/build/kube-dns/Dockerfile
+++ b/build/kube-dns/Dockerfile
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 FROM BASEIMAGE
-MAINTAINER Tim Hockin <thockin@google.com>
 ADD kube-dns /
 ENTRYPOINT ["/kube-dns"]

--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -18,7 +18,6 @@
 
 FROM java:openjdk-8-jre
 
-MAINTAINER Mik Vyatskov "vmik@google.com"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV ELASTICSEARCH_VERSION 2.4.1

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -23,8 +23,6 @@
 # information about installing fluentd using deb package.
 
 FROM gcr.io/google_containers/ubuntu-slim:0.4
-MAINTAINER Alex Robinson "arob@google.com"
-MAINTAINER Jimmi Dyson "jimmidyson@gmail.com"
 
 # Ensure there are enough file descriptors for running Fluentd.
 RUN ulimit -n 65536

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Dockerfile
@@ -17,7 +17,6 @@
 
 FROM gcr.io/google_containers/ubuntu-slim:0.4
 
-MAINTAINER Mik Vyatskov "vmik@google.com"
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV KIBANA_VERSION 4.6.1

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -22,7 +22,6 @@
 
 FROM gcr.io/google_containers/ubuntu-slim:0.4
 
-MAINTAINER Mik Vyatskov "vmik@google.com"
 
 # Disable prompts from apt
 ENV DEBIAN_FRONTEND noninteractive

--- a/cluster/addons/registry/images/Dockerfile
+++ b/cluster/addons/registry/images/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM nginx:1.11
-MAINTAINER Matthew Fisher <mfisher@deis.com>
 
 RUN apt-get update \
 	&& apt-get install -y \

--- a/cluster/gce/gci/mounter/Dockerfile
+++ b/cluster/gce/gci/mounter/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM ubuntu:xenial
-MAINTAINER vishh@google.com
 
 RUN apt-get update && apt-get install -y netbase nfs-common=1:1.2.8-9ubuntu12 glusterfs-client=3.7.6-1ubuntu1
 

--- a/cluster/images/etcd-empty-dir-cleanup/Dockerfile
+++ b/cluster/images/etcd-empty-dir-cleanup/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM gliderlabs/alpine
-MAINTAINER Mehdy Bohlool <mehdy@google.com>
 
 RUN apk-install bash
 ADD etcd-empty-dir-cleanup.sh etcd-empty-dir-cleanup.sh

--- a/cluster/images/etcd/Dockerfile
+++ b/cluster/images/etcd/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM BASEIMAGE
-MAINTAINER Wojciech Tyczynski <wojtekt@google.com>
 
 EXPOSE 2379 2380 4001 7001
 COPY etcd* etcdctl* /usr/local/bin/

--- a/cmd/kubernetes-discovery/artifacts/simple-image/Dockerfile
+++ b/cmd/kubernetes-discovery/artifacts/simple-image/Dockerfile
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 FROM fedora
-MAINTAINER David Eads <deads@redhat.com>
 ADD kubernetes-discovery /
 ENTRYPOINT ["/kubernetes-discovery"]

--- a/examples/explorer/Dockerfile
+++ b/examples/explorer/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM scratch
-MAINTAINER Daniel Smith <dbsmith@google.com>
 ADD explorer explorer
 ADD README.md README.md
 EXPOSE 8080

--- a/examples/https-nginx/Dockerfile
+++ b/examples/https-nginx/Dockerfile
@@ -14,7 +14,6 @@
 
 FROM nginx
 
-MAINTAINER Mengqi Yu <mengqiy@google.com>
 
 COPY index2.html /usr/share/nginx/html/index2.html
 RUN chmod +r /usr/share/nginx/html/index2.html

--- a/examples/kubectl-container/Dockerfile
+++ b/examples/kubectl-container/Dockerfile
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 FROM scratch
-MAINTAINER Daniel Smith <dbsmith@google.com>
 ADD kubectl kubectl
 ENTRYPOINT ["/kubectl"]

--- a/examples/meteor/dockerbase/Dockerfile
+++ b/examples/meteor/dockerbase/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM node:0.10
-MAINTAINER Christiaan Hees <christiaan@q42.nl>
 
 ONBUILD WORKDIR /appsrc
 ONBUILD COPY . /appsrc

--- a/examples/storage/hazelcast/image/Dockerfile
+++ b/examples/storage/hazelcast/image/Dockerfile
@@ -14,7 +14,6 @@
 
 FROM quay.io/pires/docker-jre:8u45-2
 
-MAINTAINER Paulo Pires <pjpires@gmail.com>
 
 EXPOSE 5701
 

--- a/examples/storage/rethinkdb/image/Dockerfile
+++ b/examples/storage/rethinkdb/image/Dockerfile
@@ -14,7 +14,6 @@
 
 FROM rethinkdb:1.16.0
 
-MAINTAINER BinZhao <wo@zhaob.in>
 
 RUN apt-get update && \
     apt-get install -yq curl && \

--- a/examples/volumes/nfs/nfs-data/Dockerfile
+++ b/examples/volumes/nfs/nfs-data/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM centos
-MAINTAINER Jan Safranek, jsafrane@redhat.com; Huamin Chen, hchen@redhat.com
 RUN yum -y install /usr/bin/ps nfs-utils && yum clean all
 RUN mkdir -p /exports
 ADD run_nfs.sh /usr/local/bin/

--- a/test/images/clusterapi-tester/Dockerfile
+++ b/test/images/clusterapi-tester/Dockerfile
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 FROM busybox
-MAINTAINER Prashanth B <beeps@google.com>
 ADD main main
 ENTRYPOINT ["/main"]

--- a/test/images/dnsutils/Dockerfile
+++ b/test/images/dnsutils/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM alpine
-MAINTAINER Bowei Du "bowei@google.com"
 
 RUN apk update --no-cache
 RUN apk add bind-tools

--- a/test/images/iperf/Dockerfile
+++ b/test/images/iperf/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM gcr.io/google_containers/ubuntu-slim:0.2
-MAINTAINER jay@apache.org
 RUN apt-get update && apt-get install -y --no-install-recommends iperf bash \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \

--- a/test/images/jessie-dnsutils/Dockerfile
+++ b/test/images/jessie-dnsutils/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM debian:jessie
-MAINTAINER Abhishek Shah "abshah@google.com"
 
 RUN apt-get -q update && \
     apt-get install -y dnsutils && \

--- a/test/images/logs-generator/Dockerfile
+++ b/test/images/logs-generator/Dockerfile
@@ -14,7 +14,6 @@
 
 FROM gcr.io/google_containers/ubuntu-slim:0.4
 
-MAINTAINER Mik Vyatskov <vmik@google.com>
 
 COPY logs-generator /
 

--- a/test/images/n-way-http/Dockerfile
+++ b/test/images/n-way-http/Dockerfile
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 FROM busybox
-MAINTAINER Prashanth B <beeps@google.com>
 ADD server server
 ENTRYPOINT ["/server"]

--- a/test/images/net/Dockerfile
+++ b/test/images/net/Dockerfile
@@ -13,6 +13,5 @@
 # limitations under the License.
 
 FROM alpine
-MAINTAINER Bowei Du <bowei@google.com>
 COPY net /net
 RUN apk update && apk add curl

--- a/test/images/netexec/Dockerfile
+++ b/test/images/netexec/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM busybox
-MAINTAINER Abhishek Shah "abshah@google.com"
 
 ADD netexec netexec
 ADD netexec.go netexec.go

--- a/test/images/network-tester/Dockerfile
+++ b/test/images/network-tester/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM scratch
-MAINTAINER Daniel Smith <dbsmith@google.com>
 ADD webserver webserver
 EXPOSE 8080
 ENTRYPOINT ["/webserver"]

--- a/test/images/pets/redis/Dockerfile
+++ b/test/images/pets/redis/Dockerfile
@@ -15,7 +15,6 @@
 # TODO: get rid of bash dependency and switch to plain busybox.
 # The tar in busybox also doesn't seem to understand compression.
 FROM debian:jessie
-MAINTAINER Prashanth.B <beeps@google.com>
 
 # TODO: just use standard redis when there is one for 3.2.0.
 RUN apt-get update && apt-get install -y wget make gcc

--- a/test/images/pets/zookeeper/Dockerfile
+++ b/test/images/pets/zookeeper/Dockerfile
@@ -15,7 +15,6 @@
 # TODO: get rid of bash dependency and switch to plain busybox.
 # The tar in busybox also doesn't seem to understand compression.
 FROM debian:jessie
-MAINTAINER Prashanth.B <beeps@google.com>
 
 RUN apt-get update && apt-get install -y wget netcat
 

--- a/test/images/porter/Dockerfile
+++ b/test/images/porter/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM scratch
-MAINTAINER Daniel Smith <dbsmith@google.com>
 ADD localhost.crt localhost.crt
 ADD localhost.key localhost.key
 ADD porter porter

--- a/test/images/resource-consumer/Dockerfile
+++ b/test/images/resource-consumer/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM jess/stress
-MAINTAINER Ewa Socala <socaa@google.com>
 ADD consumer /consumer
 ADD consume-cpu /consume-cpu
 EXPOSE 8080

--- a/test/images/resource-consumer/controller/Dockerfile
+++ b/test/images/resource-consumer/controller/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM busybox
-MAINTAINER Jerzy Szczepkowski <jsz@google.com>
 ADD controller /controller
 EXPOSE 8080
 ENTRYPOINT ["/controller"]

--- a/test/images/serve_hostname/Dockerfile
+++ b/test/images/serve_hostname/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM BASEIMAGE
-MAINTAINER Tim Hockin <thockin@google.com>
 ADD serve_hostname /serve_hostname
 EXPOSE 9376
 ENTRYPOINT ["/serve_hostname"]

--- a/test/images/volumes-tester/ceph/Dockerfile
+++ b/test/images/volumes-tester/ceph/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM centos:6
-MAINTAINER Huamin Chen, hchen@redhat.com 
 
 ADD install.sh /usr/local/bin/
 RUN /usr/local/bin/install.sh 

--- a/test/images/volumes-tester/gluster/Dockerfile
+++ b/test/images/volumes-tester/gluster/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM centos
-MAINTAINER Jan Safranek, jsafrane@redhat.com
 RUN yum -y install hostname centos-release-gluster && yum -y install glusterfs-server && yum clean all
 ADD glusterd.vol /etc/glusterfs/
 ADD run_gluster.sh /usr/local/bin/

--- a/test/images/volumes-tester/iscsi/Dockerfile
+++ b/test/images/volumes-tester/iscsi/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM fedora
-MAINTAINER Jan Safranek, jsafrane@redhat.com
 RUN yum install -y iscsi-initiator-utils targetcli net-tools strace && yum clean all
 ADD run_iscsid.sh /usr/local/bin/
 ADD initiatorname.iscsi /etc/iscsi/

--- a/test/images/volumes-tester/nfs/Dockerfile
+++ b/test/images/volumes-tester/nfs/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM centos
-MAINTAINER Jan Safranek, jsafrane@redhat.com
 RUN yum -y install /usr/bin/ps nfs-utils && yum clean all
 RUN mkdir -p /exports
 ADD run_nfs.sh /usr/local/bin/

--- a/test/images/volumes-tester/rbd/Dockerfile
+++ b/test/images/volumes-tester/rbd/Dockerfile
@@ -16,7 +16,6 @@
 # Based on image by Ricardo Rocha, ricardo@catalyst.net.nz
 
 FROM fedora
-MAINTAINER Jan Safranek jsafrane@redhat.com
 
 # Base Packages
 RUN yum install -y wget ceph ceph-fuse strace && yum clean all

--- a/test/soak/cauldron/Dockerfile
+++ b/test/soak/cauldron/Dockerfile
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 FROM busybox
-MAINTAINER Satnam Singh <satnam@google.com>
 ADD cauldron cauldron
 ADD cauldron.go cauldron.go
 ENTRYPOINT ["/cauldron"]


### PR DESCRIPTION
**What this PR does / why we need it**:
ref: https://github.com/docker/docker/pull/25466

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Remove all MAINTAINER statements in Dockerfiles in the codebase as they are deprecated by docker
```
@ixdy @thockin (who else should be notified?)