### PR TITLE
Fix spelling in package naming linter error message

### DIFF
--- a/hack/verify-pkg-names.sh
+++ b/hack/verify-pkg-names.sh
@@ -27,8 +27,8 @@ kube::golang::verify_go_version
 
 cd "${KUBE_ROOT}"
 if git --no-pager grep -E $'^(import |\t)[a-z]+[A-Z_][a-zA-Z]* "[^"]+"$' -- '**/*.go' ':(exclude)vendor/*' ':(exclude)staging/*'; then
-  echo "!!! Some package aliase break go conventions."
-  echo "To fix these errors, do not use capitalizaed or underlined characters"
+  echo "!!! Some package aliases break go conventions."
+  echo "To fix these errors, do not use capitalized or underlined characters"
   echo "in pkg aliases. Refer to https://blog.golang.org/package-names for more info."
   exit 1
 fi

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -65,8 +65,8 @@ echo "${reset}"
 echo -ne "Checking for package aliases... "
 if ! hack/verify-pkg-names.sh > /dev/null; then
   echo "${red}ERROR!"
-  echo "Some package aliase break go conventions. To fix these errors, "
-  echo "do not use capitalizaed or underlined characters in pkg aliases. "
+  echo "Some package aliases break go conventions. To fix these errors, "
+  echo "do not use capitalized or underlined characters in pkg aliases. "
   echo "Refer to https://blog.golang.org/package-names for more info."
   exit_code=1
 else


### PR DESCRIPTION
```release-note
NONE
```
