### PR TITLE
WIP: dnsprovider: Support RRSet filtering by name/type

### DIFF
--- a/federation/pkg/dnsprovider/dns.go
+++ b/federation/pkg/dnsprovider/dns.go
@@ -51,7 +51,10 @@ type Zone interface {
 
 type ResourceRecordSets interface {
 	// List returns the ResourceRecordSets of the Zone, or an error if the list operation failed.
-	List() ([]ResourceRecordSet, error)
+	// If filterName is non-empty, only ResourceRecordSets with the given name will be returned
+	// If filterType is non-empty, only ResourceRecordSets with the given type will be returned
+	// If filterType is specified without specifying filterName, an error may be returned
+	List(filterName string, filterType rrstype.RrsType) ([]ResourceRecordSet, error)
 	// Get returns the ResourceRecordSet with the name in the Zone. if the named resource record set does not exist, but no error occurred, the returned set, and error, are both nil.
 	Get(name string) (ResourceRecordSet, error)
 	// New allocates a new ResourceRecordSet, which can then be passed to ResourceRecordChangeset Add() or Remove()

--- a/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
@@ -111,7 +111,7 @@ func rrs(t *testing.T, zone dnsprovider.Zone) (r dnsprovider.ResourceRecordSets)
 }
 
 func listRrsOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets) []dnsprovider.ResourceRecordSet {
-	rrset, err := rrsets.List()
+	rrset, err := rrsets.List("", "")
 	if err != nil {
 		t.Fatalf("Failed to list recordsets: %v", err)
 	} else {

--- a/federation/pkg/dnsprovider/providers/coredns/coredns_test.go
+++ b/federation/pkg/dnsprovider/providers/coredns/coredns_test.go
@@ -111,7 +111,7 @@ func rrs(t *testing.T, zone dnsprovider.Zone) (r dnsprovider.ResourceRecordSets)
 }
 
 func listRrsOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets) []dnsprovider.ResourceRecordSet {
-	rrset, err := rrsets.List()
+	rrset, err := rrsets.List("", "")
 	if err != nil {
 		t.Fatalf("Failed to list recordsets: %v", err)
 	} else {

--- a/federation/pkg/dnsprovider/providers/coredns/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/coredns/rrsets.go
@@ -35,7 +35,7 @@ type ResourceRecordSets struct {
 	zone *Zone
 }
 
-func (rrsets ResourceRecordSets) List() ([]dnsprovider.ResourceRecordSet, error) {
+func (rrsets ResourceRecordSets) List(filterName string, filterType rrstype.RrsType) ([]dnsprovider.ResourceRecordSet, error) {
 	var list []dnsprovider.ResourceRecordSet
 	return list, fmt.Errorf("OperationNotSupported")
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
@@ -88,7 +88,7 @@ func rrs(t *testing.T, zone dnsprovider.Zone) (r dnsprovider.ResourceRecordSets)
 }
 
 func listRrsOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets) []dnsprovider.ResourceRecordSet {
-	rrset, err := rrsets.List()
+	rrset, err := rrsets.List("", "")
 	if err != nil {
 		t.Fatalf("Failed to list recordsets: %v", err)
 	} else {

--- a/federation/pkg/dnsprovider/tests/commontests.go
+++ b/federation/pkg/dnsprovider/tests/commontests.go
@@ -124,7 +124,7 @@ func getRrOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, name strin
 func assertHasRecord(t *testing.T, rrsets dnsprovider.ResourceRecordSets, rrset dnsprovider.ResourceRecordSet) {
 	var found dnsprovider.ResourceRecordSet
 
-	rrs, err := rrsets.List()
+	rrs, err := rrsets.List("", "")
 	if err != nil {
 		if err.Error() == "OperationNotSupported" {
 			found = getRrOrFail(t, rrsets, rrset.Name())


### PR DESCRIPTION
We add filtering by name & type, because providers can often push-down
the predicate, and thereby avoid more expensive calls.

On AWS in particular, this avoids paginating through multiple pages of
resource record sets (the API rate limits are based on rate of calls,
not on their complexity).

Issue #39674

```release-note
dnsprovider: Support RRSet filtering by name/type
```
