### PR TITLE
[WIP] Improve kubectl.GetPrinter

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -141,7 +141,10 @@ func GetPrinter(format, formatArgument string, noHeaders bool) (ResourcePrinter,
 			return nil, false, err
 		}
 	case "wide":
-		fallthrough
+		return NewHumanReadablePrinter(PrintOptions{
+			NoHeaders: noHeaders,
+			Wide:      true,
+		}), false, nil
 	case "":
 		return nil, false, nil
 	default:


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/38779
Addresses an item from: https://github.com/kubernetes/kubernetes/issues/38768

**Release note**:
```release-note
release-note-none
```

This patch prevents potential panics by callers of `kubectl.GetPrinter` by avoiding returning  both a `nil` error and `printer` when the specified output format is `wide`.

I am hoping this can at least serve to start a discussion for how to handle this case in `kubectl.GetPrinter`. Both [PrinterForMapping](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/util/factory_object_mapping.go#L324) and [PrinterForCommand](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/util/printing.go#L108) make a call to `kubectl.GetPrinter` (`PrinterForMapping` calls this indirectly through a call to [PrinterForCommand](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/util/factory_object_mapping.go#L325)) and only avoid dealing with both a `nil` printer and `nil` error (when output format == `wide`) due to `PrinterForCommand` simply returning the results it receives from `kubectl.GetPrinter`, and `PrinterForMapping` [creating an entirely new printer](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/util/factory_object_mapping.go#L352) when this is the case.

An alternative solution to this could be to still return a `nil` printer [in kubectl.GetPrinter](https://github.com/kubernetes/kubernetes/pull/39095/files#diff-0fc00b94def20930bb77075c7e2c7599R144), but return an error (such as `unsupported output format`) and have `PrinterForCommand` handle this error by either creating a `NewHumanReadablePrinter` at this point, or delegating the error to `PrinterForMapping` which already creates a `NewHumanReadable` printer when `generic == false` for `kubectl.GetPrinter`.

@fabianofranz 