### PR TITLE
fix image manager Start() function return

### DIFF
--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -44,7 +44,7 @@ type ImageGCManager interface {
 	GarbageCollect() error
 
 	// Start async garbage collection of images.
-	Start() error
+	Start()
 
 	GetImageList() ([]kubecontainer.Image, error)
 
@@ -152,7 +152,7 @@ func NewImageGCManager(runtime container.Runtime, cadvisorInterface cadvisor.Int
 	return im, nil
 }
 
-func (im *realImageGCManager) Start() error {
+func (im *realImageGCManager) Start() {
 	go wait.Until(func() {
 		// Initial detection make detected time "unknown" in the past.
 		var ts time.Time
@@ -178,7 +178,6 @@ func (im *realImageGCManager) Start() error {
 		}
 	}, 30*time.Second, wait.NeverStop)
 
-	return nil
 }
 
 // Get a list of images on this node

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1177,9 +1177,7 @@ func (kl *Kubelet) initializeModules() error {
 	}
 
 	// Step 4: Start the image manager.
-	if err := kl.imageManager.Start(); err != nil {
-		return fmt.Errorf("Failed to start ImageManager, images may not be garbage collected: %v", err)
-	}
+	kl.imageManager.Start()
 
 	// Step 5: Start container manager.
 	node, err := kl.getNodeAnyWay()


### PR DESCRIPTION
realImageGCManager's Start()  function will always return nil,we do not need the err return value,drop it.

