### PR TITLE
Remove cluster/mesos from hack/verify-flags/exceptions.txt

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -28,7 +28,6 @@ cluster/lib/logging.sh:    local source_file=${BASH_SOURCE[$stack_skip]}
 cluster/log-dump.sh:    local -r node_name="${1}"
 cluster/log-dump.sh:  for node_name in "${node_names[@]}"; do
 cluster/log-dump.sh:readonly report_dir="${1:-_artifacts}"
-cluster/mesos/docker/km/build.sh:  km_path=$(find-binary km darwin/amd64)
 cluster/photon-controller/templates/salt-master.sh:  api_servers: $MASTER_NAME
 cluster/photon-controller/templates/salt-minion.sh:  hostname_override: $(ip route get 1.1.1.1 | awk '{print $7}')
 cluster/photon-controller/util.sh:    node_ip=$(${PHOTON} vm networks "${node_id}" | grep -i $'\t'"00:0C:29" | grep -E '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1 | awk -F'\t' '{print $3}')


### PR DESCRIPTION
`cluster/mesos` scripts was removed; so remove it from `hack/verify-flags/exceptions.txt`.

The diff was generated by `hack/verify-flags-underscore.py -e > hack/verify-flags/exceptions.txt`.