### PR TITLE
Use $HOSTNAME as node.name by default

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/config/elasticsearch.yml
+++ b/cluster/addons/fluentd-elasticsearch/es-image/config/elasticsearch.yml
@@ -1,5 +1,6 @@
 cluster.name: kubernetes-logging
 
+node.name: ${NODE_NAME}
 node.master: ${NODE_MASTER}
 node.data: ${NODE_DATA}
 

--- a/cluster/addons/fluentd-elasticsearch/es-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/es-image/run.sh
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export NODE_NAME=${NODE_NAME:-${HOSTNAME}}
 export NODE_MASTER=${NODE_MASTER:-true}
 export NODE_DATA=${NODE_DATA:-true}
 export HTTP_PORT=${HTTP_PORT:-9200}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows to identify elasticsearch instances more easily.
As $HOSTNAME of a pod is unique, this should be no problem.