### PR TITLE
Add a custom user-agent header

### DIFF
--- a/pkg/api/context.go
+++ b/pkg/api/context.go
@@ -62,6 +62,9 @@ const (
 
 	// userAgentKey is the context key for the request user agent.
 	userAgentKey
+
+	// kubernetesUserAgentKey is the context key for the customized kubernetes user agent.
+	kubernetesUserAgentKey
 )
 
 // NewContext instantiates a base context object for request flows.
@@ -149,4 +152,15 @@ func WithUserAgent(parent Context, userAgent string) Context {
 func UserAgentFrom(ctx Context) (string, bool) {
 	userAgent, ok := ctx.Value(userAgentKey).(string)
 	return userAgent, ok
+}
+
+// WithClientVersion returns a copy of parent in which the user value is set
+func WithKubernetesUserAgent(parent Context, kubernetesUserAgent string) Context {
+	return WithValue(parent, kubernetesUserAgentKey, kubernetesUserAgent)
+}
+
+// KubernetesUserAgentFrom returns the value of the kubernetesUserAgent key on the ctx
+func KubernetesUserAgentFrom(ctx Context) (string, bool) {
+	kubernetesUserAgent, ok := ctx.Value(kubernetesUserAgentKey).(string)
+	return kubernetesUserAgent, ok
 }

--- a/pkg/apis/meta/v1/types.go
+++ b/pkg/apis/meta/v1/types.go
@@ -551,3 +551,8 @@ const (
 	LabelSelectorOpExists       LabelSelectorOperator = "Exists"
 	LabelSelectorOpDoesNotExist LabelSelectorOperator = "DoesNotExist"
 )
+
+// KubernetesUserAgentHeader is a custom http header alternative to the
+// standard User-Agent header, which might be modified when a request goes
+// through a proxy.
+const KubernetesUserAgentHeader = "Kubernetes-User-Agent"

--- a/pkg/client/transport/round_trippers.go
+++ b/pkg/client/transport/round_trippers.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 )
 
 // HTTPWrappersForConfig wraps a round tripper with any relevant layered
@@ -153,10 +154,12 @@ func NewUserAgentRoundTripper(agent string, rt http.RoundTripper) http.RoundTrip
 
 func (rt *userAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	if len(req.Header.Get("User-Agent")) != 0 {
+		req.Header.Set(metav1.KubernetesUserAgentHeader, req.Header.Get("User-Agent"))
 		return rt.rt.RoundTrip(req)
 	}
 	req = cloneRequest(req)
 	req.Header.Set("User-Agent", rt.agent)
+	req.Header.Set(metav1.KubernetesUserAgentHeader, rt.agent)
 	return rt.rt.RoundTrip(req)
 }
 

--- a/pkg/client/transport/round_trippers_test.go
+++ b/pkg/client/transport/round_trippers_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 )
 
 type testRoundTripper struct {
@@ -88,6 +90,9 @@ func TestUserAgentRoundTripper(t *testing.T) {
 	if rt.Request.Header.Get("User-Agent") != "other" {
 		t.Errorf("unexpected user agent header: %#v", rt.Request)
 	}
+	if rt.Request.Header.Get(metav1.KubernetesUserAgentHeader) != "other" {
+		t.Errorf("unexpected customized kubernetes user agent header: %#v", rt.Request)
+	}
 
 	req = &http.Request{}
 	NewUserAgentRoundTripper("test", rt).RoundTrip(req)
@@ -99,6 +104,9 @@ func TestUserAgentRoundTripper(t *testing.T) {
 	}
 	if rt.Request.Header.Get("User-Agent") != "test" {
 		t.Errorf("unexpected user agent header: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get(metav1.KubernetesUserAgentHeader) != "test" {
+		t.Errorf("unexpected customized kubernetes user agent header: %#v", rt.Request)
 	}
 }
 


### PR DESCRIPTION
Fix #38217.

We have fixed some client incompatibilities by looking at User-Agent, e.g., #35840. However, User-Agent doesn't go through all proxies untouched, so we need to use a custom header to state the user identity.

@kubernetes/sig-api-machinery-misc @jlowdermilk @lavalamp 

This is an API change, so @kubernetes/api-reviewers.