### PR TITLE
Small improve for GetContainerOOMScoreAdjust

### DIFF
--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -72,8 +72,8 @@ func GetContainerOOMScoreAdjust(pod *v1.Pod, container *v1.Container, memoryCapa
 		return (1000 + guaranteedOOMScoreAdj)
 	}
 	// Give burstable pods a higher chance of survival over besteffort pods.
-	if int(oomScoreAdjust) == besteffortOOMScoreAdj {
-		return int(oomScoreAdjust - 1)
+	if int(oomScoreAdjust) >= besteffortOOMScoreAdj {
+		return int(besteffortOOMScoreAdj - 1)
 	}
 	return int(oomScoreAdjust)
 }


### PR DESCRIPTION
In `GetContainerOOMScoreAdjust`, make logic more clear for the case `oomScoreAdjust >= besteffortOOMScoreAdj`. If `besteffortOOMScoreAdj`  is defined to another value(e.g. 996), suppose `oomScoreAdjust` is 999, the function will return 998(which equals 999 - 1) instead of 995(996 -1).