### PR TITLE
Generate a dummy BUILD file in _output/local/go to keep Bazel out of trouble

### DIFF
--- a/.gazelcfg.json
+++ b/.gazelcfg.json
@@ -9,5 +9,8 @@
 		"./federation",
 		"./examples"
 	],
+	"SkippedPaths": [
+		"^_.*"
+	],
 	"AddSourcesRules": true
 }

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -307,6 +307,12 @@ kube::golang::create_gopath_tree() {
   if [[ ! -e "${go_pkg_dir}" || "$(readlink ${go_pkg_dir})" != "${KUBE_ROOT}" ]]; then
     ln -snf "${KUBE_ROOT}" "${go_pkg_dir}"
   fi
+
+  cat >"${KUBE_GOPATH}/BUILD" <<EOF
+# This dummy BUILD file prevents Bazel from trying to descend through the
+# infinite loop created by the symlink at
+# ${go_pkg_dir}
+EOF
 }
 
 # Ensure the godep tool exists and is a viable version.


### PR DESCRIPTION
**What this PR does / why we need it**: the Kubernetes build system creates a symlink from `_output/local/go/src/k8s.io/kubernetes` back to `$KUBE_ROOT`, likely to deal with folks that don't have their `GOPATH `set up correctly.

Bazel's `glob()` is not very smart, and runs into issues with this; the `package-srcs` glob in `//BUILD.bazel` first evaluates the `**` before matching any excludes, and thus explodes on the infinite loop.

By generating a `BUILD` file along the path to the symlink, Bazel treats this as a separate package and descends no further.

(Oddly, generating a `BUILD.bazel` file doesn't seem to solve the glob explosion, but a directory with a `BUILD.bazel` file is still treated as a separate package. There's probably a subtle bug in Bazel somewhere.)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
