### PR TITLE
e2e test should fail if err==timeout

### DIFF
--- a/test/e2e/garbage_collector.go
+++ b/test/e2e/garbage_collector.go
@@ -210,7 +210,7 @@ var _ = framework.KubeDescribe("Garbage collector", func() {
 				return false, nil
 			}
 			return true, nil
-		}); err != nil && err != wait.ErrWaitTimeout {
+		}); err != nil {
 			framework.Failf("%v", err)
 		}
 		By("wait for 30 seconds to see if the garbage collector mistakenly deletes the pods")


### PR DESCRIPTION
If err==timeout, it means the replicaset (the owner) is not deleted after 30s, which indicates a bug, so the e2e test should fail.