### PR TITLE
Use const value

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -47,7 +47,7 @@ const (
 	// A subdomain added to the user specified domain for all services.
 	serviceSubdomain = "svc"
 
-	// A subdomain added to the user specified dmoain for all pods.
+	// A subdomain added to the user specified domain for all pods.
 	podSubdomain = "pod"
 
 	// Resync period for the kube controller loop.
@@ -699,7 +699,7 @@ func (kd *KubeDNS) isPodRecord(path []string) bool {
 	if len(path) != len(kd.domainPath)+3 {
 		return false
 	}
-	if path[len(kd.domainPath)] != "pod" {
+	if path[len(kd.domainPath)] != podSubdomain {
 		return false
 	}
 	for _, segment := range path {


### PR DESCRIPTION

**What this PR does / why we need it**:
Minor fixed：
1. Use const value "podSubdomain" instead of creating a local value "pod" and for consistency with const value "serviceSubdomain".
2. Fix typo comment by the way.
