### PR TITLE
Make fluentd pods critical

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
       labels:
         k8s-app: fluentd-es
         kubernetes.io/cluster-service: "true"

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   template:
     metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
       labels:
         k8s-app: fluentd-gcp
         kubernetes.io/cluster-service: "true"

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -4,6 +4,8 @@ kind: Pod
 metadata:
   name: fluentd-cloud-logging
   namespace: kube-system
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: fluentd-logging
 spec:


### PR DESCRIPTION
Related to https://github.com/kubernetes/kubernetes/issues/38322

Make fluentd critical so it will be evicted with less probability.

CC @piosz @fgrzadkowski