### PR TITLE
use debs to build k8s docker images

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -2,13 +2,6 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_tools//tools/build_defs/docker:docker.bzl", "docker_build")
 
-server_binaries = {
-    "kube-apiserver": "//cmd/kube-apiserver",
-    "kube-controller-manager": "//cmd/kube-controller-manager",
-    "kube-scheduler": "//plugin/cmd/kube-scheduler",
-    "kubernetes-discovery": "//cmd/kubernetes-discovery",
-}
-
 docker_build(
     name = "busybox",
     debs = [
@@ -40,21 +33,26 @@ docker_build(
 )
 
 [docker_build(
-    name = name,
+    name = binary,
     base = ":busybox-libc",
-    cmd = ["/" + name],
-    files = [
-        label,
+    cmd = ["/usr/bin/" + binary],
+    debs = [
+        "//build/debs:%s.deb" % binary,
     ],
     repository = "gcr.io/google-containers",
-) for name, label in server_binaries.items()]
+) for binary in [
+    "kube-apiserver",
+    "kube-controller-manager",
+    "kube-scheduler",
+    "kubernetes-discovery",
+]]
 
 docker_build(
     name = "kube-proxy",
     base = ":busybox-net",
     cmd = ["/kube-proxy"],
-    files = [
-        "//cmd/kube-proxy",
+    debs = [
+        "//build/debs:kube-proxy.deb",
     ],
     repository = "gcr.io/google-containers",
 )

--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -3,6 +3,11 @@ package(default_visibility = ["//visibility:public"])
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 load("@io_kubernetes_build//defs:deb.bzl", "k8s_deb", "deb_data")
 
+# We do not include kube-scheduler, kube-controller-manager,
+# kube-apiserver, and kube-proxy in this list even though we
+# produce debs for them. We recommend that they be run in docker
+# images. We use the debs that we produce here to build those
+# images.
 filegroup(
     name = "debs",
     srcs = [
@@ -13,11 +18,28 @@ filegroup(
     ],
 )
 
-deb_data(
-    name = "kubectl",
+[deb_data(
+    name = binary,
     data = [
         {
-            "files": ["//cmd/kubectl"],
+            "files": ["//cmd/" + binary],
+            "mode": "0755",
+            "dir": "/usr/bin",
+        },
+    ],
+) for binary in [
+    "kubectl",
+    "kube-apiserver",
+    "kube-controller-manager",
+    "kube-proxy",
+    "kubernetes-discovery",
+]]
+
+deb_data(
+    name = "kube-scheduler",
+    data = [
+        {
+            "files": ["//plugin/cmd/kube-scheduler"],
             "mode": "0755",
             "dir": "/usr/bin",
         },
@@ -67,6 +89,35 @@ k8s_deb(
     description = """Kubernetes Command Line Tool
 The Kubernetes command line tool for interacting with the Kubernetes API.
 """,
+)
+
+k8s_deb(
+    name = "kube-apiserver",
+    description = "Kubernetes API Server",
+)
+
+k8s_deb(
+    name = "kube-controller-manager",
+    description = "Kubernetes Controller Manager",
+)
+
+k8s_deb(
+    name = "kube-scheduler",
+    description = "Kubernetes Scheduler",
+)
+
+k8s_deb(
+    name = "kube-proxy",
+    depends = [
+        "iptables (>= 1.4.21)",
+        "iproute2",
+    ],
+    description = "Kubernetes Service Proxy",
+)
+
+k8s_deb(
+    name = "kubernetes-discovery",
+    description = "Kubernetes Federated API Server",
 )
 
 k8s_deb(


### PR DESCRIPTION
This puts the binaries in better paths and fixes compatibility issues.