### PR TITLE
fix nil check and typos

### DIFF
--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -156,10 +156,10 @@ func TestConfigDirCleaner(t *testing.T) {
 		for _, createFile := range test.setupFiles {
 			fullPath := filepath.Join(tmpDir, createFile)
 			f, err := os.Create(fullPath)
-			defer f.Close()
 			if err != nil {
 				t.Errorf("Unable to create test file: %s", err)
 			}
+			defer f.Close()
 		}
 
 		resetConfigDir(tmpDir, filepath.Join(tmpDir, "pki"))

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -312,7 +312,7 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 			command = append(command, "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname")
 		}
 
-		// This is a critical "bugfix". Any version above this is vulnarable unless a RBAC/ABAC-authorizer is provided (which kubeadm doesn't for the time being)
+		// This is a critical "bugfix". Any version above this is vulnerable unless a RBAC/ABAC-authorizer is provided (which kubeadm doesn't for the time being)
 		if err == nil && k8sVersion.GTE(anonAuthDisableAPIServerMinVersion) {
 			command = append(command, "--anonymous-auth=false")
 		}

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -69,7 +69,7 @@ func TestInvalidVersion(t *testing.T) {
 		ver, err := KubernetesReleaseVersion(s)
 		t.Log("Invalid: ", s, ver, err)
 		if err == nil {
-			t.Errorf("KubernetesReleaseVersion error expected for version %q, but returned succesfully", s)
+			t.Errorf("KubernetesReleaseVersion error expected for version %q, but returned successfully", s)
 		}
 		if ver != "" {
 			t.Errorf("KubernetesReleaseVersion should return empty string in case of error. Returned %q for version %q", ver, s)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. nil error should be checked before defer statement.
2. fix some typos.

Signed-off-by: bruceauyeung ouyang.qinhua@zte.com.cn