### PR TITLE
Don't evict static pods

### DIFF
--- a/pkg/kubelet/eviction/BUILD
+++ b/pkg/kubelet/eviction/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//pkg/kubelet/api/v1alpha1/stats:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/lifecycle:go_default_library",
+        "//pkg/kubelet/pod:go_default_library",
         "//pkg/kubelet/qos:go_default_library",
         "//pkg/kubelet/server/stats:go_default_library",
         "//pkg/kubelet/types:go_default_library",

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -312,6 +313,15 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 	// we kill at most a single pod during each eviction interval
 	for i := range activePods {
 		pod := activePods[i]
+		if kubepod.IsStaticPod(pod) {
+			// The eviction manager doesn't evict static pods. To stop a static
+			// pod, the admin needs to remove the manifest from kubelet's
+			// --config directory.
+			// TODO(39124): This is a short term fix, we can't assume static pods
+			// are always well behaved.
+			glog.Infof("eviction manager: NOT evicting static pod %v", pod.Name)
+			continue
+		}
 		status := v1.PodStatus{
 			Phase:   v1.PodFailed,
 			Message: fmt.Sprintf(message, resourceToReclaim),


### PR DESCRIPTION
A follow up to https://github.com/kubernetes/kubernetes/pull/38914, the desired behavior is to:    

1. deprioritize critical pods
2. never evict static pods

I don't think 1 needs a cherrypick if 2 goes in. 

partial fix for #https://github.com/kubernetes/kubernetes/issues/38322