### PR TITLE
Update dashboard version to v1.5.1

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.0
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.5.1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Latest Dashboard developments, including a CSRF issue in the dashboard POST handlers

**Release note**:
```
Set Dashboard UI version to v1.5.1
```
