### PR TITLE
CRI: add seccomp profile root path to runtime

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -672,7 +672,11 @@ type PodSandboxConfig struct {
 	//
 	//      key: security.alpha.kubernetes.io/seccomp/container/<container name>
 	//      description: the seccomp profile for the container (overides pod).
-	//      values: see below
+	//      values: see below.
+	//
+	//      key: security.alpha.kubernetes.io/seccomp/root
+	//      description: the root path of seccomp profile for localhost profiles.
+	//      value: the root path of seccomp profile.
 	//
 	//      The value of seccomp is runtime agnostic:
 	//      * runtime/default: the default profile for the container runtime

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -256,7 +256,11 @@ message PodSandboxConfig {
     //
     //      key: security.alpha.kubernetes.io/seccomp/container/<container name>
     //      description: the seccomp profile for the container (overides pod).
-    //      values: see below
+    //      values: see below.
+    //
+    //      key: security.alpha.kubernetes.io/seccomp/root
+    //      description: the root path of seccomp profile for localhost profiles.
+    //      value: the root path of seccomp profile.
     //
     //      The value of seccomp is runtime agnostic:
     //      * runtime/default: the default profile for the container runtime

--- a/pkg/kubelet/api/v1alpha1/runtime/constants.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/constants.go
@@ -24,4 +24,7 @@ const (
 	RuntimeReady = "RuntimeReady"
 	// NetworkReady means the runtime network is up and ready to accept containers which require network.
 	NetworkReady = "NetworkReady"
+
+	// SeccompPathAnnotationKey represents the key of the seccomp profile root path.
+	SeccompPathAnnotationKey = "security.alpha.kubernetes.io/seccomp/root"
 )

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -166,7 +166,7 @@ func (ds *dockerService) CreateContainer(podSandboxID string, config *runtimeapi
 	hc.Resources.Devices = devices
 
 	// Apply appArmor and seccomp options.
-	securityOpts, err := getContainerSecurityOpts(config.Metadata.GetName(), sandboxConfig, ds.seccompProfileRoot)
+	securityOpts, err := getContainerSecurityOpts(config.Metadata.GetName(), sandboxConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate container security options for container %q: %v", config.Metadata.GetName(), err)
 	}

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -351,7 +351,7 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 	setSandboxResources(hc)
 
 	// Set security options.
-	securityOpts, err := getSandboxSecurityOpts(c, ds.seccompProfileRoot)
+	securityOpts, err := getSandboxSecurityOpts(c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate sandbox security options for sandbox %q: %v", c.Metadata.GetName(), err)
 	}

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -100,13 +100,12 @@ type NetworkPluginSettings struct {
 var internalLabelKeys []string = []string{containerTypeLabelKey, containerLogPathLabelKey, sandboxIDLabelKey}
 
 // NOTE: Anything passed to DockerService should be eventually handled in another way when we switch to running the shim as a different process.
-func NewDockerService(client dockertools.DockerInterface, seccompProfileRoot string, podSandboxImage string, streamingConfig *streaming.Config, pluginSettings *NetworkPluginSettings, cgroupsName string) (DockerService, error) {
+func NewDockerService(client dockertools.DockerInterface, podSandboxImage string, streamingConfig *streaming.Config, pluginSettings *NetworkPluginSettings, cgroupsName string) (DockerService, error) {
 	c := dockertools.NewInstrumentedDockerInterface(client)
 	ds := &dockerService{
-		seccompProfileRoot: seccompProfileRoot,
-		client:             c,
-		os:                 kubecontainer.RealOS{},
-		podSandboxImage:    podSandboxImage,
+		client:          c,
+		os:              kubecontainer.RealOS{},
+		podSandboxImage: podSandboxImage,
 		streamingRuntime: &streamingRuntime{
 			client: client,
 			// Only the native exec handling is supported for now.
@@ -149,14 +148,13 @@ type DockerService interface {
 }
 
 type dockerService struct {
-	seccompProfileRoot string
-	client             dockertools.DockerInterface
-	os                 kubecontainer.OSInterface
-	podSandboxImage    string
-	streamingRuntime   *streamingRuntime
-	streamingServer    streaming.Server
-	networkPlugin      network.NetworkPlugin
-	containerManager   cm.ContainerManager
+	client           dockertools.DockerInterface
+	os               kubecontainer.OSInterface
+	podSandboxImage  string
+	streamingRuntime *streamingRuntime
+	streamingServer  streaming.Server
+	networkPlugin    network.NetworkPlugin
+	containerManager cm.ContainerManager
 }
 
 // Version returns the runtime name, runtime version and runtime API version

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -198,11 +198,12 @@ func makePortsAndBindings(pm []*runtimeapi.PortMapping) (map[dockernat.Port]stru
 // getContainerSecurityOpt gets container security options from container and sandbox config, currently from sandbox
 // annotations.
 // It is an experimental feature and may be promoted to official runtime api in the future.
-func getContainerSecurityOpts(containerName string, sandboxConfig *runtimeapi.PodSandboxConfig, seccompProfileRoot string) ([]string, error) {
+func getContainerSecurityOpts(containerName string, sandboxConfig *runtimeapi.PodSandboxConfig) ([]string, error) {
 	appArmorOpts, err := dockertools.GetAppArmorOpts(sandboxConfig.GetAnnotations(), containerName)
 	if err != nil {
 		return nil, err
 	}
+	seccompProfileRoot := sandboxConfig.Annotations[runtimeapi.SeccompPathAnnotationKey]
 	seccompOpts, err := dockertools.GetSeccompOpts(sandboxConfig.GetAnnotations(), containerName, seccompProfileRoot)
 	if err != nil {
 		return nil, err
@@ -216,9 +217,9 @@ func getContainerSecurityOpts(containerName string, sandboxConfig *runtimeapi.Po
 	return opts, nil
 }
 
-func getSandboxSecurityOpts(sandboxConfig *runtimeapi.PodSandboxConfig, seccompProfileRoot string) ([]string, error) {
+func getSandboxSecurityOpts(sandboxConfig *runtimeapi.PodSandboxConfig) ([]string, error) {
 	// sandboxContainerName doesn't exist in the pod, so pod security options will be returned by default.
-	return getContainerSecurityOpts(sandboxContainerName, sandboxConfig, seccompProfileRoot)
+	return getContainerSecurityOpts(sandboxContainerName, sandboxConfig)
 }
 
 func getNetworkNamespace(c *dockertypes.ContainerJSON) string {

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -95,7 +95,7 @@ func TestGetContainerSecurityOpts(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		opts, err := getContainerSecurityOpts(containerName, test.config, "test/seccomp/profile/root")
+		opts, err := getContainerSecurityOpts(containerName, test.config)
 		assert.NoError(t, err, "TestCase[%d]: %s", i, test.msg)
 		assert.Len(t, opts, len(test.expectedOpts), "TestCase[%d]: %s", i, test.msg)
 		for _, opt := range test.expectedOpts {
@@ -140,7 +140,7 @@ func TestGetSandboxSecurityOpts(t *testing.T) {
 	}}
 
 	for i, test := range tests {
-		opts, err := getSandboxSecurityOpts(test.config, "test/seccomp/profile/root")
+		opts, err := getSandboxSecurityOpts(test.config)
 		assert.NoError(t, err, "TestCase[%d]: %s", i, test.msg)
 		assert.Len(t, opts, len(test.expectedOpts), "TestCase[%d]: %s", i, test.msg)
 		for _, opt := range test.expectedOpts {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -538,7 +538,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 		case "docker":
 			streamingConfig := getStreamingConfig(kubeCfg, kubeDeps)
 			// Use the new CRI shim for docker.
-			ds, err := dockershim.NewDockerService(klet.dockerClient, kubeCfg.SeccompProfileRoot, kubeCfg.PodInfraContainerImage, streamingConfig, &pluginSettings, kubeCfg.RuntimeCgroups)
+			ds, err := dockershim.NewDockerService(klet.dockerClient, kubeCfg.PodInfraContainerImage, streamingConfig, &pluginSettings, kubeCfg.RuntimeCgroups)
 			if err != nil {
 				return nil, err
 			}
@@ -590,6 +590,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 		}
 		runtime, err := kuberuntime.NewKubeGenericRuntimeManager(
 			kubecontainer.FilterEventRecorder(kubeDeps.Recorder),
+			kubeCfg.SeccompProfileRoot,
 			klet.livenessManager,
 			containerRefManager,
 			machineInfo,

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -69,6 +69,7 @@ type podGetter interface {
 
 type kubeGenericRuntimeManager struct {
 	runtimeName         string
+	seccompProfileRoot  string
 	recorder            record.EventRecorder
 	osInterface         kubecontainer.OSInterface
 	containerRefManager *kubecontainer.RefManager
@@ -117,6 +118,7 @@ type KubeGenericRuntime interface {
 // NewKubeGenericRuntimeManager creates a new kubeGenericRuntimeManager
 func NewKubeGenericRuntimeManager(
 	recorder record.EventRecorder,
+	seccompProfileRoot string,
 	livenessManager proberesults.Manager,
 	containerRefManager *kubecontainer.RefManager,
 	machineInfo *cadvisorapi.MachineInfo,
@@ -138,6 +140,7 @@ func NewKubeGenericRuntimeManager(
 		cpuCFSQuota:         cpuCFSQuota,
 		livenessManager:     livenessManager,
 		containerRefManager: containerRefManager,
+		seccompProfileRoot:  seccompProfileRoot,
 		machineInfo:         machineInfo,
 		osInterface:         osInterface,
 		networkPlugin:       networkPlugin,

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -71,7 +71,7 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxConfig(pod *v1.Pod, attemp
 			Attempt:   &attempt,
 		},
 		Labels:      newPodLabels(pod),
-		Annotations: newPodAnnotations(pod),
+		Annotations: newPodAnnotations(pod, m.seccompProfileRoot),
 	}
 
 	if !kubecontainer.IsHostNetworkPod(pod) {

--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/glog"
 	"k8s.io/kubernetes/pkg/api/v1"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
@@ -92,8 +93,17 @@ func newPodLabels(pod *v1.Pod) map[string]string {
 }
 
 // newPodAnnotations creates pod annotations from v1.Pod.
-func newPodAnnotations(pod *v1.Pod) map[string]string {
-	return pod.Annotations
+func newPodAnnotations(pod *v1.Pod, seccompProfileRoot string) map[string]string {
+	annotations := map[string]string{}
+
+	// get annotations from v1.Pod
+	for k, v := range pod.Annotations {
+		annotations[k] = v
+	}
+
+	annotations[runtimeapi.SeccompPathAnnotationKey] = seccompProfileRoot
+
+	return annotations
 }
 
 // newContainerLabels creates container labels from v1.Container and v1.Pod.

--- a/pkg/kubelet/kuberuntime/labels_test.go
+++ b/pkg/kubelet/kuberuntime/labels_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api/v1"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
@@ -192,6 +193,7 @@ func TestPodLabels(t *testing.T) {
 }
 
 func TestPodAnnotations(t *testing.T) {
+	seccompProfileRoot := "/tmp/"
 	pod := &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:        "test_pod",
@@ -203,14 +205,17 @@ func TestPodAnnotations(t *testing.T) {
 			Containers: []v1.Container{},
 		},
 	}
-	expected := &annotatedPodSandboxInfo{
-		Annotations: map[string]string{"foo": "bar"},
+	expectedSandboxInfo := &annotatedPodSandboxInfo{
+		Annotations: map[string]string{
+			"foo": "bar",
+			runtimeapi.SeccompPathAnnotationKey: seccompProfileRoot,
+		},
 	}
 
 	// Test whether we can get right information from annotations
-	annotations := newPodAnnotations(pod)
+	annotations := newPodAnnotations(pod, seccompProfileRoot)
 	podSandboxInfo := getPodSandboxInfoFromAnnotations(annotations)
-	if !reflect.DeepEqual(podSandboxInfo, expected) {
-		t.Errorf("expected %v, got %v", expected, podSandboxInfo)
+	if !reflect.DeepEqual(podSandboxInfo, expectedSandboxInfo) {
+		t.Errorf("expected %v, got %v", expectedSandboxInfo, podSandboxInfo)
 	}
 }


### PR DESCRIPTION
This PR adds a new `security.alpha.kubernetes.io/seccomp/root` annotations to sandboxConfig to pass seccomp profile root path to runtime.

Fixes #36997.

cc @yujuhong @euank 