### PR TITLE
kubelet: fix nil deref in volume type check

### DIFF
--- a/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
+++ b/pkg/kubelet/volumemanager/populator/desired_state_of_world_populator.go
@@ -160,6 +160,9 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 			}
 			// Skip non-memory backed volumes belonging to terminated pods
 			volume := volumeToMount.VolumeSpec.Volume
+			if volume == nil {
+				continue
+			}
 			if (volume.EmptyDir == nil || volume.EmptyDir.Medium != api.StorageMediumMemory) &&
 				volume.ConfigMap == nil && volume.Secret == nil {
 				continue


### PR DESCRIPTION
Cherry pick https://github.com/kubernetes/kubernetes/pull/39493

@saad-ali @derekwaynecarr @grosskur @gnufied

```release-note
fix nil dereference when doing a volume type check on persistent volumes
```