### PR TITLE
add import cycle checking for staging to verify scripts

### DIFF
--- a/hack/verify-staging-imports.sh
+++ b/hack/verify-staging-imports.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+kube::golang::setup_env
+
+
+for dep in $(ls -1 ${KUBE_ROOT}/staging/src/k8s.io/); do
+	if go list -f {{.Deps}} ./vendor/k8s.io/${dep}/... | sed 's/ /\n/g' - | grep k8s.io/kubernetes | grep -v 'k8s.io/kubernetes/vendor' | LC_ALL=C sort -u | grep -e "."; then
+		echo "${dep} has a cyclical dependency"
+		exit 1
+	fi
+done
+
+exit 0


### PR DESCRIPTION
Adds an import cycle check to verify scripts since we can't yet use import-boss.  See https://github.com/kubernetes/gengo/pull/27 for details, but since the rule is very simple and global, this ought to provide sufficient protection.

@kubernetes/sig-api-machinery-misc 