### PR TITLE
Check if path exists before performing unmount

### DIFF
--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/util"
 )
 
 // This is the primary entrypoint for volume plugins.
@@ -316,6 +317,13 @@ func (c *azureDiskUnmounter) TearDown() error {
 // Unmounts the bind mount, and detaches the disk only if the PD
 // resource was the last reference to that disk on the kubelet.
 func (c *azureDiskUnmounter) TearDownAt(dir string) error {
+	if pathExists, pathErr := util.PathExists(dir); pathErr != nil {
+		return fmt.Errorf("Error checking if path exists: %v", pathErr)
+	} else if !pathExists {
+		glog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
+		return nil
+	}
+
 	notMnt, err := c.mounter.IsLikelyNotMountPoint(dir)
 	if err != nil {
 		glog.Errorf("Error checking if mountpoint %s: %v", dir, err)

--- a/pkg/volume/fc/BUILD
+++ b/pkg/volume/fc/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//pkg/util/mount:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",
+        "//pkg/volume/util:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/types",
     ],

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/util"
 )
 
 // This is the primary entrypoint for volume plugins.
@@ -222,6 +223,12 @@ func (c *fcDiskUnmounter) TearDown() error {
 }
 
 func (c *fcDiskUnmounter) TearDownAt(dir string) error {
+	if pathExists, pathErr := util.PathExists(dir); pathErr != nil {
+		return fmt.Errorf("Error checking if path exists: %v", pathErr)
+	} else if !pathExists {
+		glog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
+		return nil
+	}
 	return diskTearDown(c.manager, *c, dir, c.mounter)
 }
 

--- a/pkg/volume/flexvolume/BUILD
+++ b/pkg/volume/flexvolume/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/util/mount:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",
+        "//pkg/volume/util:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/types",

--- a/pkg/volume/flexvolume/flexvolume.go
+++ b/pkg/volume/flexvolume/flexvolume.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/util"
 )
 
 // This is the primary entrypoint for volume plugins.
