### PR TITLE
kubeadm: kube-proxy needs to know the pod subnet CIDR

### DIFF
--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -386,7 +386,9 @@ func getSchedulerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 }
 
 func getProxyCommand(cfg *kubeadmapi.MasterConfiguration) []string {
-	return getComponentBaseCommand(proxy)
+	return append(getComponentBaseCommand(proxy),
+		"--cluster-cidr="+cfg.Networking.PodSubnet,
+	)
 }
 
 func getProxyEnvVars() []api.EnvVar {

--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -572,9 +572,14 @@ func TestGetProxyCommand(t *testing.T) {
 		expected []string
 	}{
 		{
-			cfg: &kubeadmapi.MasterConfiguration{},
+			cfg: &kubeadmapi.MasterConfiguration{
+				Networking: kubeadm.Networking{
+					PodSubnet: "bar",
+				},
+			},
 			expected: []string{
 				"kube-proxy",
+				"--cluster-cidr=bar",
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: `kube-proxy` 1.5 has a new flag `cluster-cidr` that isn't specified by `kubeadm`, thus resulting in bug https://github.com/kubernetes/kubeadm/issues/102.

**Which issue this PR fixes**: fixes https://github.com/kubernetes/kubeadm/issues/102

**Special notes for your reviewer**:
/cc @luxas @dmmcquay 
