### PR TITLE
Fix gengo problem by rewriting before serialization

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package api
 
 import (
+	"k8s.io/fake-dep/pkgfoo"
 	"k8s.io/kubernetes/pkg/api/resource"
 	metav1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/fields"
@@ -3561,3 +3562,10 @@ const (
 	// DefaultFailureDomains defines the set of label keys used when TopologyKey is empty in PreferredDuringScheduling anti-affinity.
 	DefaultFailureDomains string = metav1.LabelHostname + "," + metav1.LabelZoneFailureDomain + "," + metav1.LabelZoneRegion
 )
+
+type NewTypeToCopy struct {
+	metav1.TypeMeta
+	ObjectMeta
+
+	FieldHere *pkgfoo.Foo
+}

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -21,13 +21,13 @@ limitations under the License.
 package api
 
 import (
+	pkgfoo "k8s.io/fake-dep/pkgfoo"
 	v1 "k8s.io/kubernetes/pkg/apis/meta/v1"
 	conversion "k8s.io/kubernetes/pkg/conversion"
 	fields "k8s.io/kubernetes/pkg/fields"
 	labels "k8s.io/kubernetes/pkg/labels"
 	runtime "k8s.io/kubernetes/pkg/runtime"
 	types "k8s.io/kubernetes/pkg/types"
-	pkgfoo "k8s.io/kubernetes/vendor/k8s.io/fake-dep/pkgfoo"
 	reflect "reflect"
 )
 

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -27,6 +27,7 @@ import (
 	labels "k8s.io/kubernetes/pkg/labels"
 	runtime "k8s.io/kubernetes/pkg/runtime"
 	types "k8s.io/kubernetes/pkg/types"
+	pkgfoo "k8s.io/kubernetes/vendor/k8s.io/fake-dep/pkgfoo"
 	reflect "reflect"
 )
 
@@ -109,6 +110,7 @@ func RegisterDeepCopies(scheme *runtime.Scheme) error {
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NamespaceList, InType: reflect.TypeOf(&NamespaceList{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NamespaceSpec, InType: reflect.TypeOf(&NamespaceSpec{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NamespaceStatus, InType: reflect.TypeOf(&NamespaceStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NewTypeToCopy, InType: reflect.TypeOf(&NewTypeToCopy{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Node, InType: reflect.TypeOf(&Node{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeAddress, InType: reflect.TypeOf(&NodeAddress{})},
 		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeAffinity, InType: reflect.TypeOf(&NodeAffinity{})},
@@ -1425,6 +1427,23 @@ func DeepCopy_api_NamespaceStatus(in interface{}, out interface{}, c *conversion
 		in := in.(*NamespaceStatus)
 		out := out.(*NamespaceStatus)
 		*out = *in
+		return nil
+	}
+}
+
+func DeepCopy_api_NewTypeToCopy(in interface{}, out interface{}, c *conversion.Cloner) error {
+	{
+		in := in.(*NewTypeToCopy)
+		out := out.(*NewTypeToCopy)
+		*out = *in
+		if err := DeepCopy_api_ObjectMeta(&in.ObjectMeta, &out.ObjectMeta, c); err != nil {
+			return err
+		}
+		if in.FieldHere != nil {
+			in, out := &in.FieldHere, &out.FieldHere
+			*out = new(pkgfoo.Foo)
+			**out = **in
+		}
 		return nil
 	}
 }

--- a/vendor/k8s.io/fake-dep/pkgfoo/types.go
+++ b/vendor/k8s.io/fake-dep/pkgfoo/types.go
@@ -1,0 +1,5 @@
+package pkgfoo
+
+type Foo struct {
+	Bar string
+}


### PR DESCRIPTION
Alternative to https://github.com/kubernetes/kubernetes/pull/39644 based on https://github.com/kubernetes/kubernetes/pull/39644#discussion_r95277500.  It doesn't seem much cleaner.  I kind of like knowing what the actual golang package import is in the map.

@thockin @lavalamp 

I'll open both pulls against gengo.