### PR TITLE
Remove nodeSelector from fluentd

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -34,8 +34,6 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-      nodeSelector:
-        alpha.kubernetes.io/fluentd-ds-ready: "true"
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
Remove nodeSelector `alpha.kubernetes.io/fluentd-ds-ready`

**What this PR does / why we need it**:
It removes the nodeSelector by label `alpha.kubernetes.io/fluentd-ds-ready`. 

- The marking logic with label only complicates things. When installing `fluentd-es-v1.20` DaemonSet it will install one Pod per node. This is expected behavior. But with label user needs to mark nodes proactively. When using autoscaling this creates unnecessary complexity on cluster management, that first you need to label the node, and then expect DaemonSet to appear there.
- This selector creates unneeded issues when setting up fresh Kuberetes 1.5 cluster and for all fresh comers.

According to https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/meta/v1/well_known_labels.go#L31 this `hack` was done in order to not have 2 running instances of Fluentd at once during upgrade. But then it be solved as scaling down to 0 old Fluentd Pods before upgrade, create new `fluentd-es-v1.20` DaemonSet, and then checking it.

**Which issue this PR fixes**
#39623

**Release note**:
```
1. Removes nodeSelector `alpha.kubernetes.io/fluentd-ds-ready` from Fluentd DaemonSet
2. If you have old Fluentd Pods which are not DaemonSets:
- Scale down to 0 old Fluentd Pods
- Deploy new `fluentd-es` DaemonSet
- check if logs are flowing fine
- remove old Fluentd pods
```