### PR TITLE
remove API to server library dependency

### DIFF
--- a/pkg/apis/rbac/v1alpha1/BUILD
+++ b/pkg/apis/rbac/v1alpha1/BUILD
@@ -35,7 +35,6 @@ go_library(
         "//pkg/types:go_default_library",
         "//vendor:github.com/gogo/protobuf/proto",
         "//vendor:github.com/ugorji/go/codec",
-        "//vendor:k8s.io/apiserver/pkg/authentication/user",
     ],
 )
 

--- a/pkg/apis/rbac/v1alpha1/conversion.go
+++ b/pkg/apis/rbac/v1alpha1/conversion.go
@@ -17,10 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apiserver/pkg/authentication/user"
 	api "k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/conversion"
 )
+
+// allAuthenticated matches k8s.io/apiserver/pkg/authentication/user.AllAuthenticated,
+// but we don't want an client library (which must include types), depending on a server library
+const allAuthenticated = "system:authenticated"
 
 func Convert_v1alpha1_Subject_To_rbac_Subject(in *Subject, out *api.Subject, s conversion.Scope) error {
 	if err := autoConvert_v1alpha1_Subject_To_rbac_Subject(in, out, s); err != nil {
@@ -32,7 +35,7 @@ func Convert_v1alpha1_Subject_To_rbac_Subject(in *Subject, out *api.Subject, s c
 	// Special treatment for * should not be included in v1beta1
 	if out.Kind == UserKind && out.Name == "*" {
 		out.Kind = GroupKind
-		out.Name = user.AllAuthenticated
+		out.Name = allAuthenticated
 	}
 
 	return nil


### PR DESCRIPTION
A client library (which must include api types), should not depend on our server library.  This duplicates one constant for conversion to avoid the link.

@smarterclayton @liggitt

The import-boss rule to keep us from forming these dependencies is non-trivial since some of the bits under /apis are server only (validation for instance).