### PR TITLE
Automated cherry pick of #39457

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -563,6 +563,14 @@ func NewGarbageCollector(metaOnlyClientPool dynamic.ClientPool, clientPool dynam
 		}
 		kind, err := gc.restMapper.KindFor(resource)
 		if err != nil {
+			if _, ok := err.(*meta.NoResourceMatchError); ok {
+				// ignore NoResourceMatchErrors for now because TPRs won't be registered
+				// and hence the RestMapper does not know about them. The deletableResources
+				// though are using discovery which included TPRs.
+				// TODO: use dynamic discovery for RestMapper and deletableResources
+				glog.Warningf("ignore NoResourceMatchError for %v", resource)
+				continue
+			}
 			return nil, err
 		}
 		monitor, err := gc.monitorFor(resource, kind)

--- a/pkg/master/thirdparty/thirdparty.go
+++ b/pkg/master/thirdparty/thirdparty.go
@@ -281,6 +281,7 @@ func (m *ThirdPartyResourceServer) InstallThirdPartyResource(rsrc *extensions.Th
 	m.genericAPIServer.HandlerContainer.Add(apiserver.NewGroupWebService(api.Codecs, path, apiGroup))
 
 	m.addThirdPartyResourceStorage(path, plural.Resource, thirdparty.Storage[plural.Resource].(*thirdpartyresourcedataetcd.REST), apiGroup)
+	registered.AddThirdPartyAPIGroupVersions(unversioned.GroupVersion{Group: group, Version: rsrc.Versions[0].Name})
 	return nil
 }
 


### PR DESCRIPTION
Cherry pick of #39457 on release-1.5.

#39457: warning instead error when search kinds for resources