### PR TITLE
Fix Capabilities documentation so it matches the code

### DIFF
--- a/api/swagger-spec/apps_v1alpha1.json
+++ b/api/swagger-spec/apps_v1alpha1.json
@@ -2542,14 +2542,14 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Removed capabilities"
      }

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -2541,14 +2541,14 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Removed capabilities"
      }

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -2546,14 +2546,14 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Removed capabilities"
      }

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -8343,14 +8343,14 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Removed capabilities"
      }

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -18996,14 +18996,14 @@
      "add": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Added capabilities"
      },
      "drop": {
       "type": "array",
       "items": {
-       "$ref": "v1.Capability"
+       "type": "string"
       },
       "description": "Removed capabilities"
      }


### PR DESCRIPTION
The code says Capabilities has two fields: Add which is a string array and Drop which is a string array:

https://github.com/kubernetes/kubernetes/blob/52df372f9b95d668834c1f7a3056aa1a4b56ccd3/pkg/api/types.go#L1226

