### PR TITLE
optimize externalAddresses() return

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -361,7 +361,7 @@ type nodeAddressProvider struct {
 	nodeClient corev1client.NodeInterface
 }
 
-func (n nodeAddressProvider) externalAddresses() (addresses []string, err error) {
+func (n nodeAddressProvider) externalAddresses() ([]string, error) {
 	preferredAddressTypes := []apiv1.NodeAddressType{
 		apiv1.NodeExternalIP,
 		apiv1.NodeLegacyHostIP,


### PR DESCRIPTION
We do not use addresses and err in function body,so we drop them to maintain a consistent coding style
