### PR TITLE
Node E2E: Set user with `--ssh-user` flag when running remote node e2e.

### DIFF
--- a/test/e2e_node/jenkins/e2e-node-jenkins.sh
+++ b/test/e2e_node/jenkins/e2e-node-jenkins.sh
@@ -41,9 +41,9 @@ TIMEOUT=${TIMEOUT:-"45m"}
 
 mkdir -p ${ARTIFACTS}
 
-go run test/e2e_node/runner/remote/run_remote.go  --logtostderr --vmodule=*=4 --ssh-env="gce" \
-  --zone="$GCE_ZONE" --project="$GCE_PROJECT" --hosts="$GCE_HOSTS" \
-  --images="$GCE_IMAGES" --image-project="$GCE_IMAGE_PROJECT" \
+go run test/e2e_node/runner/remote/run_remote.go  --logtostderr --vmodule=*=4 \
+  --ssh-env="gce" --ssh-user="$GCE_USER" --zone="$GCE_ZONE" --project="$GCE_PROJECT" \
+  --hosts="$GCE_HOSTS" --images="$GCE_IMAGES" --image-project="$GCE_IMAGE_PROJECT" \
   --image-config-file="$GCE_IMAGE_CONFIG_PATH" --cleanup="$CLEANUP" \
   --results-dir="$ARTIFACTS" --ginkgo-flags="--nodes=$PARALLELISM $GINKGO_FLAGS" \
   --test-timeout="$TIMEOUT" --test_args="$TEST_ARGS --kubelet-flags=\"$KUBELET_ARGS\"" \

--- a/test/e2e_node/jenkins/template.properties
+++ b/test/e2e_node/jenkins/template.properties
@@ -1,4 +1,6 @@
 # Copy this file to your home directory and modify
+# User used on the gce instances to run the test.
+GCE_USER=
 # Path to a yaml or json file describing images to run or empty
 GCE_IMAGE_CONFIG_PATH=
 # Names of gce hosts to test against (must be resolvable) or empty

--- a/test/e2e_node/remote/ssh.go
+++ b/test/e2e_node/remote/ssh.go
@@ -29,6 +29,7 @@ import (
 
 var sshOptions = flag.String("ssh-options", "", "Commandline options passed to ssh.")
 var sshEnv = flag.String("ssh-env", "", "Use predefined ssh options for environment.  Options: gce")
+var sshUser = flag.String("ssh-user", "", "Use predefined user for ssh.")
 
 var sshOptionsMap map[string]string
 
@@ -53,13 +54,18 @@ func AddHostnameIp(hostname, ip string) {
 	hostnameIpOverrides.m[hostname] = ip
 }
 
+// GetHostnameOrIp converts hostname into ip and apply user if necessary.
 func GetHostnameOrIp(hostname string) string {
 	hostnameIpOverrides.RLock()
 	defer hostnameIpOverrides.RUnlock()
+	host := hostname
 	if ip, found := hostnameIpOverrides.m[hostname]; found {
-		return ip
+		host = ip
 	}
-	return hostname
+	if *sshUser != "" {
+		host = fmt.Sprintf("%s@%s", *sshUser, host)
+	}
+	return host
 }
 
 // getSSHCommand handles proper quoting so that multiple commands are executed in the same shell over ssh


### PR DESCRIPTION
This PR unblocks https://github.com/kubernetes/test-infra/issues/1348.

In our test environment, we must login test instance as user `jenkins` because of the service account. Node e2e is always using the default user on the host, which works fine till now, because it is always run as `jenkins` in our test environment.

However, now we moved the test runner into a docker container, inside the container user is `root` by default, which will cause error:
```
Permission denied (publickey)
```

This PR added a flag `--ssh-user` to explicitly specify the user used to ssh into test instance. The dockerized test runner can set user to `jenkins` with this flag.

@krzyzacy  @ixdy 