### PR TITLE
Actually release if port == size.

### DIFF
--- a/pkg/proxy/userspace/port_allocator.go
+++ b/pkg/proxy/userspace/port_allocator.go
@@ -144,7 +144,7 @@ func (r *rangeAllocator) AllocateNext() (port int, err error) {
 
 func (r *rangeAllocator) Release(port int) {
 	port -= r.Base
-	if port < 0 || port >= r.Size {
+	if port < 0 || port > r.Size {
 		return
 	}
 	r.lock.Lock()

--- a/pkg/proxy/winuserspace/port_allocator.go
+++ b/pkg/proxy/winuserspace/port_allocator.go
@@ -144,7 +144,7 @@ func (r *rangeAllocator) AllocateNext() (port int, err error) {
 
 func (r *rangeAllocator) Release(port int) {
 	port -= r.Base
-	if port < 0 || port >= r.Size {
+	if port < 0 || port > r.Size {
 		return
 	}
 	r.lock.Lock()


### PR DESCRIPTION
I think this should solve: https://github.com/kubernetes/kubernetes/issues/38323

@xiangpengzhao @rmmh 

Looking at the `Release` function, I don't see a good reason why we should skip setting the bit if port == size. If you allocate "1-1" like this test does, then size == "1" and Port will also == "1" and you should
still release that bit.

It's possible I'm missing something tho.  (although tests pass...)