### PR TITLE
Modified restclient verb function

### DIFF
--- a/pkg/client/restclient/client.go
+++ b/pkg/client/restclient/client.go
@@ -221,9 +221,6 @@ func createSerializers(config ContentConfig) (*Serializers, error) {
 func (c *RESTClient) Verb(verb string) *Request {
 	backoff := c.createBackoffMgr()
 
-	if c.Client == nil {
-		return NewRequest(nil, verb, c.base, c.versionedAPIPath, c.contentConfig, c.serializers, backoff, c.Throttle)
-	}
 	return NewRequest(c.Client, verb, c.base, c.versionedAPIPath, c.contentConfig, c.serializers, backoff, c.Throttle)
 }
 

--- a/pkg/client/restclient/request.go
+++ b/pkg/client/restclient/request.go
@@ -722,10 +722,13 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 	}
 	req.Header = r.headers
 	client := r.client
+        fmt.Println("=====================================before",client)
 	if client == nil {
+                fmt.Println("===================================client is nil")
 		client = http.DefaultClient
 	}
 	r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
+        fmt.Println("============================",client)
 	resp, err := client.Do(req)
 	updateURLMetrics(r, resp, err)
 	if r.baseURL != nil {


### PR DESCRIPTION
we call the same function whether the c.Client is nil or not, so maybe we do not need to judge that
