### PR TITLE
[WIP] switch rbac evaluation to an interface to work around external only versions

### DIFF
--- a/pkg/apis/rbac/adapters/doc.go
+++ b/pkg/apis/rbac/adapters/doc.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters
+
+// These adapters provide a way to get the fields of the role regardless of the API version of the object.
+// This is needed so that the RBAC authorizer can cleanly support multiple API versions with a single implementation
+// but only depend upon the external clients built into client-go.  That is needed so that the generic API server
+// which provides this as an authorization option can be broken out into a separate repo that doesn't depend
+// upon the main kube repo.  This really is the *exact* case for which internal versions were created.  I have logic
+// that I don't want to duplicate, that is fully convertible between versions.  I just want a version that I support
+// negotiated with the server and then convert to the internal representation so that I can use the values.

--- a/pkg/apis/rbac/adapters/interfaces.go
+++ b/pkg/apis/rbac/adapters/interfaces.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	rbacv1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/runtime/schema"
+)
+
+// shaping the type like this prevents allocations
+type PolicyRules interface {
+	Len() int
+	Get(i int) PolicyRule
+}
+
+type PolicyRule interface {
+	Verbs() []string
+	APIGroups() []string
+	Resources() []string
+	ResourceNames() []string
+	NonResourceURLs() []string
+}
+
+// shaping the type like this prevents allocations
+type Subjects interface {
+	Len() int
+	Get(i int) Subject
+}
+
+type Subject interface {
+	Kind() string
+	APIVersion() string
+	Name() string
+	Namespace() string
+}
+
+type RoleRef interface {
+	APIGroup() string
+	Kind() string
+	Name() string
+}
+
+type Role interface {
+	Rules() PolicyRules
+}
+
+type RoleBinding interface {
+	Subjects() Subjects
+	RoleRef() RoleRef
+}
+
+type ClusterRole interface {
+	Rules() PolicyRules
+}
+
+type ClusterRoleBinding interface {
+	Subjects() Subjects
+	RoleRef() RoleRef
+}
+
+func ToClusterRole(obj runtime.Object) ClusterRole {
+	switch castObj := obj.(type) {
+	case *rbac.ClusterRole:
+		return &internalversionClusterRole{obj: castObj}
+	case *rbacv1alpha1.ClusterRole:
+		return &v1alpha1ClusterRole{obj: castObj}
+	}
+	panic(fmt.Sprintf("uncastable type: %T", obj))
+}
+
+func ToClusterRoleBinding(obj runtime.Object) ClusterRoleBinding {
+	switch castObj := obj.(type) {
+	case *rbac.ClusterRoleBinding:
+		return &internalversionClusterRoleBinding{obj: castObj}
+	case *rbacv1alpha1.ClusterRoleBinding:
+		return &v1alpha1ClusterRoleBinding{obj: castObj}
+	}
+	panic(fmt.Sprintf("uncastable type: %T", obj))
+}
+
+func ToRole(obj runtime.Object) Role {
+	switch castObj := obj.(type) {
+	case *rbac.Role:
+		return &internalversionRole{obj: castObj}
+	case *rbacv1alpha1.Role:
+		return &v1alpha1Role{obj: castObj}
+	}
+	panic(fmt.Sprintf("uncastable type: %T", obj))
+}
+
+func ToRoleBinding(obj runtime.Object) RoleBinding {
+	switch castObj := obj.(type) {
+	case *rbac.RoleBinding:
+		return &internalversionRoleBinding{obj: castObj}
+	case *rbacv1alpha1.RoleBinding:
+		return &v1alpha1RoleBinding{obj: castObj}
+	}
+	panic(fmt.Sprintf("uncastable type: %T", obj))
+}
+
+func ToPolicyRule(obj *rbac.PolicyRule) PolicyRule {
+	return &internalversionPolicyRule{obj: obj}
+}
+
+func ToSubject(obj *rbac.Subject) Subject {
+	return &internalversionSubject{obj: obj}
+}
+
+func RoleRefGroupKind(roleRef RoleRef) schema.GroupKind {
+	return schema.GroupKind{Group: roleRef.APIGroup(), Kind: roleRef.Kind()}
+}

