### PR TITLE
make discovery static when extensions/thirdpartyresources is not enabled

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -115,7 +115,7 @@ func startNamespaceController(ctx ControllerContext) (bool, error) {
 		return true, fmt.Errorf("failed to parse preferred server resources: %v", err)
 	}
 	discoverResourcesFn := namespaceKubeClient.Discovery().ServerPreferredNamespacedResources
-	if _, found := gvrs[extensions.SchemeGroupVersion.WithResource("thirdpartyresource")]; found {
+	if _, found := gvrs[extensions.SchemeGroupVersion.WithResource("thirdpartyresource")]; !found {
 		// make discovery static
 		snapshot, err := discoverResourcesFn()
 		if err != nil {


### PR DESCRIPTION
this should be a bug fix, if `extensions/thirdpartyresources` is enabled, the result of `Discovery().ServerPreferredNamespacedResources` will be dynamic then, so we are making the `discoverResourcesFn` static only when the `extensions/thirdpartyresources` is not enabled.