### PR TITLE
add kubekins as cluster-admin

### DIFF
--- a/cluster/addons/e2e-rbac-bindings/e2e-user-binding.yaml
+++ b/cluster/addons/e2e-rbac-bindings/e2e-user-binding.yaml
@@ -1,11 +1,12 @@
 # This is the main user for the e2e tests.  This is ok to leave long term
 # since the first user in the test can reasonably be high power
+# its kubecfg in gce and kubekins in gke
 # TODO consider provisioning each test its namespace and giving it an
 # admin user.  This still has to exist, but e2e wouldn't normally use it
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 kind: ClusterRoleBinding
 metadata:
-  name: kubecfg-cluster-admin
+  name: e2e-user-cluster-admin
   labels:
     kubernetes.io/cluster-service: "true"
 roleRef:
@@ -16,3 +17,6 @@ subjects:
 - apiVersion: rbac/v1alpha1
   kind: User
   name: kubecfg
+- apiVersion: rbac/v1alpha1
+  kind: User
+  name: kubekins@kubernetes-jenkins.iam.gserviceaccount.com


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/39153

We added RBAC support for e2e tests a couple hours ago.  Looks like GKE uses a different user we need grant powers for.  I suspect this just borked the queue.