### PR TITLE
Update New Relic sample docs with dynamic hostname info

### DIFF
--- a/examples/newrelic/README.md
+++ b/examples/newrelic/README.md
@@ -137,6 +137,17 @@ spec:
 
 The daemonset instructs Kubernetes to spawn pods on each node, mapping /dev/, /run/, /sys/, and /var/log to the container. It also maps the secrets we set up earlier to /etc/kube-newrelic/config, and sources them in the startup script, configuring the agent properly.
 
+#### DaemonSet customization
+
+- To include a custom hostname prefix (or other per-container environment variables that can be generated at run-time), you can modify the DaemonSet `command` value:
+
+```
+command: [ "bash", "-c", "source /etc/kube-newrelic/config && export NRSYSMOND_hostname=mycluster-$(hostname) && /usr/sbin/nrsysmond -E -F" ]
+```
+
+When the New Relic agent starts, `NRSYSMOND_hostname` is set using the output of `hostname` with `mycluster` prepended.
+
+
 ### Known issues
 
 It's a bit cludgy to define the environment variables like we do here in these config files. There is [another issue](https://github.com/kubernetes/kubernetes/issues/4710) to discuss adding mapping secrets to environment variables in Kubernetes.


### PR DESCRIPTION
This PR shows how to set extra environment variables for the New Relic DaemonSet that can be generated at runtime. I'm using this technique to prepend cluster names to host names as they are reported to New Relic.
