### PR TITLE
Remove special case for StatefulSets in scheduler

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -238,7 +238,7 @@ func GetEquivalencePod(pod *v1.Pod) interface{} {
 	// to be equivalent
 	if len(pod.OwnerReferences) != 0 {
 		for _, ref := range pod.OwnerReferences {
-			if *ref.Controller && isValidControllerKind(ref.Kind) {
+			if *ref.Controller {
 				equivalencePod.ControllerRef = ref
 				// a pod can only belongs to one controller
 				break
@@ -246,17 +246,6 @@ func GetEquivalencePod(pod *v1.Pod) interface{} {
 		}
 	}
 	return &equivalencePod
-}
-
-// isValidControllerKind checks if a given controller's kind can be applied to equivalence pod algorithm.
-func isValidControllerKind(kind string) bool {
-	switch kind {
-	// list of kinds that we cannot handle
-	case StatefulSetKind:
-		return false
-	default:
-		return true
-	}
 }
 
 // EquivalencePod is a group of pod attributes which can be reused as equivalence to schedule other pods.


### PR DESCRIPTION
**What this PR does / why we need it**: Removes special case for StatefulSet in scheduler code
/ref: https://github.com/kubernetes/kubernetes/issues/39687

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Scheduler treats StatefulSet pods as belonging to a single equivalence class.
```
