### PR TITLE
Update trusty helper scripts to use absolute path

### DIFF
--- a/cluster/gce/trusty/master-helper.sh
+++ b/cluster/gce/trusty/master-helper.sh
@@ -22,7 +22,7 @@
 # GCI and Trusty share the configuration code. We have to keep the GCI specific code
 # here as long as the release-1.2 branch has not been deprecated.
 
-source ./helper.sh
+source ${KUBE_ROOT}/cluster/gce/trusty/helper.sh
 
 # create-master-instance creates the master instance. If called with
 # an argument, the argument is used as the name to a reserved IP

--- a/cluster/gce/trusty/node-helper.sh
+++ b/cluster/gce/trusty/node-helper.sh
@@ -22,7 +22,7 @@
 # GCI and Trusty share the configuration code. We have to keep the GCI specific code
 # here as long as the release-1.2 branch has not been deprecated.
 
-source ./helper.sh
+source ${KUBE_ROOT}/cluster/gce/trusty/helper.sh
 
 # $1: template name (required)
 function create-node-instance-template {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Update trusty helper scripts to use the ${KUBE_ROOT} environment
variable in order to reference the helper.sh script using an absolute
path. This fixes an error when using trusty as the OS distribution.

<!-- **Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # -->

<!-- **Special notes for your reviewer**: -->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
Update trusty helper scripts to use the ${KUBE_ROOT} environment
variable in order to reference the helper.sh script using an absolute
path. This fixes an error when using trusty as the OS distribution.
```
