### PR TITLE
use common namespace interface

### DIFF
--- a/pkg/api/rest/strategies.go
+++ b/pkg/api/rest/strategies.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+// NamespaceScopedStrategy has a method to tell if the object must be in a namespace.
+type NamespaceScopedStrategy interface {
+	// NamespaceScoped returns if the object must be in a namespace.
+	NamespaceScoped() bool
+}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -37,8 +37,7 @@ type RESTCreateStrategy interface {
 	// The NameGenerator will be invoked prior to validation.
 	names.NameGenerator
 
-	// NamespaceScoped returns true if the object must be within a namespace.
-	NamespaceScoped() bool
+	NamespaceScopedStrategy
 	// PrepareForCreate is invoked on create before validation to normalize
 	// the object.  For example: remove fields that are not to be persisted,
 	// sort order-insensitive list fields, etc.  This should not remove fields
@@ -130,10 +129,4 @@ func objectMetaAndKind(typer runtime.ObjectTyper, obj runtime.Object) (*metav1.O
 		return nil, schema.GroupVersionKind{}, errors.NewInternalError(err)
 	}
 	return objectMeta, kinds[0], nil
-}
-
-// NamespaceScopedStrategy has a method to tell if the object must be in a namespace.
-type NamespaceScopedStrategy interface {
-	// NamespaceScoped returns if the object must be in a namespace.
-	NamespaceScoped() bool
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -34,8 +34,7 @@ import (
 // the call pattern in use.
 type RESTUpdateStrategy interface {
 	runtime.ObjectTyper
-	// NamespaceScoped returns true if the object must be within a namespace.
-	NamespaceScoped() bool
+	NamespaceScopedStrategy
 	// AllowCreateOnUpdate returns true if the object can be created by a PUT.
 	AllowCreateOnUpdate() bool
 	// PrepareForUpdate is invoked on update before validation to normalize


### PR DESCRIPTION
Create and Update share a method signature down to the comment.

There is an available interface that can be shared. I pulled it out. I did not think it should be placed in Create or Update as they share it. It can be placed elsewhere if you want.