### PR TITLE
add --controllers to controller manager

### DIFF
--- a/cmd/hyperkube/kube-controller-manager.go
+++ b/cmd/hyperkube/kube-controller-manager.go
@@ -33,6 +33,6 @@ func NewKubeControllerManager() *Server {
 			return app.Run(s)
 		},
 	}
-	s.AddFlags(hks.Flags())
+	s.AddFlags(hks.Flags(), app.KnownControllers(), app.ControllersDisabledByDefault.List())
 	return &hks
 }

--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -98,6 +99,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apimachinery/pkg/runtime/serializer",
+        "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/apiserver/pkg/healthz",
     ],
@@ -117,4 +119,12 @@ filegroup(
         "//cmd/kube-controller-manager/app/options:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["controller_manager_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//vendor:k8s.io/apimachinery/pkg/util/sets"],
 )

--- a/cmd/kube-controller-manager/app/controller_manager_test.go
+++ b/cmd/kube-controller-manager/app/controller_manager_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app implements a server that runs a set of active
+// components.  This includes replication controllers, service endpoints and
+// nodes.
+//
+package app
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestIsControllerEnabled(t *testing.T) {
+	tcs := []struct {
+		name                         string
+		controllerName               string
+		controllers                  []string
+		disabledByDefaultControllers []string
+		expected                     bool
+	}{
+		{
+			name:                         "on by name",
+			controllerName:               "bravo",
+			controllers:                  []string{"alpha", "bravo", "-charlie"},
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			expected:                     true,
+		},
+		{
+			name:                         "off by name",
+			controllerName:               "charlie",
+			controllers:                  []string{"alpha", "bravo", "-charlie"},
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			expected:                     false,
+		},
+		{
+			name:                         "on by default",
+			controllerName:               "alpha",
+			controllers:                  []string{"*"},
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			expected:                     true,
+		},
+		{
+			name:                         "off by default",
+			controllerName:               "delta",
+			controllers:                  []string{"*"},
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			expected:                     false,
+		},
+		{
+			name:                         "off by default implicit, no star",
+			controllerName:               "foxtrot",
+			controllers:                  []string{"alpha", "bravo", "-charlie"},
+			disabledByDefaultControllers: []string{"delta", "echo"},
+			expected:                     false,
+		},
+	}
+
+	for _, tc := range tcs {
+		actual := IsControllerEnabled(tc.controllerName, sets.NewString(tc.disabledByDefaultControllers...), tc.controllers...)
+		if actual != tc.expected {
+			t.Errorf("%v: expected %v, got %v", tc.name, tc.expected, actual)
+		}
+	}
+
+}

--- a/cmd/kube-controller-manager/app/options/BUILD
+++ b/cmd/kube-controller-manager/app/options/BUILD
@@ -16,6 +16,8 @@ go_library(
         "//pkg/client/leaderelection:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/util/config:go_default_library",
+        "//pkg/util/errors:go_default_library",
+        "//pkg/util/sets:go_default_library",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
     ],

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -43,7 +43,7 @@ func init() {
 
 func main() {
 	s := options.NewCMServer()
-	s.AddFlags(pflag.CommandLine)
+	s.AddFlags(pflag.CommandLine, app.KnownControllers(), app.ControllersDisabledByDefault.List())
 
 	flag.InitFlags()
 	logs.InitLogs()

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -601,6 +601,13 @@ type LeaderElectionConfiguration struct {
 type KubeControllerManagerConfiguration struct {
 	metav1.TypeMeta
 
+	// Controllers is the list of controllers to enable or disable
+	// '*' means "all enabled by default controllers"
+	// 'foo' means "enable 'foo'"
+	// '-foo' means "disable 'foo'"
+	// first item for a particular name wins
+	Controllers []string
+
 	// port is the port that the controller-manager's http service runs on.
 	Port int32
 	// address is the IP address to serve on (set to 0.0.0.0 for all interfaces).

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -73,6 +73,11 @@ func DeepCopy_componentconfig_KubeControllerManagerConfiguration(in interface{},
 		in := in.(*KubeControllerManagerConfiguration)
 		out := out.(*KubeControllerManagerConfiguration)
 		*out = *in
+		if in.Controllers != nil {
+			in, out := &in.Controllers, &out.Controllers
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		}
 		return nil
 	}
 }


### PR DESCRIPTION
Adds a `--controllers` flag to the `kube-controller-manager` to indicate which controllers are enabled and disabled.  From the help:

```
      --controllers stringSlice                                           A list of controllers to enable.  '*' enables all on-by-default controllers, 'foo' enables the controller named 'foo', '-foo' disables the controller named 'foo'.
All controllers: certificatesigningrequests, cronjob, daemonset, deployment, disruption, endpoint, garbagecollector, horizontalpodautoscaling, job, namespace, podgc, replicaset, replicationcontroller, resourcequota, serviceaccount, statefuleset
```

