### PR TITLE
StorageClass shall not be namespaced in kubectl.

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -2228,6 +2228,10 @@ func printNetworkPolicyList(list *extensions.NetworkPolicyList, w io.Writer, opt
 func printStorageClass(sc *storage.StorageClass, w io.Writer, options PrintOptions) error {
 	name := sc.Name
 
+	if options.WithNamespace {
+		return fmt.Errorf("storageClass is not namespaced")
+	}
+
 	if storageutil.IsDefaultAnnotation(sc.ObjectMeta) {
 		name += " (default)"
 	}

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/policy"
+	"k8s.io/kubernetes/pkg/apis/storage"
 	kubectltesting "k8s.io/kubernetes/pkg/kubectl/testing"
 	"k8s.io/kubernetes/pkg/runtime"
 	"k8s.io/kubernetes/pkg/runtime/schema"
@@ -1128,6 +1129,12 @@ func TestPrintHumanReadableWithNamespace(t *testing.T) {
 				Conditions: []api.ComponentCondition{
 					{Type: api.ComponentHealthy, Status: api.ConditionTrue, Message: "ok", Error: ""},
 				},
+			},
+			isNamespaced: false,
+		},
+		{
+			obj: &storage.StorageClass{
+				ObjectMeta: api.ObjectMeta{Name: name},
 			},
 			isNamespaced: false,
 		},


### PR DESCRIPTION
Kubectl shall report error when getting Storage Class
with '--all-namespaces' option specified.

Fixed #39200