### PR TITLE
fix kubectl get psp --all-namespace error

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1827,6 +1827,10 @@ func printConfigMapList(list *api.ConfigMapList, w io.Writer, options printers.P
 func printPodSecurityPolicy(item *extensions.PodSecurityPolicy, w io.Writer, options printers.PrintOptions) error {
 	name := formatResourceName(options.Kind, item.Name, options.WithKind)
 
+	if options.WithNamespace {
+		return fmt.Errorf("podSecurityPolicy is not namespaced")
+	}
+
 	_, err := fmt.Fprintf(w, "%s\t%t\t%v\t%s\t%s\t%s\t%s\t%t\t%v\n", name, item.Spec.Privileged,
 		item.Spec.AllowedCapabilities, item.Spec.SELinux.Rule,
 		item.Spec.RunAsUser.Rule, item.Spec.FSGroup.Rule, item.Spec.SupplementalGroups.Rule, item.Spec.ReadOnlyRootFilesystem, item.Spec.Volumes)

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -1214,6 +1214,28 @@ func TestPrintHumanReadableWithNamespace(t *testing.T) {
 			},
 			isNamespaced: false,
 		},
+		{
+			obj: &extensions.PodSecurityPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: name,
+				},
+				Spec: extensions.PodSecurityPolicySpec{
+					SELinux: extensions.SELinuxStrategyOptions{
+						Rule: extensions.SELinuxStrategyRunAsAny,
+					},
+					RunAsUser: extensions.RunAsUserStrategyOptions{
+						Rule: extensions.RunAsUserStrategyRunAsAny,
+					},
+					FSGroup: extensions.FSGroupStrategyOptions{
+						Rule: extensions.FSGroupStrategyRunAsAny,
+					},
+					SupplementalGroups: extensions.SupplementalGroupsStrategyOptions{
+						Rule: extensions.SupplementalGroupsStrategyRunAsAny,
+					},
+				},
+			},
+			isNamespaced: false,
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
Old:
```
# kubectl get psp --all-namespaces
NAMESPACE    NAME      PRIV      CAPS       SELINUX            RUNASUSER   FSGROUP    SUPGROUP   READONLYROOTFS   VOLUMES
privileged   true      []        RunAsAny   RunAsAny           RunAsAny    RunAsAny   false      [*]
restricted   false     []        RunAsAny   MustRunAsNonRoot   RunAsAny    RunAsAny   false      [emptyDir secret downwardAPI configMap persistentVolumeClaim]
```
New:
```
# kubectl get psp --all-namespaces
NAMESPACE   NAME      PRIV      CAPS      SELINUX   RUNASUSER   FSGROUP   SUPGROUP   READONLYROOTFS   VOLUMES
error: podSecurityPolicy is not namespaced
```