### PR TITLE
Always --pull in docker build to ensure recent base images

### DIFF
--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -21,7 +21,7 @@ TAG=$(shell cat VERSION)
 all: push
 
 build:
-	docker build -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build --pull -t gcr.io/google_containers/$(IMAGE):$(TAG) .
 
 push: build
 	gcloud docker --server=gcr.io -- push gcr.io/google_containers/$(IMAGE):$(TAG)

--- a/build/common.sh
+++ b/build/common.sh
@@ -106,7 +106,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,armel/busybox
           kube-scheduler,armel/busybox
           kube-aggregator,armel/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-arm:v4
+          kube-proxy,gcr.io/google_containers/debian-iptables-arm:v5
         );;
     "arm64")
         local targets=(
@@ -114,7 +114,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,aarch64/busybox
           kube-scheduler,aarch64/busybox
           kube-aggregator,aarch64/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-arm64:v4
+          kube-proxy,gcr.io/google_containers/debian-iptables-arm64:v5
         );;
     "ppc64le")
         local targets=(
@@ -122,7 +122,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,ppc64le/busybox
           kube-scheduler,ppc64le/busybox
           kube-aggregator,ppc64le/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-ppc64le:v4
+          kube-proxy,gcr.io/google_containers/debian-iptables-ppc64le:v5
         );;
     "s390x")
         local targets=(
@@ -130,7 +130,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,s390x/busybox
           kube-scheduler,s390x/busybox
           kube-aggregator,s390x/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-s390x:v4
+          kube-proxy,gcr.io/google_containers/debian-iptables-s390x:v5
         );;		
   esac
 

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -56,7 +56,7 @@ else
 	cd $(TEMP_DIR) && sed -i "s/CROSS_BUILD_//g" Dockerfile
 endif
 
-	docker build -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 
 push: build
 	gcloud docker -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,7 +16,7 @@
 
 REGISTRY?="gcr.io/google_containers"
 IMAGE=debian-iptables
