### PR TITLE
Fix fluentd-gcp image config by avoiding processing its own logs

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/td-agent.conf
@@ -100,7 +100,9 @@
 # problem yet to be solved as secrets are not usable in static pods which the fluentd
 # pod must be until a per-node controller is available in Kubernetes.
 
-# Do not directly collect fluentd's own logs to avoid infinite loops.
+# Prevent fluentd from handling records containing its own logs. Otherwise
+# it can lead to an infinite loop, when error in sending one message generates
+# another message which also fails to be sent and so on.
 <match fluent.**>
   type null
 </match>

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/fluent.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/fluent.conf
@@ -39,6 +39,13 @@
 # the name of the Kubernetes container regardless of how many times the
 # Kubernetes pod has been restarted (resulting in a several Docker container IDs).
 
+# Prevent fluentd from handling records containing its own logs. Otherwise
+# it can lead to an infinite loop, when error in sending one message generates
+# another message which also fails to be sent and so on.
+<match fluent.**>
+  type null
+</match>
+
 # Example:
 # {"log":"[info:2016-02-16T16:04:05.930-08:00] Some log text here\n","stream":"stdout","time":"2016-02-17T00:04:05.931087621Z"}
 <source>


### PR DESCRIPTION
Section, discarding all records generated by fluentd itself from the pipeline was deleted by mistake in https://github.com/kubernetes/kubernetes/pull/37681. Returning it back and expanding the comment.

Not bumping image version for the later cumulative update.

CC @piosz