### PR TITLE
Remove build containers

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -69,7 +69,7 @@ build: bin/$(BIN)-$(ARCH)
 
 bin/$(BIN)-$(ARCH): $(SRCS)
 	mkdir -p bin
-	docker run -u $$(id -u):$$(id -g) -v $$(pwd):/build \
+	docker run --rm -u $$(id -u):$$(id -g) -v $$(pwd):/build \
 		$(KUBE_CROSS_IMAGE):$(KUBE_CROSS_VERSION) \
 		/bin/bash -c "\
 			cd /build && \


### PR DESCRIPTION
5 containers are created during the build and not used anymore. Removing them.
