### PR TITLE
Remove HostRecord annotation (beta feature)

### DIFF
--- a/pkg/api/endpoints/util.go
+++ b/pkg/api/endpoints/util.go
@@ -28,18 +28,6 @@ import (
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 )
 
-const (
-	// TODO: to be deleted after v1.3 is released
-	// Its value is the json representation of map[string(IP)][HostRecord]
-	// example: '{"10.245.1.6":{"HostName":"my-webserver"}}'
-	PodHostnamesAnnotation = "endpoints.beta.kubernetes.io/hostnames-map"
-)
-
-// TODO: to be deleted after v1.3 is released
-type HostRecord struct {
-	HostName string
-}
-
 // RepackSubsets takes a slice of EndpointSubset objects, expands it to the full
 // representation, and then repacks that into the canonical layout.  This
 // ensures that code which operates on these objects can rely on the common

--- a/pkg/api/v1/endpoints/util.go
+++ b/pkg/api/v1/endpoints/util.go
@@ -28,18 +28,6 @@ import (
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 )
 
-const (
-	// TODO: to be deleted after v1.3 is released
-	// Its value is the json representation of map[string(IP)][HostRecord]
-	// example: '{"10.245.1.6":{"HostName":"my-webserver"}}'
-	PodHostnamesAnnotation = "endpoints.beta.kubernetes.io/hostnames-map"
-)
-
-// TODO: to be deleted after v1.3 is released
-type HostRecord struct {
-	HostName string
-}
-
 // RepackSubsets takes a slice of EndpointSubset objects, expands it to the full
 // representation, and then repacks that into the canonical layout.  This
 // ensures that code which operates on these objects can rely on the common

--- a/pkg/api/validation/BUILD
+++ b/pkg/api/validation/BUILD
@@ -19,7 +19,6 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/api/endpoints:go_default_library",
         "//pkg/api/meta:go_default_library",
         "//pkg/api/pod:go_default_library",
         "//pkg/api/resource:go_default_library",


### PR DESCRIPTION
The annotation has made it to GA so this code should be deleted.

**Release note**:
```release-note
The 'endpoints.beta.kubernetes.io/hostnames-map' annotation is no longer supported.  Users can use the 'Endpoints.subsets[].addresses[].hostname' field instead.
```