### PR TITLE
Revert two pulls since the last good GKE run

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -63,7 +63,6 @@ const (
 	HostClusterLocalDNSZoneName = "cluster.local."
 
 	lbAddrRetryInterval = 5 * time.Second
-	podWaitInterval     = 2 * time.Second
 )
 
 var (
@@ -231,15 +230,6 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	}
 
 	if !dryRun {
-		fedPods := []string{serverName, cmName}
-		err = waitForPods(hostClientset, fedPods, initFlags.FederationSystemNamespace)
-		if err != nil {
-			return err
-		}
-		err = waitSrvHealthy(config, initFlags.Name, initFlags.Kubeconfig)
-		if err != nil {
-			return err
-		}
 		return printSuccess(cmdOut, ips, hostnames)
 	}
 	_, err = fmt.Fprintf(cmdOut, "Federation control plane runs (dry run)\n")
@@ -584,48 +574,6 @@ func createControllerManager(clientset *client.Clientset, namespace, name, svcNa
 		return dep, nil
 	}
 	return clientset.Extensions().Deployments(namespace).Create(dep)
-}
-
-func waitForPods(clientset *client.Clientset, fedPods []string, namespace string) error {
-	err := wait.PollInfinite(podWaitInterval, func() (bool, error) {
-		podCheck := len(fedPods)
-		podList, err := clientset.Core().Pods(namespace).List(api.ListOptions{})
-		if err != nil {
-			return false, nil
-		}
-		for _, pod := range podList.Items {
-			for _, fedPod := range fedPods {
-				if strings.HasPrefix(pod.Name, fedPod) && pod.Status.Phase == "Running" {
-					podCheck -= 1
-				}
-			}
-			//ensure that all pods are in running state or keep waiting
-			if podCheck == 0 {
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-	return err
-}
-
-func waitSrvHealthy(config util.AdminConfig, context, kubeconfig string) error {
-	fedClientSet, err := config.FederationClientset(context, kubeconfig)
-	if err != nil {
-		return err
-	}
-	fedDiscoveryClient := fedClientSet.Discovery()
-	err = wait.PollInfinite(podWaitInterval, func() (bool, error) {
-		body, err := fedDiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do().Raw()
-		if err != nil {
-			return false, nil
-		}
-		if strings.EqualFold(string(body), "ok") {
-			return true, nil
-		}
-		return false, nil
-	})
-	return err
 }
 
 func printSuccess(cmdOut io.Writer, ips, hostnames []string) error {

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -693,38 +693,6 @@ func fakeInitHostFactory(federationName, namespaceName, ip, dnsZoneName, image, 
 		},
 	}
 
-	podList := v1.PodList{}
-	apiServerPod := v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: testapi.Extensions.GroupVersion().String(),
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      svcName,
-			Namespace: namespaceName,
-		},
-		Status: v1.PodStatus{
-			Phase: "Running",
-		},
-	}
-
-	cmPod := v1.Pod{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "Pod",
-			APIVersion: testapi.Extensions.GroupVersion().String(),
-		},
-		ObjectMeta: v1.ObjectMeta{
-			Name:      cmName,
-			Namespace: namespaceName,
-		},
-		Status: v1.PodStatus{
-			Phase: "Running",
-		},
-	}
-
-	podList.Items = append(podList.Items, apiServerPod)
-	podList.Items = append(podList.Items, cmPod)
-
 	f, tf, codec, _ := cmdtesting.NewAPIFactory()
 	extCodec := testapi.Extensions.Codec()
 	ns := dynamic.ContentConfig().NegotiatedSerializer
@@ -733,8 +701,6 @@ func fakeInitHostFactory(federationName, namespaceName, ip, dnsZoneName, image, 
 		NegotiatedSerializer: ns,
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch p, m := req.URL.Path, req.Method; {
-			case p == "/healthz":
-				return &http.Response{StatusCode: http.StatusOK, Header: kubefedtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader([]byte("ok")))}, nil
 			case p == "/api/v1/namespaces" && m == http.MethodPost:
 				body, err := ioutil.ReadAll(req.Body)
 				if err != nil {
@@ -828,8 +794,6 @@ func fakeInitHostFactory(federationName, namespaceName, ip, dnsZoneName, image, 
 					return nil, fmt.Errorf("Unexpected deployment object\n\tDiff: %s", diff.ObjectGoPrintDiff(got, want))
 				}
 				return &http.Response{StatusCode: http.StatusCreated, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(extCodec, &want)}, nil
-			case p == "/api/v1/namespaces/federation-system/pods" && m == http.MethodGet:
-				return &http.Response{StatusCode: http.StatusOK, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(codec, &podList)}, nil
 			default:
 				return nil, fmt.Errorf("unexpected request: %#v\n%#v", req.URL, req)
 			}

--- a/federation/pkg/kubefed/testing/BUILD
+++ b/federation/pkg/kubefed/testing/BUILD
@@ -12,7 +12,6 @@ go_library(
     srcs = ["testing.go"],
     tags = ["automanaged"],
     deps = [
-        "//federation/client/clientset_generated/federation_clientset:go_default_library",
         "//federation/pkg/kubefed/util:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/apimachinery/registered:go_default_library",

--- a/federation/pkg/kubefed/testing/testing.go
+++ b/federation/pkg/kubefed/testing/testing.go
@@ -23,7 +23,6 @@ import (
 	"net/http"
 	"os"
 
-	fedclient "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
 	"k8s.io/kubernetes/federation/pkg/kubefed/util"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apimachinery/registered"
@@ -52,18 +51,6 @@ func NewFakeAdminConfig(f cmdutil.Factory, kubeconfigGlobal string) (util.AdminC
 
 func (f *fakeAdminConfig) PathOptions() *clientcmd.PathOptions {
 	return f.pathOptions
-}
-
-func (f *fakeAdminConfig) FederationClientset(context, kubeconfigPath string) (*fedclient.Clientset, error) {
-	fakeRestClient, err := f.hostFactory.RESTClient()
-	if err != nil {
-		return nil, err
-	}
-
-	// we ignore the function params and use the client from
-	// the same fakefactory to create a federation clientset
-	// our fake factory exposes only the healthz api for this client
-	return fedclient.New(fakeRestClient), nil
 }
 
 func (f *fakeAdminConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {

--- a/federation/pkg/kubefed/util/BUILD
+++ b/federation/pkg/kubefed/util/BUILD
@@ -12,7 +12,6 @@ go_library(
     srcs = ["util.go"],
     tags = ["automanaged"],
     deps = [
-        "//federation/client/clientset_generated/federation_clientset:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/client/unversioned/clientcmd:go_default_library",

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	fedclient "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
 	"k8s.io/kubernetes/pkg/api"
 	client "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
@@ -40,16 +39,13 @@ const (
 
 // AdminConfig provides a filesystem based kubeconfig (via
 // `PathOptions()`) and a mechanism to talk to the federation
-// host cluster and the federation control plane api server.
+// host cluster.
 type AdminConfig interface {
 	// PathOptions provides filesystem based kubeconfig access.
 	PathOptions() *clientcmd.PathOptions
-	// FedClientSet provides a federation API compliant clientset
-	// to communicate with the federation control plane api server
-	FederationClientset(context, kubeconfigPath string) (*fedclient.Clientset, error)
 	// HostFactory provides a mechanism to communicate with the
 	// cluster where federation control plane is hosted.
-	HostFactory(hostcontext, kubeconfigPath string) cmdutil.Factory
+	HostFactory(host, kubeconfigPath string) cmdutil.Factory
 }
 
 // adminConfig implements the AdminConfig interface.
@@ -68,30 +64,17 @@ func (a *adminConfig) PathOptions() *clientcmd.PathOptions {
 	return a.pathOptions
 }
 
-func (a *adminConfig) FederationClientset(context, kubeconfigPath string) (*fedclient.Clientset, error) {
-	fedConfig := a.getClientConfig(context, kubeconfigPath)
-	fedClientConfig, err := fedConfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	return fedclient.NewForConfigOrDie(fedClientConfig), nil
-}
-
-func (a *adminConfig) HostFactory(hostcontext, kubeconfigPath string) cmdutil.Factory {
-	hostClientConfig := a.getClientConfig(hostcontext, kubeconfigPath)
-	return cmdutil.NewFactory(hostClientConfig)
-}
-
-func (a *adminConfig) getClientConfig(context, kubeconfigPath string) clientcmd.ClientConfig {
+func (a *adminConfig) HostFactory(host, kubeconfigPath string) cmdutil.Factory {
 	loadingRules := *a.pathOptions.LoadingRules
 	loadingRules.Precedence = a.pathOptions.GetLoadingPrecedence()
 	loadingRules.ExplicitPath = kubeconfigPath
 	overrides := &clientcmd.ConfigOverrides{
-		CurrentContext: context,
+		CurrentContext: host,
 	}
 
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, overrides)
+	hostClientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, overrides)
+
+	return cmdutil.NewFactory(hostClientConfig)
 }
 
 // SubcommandFlags holds the flags required by the subcommands of


### PR DESCRIPTION
Reverts kubernetes/kubernetes#39230
Reverts kubernetes/kubernetes#39718

Test grid shows sharp increase in failures on GKE here https://k8s-testgrid.appspot.com/google-gke#gci-gke&include-filter-by-regex=%5EOverall%24%7CUp and here https://k8s-testgrid.appspot.com/google-gke#gci-gke-slow&include-filter-by-regex=%5EOverall%24%7CUp .  It fails on https://github.com/kubernetes/kubernetes/commit/ba611194f7eda2257e32399cb98603c6a45998a4 and passed on https://github.com/kubernetes/kubernetes/commit/14e322cc827ca546eb80b721a825a43311a99437 .  This just reverts the two pulls in between.

