### PR TITLE
e2e: Use sudo to start/stop kubelet service

### DIFF
--- a/test/e2e/persistent_volumes-disruptive.go
+++ b/test/e2e/persistent_volumes-disruptive.go
@@ -233,7 +233,7 @@ func kubeletCommand(kOp kubeletOpt, c clientset.Interface, pod *v1.Pod) {
 	nodeIP, err := framework.GetHostExternalAddress(c, pod)
 	Expect(err).NotTo(HaveOccurred())
 	nodeIP = nodeIP + ":22"
-	sshResult, err := framework.SSH("/etc/init.d/kubelet "+string(kOp), nodeIP, framework.TestContext.Provider)
+	sshResult, err := framework.SSH("sudo /etc/init.d/kubelet "+string(kOp), nodeIP, framework.TestContext.Provider)
 	Expect(err).NotTo(HaveOccurred())
 	framework.LogSSHResult(sshResult)
 


### PR DESCRIPTION
It seems that user 'jenkins' does not have permissions to manage services. sudo is already used to e.g. check iptables in https://github.com/kubernetes/kubernetes/blob/master/test/e2e/service.go#L402

Fixes #37956