### PR TITLE
[Federation] Kubefed init verifies if control plane pods are up before returning success

### DIFF
--- a/federation/pkg/kubefed/testing/BUILD
+++ b/federation/pkg/kubefed/testing/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["testing.go"],
     tags = ["automanaged"],
     deps = [
+        "//federation/client/clientset_generated/federation_clientset:go_default_library",
         "//federation/pkg/kubefed/util:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/apimachinery/registered:go_default_library",

--- a/federation/pkg/kubefed/testing/testing.go
+++ b/federation/pkg/kubefed/testing/testing.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 
+	fedclient "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
 	"k8s.io/kubernetes/federation/pkg/kubefed/util"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
@@ -51,6 +52,18 @@ func NewFakeAdminConfig(f cmdutil.Factory, kubeconfigGlobal string) (util.AdminC
 
 func (f *fakeAdminConfig) PathOptions() *clientcmd.PathOptions {
 	return f.pathOptions
+}
+
+func (f *fakeAdminConfig) FederationClientset(context, kubeconfigPath string) (*fedclient.Clientset, error) {
+	fakeRestClient, err := f.hostFactory.RESTClient()
+	if err != nil {
+		return nil, err
+	}
+
+	// we ignore the function params and use the client from
+	// the same fakefactory to create a federation clientset
+	// our fake factory exposes only the healthz api for this client
+	return fedclient.New(fakeRestClient), nil
 }
 
 func (f *fakeAdminConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {

--- a/federation/pkg/kubefed/util/BUILD
+++ b/federation/pkg/kubefed/util/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["util.go"],
     tags = ["automanaged"],
     deps = [
+        "//federation/client/clientset_generated/federation_clientset:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/client/unversioned/clientcmd:go_default_library",

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	fedclient "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
@@ -39,13 +40,16 @@ const (
 
 // AdminConfig provides a filesystem based kubeconfig (via
 // `PathOptions()`) and a mechanism to talk to the federation
-// host cluster.
+// host cluster and the federation control plane api server.
 type AdminConfig interface {
 	// PathOptions provides filesystem based kubeconfig access.
 	PathOptions() *clientcmd.PathOptions
+	// FedClientSet provides a federation API compliant clientset
+	// to communicate with the federation control plane api server
+	FederationClientset(context, kubeconfigPath string) (*fedclient.Clientset, error)
 	// HostFactory provides a mechanism to communicate with the
 	// cluster where federation control plane is hosted.
-	HostFactory(host, kubeconfigPath string) cmdutil.Factory
+	HostFactory(hostcontext, kubeconfigPath string) cmdutil.Factory
 }
 
 // adminConfig implements the AdminConfig interface.
@@ -64,17 +68,30 @@ func (a *adminConfig) PathOptions() *clientcmd.PathOptions {
 	return a.pathOptions
 }
 
-func (a *adminConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
+func (a *adminConfig) FederationClientset(context, kubeconfigPath string) (*fedclient.Clientset, error) {
+	fedConfig := a.getClientConfig(context, kubeconfigPath)
+	fedClientConfig, err := fedConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	return fedclient.NewForConfigOrDie(fedClientConfig), nil
+}
+
+func (a *adminConfig) HostFactory(hostcontext, kubeconfigPath string) cmdutil.Factory {
+	hostClientConfig := a.getClientConfig(hostcontext, kubeconfigPath)
+	return cmdutil.NewFactory(hostClientConfig)
+}
+
+func (a *adminConfig) getClientConfig(context, kubeconfigPath string) clientcmd.ClientConfig {
 	loadingRules := *a.pathOptions.LoadingRules
 	loadingRules.Precedence = a.pathOptions.GetLoadingPrecedence()
 	loadingRules.ExplicitPath = kubeconfigPath
 	overrides := &clientcmd.ConfigOverrides{
-		CurrentContext: host,
+		CurrentContext: context,
 	}
 
-	hostClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, overrides)
-
-	return cmdutil.NewFactory(hostClientConfig)
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, overrides)
 }
 
 // SubcommandFlags holds the flags required by the subcommands of


### PR DESCRIPTION
This PR updates the functionality as needed in issue https://github.com/kubernetes/kubernetes/issues/37841.

cc @kubernetes/sig-cluster-federation @nikhiljindal @madhusudancs @shashidharatd 
