### PR TITLE
Adds assignees for kube-dns

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/OWNERS
+++ b/cluster/addons/dns-horizontal-autoscaler/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- bowei
+- mrhohn

--- a/cluster/addons/dns/OWNERS
+++ b/cluster/addons/dns/OWNERS
@@ -1,0 +1,3 @@
+assignees:
+- bowei
+- mrhohn


### PR DESCRIPTION
Adds assignees for auto-assigning. Does not add assignees for pkg/dns folder as we are moving it out.

@thockin 