### PR TITLE
Automated cherry pick of #39115 #39074

### DIFF
--- a/test/e2e_node/jenkins/e2e-node-jenkins.sh
+++ b/test/e2e_node/jenkins/e2e-node-jenkins.sh
@@ -42,9 +42,9 @@ TIMEOUT=${TIMEOUT:-"45m"}
 
 mkdir -p ${ARTIFACTS}
 
-go run test/e2e_node/runner/remote/run_remote.go  --logtostderr --vmodule=*=4 --ssh-env="gce" \
-  --zone="$GCE_ZONE" --project="$GCE_PROJECT" --hosts="$GCE_HOSTS" \
-  --images="$GCE_IMAGES" --image-project="$GCE_IMAGE_PROJECT" \
+go run test/e2e_node/runner/remote/run_remote.go  --logtostderr --vmodule=*=4 \
+  --ssh-env="gce" --ssh-user="$GCE_USER" --zone="$GCE_ZONE" --project="$GCE_PROJECT" \
+  --hosts="$GCE_HOSTS" --images="$GCE_IMAGES" --image-project="$GCE_IMAGE_PROJECT" \
   --image-config-file="$GCE_IMAGE_CONFIG_PATH" --cleanup="$CLEANUP" \
   --results-dir="$ARTIFACTS" --ginkgo-flags="--nodes=$PARALLELISM $GINKGO_FLAGS" \
   --test-timeout="$TIMEOUT" --setup-node="$SETUP_NODE" --test_args="$TEST_ARGS" \

--- a/test/e2e_node/jenkins/template.properties
+++ b/test/e2e_node/jenkins/template.properties
@@ -1,4 +1,6 @@
 # Copy this file to your home directory and modify
+# User used on the gce instances to run the test.
+GCE_USER=
 # Path to a yaml or json file describing images to run or empty
 GCE_IMAGE_CONFIG_PATH=
 # Names of gce hosts to test against (must be resolvable) or empty

--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -212,9 +212,10 @@ func RunRemote(archive string, host string, cleanup bool, junitFilePrefix string
 
 	// Extract the archive
 	cmd = getSshCommand(" && ", fmt.Sprintf("cd %s", tmp), fmt.Sprintf("tar -xzvf ./%s", archiveName))
-	glog.Infof("Extracting tar on %s", host)
-	output, err := RunSshCommand("ssh", GetHostnameOrIp(host), "--", "sh", "-c", cmd)
-	if err != nil {
+	glog.V(2).Infof("Extracting tar on %q", host)
+	// Do not use sudo here, because `sudo tar -x` will recover the file ownership inside the tar ball, but
+	// we want the extracted files to be owned by the current user.
+	if output, err := SSHNoSudo(host, "sh", "-c", cmd); err != nil {
 		// Exit failure with the error
 		return "", false, err
 	}


### PR DESCRIPTION
Cherry pick of #39115 #39074 on release-1.4.

#39115: Do not use sudo when untar node e2e tar ball.
#39074: Support set user with `--ssh-user` flag when running remote