### PR TITLE
Pass pod metadata to flex plugin

### DIFF
--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -51,6 +51,12 @@ const (
 	optionKeySecret = "kubernetes.io/secret"
 	optionFSGroup   = "kubernetes.io/fsGroup"
 	optionMountsDir = "kubernetes.io/mountsDir"
+
+	optionKeyPodName      = "kubernetes.io/pod.name"
+	optionKeyPodNamespace = "kubernetes.io/pod.namespace"
+	optionKeyPodUID       = "kubernetes.io/pod.uid"
+
+	optionKeyServiceAccountName = "kubernetes.io/serviceAccount.name"
 )
 
 const (

--- a/pkg/volume/flexvolume/mounter.go
+++ b/pkg/volume/flexvolume/mounter.go
@@ -66,6 +66,13 @@ func (f *flexVolumeMounter) SetUpAt(dir string, fsGroup *types.UnixGroupID) erro
 
 	extraOptions := make(map[string]string)
 
+	// pod metadata
+	extraOptions[optionKeyPodName] = f.podName
+	extraOptions[optionKeyPodNamespace] = f.podNamespace
+	extraOptions[optionKeyPodUID] = string(f.podUID)
+	// service account metadata
+	extraOptions[optionKeyServiceAccountName] = f.podServiceAccountName
+
 	// Extract secret and pass it as options.
 	if err := addSecretsToOptions(extraOptions, f.spec, f.podNamespace, f.driverName, f.plugin.host); err != nil {
 		return err

--- a/pkg/volume/flexvolume/mounter_test.go
+++ b/pkg/volume/flexvolume/mounter_test.go
@@ -19,6 +19,7 @@ package flexvolume
 import (
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -26,7 +27,16 @@ import (
 
 func TestSetUpAt(t *testing.T) {
 	spec := fakeVolumeSpec()
-	pod := &v1.Pod{}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-pod",
+			Namespace: "my-ns",
+			UID:       types.UID("my-uid"),
+		},
+		Spec: v1.PodSpec{
+			ServiceAccountName: "my-sa",
+		},
+	}
 	mounter := &mount.FakeMounter{}
 
 	plugin, rootDir := testPlugin()
@@ -34,12 +44,21 @@ func TestSetUpAt(t *testing.T) {
 	plugin.runner = fakeRunner(
 		// first call without fsGroup
 		assertDriverCall(t, successOutput(), mountCmd, rootDir+"/mount-dir",
-			specJson(plugin, spec, nil)),
+			specJson(plugin, spec, map[string]string{
+				optionKeyPodName:            "my-pod",
+				optionKeyPodNamespace:       "my-ns",
+				optionKeyPodUID:             "my-uid",
+				optionKeyServiceAccountName: "my-sa",
+			})),
 
 		// second test has fsGroup
 		assertDriverCall(t, notSupportedOutput(), mountCmd, rootDir+"/mount-dir",
 			specJson(plugin, spec, map[string]string{
-				optionFSGroup: "42",
+				optionFSGroup:               "42",
+				optionKeyPodName:            "my-pod",
+				optionKeyPodNamespace:       "my-ns",
+				optionKeyPodUID:             "my-uid",
+				optionKeyServiceAccountName: "my-sa",
 			})),
 		assertDriverCall(t, fakeVolumeNameOutput("sdx"), getVolumeNameCmd,
 			specJson(plugin, spec, nil)),

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -108,13 +108,15 @@ func (plugin *flexVolumePlugin) newMounterInternal(spec *volume.Spec, pod *api.P
 	source, readOnly := getVolumeSource(spec)
 	return &flexVolumeMounter{
 		flexVolume: &flexVolume{
-			driverName:   source.Driver,
-			execPath:     plugin.getExecutable(),
-			mounter:      mounter,
-			plugin:       plugin,
-			podUID:       pod.UID,
-			podNamespace: pod.Namespace,
-			volName:      spec.Name(),
+			driverName:            source.Driver,
+			execPath:              plugin.getExecutable(),
+			mounter:               mounter,
+			plugin:                plugin,
+			podName:               pod.Name,
+			podUID:                pod.UID,
+			podNamespace:          pod.Namespace,
+			podServiceAccountName: pod.Spec.ServiceAccountName,
+			volName:               spec.Name(),
 		},
 		runner:             runner,
 		spec:               spec,

--- a/pkg/volume/flexvolume/volume.go
+++ b/pkg/volume/flexvolume/volume.go
@@ -30,10 +30,14 @@ type flexVolume struct {
 	// mounter provides the interface that is used to mount the actual
 	// block device.
 	mounter mount.Interface
+	// podName is the name of the pod, if available.
+	podName string
 	// podUID is the UID of the pod.
 	podUID types.UID
-	// podNamespace is the namespace of the pod.
+	// podNamespace is the namespace of the pod, if available.
 	podNamespace string
+	// podServiceAccountName is the service account name of the pod, if available.
+	podServiceAccountName string
 	// volName is the name of the pod's volume.
 	volName string
 	// the underlying plugin


### PR DESCRIPTION
Normal volume plugins get the pod spec to pull information from when setting up their volume, but flex plugins do not.

If a flex volume wants to set up things unique to the pod, or limited in permission based on the service account, the pod namespace, name, uid, and service account name are needed.

This PR adds pod uid, name, namespace, and service account name to the options passed to the plugin available during mounting

```release-note
The options passed to a flexvolume plugin's mount command now contains the pod name (`kubernetes.io/pod.name`), namespace (`kubernetes.io/pod.namespace`), uid (`kubernetes.io/pod.uid`), and service account name (`kubernetes.io/serviceAccount.name`).
```