### PR TITLE
Automated cherry pick of #39454 #39544

### DIFF
--- a/pkg/controller/disruption/BUILD
+++ b/pkg/controller/disruption/BUILD
@@ -46,15 +46,9 @@ go_test(
         "//pkg/api:go_default_library",
         "//pkg/api/unversioned:go_default_library",
         "//pkg/apimachinery/registered:go_default_library",
-<<<<<<< HEAD
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/policy:go_default_library",
-=======
-        "//pkg/apis/apps/v1beta1:go_default_library",
-        "//pkg/apis/extensions/v1beta1:go_default_library",
-        "//pkg/apis/meta/v1:go_default_library",
-        "//pkg/apis/policy/v1beta1:go_default_library",
->>>>>>> Updated bazel
+        "//pkg/apis/apps:go_default_library",
         "//pkg/client/cache:go_default_library",
         "//pkg/client/record:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/controller/disruption/BUILD
+++ b/pkg/controller/disruption/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/api/unversioned:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/policy:go_default_library",
+        "//pkg/apis/apps:go_default_library",
         "//pkg/client/cache:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
@@ -45,8 +46,15 @@ go_test(
         "//pkg/api:go_default_library",
         "//pkg/api/unversioned:go_default_library",
         "//pkg/apimachinery/registered:go_default_library",
+<<<<<<< HEAD
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/policy:go_default_library",
+=======
+        "//pkg/apis/apps/v1beta1:go_default_library",
+        "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/apis/policy/v1beta1:go_default_library",
+>>>>>>> Updated bazel
         "//pkg/client/cache:go_default_library",
         "//pkg/client/record:go_default_library",
         "//pkg/controller:go_default_library",

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/client/cache"
@@ -50,7 +51,7 @@ const statusUpdateRetries = 2
 // all and the corresponding entry can be removed from pdb.Status.DisruptedPods. It is assumed that
 // pod/pdb apiserver to controller latency is relatively small (like 1-2sec) so the below value should
 // be more than enough.
-// If the cotroller is running on a different node it is important that the two nodes have synced
+// If the controller is running on a different node it is important that the two nodes have synced
 // clock (via ntp for example). Otherwise PodDisruptionBudget controller may not provide enough
 // protection against unwanted pod disruptions.
 const DeletionTimeout = 2 * 60 * time.Second
@@ -78,6 +79,10 @@ type DisruptionController struct {
 	dIndexer    cache.Indexer
 	dController *cache.Controller
 	dLister     cache.StoreToDeploymentLister
+
+	ssStore      cache.Store
+	ssController *cache.Controller
+	ssLister     cache.StoreToStatefulSetLister
 
 	// PodDisruptionBudget keys that need to be synced.
 	queue        workqueue.RateLimitingInterface
@@ -186,8 +191,22 @@ func NewDisruptionController(podInformer cache.SharedIndexInformer, kubeClient i
 		cache.ResourceEventHandlerFuncs{},
 		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 	)
-
 	dc.dLister.Indexer = dc.dIndexer
+
+	dc.ssStore, dc.ssController = cache.NewInformer(
+		&cache.ListWatch{
+			ListFunc: func(options api.ListOptions) (runtime.Object, error) {
+				return dc.kubeClient.Apps().StatefulSets(api.NamespaceAll).List(options)
+			},
+			WatchFunc: func(options api.ListOptions) (watch.Interface, error) {
+				return dc.kubeClient.Apps().StatefulSets(api.NamespaceAll).Watch(options)
+			},
+		},
+		&apps.StatefulSet{},
+		30*time.Second,
+		cache.ResourceEventHandlerFuncs{},
+	)
+	dc.ssLister.Store = dc.ssStore
 
 	return dc
 }
@@ -200,7 +219,8 @@ func NewDisruptionController(podInformer cache.SharedIndexInformer, kubeClient i
 // and we may well need further tweaks just to be able to access scale
 // subresources.
 func (dc *DisruptionController) finders() []podControllerFinder {
-	return []podControllerFinder{dc.getPodReplicationControllers, dc.getPodDeployments, dc.getPodReplicaSets}
+	return []podControllerFinder{dc.getPodReplicationControllers, dc.getPodDeployments, dc.getPodReplicaSets,
+		dc.getPodStatefulSets}
 }
 
 // getPodReplicaSets finds replicasets which have no matching deployments.
@@ -221,6 +241,29 @@ func (dc *DisruptionController) getPodReplicaSets(pod *api.Pod) ([]controllerAnd
 			continue
 		}
 		controllerScale[rs.UID] = rs.Spec.Replicas
+	}
+
+	for uid, scale := range controllerScale {
+		cas = append(cas, controllerAndScale{UID: uid, scale: scale})
+	}
+
+	return cas, nil
+}
+
+// getPodStatefulSet returns the statefulset managing the given pod.
+func (dc *DisruptionController) getPodStatefulSets(pod *api.Pod) ([]controllerAndScale, error) {
+	cas := []controllerAndScale{}
+	ss, err := dc.ssLister.GetPodStatefulSets(pod)
+
+	// GetPodStatefulSets returns an error only if no StatefulSets are found. We
+	// don't return that as an error to the caller.
+	if err != nil {
+		return cas, nil
+	}
+
+	controllerScale := map[types.UID]int32{}
+	for _, s := range ss {
+		controllerScale[s.UID] = s.Spec.Replicas
 	}
 
 	for uid, scale := range controllerScale {
@@ -283,6 +326,7 @@ func (dc *DisruptionController) Run(stopCh <-chan struct{}) {
 	go dc.rcController.Run(stopCh)
 	go dc.rsController.Run(stopCh)
 	go dc.dController.Run(stopCh)
+	go dc.ssController.Run(stopCh)
 	go wait.Until(dc.worker, time.Second, stopCh)
 	go wait.Until(dc.recheckWorker, time.Second, stopCh)
 


### PR DESCRIPTION
Cherry pick of #39454 #39544 on release-1.5.

#39454: Make PDBs represent percentage in StatefulSet
#39544: Allow disruption controller to read statefulsets

/cc @davidopp @maisem @kubernetes/sig-apps-misc 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
Fixed bug which prevents PDBs which have minAvailable specified as a percentage working with StatefulSet pods
```
