### PR TITLE
Disable verify-test-owners.sh and make `go vet` more obvious

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -26,6 +26,7 @@ EXCLUDED_CHECKS=(
   "verify-linkcheck.sh"  # runs in separate Jenkins job once per day due to high network usage
   "verify-govet.sh"      # it has a separate make vet target
   "verify-staging-client-go.sh" # TODO: enable the script after 1.5 code freeze
+  "verify-test-owners.sh"  # TODO(rmmh): figure out how to avoid endless conflicts
   )
 
 function is-excluded {

--- a/hack/make-rules/vet.sh
+++ b/hack/make-rules/vet.sh
@@ -46,4 +46,5 @@ if [[ ${#targets[@]} -eq 0 ]]; then
   targets=$(go list -e ./... | egrep -v "/(third_party|vendor|staging|clientset_generated)/")
 fi
 
+set -x
 go vet "${goflags[@]:+${goflags[@]}}" ${targets[@]}

--- a/hack/verify-test-owners.sh
+++ b/hack/verify-test-owners.sh
@@ -24,6 +24,5 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 cd "${KUBE_ROOT}"
 if ! hack/update_owners.py --check; then
     echo 'Run ./hack/update_owners.py to fix it'
-    exit  # TODO(rmmh): fix Github merging to respect .gitattributes
     exit 1
 fi


### PR DESCRIPTION
**What this PR does / why we need it**: I and others keep seeing the verify-test-owners.sh failure and think that's why the PR failed checks. Rather than making verify-test-owners.sh pass with errors, just skip it entirely.

Also print out the `go vet` command we're running, to make that failure more obvious.

cc @k82cn @saad-ali 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
