### PR TITLE
Fix verify godeps again

### DIFF
--- a/pkg/watch/BUILD
+++ b/pkg/watch/BUILD
@@ -60,6 +60,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/watch/json:all-srcs",
+        "//pkg/watch/versioned:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/pkg/watch/versioned/BUILD
+++ b/pkg/watch/versioned/BUILD
@@ -1,0 +1,27 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["readonly.go"],
+    tags = ["automanaged"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/watch/versioned/readonly.go
+++ b/pkg/watch/versioned/readonly.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package versioned exists solely to make godep happy; it will be removed when all external
+// dependencies that rely on this package are updated to use its new location.
+package versioned


### PR DESCRIPTION
Fix broken godeps, again (broken by #39439). That PR removed pkg/watch/versioned, but we have godeps such as heapster that depend on that package (which they usually get by vendoring it themselves). This adds back the package with a comment stating it's only here temporarily.

@k8s-oncall @eparis @smarterclayton @sttts 