### PR TITLE
kubeadm: Default to using token discovery.

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -52,4 +52,8 @@ func SetDefaults_MasterConfiguration(obj *MasterConfiguration) {
 	if obj.Networking.DNSDomain == "" {
 		obj.Networking.DNSDomain = DefaultServiceDNSDomain
 	}
+
+	if obj.Discovery.Token == nil && obj.Discovery.File == nil && obj.Discovery.HTTPS == nil {
+		obj.Discovery.Token = &TokenDiscovery{}
+	}
 }

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -550,6 +550,7 @@ func FuzzerFor(t *testing.T, version schema.GroupVersion, src rand.Source) *fuzz
 			obj.API.Port = 20
 			obj.Networking.ServiceSubnet = "foo"
 			obj.Networking.DNSDomain = "foo"
+			obj.Discovery.Token = &kubeadm.TokenDiscovery{}
 		},
 		func(s *policy.PodDisruptionBudgetStatus, c fuzz.Continue) {
 			c.FuzzNoCustom(s) // fuzz self without calling this function again


### PR DESCRIPTION
Recent changes to support multiple methods for discovery meant that
"kubeadm init" no longer was sufficient and users would need to add
"--discovery token://" to achieve the same results.

Instead lets assume discovery if the user does not specify anything else
to maintain parity and the brevity of our original instructions.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

CC @mikedanese @luxas 