### PR TITLE
Add hack/verify-readonly-packages.sh

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -402,6 +402,7 @@ kube::util::git_upstream_remote_name() {
 kube::util::has_changes_against_upstream_branch() {
   local -r git_branch=$1
   local -r pattern=$2
+  local -r not_pattern=${3:-totallyimpossiblepattern}
   local full_branch
 
   full_branch="$(kube::util::git_upstream_remote_name)/${git_branch}"
@@ -412,11 +413,11 @@ kube::util::has_changes_against_upstream_branch() {
     exit 1
   fi
   # notice this uses ... to find the first shared ancestor
-  if git diff --name-only "${full_branch}...HEAD" | grep "${pattern}" > /dev/null; then
+  if git diff --name-only "${full_branch}...HEAD" | grep -v "${not_pattern}" | grep "${pattern}" > /dev/null; then
     return 0
   fi
   # also check for pending changes
-  if git status --porcelain | grep "${pattern}" > /dev/null; then
+  if git status --porcelain | grep -v "${not_pattern}" | grep "${pattern}" > /dev/null; then
     echo "Detected '${pattern}' uncommitted changes."
     return 0
   fi

--- a/hack/verify-readonly-packages.sh
+++ b/hack/verify-readonly-packages.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# verify-readonly-packages.sh checks whether between $KUBE_VERIFY_GIT_BRANCH and HEAD files
+# in readonly directories were modified. A directory is readonly iff it contains a .readonly
+# file. Being readonly DOES NOT apply recursively to subdirectories.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './_output' \
+        -o -wholename './_gopath' \
+        -o -wholename './release' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/vendor/*' \
+        -o -wholename './staging' \
+      \) -prune \
+    \) -name '.readonly'
+}
+
+IFS=$'\n'
+conflicts=($(find_files | sed 's|/.readonly||' | while read dir; do
+    dir=${dir#./}
+    if kube::util::has_changes_against_upstream_branch "${branch}" "^${dir}/[^/]*\$" "/.readonly\$" &>/dev/null; then
+        echo "${dir}"
+    fi
+done))
+unset IFS
+
+if [ ${#conflicts[@]} -gt 0 ]; then
+    exec 1>&2
+    for dir in "${conflicts[@]}"; do
+        echo "Found ${dir}/.readonly, but files changed compared to \"${branch}\" branch."
+    done
+    exit 1
+else
+    echo "Readonly packages verified."
+fi
+# ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
Create a `.readonly` file in a package. Any change between `$KUBE_VERIFY_GIT_BRANCH` and `HEAD` will lead to output like:

```shell
$ hack/verify-readonly-packages.sh
Readonly packages changed compared to "master" branch: pkg/generated
```

This is part of https://github.com/kubernetes/kubernetes/issues/39528