### PR TITLE
DO NOT MERGE: add a test that always fails

### DIFF
--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1486,3 +1486,7 @@ func TestTruncatePodHostname(t *testing.T) {
 		assert.Equal(t, test.output, output)
 	}
 }
+
+func TestAlwaysFail(t *testing.T) {
+	t.Fatal("this should always fail")
+}


### PR DESCRIPTION
Trying to demonstrate the difference in test results from test-go vs. bazel.