### PR TITLE
pkg/labels: fix the godoc for Parse()

### DIFF
--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -728,15 +728,16 @@ func (p *Parser) parseExactValue() (sets.String, error) {
 // as they parse different selectors with different syntaxes.
 // The input will cause an error if it does not follow this form:
 //
-// <selector-syntax> ::= <requirement> | <requirement> "," <selector-syntax> ]
-// <requirement> ::= [!] KEY [ <set-based-restriction> | <exact-match-restriction> ]
-// <set-based-restriction> ::= "" | <inclusion-exclusion> <value-set>
-// <inclusion-exclusion> ::= <inclusion> | <exclusion>
-//           <exclusion> ::= "notin"
-//           <inclusion> ::= "in"
-//           <value-set> ::= "(" <values> ")"
-//              <values> ::= VALUE | VALUE "," <values>
-// <exact-match-restriction> ::= ["="|"=="|"!="] VALUE
+//  <selector-syntax>         ::= <requirement> | <requirement> "," <selector-syntax>
+//  <requirement>             ::= [!] KEY [ <set-based-restriction> | <exact-match-restriction> ]
+//  <set-based-restriction>   ::= "" | <inclusion-exclusion> <value-set>
+//  <inclusion-exclusion>     ::= <inclusion> | <exclusion>
+//  <exclusion>               ::= "notin"
+//  <inclusion>               ::= "in"
+//  <value-set>               ::= "(" <values> ")"
+//  <values>                  ::= VALUE | VALUE "," <values>
+//  <exact-match-restriction> ::= ["="|"=="|"!="] VALUE
+//
 // KEY is a sequence of one or more characters following [ DNS_SUBDOMAIN "/" ] DNS_LABEL. Max length is 63 characters.
 // VALUE is a sequence of zero or more characters "([A-Za-z0-9_-\.])". Max length is 63 characters.
 // Delimiter is white space: (' ', '\t')


### PR DESCRIPTION
previously the formatting was broken for labels.Parse() function. I
fixed the spacing so it will format correctly for the generated go docs.
There was also a dangling "]" at the end of the first line so i deleted
it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This fixes a formatting issue with the generated go documentation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
