### PR TITLE
Update kubectl to stable version for Addon Manager

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 6.2 (Thu January 12 2017 Zihong Zheng <zihongz@google.com>)
+ - Update kubectl to the stable version.
+
 ### Version 6.1 (Tue November 29 2016 Zihong Zheng <zihongz@google.com>)
  - Support pruning old Deployments.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v6.1
-KUBECTL_VERSION?=v1.5.0-beta.2
+VERSION=v6.2
+KUBECTL_VERSION?=v1.5.2
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=bashell/alpine-bash

--- a/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.1",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.2",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.1",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.2",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -12,7 +12,7 @@ spec:
     # When updating version also bump it in:
     # - cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
     # - cluster/images/hyperkube/static-pods/addon-manager-multinode.json
-    image: gcr.io/google-containers/kube-addon-manager:v6.1
+    image: gcr.io/google-containers/kube-addon-manager:v6.2
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
Bumps up Addon Manager to v6.2, below images are pushed:
- gcr.io/google-containers/kube-addon-manager:v6.2
- gcr.io/google-containers/kube-addon-manager-amd64:v6.2
- gcr.io/google-containers/kube-addon-manager-arm:v6.2
- gcr.io/google-containers/kube-addon-manager-arm64:v6.2
- gcr.io/google-containers/kube-addon-manager-ppc64le:v6.2
- gcr.io/google-containers/kube-addon-manager-s390x:v6.2

@mikedanese 

cc @ixdy 