### PR TITLE
nodeports usage should be part of LoadBalancer service type

### DIFF
--- a/pkg/quota/evaluator/core/services.go
+++ b/pkg/quota/evaluator/core/services.go
@@ -141,7 +141,9 @@ func (p *serviceEvaluator) Usage(item runtime.Object) (api.ResourceList, error) 
 		value := resource.NewQuantity(int64(ports), resource.DecimalSI)
 		result[api.ResourceServicesNodePorts] = *value
 	case api.ServiceTypeLoadBalancer:
-		// load balancer services need to count load balancers
+		// load balancer services need to count node ports and load balancers
+		value := resource.NewQuantity(int64(ports), resource.DecimalSI)
+		result[api.ResourceServicesNodePorts] = *value
 		result[api.ResourceServicesLoadBalancers] = *(resource.NewQuantity(1, resource.DecimalSI))
 	}
 	return result, nil


### PR DESCRIPTION
Since a creation of Service of type LoadBalancer will allocate NodePorts as well, so it makes more sense to account for the NodePort usage in the LoadBalancer switch case.

check here: https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/service/rest.go#L553 for the logic on whether it should assign a nodeport for the service.

```release-note
services of type loadbalancer consume both loadbalancer and nodeport quota.
```