@@ -371,6 +372,12 @@ func (f *flexVolumeUnmounter) TearDown() error {
 
 // TearDownAt simply deletes everything in the directory.
 func (f *flexVolumeUnmounter) TearDownAt(dir string) error {
+	if pathExists, pathErr := util.PathExists(dir); pathErr != nil {
+		return fmt.Errorf("Error checking if path exists: %v", pathErr)
+	} else if !pathExists {
+		glog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
+		return nil
+	}
 
 	notmnt, err := f.mounter.IsLikelyNotMountPoint(dir)
 	if err != nil {

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -230,6 +230,12 @@ func (c *iscsiDiskUnmounter) TearDown() error {
 }
 
 func (c *iscsiDiskUnmounter) TearDownAt(dir string) error {
+	if pathExists, pathErr := ioutil.PathExists(dir); pathErr != nil {
+		return fmt.Errorf("Error checking if path exists: %v", pathErr)
+	} else if !pathExists {
+		glog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
+		return nil
+	}
 	return diskTearDown(c.manager, *c, dir, c.mounter)
 }
 

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -413,6 +413,12 @@ func (c *rbdUnmounter) TearDown() error {
 }
 
 func (c *rbdUnmounter) TearDownAt(dir string) error {
+	if pathExists, pathErr := volutil.PathExists(dir); pathErr != nil {
+		return fmt.Errorf("Error checking if path exists: %v", pathErr)
+	} else if !pathExists {
+		glog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
+		return nil
+	}
 	return diskTearDown(c.manager, *c, dir, c.mounter)
 }
 

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -32,6 +32,7 @@ ConfigMap should be consumable from pods in volume with mappings as non-root,ape
 ConfigMap should be consumable from pods in volume with mappings as non-root with FSGroup,zmerlynn,1
 ConfigMap should be consumable in multiple volumes in the same pod,caesarxuchao,1
 ConfigMap should be consumable via environment variable,ncdc,1
+ConfigMap should be consumable via the environment,rkouj,0
 ConfigMap updates should be reflected in volume,kevin-wangzefeng,1
 Container Lifecycle Hook when create a pod with lifecycle hook when it is exec hook should execute poststart exec hook properly,kargakis,1
 Container Lifecycle Hook when create a pod with lifecycle hook when it is exec hook should execute prestop exec hook properly,rrati,0
@@ -44,6 +45,7 @@ ContainerLogPath Pod with a container printed log to stdout should print log to 
 CronJob should not emit unexpected warnings,soltysh,1
 CronJob should not schedule jobs when suspended,soltysh,1
 CronJob should not schedule new jobs when ForbidConcurrent,soltysh,1
+CronJob should remove from active list jobs that have been deleted,rkouj,0
 CronJob should replace jobs when ReplaceConcurrent,soltysh,1
 CronJob should schedule multiple jobs concurrently,soltysh,1
 DNS config map should be able to change configuration,rkouj,0
@@ -63,7 +65,7 @@ Density create a batch of pods latency/resource should be within limit when crea
 Density create a batch of pods with higher API QPS latency/resource should be within limit when create * pods with * interval (QPS *),jlowdermilk,1
 Density create a sequence of pods latency/resource should be within limit when create * pods with * background pods,wojtek-t,1
 Density should allow running maximum capacity pods on nodes,smarterclayton,1
-Density should allow starting * pods per node using * with * secrets,brendandburns,0
+Density should allow starting * pods per node using * with * secrets and * daemons,rkouj,0
 Deployment RecreateDeployment should delete old pods and create new ones,pwittrock,0
 Deployment RollingUpdateDeployment should delete old pods and create new ones,pwittrock,0
 Deployment deployment reaping should cascade to its replica sets and pods,wojtek-t,1
@@ -141,8 +143,10 @@ Events should be sent by kubelets and the scheduler about pods scheduling and ru
 Federated Services DNS non-local federated service missing local service should never find DNS entries for a missing local service,mml,0
 Federated Services DNS non-local federated service should be able to discover a non-local federated service,jlowdermilk,1
 Federated Services DNS should be able to discover a federated service,derekwaynecarr,1
+Federated Services Service creation should be deleted from underlying clusters when OrphanDependents is false,rkouj,0
 Federated Services Service creation should create matching services in underlying clusters,jbeda,1
-Federated Services Service creation should not be deleted from underlying clusters when it is deleted,madhusudancs,0
+Federated Services Service creation should not be deleted from underlying clusters when OrphanDependents is nil,rkouj,0
+Federated Services Service creation should not be deleted from underlying clusters when OrphanDependents is true,rkouj,0
 Federated Services Service creation should succeed,rmmh,1
 Federated ingresses Federated Ingresses Ingress connectivity and DNS should be able to connect to a federated ingress via its load balancer,rmmh,1
 Federated ingresses Federated Ingresses should be created and deleted successfully,dchen1107,1
@@ -280,7 +284,7 @@ KubeletManagedEtcHosts should test kubelet managed /etc/hosts file,Random-Liu,1
 Kubernetes Dashboard should check that the kubernetes-dashboard instance is alive,wonderfly,0
 LimitRange should create a LimitRange with defaults and ensure pod has those defaults applied.,cjcullen,1
 Liveness liveness pods should be automatically restarted,derekwaynecarr,0
-Load capacity should be able to handle * pods per node * with * secrets,brendandburns,0
+Load capacity should be able to handle * pods per node * with * secrets and * daemons,rkouj,0
 Loadbalancing: L7 GCE shoud create ingress with given static-ip,derekwaynecarr,0
 Loadbalancing: L7 GCE should conform to Ingress spec,derekwaynecarr,0
 Loadbalancing: L7 Nginx should conform to Ingress spec,ncdc,1
@@ -345,6 +349,7 @@ PersistentVolumes PersistentVolumes:NFS with Single PV - PVC pairs should create
 PersistentVolumes PersistentVolumes:NFS with multiple PVs and PVCs all in same ns should create 2 PVs and 4 PVCs: test write access,copejon,0
 PersistentVolumes PersistentVolumes:NFS with multiple PVs and PVCs all in same ns should create 3 PVs and 3 PVCs: test write access,copejon,0
 PersistentVolumes PersistentVolumes:NFS with multiple PVs and PVCs all in same ns should create 4 PVs and 2 PVCs: test write access,copejon,0
+PersistentVolumes when kubelet restarts *,rkouj,0
 Pet Store should scale to persist a nominal number ( * ) of transactions in * seconds,xiang90,1
 "Pod Disks Should schedule a pod w/ a RW PD, gracefully remove it, then schedule it on another host",saad-ali,0
 "Pod Disks Should schedule a pod w/ a readonly PD on two hosts, then remove both gracefully.",saad-ali,0
@@ -355,7 +360,8 @@ Pod Disks should be able to detach from a node whose api object was deleted,rkou
 "Pod Disks should schedule a pod w/ a readonly PD on two hosts, then remove both ungracefully.",saad-ali,1
 "Pod Disks should schedule a pod w/two RW PDs both mounted to one container, write to PD, verify contents, delete pod, recreate pod, verify contents, and repeat in rapid succession",saad-ali,0
 Pod garbage collector should handle the creation of 1000 pods,wojtek-t,1
-Pods Delete Grace Period should be submitted and removed,bdbauer,0
+Pods Extended Delete Grace Period should be submitted and removed,rkouj,0
+Pods Extended Pods Set QOS Class should be submitted and removed,rkouj,0
 Pods should allow activeDeadlineSeconds to be updated,derekwaynecarr,0
 Pods should be submitted and removed,davidopp,1
 Pods should be updated,derekwaynecarr,1
@@ -365,9 +371,12 @@ Pods should get a host IP,xiang90,1
 Pods should have their auto-restart back-off timer reset on image update,mikedanese,1
 Pods should support remote command execution over websockets,madhusudancs,1
 Pods should support retrieving logs from the container over websockets,vishh,0
-"Port forwarding With a server that expects a client request should support a client that connects, sends data, and disconnects",sttts,0
-"Port forwarding With a server that expects a client request should support a client that connects, sends no data, and disconnects",sttts,0
-"Port forwarding With a server that expects no client request should support a client that connects, sends no data, and disconnects",sttts,0
+"Port forwarding With a server listening on 0.0.0.0 that expects a client request should support a client that connects, sends data, and disconnects",rkouj,0
+"Port forwarding With a server listening on 0.0.0.0 that expects a client request should support a client that connects, sends no data, and disconnects",rkouj,0
+"Port forwarding With a server listening on 0.0.0.0 that expects no client request should support a client that connects, sends data, and disconnects",rkouj,0
+"Port forwarding With a server listening on localhost that expects a client request should support a client that connects, sends data, and disconnects",rkouj,0
+"Port forwarding With a server listening on localhost that expects a client request should support a client that connects, sends no data, and disconnects",rkouj,0
+"Port forwarding With a server listening on localhost that expects no client request should support a client that connects, sends data, and disconnects",rkouj,0
 PreStop should call prestop when killing a pod,ncdc,1
 PrivilegedPod should enable privileged commands,derekwaynecarr,0
 Probing container should *not* be restarted with a /healthz http liveness probe,Random-Liu,0
@@ -506,6 +515,7 @@ Volumes PD should be mountable,caesarxuchao,1
 Volumes iSCSI should be mountable,jsafrane,1
 k8s.io/kubernetes/cmd/genutils,rmmh,1
 k8s.io/kubernetes/cmd/hyperkube,jbeda,0
+k8s.io/kubernetes/cmd/kube-aggregator/pkg/apiserver,brendandburns,0
 k8s.io/kubernetes/cmd/kube-apiserver/app/options,nikhiljindal,0
 k8s.io/kubernetes/cmd/kube-discovery/app,pmorie,1
 k8s.io/kubernetes/cmd/kube-proxy/app,luxas,1
@@ -514,11 +524,12 @@ k8s.io/kubernetes/cmd/kubeadm/app/discovery,brendandburns,0
 k8s.io/kubernetes/cmd/kubeadm/app/images,davidopp,1
 k8s.io/kubernetes/cmd/kubeadm/app/master,apprenda,0
 k8s.io/kubernetes/cmd/kubeadm/app/node,apprenda,0
+k8s.io/kubernetes/cmd/kubeadm/app/phases/certs,rkouj,0
+k8s.io/kubernetes/cmd/kubeadm/app/phases/kubeconfig,rkouj,0
 k8s.io/kubernetes/cmd/kubeadm/app/preflight,apprenda,0
 k8s.io/kubernetes/cmd/kubeadm/app/util,krousey,1
 k8s.io/kubernetes/cmd/kubeadm/test,pipejakob,0
 k8s.io/kubernetes/cmd/kubelet/app,derekwaynecarr,0
-k8s.io/kubernetes/cmd/kube-aggregator/pkg/apiserver,brendandburns,0
 k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types,caesarxuchao,0
 k8s.io/kubernetes/cmd/libs/go2idl/go-to-protobuf/protobuf,smarterclayton,0
 k8s.io/kubernetes/cmd/libs/go2idl/openapi-gen/generators,davidopp,1
@@ -557,6 +568,7 @@ k8s.io/kubernetes/pkg/api/events,jlowdermilk,1
 k8s.io/kubernetes/pkg/api/install,timothysc,1
 k8s.io/kubernetes/pkg/api/meta,fabioy,1
 k8s.io/kubernetes/pkg/api/resource,smarterclayton,1
+k8s.io/kubernetes/pkg/api/rest,rkouj,0
 k8s.io/kubernetes/pkg/api/service,spxtr,1
 k8s.io/kubernetes/pkg/api/testapi,caesarxuchao,1
 k8s.io/kubernetes/pkg/api/util,rkouj,0
@@ -565,10 +577,12 @@ k8s.io/kubernetes/pkg/api/v1/endpoints,rkouj,0
 k8s.io/kubernetes/pkg/api/v1/pod,rkouj,0
 k8s.io/kubernetes/pkg/api/v1/service,rkouj,0
 k8s.io/kubernetes/pkg/api/validation,smarterclayton,1
+k8s.io/kubernetes/pkg/api/validation/genericvalidation,rkouj,0
 k8s.io/kubernetes/pkg/api/validation/path,luxas,1
 k8s.io/kubernetes/pkg/apimachinery,gmarek,1
 k8s.io/kubernetes/pkg/apimachinery/announced,kargakis,1
 k8s.io/kubernetes/pkg/apimachinery/registered,jlowdermilk,1
+k8s.io/kubernetes/pkg/apimachinery/tests,rkouj,0
 k8s.io/kubernetes/pkg/apis/abac/v0,liggitt,0
 k8s.io/kubernetes/pkg/apis/abac/v1beta1,liggitt,0
 k8s.io/kubernetes/pkg/apis/apps/validation,derekwaynecarr,1
@@ -583,18 +597,11 @@ k8s.io/kubernetes/pkg/apis/extensions,bgrant0607,1
 k8s.io/kubernetes/pkg/apis/extensions/v1beta1,madhusudancs,1
 k8s.io/kubernetes/pkg/apis/extensions/validation,nikhiljindal,1
 k8s.io/kubernetes/pkg/apis/meta/v1,sttts,0
-k8s.io/kubernetes/pkg/apis/meta/v1/unstructured,smarterclayton,0
 k8s.io/kubernetes/pkg/apis/meta/v1/validation,smarterclayton,0
 k8s.io/kubernetes/pkg/apis/policy/validation,deads2k,1
 k8s.io/kubernetes/pkg/apis/rbac/v1alpha1,liggitt,0
 k8s.io/kubernetes/pkg/apis/rbac/validation,erictune,0
 k8s.io/kubernetes/pkg/apis/storage/validation,caesarxuchao,1
-k8s.io/kubernetes/pkg/genericapiserver/api,nikhiljindal,0
-k8s.io/kubernetes/pkg/genericapiserver/api/filters,dchen1107,1
-k8s.io/kubernetes/pkg/genericapiserver/api/handlers,rkouj,0
-k8s.io/kubernetes/pkg/genericapiserver/api/handlers/errors,rkouj,0
-k8s.io/kubernetes/pkg/genericapiserver/api/handlers/negotiation,rkouj,0
-k8s.io/kubernetes/pkg/genericapiserver/api/request,lavalamp,1
 k8s.io/kubernetes/pkg/auth/authenticator/bearertoken,liggitt,0
 k8s.io/kubernetes/pkg/auth/authorizer/abac,liggitt,0
 k8s.io/kubernetes/pkg/auth/authorizer/union,liggitt,0
@@ -606,6 +613,7 @@ k8s.io/kubernetes/pkg/client/leaderelection,xiang90,1
 k8s.io/kubernetes/pkg/client/listers/batch/internalversion,mqliang,0
 k8s.io/kubernetes/pkg/client/record,rrati,0
 k8s.io/kubernetes/pkg/client/restclient,kargakis,1
+k8s.io/kubernetes/pkg/client/restclient/watch,rkouj,0
 k8s.io/kubernetes/pkg/client/retry,caesarxuchao,1
 k8s.io/kubernetes/pkg/client/testing/cache,mikedanese,1
 k8s.io/kubernetes/pkg/client/testing/core,maisem,1
@@ -629,6 +637,7 @@ k8s.io/kubernetes/pkg/cloudprovider/providers/photon,luomiao,0
 k8s.io/kubernetes/pkg/cloudprovider/providers/rackspace,caesarxuchao,1
 k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere,apelisse,1
 k8s.io/kubernetes/pkg/controller,mikedanese,1
+k8s.io/kubernetes/pkg/controller/certificates,rkouj,0
 k8s.io/kubernetes/pkg/controller/cloud,rkouj,0
 k8s.io/kubernetes/pkg/controller/cronjob,soltysh,1
 k8s.io/kubernetes/pkg/controller/daemon,Q-Lee,1
@@ -661,19 +670,21 @@ k8s.io/kubernetes/pkg/credentialprovider,justinsb,1
 k8s.io/kubernetes/pkg/credentialprovider/aws,zmerlynn,1
 k8s.io/kubernetes/pkg/credentialprovider/azure,brendandburns,0
 k8s.io/kubernetes/pkg/credentialprovider/gcp,mml,1
-k8s.io/kubernetes/pkg/dns,rkouj,0
-k8s.io/kubernetes/pkg/dns/config,rkouj,0
-k8s.io/kubernetes/pkg/dns/federation,rkouj,0
-k8s.io/kubernetes/pkg/dns/treecache,bowei,0
 k8s.io/kubernetes/pkg/fieldpath,childsb,1
 k8s.io/kubernetes/pkg/fields,jsafrane,1
 k8s.io/kubernetes/pkg/genericapiserver,nikhiljindal,0
+k8s.io/kubernetes/pkg/genericapiserver/api,nikhiljindal,0
+k8s.io/kubernetes/pkg/genericapiserver/api/filters,dchen1107,1
+k8s.io/kubernetes/pkg/genericapiserver/api/handlers,rkouj,0
+k8s.io/kubernetes/pkg/genericapiserver/api/handlers/negotiation,rkouj,0
+k8s.io/kubernetes/pkg/genericapiserver/api/handlers/responsewriters,rkouj,0
+k8s.io/kubernetes/pkg/genericapiserver/api/request,lavalamp,1
 k8s.io/kubernetes/pkg/genericapiserver/authorizer,lavalamp,1
 k8s.io/kubernetes/pkg/genericapiserver/filters,dchen1107,1
 k8s.io/kubernetes/pkg/genericapiserver/mux,spxtr,1
 k8s.io/kubernetes/pkg/genericapiserver/openapi,davidopp,1
-k8s.io/kubernetes/pkg/healthz,thockin,1
 k8s.io/kubernetes/pkg/httplog,mtaufen,1
+k8s.io/kubernetes/pkg/kubeapiserver/admission,rkouj,0
 k8s.io/kubernetes/pkg/kubeapiserver/authorizer,rkouj,0
 k8s.io/kubernetes/pkg/kubectl,madhusudancs,1
 k8s.io/kubernetes/pkg/kubectl/cmd,rmmh,1
@@ -803,13 +814,13 @@ k8s.io/kubernetes/pkg/registry/generic/registry,jsafrane,1
 k8s.io/kubernetes/pkg/registry/generic/rest,smarterclayton,1
 k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget,Q-Lee,1
 k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget/etcd,xiang90,1
+k8s.io/kubernetes/pkg/registry/rbac/validation,rkouj,0
 k8s.io/kubernetes/pkg/registry/storage/storageclass,brendandburns,1
 k8s.io/kubernetes/pkg/registry/storage/storageclass/etcd,eparis,1
 k8s.io/kubernetes/pkg/runtime,wojtek-t,0
 k8s.io/kubernetes/pkg/runtime/schema,rkouj,0
 k8s.io/kubernetes/pkg/runtime/serializer,wojtek-t,0
 k8s.io/kubernetes/pkg/runtime/serializer/json,wojtek-t,0
-k8s.io/kubernetes/pkg/runtime/serializer/protobuf,wojtek-t,0
 k8s.io/kubernetes/pkg/runtime/serializer/recognizer/testing,wojtek-t,0
 k8s.io/kubernetes/pkg/runtime/serializer/streaming,wojtek-t,0
 k8s.io/kubernetes/pkg/runtime/serializer/versioning,wojtek-t,0
@@ -845,7 +856,6 @@ k8s.io/kubernetes/pkg/util/env,asalkeld,0
 k8s.io/kubernetes/pkg/util/errors,jlowdermilk,1
 k8s.io/kubernetes/pkg/util/exec,krousey,1
 k8s.io/kubernetes/pkg/util/flowcontrol,ixdy,1
-k8s.io/kubernetes/pkg/util/flushwriter,rrati,0
 k8s.io/kubernetes/pkg/util/framer,piosz,1
 k8s.io/kubernetes/pkg/util/goroutinemap,saad-ali,0
 k8s.io/kubernetes/pkg/util/hash,timothysc,1
@@ -914,7 +924,6 @@ k8s.io/kubernetes/pkg/volume/util/nestedpendingoperations,freehan,1
 k8s.io/kubernetes/pkg/volume/util/operationexecutor,rkouj,0
 k8s.io/kubernetes/pkg/volume/vsphere_volume,deads2k,1
 k8s.io/kubernetes/pkg/watch,mwielgus,1
-k8s.io/kubernetes/pkg/watch/versioned,childsb,1
 k8s.io/kubernetes/plugin/pkg/admission/admit,piosz,1
 k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages,kargakis,1
 k8s.io/kubernetes/plugin/pkg/admission/antiaffinity,timothysc,1


### PR DESCRIPTION
This is part 3 of an effort to check if path exists before performing an unmount operation.
[Part 1](https://github.com/kubernetes/kubernetes/pull/38547) and [part 2](https://github.com/kubernetes/kubernetes/pull/39311) involved auditing the different volume plugins and refactoring their `TearDownAt()s` to use the common util function/or create one if absent.

The ideal way to do this change would involve refactoring of the `TearDownAt()s` of these plugins and make a common util function that checks path. (The plugins involved in this PR use someway of unmounting a bind mount and unmounting a global path, there is also refactoring needed to consolidate disk_manager of fc, rbd and iscsi). A non-goal part of this effort can also involve refactoring all the `SetupAt()s`

In the interest of time and considering other higher priority issues that I am caught up with, I am unable to give the time the refactoring needs. Hence I've made the minimum change that would give the desired output.

I am tracking the work pending in this issue: https://github.com/kubernetes/kubernetes/issues/39251

```release-note
NONE
```
