### PR TITLE
support -E and -S command in iptables

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -48,10 +48,14 @@ type Interface interface {
 	FlushChain(table Table, chain Chain) error
 	// DeleteChain deletes the specified chain.  If the chain did not exist, return error.
 	DeleteChain(table Table, chain Chain) error
+	// RenameChain renames chain from oldChain to newChain. If the old chain did not exist or new chain had conflict, return error.
+	RenameChain(table Table, oldChain, newChain Chain) error
 	// EnsureRule checks if the specified rule is present and, if not, creates it.  If the rule existed, return true.
 	EnsureRule(position RulePosition, table Table, chain Chain, args ...string) (bool, error)
 	// DeleteRule checks if the specified rule is present and, if so, deletes it.
 	DeleteRule(table Table, chain Chain, args ...string) error
+	// ListRules lists all rules in the selected chain. If no chain is selected, all chains are listed like iptables-save.
+	ListRules(table Table, chain Chain, args ...string) ([]byte, error)
 	// IsIpv6 returns true if this is managing ipv6 tables
 	IsIpv6() bool
 	// TODO: (BenTheElder) Unit-Test Save/SaveAll, Restore/RestoreAll
@@ -242,6 +246,18 @@ func (runner *runner) DeleteChain(table Table, chain Chain) error {
 	return nil
 }
 
+// RenameChain is part of Interface.
+func (runner *runner) RenameChain(table Table, oldChain, newChain Chain) error {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+
+	out, err := runner.run(opRenameChain, []string{string(oldChain), string(newChain), "-t", string(table)})
+	if err != nil {
+		return fmt.Errorf("error renaming chain from %q to %q: %v: %s", oldChain, newChain, err, out)
+	}
+	return nil
+}
+
 // EnsureRule is part of Interface.
 func (runner *runner) EnsureRule(position RulePosition, table Table, chain Chain, args ...string) (bool, error) {
 	fullArgs := makeFullArgs(table, chain, args...)
@@ -282,6 +298,21 @@ func (runner *runner) DeleteRule(table Table, chain Chain, args ...string) error
 		return fmt.Errorf("error deleting rule: %v: %s", err, out)
 	}
 	return nil
+}
+
+// ListRules is part of Interface
+func (runner *runner) ListRules(table Table, chain Chain, args ...string) ([]byte, error) {
+	runner.mu.Lock()
+	defer runner.mu.Unlock()
+
+	var fullArgs []string
+	if string(chain) != "" /* only append chain name if it exists */ {
+		fullArgs = append(fullArgs, string(chain))
+	}
+	if len(args) != 0 {
+		fullArgs = append(fullArgs, args...)
+	}
+	return runner.run(opListRules, append(fullArgs, "-t", string(table)))
 }
 
 func (runner *runner) IsIpv6() bool {
@@ -454,6 +485,8 @@ const (
 	opAppendRule  operation = "-A"
 	opCheckRule   operation = "-C"
 	opDeleteRule  operation = "-D"
+	opRenameChain operation = "-E"
+	opListRules   operation = "-S"
 )
 
 func makeFullArgs(table Table, chain Chain, args ...string) []string {

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -173,6 +173,44 @@ func TestDeleteChain(t *testing.T) {
 	}
 }
 
+func TestRenameChain(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Success.
+			func() ([]byte, error) { return []byte{}, nil },
+			// Failure.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	// Success.
+	err := runner.RenameChain(TableFilter, Chain("FOO"), Chain("BAR"))
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-E", "FOO", "BAR", "-t", "filter") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+	// Failure.
+	err = runner.RenameChain(TableFilter, Chain("BAR"), Chain("BAR"))
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+}
+
 func TestEnsureRuleAlreadyExists(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
@@ -364,6 +402,62 @@ func TestDeleteRuleNew(t *testing.T) {
 		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
 	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-t", "nat", "-D", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
+	}
+}
+
+func TestListRules(t *testing.T) {
+	iptables_list_all := `-P INPUT ACCEPT
+-P FORWARD ACCEPT
+-P OUTPUT ACCEPT
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT`
+
+	iptables_list_input_chain := `-P INPUT ACCEPT
+-A INPUT -m state --state RELATED,ESTABLISHED -j ACCEPT`
+
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Success on the first call.
+			func() ([]byte, error) { return []byte(iptables_list_all), nil },
+			// Success on the second call.
+			func() ([]byte, error) { return []byte(iptables_list_input_chain), nil },
+			// Status 1 on the third call.
+			func() ([]byte, error) { return []byte{}, &exec.FakeExitError{Status: 1} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// following Command() call is listing the rules.
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	_, err := runner.ListRules(TableFilter, "") // list all rules
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	_, err = runner.ListRules(TableFilter, ChainInput) // list all rules in INPUT chain
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	_, err = runner.ListRules(TableFilter, "FOO", "abc", "123")
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+	if fcmd.CombinedOutputCalls != 4 {
+		t.Errorf("expected 4 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-S", "-t", "filter") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-S", "INPUT", "-t", "filter") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
 }

--- a/pkg/util/iptables/testing/fake.go
+++ b/pkg/util/iptables/testing/fake.go
@@ -60,12 +60,20 @@ func (*FakeIPTables) DeleteChain(table iptables.Table, chain iptables.Chain) err
 	return nil
 }
 
+func (*FakeIPTables) RenameChain(table iptables.Table, oldChain, newChain iptables.Chain) error {
+	return nil
+}
+
 func (*FakeIPTables) EnsureRule(position iptables.RulePosition, table iptables.Table, chain iptables.Chain, args ...string) (bool, error) {
 	return true, nil
 }
 
 func (*FakeIPTables) DeleteRule(table iptables.Table, chain iptables.Chain, args ...string) error {
 	return nil
+}
+
+func (*FakeIPTables) ListRules(table iptables.Table, chain iptables.Chain, args ...string) ([]byte, error) {
+	return []byte{}, nil
 }
 
 func (*FakeIPTables) IsIpv6() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to support two more commands in iptables tool.
-E to rename old chain name to new one
-S to list all rules or rules in specific chain


