### PR TITLE
Add authorization mode to kubeadm

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -39,6 +39,7 @@ type MasterConfiguration struct {
 	Networking        Networking
 	KubernetesVersion string
 	CloudProvider     string
+	AuthorizationMode string
 }
 
 type API struct {

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -29,6 +29,7 @@ type MasterConfiguration struct {
 	Networking        Networking `json:"networking"`
 	KubernetesVersion string     `json:"kubernetesVersion"`
 	CloudProvider     string     `json:"cloudProvider"`
+	AuthorizationMode string     `json:"authorizationMode"`
 }
 
 type API struct {

--- a/cmd/kubeadm/app/cmd/flags/authentication_mode.go
+++ b/cmd/kubeadm/app/cmd/flags/authentication_mode.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+var modes = []string{
+	"ABAC",
+	"RBAC",
+}
+
+func NewAuthorizationModeFlag(mode *string) pflag.Value {
+	return &authorizationModeValue{mode: mode}
+}
+
+type authorizationModeValue struct {
+	mode *string
+}
+
+func (c *authorizationModeValue) String() string {
+	return *c.mode
+}
+
+func (c *authorizationModeValue) Set(s string) error {
+	if ValidateAuthorizationMode(s) {
+		*c.mode = s
+		return nil
+	}
+
+	return fmt.Errorf("authorization mode %q is not supported, you can use any of %v", s, modes)
+}
+
+func (c *authorizationModeValue) Type() string {
+	return "mode"
+}
+
+func ValidateAuthorizationMode(mode string) bool {
+	for _, supported := range modes {
+		if mode == supported {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -104,6 +104,10 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 		flags.NewCloudProviderFlag(&cfg.CloudProvider), "cloud-provider",
 		`Enable cloud provider features (external load-balancers, storage, etc). Note that you have to configure all kubelets manually`,
 	)
+	cmd.PersistentFlags().Var(
+		flags.NewAuthorizationModeFlag(&cfg.AuthorizationMode), "authorization-mode",
+		`Enable an authorization mode.`,
+	)
 
 	cmd.PersistentFlags().StringVar(
 		&cfg.KubernetesVersion, "use-kubernetes-version", cfg.KubernetesVersion,

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -296,6 +296,20 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 		"--allow-privileged",
 	)
 
+	if cfg.AuthorizationMode != "" {
+		switch cfg.AuthorizationMode {
+		case "ABAC":
+			command = append(command, "--authorization-mode="+cfg.AuthorizationMode,
+				"--authorization-policy-file=/etc/kubernetes/authorization.conf",
+			)
+		case "RBAC":
+			command = append(command, "--authorization-mode="+cfg.AuthorizationMode,
+				"--runtime-config=rbac.authorization.k8s.io/v1alpha1",
+				"--authorization-rbac-super-user=kubernetes-client",
+			)
+		}
+	}
+
 	// Use first address we are given
 	if len(cfg.API.AdvertiseAddresses) > 0 {
 		command = append(command, fmt.Sprintf("--advertise-address=%s", cfg.API.AdvertiseAddresses[0]))

--- a/staging/src/k8s.io/client-go/pkg/apis/kubeadm/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/kubeadm/types.go
@@ -39,6 +39,7 @@ type MasterConfiguration struct {
 	Networking        Networking
 	KubernetesVersion string
 	CloudProvider     string
+	AuthorizationMode string
 }
 
 type API struct {

--- a/staging/src/k8s.io/client-go/pkg/apis/kubeadm/v1alpha1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/kubeadm/v1alpha1/types.go
@@ -29,6 +29,7 @@ type MasterConfiguration struct {
 	Networking        Networking `json:"networking"`
 	KubernetesVersion string     `json:"kubernetesVersion"`
 	CloudProvider     string     `json:"cloudProvider"`
+	AuthorizationMode string     `json:"authorizationMode"`
 }
 
 type API struct {


### PR DESCRIPTION
This PR adds a flag to kubeadm to allow a user to specify an [authorization plugin](https://kubernetes.io/docs/admin/authorization/).