### PR TITLE
Automated cherry pick of #39725

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -97,7 +97,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-apiserver,busybox
           kube-controller-manager,busybox
           kube-scheduler,busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-amd64:v4
+          kube-proxy,gcr.io/google_containers/debian-iptables-amd64:v5
         );;
     "arm")
         local targets=(


### PR DESCRIPTION
Cherry pick of #39725 on release-1.5.

#39725: Update amd64 kube-proxy base image to