### PR TITLE
Update amd64 kube-proxy base image to debian-iptables-amd64:v5

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -98,7 +98,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,busybox
           kube-scheduler,busybox
           kube-aggregator,busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-amd64:v4
+          kube-proxy,gcr.io/google_containers/debian-iptables-amd64:v5
         );;
     "arm")
         local targets=(


### PR DESCRIPTION
**What this PR does / why we need it**: this was supposed to go into #39695, but I screwed up the rebase.
