### PR TITLE
Fix cloud-config name in test case

### DIFF
--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -86,7 +86,7 @@ func TestConfigDirCleaner(t *testing.T) {
 				"manifests",
 			},
 		},
-		"preserve cloud-config.json": {
+		"preserve cloud-config": {
 			setupDirs: []string{
 				"manifests",
 				"pki",
@@ -97,12 +97,12 @@ func TestConfigDirCleaner(t *testing.T) {
 				"pki/ca.pem",
 				"admin.conf",
 				"kubelet.conf",
-				"cloud-config.json",
+				"cloud-config",
 			},
 			verifyExists: []string{
 				"manifests",
 				"pki",
-				"cloud-config.json",
+				"cloud-config",
 			},
 		},
 		"preserve hidden files and directories": {
@@ -117,13 +117,13 @@ func TestConfigDirCleaner(t *testing.T) {
 				"pki/ca.pem",
 				"admin.conf",
 				"kubelet.conf",
-				".cloud-config.json",
+				".cloud-config",
 				".mydir/.myfile",
 			},
 			verifyExists: []string{
 				"manifests",
 				"pki",
-				".cloud-config.json",
+				".cloud-config",
 				".mydir",
 				".mydir/.myfile",
 			},


### PR DESCRIPTION
**What this PR does / why we need it**: fixes default cloud-config name in test cases for reset.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: related to kubernetes/kubeadm#75

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
