### PR TITLE
Use privileged containers for host path e2e tests

### DIFF
--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -132,6 +132,7 @@ func mount(source *v1.HostPathVolumeSource) []v1.Volume {
 //TODO: To merge this with the emptyDir tests, we can make source a lambda.
 func testPodWithHostVol(path string, source *v1.HostPathVolumeSource) *v1.Pod {
 	podName := "pod-host-path-test"
+	privileged := true
 
 	return &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
@@ -152,6 +153,9 @@ func testPodWithHostVol(path string, source *v1.HostPathVolumeSource) *v1.Pod {
 							MountPath: path,
 						},
 					},
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &privileged,
+					},
 				},
 				{
 					Name:  containerName2,
@@ -161,6 +165,9 @@ func testPodWithHostVol(path string, source *v1.HostPathVolumeSource) *v1.Pod {
 							Name:      volumeName,
 							MountPath: path,
 						},
+					},
+					SecurityContext: &v1.SecurityContext{
+						Privileged: &privileged,
 					},
 				},
 			},


### PR DESCRIPTION
Test containers need to run as spc_t in order to interact with the host
filesystem under /tmp, as the tests for HostPath are doing. Docker will
transition the container into this domain when running the container as
privileged.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Currently, this test fails with AVC denials like:
```
time->Thu Jan  5 10:17:51 2017
type=SYSCALL msg=audit(1483629471.846:6623): arch=c000003e syscall=257 success=no exit=-13 a0=ffffffffffffff9c a1=c820010120 a2=80241 a3=1a4 items=0 ppid=4112 pid=4130 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="mt" exe="/mt" subj=system_u:system_r:svirt_lxc_net_t:s0:c123,c328 key=(null)
type=AVC msg=audit(1483629471.846:6623): avc:  denied  { write } for  pid=4130 comm="mt" name="sub-path" dev="xvda2" ino=118491348 scontext=system_u:system_r:svirt_lxc_net_t:s0:c123,c328 tcontext=system_u:object_r:container_runtime_tmp_t:s0 tclass=dir
```

```release-note
NONE
```

/cc @ncdc @pmorie 
