### PR TITLE
Add flag to node e2e test specifying location of ssh privkey

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -36,6 +36,7 @@ cluster/photon-controller/templates/salt-minion.sh:  hostname_override: $(ip rou
 cluster/photon-controller/util.sh:    node_ip=$(${PHOTON} vm networks "${node_id}" | grep -i $'\t'"00:0C:29" | grep -E '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1 | awk -F'\t' '{print $3}')
 cluster/photon-controller/util.sh:  local cert_dir="/srv/kubernetes"
 cluster/photon-controller/util.sh:  node_name=${1}
+cluster/photon-controller/util.sh:  ssh_key=$(ssh-add -L | head -1)
 cluster/rackspace/util.sh:    local node_ip=$(nova show --minimal ${NODE_NAMES[$i]} \
 cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest:{% set params = pillar['autoscaler_mig_config'] + " " + cloud_config -%}
 cluster/saltbase/salt/etcd/etcd.manifest:        "value": "{{ storage_backend }}"

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -573,6 +573,7 @@ sort-by
 source-file
 ssh-env
 ssh-keyfile
+ssh-key
 ssh-options
 ssh-user
 start-services


### PR DESCRIPTION
**What this PR does / why we need it**: in CI, the ssh private key is not always located at `$HOME/.ssh`, so it's helpful to be able to override it.

@krzyzacy here's my resurrected change. I'm not sure why I neglected to follow-through on it originally.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
