### PR TITLE
Fix and sync kube-dns multiarch template in juju.

### DIFF
--- a/cluster/juju/layers/kubernetes/templates/kubedns-controller.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-controller.yaml
@@ -97,7 +97,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-{{ arch }}:1.4
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-{{ arch }}:1.11.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -119,8 +119,13 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
+        # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+        resources:
+          requests:
+            cpu: 150m
+            memory: 10Mi
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-sidecar-{{ arch }}:1.11.0
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
The side car image in juju's template should use `{{ arch }}` instead of `amd64`. Also keep it in sync.

Seems like this is the last kube-dns template file we have in the cluster folder (expect cluster/addons/dns). Does it make sense to create a multi-arch template like `kubedns-controller.yaml.cross.base` in cluster/addons/dns and remove this one?

@bowei 