### PR TITLE
Don't blame DNS spec on Kubernetes requirement for lower-case DNS labels.

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -35,8 +35,8 @@ import (
 )
 
 const (
-	dnsLabelErrMsg          = "a valid DNS (RFC 1123) label must consist of"
-	dnsSubdomainLabelErrMsg = "a valid DNS (RFC 1123) subdomain"
+	dnsLabelErrMsg          = "a DNS-1123 label must consist of"
+	dnsSubdomainLabelErrMsg = "a DNS-1123 subdomain"
 	labelErrMsg             = "a valid label must be an empty string or consist of"
 	lowerCaseLabelErrMsg    = "a valid label must consist of"
 	maxLengthErrMsg         = "must be no more than"

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -88,7 +88,7 @@ func IsValidLabelValue(value string) []string {
 }
 
 const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
-const dns1123LabelErrMsg string = "a valid DNS (RFC 1123) label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+const dns1123LabelErrMsg string = "a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
 const DNS1123LabelMaxLength int = 63
 
 var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
@@ -107,7 +107,7 @@ func IsDNS1123Label(value string) []string {
 }
 
 const dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
-const dns1123SubdomainErrorMsg string = "a valid DNS (RFC 1123) subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
+const dns1123SubdomainErrorMsg string = "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
 const DNS1123SubdomainMaxLength int = 253
 
 var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
@@ -126,7 +126,7 @@ func IsDNS1123Subdomain(value string) []string {
 }
 
 const dns1035LabelFmt string = "[a-z]([-a-z0-9]*[a-z0-9])?"
-const dns1035LabelErrMsg string = "a valid DNS (RFC 1035) label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+const dns1035LabelErrMsg string = "a DNS-1035 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
 const DNS1035LabelMaxLength int = 63
 
 var dns1035LabelRegexp = regexp.MustCompile("^" + dns1035LabelFmt + "$")
@@ -149,7 +149,7 @@ func IsDNS1035Label(value string) []string {
 // - valid: *.bar.com, *.foo.bar.com
 // - invalid: *.*.bar.com, *.foo.*.com, *bar.com, f*.bar.com, *
 const wildcardDNS1123SubdomainFmt = "\\*\\." + dns1123SubdomainFmt
-const wildcardDNS1123SubdomainErrMsg = "a valid wildcard DNS (RFC 1123) subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character"
+const wildcardDNS1123SubdomainErrMsg = "a wildcard DNS-1123 subdomain must start with '*.', followed by a valid DNS subdomain, which must consist of lower case alphanumeric characters, '-' or '.' and end with an alphanumeric character"
 
 // IsWildcardDNS1123Subdomain tests for a string that conforms to the definition of a
 // wildcard subdomain in DNS (RFC 1034 section 4.3.3).


### PR DESCRIPTION
**What this PR does / why we need it**: #39635 was rejected because it wasn't clear to the author (me) that lower-case DNS labels are in fact a [Kubernetes requirement](https://github.com/kubernetes/kubernetes/pull/39635#issuecomment-271404975) rather than from the [DNS RFC 1035](https://www.ietf.org/rfc/rfc1035.txt) or/and [DNS RFC 1123](https://www.ietf.org/rfc/rfc1123.txt).

**Special notes for your reviewer**: @thockin this is a first pass to make the error messages clearer about the fact that DNS specs are not to _blame_.
