### PR TITLE
dockertools: fix build on OSX

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager_unsupported.go
+++ b/pkg/kubelet/dockertools/docker_manager_unsupported.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 
 	dockertypes "github.com/docker/engine-api/types"
+	dockercontainer "github.com/docker/engine-api/types/container"
 )
 
 // These two functions are OS specific (for now at least)


### PR DESCRIPTION
#39005 introduces a build problem on OSX. This PR fixes it.

Refer [here](https://github.com/kubernetes/kubernetes/pull/39005#issuecomment-271781026).