### PR TITLE
optimize relist() function

### DIFF
--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -197,8 +197,7 @@ func (g *GenericPLEG) relist() {
 		glog.Errorf("GenericPLEG: Unable to retrieve pods: %v", err)
 		return
 	}
-	pods := kubecontainer.Pods(podList)
-	g.podRecords.setCurrent(pods)
+	g.podRecords.setCurrent(podList)
 
 	// Compare the old and the current pods, and generate events.
 	eventsByPodID := map[types.UID][]*PodLifecycleEvent{}


### PR DESCRIPTION
g.runtime.GetPods already return type []*Pod, so maybe we do not to do the type conversion
