### PR TITLE
Automated cherry pick of #38836 #39114 #39059 upstream release 1.4

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -38,6 +38,14 @@ kind: Pod
 metadata:
   name: kube-proxy
   namespace: kube-system
+  # This annotation lowers the possibility that kube-proxy gets evicted when the
+  # node is under memory pressure, and prioritizes it for admission, even if
+  # the node is under memory pressure.
+  # Note that kube-proxy runs as a static pod so this annotation does NOT have
+  # any effect on rescheduler (default scheduler and rescheduler are not
+  # involved in scheduling kube-proxy).
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     tier: node
     component: kube-proxy

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -247,9 +248,18 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 	// we kill at most a single pod during each eviction interval
 	for i := range activePods {
 		pod := activePods[i]
+		if kubepod.IsStaticPod(pod) {
+			// The eviction manager doesn't evict static pods. To stop a static
+			// pod, the admin needs to remove the manifest from kubelet's
+			// --config directory.
+			// TODO(39124): This is a short term fix, we can't assume static pods
+			// are always well behaved.
+			glog.Infof("eviction manager: NOT evicting static pod %v", pod.Name)
+			continue
+		}
 		status := api.PodStatus{
 			Phase:   api.PodFailed,
-			Message: message,
+			Message: fmt.Sprintf(message, resourceToReclaim),
 			Reason:  reason,
 		}
 		// record that we are evicting the pod

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
@@ -101,7 +102,7 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 	// the node has memory pressure, admit if not best-effort
 	if hasNodeCondition(m.nodeConditions, api.NodeMemoryPressure) {
 		notBestEffort := qos.BestEffort != qos.GetPodQOS(attrs.Pod)
-		if notBestEffort {
+		if notBestEffort || kubepod.IsCriticalPod(attrs.Pod) {
 			return lifecycle.PodAdmitResult{Admit: true}
 		}
 	}

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
-	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/server/stats"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/util/clock"
 	"k8s.io/kubernetes/pkg/util/wait"
@@ -102,7 +102,7 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 	// the node has memory pressure, admit if not best-effort
 	if hasNodeCondition(m.nodeConditions, api.NodeMemoryPressure) {
 		notBestEffort := qos.BestEffort != qos.GetPodQOS(attrs.Pod)
-		if notBestEffort || kubepod.IsCriticalPod(attrs.Pod) {
+		if notBestEffort || kubetypes.IsCriticalPod(attrs.Pod) {
 			return lifecycle.PodAdmitResult{Admit: true}
 		}
 	}

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -259,7 +259,7 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 		}
 		status := api.PodStatus{
 			Phase:   api.PodFailed,
-			Message: fmt.Sprintf(message, resourceToReclaim),
+			Message: message,
 			Reason:  reason,
 		}
 		// record that we are evicting the pod

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2432,7 +2432,7 @@ func (kl *Kubelet) HandlePodAdditions(pods []*api.Pod) {
 	var criticalPods []*api.Pod
 	var nonCriticalPods []*api.Pod
 	for _, p := range pods {
-		if kubepod.IsCriticalPod(p) {
+		if kubetypes.IsCriticalPod(p) {
 			criticalPods = append(criticalPods, p)
 		} else {
 			nonCriticalPods = append(nonCriticalPods, p)

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2442,12 +2442,6 @@ func (kl *Kubelet) HandlePodAdditions(pods []*api.Pod) {
 	sort.Sort(sliceutils.PodsByCreationTime(nonCriticalPods))
 
 	for _, pod := range append(criticalPods, nonCriticalPods...) {
-		existingPods := kl.podManager.GetPods()
-		// Always add the pod to the pod manager. Kubelet relies on the pod
-		// manager as the source of truth for the desired state. If a pod does
-		// not exist in the pod manager, it means that it has been deleted in
-		// the apiserver and no action (other than cleanup) is required.
-		kl.podManager.AddPod(pod)
 
 		if kubepod.IsMirrorPod(pod) {
 			kl.podManager.AddPod(pod)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -1997,6 +1997,68 @@ func TestHandlePortConflicts(t *testing.T) {
 	require.Equal(t, api.PodPending, status.Phase)
 }
 
+// Tests that we sort pods based on criticality.
+func TestCriticalPrioritySorting(t *testing.T) {
+	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
+	kl := testKubelet.kubelet
+	nodes := []v1.Node{
+		{ObjectMeta: v1.ObjectMeta{Name: testKubeletHostname},
+			Status: v1.NodeStatus{Capacity: v1.ResourceList{}, Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    *resource.NewMilliQuantity(10, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(100, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(40, resource.DecimalSI),
+			}}},
+	}
+	kl.nodeLister = testNodeLister{nodes: nodes}
+	kl.nodeInfo = testNodeInfo{nodes: nodes}
+	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
+	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
+	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
+
+	spec := v1.PodSpec{NodeName: string(kl.nodeName),
+		Containers: []v1.Container{{Resources: v1.ResourceRequirements{
+			Requests: v1.ResourceList{
+				"memory": resource.MustParse("90"),
+			},
+		}}}}
+	pods := []*v1.Pod{
+		podWithUidNameNsSpec("000000000", "newpod", "foo", spec),
+		podWithUidNameNsSpec("987654321", "oldpod", "foo", spec),
+		podWithUidNameNsSpec("123456789", "middlepod", "foo", spec),
+	}
+
+	// Pods are not sorted by creation time.
+	startTime := time.Now()
+	pods[0].CreationTimestamp = metav1.NewTime(startTime.Add(10 * time.Second))
+	pods[1].CreationTimestamp = metav1.NewTime(startTime)
+	pods[2].CreationTimestamp = metav1.NewTime(startTime.Add(1 * time.Second))
+
+	// Make the middle and new pod critical, the middle pod should win
+	// even though it comes later in the list
+	critical := map[string]string{kubetypes.CriticalPodAnnotationKey: ""}
+	pods[0].Annotations = critical
+	pods[1].Annotations = map[string]string{}
+	pods[2].Annotations = critical
+
+	// The non-critical pod should be rejected
+	notfittingPods := []*v1.Pod{pods[0], pods[1]}
+	fittingPod := pods[2]
+
+	kl.HandlePodAdditions(pods)
+	// Check pod status stored in the status map.
+	// notfittingPod should be Failed
+	for _, p := range notfittingPods {
+		status, found := kl.statusManager.GetPodStatus(p.UID)
+		require.True(t, found, "Status of pod %q is not found in the status map", p.UID)
+		require.Equal(t, v1.PodFailed, status.Phase)
+	}
+
+	// fittingPod should be Pending
+	status, found := kl.statusManager.GetPodStatus(fittingPod.UID)
+	require.True(t, found, "Status of pod %q is not found in the status map", fittingPod.UID)
+	require.Equal(t, v1.PodPending, status.Phase)
+}
+
 // Tests that we handle host name conflicts correctly by setting the failed status in status map.
 func TestHandleHostNameConflicts(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)

--- a/pkg/kubelet/pod/pod_manager.go
+++ b/pkg/kubelet/pod/pod_manager.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/types"
 )
 
@@ -305,4 +306,12 @@ func (pm *basicManager) GetPodByMirrorPod(mirrorPod *api.Pod) (*api.Pod, bool) {
 	defer pm.lock.RUnlock()
 	pod, ok := pm.podByFullName[kubecontainer.GetPodFullName(mirrorPod)]
 	return pod, ok
+}
+
+// IsCriticalPod returns true if the pod bears the critical pod annotation
+// key. Both the rescheduler and the kubelet use this key to make admission
+// and scheduling decisions.
+func IsCriticalPod(pod *v1.Pod) bool {
+	_, ok := pod.Annotations[kubetypes.CriticalPodAnnotationKey]
+	return ok
 }

--- a/pkg/kubelet/pod/pod_manager.go
+++ b/pkg/kubelet/pod/pod_manager.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/types"
 )
 
@@ -306,12 +305,4 @@ func (pm *basicManager) GetPodByMirrorPod(mirrorPod *api.Pod) (*api.Pod, bool) {
 	defer pm.lock.RUnlock()
 	pod, ok := pm.podByFullName[kubecontainer.GetPodFullName(mirrorPod)]
 	return pod, ok
-}
-
-// IsCriticalPod returns true if the pod bears the critical pod annotation
-// key. Both the rescheduler and the kubelet use this key to make admission
-// and scheduling decisions.
-func IsCriticalPod(pod *v1.Pod) bool {
-	_, ok := pod.Annotations[kubetypes.CriticalPodAnnotationKey]
-	return ok
 }

--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -18,7 +18,7 @@ package qos
 
 import (
 	"k8s.io/kubernetes/pkg/api"
-	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 const (
@@ -44,7 +44,7 @@ const (
 // and 1000. Containers with higher OOM scores are killed if the system runs out of memory.
 // See https://lwn.net/Articles/391222/ for more information.
 func GetContainerOOMScoreAdjust(pod *api.Pod, container *api.Container, memoryCapacity int64) int {
-	if kubepod.IsCriticalPod(pod) {
+	if kubetypes.IsCriticalPod(pod) {
 		return CriticalPodOOMAdj
 	}
 

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -27,6 +27,15 @@ const ConfigMirrorAnnotationKey = "kubernetes.io/config.mirror"
 const ConfigFirstSeenAnnotationKey = "kubernetes.io/config.seen"
 const ConfigHashAnnotationKey = "kubernetes.io/config.hash"
 
+// This key needs to sync with the key used by the rescheduler, which currently
+// lives in contrib. Its presence indicates 2 things, as far as the kubelet is
+// concerned:
+// 1. Resource related admission checks will prioritize the admission of
+//    pods bearing the key, over pods without the key, regardless of QoS.
+// 2. The OOM score of pods bearing the key will be <= pods without
+//    the key (where the <= part is determied by QoS).
+const CriticalPodAnnotationKey = "scheduler.alpha.kubernetes.io/critical-pod"
+
 // PodOperation defines what changes will be made on a pod configuration.
 type PodOperation int
 

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -140,3 +140,11 @@ func (sp SyncPodType) String() string {
 		return "unknown"
 	}
 }
+
+// IsCriticalPod returns true if the pod bears the critical pod annotation
+// key. Both the rescheduler and the kubelet use this key to make admission
+// and scheduling decisions.
+func IsCriticalPod(pod *v1.Pod) bool {
+	_, ok := pod.Annotations[CriticalPodAnnotationKey]
+	return ok
+}

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -144,7 +144,7 @@ func (sp SyncPodType) String() string {
 // IsCriticalPod returns true if the pod bears the critical pod annotation
 // key. Both the rescheduler and the kubelet use this key to make admission
 // and scheduling decisions.
-func IsCriticalPod(pod *v1.Pod) bool {
+func IsCriticalPod(pod *api.Pod) bool {
 	_, ok := pod.Annotations[CriticalPodAnnotationKey]
 	return ok
 }


### PR DESCRIPTION
Fixed #38322

**Release note**:

```
* Kubelet admits critical pods including kube-proxy even under memory pressure
* Make critical pods have the same oom score as the guaranteed pods
* Stop evicting static pods
```
