### PR TITLE
fix request function

### DIFF
--- a/pkg/client/restclient/request.go
+++ b/pkg/client/restclient/request.go
@@ -805,10 +805,12 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 		}
 		resp, err := client.Do(req)
 		updateURLMetrics(r, resp, err)
-		if err != nil {
-			r.backoffMgr.UpdateBackoff(r.URL(), err, 0)
-		} else {
-			r.backoffMgr.UpdateBackoff(r.URL(), err, resp.StatusCode)
+		if r.baseURL != nil {
+			if err != nil {
+				r.backoffMgr.UpdateBackoff(r.URL(), err, 0)
+			} else {
+				r.backoffMgr.UpdateBackoff(r.URL(), err, resp.StatusCode)
+			}
 		}
 		if err != nil {
 			// "Connection reset by peer" is usually a transient error.

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -805,10 +805,12 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 		}
 		resp, err := client.Do(req)
 		updateURLMetrics(r, resp, err)
-		if err != nil {
-			r.backoffMgr.UpdateBackoff(r.URL(), err, 0)
-		} else {
-			r.backoffMgr.UpdateBackoff(r.URL(), err, resp.StatusCode)
+                if r.baseURL != nil {
+			if err != nil {
+				r.backoffMgr.UpdateBackoff(r.URL(), err, 0)
+			} else {
+				r.backoffMgr.UpdateBackoff(r.URL(), err, resp.StatusCode)
+			}
 		}
 		if err != nil {
 			return err


### PR DESCRIPTION
add r.baseUrl judgement before calling UpdateBackoff() function just like the function Stream() and Watch() do in the same file.
UpdateBackoff() function will call baseUrlKey()  and baseUrlKey() now returns the url.Host. If r.baseUrl is nil,url.Host has no value after calling URL().

