### PR TITLE
Remove system:anonymous check from kubectl test

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -583,11 +583,11 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			_, err := framework.RunHostCmd(ns, simplePodName, "/kubectl get pods --token=invalid --v=7 2>&1")
 			framework.Logf("got err %v", err)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(ContainSubstring("User \"system:anonymous\" cannot list pods in the namespace"))
 			Expect(err).To(ContainSubstring("Using in-cluster namespace"))
 			Expect(err).To(ContainSubstring("Using in-cluster configuration"))
 			Expect(err).To(ContainSubstring("Authorization: Bearer invalid"))
-			Expect(err).To(ContainSubstring("Response Status: 403 Forbidden"))
+			// TODO(kubernetes/kubernetes#39267): We should only see a 401 from an invalid bearer token.
+			Expect(err).To(Or(ContainSubstring("Response Status: 403 Forbidden"), ContainSubstring("Response Status: 401 Unauthorized")))
 
 			By("trying to use kubectl with invalid server")
 			_, err = framework.RunHostCmd(ns, simplePodName, "/kubectl get pods --server=invalid --v=6 2>&1")


### PR DESCRIPTION
This verbiage doesn't appear when the cluster is `AlwaysAllow` (and just makes the check more brittle).

Follow-on to #39263, this is the last (consistent) failure on [kops-aws](https://k8s-testgrid.appspot.com/google-aws#kops-aws&sort-by-failures=)