### PR TITLE
Adding storageclass to resource printers for get pv and pvc

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -503,8 +503,8 @@ var (
 	namespaceColumns                 = []string{"NAME", "STATUS", "AGE"}
 	secretColumns                    = []string{"NAME", "TYPE", "DATA", "AGE"}
 	serviceAccountColumns            = []string{"NAME", "SECRETS", "AGE"}
-	persistentVolumeColumns          = []string{"NAME", "CAPACITY", "ACCESSMODES", "RECLAIMPOLICY", "STATUS", "CLAIM", "REASON", "AGE"}
-	persistentVolumeClaimColumns     = []string{"NAME", "STATUS", "VOLUME", "CAPACITY", "ACCESSMODES", "AGE"}
+	persistentVolumeColumns          = []string{"NAME", "CAPACITY", "ACCESSMODES", "RECLAIMPOLICY", "STATUS", "CLAIM", "STORAGECLASS", "REASON", "AGE"}
+	persistentVolumeClaimColumns     = []string{"NAME", "STATUS", "VOLUME", "CAPACITY", "ACCESSMODES", "STORAGECLASS", "AGE"}
 	componentStatusColumns           = []string{"NAME", "STATUS", "MESSAGE", "ERROR"}
 	thirdPartyResourceColumns        = []string{"NAME", "DESCRIPTION", "VERSION(S)"}
 	roleColumns                      = []string{"NAME", "AGE"}
@@ -1618,11 +1618,12 @@ func printPersistentVolume(pv *api.PersistentVolume, w io.Writer, options PrintO
 	aQty := pv.Spec.Capacity[api.ResourceStorage]
 	aSize := aQty.String()
 
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s",
 		name,
 		aSize, modesStr, reclaimPolicyStr,
 		pv.Status.Phase,
 		claimRefUID,
+		storageutil.GetStorageClassAnnotation(pv.ObjectMeta),
 		pv.Status.Reason,
 		translateTimestamp(pv.CreationTimestamp),
 	); err != nil {
@@ -1665,7 +1666,7 @@ func printPersistentVolumeClaim(pvc *api.PersistentVolumeClaim, w io.Writer, opt
 		capacity = storage.String()
 	}
 
-	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s", name, phase, pvc.Spec.VolumeName, capacity, accessModes, translateTimestamp(pvc.CreationTimestamp)); err != nil {
+	if _, err := fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s", name, phase, pvc.Spec.VolumeName, capacity, accessModes, storageutil.GetStorageClassAnnotation(pvc.ObjectMeta), translateTimestamp(pvc.CreationTimestamp)); err != nil {
 		return err
 	}
 	if _, err := fmt.Fprint(w, AppendLabels(pvc.Labels, options.ColumnLabels)); err != nil {


### PR DESCRIPTION
Give ability to see what Storage Class a PV is using, as well as what StorageClass a PVC has requested

```
[root@screeley-sc1 gce]# kubectl get pv
NAME                                       CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM                            STORAGECLASS   REASON    AGE
pv-gce                                     2Gi        RWO           Retain          Available                                    anything                 41m
pvc-774217fd-d440-11e6-9d11-42010af00010   2Gi        RWO           Delete          Bound       default/gce-claim-storageclass   slow                     0s

[root@screeley-sc1 gce]# kubectl get pvc
NAME                              STATUS    VOLUME                                     CAPACITY   ACCESSMODES   REQUESTEDSTORAGECLASS   AGE
gce-claim-class1                  Pending                                                                                      		6m
gce-claim-classless               Pending                                                                                      		6m
gce-claim-storageclass            Bound     pvc-774217fd-d440-11e6-9d11-42010af00010   2Gi        RWO           slow           		6m
gce-claim-storageclass-nonexist   Pending                                                                       superfly       		4s
```
@kubernetes/sig-storage