### PR TITLE
fix kubecfg-file flag description of kube-dns

### DIFF
--- a/cmd/kube-dns/app/options/options.go
+++ b/cmd/kube-dns/app/options/options.go
@@ -139,8 +139,8 @@ func (s *KubeDNSConfig) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.KubeConfigFile, "kubecfg-file", s.KubeConfigFile,
 		"Location of kubecfg file for access to kubernetes master service;"+
-			" --kube-master-url overrides the URL part of this; if neither this nor"+
-			" --kube-master-url are provided, defaults to service account tokens")
+			" --kube-master-url overrides the URL part of this; if this is not"+
+			" provided, defaults to service account tokens")
 	fs.Var(kubeMasterURLVar{&s.KubeMasterURL}, "kube-master-url",
 		"URL to reach kubernetes master. Env variables in this flag will be expanded.")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
kube-dns module could run just specified the `--kube-master-url` flag and without provided `--kubecfg-file`. As the flag description of `--kubecfg-file` says : 
>Location of kubecfg file for access to kubernetes master service; --kube-master-url overrides the URL part of this; if neither this nor --kube-master-url are provided, defaults to service account tokens

i.e. only used InClusterConfig when both `--kube-master-url` and `--kubecfg-file` were not provided.

But after this pr #39118 
kube-dns will use `InClusterConfig` when just only the `--kubecfg-file` was not provided , so update this flag description. 
