### PR TITLE
Added MULTIZONE flag to e2e remove master script.

### DIFF
--- a/hack/e2e-internal/e2e-remove-master.sh
+++ b/hack/e2e-internal/e2e-remove-master.sh
@@ -19,6 +19,9 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 if [[ ! -z "${1:-}" ]]; then
   export KUBE_GCE_ZONE="${1}"
 fi
+if [[ ! -z "${2:-}" ]]; then
+  export MULTIZONE="${2}"
+fi
 export KUBE_DELETE_NODES=false
 
 source "${KUBE_ROOT}/hack/e2e-internal/e2e-down.sh"

--- a/test/e2e/ha_master.go
+++ b/test/e2e/ha_master.go
@@ -42,7 +42,7 @@ func addMasterReplica(zone string) error {
 
 func removeMasterReplica(zone string) error {
 	framework.Logf(fmt.Sprintf("Removing an existing master replica, zone: %s", zone))
-	v, _, err := framework.RunCmd(path.Join(framework.TestContext.RepoRoot, "hack/e2e-internal/e2e-remove-master.sh"), zone)
+	v, _, err := framework.RunCmd(path.Join(framework.TestContext.RepoRoot, "hack/e2e-internal/e2e-remove-master.sh"), zone, "true")
 	framework.Logf("%s", v)
 	if err != nil {
 		return err


### PR DESCRIPTION
Added MULTIZONE flag to e2e remove master script. The script is used by HA tests which set-up multizone cluster.