### PR TITLE
add additional e2e rbac bindings to match existing users

### DIFF
--- a/cluster/addons/e2e-rbac-bindings/README.md
+++ b/cluster/addons/e2e-rbac-bindings/README.md
@@ -1,0 +1,3 @@
+These resources are used to add extra (non-default) bindings to e2e to match users and groups
+that are particular to the e2e environment.  These are not standard bootstrap bindings and 
+not standard users they are bound to.  This is not a recipe for adding bootstrap bindings.

--- a/cluster/addons/e2e-rbac-bindings/admin-binding.yaml
+++ b/cluster/addons/e2e-rbac-bindings/admin-binding.yaml
@@ -1,0 +1,16 @@
+# something in the kube e2e uses an admin identity to list pods
+# TODO figure out what is doing this and ultimately remove this binding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-cluster-admin
+  labels:
+    kubernetes.io/cluster-service: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiVersion: rbac/v1alpha1
+  kind: User
+  name: admin

--- a/cluster/addons/e2e-rbac-bindings/kubecfg-binding.yaml
+++ b/cluster/addons/e2e-rbac-bindings/kubecfg-binding.yaml
@@ -1,0 +1,18 @@
+# This is the main user for the e2e tests.  This is ok to leave long term
+# since the first user in the test can reasonably be high power
+# TODO consider provisioning each test its namespace and giving it an
+# admin user.  This still has to exist, but e2e wouldn't normally use it
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: kubecfg-cluster-admin
+  labels:
+    kubernetes.io/cluster-service: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiVersion: rbac/v1alpha1
+  kind: User
+  name: kubecfg

--- a/cluster/addons/e2e-rbac-bindings/kubelet-binding.yaml
+++ b/cluster/addons/e2e-rbac-bindings/kubelet-binding.yaml
@@ -1,0 +1,19 @@
+# The GKE environments don't have kubelets with certificates that
+# identify the system:nodes group.  They use the kubelet identity
+# TODO cjcullen should figure out how wants to manage his upgrade
+# this will only hold the e2e tests until we get an authorizer
+# which authorizes particular nodes
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelet-cluster-admin
+  labels:
+    kubernetes.io/cluster-service: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- apiVersion: rbac/v1alpha1
+  kind: User
+  name: kubelet

--- a/cluster/addons/e2e-rbac-bindings/random-addon-grabbag.yaml
+++ b/cluster/addons/e2e-rbac-bindings/random-addon-grabbag.yaml
@@ -1,0 +1,19 @@
+# TODO remove this
+# currently, the kube-addon-manager is adding lots of pods which all share
+# the system:serviceaccount:kube-system:default identity.  We need to subdivide
+# those service accounts, figure out which ones we're going to make bootstrap roles for
+# and bind those particular roles in the addon yaml itself.  This just gets us started
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+kind: ClusterRoleBinding
+metadata:
+  name: todo-remove-grabbag-cluster-admin
+  labels:
+    kubernetes.io/cluster-service: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: kube-system

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1058,6 +1058,10 @@ function start-kube-addons {
   echo "Prepare kube-addons manifests and start kube addon manager"
   local -r src_dir="${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty"
   local -r dst_dir="/etc/kubernetes/addons"
+
+  # prep the additional bindings that are particular to e2e users and groups
+  setup-addon-manifests "addons" "e2e-rbac-bindings"
+
   # Set up manifests of other addons.
   if [[ "${ENABLE_CLUSTER_MONITORING:-}" == "influxdb" ]] || \
      [[ "${ENABLE_CLUSTER_MONITORING:-}" == "google" ]] || \


### PR DESCRIPTION
Adds RBAC bindings that are particular to the users and groups for e2e tests to prime the authorizer.