### PR TITLE
Automated cherry pick of #39691

### DIFF
--- a/cluster/gce/gci/health-monitor.sh
+++ b/cluster/gce/gci/health-monitor.sh
@@ -26,7 +26,7 @@ set -o pipefail
 # automatically restart the process.
 function docker_monitoring {
   while [ 1 ]; do
-    if ! timeout 10 docker ps > /dev/null; then
+    if ! timeout 60 docker ps > /dev/null; then
       echo "Docker daemon failed!"
       pkill docker
       # Wait for a while, as we don't want to kill it again before it is really up.


### PR DESCRIPTION
Cherry pick of #39691 on release-1.5.

#39691: Bump container-linux and gci timeout for docker health check