### PR TITLE
Allow rolebinding/clusterrolebinding with explicit bind permission check

### DIFF
--- a/cluster/addons/e2e-rbac-bindings/e2e-user-binding.yaml
+++ b/cluster/addons/e2e-rbac-bindings/e2e-user-binding.yaml
@@ -1,6 +1,6 @@
 # This is the main user for the e2e tests.  This is ok to leave long term
 # since the first user in the test can reasonably be high power
-# its kubecfg in gce and kubekins in gke
+# its kubecfg in gce
 # TODO consider provisioning each test its namespace and giving it an
 # admin user.  This still has to exist, but e2e wouldn't normally use it
 apiVersion: rbac.authorization.k8s.io/v1alpha1
@@ -17,6 +17,3 @@ subjects:
 - apiVersion: rbac/v1alpha1
   kind: User
   name: kubecfg
-- apiVersion: rbac/v1alpha1
-  kind: User
-  name: kubekins@kubernetes-jenkins.iam.gserviceaccount.com

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -252,7 +252,7 @@ func (c completedConfig) New() (*Master, error) {
 		certificatesrest.RESTStorageProvider{},
 		extensionsrest.RESTStorageProvider{ResourceInterface: thirdparty.NewThirdPartyResourceServer(s, c.StorageFactory)},
 		policyrest.RESTStorageProvider{},
-		rbacrest.RESTStorageProvider{},
+		rbacrest.RESTStorageProvider{Authorizer: c.GenericConfig.Authorizer},
 		storagerest.RESTStorageProvider{},
 	}
 	m.InstallAPIs(c.Config.APIResourceConfigSource, restOptionsFactory, restStorageProviders...)

--- a/pkg/registry/rbac/BUILD
+++ b/pkg/registry/rbac/BUILD
@@ -12,8 +12,11 @@ go_library(
     srcs = ["escalation_check.go"],
     tags = ["automanaged"],
     deps = [
+        "//pkg/apis/rbac:go_default_library",
         "//pkg/genericapiserver/api/request:go_default_library",
+        "//pkg/util/runtime:go_default_library",
         "//vendor:k8s.io/apiserver/pkg/authentication/user",
+        "//vendor:k8s.io/apiserver/pkg/authorization/authorizer",
     ],
 )
 

--- a/pkg/registry/rbac/clusterrolebinding/policybased/BUILD
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/genericapiserver/api/request:go_default_library",
         "//pkg/registry/rbac:go_default_library",
         "//pkg/runtime:go_default_library",
