### PR TITLE
DNS is case-insensitive.

### DIFF
--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -87,8 +87,8 @@ func IsValidLabelValue(value string) []string {
 	return errs
 }
 
-const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
-const dns1123LabelErrMsg string = "a valid DNS (RFC 1123) label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+const dns1123LabelFmt string = "[a-zA-Z0-9]([-a-z-A-Z0-9]*[a-zA-Z0-9])?"
+const dns1123LabelErrMsg string = "a valid DNS (RFC 1123) label must consist of alphanumeric characters or '-', and must start and end with an alphanumeric character"
 const DNS1123LabelMaxLength int = 63
 
 var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
@@ -107,7 +107,7 @@ func IsDNS1123Label(value string) []string {
 }
 
 const dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
-const dns1123SubdomainErrorMsg string = "a valid DNS (RFC 1123) subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
+const dns1123SubdomainErrorMsg string = "a valid DNS (RFC 1123) subdomain must consist of alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
 const DNS1123SubdomainMaxLength int = 253
 
 var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
@@ -125,8 +125,8 @@ func IsDNS1123Subdomain(value string) []string {
 	return errs
 }
 
-const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
-const dns1035LabelErrMsg string = "a valid DNS (RFC 1035) label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+const dns1035LabelFmt string = "[a-zA-Z]([-a-z-A-Z0-9]*[a-zA-Z0-9])?"
+const dns1035LabelErrMsg string = "a valid DNS (RFC 1035) label must consist of alphanumeric characters or '-', and must start and end with an alphanumeric character"
 const DNS1035LabelMaxLength int = 63
 
 var dns1035LabelRegexp = regexp.MustCompile("^" + dns1035LabelFmt + "$")

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -34,7 +34,7 @@ func TestIsDNS1123Label(t *testing.T) {
 	}
 
 	badValues := []string{
-		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"",
 		"-", "a-", "-a", "1-", "-1",
 		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
 		".", "a.", ".a", "a.b", "1.", ".1", "1.2",
@@ -66,15 +66,11 @@ func TestIsDNS1123Subdomain(t *testing.T) {
 	}
 
 	badValues := []string{
-		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"",
 		"-", "a-", "-a", "1-", "-1",
 		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
 		".", "a.", ".a", "a..b", "1.", ".1", "1..2",
 		" ", "a ", " a", "a b", "1 ", " 1", "1 2",
-		"A.a", "aB.a", "ab.A", "A1.a", "a1.A",
-		"A.1", "aB.1", "A1.1", "1A.1",
-		"0.A", "01.A", "012.A", "1A.a", "1a.A",
-		"A.B.C.D.E", "AA.BB.CC.DD.EE", "a.B.c.d.e", "aa.bB.cc.dd.ee",
 		"a@b", "a,b", "a_b", "a;b",
 		"a:b", "a%b", "a?b", "a$b",
 		strings.Repeat("a", 254),
@@ -99,7 +95,7 @@ func TestIsDNS1035Label(t *testing.T) {
 
 	badValues := []string{
 		"0", "01", "012", "1a", "1-a", "1--a--b--2",
-		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"", "1-A",
 		"-", "a-", "-a", "1-", "-1",
 		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
 		".", "a.", ".a", "a.b", "1.", ".1", "1.2",
@@ -233,7 +229,6 @@ func TestIsQualifiedName(t *testing.T) {
 		"cantendwithadash-",
 		"-cantstartwithadash-",
 		"only/one/slash",
-		"Example.com/abc",
 		"example_com/abc",
 		"example.com/",
 		"/simple",


### PR DESCRIPTION
**What this PR does / why we need it**: This PR fixes an erroneous DNS name validation where only lower case names were accepted. DNS is case-insensitive as per [RFC 4343 -  Domain Name System (DNS) Case Insensitivity Clarification](https://tools.ietf.org/html/rfc4343):
>According to the original DNS design decision, comparisons on name
>lookup for DNS queries should be case insensitive [STD13].  That is
>to say, a lookup string octet with a value in the inclusive
>from 0x41 to 0x5A, the uppercase ASCII letters, MUST match the
>identical value and also match the corresponding value in the
>inclusive range from 0x61 to 0x7A, the lowercase ASCII letters.  A
>lookup string octet with a lowercase ASCII letter value MUST
>similarly match the identical value and also match the corresponding
>value in the uppercase ASCII letter range.

**Which issue this PR fixes**: fixes https://github.com/kubernetes/kubeadm/issues/104

**Special notes for your reviewer**: /cc @mikedanese (issue reporter), @thockin (regexp author).
