### PR TITLE
examples: use 'kubectl scale' in cockroach statefulset example

### DIFF
--- a/examples/cockroachdb/README.md
+++ b/examples/cockroachdb/README.md
@@ -98,10 +98,10 @@ database and ensuring the other replicas have all data that was written.
 
 ## Scaling up or down
 
-Simply patch the Stateful Set by running
+Scale the Stateful Set by running
 
 ```shell
-kubectl patch statefulset cockroachdb -p '{"spec":{"replicas":4}}'
+kubectl scale statefulset cockroachdb --replicas=4
 ```
 
 Note that you may need to create a new persistent volume claim first. If you


### PR DESCRIPTION
A scaler for statefulsets has been added since 1.4 (https://github.com/kubernetes/kubernetes/pull/30813).