### PR TITLE
Use controller interface for everything in config factory

### DIFF
--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -80,12 +80,12 @@ type ConfigFactory struct {
 	StopEverything chan struct{}
 
 	informerFactory       informers.SharedInformerFactory
-	scheduledPodPopulator *cache.Controller
-	nodePopulator         *cache.Controller
-	pvPopulator           *cache.Controller
+	scheduledPodPopulator cache.ControllerInterface
+	nodePopulator         cache.ControllerInterface
+	pvPopulator           cache.ControllerInterface
 	pvcPopulator          cache.ControllerInterface
-	servicePopulator      *cache.Controller
-	controllerPopulator   *cache.Controller
+	servicePopulator      cache.ControllerInterface
+	controllerPopulator   cache.ControllerInterface
 
 	schedulerCache schedulercache.Cache
 


### PR DESCRIPTION
**What this PR does / why we need it**:

We want to replace controller structs with interfaces 
- per the TODO in `ControllerInterface`
- Specifically this will make the decoupling from Config and reuse of the scheduler's subcomponents cleaner.