### PR TITLE
kubeadm: updated preflight types to avoid stutter

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -38,14 +38,14 @@ func (pfct preflightCheckTest) Check() (warning, errors []error) {
 
 func TestRunChecks(t *testing.T) {
 	var tokenTest = []struct {
-		p        []PreFlightCheck
+		p        []Checker
 		expected bool
 		output   string
 	}{
-		{[]PreFlightCheck{}, true, ""},
-		{[]PreFlightCheck{preflightCheckTest{"warning"}}, true, "[preflight] WARNING: warning\n"}, // should just print warning
-		{[]PreFlightCheck{preflightCheckTest{"error"}}, false, ""},
-		{[]PreFlightCheck{preflightCheckTest{"test"}}, false, ""},
+		{[]Checker{}, true, ""},
+		{[]Checker{preflightCheckTest{"warning"}}, true, "[preflight] WARNING: warning\n"}, // should just print warning
+		{[]Checker{preflightCheckTest{"error"}}, false, ""},
+		{[]Checker{preflightCheckTest{"test"}}, false, ""},
 	}
 	for _, rt := range tokenTest {
 		buf := new(bytes.Buffer)

--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -61,7 +61,7 @@ func checkErr(prefix string, err error, handleErr func(string, int)) {
 	switch err.(type) {
 	case nil:
 		return
-	case *preflight.PreFlightError:
+	case *preflight.Error:
 		handleErr(err.Error(), PreFlightExitCode)
 	default:
 		handleErr(err.Error(), DefaultErrorExitCode)

--- a/cmd/kubeadm/app/util/error_test.go
+++ b/cmd/kubeadm/app/util/error_test.go
@@ -35,7 +35,7 @@ func TestCheckErr(t *testing.T) {
 	}{
 		{nil, 0},
 		{fmt.Errorf(""), DefaultErrorExitCode},
-		{&preflight.PreFlightError{}, PreFlightExitCode},
+		{&preflight.Error{}, PreFlightExitCode},
 	}
 
 	for _, rt := range tokenTest {


### PR DESCRIPTION
Small change to kubeadm preflight pkg to remove stutter from preflight types PreFlightError and PreFlightCheck (now names Error and Checker). 

**Release note**:

`NONE`
