### PR TITLE
Node E2E: Do not use sudo when untar node e2e tar ball.

### DIFF
--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -93,7 +93,9 @@ func RunRemote(suite TestSuite, archive string, host string, cleanup bool, junit
 		fmt.Sprintf("tar -xzvf ./%s", archiveName),
 	)
 	glog.V(2).Infof("Extracting tar on %q", host)
-	if output, err := SSH(host, "sh", "-c", cmd); err != nil {
+	// Do not use sudo here, because `sudo tar -x` will recover the file ownership inside the tar ball, but
+	// we want the extracted files to be owned by the current user.
+	if output, err := SSHNoSudo(host, "sh", "-c", cmd); err != nil {
 		// Exit failure with the error
 		return "", false, fmt.Errorf("failed to extract test archive: %v, output: %q", err, output)
 	}


### PR DESCRIPTION
`sudo tar -x` will [extract files with original file ownership](http://unix.stackexchange.com/questions/264464/sudo-tar-changes-extracted-files-ownership-to-unknown-user), which is not what we want.
This also causes problem to https://github.com/kubernetes/test-infra/issues/1348.

Because in https://github.com/kubernetes/test-infra/issues/1348 we move node e2e runner into a docker container. Inside the container, the user is `root` by default, so the tar ball has `root` ownership.

If we untar the tar ball with `sudo`, it will recover the `root` ownership and the following operation may not have enough permission.

No matter what, we should not recover the file ownership inside the tar ball because:
* We don't care it.
* It may even not exist on the host.

@krzyzacy 