### PR TITLE
plugin/pkg/client/auth: add openstack auth provider

### DIFF
--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -175,6 +175,34 @@
 			"Rev": "0c5108395e2debce0d731cf0287ddf7242066aba"
 		},
 		{
+			"ImportPath": "github.com/gophercloud/gophercloud",
+			"Rev": "ed590d9afe113c6107cd60717b196155e6579e78"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack",
+			"Rev": "ed590d9afe113c6107cd60717b196155e6579e78"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
+			"Rev": "ed590d9afe113c6107cd60717b196155e6579e78"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
+			"Rev": "ed590d9afe113c6107cd60717b196155e6579e78"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
+			"Rev": "ed590d9afe113c6107cd60717b196155e6579e78"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/openstack/utils",
+			"Rev": "ed590d9afe113c6107cd60717b196155e6579e78"
+		},
+		{
+			"ImportPath": "github.com/gophercloud/gophercloud/pagination",
+			"Rev": "ed590d9afe113c6107cd60717b196155e6579e78"
+		},
+		{
 			"ImportPath": "github.com/gregjones/httpcache",
 			"Rev": "787624de3eb7bd915c329cba748687a3b22666a6"
 		},

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/azure:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/gcp:go_default_library",
         "//vendor/k8s.io/client-go/plugin/pkg/client/auth/oidc:go_default_library",
+        "//vendor/k8s.io/client-go/plugin/pkg/client/auth/openstack:go_default_library",
     ],
 )
 
