### PR TITLE
Support 'mixed' container runtime mode

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -129,7 +129,7 @@ func UnsecuredKubeletDeps(s *options.KubeletServer) (*kubelet.KubeletDeps, error
 	}
 
 	var dockerClient dockertools.DockerInterface
-	if s.ContainerRuntime == "docker" {
+	if s.ContainerRuntime == "docker" || s.ContainerRuntime == "mixed" {
 		dockerClient = dockertools.ConnectToDockerOrDie(s.DockerEndpoint, s.RuntimeRequestTimeout.Duration,
 			s.ImagePullProgressDeadline.Duration)
 	} else {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -368,7 +368,7 @@ func (cm *containerManagerImpl) setupNode() error {
 	}
 
 	systemContainers := []*systemContainer{}
-	if cm.ContainerRuntime == "docker" {
+	if cm.ContainerRuntime == "docker" || (cm.EnableCRI && cm.ContainerRuntime == "mixed") {
 		dockerVersion := getDockerVersion(cm.cadvisorInterface)
 		if cm.EnableCRI {
 			// If kubelet uses CRI, dockershim will manage the cgroups and oom

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -535,7 +535,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 		var err error
 
 		switch kubeCfg.ContainerRuntime {
-		case "docker":
+		case "docker", "mixed":
 			streamingConfig := getStreamingConfig(kubeCfg, kubeDeps)
 			// Use the new CRI shim for docker.
 			ds, err := dockershim.NewDockerService(klet.dockerClient, kubeCfg.SeccompProfileRoot, kubeCfg.PodInfraContainerImage,
@@ -561,8 +561,10 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 					// The unix socket for kubelet <-> dockershim communication.
 					ep = "/var/run/dockershim.sock"
 				)
-				kubeCfg.RemoteRuntimeEndpoint = ep
-				kubeCfg.RemoteImageEndpoint = ep
+				if kubeCfg.ContainerRuntime == "docker" {
+					kubeCfg.RemoteRuntimeEndpoint = ep
+					kubeCfg.RemoteImageEndpoint = ep
+				}
 
 				server := dockerremote.NewDockerServer(ep, ds)
 				glog.V(2).Infof("Starting the GRPC server for the docker CRI shim.")
@@ -575,9 +577,13 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 					return nil, err
 				}
 			}
-			// TODO: Move the instrumented interface wrapping into kuberuntime.
-			runtimeService = kuberuntime.NewInstrumentedRuntimeService(rs)
-			imageService = is
+			if kubeCfg.ContainerRuntime == "docker" {
+				// TODO: Move the instrumented interface wrapping into kuberuntime.
+				runtimeService = kuberuntime.NewInstrumentedRuntimeService(rs)
+				imageService = is
+			} else if runtimeService, imageService, err = getRuntimeAndImageServices(kubeCfg); err != nil {
+				return nil, err
+			}
 		case "remote":
 			runtimeService, imageService, err = getRuntimeAndImageServices(kubeCfg)
 			if err != nil {

--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -58,7 +58,7 @@ func effectiveHairpinMode(hairpinMode componentconfig.HairpinMode, containerRunt
 	// - It's set to "none".
 	if hairpinMode == componentconfig.PromiscuousBridge || hairpinMode == componentconfig.HairpinVeth {
 		// Only on docker.
-		if containerRuntime != "docker" {
+		if containerRuntime != "docker" && containerRuntime != "mixed" {
 			glog.Warningf("Hairpin mode set to %q but container runtime is %q, ignoring", hairpinMode, containerRuntime)
 			return componentconfig.HairpinNone, nil
 		}


### PR DESCRIPTION
(The PR is here for the purpose of discussion first)

This PR adds `mixed` CRI mode to kubelet. For example, the following
kubelet args may be used with this patch:
```--experimental-cri --container-runtime=mixed --container-runtime-endpoint=/run/criproxy.sock --image-service-endpoint=/run/criproxy.sock```

In `mixed` mode, kubelet starts in-process `docker-shim`, but connects to the specified container runtime / image service endpoints instead. This makes it possible to have multiple CRI implementations on the same node using CRI proxy ([here's an example](https://github.com/Mirantis/virtlet/tree/master/pkg/criproxy) of such a proxy).

Why this may be necessary: currently using an 'exotic' CRI implementation like [virtlet](https://github.com/Mirantis/virtlet) or other VM-based one means that the node that supports the runtime must be deployed in a manner different from the other nodes. E.g. kubeadm runs `kube-proxy` as a DaemonSet and thus it can't be used to prepare nodes for alternative CRI impls. Also, depending on the cluster, it may be necessary to have housekeeping / hardware support / etc. DaemonSets that should be run by all/most nodes, and the 'exotic' nodes will have no way to run pods from these DaemonSets. Last but not least, deploying and updating these CRI implementations themselves may be extra burden, while with 'proxy' mechanism in place it's possible to just run them as DaemonSets themselves.

This mechanism makes it possible to solve #29913 using an external solution.
