### PR TITLE
Fixing 'systemd restart docker' command in kubemark master

### DIFF
--- a/test/kubemark/resources/start-kubemark-master.sh
+++ b/test/kubemark/resources/start-kubemark-master.sh
@@ -141,7 +141,7 @@ function assemble-docker-flags {
 	# TODO(shyamjvs): Incorporate network plugin options, etc later.
 	echo "DOCKER_OPTS=\"${docker_opts}\"" > /etc/default/docker
 	echo "DOCKER_NOFILE=65536" >> /etc/default/docker  # For setting ulimit -n
-	systemd restart docker
+	systemctl restart docker
 }
 
 # A helper function for loading a docker image. It keeps trying up to 5 times.
@@ -224,6 +224,9 @@ function start-kubelet {
 	# Create systemd config.
 	local -r kubelet_bin="/usr/bin/kubelet"
 	create-kubelet-conf "${kubelet_bin}"
+
+	# Flush iptables nat table
+  	iptables -t nat -F || true
 
 	# Start the kubelet service.
 	systemctl start kubelet.service


### PR DESCRIPTION
We try to restart docker after assembling it's flags in kubemark master using `systemd`, while it doesn't exist on the gci image. Changed it to `systemctl` instead.
This means that docker wasn't getting restarted in gci after changing DOCKER_OPTS all this while and hence not flushing the nat iptable didn't really matter.
But now, since we have the flag `--ip-masq=false` in DOCKER_OPTS taking effect, flushing the nat table makes sense, in order to make both of them consistent wrt masquerading.

Also, do you think that this might have anything to do with the failing kubemark tests (if there were some containers that did not want to allow iptable modification / masquerading)?

@kubernetes/sig-scalability-misc @wojtek-t @gmarek 