### PR TITLE
Bump container-linux and gci timeout for docker health check

### DIFF
--- a/cluster/gce/container-linux/health-monitor.sh
+++ b/cluster/gce/container-linux/health-monitor.sh
@@ -26,7 +26,7 @@ set -o pipefail
 # automatically restart the process.
 function docker_monitoring {
   while [ 1 ]; do
-    if ! timeout 10 docker ps > /dev/null; then
+    if ! timeout 60 docker ps > /dev/null; then
       echo "Docker daemon failed!"
       pkill docker
       # Wait for a while, as we don't want to kill it again before it is really up.

--- a/cluster/gce/gci/health-monitor.sh
+++ b/cluster/gce/gci/health-monitor.sh
@@ -26,7 +26,7 @@ set -o pipefail
 # automatically restart the process.
 function docker_monitoring {
   while [ 1 ]; do
-    if ! timeout 10 docker ps > /dev/null; then
+    if ! timeout 60 docker ps > /dev/null; then
       echo "Docker daemon failed!"
       pkill docker
       # Wait for a while, as we don't want to kill it again before it is really up.


### PR DESCRIPTION
The command `docker ps` can take longer time to respond under heavy load or
when encountering some known issues. In these cases, the containers are running
fine, so aggressive health check could cause serious disruption. Bump the
timeout to 60s to be consistent with the debian-based containerVM.

This addresses #38588