### PR TITLE
Update fluentd-gcp addon to 1.21.1

### DIFF
--- a/cluster/addons/gci/fluentd-gcp.yaml
+++ b/cluster/addons/gci/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.21
+    image: gcr.io/google_containers/fluentd-gcp:1.21.1
     command:
       - '/bin/sh'
       - '-c'

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.21
+    image: gcr.io/google_containers/fluentd-gcp:1.21.1
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
**What this PR does / why we need it**: updates fluentd-gcp specs to use versions with a newer ubuntu base image. Functionally I expect no changes.

**Special notes for your reviewer**: it's infeasible to follow the regular cherry-pick process for this, since master is using a much newer version of fluentd-gcp, and we don't want to upgrade versions here.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```