-TAG=v4
+TAG=v5
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -295,7 +295,7 @@ function kube::release::create_docker_images_for_server() {
           local docker_image_tag=gcr.io/google_containers/${binary_name}-${arch}:${md5_sum}
         fi
 
-        "${DOCKER[@]}" build -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null
+        "${DOCKER[@]}" build --pull -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null
         "${DOCKER[@]}" save ${docker_image_tag} > ${binary_dir}/${binary_name}.tar
         echo $md5_sum > ${binary_dir}/${binary_name}.docker_tag
 

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -78,7 +78,7 @@ bin/$(BIN)-$(ARCH): $(SRCS)
 
 container: .container-$(ARCH)
 .container-$(ARCH): bin/$(BIN)-$(ARCH)
-	docker build -t $(IMAGE):$(TAG) --build-arg ARCH=$(ARCH) .
+	docker build --pull -t $(IMAGE):$(TAG) --build-arg ARCH=$(ARCH) .
 ifeq ($(ARCH),amd64)
 	docker rmi $(LEGACY_AMD64_IMAGE):$(TAG) || true
 	docker tag $(IMAGE):$(TAG) $(LEGACY_AMD64_IMAGE):$(TAG)

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -43,7 +43,7 @@ build:
 	curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/linux/$(ARCH)/kubectl > $(TEMP_DIR)/kubectl
 	chmod +x $(TEMP_DIR)/kubectl
 	cd $(TEMP_DIR) && sed -i.back "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
-	docker build -t $(IMAGE)-$(ARCH):$(VERSION) $(TEMP_DIR)
+	docker build --pull -t $(IMAGE)-$(ARCH):$(VERSION) $(TEMP_DIR)
 
 push: build
 	gcloud docker -- push $(IMAGE)-$(ARCH):$(VERSION)

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -19,7 +19,7 @@
 TAG = v2.4.1
 
 build:	elasticsearch_logging_discovery
-	docker build -t gcr.io/google_containers/elasticsearch:$(TAG) .
+	docker build --pull -t gcr.io/google_containers/elasticsearch:$(TAG) .
 
 push:
 	gcloud docker -- push gcr.io/google_containers/elasticsearch:$(TAG)

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -19,7 +19,7 @@ IMAGE = fluentd-elasticsearch
 TAG = 1.20
 
 build:
-	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
+	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push:
 	gcloud docker --server=gcr.io -- push $(PREFIX)/$(IMAGE):$(TAG)

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
@@ -18,7 +18,7 @@ TAG = v4.6.1
 PREFIX = gcr.io/google_containers
 
 build:
-	docker build -t $(PREFIX)/kibana:$(TAG) .
+	docker build --pull -t $(PREFIX)/kibana:$(TAG) .
 
 push:
 	gcloud docker -- push $(PREFIX)/kibana:$(TAG)

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -29,7 +29,7 @@ PREFIX=gcr.io/google_containers
 TAG = 1.31
 
 build:
-	docker build -t $(PREFIX)/fluentd-gcp:$(TAG) .
+	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .
 
 
 push:

--- a/cluster/addons/python-image/Makefile
+++ b/cluster/addons/python-image/Makefile
@@ -18,7 +18,7 @@ VERSION=v1
 .PHONY: build push
 
 build:
-	docker build -t "$(IMAGE):$(VERSION)" .
+	docker build --pull -t "$(IMAGE):$(VERSION)" .
 
 push:
 	gcloud docker -- push "$(IMAGE):$(VERSION)"

--- a/cluster/addons/registry/images/Makefile
+++ b/cluster/addons/registry/images/Makefile
@@ -18,7 +18,7 @@ TAG = 0.4
 REPO = gcr.io/google_containers/kube-registry-proxy
 
 build:
-	docker build -t $(REPO):$(TAG) .
+	docker build --pull -t $(REPO):$(TAG) .
 
 push:
 	gcloud docker -- push $(REPO):$(TAG)

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -25,7 +25,7 @@ build: clean
 	curl -L -O https://github.com/coreos/etcd/releases/download/v$(ETCD_VERSION)/etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
 	tar xzvf etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
 	cp etcd-v$(ETCD_VERSION)-linux-amd64/etcdctl .
-	docker build -t $(IMAGE):$(TAG) .
+	docker build --pull -t $(IMAGE):$(TAG) .
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
 
 push: build

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -102,7 +102,7 @@ endif
 	cd $(TEMP_DIR) && sed -i.bak 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 
 	# And build the image
-	docker build -t $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG) $(TEMP_DIR)
+	docker build --pull -t $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG) $(TEMP_DIR)
 
 push: build
 	gcloud docker -- push $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG)

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -106,7 +106,7 @@ endif
 	# Download CNI
 	curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/cni-${ARCH}-${CNI_RELEASE}.tar.gz | tar -xz -C ${TEMP_DIR}/cni-bin
 
-	docker build -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
+	docker build --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
 
 push: build

