### PR TITLE
PodFitsPorts has been replaced by PodFitsHostPorts

### DIFF
--- a/examples/scheduler-policy-config-with-extender.json
+++ b/examples/scheduler-policy-config-with-extender.json
@@ -2,7 +2,7 @@
 "kind" : "Policy",
 "apiVersion" : "v1",
 "predicates" : [
-	{"name" : "PodFitsPorts"},
+	{"name" : "PodFitsHostPorts"},
 	{"name" : "PodFitsResources"},
 	{"name" : "NoDiskConflict"},
 	{"name" : "MatchNodeSelector"},

--- a/examples/scheduler-policy-config.json
+++ b/examples/scheduler-policy-config.json
@@ -2,7 +2,7 @@
 "kind" : "Policy",
 "apiVersion" : "v1",
 "predicates" : [
-	{"name" : "PodFitsPorts"},
+	{"name" : "PodFitsHostPorts"},
 	{"name" : "PodFitsResources"},
 	{"name" : "NoDiskConflict"},
 	{"name" : "NoVolumeZoneConflict"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

in  [defaults.go](https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go)
>  PodFitsPorts has been replaced by PodFitsHostPorts for better user understanding.
 For backwards compatibility with 1.0, PodFitsPorts is registered as well.



So  ,  I replaced PodFitsPorts  with PodFitsHostPorts  in scheduler examples

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
