### PR TITLE
Use dockerd process name to find the docker PID

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -58,7 +58,7 @@ const (
 	// The minimum memory limit allocated to docker container: 150Mi
 	MinDockerMemoryLimit = 150 * 1024 * 1024
 
-	dockerProcessName     = "docker"
+	dockerProcessName     = "dockerd?"
 	dockerPidFile         = "/var/run/docker.pid"
 	containerdProcessName = "docker-containerd"
 	containerdPidFile     = "/run/docker/libcontainerd/docker-containerd.pid"


### PR DESCRIPTION
Since docker 1.13 the docker daemon moved to a separate binary called *dockerd*

So instead of looking for *docker* process name to figure out the docker daemon's PID we should use *dockerd*.

That change is reflected here:
https://github.com/docker/docker/blob/master/CHANGELOG.md
> Marked the docker daemon command as deprecated. The daemon is moved to a separate binary (dockerd), and should be used instead #26834

Current solution works since it looks at `/var/run/docker.pid` first and only after that tries to do regexp search over the `/proc` tree.