### PR TITLE
kubelet: fix nil deref in volume type check

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -162,6 +162,9 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 			}
 			// Skip non-memory backed volumes belonging to terminated pods
 			volume := volumeToMount.VolumeSpec.Volume
+			if volume == nil {
+				continue
+			}
 			if (volume.EmptyDir == nil || volume.EmptyDir.Medium != v1.StorageMediumMemory) &&
 				volume.ConfigMap == nil && volume.Secret == nil {
 				continue


### PR DESCRIPTION
An attempt to address memory exhaustion through a build up of terminated pods with memory backed volumes on the node in PR https://github.com/kubernetes/kubernetes/pull/36779 introduced this.

For the `VolumeSpec`, either the `Volume` or `PersistentVolume` field is set, not both.  This results in a situation where there is a nil deref on PVs.  Since PVs are inherently not memory-backend, only local/temporal volumes should be considered.

This needs to go into 1.5 as well.

Fixes #39480

@saad-ali @derekwaynecarr @grosskur @gnufied

```release-note
fixes nil dereference when doing a volume type check on persistent volumes
```
