### PR TITLE
Tolerate a Forbidden error in e2e RBAC RoleBinding setup.

### DIFF
--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"time"
 
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	legacyv1 "k8s.io/kubernetes/pkg/api/v1"
 	rbacv1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
 	"k8s.io/kubernetes/pkg/runtime/schema"
@@ -94,6 +95,13 @@ var _ = framework.KubeDescribe("Loadbalancing: L7", func() {
 				},
 			},
 		})
+		if apierrors.IsForbidden(err) {
+			// The user is not allowed to create ClusterRoleBindings. This
+			// probably means that RBAC is not being used. If RBAC is being
+			// used, this test will probably fail later.
+			framework.Logf("Attempt to create ClusterRoleBinding was forbidden: %v.", err)
+			return
+		}
 		framework.ExpectNoError(err)
 
 		err = framework.WaitForAuthorizationUpdate(jig.client.Authorization(),

--- a/test/e2e/node_problem_detector.go
+++ b/test/e2e/node_problem_detector.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/v1"
 	legacyv1 "k8s.io/kubernetes/pkg/api/v1"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
@@ -81,6 +82,13 @@ var _ = framework.KubeDescribe("NodeProblemDetector", func() {
 				},
 			},
 		})
+		if apierrors.IsForbidden(err) {
+			// The user is not allowed to create ClusterRoleBindings. This
+			// probably means that RBAC is not being used. If RBAC is being
+			// used, this test will probably fail later.
+			framework.Logf("Attempt to create ClusterRoleBinding was forbidden: %v.", err)
+			return
+		}
 		framework.ExpectNoError(err)
 
 		err = framework.WaitForAuthorizationUpdate(f.ClientSet.Authorization(),

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/v1"
 	legacyv1 "k8s.io/kubernetes/pkg/api/v1"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
@@ -187,6 +188,13 @@ var _ = framework.KubeDescribe("PreStop", func() {
 				},
 			},
 		})
+		if apierrors.IsForbidden(err) {
+			// The user is not allowed to create ClusterRoleBindings. This
+			// probably means that RBAC is not being used. If RBAC is being
+			// used, this test will probably fail later.
+			framework.Logf("Attempt to create ClusterRoleBinding was forbidden: %v.", err)
+			return
+		}
 		framework.ExpectNoError(err)
 
 		err = framework.WaitForAuthorizationUpdate(f.ClientSet.Authorization(),


### PR DESCRIPTION
The three tests that require RBAC rolebindings to be set up currently fail if RBAC is not enabled. This allows those tests to work as they did before we added the RBAC setup step.

Addresses #39259