### PR TITLE
container-linux: restart rkt-api on failure

### DIFF
--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -1191,6 +1191,7 @@ After=network.target
 
 [Service]
 ExecStart=${RKT_BIN} api-service --listen=127.0.0.1:15441
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This works around a flake I saw which had the same root cause as
https://github.com/coreos/rkt/issues/3513.

This will potentially help reduce the impact of such future problems as
well.

```release-note
NONE
```