### PR TITLE
kubeadm: updated DNS deployment.

### DIFF
--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -31,19 +31,17 @@ const (
 	KubeSchedulerImage         = "scheduler"
 	KubeProxyImage             = "proxy"
 
-	KubeDNSImage            = "kubedns"
-	KubeDNSmasqImage        = "kube-dnsmasq"
-	KubeDNSmasqMetricsImage = "dnsmasq-metrics"
-	KubeExechealthzImage    = "exechealthz"
-	Pause                   = "pause"
+	KubeDNSImage        = "k8s-dns-kube-dns"
+	KubeDNSmasqImage    = "k8s-dns-dnsmasq"
+	KubeDNSSidecarImage = "k8s-dns-sidecar"
+	Pause               = "pause"
 
 	gcrPrefix   = "gcr.io/google_containers"
 	etcdVersion = "3.0.14-kubeadm"
 
-	kubeDNSVersion        = "1.9"
-	dnsmasqVersion        = "1.4"
-	exechealthzVersion    = "1.2"
-	dnsmasqMetricsVersion = "1.0"
+	kubeDNSVersion        = "1.10.1"
+	dnsmasqVersion        = "1.10.1"
+	kubeDNSSidecarVersion = "1.10.1"
 	pauseVersion          = "3.0"
 )
 
@@ -64,10 +62,9 @@ func GetCoreImage(image string, cfg *kubeadmapi.MasterConfiguration, overrideIma
 func GetAddonImage(image string) string {
 	repoPrefix := kubeadmapi.GlobalEnvParams.RepositoryPrefix
 	return map[string]string{
-		KubeDNSImage:            fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kubedns", runtime.GOARCH, kubeDNSVersion),
-		KubeDNSmasqImage:        fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kube-dnsmasq", runtime.GOARCH, dnsmasqVersion),
-		KubeDNSmasqMetricsImage: fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "dnsmasq-metrics", runtime.GOARCH, dnsmasqMetricsVersion),
-		KubeExechealthzImage:    fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "exechealthz", runtime.GOARCH, exechealthzVersion),
-		Pause:                   fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "pause", runtime.GOARCH, pauseVersion),
+		KubeDNSImage:        fmt.Sprintf("%s/%s-%s:%s", repoPrefix, KubeDNSImage, runtime.GOARCH, kubeDNSVersion),
+		KubeDNSmasqImage:    fmt.Sprintf("%s/%s-%s:%s", repoPrefix, KubeDNSmasqImage, runtime.GOARCH, dnsmasqVersion),
+		KubeDNSSidecarImage: fmt.Sprintf("%s/%s-%s:%s", repoPrefix, KubeDNSSidecarImage, runtime.GOARCH, kubeDNSSidecarVersion),
+		Pause:               fmt.Sprintf("%s/%s-%s:%s", repoPrefix, Pause, runtime.GOARCH, pauseVersion),
 	}[image]
 }

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -84,19 +84,19 @@ func TestGetAddonImage(t *testing.T) {
 		{"matches nothing", ""},
 		{
 			KubeDNSImage,
-			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kubedns", runtime.GOARCH, kubeDNSVersion),
+			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, KubeDNSImage, runtime.GOARCH, kubeDNSVersion),
 		},
 		{
 			KubeDNSmasqImage,
-			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-dnsmasq", runtime.GOARCH, dnsmasqVersion),
+			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, KubeDNSmasqImage, runtime.GOARCH, dnsmasqVersion),
 		},
 		{
-			KubeExechealthzImage,
-			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "exechealthz", runtime.GOARCH, exechealthzVersion),
+			KubeDNSSidecarImage,
+			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, KubeDNSSidecarImage, runtime.GOARCH, kubeDNSSidecarVersion),
 		},
 		{
 			Pause,
-			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "pause", runtime.GOARCH, pauseVersion),
+			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, Pause, runtime.GOARCH, pauseVersion),
 		},
 	}
 	for _, rt := range tokenTest {

--- a/cmd/kubeadm/app/master/addons.go
+++ b/cmd/kubeadm/app/master/addons.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/v1"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	"k8s.io/kubernetes/pkg/util/intstr"
 )
