### PR TITLE
add admin bind to booststrppolicy

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -263,6 +263,7 @@ func ClusterRoles() []rbac.ClusterRole {
 // ClusterRoleBindings return default rolebindings to the default roles
 func ClusterRoleBindings() []rbac.ClusterRoleBinding {
 	rolebindings := []rbac.ClusterRoleBinding{
+		rbac.NewClusterBinding("admin").Groups(user.AdminGroup).BindingOrDie(),
 		rbac.NewClusterBinding("cluster-admin").Groups(user.SystemPrivilegedGroup).BindingOrDie(),
 		rbac.NewClusterBinding("system:discovery").Groups(user.AllAuthenticated, user.AllUnauthenticated).BindingOrDie(),
 		rbac.NewClusterBinding("system:basic-user").Groups(user.AllAuthenticated, user.AllUnauthenticated).BindingOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
@@ -6,6 +6,20 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: admin
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: ClusterRole
+    name: admin
+  subjects:
+  - kind: Group
+    name: system:admins
+- apiVersion: rbac.authorization.k8s.io/v1alpha1
+  kind: ClusterRoleBinding
+  metadata:
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: cluster-admin
   roleRef:
     apiGroup: rbac.authorization.k8s.io

--- a/staging/src/k8s.io/apiserver/pkg/authentication/user/user.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/user/user.go
@@ -68,6 +68,7 @@ func (i *DefaultInfo) GetExtra() map[string][]string {
 
 // well-known user and group names
 const (
+	AdminGroup            = "system:admins"
 	SystemPrivilegedGroup = "system:masters"
 	NodesGroup            = "system:nodes"
 	AllUnauthenticated    = "system:unauthenticated"

--- a/staging/src/k8s.io/client-go/pkg/auth/user/user.go
+++ b/staging/src/k8s.io/client-go/pkg/auth/user/user.go
@@ -68,6 +68,7 @@ func (i *DefaultInfo) GetExtra() map[string][]string {
 
 // well-known user and group names
 const (
+	AdminGroup            = "system:admins"
 	SystemPrivilegedGroup = "system:masters"
 	NodesGroup            = "system:nodes"
 	AllUnauthenticated    = "system:unauthenticated"


### PR DESCRIPTION
GCE Error:
```
# cluster/kube-up.sh
Error from server (Forbidden): User "admin" cannot list nodes at the cluster scope. (get nodes)
(kubectl failed, will retry 2 times)
...
```
We should add a clusterrolebinding to admin at the booststrap to fix it.
Admin is used in some places.
```
hack/update-openapi-spec.sh
55:echo "dummy_token,admin,admin" > $TMP_DIR/tokenauth.csv

hack/update-federation-openapi-spec.sh
53:echo "dummy_token,admin,admin" > $TMP_DIR/tokenauth.csv

federation/cluster/common.sh
159:    export FEDERATION_API_KNOWN_TOKENS="${FEDERATION_API_TOKEN},admin,admin"

cluster/images/hyperkube/setup-files.sh
54:	echo "admin,admin,admin" > ${DATA_DIR}/basic_auth.csv
64:	echo "$(create_token),admin,admin" >> ${DATA_DIR}/known_tokens.csv

cluster/rackspace/authorization.sh
29:  echo "$(create_token),admin,admin" >> ${KUBE_TEMP}/known_tokens.csv

cluster/gce/configure-vm.sh
670:      echo "${KUBE_BEARER_TOKEN},admin,admin" > "${KNOWN_TOKENS_FILE}";

cluster/gce/trusty/configure-helper.sh
310:    echo "${KUBE_BEARER_TOKEN},admin,admin" > "${known_tokens_csv}"

cluster/gce/gci/configure-helper.sh
210:    echo "${KUBE_BEARER_TOKEN},admin,admin" > "${known_tokens_csv}"

cluster/gce/container-linux/configure-helper.sh
147:    echo "${KUBE_BEARER_TOKEN},admin,admin" > "${known_tokens_csv}"

cluster/vagrant/provision-master.sh
79:   echo "$KUBE_BEARER_TOKEN,admin,admin" >> $known_tokens_file)

test/kubemark/start-kubemark.sh
154:    sudo bash -c \"echo \"${KUBE_BEARER_TOKEN},admin,admin\" > /etc/srv/kubernetes/known_tokens.csv\" && \
157:    sudo bash -c \"echo ${password},admin,admin > /etc/srv/kubernetes/basic_auth.csv\""
```