### PR TITLE
If etcd server name starts with any of 'h','t' or 'p', API server

### DIFF
--- a/pkg/storage/storagebackend/factory/etcd3.go
+++ b/pkg/storage/storagebackend/factory/etcd3.go
@@ -31,7 +31,7 @@ import (
 func newETCD3Storage(c storagebackend.Config, codec runtime.Codec) (storage.Interface, error) {
 	endpoints := c.ServerList
 	for i, s := range endpoints {
-		endpoints[i] = strings.TrimLeft(s, "http://")
+		endpoints[i] = strings.TrimPrefix(s, "http://")
 	}
 	cfg := clientv3.Config{
 		Endpoints: endpoints,


### PR DESCRIPTION
truncates the leading characters and complains that it cannot
connect to the etcd cluster. For e.g., if
--etcd-servers=http://his-etcd.abc.com:2379, the API server
tries connecting is-etcd.abc.com:2379.

Fixes https://github.com/kubernetes/kubernetes/issues/39035

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Bug fix

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #39035

**Special notes for your reviewer**:
Please refer to TrimLeft documentation: https://golang.org/pkg/strings/#TrimLeft. From the documentation: _TrimLeft returns a slice of the string s with all leading Unicode code points contained in cutset removed_

This issue exists only in release-1.3 branch (https://github.com/kubernetes/kubernetes/blob/release-1.3/pkg/storage/storagebackend/factory/etcd3.go#L34), in which the etcd endpoint (starting with http://) is trimmed before creating the etcd client. However in later versions & master, endpoints are passed as is to etcd client: https://github.com/kubernetes/kubernetes/blob/master/pkg/storage/storagebackend/factory/etcd3.go

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
