### PR TITLE
Set MemorySwap to zero on Windows

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -141,7 +141,7 @@ func (ds *dockerService) CreateContainer(podSandboxID string, config *runtimeApi
 		if rOpts != nil {
 			hc.Resources = dockercontainer.Resources{
 				Memory:     rOpts.GetMemoryLimitInBytes(),
-				MemorySwap: -1,
+				MemorySwap: dockertools.DefaultMemorySwap(),
 				CPUShares:  rOpts.GetCpuShares(),
 				CPUQuota:   rOpts.GetCpuQuota(),
 				CPUPeriod:  rOpts.GetCpuPeriod(),

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -26,6 +26,7 @@ import (
 
 	runtimeApi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 )
@@ -370,7 +371,7 @@ func sharesHostNetwork(container *dockertypes.ContainerJSON) bool {
 
 func setSandboxResources(hc *dockercontainer.HostConfig) {
 	hc.Resources = dockercontainer.Resources{
-		MemorySwap: -1,
+		MemorySwap: dockertools.DefaultMemorySwap(),
 		CPUShares:  defaultSandboxCPUshares,
 		// Use docker's default cpu quota/period.
 	}

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -702,7 +702,7 @@ func (dm *DockerManager) runContainer(
 		SecurityOpt: fmtSecurityOpts,
 	}
 
-	updateHostConfig(hc)
+	updateHostConfig(hc, opts)
 
 	// Set sysctls if requested
 	if container.Name == PodInfraContainerName {

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -28,7 +28,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -703,11 +702,7 @@ func (dm *DockerManager) runContainer(
 		SecurityOpt: fmtSecurityOpts,
 	}
 
-	// There is no /etc/resolv.conf in Windows, DNS and DNSSearch options would have to be passed to Docker runtime instead
-	if runtime.GOOS == "windows" {
-		hc.DNS = opts.DNS
-		hc.DNSSearch = opts.DNSSearch
-	}
+	updateHostConfig(hc)
 
 	// Set sysctls if requested
 	if container.Name == PodInfraContainerName {

--- a/pkg/kubelet/dockertools/docker_manager_linux.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux.go
@@ -33,7 +33,7 @@ func updateHostConfig(hc *dockercontainer.HostConfig, opts *kubecontainer.RunCon
 }
 
 func DefaultMemorySwap() int64 {
-	return -1
+	return 0
 }
 
 func getContainerIP(container *dockertypes.ContainerJSON) string {

--- a/pkg/kubelet/dockertools/docker_manager_linux.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux.go
@@ -23,7 +23,6 @@ import (
 	dockercontainer "github.com/docker/engine-api/types/container"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/dockertools/docker_manager_linux.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux.go
@@ -20,8 +20,20 @@ package dockertools
 
 import (
 	dockertypes "github.com/docker/engine-api/types"
+	dockercontainer "github.com/docker/engine-api/types/container"
+
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 )
+
+// These two functions are OS specific (for now at least)
+func updateHostConfig(config *dockercontainer.HostConfig) {
+	// no-op, there is a windows implementation that is different.
+}
+
+func DefaultMemorySwap() int64 {
+	return -1
+}
 
 func getContainerIP(container *dockertypes.ContainerJSON) string {
 	result := ""

--- a/pkg/kubelet/dockertools/docker_manager_linux.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux.go
@@ -24,10 +24,11 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // These two functions are OS specific (for now at least)
-func updateHostConfig(config *dockercontainer.HostConfig) {
+func updateHostConfig(hc *dockercontainer.HostConfig, opts *kubecontainer.RunContainerOptions) {
 	// no-op, there is a windows implementation that is different.
 }
 

--- a/pkg/kubelet/dockertools/docker_manager_unsupported.go
+++ b/pkg/kubelet/dockertools/docker_manager_unsupported.go
@@ -24,6 +24,14 @@ import (
 	dockertypes "github.com/docker/engine-api/types"
 )
 
+// These two functions are OS specific (for now at least)
+func updateHostConfig(config *dockercontainer.HostConfig) {
+}
+
+func DefaultMemorySwap() int64 {
+	return -1
+}
+
 func getContainerIP(container *dockertypes.ContainerJSON) string {
 	return ""
 }

--- a/pkg/kubelet/dockertools/docker_manager_unsupported.go
+++ b/pkg/kubelet/dockertools/docker_manager_unsupported.go
@@ -19,12 +19,10 @@ limitations under the License.
 package dockertools
 
 import (
-	"k8s.io/kubernetes/pkg/api"
-
 	dockertypes "github.com/docker/engine-api/types"
 	dockercontainer "github.com/docker/engine-api/types/container"
 
-	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/api"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/dockertools/docker_manager_unsupported.go
+++ b/pkg/kubelet/dockertools/docker_manager_unsupported.go
@@ -22,10 +22,14 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 
 	dockertypes "github.com/docker/engine-api/types"
+	dockercontainer "github.com/docker/engine-api/types/container"
+
+	"k8s.io/kubernetes/pkg/api/v1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // These two functions are OS specific (for now at least)
-func updateHostConfig(config *dockercontainer.HostConfig) {
+func updateHostConfig(hc *dockercontainer.HostConfig, opts *kubecontainer.RunContainerOptions) {
 }
 
 func DefaultMemorySwap() int64 {

--- a/pkg/kubelet/dockertools/docker_manager_windows.go
+++ b/pkg/kubelet/dockertools/docker_manager_windows.go
@@ -24,7 +24,23 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 
 	dockertypes "github.com/docker/engine-api/types"
+	dockercontainer "github.com/docker/engine-api/types/container"
 )
+
+// These two functions are OS specific (for now at least)
+func updateHostConfig(config *dockercontainer.HostConfig) {
+	// There is no /etc/resolv.conf in Windows, DNS and DNSSearch options would have to be passed to Docker runtime instead
+	hc.DNS = opts.DNS
+	hc.DNSSearch = opts.DNSSearch
+
+	// MemorySwap == -1 is not currently supported in Docker 1.14 on Windows
+	// https://github.com/docker/docker/blob/master/daemon/daemon_windows.go#L175
+	hc.Resources.MemorySwap = 0
+}
+
+func DefaultMemorySwap() int64 {
+	return 0
+}
 
 func getContainerIP(container *dockertypes.ContainerJSON) string {
 	if container.NetworkSettings != nil {

--- a/pkg/kubelet/dockertools/docker_manager_windows.go
+++ b/pkg/kubelet/dockertools/docker_manager_windows.go
@@ -25,7 +25,6 @@ import (
 	dockercontainer "github.com/docker/engine-api/types/container"
 
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/v1"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 

--- a/pkg/kubelet/dockertools/docker_manager_windows.go
+++ b/pkg/kubelet/dockertools/docker_manager_windows.go
@@ -21,14 +21,16 @@ package dockertools
 import (
 	"os"
 
-	"k8s.io/kubernetes/pkg/api"
-
 	dockertypes "github.com/docker/engine-api/types"
 	dockercontainer "github.com/docker/engine-api/types/container"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 // These two functions are OS specific (for now at least)
-func updateHostConfig(config *dockercontainer.HostConfig) {
+func updateHostConfig(hc *dockercontainer.HostConfig, opts *kubecontainer.RunContainerOptions) {
 	// There is no /etc/resolv.conf in Windows, DNS and DNSSearch options would have to be passed to Docker runtime instead
 	hc.DNS = opts.DNS
 	hc.DNSSearch = opts.DNSSearch


### PR DESCRIPTION
Cherry pick of #39005 to fix kubelet + Docker 1.14-dev on Windows.  See https://github.com/kubernetes/kubernetes/issues/39003 for details.

@saad-ali @kubernetes/release-admins @kubernetes/release-reviewers 