--- a/cluster/images/kube-discovery/Makefile
+++ b/cluster/images/kube-discovery/Makefile
@@ -48,7 +48,7 @@ build:
 	cp -r ./* ${TEMP_DIR}
 	cp ../../../_output/dockerized/bin/linux/${ARCH}/kube-discovery ${TEMP_DIR}
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
-	docker build -t ${REGISTRY}/kube-discovery-${ARCH}:${VERSION} ${TEMP_DIR}
+	docker build --pull -t ${REGISTRY}/kube-discovery-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
 
 push: build

--- a/cluster/images/kubemark/Makefile
+++ b/cluster/images/kubemark/Makefile
@@ -16,7 +16,7 @@
 # This makefile assumes that the kubemark binary is present in this directory.
 
 all:
-	docker build -t gcr.io/$(PROJECT)/kubemark .
+	docker build --pull -t gcr.io/$(PROJECT)/kubemark .
 	gcloud docker -- push gcr.io/$(PROJECT)/kubemark
 
 .PHONY: all

--- a/examples/cluster-dns/images/backend/Makefile
+++ b/examples/cluster-dns/images/backend/Makefile
@@ -19,7 +19,7 @@ IMAGE = example-dns-backend
 all: push
 
 image:
-	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
+	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/$(IMAGE)

--- a/examples/cluster-dns/images/frontend/Makefile
+++ b/examples/cluster-dns/images/frontend/Makefile
@@ -19,7 +19,7 @@ IMAGE = example-dns-frontend
 all: push
 
 image:
-	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
+	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/$(IMAGE)

--- a/examples/explorer/Makefile
+++ b/examples/explorer/Makefile
@@ -21,7 +21,7 @@ explorer: explorer.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./explorer.go
 
 container: explorer
-	docker build -t gcr.io/google_containers/explorer:$(TAG) .
+	docker build --pull -t gcr.io/google_containers/explorer:$(TAG) .
 
 push: container
 	gcloud docker -- push gcr.io/google_containers/explorer:$(TAG)

--- a/examples/guestbook-go/Makefile
+++ b/examples/guestbook-go/Makefile
@@ -24,8 +24,8 @@ release: clean build push clean
 # builds a docker image that builds the app and packages it into a minimal docker image
 build:
 	@cp ../../bazel-bin/examples/guestbook-go/guestbook-go guestbook_bin
-	docker build --rm --force-rm -t ${REGISTRY}/guestbook-builder .
-	docker run --rm ${REGISTRY}/guestbook-builder | docker build -t "${REGISTRY}/guestbook:${VERSION}" -
+	docker build --pull --rm --force-rm -t ${REGISTRY}/guestbook-builder .
+	docker run --rm ${REGISTRY}/guestbook-builder | docker build --pull -t "${REGISTRY}/guestbook:${VERSION}" -
 
 # push the image to an registry
 push:

--- a/examples/https-nginx/Makefile
+++ b/examples/https-nginx/Makefile
@@ -28,7 +28,7 @@ secret:
 	go run make_secret.go -crt $(CERT) -key $(KEY) > $(SECRET)
 
 container:
-	docker build -t $(PREFIX):$(TAG) .
+	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
 	docker push $(PREFIX):$(TAG)

--- a/examples/kubectl-container/Makefile
+++ b/examples/kubectl-container/Makefile
@@ -37,7 +37,7 @@ tag: .tag
 
 container:
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' to see a suggestion))
-	docker build -t gcr.io/google_containers/kubectl:$(TAG) .
+	docker build --pull -t gcr.io/google_containers/kubectl:$(TAG) .
 
 push: container
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' to see a suggestion))

--- a/examples/storage/cassandra/image/Makefile
+++ b/examples/storage/cassandra/image/Makefile
@@ -26,7 +26,7 @@ kubernetes-cassandra.jar: ../java/* ../java/src/main/java/io/k8s/cassandra/*.jav
 	cd ../java && mvn clean
 
 build: kubernetes-cassandra.jar
-	docker build -t ${PROJECT}/cassandra:${VERSION} .
+	docker build --pull -t ${PROJECT}/cassandra:${VERSION} .
 
 push: build
 	gcloud docker -- push ${PROJECT}/cassandra:${VERSION}

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -335,7 +335,7 @@ function push-federation-images {
         # TODO(madhusudancs): Remove this code when the new turn up mechanism work
         # is merged.
         kube::log::status "Building docker image ${docker_image_tag} from the binary"
-        docker build -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null
+        docker build --pull -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null
 
         rm -rf ${docker_build_path}
 

--- a/test/e2e_node/conformance/build/Makefile
+++ b/test/e2e_node/conformance/build/Makefile
@@ -52,7 +52,7 @@ endif
 		e2e_node.test \
 		ginkgo
 
-	docker build -t ${REGISTRY}/node-test-${ARCH}:${VERSION} ${TEMP_DIR}
+	docker build --pull -t ${REGISTRY}/node-test-${ARCH}:${VERSION} ${TEMP_DIR}
 
 push: build
 	gcloud docker push ${REGISTRY}/node-test-${ARCH}:${VERSION}

--- a/test/images/clusterapi-tester/Makefile
+++ b/test/images/clusterapi-tester/Makefile
@@ -22,7 +22,7 @@ main: main.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o main ./main.go
 
 container: main
-	docker build -t $(PREFIX):$(TAG) .
+	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
 	gcloud docker -- push $(PREFIX):$(TAG)

--- a/test/images/dnsutils/Makefile
+++ b/test/images/dnsutils/Makefile
@@ -19,7 +19,7 @@ PREFIX ?= gcr.io/google_containers
 all: push
 
 image:
-	docker build -t $(PREFIX)/dnsutils .
+	docker build --pull -t $(PREFIX)/dnsutils .
 
 push: image
 	gcloud docker -- push $(PREFIX)/dnsutils

--- a/test/images/entrypoint-tester/Makefile
+++ b/test/images/entrypoint-tester/Makefile
@@ -21,7 +21,7 @@ ep: ep.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./ep.go
 
 image: ep
-	sudo docker build -t $(PREFIX)/eptest:$(TAG) .
+	sudo docker build --pull -t $(PREFIX)/eptest:$(TAG) .
 
 push: image
 	sudo docker push $(PREFIX)/eptest:$(TAG)

--- a/test/images/fakegitserver/Makefile
+++ b/test/images/fakegitserver/Makefile
@@ -21,7 +21,7 @@ ARCH = amd64
 
 image:
 	./prepare.sh $(ARCH)
-	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
+	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/$(IMAGE):$(TAG)

--- a/test/images/goproxy/Makefile
+++ b/test/images/goproxy/Makefile
@@ -21,7 +21,7 @@ goproxy: goproxy.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./goproxy.go
 
 image: goproxy
-	docker build -t $(PREFIX)/goproxy:$(TAG) .
+	docker build --pull -t $(PREFIX)/goproxy:$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/goproxy:$(TAG)

--- a/test/images/hostexec/Makefile
+++ b/test/images/hostexec/Makefile
@@ -21,7 +21,7 @@ PREFIX = gcr.io/google_containers
 all: push
 
 image:
-	docker build -t $(PREFIX)/hostexec:$(TAG) .
+	docker build --pull -t $(PREFIX)/hostexec:$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/hostexec:$(TAG)

--- a/test/images/iperf/Makefile
+++ b/test/images/iperf/Makefile
@@ -21,7 +21,7 @@ all: push
 container: image
 
 image:
-	docker build -t $(PREFIX)/${IMAGE} . # Build new image and automatically tag it as latest
+	docker build --pull -t $(PREFIX)/${IMAGE} . # Build new image and automatically tag it as latest
 	docker tag $(PREFIX)/${IMAGE} $(PREFIX)/${IMAGE}:$(TAG) # Add the version tag to the latest image
 
 push: image

--- a/test/images/jessie-dnsutils/Makefile
+++ b/test/images/jessie-dnsutils/Makefile
@@ -19,7 +19,7 @@ PREFIX = gcr.io/google_containers
 all: push
 
 image:
-	docker build -t $(PREFIX)/jessie-dnsutils .
+	docker build --pull -t $(PREFIX)/jessie-dnsutils .
 
 push: image
 	gcloud docker -- push $(PREFIX)/jessie-dnsutils

--- a/test/images/logs-generator/Makefile
+++ b/test/images/logs-generator/Makefile
@@ -23,7 +23,7 @@ binary:
 	go build -a --ldflags '-w' -o logs-generator .
 
 container:
-	docker build -t $(PREFIX)/logs-generator:$(TAG) .
+	docker build --pull -t $(PREFIX)/logs-generator:$(TAG) .
 
 push:
 	gcloud docker -- push $(PREFIX)/logs-generator:$(TAG)

--- a/test/images/mount-tester-user/Makefile
+++ b/test/images/mount-tester-user/Makefile
@@ -18,7 +18,7 @@ PREFIX = gcr.io/google_containers
 all: push
 
 image:
-	sudo docker build -t $(PREFIX)/mounttest-user:$(TAG) .
+	sudo docker build --pull -t $(PREFIX)/mounttest-user:$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/mounttest-user:$(TAG)

--- a/test/images/mount-tester/Makefile
+++ b/test/images/mount-tester/Makefile
@@ -21,7 +21,7 @@ mt: mt.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./mt.go
 
 image: mt
-	sudo docker build -t $(PREFIX)/mounttest:$(TAG) .
+	sudo docker build --pull -t $(PREFIX)/mounttest:$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/mounttest:$(TAG)

--- a/test/images/n-way-http/Makefile
+++ b/test/images/n-way-http/Makefile
@@ -22,7 +22,7 @@ server: server.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' -o server ./server.go
 
 container: server
-	docker build -t $(PREFIX):$(TAG) .
+	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
 	gcloud docker -- push $(PREFIX):$(TAG)

--- a/test/images/net/Makefile
+++ b/test/images/net/Makefile
@@ -25,7 +25,7 @@ net: $(SRCS)
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w'
 
 image: test net
-	docker build -t $(PREFIX)/$(IMAGE):$(TAG) .
+	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/$(IMAGE):$(TAG)

--- a/test/images/netexec/Makefile
+++ b/test/images/netexec/Makefile
@@ -24,7 +24,7 @@ netexec: netexec.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./netexec.go
 
 image: netexec
-	docker build -t $(PREFIX)/netexec:$(TAG) .
+	docker build --pull -t $(PREFIX)/netexec:$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/netexec:$(TAG)

--- a/test/images/network-tester/Makefile
+++ b/test/images/network-tester/Makefile
@@ -23,7 +23,7 @@ webserver: webserver.go
 container: image
 
 image: webserver
-	docker build -t $(PREFIX)/nettest:$(TAG) .
+	docker build --pull -t $(PREFIX)/nettest:$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/nettest:$(TAG)

--- a/test/images/pets/redis/Makefile
+++ b/test/images/pets/redis/Makefile
@@ -18,7 +18,7 @@ TAG = e2e
 PREFIX = gcr.io/google_containers/redis-install-3.2.0
 
 container:
-	docker build -t $(PREFIX):$(TAG) .
+	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
 	gcloud docker -- push $(PREFIX):$(TAG)

--- a/test/images/pets/zookeeper/Makefile
+++ b/test/images/pets/zookeeper/Makefile
@@ -18,7 +18,7 @@ TAG = e2e
 PREFIX = gcr.io/google_containers/zookeeper-install-3.5.0-alpha
 
 container:
-	docker build -t $(PREFIX):$(TAG) .
+	docker build --pull -t $(PREFIX):$(TAG) .
 
 push: container
 	gcloud docker -- push $(PREFIX):$(TAG)

--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -21,7 +21,7 @@ portforwardtester: portforwardtester.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./portforwardtester.go
 
 image: portforwardtester
-	docker build -t $(PREFIX)/portforwardtester:$(TAG) .
+	docker build --pull -t $(PREFIX)/portforwardtester:$(TAG) .
 
 push: image
 	gcloud docker -- push $(PREFIX)/portforwardtester:$(TAG)

--- a/test/images/porter/Makefile
+++ b/test/images/porter/Makefile
@@ -37,7 +37,7 @@ container: image
 
 image:
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' after committing changes to see a suggestion))
-	docker build -t $(PREFIX)/porter:$(TAG) .
+	docker build --pull -t $(PREFIX)/porter:$(TAG) .
 
 push:
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' after committing changes to see a suggestion))

--- a/test/images/resource-consumer/Makefile
+++ b/test/images/resource-consumer/Makefile
@@ -25,8 +25,8 @@ consumer:
 container: image
 
 image:
-	sudo docker build -t $(PREFIX)/resource_consumer:$(TAG) .
-	sudo docker build -t $(PREFIX)/resource_consumer/controller:$(TAG) controller
+	sudo docker build --pull -t $(PREFIX)/resource_consumer:$(TAG) .
+	sudo docker build --pull -t $(PREFIX)/resource_consumer/controller:$(TAG) controller
 
 run_container:
 	docker run --publish=8080:8080 $(PREFIX)/resource_consumer:$(TAG)

--- a/test/images/serve_hostname/Makefile
+++ b/test/images/serve_hostname/Makefile
@@ -86,7 +86,7 @@ container: .container-$(ARCH)
 	# Set the base image
 	cd $(TEMP_DIR) && sed -i.bak 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile
 
-	docker build -t $(IMAGE):$(TAG) $(TEMP_DIR)
+	docker build --pull -t $(IMAGE):$(TAG) $(TEMP_DIR)
 	if [ -n "$(TEST_REGISTRY)" ]; then \
 		docker tag $(IMAGE):$(TAG) $(TEST_IMAGE):$(TAG) ;\
 	fi

--- a/test/images/volumes-tester/ceph/Makefile
+++ b/test/images/volumes-tester/ceph/Makefile
@@ -20,7 +20,7 @@ all: push
 container: image
 
 image:
-	docker build -t $(PREFIX)/volume-ceph . # Build new image and automatically tag it as latest
+	docker build --pull -t $(PREFIX)/volume-ceph . # Build new image and automatically tag it as latest
 	docker tag $(PREFIX)/volume-ceph $(PREFIX)/volume-ceph:$(TAG)  # Add the version tag to the latest image
 
 push: image

--- a/test/images/volumes-tester/gluster/Makefile
+++ b/test/images/volumes-tester/gluster/Makefile
@@ -20,7 +20,7 @@ all: push
 container: image
 
 image:
-	docker build -t $(PREFIX)/volume-gluster . # Build new image and automatically tag it as latest
+	docker build --pull -t $(PREFIX)/volume-gluster . # Build new image and automatically tag it as latest
 	docker tag $(PREFIX)/volume-gluster $(PREFIX)/volume-gluster:$(TAG)  # Add the version tag to the latest image
 
 push: image

--- a/test/images/volumes-tester/iscsi/Makefile
+++ b/test/images/volumes-tester/iscsi/Makefile
@@ -21,7 +21,7 @@ container: image
 
 image:
 	# Build new image and automatically tag it as latest
-	docker build -t $(PREFIX)/volume-iscsi .
+	docker build --pull -t $(PREFIX)/volume-iscsi .
 	# Add the version tag to the latest image
 	docker tag $(PREFIX)/volume-iscsi $(PREFIX)/volume-iscsi:$(TAG)
 

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -20,7 +20,7 @@ all: push
 container: image
 
 image:
-	docker build -t $(PREFIX)/volume-nfs . # Build new image and automatically tag it as latest
+	docker build --pull -t $(PREFIX)/volume-nfs . # Build new image and automatically tag it as latest
 	docker tag $(PREFIX)/volume-nfs $(PREFIX)/volume-nfs:$(TAG) # Add the version tag to the latest image
 
 push: image

--- a/test/images/volumes-tester/rbd/Makefile
+++ b/test/images/volumes-tester/rbd/Makefile
@@ -21,7 +21,7 @@ container: image
 
 image:
 	# Build new image and automatically tag it as latest
-	docker build -t $(PREFIX)/volume-rbd .
+	docker build --pull -t $(PREFIX)/volume-rbd .
 	# Add the version tag to the latest image
 	docker tag $(PREFIX)/volume-rbd $(PREFIX)/volume-rbd:$(TAG)
 

--- a/test/soak/cauldron/Makefile
+++ b/test/soak/cauldron/Makefile
@@ -20,7 +20,7 @@ cauldron:
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -a -installsuffix cgo --ldflags '-w' cauldron.go
 
 container:	cauldron
-	docker build -t kubernetes/cauldron:$(TAG) .
+	docker build --pull -t kubernetes/cauldron:$(TAG) .
 
 push:
 	docker push kubernetes/cauldron:$(TAG)


### PR DESCRIPTION
**What this PR does / why we need it**: By default, Docker will use a locally cached image rather than looking for a newer image. This can be problematic when using a common base image like debian:jessie, since you may end up unintentionally using a very old base image.

I think everything here is only used on release paths, so it shouldn't affect any regular development workflows.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Update kube-proxy image to be based off of Debian 8.6 base image.
```
