### PR TITLE
Fix kubelet cross build

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -709,7 +709,7 @@ func (dm *DockerManager) runContainer(
 		SecurityOpt: fmtSecurityOpts,
 	}
 
-	updateHostConfig(hc)
+	updateHostConfig(hc, opts)
 
 	// Set sysctls if requested
 	if container.Name == PodInfraContainerName {

--- a/pkg/kubelet/dockertools/docker_manager_linux.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux.go
@@ -23,10 +23,11 @@ import (
 	dockercontainer "github.com/docker/engine-api/types/container"
 
 	"k8s.io/kubernetes/pkg/api/v1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // These two functions are OS specific (for now at least)
-func updateHostConfig(config *dockercontainer.HostConfig) {
+func updateHostConfig(hc *dockercontainer.HostConfig, opts *kubecontainer.RunContainerOptions) {
 	// no-op, there is a windows implementation that is different.
 }
 

--- a/pkg/kubelet/dockertools/docker_manager_linux.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux.go
@@ -32,7 +32,7 @@ func updateHostConfig(hc *dockercontainer.HostConfig, opts *kubecontainer.RunCon
 }
 
 func DefaultMemorySwap() int64 {
-	return -1
+	return 0
 }
 
 func getContainerIP(container *dockertypes.ContainerJSON) string {

--- a/pkg/kubelet/dockertools/docker_manager_unsupported.go
+++ b/pkg/kubelet/dockertools/docker_manager_unsupported.go
@@ -19,14 +19,15 @@ limitations under the License.
 package dockertools
 
 import (
-	"k8s.io/kubernetes/pkg/api/v1"
-
 	dockertypes "github.com/docker/engine-api/types"
 	dockercontainer "github.com/docker/engine-api/types/container"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // These two functions are OS specific (for now at least)
-func updateHostConfig(config *dockercontainer.HostConfig) {
+func updateHostConfig(hc *dockercontainer.HostConfig, opts *kubecontainer.RunContainerOptions) {
 }
 
 func DefaultMemorySwap() int64 {

--- a/pkg/kubelet/dockertools/docker_manager_windows.go
+++ b/pkg/kubelet/dockertools/docker_manager_windows.go
@@ -21,14 +21,15 @@ package dockertools
 import (
 	"os"
 
-	"k8s.io/kubernetes/pkg/api/v1"
-
 	dockertypes "github.com/docker/engine-api/types"
 	dockercontainer "github.com/docker/engine-api/types/container"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // These two functions are OS specific (for now at least)
-func updateHostConfig(config *dockercontainer.HostConfig) {
+func updateHostConfig(hc *dockercontainer.HostConfig, opts *kubecontainer.RunContainerOptions) {
 	// There is no /etc/resolv.conf in Windows, DNS and DNSSearch options would have to be passed to Docker runtime instead
 	hc.DNS = opts.DNS
 	hc.DNSSearch = opts.DNSSearch


### PR DESCRIPTION
**What this PR does / why we need it**: Cross builds are not passing for MacOS and Windows. We are expecting Windows binaries for `kubelet` and `kube-proxy` to be released by the first time with 1.5.2 to be released later today.

**Which issue this PR fixes**:
fixes #39005
fixes #39714

**Special notes for your reviewer**: /cc @feiskyer @smarterclayton @vishh this should be P0 in order to be merged before 1.5.2 and obviously fix the cross build.

```release-note
kubelet/dockertools : disabled memory swap on Linux.
```