### PR TITLE
Add support of Keystone v3 'domain-name' to 'openstack-heat' cluster setup

### DIFF
--- a/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
@@ -34,6 +34,7 @@ write_files:
       password=$OS_PASSWORD
       region=$OS_REGION_NAME
       tenant-name=$OS_TENANT_NAME
+      domain-name=$OS_USER_DOMAIN_NAME
       [LoadBalancer]
       lb-version=$LBAAS_VERSION
       subnet-id=$SUBNET_ID

--- a/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
@@ -128,6 +128,10 @@ parameters:
     description: OpenStack Tenant Name
     default: false
 
+  os_user_domain_name:
+    type: string
+    description: OpenStack User Domain Name (Domain-level authorization scope for keystone v3)
+
   enable_proxy:
     type: string
     description: Whether or not to enable proxy settings
@@ -314,6 +318,7 @@ resources:
             "$OS_PASSWORD": {get_param: os_password}
             "$OS_REGION_NAME": {get_param: os_region_name}
             "$OS_TENANT_NAME": {get_param: os_tenant_name}
+            "$OS_USER_DOMAIN_NAME": {get_param: os_user_domain_name}
             "$LBAAS_VERSION": {get_param: lbaas_version}
             "$SUBNET_ID": {get_resource: fixed_subnet}
             "$FLOATING_NETWORK_ID": {get_attr: [kube_master_floating, floating_network_id]}
@@ -423,6 +428,7 @@ resources:
           os_password: {get_param: os_password}
           os_region_name: {get_param: os_region_name}
           os_tenant_name: {get_param: os_tenant_name}
+          os_user_domain_name: {get_param: os_user_domain_name}
           enable_proxy: {get_param: enable_proxy }
           ftp_proxy: {get_param: ftp_proxy }
           http_proxy: {get_param: http_proxy }

--- a/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
@@ -66,6 +66,10 @@ parameters:
     description: OpenStack Tenant Name
     default: false
 
+  os_user_domain_name:
+    type: string
+    description: OpenStack User Domain Name (Domain-level authorization scope for keystone v3)
+
   enable_proxy:
     type: string
     description: Whether or not to enable proxy settings
@@ -217,6 +221,7 @@ resources:
             "$OS_PASSWORD": {get_param: os_password}
             "$OS_REGION_NAME": {get_param: os_region_name}
             "$OS_TENANT_NAME": {get_param: os_tenant_name}
+            "$OS_USER_DOMAIN_NAME": {get_param: os_user_domain_name}
             "$role": "kubernetes-pool"
             "$cluster_cidr": {get_param: cluster_cidr}
 

--- a/cluster/openstack-heat/openrc-default.sh
+++ b/cluster/openstack-heat/openrc-default.sh
@@ -22,4 +22,5 @@ export OS_USERNAME=${OS_USERNAME:-admin}
 export OS_PASSWORD=${OS_PASSWORD:-secretsecret}
 export OS_AUTH_URL=${OS_AUTH_URL:-http://192.168.123.100:5000/v2.0}
 export OS_TENANT_NAME=${OS_TENANT_NAME:-admin}
+export OS_USER_DOMAIN_NAME=${OS_USER_DOMAIN_NAME:-}
 export OS_REGION_NAME=${OS_REGION_NAME:-RegionOne}

--- a/cluster/openstack-heat/openrc-swift.sh
+++ b/cluster/openstack-heat/openrc-swift.sh
@@ -23,4 +23,5 @@ export OS_USERNAME=${OS_USERNAME:-admin}
 export OS_PASSWORD=${OS_PASSWORD:-secretsecret}
 export OS_AUTH_URL=${OS_AUTH_URL:-http://192.168.123.100:5000/v2.0}
 export OS_TENANT_NAME=${OS_TENANT_NAME:-admin}
+export OS_USER_DOMAIN_NAME=${OS_USER_DOMAIN_NAME:-}
 export OS_REGION_NAME=${OS_REGION_NAME:-RegionOne}

--- a/cluster/openstack-heat/util.sh
+++ b/cluster/openstack-heat/util.sh
@@ -224,6 +224,7 @@ function run-heat-script() {
       --parameter os_password=${OS_PASSWORD} \
       --parameter os_region_name=${OS_REGION_NAME} \
       --parameter os_tenant_name=${OS_TENANT_NAME} \
+      --parameter os_user_domain_name=${OS_USER_DOMAIN_NAME} \
       --parameter enable_proxy=${ENABLE_PROXY} \
       --parameter ftp_proxy="${FTP_PROXY}" \
       --parameter http_proxy="${HTTP_PROXY}" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Keystone v3 authentication by user name [requires the domain (name or ID)](http://developer.openstack.org/api-ref/identity/v3/index.html?expanded=password-authentication-with-scoped-authorization-detail). If `domain-name` is not provided kubelet fails as seen below:
  
```
kubelet: error: failed to run Kubelet: could not init cloud provider "openstack": You must provide exactly one of DomainID or DomainName to authenticate by Username
systemd: kubelet.service: main process exited, code=exited, status=1/FAILURE
systemd: Unit kubelet.service entered failed state.
systemd: kubelet.service failed.
```

To solve this I pass a new`OS_USER_DOMAIN_NAME` environment variable through openstack-heat's heat-templates to write it as `domain-name` in `/srv/kubernetes/openstack.conf`. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #39783

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
domain-name support for Keystone v3 added to openstack-heat cluster setup
```
