### PR TITLE
add owners to apimachinery

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- caesarxuchao
+- deads2k
+- lavalamp
+- smarterclayton


### PR DESCRIPTION
Adds owners to apimachinery/pkg and I need a commit to use as an example for my sync'ing script.

@kubernetes/sig-api-machinery-misc @smarterclayton @lavalamp should be non-contentious I'd think.