### PR TITLE
kubelet: request client auth certificates from certificate API.

### DIFF
--- a/pkg/controller/certificates/BUILD
+++ b/pkg/controller/certificates/BUILD
@@ -56,7 +56,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["cfssl_signer_test.go"],
+    srcs = [
+        "cfssl_signer_test.go",
+        "groupapprove_test.go",
+    ],
     data = [
         "testdata/ca.crt",
         "testdata/ca.key",

--- a/pkg/controller/certificates/groupapprove_test.go
+++ b/pkg/controller/certificates/groupapprove_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"testing"
+
+	certificates "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1"
+)
+
+func TestHasKubeletUsages(t *testing.T) {
+	cases := []struct {
+		usages   []certificates.KeyUsage
+		expected bool
+	}{
+		{
+			usages:   nil,
+			expected: false,
+		},
+		{
+			usages:   []certificates.KeyUsage{},
+			expected: false,
+		},
+		{
+			usages: []certificates.KeyUsage{
+				certificates.UsageKeyEncipherment,
+				certificates.UsageDigitalSignature,
+			},
+			expected: false,
+		},
+		{
+			usages: []certificates.KeyUsage{
+				certificates.UsageKeyEncipherment,
+				certificates.UsageDigitalSignature,
+				certificates.UsageServerAuth,
+			},
+			expected: false,
+		},
+		{
+			usages: []certificates.KeyUsage{
+				certificates.UsageKeyEncipherment,
+				certificates.UsageDigitalSignature,
+				certificates.UsageClientAuth,
+			},
+			expected: true,
+		},
+	}
+	for _, c := range cases {
+		if hasExactUsages(&certificates.CertificateSigningRequest{
+			Spec: certificates.CertificateSigningRequestSpec{
+				Usages: c.usages,
+			},
+		}, kubeletClientUsages) != c.expected {
+			t.Errorf("unexpected result of hasKubeletUsages(%v), expecting: %v", c.usages, c.expected)
+		}
+	}
+}

--- a/pkg/kubelet/util/csr/csr.go
+++ b/pkg/kubelet/util/csr/csr.go
@@ -54,9 +54,14 @@ func RequestNodeCertificate(client unversionedcertificates.CertificateSigningReq
 		TypeMeta:   metav1.TypeMeta{Kind: "CertificateSigningRequest"},
 		ObjectMeta: v1.ObjectMeta{GenerateName: "csr-"},
 
-		// TODO: For now, this is a request for a certificate with allowed usage of "TLS Web Client Authentication".
-		// Need to figure out whether/how to surface the allowed usage in the spec.
-		Spec: certificates.CertificateSigningRequestSpec{Request: csr},
+		Spec: certificates.CertificateSigningRequestSpec{
+			Request: csr,
+			Usages: []certificates.KeyUsage{
+				certificates.UsageDigitalSignature,
+				certificates.UsageKeyEncipherment,
+				certificates.UsageClientAuth,
+			},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("cannot create certificate signing request: %v", err)


### PR DESCRIPTION
This fixes kubeadm and --experiment-kubelet-bootstrap.

cc @liggitt 