### PR TITLE
Change the version of storage class from alpha to beta

### DIFF
--- a/examples/cockroachdb/cockroachdb-statefulset.yaml
+++ b/examples/cockroachdb/cockroachdb-statefulset.yaml
@@ -165,7 +165,7 @@ spec:
   - metadata:
       name: datadir
       annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
+        volume.beta.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - "ReadWriteOnce"

--- a/examples/storage/cassandra/README.md
+++ b/examples/storage/cassandra/README.md
@@ -255,7 +255,7 @@ spec:
   - metadata:
       name: cassandra-data
       annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
+        volume.beta.kubernetes.io/storage-class: anything
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/examples/storage/cassandra/cassandra-statefulset.yaml
+++ b/examples/storage/cassandra/cassandra-statefulset.yaml
@@ -74,7 +74,7 @@ spec:
   - metadata:
       name: cassandra-data
       annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
+        volume.beta.kubernetes.io/storage-class: anything
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/examples/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
+++ b/examples/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     demo: nfs-pv-provisioning
   annotations:
-    volume.alpha.kubernetes.io/storage-class: any
+    volume.beta.kubernetes.io/storage-class: any
 spec:
   accessModes: [ "ReadWriteOnce" ]
   resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Update the yamls in /example. 
**Which issue this PR fixes** 
The current storage-class version is beta. Replace `volume.alpha.kubernetes.io/storage-class` with `volume.beta.kubernetes.io/storage-class` in yamls.
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
