### PR TITLE
fix group in create clusterrolebinding

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -426,6 +426,11 @@ runTests() {
   kube::test::get_object_assert clusterrolebindings/cluster-admin "{{.metadata.name}}" 'cluster-admin'
   kubectl create "${kube_flags[@]}" clusterrolebinding super-admin --clusterrole=admin --user=super-admin
   kube::test::get_object_assert clusterrolebinding/super-admin "{{range.subjects}}{{.name}}:{{end}}" 'super-admin:'
+  kubectl create "${kube_flags[@]}" clusterrolebinding super-group --clusterrole=admin --group=the-group
+  kube::test::get_object_assert clusterrolebinding/super-group "{{range.subjects}}{{.name}}:{{end}}" 'the-group:'
+  kubectl create "${kube_flags[@]}" clusterrolebinding super-sa --clusterrole=admin --serviceaccount=otherns:sa-name
+  kube::test::get_object_assert clusterrolebinding/super-sa "{{range.subjects}}{{.namespace}}:{{end}}" 'otherns:'
+  kube::test::get_object_assert clusterrolebinding/super-sa "{{range.subjects}}{{.name}}:{{end}}" 'sa-name:'
   kubectl create "${kube_flags[@]}" rolebinding admin --clusterrole=admin --user=default-admin -n default
   kube::test::get_object_assert rolebinding/admin "{{range.subjects}}{{.name}}:{{end}}" 'default-admin:'
   kubectl create "${kube_flags[@]}" rolebinding localrole --role=localrole --group=the-group -n default

--- a/pkg/kubectl/clusterrolebinding.go
+++ b/pkg/kubectl/clusterrolebinding.go
@@ -123,6 +123,13 @@ func (s ClusterRoleBindingGeneratorV1) StructuredGenerate() (runtime.Object, err
 			Name:       user,
 		})
 	}
+	for _, group := range s.Groups {
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbac.Subject{
+			Kind:       rbac.GroupKind,
+			APIVersion: "rbac/v1alpha1",
+			Name:       group,
+		})
+	}
 	for _, sa := range s.ServiceAccounts {
 		tokens := strings.Split(sa, ":")
 		if len(tokens) != 2 {


### PR DESCRIPTION
group lost.

```
#kubectl create clusterrolebinding test --clusterrole=a --group=b
clusterrolebinding "test" created

#kubectl get clusterrolebinding test -o yaml
apiVersion: rbac.authorization.k8s.io/v1alpha1
kind: ClusterRoleBinding
metadata:
  creationTimestamp: 2016-12-20T03:13:24Z
  name: test
  resourceVersion: "284"
  selfLink: /apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindingstest
  uid: 44d3476d-c662-11e6-a439-7427ea6f0fe3
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: a
subjects: null
```