### PR TITLE
Add AndSelectors helper function

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
@@ -276,3 +276,8 @@ func parseSelector(selector string, fn TransformFunc) (Selector, error) {
 func OneTermEqualSelector(k, v string) Selector {
 	return &hasTerm{field: k, value: v}
 }
+
+// AndSelectors creates a selector that is the logical AND of all the given selectors
+func AndSelectors(selectors ...Selector) Selector {
+	return andTerm(selectors)
+}


### PR DESCRIPTION
I needed a simple way to logically `AND` two `Selectors` in https://github.com/openshift/origin/pull/11909 for [this](https://github.com/enj/origin/blob/7259bf75966b961cb9c7aa2c0ee2930471a59eed/pkg/oauth/registry/oauthclientauthorization/etcd/etcd.go#L95-L114).

This seems like the cleanest way to express that intent.

Signed-off-by: Monis Khan <mkhan@redhat.com>
