### PR TITLE
install latest etcd and then fix issue 38962

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -40,7 +40,7 @@ kube::etcd::validate() {
    export PATH=$KUBE_ROOT/third_party/etcd:$PATH
    hash etcd
    echo $PATH
-   ls $KUBE_ROOT/third_party/etcd
+   # ls $KUBE_ROOT/third_party/etcd
    version=$(etcd --version | head -n 1 | cut -d " " -f 3)
    if [[ "${version}" < "${ETCD_VERSION}" ]]; then
     kube::log::usage "etcd version ${ETCD_VERSION} or greater required."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: there is no third_party/etcd directory in federation/* , so ls operation could cause some unexpected failures when running part of hack/verify-*.sh

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #38962 

**Special notes for your reviewer**: what's the general purpose for third_party/etcd 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
