### PR TITLE
comment:  _ "k8s.io/kubernetes/pkg/cloudprovider/providers" is not uesd

### DIFF
--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -25,7 +25,7 @@ import (
 
 	// Cloud providers
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
-	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
+	//_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
 
 	// Volume plugins
 	"github.com/golang/glog"


### PR DESCRIPTION
**What this PR does / why we need it**:

_ "k8s.io/kubernetes/pkg/cloudprovider/providers" is not uesd
