### PR TITLE
Add pod anti-affinity and a disruption budget to cockroachdb example

### DIFF
--- a/examples/cockroachdb/README.md
+++ b/examples/cockroachdb/README.md
@@ -116,7 +116,7 @@ Because all of the resources in this example have been tagged with the label `ap
 we can clean up everything that we created in one quick command using a selector on that label:
 
 ```shell
-kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget -l app=cockroachdb
 ```
 
 

--- a/examples/cockroachdb/cockroachdb-statefulset.yaml
+++ b/examples/cockroachdb/cockroachdb-statefulset.yaml
@@ -54,6 +54,18 @@ spec:
   selector:
     app: cockroachdb
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: cockroachdb-budget
+  labels:
+    app: cockroachdb
+spec:
+  selector:
+    matchLabels:
+      app: cockroachdb
+  minAvailable: 67%
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -66,6 +78,22 @@ spec:
       labels:
         app: cockroachdb
       annotations:
+        scheduler.alpha.kubernetes.io/affinity: >
+            {
+              "podAntiAffinity": {
+                "preferredDuringSchedulingIgnoredDuringExecution": [{
+                  "weight": 100,
+                  "labelSelector": {
+                    "matchExpressions": [{
+                      "key": "app",
+                      "operator": "In",
+                      "values": ["cockroachdb"]
+                    }]
+                  },
+                  "topologyKey": "kubernetes.io/hostname"
+                }]
+              }
+            }
         # Init containers are run only once in the lifetime of a pod, before
         # it's started up for the first time. It has to exit successfully
         # before the pod's main containers are allowed to start.
@@ -80,6 +108,7 @@ spec:
             {
                 "name": "bootstrap",
                 "image": "cockroachdb/cockroach-k8s-init:0.1",
+                "imagePullPolicy": "IfNotPresent",
                 "args": [
                   "-on-start=/on-start.sh",
                   "-service=cockroachdb"

--- a/examples/cockroachdb/minikube.sh
+++ b/examples/cockroachdb/minikube.sh
@@ -29,7 +29,7 @@
 set -exuo pipefail
 
 # Clean up anything from a prior run:
-kubectl delete statefulsets,pods,persistentvolumes,persistentvolumeclaims,services -l app=cockroachdb
+kubectl delete statefulsets,persistentvolumes,persistentvolumeclaims,services,poddisruptionbudget -l app=cockroachdb
 
 # Make persistent volumes and (correctly named) claims. We must create the
 # claims here manually even though that sounds counter-intuitive. For details


### PR DESCRIPTION
Pulling in some useful 1.5 features.