### PR TITLE
do not filter kubectl get pods if -o json or yaml

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -187,8 +187,11 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 	if err != nil {
 		return err
 	}
-	if len(options.Filenames) > 0 || argsHasNames {
-		cmd.Flag("show-all").Value.Set("true")
+	output := cmdutil.GetFlagString(cmd, "output")
+	if len(options.Filenames) > 0 || argsHasNames || output == "json" || output == "yaml" {
+		if !cmd.Flag("show-all").Changed {
+			cmd.Flag("show-all").Value.Set("true")
+		}
 	}
 	export := cmdutil.GetFlagBool(cmd, "export")
 

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -189,7 +189,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 
 	// always show resources when getting by name or filename, or if the output
 	// is machine-consumable, or if multiple resource kinds were requested.
-	if len(options.Filenames) > 0 || argsHasNames || cmdutil.OutputsRawFormat(cmd) || resource.MultipleTypesRequested(args) {
+	if len(options.Filenames) > 0 || argsHasNames || cmdutil.OutputsRawFormat(cmd) {
 		if !cmd.Flag("show-all").Changed {
 			cmd.Flag("show-all").Value.Set("true")
 		}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -182,13 +182,14 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 		return cmdutil.UsageError(cmd, usageString)
 	}
 
-	// always show resources when getting by name or filename
 	argsHasNames, err := resource.HasNames(args)
 	if err != nil {
 		return err
 	}
-	output := cmdutil.GetFlagString(cmd, "output")
-	if len(options.Filenames) > 0 || argsHasNames || output == "json" || output == "yaml" {
+
+	// always show resources when getting by name or filename, or if the output
+	// is machine-consumable, or if multiple resource kinds were requested.
+	if len(options.Filenames) > 0 || argsHasNames || cmdutil.OutputsRawFormat(cmd) || resource.MultipleTypesRequested(args) {
 		if !cmd.Flag("show-all").Changed {
 			cmd.Flag("show-all").Value.Set("true")
 		}

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -729,3 +729,19 @@ func RequireNoArguments(c *cobra.Command, args []string) {
 		CheckErr(UsageError(c, fmt.Sprintf(`unknown command %q`, strings.Join(args, " "))))
 	}
 }
+
+// OutputsRawFormat determines if a command's output format is machine parsable
+// or returns false if it is human readable (name, wide, etc.)
+func OutputsRawFormat(cmd *cobra.Command) bool {
+	output := GetFlagString(cmd, "output")
+	if output == "json" ||
+		output == "yaml" ||
+		output == "go-template" ||
+		output == "go-template-file" ||
+		output == "jsonpath" ||
+		output == "jsonpath-file" {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/38327

This patch sets the value of --show-all to true if the output format
specified is 'json' or 'yaml'.

**Release note**:
```release-note
release-note-none
```

@smarterclayton 