### PR TITLE
remove BUILD spammy output

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -244,7 +244,8 @@ genrule(
     testonly = 1,
     srcs = [":go_default_test"],
     outs = ["e2e.test"],
-    cmd = "set -x; srcs=($(SRCS)); cp $$(dirname $${srcs[0]})/go_default_test $@;",
+    cmd = "srcs=($(SRCS)); cp $$(dirname $${srcs[0]})/go_default_test $@;",
+    output_to_bindir = 1,
 )
 
 filegroup(


### PR DESCRIPTION
leftover from debugging