### PR TITLE
Fix bug when printing replicas in Deployment Describer

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -172,6 +172,7 @@ go_test(
         "//pkg/client/testing/core:go_default_library",
         "//pkg/controller/deployment/util:go_default_library",
         "//pkg/kubectl/testing:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/intstr:go_default_library",
         "//pkg/util/testing:go_default_library",
         "//vendor:github.com/ghodss/yaml",

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -2266,7 +2266,7 @@ func (dd *DeploymentDescriber) Describe(namespace, name string, describerSetting
 		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", d.CreationTimestamp.Time.Format(time.RFC1123Z))
 		printLabelsMultiline(w, "Labels", d.Labels)
 		w.Write(LEVEL_0, "Selector:\t%s\n", selector)
-		w.Write(LEVEL_0, "Replicas:\t%d updated | %d total | %d available | %d unavailable\n", d.Status.UpdatedReplicas, d.Spec.Replicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
+		w.Write(LEVEL_0, "Replicas:\t%d updated | %d total | %d available | %d unavailable\n", d.Status.UpdatedReplicas, *d.Spec.Replicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
 		w.Write(LEVEL_0, "StrategyType:\t%s\n", d.Spec.Strategy.Type)
 		w.Write(LEVEL_0, "MinReadySeconds:\t%d\n", d.Spec.MinReadySeconds)
 		if d.Spec.Strategy.RollingUpdate != nil {
@@ -2349,7 +2349,7 @@ func printReplicaSetsByLabels(matchingRSs []*versionedextension.ReplicaSet) stri
 	// Format the matching ReplicaSets into strings.
 	rsStrings := make([]string, 0, len(matchingRSs))
 	for _, rs := range matchingRSs {
-		rsStrings = append(rsStrings, fmt.Sprintf("%s (%d/%d replicas created)", rs.Name, rs.Status.Replicas, rs.Spec.Replicas))
+		rsStrings = append(rsStrings, fmt.Sprintf("%s (%d/%d replicas created)", rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
 	}
 
 	list := strings.Join(rsStrings, ", ")

--- a/pkg/kubectl/describe_test.go
+++ b/pkg/kubectl/describe_test.go
@@ -38,6 +38,7 @@ import (
 	versionedfake "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
+	"k8s.io/kubernetes/pkg/util"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
 
@@ -638,6 +639,7 @@ func TestDescribeDeployment(t *testing.T) {
 			Namespace: "foo",
 		},
 		Spec: v1beta1.DeploymentSpec{
+			Replicas: util.Int32Ptr(1),
 			Selector: &metav1.LabelSelector{},
 			Template: v1.PodTemplateSpec{},
 		},
@@ -770,6 +772,7 @@ func TestDescribeEvents(t *testing.T) {
 					Namespace: "foo",
 				},
 				Spec: v1beta1.DeploymentSpec{
+					Replicas: util.Int32Ptr(1),
 					Selector: &metav1.LabelSelector{},
 				},
 			}),


### PR DESCRIPTION
Deployment describer is printing replicas using pointer instead of integer. This bug is introduced by #36673 which updates the describer to use versioned API. cc @caesarxuchao 

Fixes #38697