### PR TITLE
[CRI]Make dockershim RemoveContainer/PodSandbox API idempodent

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -254,6 +254,10 @@ func (ds *dockerService) RemoveContainer(containerID string) error {
 	// we can't prevent that now, so we also clean up the symlink here.
 	err := ds.removeContainerLogSymlink(containerID)
 	if err != nil {
+		// no-op if container has already been removed.
+		if containerNotExistErr(err) {
+			return nil
+		}
 		return err
 	}
 	err = ds.client.RemoveContainer(containerID, dockertypes.ContainerRemoveOptions{RemoveVolumes: true})

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -127,7 +127,13 @@ func (ds *dockerService) StopPodSandbox(podSandboxID string) error {
 // RemovePodSandbox removes the sandbox. If there are running containers in the
 // sandbox, they should be forcibly removed.
 func (ds *dockerService) RemovePodSandbox(podSandboxID string) error {
-	return ds.client.RemoveContainer(podSandboxID, dockertypes.ContainerRemoveOptions{RemoveVolumes: true})
+	err := ds.client.RemoveContainer(podSandboxID, dockertypes.ContainerRemoveOptions{RemoveVolumes: true})
+
+	// no-op if sandbox has already been removed.
+	if err != nil && !containerNotExistErr(err) {
+		return err
+	}
+	return nil
 	// TODO: remove all containers in the sandbox.
 }
 

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -35,7 +35,8 @@ import (
 )
 
 const (
-	annotationPrefix = "annotation."
+	annotationPrefix            = "annotation."
+	noSuchContainerErrorMessage = "No such cotainer: "
 )
 
 var (
@@ -313,4 +314,9 @@ func recoverFromConflictIfNeeded(client dockertools.DockerInterface, err error) 
 	} else {
 		glog.V(2).Infof("Successfully removed conflicting sandbox %q", id)
 	}
+}
+
+// containerNotExistErr returns if error message in given err is NoSuchContainer type error.
+func containerNotExistErr(err error) bool {
+	return strings.Contains(err.Error(), noSuchContainerErrorMessage)
 }


### PR DESCRIPTION
Signed-off-by: Crazykev <crazykev@zju.edu.cn>

**What this PR does / why we need it**:

According to latest CRI API:
>
    // RemovePodSandbox removes the sandbox. If there are any running containers
    // in the sandbox, they must be forcibly terminated and removed.
    // This call is idempotent, and must not return an error if the sandbox has
    // already been removed.

RemovePodSandbox should be idempotent, same as RemoveContainer/StopPodSandbox/Container API, StopContainer has been guaranteed by underlaying docker implement(return 304 http code), this PR make Remove API idempotent by checking container whether exist first.

/cc @yujuhong @feiskyer 