### PR TITLE
api: well-known-labels redo the master / node labels

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1588,10 +1588,22 @@ func getNodeExternalIP(node *api.Node) string {
 
 // findNodeRole returns the role of a given node, or "" if none found.
 // The role is determined by looking in order for:
-// * a kubernetes.io/role label
-// * a kubeadm.alpha.kubernetes.io/role label
+// * a node-role.kubernetes.io/{node,master} label (v1.6+)
+// * a kubernetes.io/role label (v1.5)
+// * a kubeadm.alpha.kubernetes.io/role label (pre-v1.5)
 // If no role is found, ("", nil) is returned
 func findNodeRole(node *api.Node) string {
+	var roles []string
+	if role := node.Labels[metav1.LabelNodeRoleMaster]; role == "true" {
+		roles = append(roles, "master")
+	}
+	if role := node.Labels[metav1.LabelNodeRoleNode]; role == "true" {
+		roles = append(roles, "node")
+	}
+	if len(roles) > 0 {
+		return strings.Join(roles, ",")
+	}
+
 	if role := node.Labels[metav1.NodeLabelRole]; role != "" {
 		return role
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/well_known_labels.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/well_known_labels.go
@@ -35,7 +35,7 @@ const (
 	LabelFluentdDsReady = "alpha.kubernetes.io/fluentd-ds-ready"
 )
 
-// Role labels are applied to Nodes to mark their purpose.  In particular, we
+// Node Role labels are applied to Nodes to mark their purpose.  In particular, we
 // usually want to distinguish the master, so that we can isolate privileged
 // pods and operations.
 //
@@ -52,9 +52,27 @@ const (
 //
 // So that we can recognize master nodes in consequent places though (such as
 // kubectl get nodes), we encourage installations to use the well-known labels.
-// We define NodeLabelRole, which is the preferred form, but we will also recognize
-// other forms that are known to be in widespread use (NodeLabelKubeadmAlphaRole).
+//
+// We define LabelNodeRoleMaster and LabelNodeRoleNode, which are the preferred
+// form, but we will also recognize other forms that are known to be in
+// widespread use (NodeLabelKubeadmAlphaRole, NodeLabelRole, etc) .
 
+const (
+	// LabelNodeRoleMaster is set to the value "true" indicating a master node.
+	// A master node typically runs kubernetes system components and will not typically run user workloads.
+	// When set to any value other than "true" it is ignored.
+	LabelNodeRoleMaster = "node-role.kubernetes.io/master"
+
+	// LabelNodeRoleNode is set to the value "true" indicating a "normal" node.
+	// When set to any value other than "true" it is ignored.
+	LabelNodeRoleNode = "node-role.kubernetes.io/node"
+)
+
+// NodeLabelRole and NodeLabelKubeadmAlphaRole are in-use but
+// LabelNodeRoleMaster and LabelNodeRoleNode are preferred. NodeLabelRole
+// worked but did not allow Nodes to take on multiple roles. For example, a
+// single-node minikube cluster will have a node that is both a "master role"
+// and "node role".
 const (
 	// NodeLabelRole is the preferred label applied to a Node as a hint that it has a particular purpose (defined by the value).
 	NodeLabelRole = "kubernetes.io/role"


### PR DESCRIPTION
The setup of the kubernetes.io/role labels makes it impossible to have a
node be both "master" and "normal" at the same time. If possible I want
to enable people to use Kubernetes in single node configurations for
development and match production as close as possible.

For example if these labels are used to make decisions say using
nodeSelectors then this is troublesome in single node cases.

Alternatives:

- Create kubernetes.io/role=master+node for these combined role
- Ask users to select role=master OR role=node

Both of these force the complexity on the user and creates problems if
we come up with some future role like perhaps role=federation or
something.

Thanks to @jbeda for discussing this with me.