### PR TITLE
Fix unpack docker.tar.gz failure bug

### DIFF
--- a/cluster/centos/build.sh
+++ b/cluster/centos/build.sh
@@ -95,8 +95,8 @@ function unpack-releases() {
   fi
 
   # docker
-  if [[ -f ${RELEASES_DIR}/docker.tgz ]]; then
-    tar xzf ${RELEASES_DIR}/docker.tgz -C ${RELEASES_DIR}
+  if [[ -f ${RELEASES_DIR}/docker.tar.gz ]]; then
+    tar xzf ${RELEASES_DIR}/docker.tar.gz -C ${RELEASES_DIR}
 
     cp ${RELEASES_DIR}/docker/docker* ${BINARY_DIR}/node/bin
   fi


### PR DESCRIPTION
In centOS, there is a conflict bug of docker. We save docker as [docker.tar.gz](https://github.com/kubernetes/kubernetes/blob/master/cluster/centos/build.sh#L57) in function `download-releases()`, but uncompress [docker.tgz](https://github.com/kubernetes/kubernetes/blob/master/cluster/centos/build.sh#L98) in function `unpack-releases()`. 