@@ -82,16 +82,14 @@ func createKubeProxyPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.PodSpec {
 }
 
 func createKubeDNSPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.PodSpec {
-
 	kubeDNSPort := int32(10053)
 	dnsmasqPort := int32(53)
-	dnsMasqMetricsUser := int64(0)
 
 	return v1.PodSpec{
 		Containers: []v1.Container{
 			// DNS server
 			{
-				Name:  "kube-dns",
+				Name:  "kubedns",
 				Image: images.GetAddonImage(images.KubeDNSImage),
 				Resources: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
@@ -105,8 +103,8 @@ func createKubeDNSPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.PodSpec {
 				LivenessProbe: &v1.Probe{
 					Handler: v1.Handler{
 						HTTPGet: &v1.HTTPGetAction{
-							Path:   "/healthz-kubedns",
-							Port:   intstr.FromInt(8080),
+							Path:   "/healthcheck/kubedns",
+							Port:   intstr.FromInt(10054),
 							Scheme: v1.URISchemeHTTP,
 						},
 					},
@@ -165,8 +163,8 @@ func createKubeDNSPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.PodSpec {
 				LivenessProbe: &v1.Probe{
 					Handler: v1.Handler{
 						HTTPGet: &v1.HTTPGetAction{
-							Path:   "/healthz-dnsmasq",
-							Port:   intstr.FromInt(8080),
+							Path:   "/healthcheck/dnsmasq",
+							Port:   intstr.FromInt(10054),
 							Scheme: v1.URISchemeHTTP,
 						},
 					},
@@ -201,8 +199,8 @@ func createKubeDNSPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.PodSpec {
 				},
 			},
 			{
-				Name:  "dnsmasq-metrics",
-				Image: images.GetAddonImage(images.KubeDNSmasqMetricsImage),
+				Name:  "sidecar",
+				Image: images.GetAddonImage(images.KubeDNSSidecarImage),
 				LivenessProbe: &v1.Probe{
 					Handler: v1.Handler{
 						HTTPGet: &v1.HTTPGetAction{
@@ -216,16 +214,11 @@ func createKubeDNSPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.PodSpec {
 					SuccessThreshold:    1,
 					FailureThreshold:    5,
 				},
-				// The code below is a workaround for https://github.com/kubernetes/contrib/blob/master/dnsmasq-metrics/Dockerfile.in#L21
-				// This is just the normal mode (to run with user 0), all other containers do it except for this one, which may lead to
-				// that the DNS pod fails if the "nobody" _group_ doesn't exist. I think it's a typo in the Dockerfile manifest and
-				// that it should be "USER nobody:nogroup" instead of "USER nobody:nobody". However, this fixes the problem.
-				SecurityContext: &v1.SecurityContext{
-					RunAsUser: &dnsMasqMetricsUser,
-				},
 				Args: []string{
 					"--v=2",
 					"--logtostderr",
+					fmt.Sprintf("--probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.%s,5,A", cfg.Networking.DNSDomain),
+					fmt.Sprintf("--probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.%s,5,A", cfg.Networking.DNSDomain),
 				},
 				Ports: []v1.ContainerPort{
 					{
@@ -236,35 +229,10 @@ func createKubeDNSPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.PodSpec {
 				},
 				Resources: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
-						v1.ResourceName(v1.ResourceMemory): resource.MustParse("10Mi"),
-					},
-				},
-			},
-			// healthz
-			{
-				Name:  "healthz",
-				Image: images.GetAddonImage(images.KubeExechealthzImage),
-				Resources: v1.ResourceRequirements{
-					Limits: v1.ResourceList{
-						v1.ResourceName(v1.ResourceMemory): resource.MustParse("50Mi"),
-					},
-					Requests: v1.ResourceList{
+						v1.ResourceName(v1.ResourceMemory): resource.MustParse("20Mi"),
 						v1.ResourceName(v1.ResourceCPU):    resource.MustParse("10m"),
-						v1.ResourceName(v1.ResourceMemory): resource.MustParse("50Mi"),
 					},
 				},
-				Args: []string{
-					fmt.Sprintf("--cmd=nslookup kubernetes.default.svc.%s 127.0.0.1 >/dev/null", cfg.Networking.DNSDomain),
-					"--url=/healthz-dnsmasq",
-					fmt.Sprintf("--cmd=nslookup kubernetes.default.svc.%s 127.0.0.1:%d >/dev/null", cfg.Networking.DNSDomain, kubeDNSPort),
-					"--url=/healthz-kubedns",
-					"--port=8080",
-					"--quiet",
-				},
-				Ports: []v1.ContainerPort{{
-					ContainerPort: 8080,
-					Protocol:      v1.ProtocolTCP,
-				}},
 			},
 		},
 		DNSPolicy: v1.DNSDefault,


### PR DESCRIPTION
**What this PR does / why we need it**: Updates KubeDNS deployment to match upstream.

**Special notes for your reviewer**: It was tested manually by bootstrapping a new cluster, running a busybox container and making sure one could `nslookup` from within the container to find `kubernetes` and other services.