--- a/pkg/apis/rbac/adapters/internalversion.go
+++ b/pkg/apis/rbac/adapters/internalversion.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters
+
+import (
+	"k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+type internalversionPolicyRules struct {
+	obj []rbac.PolicyRule
+}
+
+func (o *internalversionPolicyRules) Len() int {
+	return len(o.obj)
+}
+func (o *internalversionPolicyRules) Get(i int) PolicyRule {
+	return &internalversionPolicyRule{obj: &o.obj[i]}
+}
+
+type internalversionPolicyRule struct {
+	obj *rbac.PolicyRule
+}
+
+func (o *internalversionPolicyRule) Verbs() []string {
+	return o.obj.Verbs
+}
+func (o *internalversionPolicyRule) APIGroups() []string {
+	return o.obj.APIGroups
+}
+func (o *internalversionPolicyRule) Resources() []string {
+	return o.obj.Resources
+}
+func (o *internalversionPolicyRule) ResourceNames() []string {
+	return o.obj.ResourceNames
+}
+func (o *internalversionPolicyRule) NonResourceURLs() []string {
+	return o.obj.NonResourceURLs
+}
+
+type internalversionSubjects struct {
+	obj []rbac.Subject
+}
+
+func (o *internalversionSubjects) Len() int {
+	return len(o.obj)
+}
+func (o *internalversionSubjects) Get(i int) Subject {
+	return &internalversionSubject{obj: &o.obj[i]}
+}
+
+type internalversionSubject struct {
+	obj *rbac.Subject
+}
+
+func (o *internalversionSubject) Kind() string {
+	return o.obj.Kind
+}
+func (o *internalversionSubject) APIVersion() string {
+	return o.obj.APIVersion
+}
+func (o *internalversionSubject) Name() string {
+	return o.obj.Name
+}
+func (o *internalversionSubject) Namespace() string {
+	return o.obj.Namespace
+}
+
+type internalversionRoleRef struct {
+	obj *rbac.RoleRef
+}
+
+func (o *internalversionRoleRef) APIGroup() string {
+	return o.obj.APIGroup
+}
+func (o *internalversionRoleRef) Kind() string {
+	return o.obj.Kind
+}
+func (o *internalversionRoleRef) Name() string {
+	return o.obj.Name
+}
+
+type internalversionRole struct {
+	obj *rbac.Role
+}
+
+func (o *internalversionRole) Rules() PolicyRules {
+	return &internalversionPolicyRules{obj: o.obj.Rules}
+}
+
+type internalversionRoleBinding struct {
+	obj *rbac.RoleBinding
+}
+
+func (o *internalversionRoleBinding) Subjects() Subjects {
+	return &internalversionSubjects{obj: o.obj.Subjects}
+}
+func (o *internalversionRoleBinding) RoleRef() RoleRef {
+	return &internalversionRoleRef{obj: &o.obj.RoleRef}
+}
+
+type internalversionClusterRole struct {
+	obj *rbac.ClusterRole
+}
+
+func (o *internalversionClusterRole) Rules() PolicyRules {
+	return &internalversionPolicyRules{obj: o.obj.Rules}
+}
+
+type internalversionClusterRoleBinding struct {
+	obj *rbac.ClusterRoleBinding
+}
+
+func (o *internalversionClusterRoleBinding) Subjects() Subjects {
+	return &internalversionSubjects{obj: o.obj.Subjects}
+}
+func (o *internalversionClusterRoleBinding) RoleRef() RoleRef {
+	return &internalversionRoleRef{obj: &o.obj.RoleRef}
+}