+        "//vendor:k8s.io/apiserver/pkg/authorization/authorizer",
     ],
 )
 

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -18,6 +18,7 @@ limitations under the License.
 package policybased
 
 import (
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
@@ -32,11 +33,13 @@ var groupResource = rbac.Resource("clusterrolebindings")
 type Storage struct {
 	rest.StandardStorage
 
+	authorizer authorizer.Authorizer
+
 	ruleResolver validation.AuthorizationRuleResolver
 }
 
-func NewStorage(s rest.StandardStorage, ruleResolver validation.AuthorizationRuleResolver) *Storage {
-	return &Storage{s, ruleResolver}
+func NewStorage(s rest.StandardStorage, authorizer authorizer.Authorizer, ruleResolver validation.AuthorizationRuleResolver) *Storage {
+	return &Storage{s, authorizer, ruleResolver}
 }
 
 func (s *Storage) Create(ctx genericapirequest.Context, obj runtime.Object) (runtime.Object, error) {
@@ -45,6 +48,10 @@ func (s *Storage) Create(ctx genericapirequest.Context, obj runtime.Object) (run
 	}
 
 	clusterRoleBinding := obj.(*rbac.ClusterRoleBinding)
+	if rbacregistry.BindingAuthorized(ctx, clusterRoleBinding.RoleRef, clusterRoleBinding.Namespace, s.authorizer) {
+		return s.StandardStorage.Create(ctx, obj)
+	}
+
 	rules, err := s.ruleResolver.GetRoleReferenceRules(clusterRoleBinding.RoleRef, clusterRoleBinding.Namespace)
 	if err != nil {
 		return nil, err
@@ -63,6 +70,12 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx genericapirequest.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
 		clusterRoleBinding := obj.(*rbac.ClusterRoleBinding)
 
+		// if we're explicitly authorized to bind this clusterrole, return
+		if rbacregistry.BindingAuthorized(ctx, clusterRoleBinding.RoleRef, clusterRoleBinding.Namespace, s.authorizer) {
+			return obj, nil
+		}
+
+		// Otherwise, see if we already have all the permissions contained in the referenced clusterrole
 		rules, err := s.ruleResolver.GetRoleReferenceRules(clusterRoleBinding.RoleRef, clusterRoleBinding.Namespace)
 		if err != nil {
 			return nil, err

--- a/pkg/registry/rbac/rest/BUILD
+++ b/pkg/registry/rbac/rest/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/wait:go_default_library",
         "//plugin/pkg/auth/authorizer/rbac/bootstrappolicy:go_default_library",
         "//vendor:github.com/golang/glog",
+        "//vendor:k8s.io/apiserver/pkg/authorization/authorizer",
     ],
 )
 

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/rest"
 	"k8s.io/kubernetes/pkg/apis/rbac"
@@ -48,7 +49,9 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 )
 
-type RESTStorageProvider struct{}
+type RESTStorageProvider struct {
+	Authorizer authorizer.Authorizer
+}
 
 var _ genericapiserver.PostStartHookProvider = RESTStorageProvider{}
 
@@ -98,7 +101,7 @@ func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource genericapis
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("rolebindings")) {
 		initializeStorage()
-		storage["rolebindings"] = rolebindingpolicybased.NewStorage(roleBindingsStorage, authorizationRuleResolver)
+		storage["rolebindings"] = rolebindingpolicybased.NewStorage(roleBindingsStorage, p.Authorizer, authorizationRuleResolver)
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("clusterroles")) {
 		initializeStorage()
@@ -106,7 +109,7 @@ func (p RESTStorageProvider) v1alpha1Storage(apiResourceConfigSource genericapis
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("clusterrolebindings")) {
 		initializeStorage()
-		storage["clusterrolebindings"] = clusterrolebindingpolicybased.NewStorage(clusterRoleBindingsStorage, authorizationRuleResolver)
+		storage["clusterrolebindings"] = clusterrolebindingpolicybased.NewStorage(clusterRoleBindingsStorage, p.Authorizer, authorizationRuleResolver)
 	}
 	return storage
 }

--- a/pkg/registry/rbac/rolebinding/policybased/BUILD
+++ b/pkg/registry/rbac/rolebinding/policybased/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/genericapiserver/api/request:go_default_library",
         "//pkg/registry/rbac:go_default_library",
         "//pkg/runtime:go_default_library",
+        "//vendor:k8s.io/apiserver/pkg/authorization/authorizer",
     ],
 )
 


### PR DESCRIPTION
Previously, a user could only create/update a role binding if they already had all the permissions contained in the referenced role (at the same scope as the role binding) via an existing RBAC role grant.

This PR also allows them to create/update a role binding if they’ve been given explicit permission to perform the `bind` verb on the referenced role. When using multiple authorizers (`--authorization-mode=RBAC,WebHook`, etc), that `bind` permission can be granted by any of the configured authorizers. This lets a non-RBAC authorizer indicate a user is allowed to bind specific RBAC roles.

For example, if “user-1” does not have the ability to list secrets in a namespace, they cannot create a RoleBinding to a role that grants that permission (like the `admin`, or `edit` role). This cluster role and role binding would now allow “user-1” to grant other users the `admin` and `edit` roles in the “user-1-namespace” namespace:

```yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: ClusterRole
metadata:
  name: role-grantor
rules:
- apiGroups: ["rbac.authorization.k8s.io"]
  resources: ["rolebindings"]
  verbs: ["create"]
- apiGroups: ["rbac.authorization.k8s.io"]
  resources: ["clusterroles"]
  verbs: ["bind"]
  resourceNames: ["admin","edit","view"]
---
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: RoleBinding
metadata:
  name: role-grantor-binding
  namespace: user-1-namespace
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: role-grantor
subjects:
- apiGroup: rbac.authorization.k8s.io
  kind: User
  name: user-1
```

Fixes https://github.com/kubernetes/kubernetes/issues/39176
Fixes https://github.com/kubernetes/kubernetes/issues/39258

Allows creating/updating a rolebinding/clusterrolebinding if the user has explicitly been granted permission to perform the "bind" verb against the referenced role/clusterrole (previously, they could only bind if they already had all the permissions in the referenced role via an RBAC role themselves)

```release-note
To create or update an RBAC RoleBinding or ClusterRoleBinding object, a user must:
1. Be authorized to make the create or update API request
2. Be allowed to bind the referenced role, either by already having all of the permissions contained in the referenced role, or by having the "bind" permission on the referenced role.
```