### PR TITLE
Automated cherry pick of #38410

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials.go
+++ b/pkg/credentialprovider/aws/aws_credentials.go
@@ -44,6 +44,7 @@ var AWSRegions = [...]string{
 	"ap-southeast-2",
 	"ap-northeast-1",
 	"ap-northeast-2",
+	"ca-central-1",
 	"cn-north-1",
 	"us-gov-west-1",
 	"sa-east-1",


### PR DESCRIPTION
Cherry pick of #38410 on release-1.5.

#38410: AWS: Recognize ca-central-1 region