### PR TITLE
fix incorrect parameter passing

### DIFF
--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig_test.go
@@ -177,7 +177,7 @@ func TestWriteKubeconfigToDisk(t *testing.T) {
 				err,
 			)
 		}
-		newFile, err := ioutil.ReadFile(configPath)
+		newFile, _ := ioutil.ReadFile(configPath)
 		if !bytes.Equal(newFile, rt.file) {
 			t.Errorf(
 				"failed WriteKubeconfigToDisk config write:\n\texpected: %s\n\t  actual: %s",


### PR DESCRIPTION
Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>


**What this PR does / why we need it**:
1. fix incorrect parameter passing when creating error
2. fix ineffectual assignment to err variable.

