### PR TITLE
Add support for groups to passwordfile

### DIFF
--- a/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile.go
+++ b/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/golang/glog"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -47,6 +48,7 @@ func NewCSV(path string) (*PasswordAuthenticator, error) {
 	recordNum := 0
 	users := make(map[string]*userPasswordInfo)
 	reader := csv.NewReader(file)
+	reader.FieldsPerRecord = -1
 	for {
 		record, err := reader.Read()
 		if err == io.EOF {
@@ -61,6 +63,9 @@ func NewCSV(path string) (*PasswordAuthenticator, error) {
 		obj := &userPasswordInfo{
 			info:     &user.DefaultInfo{Name: record[1], UID: record[2]},
 			password: record[0],
+		}
+		if len(record) >= 4 {
+			obj.info.Groups = strings.Split(record[3], ",")
 		}
 		recordNum++
 		if _, exist := users[obj.info.Name]; exist {

--- a/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile_test.go
+++ b/plugin/pkg/auth/authenticator/password/passwordfile/passwordfile_test.go
@@ -29,6 +29,11 @@ func TestPasswordFile(t *testing.T) {
 	auth, err := newWithContents(t, `
 password1,user1,uid1
 password2,user2,uid2
+password3,user3,uid3,"group1,group2"
+password4,user4,uid4,"group2"
+password5,user5,uid5,group5
+password6,user6,uid6,group5,otherdata
+password7,user7,uid7,"group1,group2",otherdata
 `)
 	if err != nil {
 		t.Fatalf("unable to read passwordfile: %v", err)
@@ -64,10 +69,44 @@ password2,user2,uid2
 		{
 			Username: "user3",
 			Password: "password3",
+			User:     &user.DefaultInfo{Name: "user3", UID: "uid3", Groups: []string{"group1", "group2"}},
+			Ok:       true,
 		},
 		{
 			Username: "user4",
 			Password: "password4",
+			User:     &user.DefaultInfo{Name: "user4", UID: "uid4", Groups: []string{"group2"}},
+			Ok:       true,
+		},
+		{
+			Username: "user5",
+			Password: "password5",
+			User:     &user.DefaultInfo{Name: "user5", UID: "uid5", Groups: []string{"group5"}},
+			Ok:       true,
+		},
+		{
+			Username: "user6",
+			Password: "password6",
+			User:     &user.DefaultInfo{Name: "user6", UID: "uid6", Groups: []string{"group5"}},
+			Ok:       true,
+		},
+		{
+			Username: "user7",
+			Password: "password7",
+			User:     &user.DefaultInfo{Name: "user7", UID: "uid7", Groups: []string{"group1", "group2"}},
+			Ok:       true,
+		},
+		{
+			Username: "user7",
+			Password: "passwordbad",
+		},
+		{
+			Username: "userbad",
+			Password: "password7",
+		},
+		{
+			Username: "user8",
+			Password: "password8",
 		},
 	}
 	for i, testCase := range testCases {


### PR DESCRIPTION
As we move deployment methods to using RBAC, it is useful to be able to place the admin user in the bootstrap kubeconfig files in a superuser group. The tokencsv file supports specifying group membership, but the basicauth file does not. This adds it for parity.

I plan to update the generated password file to put the admin user in a group (similar to the way https://github.com/kubernetes/kubernetes/pull/39537 puts that user in a group in the token file)

```release-note
--basic-auth-file supports optionally specifying groups in the fourth column of the file
```