### PR TITLE
Update images that use ubuntu-slim base image to :0.6

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -1,23 +1,23 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: fluentd-es-v1.20
+  name: fluentd-es-v1.22
   namespace: kube-system
   labels:
     k8s-app: fluentd-es
     kubernetes.io/cluster-service: "true"
-    version: v1.20
+    version: v1.22
 spec:
   template:
     metadata:
       labels:
         k8s-app: fluentd-es
         kubernetes.io/cluster-service: "true"
-        version: v1.20
+        version: v1.22
     spec:
       containers:
       - name: fluentd-es
-        image: gcr.io/google_containers/fluentd-elasticsearch:1.20
+        image: gcr.io/google_containers/fluentd-elasticsearch:1.22
         command:
           - '/bin/sh'
           - '-c'

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -22,7 +22,7 @@
 # Please see http://docs.fluentd.org/articles/install-by-deb for more
 # information about installing fluentd using deb package.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.4
+FROM gcr.io/google_containers/ubuntu-slim:0.6
 
 # Ensure there are enough file descriptors for running Fluentd.
 RUN ulimit -n 65536

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -16,7 +16,7 @@
 
 PREFIX = gcr.io/google_containers
 IMAGE = fluentd-elasticsearch
-TAG = 1.21
+TAG = 1.22
 
 build:
 	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-controller.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: gcr.io/google_containers/kibana:v4.6.1
+        image: gcr.io/google_containers/kibana:v4.6.1-1
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Dockerfile
@@ -15,7 +15,7 @@
 # A Dockerfile for creating a Kibana container that is designed
 # to work with Kubernetes logging.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.4
+FROM gcr.io/google_containers/ubuntu-slim:0.6
 
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY:	build push
 
-TAG = v4.6.1
+TAG = v4.6.1-1
 PREFIX = gcr.io/google_containers
 
 build:

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google_containers/fluentd-gcp:1.31
+        image: gcr.io/google_containers/fluentd-gcp:1.32
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
         # tries to send this message to the server => fails to send a chunk and so on.

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -20,7 +20,7 @@
 # scope and that the Logging API has been enabled for the project
 # in the Google Developer Console.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.4
+FROM gcr.io/google_containers/ubuntu-slim:0.6
 
 
 # Disable prompts from apt

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -26,7 +26,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google_containers
-TAG = 1.31
+TAG = 1.32
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -10,7 +10,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.31
+    image: gcr.io/google_containers/fluentd-gcp:1.32
     # If fluentd consumes its own logs, the following situation may happen:
     # fluentd fails to send a chunk to the server => writes it to the log =>
     # tries to send this message to the server => fails to send a chunk and so on.

--- a/test/images/iperf/Dockerfile
+++ b/test/images/iperf/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.2
+FROM gcr.io/google_containers/ubuntu-slim:0.6
 RUN apt-get update && apt-get install -y --no-install-recommends iperf bash \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/* \

--- a/test/images/logs-generator/Dockerfile
+++ b/test/images/logs-generator/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.4
+FROM gcr.io/google_containers/ubuntu-slim:0.6
 
 
 COPY logs-generator /

--- a/test/images/logs-generator/Makefile
+++ b/test/images/logs-generator/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = v0.1.0
+TAG = v0.1.1
 PREFIX = gcr.io/google_containers
 
 all: build

--- a/test/images/logs-generator/README.md
+++ b/test/images/logs-generator/README.md
@@ -33,7 +33,7 @@ line in a given run of the container.
 Image is located in the public repository of Google Container Registry under the name
 
 ```
-gcr.io/google_containers/logs-generator:v0.1.0
+gcr.io/google_containers/logs-generator:v0.1.1
 ```
 
 ## Examples
@@ -42,13 +42,13 @@ gcr.io/google_containers/logs-generator:v0.1.0
 docker run -i \
   -e "LOGS_GENERATOR_LINES_TOTAL=10" \
   -e "LOGS_GENERATOR_DURATION=1s" \
-  gcr.io/google_containers/logs-generator:v0.1.0
+  gcr.io/google_containers/logs-generator:v0.1.1
 ```
 
 ```
 kubectl run logs-generator \
   --generator=run-pod/v1 \
-  --image=gcr.io/google_containers/logs-generator:v0.1.0 \
+  --image=gcr.io/google_containers/logs-generator:v0.1.1 \
   --restart=Never \
   --env "LOGS_GENERATOR_LINES_TOTAL=1000" \
   --env "LOGS_GENERATOR_DURATION=1m"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: `ubuntu-slim:0.4` is somewhat old, being based on Ubuntu 16.04, whereas `ubuntu-slim:0.6` is based on Ubuntu 16.04.1.

**Special notes for your reviewer**: I haven't pushed any of these images yet, so I expect all of the e2e builds to fail. If we're happy with the changes, I can push the images and then re-trigger tests.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

cc @aledbf as FYI