--- a/pkg/apis/rbac/adapters/matching.go
+++ b/pkg/apis/rbac/adapters/matching.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/apis/rbac"
+)
+
+func VerbMatches(rule PolicyRule, requestedVerb string) bool {
+	for _, ruleVerb := range rule.Verbs() {
+		if ruleVerb == rbac.VerbAll {
+			return true
+		}
+		if ruleVerb == requestedVerb {
+			return true
+		}
+	}
+
+	return false
+}
+
+func APIGroupMatches(rule PolicyRule, requestedGroup string) bool {
+	for _, ruleGroup := range rule.APIGroups() {
+		if ruleGroup == rbac.APIGroupAll {
+			return true
+		}
+		if ruleGroup == requestedGroup {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ResourceMatches(rule PolicyRule, requestedResource string) bool {
+	for _, ruleResource := range rule.Resources() {
+		if ruleResource == rbac.ResourceAll {
+			return true
+		}
+		if ruleResource == requestedResource {
+			return true
+		}
+	}
+
+	return false
+}
+
+func ResourceNameMatches(rule PolicyRule, requestedName string) bool {
+	if len(rule.ResourceNames()) == 0 {
+		return true
+	}
+
+	for _, ruleName := range rule.ResourceNames() {
+		if ruleName == requestedName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func NonResourceURLMatches(rule PolicyRule, requestedURL string) bool {
+	for _, ruleURL := range rule.NonResourceURLs() {
+		if ruleURL == rbac.NonResourceAll {
+			return true
+		}
+		if ruleURL == requestedURL {
+			return true
+		}
+		if strings.HasSuffix(ruleURL, "*") && strings.HasPrefix(requestedURL, strings.TrimRight(ruleURL, "*")) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// subjectsStrings returns users, groups, serviceaccounts, unknown for display purposes.
+func SubjectsStrings(subjects []Subject) ([]string, []string, []string, []string) {
+	users := []string{}
+	groups := []string{}
+	sas := []string{}
+	others := []string{}
+
+	for _, subject := range subjects {
+		switch subject.Kind() {
+		case rbac.ServiceAccountKind:
+			sas = append(sas, fmt.Sprintf("%s/%s", subject.Namespace(), subject.Name()))
+
+		case rbac.UserKind:
+			users = append(users, subject.Name())
+
+		case rbac.GroupKind:
+			groups = append(groups, subject.Name())
+
+		default:
+			others = append(others, fmt.Sprintf("%s/%s/%s", subject.Kind(), subject.Namespace(), subject.Name()))
+		}
+	}
+
+	return users, groups, sas, others
+}

--- a/pkg/apis/rbac/adapters/v1alpha1.go
+++ b/pkg/apis/rbac/adapters/v1alpha1.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters
+
+import (
+	rbac "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
+)
+
+type v1alpha1PolicyRules struct {
+	obj []rbac.PolicyRule
+}
+
+func (o *v1alpha1PolicyRules) Len() int {
+	return len(o.obj)
+}
+func (o *v1alpha1PolicyRules) Get(i int) PolicyRule {
+	return &v1alpha1PolicyRule{obj: &o.obj[i]}
+}
+
+type v1alpha1PolicyRule struct {
+	obj *rbac.PolicyRule
+}
+
+func (o *v1alpha1PolicyRule) Verbs() []string {
+	return o.obj.Verbs
+}
+func (o *v1alpha1PolicyRule) APIGroups() []string {
+	return o.obj.APIGroups
+}
+func (o *v1alpha1PolicyRule) Resources() []string {
+	return o.obj.Resources
+}
+func (o *v1alpha1PolicyRule) ResourceNames() []string {
+	return o.obj.ResourceNames
+}
+func (o *v1alpha1PolicyRule) NonResourceURLs() []string {
+	return o.obj.NonResourceURLs
+}
+
+type v1alpha1Subjects struct {
+	obj []rbac.Subject
+}
+
+func (o *v1alpha1Subjects) Len() int {
+	return len(o.obj)
+}
+func (o *v1alpha1Subjects) Get(i int) Subject {
+	return &v1alpha1Subject{obj: &o.obj[i]}
+}
+
+type v1alpha1Subject struct {
+	obj *rbac.Subject
+}
+
+func (o *v1alpha1Subject) Kind() string {
+	return o.obj.Kind
+}
+func (o *v1alpha1Subject) APIVersion() string {
+	return o.obj.APIVersion
+}
+func (o *v1alpha1Subject) Name() string {
+	return o.obj.Name
+}
+func (o *v1alpha1Subject) Namespace() string {
+	return o.obj.Namespace
+}
+
+type v1alpha1RoleRef struct {
+	obj *rbac.RoleRef
+}
+
+func (o *v1alpha1RoleRef) APIGroup() string {
+	return o.obj.APIGroup
+}
+func (o *v1alpha1RoleRef) Kind() string {
+	return o.obj.Kind
+}
+func (o *v1alpha1RoleRef) Name() string {
+	return o.obj.Name
+}
+
+type v1alpha1Role struct {
+	obj *rbac.Role
+}
+
+func (o *v1alpha1Role) Rules() PolicyRules {
+	return &v1alpha1PolicyRules{obj: o.obj.Rules}
+}
+
+type v1alpha1RoleBinding struct {
+	obj *rbac.RoleBinding
+}
+
+func (o *v1alpha1RoleBinding) Subjects() Subjects {
+	return &v1alpha1Subjects{obj: o.obj.Subjects}
+}
+func (o *v1alpha1RoleBinding) RoleRef() RoleRef {
+	return &v1alpha1RoleRef{obj: &o.obj.RoleRef}
+}
+
+type v1alpha1ClusterRole struct {
+	obj *rbac.ClusterRole
+}
+
+func (o *v1alpha1ClusterRole) Rules() PolicyRules {
+	return &v1alpha1PolicyRules{obj: o.obj.Rules}
+}
+
+type v1alpha1ClusterRoleBinding struct {
+	obj *rbac.ClusterRoleBinding
+}
+
+func (o *v1alpha1ClusterRoleBinding) Subjects() Subjects {
+	return &v1alpha1Subjects{obj: o.obj.Subjects}
+}
+func (o *v1alpha1ClusterRoleBinding) RoleRef() RoleRef {
+	return &v1alpha1RoleRef{obj: &o.obj.RoleRef}
+}

--- a/pkg/apis/rbac/validation/policy_comparator.go
+++ b/pkg/apis/rbac/validation/policy_comparator.go
@@ -20,22 +20,23 @@ import (
 	"strings"
 
 	"k8s.io/kubernetes/pkg/apis/rbac"
+	rbacadapters "k8s.io/kubernetes/pkg/apis/rbac/adapters"
 )
 
 // Covers determines whether or not the ownerRules cover the servantRules in terms of allowed actions.
 // It returns whether or not the ownerRules cover and a list of the rules that the ownerRules do not cover.
-func Covers(ownerRules, servantRules []rbac.PolicyRule) (bool, []rbac.PolicyRule) {
+func Covers(ownerRules, servantRules []rbacadapters.PolicyRule) (bool, []rbacadapters.PolicyRule) {
 	// 1.  Break every servantRule into individual rule tuples: group, verb, resource, resourceName
 	// 2.  Compare the mini-rules against each owner rule.  Because the breakdown is down to the most atomic level, we're guaranteed that each mini-servant rule will be either fully covered or not covered by a single owner rule
 	// 3.  Any left over mini-rules means that we are not covered and we have a nice list of them.
 	// TODO: it might be nice to collapse the list down into something more human readable
 
-	subrules := []rbac.PolicyRule{}
+	subrules := []rbacadapters.PolicyRule{}
 	for _, servantRule := range servantRules {
 		subrules = append(subrules, breakdownRule(servantRule)...)
 	}
 
-	uncoveredRules := []rbac.PolicyRule{}
+	uncoveredRules := []rbacadapters.PolicyRule{}
 	for _, subrule := range subrules {
 		covered := false
 		for _, ownerRule := range ownerRules {
@@ -55,18 +56,18 @@ func Covers(ownerRules, servantRules []rbac.PolicyRule) (bool, []rbac.PolicyRule
 
 // breadownRule takes a rule and builds an equivalent list of rules that each have at most one verb, one
 // resource, and one resource name
-func breakdownRule(rule rbac.PolicyRule) []rbac.PolicyRule {
-	subrules := []rbac.PolicyRule{}
-	for _, group := range rule.APIGroups {
-		for _, resource := range rule.Resources {
-			for _, verb := range rule.Verbs {
-				if len(rule.ResourceNames) > 0 {
-					for _, resourceName := range rule.ResourceNames {
-						subrules = append(subrules, rbac.PolicyRule{APIGroups: []string{group}, Resources: []string{resource}, Verbs: []string{verb}, ResourceNames: []string{resourceName}})
+func breakdownRule(rule rbacadapters.PolicyRule) []rbacadapters.PolicyRule {
+	subrules := []rbacadapters.PolicyRule{}
+	for _, group := range rule.APIGroups() {
+		for _, resource := range rule.Resources() {
+			for _, verb := range rule.Verbs() {
+				if len(rule.ResourceNames()) > 0 {
+					for _, resourceName := range rule.ResourceNames() {
+						subrules = append(subrules, rbacadapters.ToPolicyRule(&rbac.PolicyRule{APIGroups: []string{group}, Resources: []string{resource}, Verbs: []string{verb}, ResourceNames: []string{resourceName}}))
 					}
 
 				} else {
-					subrules = append(subrules, rbac.PolicyRule{APIGroups: []string{group}, Resources: []string{resource}, Verbs: []string{verb}})
+					subrules = append(subrules, rbacadapters.ToPolicyRule(&rbac.PolicyRule{APIGroups: []string{group}, Resources: []string{resource}, Verbs: []string{verb}}))
 				}
 
 			}
@@ -74,9 +75,9 @@ func breakdownRule(rule rbac.PolicyRule) []rbac.PolicyRule {
 	}
 
 	// Non-resource URLs are unique because they only combine with verbs.
-	for _, nonResourceURL := range rule.NonResourceURLs {
-		for _, verb := range rule.Verbs {
-			subrules = append(subrules, rbac.PolicyRule{NonResourceURLs: []string{nonResourceURL}, Verbs: []string{verb}})
+	for _, nonResourceURL := range rule.NonResourceURLs() {
+		for _, verb := range rule.Verbs() {
+			subrules = append(subrules, rbacadapters.ToPolicyRule(&rbac.PolicyRule{NonResourceURLs: []string{nonResourceURL}, Verbs: []string{verb}}))
 		}
 	}
 
@@ -130,18 +131,18 @@ func nonResourceURLCovers(ownerPath, subPath string) bool {
 
 // ruleCovers determines whether the ownerRule (which may have multiple verbs, resources, and resourceNames) covers
 // the subrule (which may only contain at most one verb, resource, and resourceName)
-func ruleCovers(ownerRule, subRule rbac.PolicyRule) bool {
-	verbMatches := has(ownerRule.Verbs, rbac.VerbAll) || hasAll(ownerRule.Verbs, subRule.Verbs)
-	groupMatches := has(ownerRule.APIGroups, rbac.APIGroupAll) || hasAll(ownerRule.APIGroups, subRule.APIGroups)
-	resourceMatches := has(ownerRule.Resources, rbac.ResourceAll) || hasAll(ownerRule.Resources, subRule.Resources)
-	nonResourceURLMatches := nonResourceURLsCoversAll(ownerRule.NonResourceURLs, subRule.NonResourceURLs)
+func ruleCovers(ownerRule, subRule rbacadapters.PolicyRule) bool {
+	verbMatches := has(ownerRule.Verbs(), rbac.VerbAll) || hasAll(ownerRule.Verbs(), subRule.Verbs())
+	groupMatches := has(ownerRule.APIGroups(), rbac.APIGroupAll) || hasAll(ownerRule.APIGroups(), subRule.APIGroups())
+	resourceMatches := has(ownerRule.Resources(), rbac.ResourceAll) || hasAll(ownerRule.Resources(), subRule.Resources())
+	nonResourceURLMatches := nonResourceURLsCoversAll(ownerRule.NonResourceURLs(), subRule.NonResourceURLs())
 
 	resourceNameMatches := false
 
-	if len(subRule.ResourceNames) == 0 {
-		resourceNameMatches = (len(ownerRule.ResourceNames) == 0)
+	if len(subRule.ResourceNames()) == 0 {
+		resourceNameMatches = (len(ownerRule.ResourceNames()) == 0)
 	} else {
-		resourceNameMatches = (len(ownerRule.ResourceNames) == 0) || hasAll(ownerRule.ResourceNames, subRule.ResourceNames)
+		resourceNameMatches = (len(ownerRule.ResourceNames()) == 0) || hasAll(ownerRule.ResourceNames(), subRule.ResourceNames())
 	}
 
 	return verbMatches && groupMatches && resourceMatches && resourceNameMatches && nonResourceURLMatches


### PR DESCRIPTION
1. The generic API server needs to be split out from the main repo.  
1. To do that, it must not rely on kubernetes/kubernetes only package.  
1. The internal clients are only in kube/kube.  
1. The RBAC authorizer uses the internal API types, which use the internal client
1. The RBAC authorizer needs to use the external types
1. The RBAC authorizer shares helpers with the RBAC storage for subject to rule resolution
1. The RBAC storage and those helpers should not be duplicated for every version.
1. We cannot reasonably pay conversion costs at the edges of the lister.
1. Two possible solutions: create an interface with adapters from all API version, create a secondary internal version cache driven by external version caches.

This is the first of the two possible solutions.  I'll try to wire up the second option next.

@kubernetes/sig-api-machinery-misc @smarterclayton @liggitt @sttts @ncdc I'm looking for alternative ideas and lacking those, I'm trying to sort out just how insane people think this is.