### PR TITLE
Automated cherry pick of #38669 #39078 upstream release 1.5

### DIFF
--- a/pkg/storage/BUILD
+++ b/pkg/storage/BUILD
@@ -48,6 +48,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cacher_whitebox_test.go",
         "selection_predicate_test.go",
         "util_test.go",
         "watch_cache_test.go",

--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -805,9 +805,27 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) {
 	case !curObjPasses && oldObjPasses:
 		watchEvent = watch.Event{Type: watch.Deleted, Object: object}
 	}
+
+	// We need to ensure that if we put event X to the c.result, all
+	// previous events were already put into it before, no matter whether
+	// c.done is close or not.
+	// Thus we cannot simply select from c.done and c.result and this
+	// would give us non-determinism.
+	// At the same time, we don't want to block infinitely on putting
+	// to c.result, when c.done is already closed.
+
+	// This ensures that with c.done already close, we at most once go
+	// into the next select after this. With that, no matter which
+	// statement we choose there, we will deliver only consecutive
+	// events.
+	select {
+	case <-c.done:
+		return
+	default:
+	}
+
 	select {
 	case c.result <- watchEvent:
-	// don't block on c.result if c.done is closed
 	case <-c.done:
 	}
 }

--- a/pkg/storage/cacher.go
+++ b/pkg/storage/cacher.go
@@ -696,6 +696,7 @@ type cacheWatcher struct {
 	input   chan watchCacheEvent
 	result  chan watch.Event
 	filter  filterObjectFunc
+	done    chan struct{}
 	stopped bool
 	forget  func(bool)
 }
@@ -704,6 +705,7 @@ func newCacheWatcher(resourceVersion uint64, chanSize int, initEvents []watchCac
 	watcher := &cacheWatcher{
 		input:   make(chan watchCacheEvent, chanSize),
 		result:  make(chan watch.Event, chanSize),
+		done:    make(chan struct{}),
 		filter:  filter,
 		stopped: false,
 		forget:  forget,
@@ -728,6 +730,7 @@ func (c *cacheWatcher) stop() {
 	defer c.Unlock()
 	if !c.stopped {
 		c.stopped = true
+		close(c.done)
 		close(c.input)
 	}
 }
@@ -793,13 +796,19 @@ func (c *cacheWatcher) sendWatchCacheEvent(event *watchCacheEvent) {
 		glog.Errorf("unexpected copy error: %v", err)
 		return
 	}
+	var watchEvent watch.Event
 	switch {
 	case curObjPasses && !oldObjPasses:
-		c.result <- watch.Event{Type: watch.Added, Object: object}
+		watchEvent = watch.Event{Type: watch.Added, Object: object}
 	case curObjPasses && oldObjPasses:
-		c.result <- watch.Event{Type: watch.Modified, Object: object}
+		watchEvent = watch.Event{Type: watch.Modified, Object: object}
 	case !curObjPasses && oldObjPasses:
-		c.result <- watch.Event{Type: watch.Deleted, Object: object}
+		watchEvent = watch.Event{Type: watch.Deleted, Object: object}
+	}
+	select {
+	case c.result <- watchEvent:
+	// don't block on c.result if c.done is closed
+	case <-c.done:
 	}
 }
 

--- a/pkg/storage/cacher_whitebox_test.go
+++ b/pkg/storage/cacher_whitebox_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+// verifies the cacheWatcher.process goroutine is properly cleaned up even if
+// the writes to cacheWatcher.result channel is blocked.
+func TestCacheWatcherCleanupNotBlockedByResult(t *testing.T) {
+	var lock sync.RWMutex
+	count := 0
+	filter := func(string, runtime.Object) bool { return true }
+	forget := func(bool) {
+		lock.Lock()
+		defer lock.Unlock()
+		count++
+	}
+	initEvents := []watchCacheEvent{
+		{Object: &api.Pod{}},
+		{Object: &api.Pod{}},
+	}
+	// set the size of the buffer of w.result to 0, so that the writes to
+	// w.result is blocked.
+	w := newCacheWatcher(0, 0, initEvents, filter, forget)
+	w.Stop()
+	if err := wait.PollImmediate(1*time.Second, 5*time.Second, func() (bool, error) {
+		lock.RLock()
+		defer lock.RUnlock()
+		return count == 2, nil
+	}); err != nil {
+		t.Fatalf("expected forget() to be called twice, because sendWatchCacheEvent should not be blocked by the result channel: %v", err)
+	}
+}


### PR DESCRIPTION
Cherrypick changes to fix go-routine leaks in cacher.

Ref #38669 #39078

@davidopp 