### PR TITLE
kubeadm: change etcd data dir to match host path.

### DIFF
--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -113,7 +113,7 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 				"etcd",
 				"--listen-client-urls=http://127.0.0.1:2379",
 				"--advertise-client-urls=http://127.0.0.1:2379",
-				"--data-dir=/var/etcd/data",
+				"--data-dir=/var/lib/etcd",
 			},
 			VolumeMounts:  []api.VolumeMount{certsVolumeMount(), etcdVolumeMount(), k8sVolumeMount()},
 			Image:         images.GetCoreImage(images.KubeEtcdImage, cfg, kubeadmapi.GlobalEnvParams.EtcdImage),
@@ -161,7 +161,7 @@ func etcdVolume(cfg *kubeadmapi.MasterConfiguration) api.Volume {
 func etcdVolumeMount() api.VolumeMount {
 	return api.VolumeMount{
 		Name:      "etcd",
-		MountPath: "/var/etcd",
+		MountPath: "/var/lib/etcd",
 	}
 }
 

--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -103,7 +103,7 @@ func TestEtcdVolumeMount(t *testing.T) {
 		{
 			expected: api.VolumeMount{
 				Name:      "etcd",
-				MountPath: "/var/etcd",
+				MountPath: "/var/lib/etcd",
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Trivial change that adopts a well-known path for etcd data, following the `hostPath` defined.

**Which issue this PR fixes**: Fixes https://github.com/kubernetes/kubeadm/issues/80

**Special notes for your reviewer**:
/cc @luxas @kad
