### PR TITLE
Modify help description

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -52,7 +52,7 @@ func AddOutputFlags(cmd *cobra.Command) {
 
 // AddNoHeadersFlags adds no-headers flags to a command.
 func AddNoHeadersFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("no-headers", false, "When using the default or custom-column output format, don't print headers.")
+	cmd.Flags().Bool("no-headers", false, "When using the default or custom-column output format, print headers.")
 }
 
 // PrintSuccess prints message after finishing mutating operations


### PR DESCRIPTION
When the default value, the headers  is actually printed
root@ubuntu:/home/template# kubectl get nodes
NAME            STATUS    AGE
10.*.*.*             Ready     4h
10.*.*.*             Ready     4h
root@ubuntu:/home/template# kubectl get nodes --no-headers=true
10.*.*.*             Ready     4h
10.*.*.*             Ready     4h