### PR TITLE
log cfgzErr if err happened

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -356,6 +356,8 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.KubeletDeps) (err error) {
 				if err != nil {
 					return err
 				}
+			} else {
+				glog.Errorf("failed to init dynamic Kubelet configuration sync: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
We need to log err info when err info returned by initConfigz(),no matter what the result of utilconfig.DefaultFeatureGate.DynamicKubeletConfig() is and
whether s.RunOnce is true or not.
We should log the initKubeletConfigSync() err info too.
