### PR TITLE
route53: configure verbose authentication errors

### DIFF
--- a/federation/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -20,6 +20,7 @@ package route53
 import (
 	"io"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
@@ -53,7 +54,13 @@ func route53HandlerLogger(req *request.Request) {
 func newRoute53(config io.Reader) (*Interface, error) {
 	// Connect to AWS Route53 - TODO: Do more sophisticated auth
 
-	svc := route53.New(session.New())
+	awsConfig := aws.NewConfig()
+
+	// This avoids a confusing error message when we fail to get credentials
+	// e.g. https://github.com/kubernetes/kops/issues/605
+	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
+
+	svc := route53.New(session.New(), awsConfig)
 
 	// Add our handler that will log requests
 	svc.Handlers.Sign.PushFrontNamed(request.NamedHandler{


### PR DESCRIPTION
Otherwise we get an error message which is confusingly written on
authentication failures.

Probably blocked on #39854 
