### PR TITLE
Use the same name in volumeMounts and volumes

### DIFF
--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -176,7 +176,7 @@
           - name: test-volume
             mountPath: /test-vmdk
         volumes:
-        - name: vmdk-storage
+        - name: test-volume
           persistentVolumeClaim:
             claimName: pvc0001
       ```
@@ -315,7 +315,7 @@
           - name: test-volume
             mountPath: /test-vmdk
         volumes:
-        - name: vmdk-storage
+        - name: test-volume
           persistentVolumeClaim:
             claimName: pvcsc001
       ```

--- a/examples/volumes/vsphere/vsphere-volume-pvcpod.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-pvcpod.yaml
@@ -10,6 +10,6 @@ spec:
     - name: test-volume
       mountPath: /test-vmdk
   volumes:
-  - name: vmdk-storage
+  - name: test-volume
     persistentVolumeClaim:
       claimName: pvc0001

--- a/examples/volumes/vsphere/vsphere-volume-pvcscpod.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-pvcscpod.yaml
@@ -12,4 +12,4 @@ spec:
   volumes:
   - name: test-volume
     persistentVolumeClaim:
-      claimName: pvcsc0001
+      claimName: pvcsc001

--- a/examples/volumes/vsphere/vsphere-volume-pvcscpod.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-pvcscpod.yaml
@@ -10,6 +10,6 @@ spec:
     - name: test-volume
       mountPath: /test-vmdk
   volumes:
-  - name: vmdk-storage
+  - name: test-volume
     persistentVolumeClaim:
       claimName: pvcsc0001


### PR DESCRIPTION
In some example files of vSphere volumes, volumeMounts and volumes
have different names. kubectl create will fail with error message
saying the pod is invalid because volumeMount with the name is not
found.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
