### PR TITLE
Fixed typo.

### DIFF
--- a/pkg/kubectl/cmd/create_configmap_test.go
+++ b/pkg/kubectl/cmd/create_configmap_test.go
@@ -50,6 +50,6 @@ func TestCreateConfigMap(t *testing.T) {
 	cmd.Run(cmd, []string{configMap.Name})
 	expectedOutput := "configmap/" + configMap.Name + "\n"
 	if buf.String() != expectedOutput {
-		t.Errorf("expected output: %s, but got: %s", buf.String(), expectedOutput)
+		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}
 }

--- a/pkg/kubectl/cmd/create_namespace_test.go
+++ b/pkg/kubectl/cmd/create_namespace_test.go
@@ -49,6 +49,6 @@ func TestCreateNamespace(t *testing.T) {
 	cmd.Run(cmd, []string{namespaceObject.Name})
 	expectedOutput := "namespace/" + namespaceObject.Name + "\n"
 	if buf.String() != expectedOutput {
-		t.Errorf("expected output: %s, but got: %s", buf.String(), expectedOutput)
+		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}
 }

--- a/pkg/kubectl/cmd/create_secret_test.go
+++ b/pkg/kubectl/cmd/create_secret_test.go
@@ -57,7 +57,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 	cmd.Run(cmd, []string{secretObject.Name})
 	expectedOutput := "secret/" + secretObject.Name + "\n"
 	if buf.String() != expectedOutput {
-		t.Errorf("expected output: %s, but got: %s", buf.String(), expectedOutput)
+		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
 	}
 }
 


### PR DESCRIPTION
Fixed variable sequence typo in kubectl create sub-command tests.
