### PR TITLE
fix sudo usage to not create directories with root perms in user's directory

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -988,7 +988,7 @@ function parse-master-env() {
 function update-or-verify-gcloud() {
   local sudo_prefix=""
   if [ ! -w $(dirname `which gcloud`) ]; then
-    sudo_prefix="sudo"
+    sudo_prefix="sudo -H"
   fi
   # update and install components as needed
   if [[ "${KUBE_PROMPT_FOR_UPDATE}" == "y" ]]; then
@@ -996,7 +996,7 @@ function update-or-verify-gcloud() {
     ${sudo_prefix} gcloud ${gcloud_prompt:-} components install beta
     ${sudo_prefix} gcloud ${gcloud_prompt:-} components update
   else
-    local version=$(${sudo_prefix} gcloud version --format=json)
+    local version=$(gcloud version --format=json)
     python -c'
 import json,sys
 from distutils import version


### PR DESCRIPTION
**What this PR does / why we need it**:

sudo is called in a way that is very configuration specific,

i.e. what is the home directory of the "sudo" user.  is it root's or is the users.

If it's the user (such as default on Ubuntu), this will cause gcloud to drop log files in user's home directory that are owned by root.

sudo -H avoids this problem

Also, gcloud version shouldn't needed to run with sudo

**Which issue this PR fixes**
Fixes: https://github.com/kubernetes/kubernetes/issues/20228

**Special notes for your reviewer**:

**Release note**:
```release-note 
NONE
```
