### PR TITLE
Add verbs to thirdparty resources in discovery

### DIFF
--- a/pkg/master/thirdparty/thirdparty.go
+++ b/pkg/master/thirdparty/thirdparty.go
@@ -207,6 +207,9 @@ func (m *ThirdPartyResourceServer) getExistingThirdPartyResources(path string) [
 				Name:       key,
 				Namespaced: true,
 				Kind:       obj.Kind(),
+				Verbs: metav1.Verbs([]string{
+					"delete", "deletecollection", "get", "list", "patch", "create", "update", "watch",
+				}),
 			})
 		}
 	}


### PR DESCRIPTION
The namespace controller ignores thirdparty resources right now because verbs are not set. This PR sets a static list of verbs.

Moreover, integration tests are added for the discovery info of thirdparty resources.

/cc @zhouhaibing089