@@ -32,6 +33,7 @@ filegroup(
         "//staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure:all-srcs",
         "//staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp:all-srcs",
         "//staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc:all-srcs",
+        "//staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/BUILD
@@ -1,0 +1,40 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["openstack_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["openstack.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/gophercloud/gophercloud/openstack:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/gophercloud/gophercloud/openstack"
+
+	restclient "k8s.io/client-go/rest"
+)
+
+func init() {
+	if err := restclient.RegisterAuthProviderPlugin("openstack", newOpenstackAuthProvider); err != nil {
+		glog.Fatalf("Failed to register openstack auth plugin: %s", err)
+	}
+}
+
+// DefaultTTLDuration is the time before a token gets expired.
+const DefaultTTLDuration = 10 * time.Minute
+
+// openstackAuthProvider is an authprovider for openstack. this provider reads
+// the environment variables to determine the client identity, and generates a
+// token which will be inserted into the request header later.
+type openstackAuthProvider struct {
+	ttl time.Duration
+
+	tokenGetter TokenGetter
+}
+
+// TokenGetter returns a bearer token that can be inserted into request.
+type TokenGetter interface {
+	Token() (string, error)
+}
+
+type tokenGetter struct{}
+
+// Token creates a token by authenticate with keystone.
+func (*tokenGetter) Token() (string, error) {
+	options, err := openstack.AuthOptionsFromEnv()
+	if err != nil {
+		return "", fmt.Errorf("failed to read openstack env vars: %s", err)
+	}
+	client, err := openstack.AuthenticatedClient(options)
+	if err != nil {
+		return "", fmt.Errorf("authentication failed: %s", err)
+	}
+	return client.TokenID, nil
+}
+
+// cachedGetter caches a token until it gets expired, after the expiration, it will
+// generate another token and cache it.
+type cachedGetter struct {
+	mutex       sync.Mutex
+	tokenGetter TokenGetter
+
+	token string
+	born  time.Time
+	ttl   time.Duration
+}
+
+// Token returns the current available token, create a new one if expired.
+func (c *cachedGetter) Token() (string, error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	var err error
+	// no token or exceeds the TTL
+	if c.token == "" || time.Now().Sub(c.born) > c.ttl {
+		c.token, err = c.tokenGetter.Token()
+		if err != nil {
+			return "", fmt.Errorf("failed to get token: %s", err)
+		}
+		c.born = time.Now()
+	}
+	return c.token, nil
+}
+
+// tokenRoundTripper implements the RoundTripper interface: adding the bearer token
+// into the request header.
+type tokenRoundTripper struct {
+	http.RoundTripper
+
+	tokenGetter TokenGetter
+}
+
+// RoundTrip adds the bearer token into the request.
+func (t *tokenRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	// if the authorization header already present, use it.
+	if req.Header.Get("Authorization") != "" {
+		return t.RoundTripper.RoundTrip(req)
+	}
+
+	token, err := t.tokenGetter.Token()
+	if err == nil {
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		glog.V(4).Infof("failed to get token: %s", err)
+	}
+
+	return t.RoundTripper.RoundTrip(req)
+}
+
+// newOpenstackAuthProvider creates an auth provider which works with openstack
+// environment.
+func newOpenstackAuthProvider(clusterAddress string, config map[string]string, persister restclient.AuthProviderConfigPersister) (restclient.AuthProvider, error) {
+	var ttlDuration time.Duration
+	var err error
+
+	ttl, found := config["ttl"]
+	if !found {
+		ttlDuration = DefaultTTLDuration
+		// persist to config
+		config["ttl"] = ttlDuration.String()
+		if err = persister.Persist(config); err != nil {
+			return nil, fmt.Errorf("failed to persist config: %s", err)
+		}
+	} else {
+		ttlDuration, err = time.ParseDuration(ttl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ttl config: %s", err)
+		}
+	}
+
+	// TODO: read/persist client configuration(OS_XXX env vars) in config
+
+	return &openstackAuthProvider{
+		ttl:         ttlDuration,
+		tokenGetter: &tokenGetter{},
+	}, nil
+}
+
+func (oap *openstackAuthProvider) WrapTransport(rt http.RoundTripper) http.RoundTripper {
+	return &tokenRoundTripper{
+		RoundTripper: rt,
+		tokenGetter: &cachedGetter{
+			tokenGetter: oap.tokenGetter,
+			ttl:         oap.ttl,
+		},
+	}
+}
+
+func (oap *openstackAuthProvider) Login() error { return nil }

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/openstack/openstack_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"math/rand"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// testTokenGetter is a simple random token getter.
+type testTokenGetter struct{}
+
+const LetterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+func RandStringBytes(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = LetterBytes[rand.Intn(len(LetterBytes))]
+	}
+	return string(b)
+}
+
+func (*testTokenGetter) Token() (string, error) {
+	return RandStringBytes(32), nil
+}
+
+// testRoundTripper is mocked roundtripper which responds with unauthorized when
+// there is no authorization header, otherwise returns status ok.
+type testRoundTripper struct{}
+
+func (trt *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	authHeader := req.Header.Get("Authorization")
+	if authHeader == "" || authHeader == "Bearer " {
+		return &http.Response{
+			StatusCode: http.StatusUnauthorized,
+		}, nil
+	}
+	return &http.Response{StatusCode: http.StatusOK}, nil
+}
+
+func TestOpenstackAuthProvider(t *testing.T) {
+	trt := &tokenRoundTripper{
+		RoundTripper: &testRoundTripper{},
+	}
+
+	tests := []struct {
+		name     string
+		ttl      time.Duration
+		interval time.Duration
+		same     bool
+	}{
+		{
+			name:     "normal",
+			ttl:      2 * time.Second,
+			interval: 1 * time.Second,
+			same:     true,
+		},
+		{
+			name:     "expire",
+			ttl:      1 * time.Second,
+			interval: 2 * time.Second,
+			same:     false,
+		},
+	}
+
+	for _, test := range tests {
+		trt.tokenGetter = &cachedGetter{
+			tokenGetter: &testTokenGetter{},
+			ttl:         test.ttl,
+		}
+
+		req, err := http.NewRequest(http.MethodPost, "https://test-api-server.com", nil)
+		if err != nil {
+			t.Errorf("failed to new request: %s", err)
+		}
+		trt.RoundTrip(req)
+		header := req.Header.Get("Authorization")
+		if header == "" {
+			t.Errorf("expect to see token in header, but is absent")
+		}
+
+		time.Sleep(test.interval)
+
+		req, err = http.NewRequest(http.MethodPost, "https://test-api-server.com", nil)
+		if err != nil {
+			t.Errorf("failed to new request: %s", err)
+		}
+		trt.RoundTrip(req)
+		newHeader := req.Header.Get("Authorization")
+		if newHeader == "" {
+			t.Errorf("expect to see token in header, but is absent")
+		}
+
+		same := newHeader == header
+		if same != test.same {
+			t.Errorf("expect to get %t when compare header, but saw %t", test.same, same)
+		}
+	}
+
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins.go
@@ -21,4 +21,5 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/openstack"
 )


### PR DESCRIPTION
This is an implementation of auth provider for OpenStack world, just like python-openstackclient, we read the environment variables of a list `OS_*`, and client will cache a token to interact with each components, we can do the same here, the client side can cache a token locally at the first time, and rotate automatically when it expires.

This requires an implementation of token authenticator at server side, refer:

1.  [made by me] https://github.com/kubernetes/kubernetes/pull/25536, I can carry this on when it is fine to go.
2.  [made by @kfox1111] https://github.com/kubernetes/kubernetes/pull/25391

The reason why I want to add this is due to the `client-side` nature, it will be confusing to implement it downstream, we would like to add this support here, and customers can get `kubectl` like they usually do(`brew install kubernetes-cli`), and it will just work.

When this is done, we can deprecate the password keystone authenticator as the following reasons:

1.  as mentioned at some other places, the `domain` is another parameters which should be provided.
2.  in case the user supplies `apikey` and `secrets`, we might want to fill the `UserInfo` with the real name which is not implemented for now.

cc @erictune @liggitt 

```
add openstack auth provider
```
