### PR TITLE
Include swaggerapi urls in system:discovery role

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -82,7 +82,7 @@ func ClusterRoles() []rbac.ClusterRole {
 			// a role which provides just enough power to discovery API versions for negotiation
 			ObjectMeta: api.ObjectMeta{Name: "system:discovery"},
 			Rules: []rbac.PolicyRule{
-				rbac.NewRule("get").URLs("/version", "/api", "/api/*", "/apis", "/apis/*").RuleOrDie(),
+				rbac.NewRule("get").URLs("/version", "/swaggerapi", "/swaggerapi/*", "/api", "/api/*", "/apis", "/apis/*").RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -383,6 +383,8 @@ items:
     - /api/*
     - /apis
     - /apis/*
+    - /swaggerapi
+    - /swaggerapi/*
     - /version
     verbs:
     - get


### PR DESCRIPTION
Used by client side API validation and for client schema generation