### PR TITLE
kubeadm token discovery URL may not have valid input for url.Parse

### DIFF
--- a/cmd/kubeadm/app/discovery/flags.go
+++ b/cmd/kubeadm/app/discovery/flags.go
@@ -76,6 +76,15 @@ func ParseURL(d *kubeadm.Discovery, s string) error {
 	case "file":
 		return file.Parse(u, d)
 	case "token":
+		// Make sure a valid RFC 3986 URL has been passed and parsed.
+		// See https://github.com/kubernetes/kubeadm/issues/95#issuecomment-270431296 for more details.
+		if !strings.Contains(s, "@") {
+			s := s + "@"
+			u, err = url.Parse(s)
+			if err != nil {
+				return err
+			}
+		}
 		return token.Parse(u, d)
 	default:
 		return fmt.Errorf("unknown discovery scheme")

--- a/cmd/kubeadm/app/discovery/flags_test.go
+++ b/cmd/kubeadm/app/discovery/flags_test.go
@@ -38,6 +38,24 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
+			url: "token://c05de9:ab224260fb3cd718",
+			expect: kubeadm.Discovery{
+				Token: &kubeadm.TokenDiscovery{
+					ID:     "c05de9",
+					Secret: "ab224260fb3cd718",
+				},
+			},
+		},
+		{
+			url: "token://c05de9:ab224260fb3cd718@",
+			expect: kubeadm.Discovery{
+				Token: &kubeadm.TokenDiscovery{
+					ID:     "c05de9",
+					Secret: "ab224260fb3cd718",
+				},
+			},
+		},
+		{
 			url: "token://c05de9:ab224260fb3cd718@192.168.0.1:6555,191.168.0.2:6443",
 			expect: kubeadm.Discovery{
 				Token: &kubeadm.TokenDiscovery{
@@ -76,7 +94,7 @@ func TestParseURL(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(d, c.expect) {
-			t.Errorf("expected discovery config to be equeal but got:\n\ta: %s\n\tb: %s", spew.Sdump(d), spew.Sdump(c.expect))
+			t.Errorf("expected discovery config to be equal but got:\n\tactual: %s\n\texpected: %s", spew.Sdump(d), spew.Sdump(c.expect))
 		}
 
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**: fixes https://github.com/kubernetes/kubeadm/issues/95

**Special notes for your reviewer**:
/cc @dgoodwin @luxas @mikedanese this is a WIP! Need a couple things:
* decide token separator, `.` or `:`
* define error handling in `token.go::37`
