### PR TITLE
Adds kubernetes.io link for dns autoscaler addon

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/README.md
+++ b/cluster/addons/dns-horizontal-autoscaler/README.md
@@ -6,7 +6,9 @@ status from the APIServer, horizontally scales the number of DNS backends based
 on demand. Autoscaling parameters could be tuned by modifying the `kube-dns-autoscaler`
 ConfigMap in `kube-system` namespace.
 
-Learn more at: https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
+Learn more about:
+- Usage: http://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/
+- Implementation: https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/
 
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/dns-horizontal-autoscaler/README.md?pixel)]()


### PR DESCRIPTION
The [official page for DNS Horizontal Autoscaling](http://kubernetes.io/docs/tasks/administer-cluster/dns-horizontal-autoscaling/) is available on kubernetes.io after 1.5 release. Putting the link into this dns autoscaler addon folder as well.

@bowei 