### PR TITLE
Add StatefulSets checks at Service level

### DIFF
--- a/pkg/controller/statefulset/identity_mappers_test.go
+++ b/pkg/controller/statefulset/identity_mappers_test.go
@@ -57,7 +57,6 @@ func TestPetIDDNS(t *testing.T) {
 		if hostname, ok := pod.Annotations[apipod.PodHostnameAnnotation]; !ok || hostname != petName {
 			t.Errorf("Wrong hostname: %v", hostname)
 		}
-		// TODO: Check this against the governing service.
 		if subdomain, ok := pod.Annotations[apipod.PodSubdomainAnnotation]; !ok || subdomain != petSubdomain {
 			t.Errorf("Wrong subdomain: %v", subdomain)
 		}

--- a/test/e2e/statefulset.go
+++ b/test/e2e/statefulset.go
@@ -125,6 +125,9 @@ var _ = framework.KubeDescribe("StatefulSet", func() {
 			By("Verifying statefulset provides a stable hostname for each pod")
 			framework.ExpectNoError(sst.checkHostname(ss))
 
+			By("Verifying statefulset set proper service name")
+			framework.ExpectNoError(sst.checkServiceName(ss, headlessSvcName))
+
 			cmd := "echo $(hostname) > /data/hostname; sync;"
 			By("Running " + cmd + " in all stateful pods")
 			framework.ExpectNoError(sst.execInStatefulPods(ss, cmd))
@@ -961,6 +964,16 @@ func (s *statefulSetTester) waitForStatus(ss *apps.StatefulSet, expectedReplicas
 	if pollErr != nil {
 		framework.Failf("Failed waiting for stateful set status.replicas updated to %d: %v", expectedReplicas, pollErr)
 	}
+}
+
+func (p *statefulSetTester) checkServiceName(ps *apps.StatefulSet, expectedServiceName string) error {
+	framework.Logf("Checking if statefulset spec.serviceName is %s", expectedServiceName)
+
+	if expectedServiceName != ps.Spec.ServiceName {
+		return fmt.Errorf("Wrong service name governing statefulset. Expected %s got %s", expectedServiceName, ps.Spec.ServiceName)
+	}
+
+	return nil
 }
 
 func deleteAllStatefulSets(c clientset.Interface, ns string) {


### PR DESCRIPTION
Hi!

Please let me propose some very small e2e testsuite enhancement. 

This PR removed a `TODO` about checking governing service at unit test level (which is hard) and adds this to e2e testsuite.

Thanks
Sebastian