### PR TITLE
make: allow overriding quick-release opts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,10 @@ KUBE_GOFLAGS := $(GOFLAGS)
 KUBE_GOLDFLAGS := $(GOLDFLAGS)
 KUBE_GOGCFLAGS = $(GOGCFLAGS)
 
+# Extra options for the release or quick-release options:
+KUBE_RELEASE_RUN_TESTS := $(KUBE_RELEASE_RUN_TESTS) 
+KUBE_FASTBUILD := $(KUBE_FASTBUILD)
+
 # This controls the verbosity of the build.  Higher numbers mean more output.
 KUBE_VERBOSE ?= 1
 
@@ -347,17 +351,23 @@ endif
 
 define RELEASE_SKIP_TESTS_HELP_INFO
 # Build a release, but skip tests
+# 
+# Args:
+#   KUBE_RELEASE_RUN_TESTS: Whether to run tests. Set to 'y' to run tests anyways.
+#   KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'true' to do so.
 #
 # Example:
 #   make release-skip-tests
+#   make quick-release
 endef
 .PHONY: release-skip-tests quick-release
 ifeq ($(PRINT_HELP),y)
 release-skip-tests quick-release:
 	@echo "$$RELEASE_SKIP_TESTS_HELP_INFO"
 else
+release-skip-tests quick-release: KUBE_RELEASE_RUN_TESTS = n KUBE_FASTBUILD = true
 release-skip-tests quick-release:
-	KUBE_RELEASE_RUN_TESTS=n KUBE_FASTBUILD=true build/release.sh
+	build/release.sh
 endif
 
 define CROSS_HELP_INFO


### PR DESCRIPTION
Prior to this change, `make quick-release KUBE_RELEASE_RUN_TESTS=y`
would still not run the tests. This change makes it so such overriding
works.

It also specifies the options as variables, which helps some shells with
tab-completion.

Finally, I plan to add a new "quick-release" option that not everyone will want on in #35249 (`RELEASE_HYPERKUBE_ONLY`), and this sets the needed groundwork to make such an "opt-in for quickness" flag possible.

**Release note**:
```release-note
NONE
```
