### PR TITLE
Disable TestValidOpenAPISpec when -race test flag exists

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -90,6 +90,7 @@ go_test(
     srcs = [
         "controller_test.go",
         "import_known_versions_test.go",
+        "master_openapi_test.go",
         "master_test.go",
     ],
     library = ":go_default_library",

--- a/pkg/master/master_openapi_test.go
+++ b/pkg/master/master_openapi_test.go
@@ -1,0 +1,95 @@
+// +build !race
+
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+// This test file is separated from master_test.go so we would be able to disable
+// race check for it. TestValidOpenAPISpec will became extremely slow if -race
+// flag exists, and will cause the tests to timeout.
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	openapigen "k8s.io/kubernetes/pkg/generated/openapi"
+	"k8s.io/kubernetes/pkg/genericapiserver"
+
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/spec"
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/validate"
+)
+
+// TestValidOpenAPISpec verifies that the open api is added
+// at the proper endpoint and the spec is valid.
+func TestValidOpenAPISpec(t *testing.T) {
+	_, etcdserver, config, assert := setUp(t)
+	defer etcdserver.Terminate(t)
+
+	config.GenericConfig.EnableIndex = true
+	config.GenericConfig.OpenAPIConfig = genericapiserver.DefaultOpenAPIConfig(openapigen.OpenAPIDefinitions)
+	config.GenericConfig.OpenAPIConfig.Info = &spec.Info{
+		InfoProps: spec.InfoProps{
+			Title:   "Kubernetes",
+			Version: "unversioned",
+		},
+	}
+	config.GenericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
+
+	master, err := config.Complete().New()
+	if err != nil {
+		t.Fatalf("Error in bringing up the master: %v", err)
+	}
+
+	// make sure swagger.json is not registered before calling PrepareRun.
+	server := httptest.NewServer(master.GenericAPIServer.HandlerContainer.ServeMux)
+	defer server.Close()
+	resp, err := http.Get(server.URL + "/swagger.json")
+	if !assert.NoError(err) {
+		t.Errorf("unexpected error: %v", err)
+	}
+	assert.Equal(http.StatusNotFound, resp.StatusCode)
+
+	master.GenericAPIServer.PrepareRun()
+
+	resp, err = http.Get(server.URL + "/swagger.json")
+	if !assert.NoError(err) {
+		t.Errorf("unexpected error: %v", err)
+	}
+	assert.Equal(http.StatusOK, resp.StatusCode)
+
+	// as json schema
+	var sch spec.Schema
+	if assert.NoError(decodeResponse(resp, &sch)) {
+		validator := validate.NewSchemaValidator(spec.MustLoadSwagger20Schema(), nil, "", strfmt.Default)
+		res := validator.Validate(&sch)
+		assert.NoError(res.AsError())
+	}
+
+	// Validate OpenApi spec
+	doc, err := loads.Spec(server.URL + "/swagger.json")
+	if assert.NoError(err) {
+		validator := validate.NewSpecValidator(doc.Schema(), strfmt.Default)
+		res, warns := validator.Validate(doc)
+		assert.NoError(res.AsError())
+		if !warns.IsValid() {
+			t.Logf("Open API spec on root has some warnings : %v", warns)
+		}
+	}
+}


### PR DESCRIPTION
"-race" test flag makes TestValidOpenAPISpec extremely slow and causes test timeouts. Moving it to a new file and set build flag to disable it when race checking is enabled.

fixes #39604 