### PR TITLE
use fake clock in lruexpiration cache test

### DIFF
--- a/pkg/util/cache/BUILD
+++ b/pkg/util/cache/BUILD
@@ -26,7 +26,10 @@ go_test(
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//vendor:github.com/golang/groupcache/lru"],
+    deps = [
+        "//pkg/util/clock:go_default_library",
+        "//vendor:github.com/golang/groupcache/lru",
+    ],
 )
 
 filegroup(

--- a/pkg/util/cache/lruexpirecache_test.go
+++ b/pkg/util/cache/lruexpirecache_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/kubernetes/pkg/util/clock"
+
 	"github.com/golang/groupcache/lru"
 )
 
@@ -43,8 +45,11 @@ func TestSimpleGet(t *testing.T) {
 }
 
 func TestExpiredGet(t *testing.T) {
-	c := NewLRUExpireCache(10)
-	c.Add("short-lived", "12345", 0*time.Second)
+	fakeClock := clock.NewFakeClock(time.Now())
+	c := NewLRUExpireCacheWithClock(10, fakeClock)
+	c.Add("short-lived", "12345", 1*time.Millisecond)
+	// ensure the entry expired
+	fakeClock.Step(2 * time.Millisecond)
 	expectNotEntry(t, c, "short-lived")
 }
 


### PR DESCRIPTION
when the system clock is extremely slow(usually see in VMs), this [check](https://github.com/kubernetes/kubernetes/blob/master/pkg/util/cache/lruexpirecache.go#L74) might still return the value.  

```go
if c.clock.Now().After(e.(*cacheEntry).expireTime) {
	go c.remove(key)
	return nil, false
}
```

that means even we set the ttl to be 0 second, the after check might still be false(because the clock is too slow, and thus equals).

the change here helps to reduce flakes.