### PR TITLE
Working on an IP based connection limit to harden APIServer.

### DIFF
--- a/pkg/client/unversioned/remotecommand/remotecommand.go
+++ b/pkg/client/unversioned/remotecommand/remotecommand.go
@@ -19,6 +19,7 @@ package remotecommand
 import (
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -132,7 +133,10 @@ func (e *streamExecutor) Dial(protocols ...string) (httpstream.Connection, strin
 	if err != nil {
 		return nil, "", fmt.Errorf("error sending request: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+	}()
 
 	conn, err := e.upgrader.NewConnection(resp)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -42,6 +42,8 @@ type ServerRunOptions struct {
 	ExternalHost                string
 	MaxRequestsInFlight         int
 	MaxMutatingRequestsInFlight int
+	SecureMaxConnections        int
+	SecureMaxConnectionsPerIP   int
 	MinRequestTimeout           int
 	TargetRAMMB                 int
 	WatchCacheSizes             []string
@@ -54,6 +56,8 @@ func NewServerRunOptions() *ServerRunOptions {
 		AdmissionControl:            "AlwaysAdmit",
 		MaxRequestsInFlight:         defaults.MaxRequestsInFlight,
 		MaxMutatingRequestsInFlight: defaults.MaxMutatingRequestsInFlight,
+		SecureMaxConnections:        defaults.SecureServingInfo.IPLimit.Max,
+		SecureMaxConnectionsPerIP:   defaults.SecureServingInfo.IPLimit.MaxPerIP,
 		MinRequestTimeout:           defaults.MinRequestTimeout,
 	}
 }
@@ -64,6 +68,8 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.ExternalAddress = s.ExternalHost
 	c.MaxRequestsInFlight = s.MaxRequestsInFlight
 	c.MaxMutatingRequestsInFlight = s.MaxMutatingRequestsInFlight
+	c.SecureServingInfo.IPLimit.Max = s.SecureMaxConnections
+	c.SecureServingInfo.IPLimit.MaxPerIP = s.SecureMaxConnectionsPerIP
 	c.MinRequestTimeout = s.MinRequestTimeout
 	c.PublicAddress = s.AdvertiseAddress
 
@@ -143,6 +149,14 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.MaxMutatingRequestsInFlight, "max-mutating-requests-inflight", s.MaxMutatingRequestsInFlight, ""+
 		"The maximum number of mutating requests in flight at a given time. When the server exceeds this, "+
 		"it rejects requests. Zero for no limit.")
+
+	fs.IntVar(&s.SecureMaxConnections, "secure-max-connections", s.SecureMaxConnections, ""+
+		"The maximum number of secure connections the server should allow from outside concurrently. "+
+		"Set secure-max-connections to zero for no limit.")
+
+	fs.IntVar(&s.SecureMaxConnectionsPerIP, "secure-max-connections-per-ip", s.SecureMaxConnectionsPerIP, ""+
+		"The maximum number of secure connections the server should allow from a single outside address. "+
+		"Set secure-max-connections to zero for no limit.")
 
 	fs.IntVar(&s.MinRequestTimeout, "min-request-timeout", s.MinRequestTimeout, ""+
 		"An optional field indicating the minimum number of seconds a handler must keep "+

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -176,12 +176,7 @@ func (s *SecureServingOptions) applyServingInfoTo(c *server.Config) error {
 	if s.ServingOptions.BindPort <= 0 {
 		return nil
 	}
-
-	secureServingInfo := &server.SecureServingInfo{
-		ServingInfo: server.ServingInfo{
-			BindAddress: net.JoinHostPort(s.ServingOptions.BindAddress.String(), strconv.Itoa(s.ServingOptions.BindPort)),
-		},
-	}
+	c.SecureServingInfo.BindAddress = net.JoinHostPort(s.ServingOptions.BindAddress.String(), strconv.Itoa(s.ServingOptions.BindPort))
 
 	serverCertFile, serverKeyFile := s.ServerCert.CertKey.CertFile, s.ServerCert.CertKey.KeyFile
 
@@ -191,7 +186,7 @@ func (s *SecureServingOptions) applyServingInfoTo(c *server.Config) error {
 		if err != nil {
 			return fmt.Errorf("unable to load server certificate: %v", err)
 		}
-		secureServingInfo.Cert = &tlsCert
+		c.SecureServingInfo.Cert = &tlsCert
 	}
 
 	// optionally load CA cert
@@ -207,7 +202,7 @@ func (s *SecureServingOptions) applyServingInfoTo(c *server.Config) error {
 		if block.Type != "CERTIFICATE" {
 			return fmt.Errorf("expected CERTIFICATE block in certiticate authority file %q, found: %s", s.ServerCert.CACertFile, block.Type)
 		}
-		secureServingInfo.CACert = &tls.Certificate{
+		c.SecureServingInfo.CACert = &tls.Certificate{
 			Certificate: [][]byte{block.Bytes},
 		}
 	}
@@ -225,12 +220,11 @@ func (s *SecureServingOptions) applyServingInfoTo(c *server.Config) error {
 		}
 	}
 	var err error
-	secureServingInfo.SNICerts, err = server.GetNamedCertificateMap(namedTLSCerts)
+	c.SecureServingInfo.SNICerts, err = server.GetNamedCertificateMap(namedTLSCerts)
 	if err != nil {
 		return err
 	}
 
-	c.SecureServingInfo = secureServingInfo
 	c.ReadWritePort = s.ServingOptions.BindPort
 
 	return nil

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/profiling.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/profiling.go
@@ -17,6 +17,7 @@ limitations under the License.
 package routes
 
 import (
+	"net/http"
 	"net/http/pprof"
 
 	"k8s.io/apiserver/pkg/server/mux"
@@ -26,8 +27,9 @@ import (
 type Profiling struct{}
 
 // Install adds the Profiling webservice to the given mux.
-func (d Profiling) Install(c *mux.APIContainer) {
+func (d Profiling) Install(c *mux.APIContainer, secureConnHandler func(http.ResponseWriter, *http.Request)) {
 	c.UnlistedRoutes.HandleFunc("/debug/pprof/", pprof.Index)
 	c.UnlistedRoutes.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	c.UnlistedRoutes.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	c.UnlistedRoutes.HandleFunc("/debug/connections/secure", secureConnHandler)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/serve_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/serve_test.go
@@ -1,0 +1,339 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func (i *IPBasedLimit) decrementIP(conn, sourceIP string) {
+	i.mutex.Lock()
+	defer i.mutex.Unlock()
+	i.decrementIPLocked(conn, sourceIP)
+}
+
+func TestBasicIPLimit(t *testing.T) {
+	var ipLimit IPBasedLimit
+	validateIPLimitState(t, &ipLimit, "Basic/raw IPBasedLimit", 0, 0, 0, 0)
+	ipLimit.incrementIP("1.2.3.4:1234", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Basic/raw IPBasedLimit increment", 0, 0, 0, 0)
+	ipLimit.decrementIP("1.2.3.4:1235", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Basic/raw IPBasedLimit decrement", 0, 0, 0, 0)
+	ipLimit.incrementIP("127.0.0.1:99999", "127.0.0.1")
+	validateIPLimitState(t, &ipLimit, "Basic/raw IPBasedLimit increment localhost", 0, 0, 0, 0)
+	ipLimit.decrementIP("127.0.0.1:1", "127.0.0.1")
+	validateIPLimitState(t, &ipLimit, "Basic/raw IPBasedLimit decrement localhost", 0, 0, 0, 0)
+}
+
+func TestIPLimitInitialization(t *testing.T) {
+	ipLimit := IPBasedLimit{Limits: make(map[string]int), Decrementers: make(map[string]func()), MaxPerIP: 10, Max: 20}
+	validateIPLimitState(t, &ipLimit, "IPBasedLimit explicit initialization", 0, 10, 0, 20)
+}
+
+func TestIPLimitWithLocalHost(t *testing.T) {
+	ipLimit := IPBasedLimit{Limits: make(map[string]int), Decrementers: make(map[string]func()), MaxPerIP: 10, Max: 20}
+	ipLimit.incrementIP("127.0.0.1:99999", "127.0.0.1")
+	validateIPLimitState(t, &ipLimit, "IPv4 localhost increment call for IPBasedLimit", 0, 10, 0, 20)
+	ipLimit.decrementIP("127.0.0.1:1", "127.0.0.1")
+	validateIPLimitState(t, &ipLimit, "IPv4 localhost decrement call for IPBasedLimit", 0, 10, 0, 20)
+	ipv6loopback := net.IPv6loopback.String()
+	ipLimit.incrementIP(ipv6loopback+":42", ipv6loopback)
+	validateIPLimitState(t, &ipLimit, "IPv6 localhost increment call for IPBasedLimit", 0, 10, 0, 20)
+	ipLimit.decrementIP(ipv6loopback+":42", ipv6loopback)
+	validateIPLimitState(t, &ipLimit, "IPv6 localhost decrement call for IPBasedLimit", 0, 10, 0, 20)
+}
+
+func TestIPLimitIncrementAndDecrement(t *testing.T) {
+	ipLimit := IPBasedLimit{Limits: make(map[string]int), Decrementers: make(map[string]func()), MaxPerIP: 10, Max: 20}
+	ipLimit.incrementIP("1.2.3.4:1234", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "First increment call for IPBasedLimit", 1, 10, 1, 20)
+	val, ok := ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+	ipLimit.incrementIP("1.2.3.4:1235", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Second increment call for IPBasedLimit", 1, 10, 2, 20)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 2, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.incrementIP("4.3.2.1:111", "4.3.2.1")
+	validateIPLimitState(t, &ipLimit, "First increment call for IPBasedLimit", 2, 10, 3, 20)
+	val, ok = ipLimit.Limits["4.3.2.1"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+	ipLimit.incrementIP("4.3.2.1:222", "4.3.2.1")
+	validateIPLimitState(t, &ipLimit, "Second increment call for IPBasedLimit", 2, 10, 4, 20)
+	val, ok = ipLimit.Limits["4.3.2.1"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 2, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("4.3.2.1:111", "4.3.2.1")
+	validateIPLimitState(t, &ipLimit, "First decrement call for IPBasedLimit", 2, 10, 3, 20)
+	val, ok = ipLimit.Limits["4.3.2.1"]
+	assert.True(t, ok, "Decrement call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("4.3.2.1:222", "4.3.2.1")
+	validateIPLimitState(t, &ipLimit, "Deleting decrement call for IPBasedLimit", 1, 10, 2, 20)
+	val, ok = ipLimit.Limits["4.3.2.1"]
+	assert.EqualValues(t, val, 0, "Deleting decrement call for IPBasedLimit has a val of %d", 0)
+	assert.False(t, ok, "Deleting decrement call for IPBasedLimit had a val")
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Unmodified ip in IPBasedLimit had no val")
+	assert.EqualValues(t, val, 2, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("1.2.3.4:1235", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "First decrement call for IPBasedLimit", 1, 10, 1, 20)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Decrement call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("1.2.3.4:1234", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Deleting decrement call for IPBasedLimit", 0, 10, 0, 20)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.False(t, ok, "Deleting decrement call for IPBasedLimit had a val")
+	assert.EqualValues(t, val, 0, "Deleting decrement call for IPBasedLimit has a val of %d", 0)
+}
+
+func TestIPLimitIncrementFailOnIPLimit(t *testing.T) {
+	ipLimit := IPBasedLimit{Limits: make(map[string]int), Decrementers: make(map[string]func()), MaxPerIP: 3, Max: 6}
+	err := ipLimit.incrementIP("1.2.3.4:1234", "1.2.3.4")
+	assert.NoError(t, err)
+	validateIPLimitState(t, &ipLimit, "First increment call for IPBasedLimit", 1, 3, 1, 6)
+	val, ok := ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+
+	err = ipLimit.incrementIP("1.2.3.4:1235", "1.2.3.4")
+	assert.NoError(t, err)
+	validateIPLimitState(t, &ipLimit, "Second increment call for IPBasedLimit", 1, 3, 2, 6)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.EqualValues(t, val, 2, "Post increment IPBasedLimit has a Max of %d", val)
+
+	err = ipLimit.incrementIP("1.2.3.4:1236", "1.2.3.4")
+	assert.NoError(t, err)
+	validateIPLimitState(t, &ipLimit, "Third increment call for IPBasedLimit", 1, 3, 3, 6)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 3, "Post increment IPBasedLimit has a Max of %d", val)
+
+	err = ipLimit.incrementIP("1.2.3.4:1234", "1.2.3.4")
+	assert.Error(t, err)
+	if limErr, ok := err.(IPLimitExceededError); ok {
+		assert.True(t, limErr.Timeout(), "IPLimit IPLimitExceededError should return timeout true")
+		assert.True(t, limErr.Temporary(), "IPLimit IPLimitExceededError should return temporary true")
+	} else {
+		assert.Fail(t, "Expected a IPLimitExceededError from incrementIP fail but got %T", err)
+	}
+	validateIPLimitState(t, &ipLimit, "Second increment call for IPBasedLimit", 1, 3, 3, 6)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 3, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("1.2.3.4:1234", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Decrement call for IPBasedLimit", 1, 3, 2, 6)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Decrement call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 2, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("1.2.3.4:1235", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Decrement call for IPBasedLimit", 1, 3, 1, 6)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Decrement call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("1.2.3.4:1236", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Deleting decrement call for IPBasedLimit", 0, 3, 0, 6)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.False(t, ok, "Deleting decrement call for IPBasedLimit had a val")
+	assert.EqualValues(t, val, 0, "Deleting decrement call for IPBasedLimit has a val of %d", 0)
+}
+
+func TestIPLimitIncrementFailOnTotalLimit(t *testing.T) {
+	ipLimit := IPBasedLimit{Limits: make(map[string]int), Decrementers: make(map[string]func()), MaxPerIP: 2, Max: 3}
+	err := ipLimit.incrementIP("1.2.3.4:1234", "1.2.3.4")
+	assert.NoError(t, err)
+	validateIPLimitState(t, &ipLimit, "First increment call for IPBasedLimit", 1, 2, 1, 3)
+	val, ok := ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+
+	err = ipLimit.incrementIP("1.2.3.4:1235", "1.2.3.4")
+	assert.NoError(t, err)
+	validateIPLimitState(t, &ipLimit, "Second increment call for IPBasedLimit", 1, 2, 2, 3)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 2, "Post increment IPBasedLimit has a Max of %d", val)
+
+	err = ipLimit.incrementIP("4.3.2.1:111", "4.3.2.1")
+	assert.NoError(t, err)
+	validateIPLimitState(t, &ipLimit, "First increment call for second ip IPBasedLimit", 2, 2, 3, 3)
+	val, ok = ipLimit.Limits["4.3.2.1"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+
+	err = ipLimit.incrementIP("4.3.2.1:222", "4.3.2.1")
+	assert.Error(t, err)
+	if limErr, ok := err.(IPLimitExceededError); ok {
+		assert.True(t, limErr.Timeout(), "IPLimit IPLimitExceededError should return timeout true")
+		assert.True(t, limErr.Temporary(), "IPLimit IPLimitExceededError should return temporary true")
+	} else {
+		assert.Fail(t, "Expected a IPLimitExceededError from incrementIP fail but got %T", err)
+	}
+	validateIPLimitState(t, &ipLimit, "Second increment call for IPBasedLimit", 2, 2, 3, 3)
+	val, ok = ipLimit.Limits["4.3.2.1"]
+	assert.True(t, ok, "Increment call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("1.2.3.4:1235", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Decrement call for IPBasedLimit", 2, 2, 2, 3)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.True(t, ok, "Decrement call for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Post increment IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("1.2.3.4:1234", "1.2.3.4")
+	validateIPLimitState(t, &ipLimit, "Deleting decrement call for IPBasedLimit", 1, 2, 1, 3)
+	val, ok = ipLimit.Limits["1.2.3.4"]
+	assert.False(t, ok, "Deleting decrement call for IPBasedLimit had a val")
+	assert.EqualValues(t, val, 0, "Deleting decrement call for IPBasedLimit has a val of %d", 0)
+	val, ok = ipLimit.Limits["4.3.2.1"]
+	assert.True(t, ok, "Unmodified IP for IPBasedLimit had no val")
+	assert.EqualValues(t, val, 1, "Unmodified IP for IPBasedLimit has a Max of %d", val)
+
+	ipLimit.decrementIP("4.3.2.1:111", "4.3.2.1")
+	validateIPLimitState(t, &ipLimit, "Deleting decrement call for IPBasedLimit", 0, 2, 0, 3)
+	val, ok = ipLimit.Limits["4.3.2.1"]
+	assert.False(t, ok, "Deleting decrement call for IPBasedLimit had a val")
+	assert.EqualValues(t, val, 0, "Deleting decrement call for IPBasedLimit has a val of %d", 0)
+}
+
+func TestParallelIPLimitAccessNoLimit(t *testing.T) {
+	ipLimit := IPBasedLimit{Limits: make(map[string]int), Decrementers: make(map[string]func()), MaxPerIP: 10, Max: 100}
+	stop := time.Now().Add(time.Second * 10) // Long enough to prevent flaky ???
+	stateHolder := parallelStateHolder{ipLimit: &ipLimit, waitSize: 100,
+		stop: stop, good: 0, limit: 0, count: 0}
+	ips := []string{"1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4", "5.5.5.5",
+		"6.6.6.6", "7.7.7.7", "8.8.8.8", "9.9.9.9",
+		"1973:dead:beef:0121:1973:dead:beef:0121"}
+	done := make(chan struct{}, 100)
+	defer close(done)
+	for ctr, ip := range ips {
+		for i := 0; i < 10; i++ {
+			go stateHolder.accessIPLimit(ip, ctr, done)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+	validateIPLimitState(t, &ipLimit, "Deleting decrement call for IPBasedLimit", 0, 10, 0, 100)
+	assert.EqualValues(t, stateHolder.good, 100, "Concurrent increment count for IPBasedLimit %d successes", 0)
+	assert.EqualValues(t, stateHolder.limit, 0, "Concurrent increment count for IPBasedLimit %d Limits", 0)
+}
+
+func TestParallelIPLimitHitIPLimit(t *testing.T) {
+	ipLimit := IPBasedLimit{Limits: make(map[string]int), Decrementers: make(map[string]func()), MaxPerIP: 8, Max: 100}
+	stop := time.Now().Add(time.Second * 10) // Long enough to prevent flaky ???
+	stateHolder := parallelStateHolder{ipLimit: &ipLimit, waitSize: 100,
+		stop: stop, good: 0, limit: 0, count: 0}
+	ips := []string{"1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4", "5.5.5.5",
+		"6.6.6.6", "7.7.7.7", "8.8.8.8", "9.9.9.9",
+		"1973:dead:beef:0121:1973:dead:beef:0121"}
+	done := make(chan struct{}, 100)
+	defer close(done)
+	for ctr, ip := range ips {
+		for i := 0; i < 10; i++ {
+			go stateHolder.accessIPLimit(ip, ctr, done)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+	validateIPLimitState(t, &ipLimit, "Deleting decrement call for IPBasedLimit", 0, 8, 0, 100)
+	assert.EqualValues(t, stateHolder.good, 80, "Concurrent increment count for IPBasedLimit %d successes", 0)
+	assert.EqualValues(t, stateHolder.limit, 20, "Concurrent increment count for IPBasedLimit %d Limits", 0)
+}
+
+func TestParallelIPLimitHitTotalLimit(t *testing.T) {
+	ipLimit := IPBasedLimit{Limits: make(map[string]int), Decrementers: make(map[string]func()), MaxPerIP: 10, Max: 79}
+	stop := time.Now().Add(time.Second * 10) // Long enough to prevent flaky ???
+	stateHolder := parallelStateHolder{ipLimit: &ipLimit, waitSize: 100,
+		stop: stop, good: 0, limit: 0, count: 0}
+	ips := []string{"1.1.1.1", "2.2.2.2", "3.3.3.3", "4.4.4.4", "5.5.5.5",
+		"6.6.6.6", "7.7.7.7", "8.8.8.8", "9.9.9.9",
+		"1977:dead:beef:0525:2015:dead:beef:1218"}
+	done := make(chan struct{}, 100)
+	defer close(done)
+	for ctr, ip := range ips {
+		for i := 0; i < 10; i++ {
+			go stateHolder.accessIPLimit(ip, ctr, done)
+		}
+	}
+	for i := 0; i < 100; i++ {
+		<-done
+	}
+	validateIPLimitState(t, &ipLimit, "Deleting decrement call for IPBasedLimit", 0, 10, 0, 79)
+	assert.EqualValues(t, stateHolder.good, 79, "Concurrent increment count for IPBasedLimit %d successes", 0)
+	assert.EqualValues(t, stateHolder.limit, 21, "Concurrent increment count for IPBasedLimit %d Limits", 0)
+}
+
+func (sh *parallelStateHolder) accessIPLimit(ip string, ctr int, done chan<- struct{}) {
+	defer func() { done <- struct{}{} }()
+	err := sh.ipLimit.incrementIP(fmt.Sprintf("%s:%d", ip, ctr), ip)
+	if err == nil {
+		atomic.AddUint64(&sh.good, 1)
+	} else {
+		atomic.AddUint64(&sh.limit, 1)
+	}
+	atomic.AddUint64(&sh.count, 1)
+	if err == nil {
+		sh.wait()
+		sh.ipLimit.decrementIP(fmt.Sprintf("%s:%d", ip, ctr), ip)
+	}
+}
+
+func (sh *parallelStateHolder) wait() {
+	var current uint64
+	for current < sh.waitSize {
+		time.Sleep(time.Millisecond * 10)
+		if time.Now().After(sh.stop) {
+			break
+		}
+		current = atomic.LoadUint64(&sh.count)
+	}
+}
+
+type parallelStateHolder struct {
+	ipLimit  *IPBasedLimit
+	waitSize uint64
+	stop     time.Time
+	good     uint64
+	limit    uint64
+	count    uint64
+}
+
+func validateIPLimitState(t *testing.T, ipLimit *IPBasedLimit, base string, expMapSize, expIpMax, expTtl, expMax int) {
+	assert.EqualValues(t, len(ipLimit.Limits), expMapSize, "%s map is size %d not %d", base, len(ipLimit.Limits), expMapSize)
+	assert.EqualValues(t, ipLimit.MaxPerIP, expIpMax, "%s MaxPerIP is %d not %d", base, ipLimit.MaxPerIP, expIpMax)
+	assert.EqualValues(t, ipLimit.total, expTtl, "%s count is %d not %d", base, ipLimit.total, expTtl)
+	assert.EqualValues(t, ipLimit.Max, expMax, "%s Max is %d not %d", base, ipLimit.Max, expMax)
+}

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -110,6 +110,12 @@ type Config struct {
 	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
 	Timeout time.Duration
 
+	// Flag to indicate whether we want to enable the fairly heavy weight debug concurrent functionality
+	// When turned on it will track connection/requests and where in the code they were invoked from.
+	// This state can then be dumped to track all open connections/requests. Currently this would
+	// be dumped when we get the right class of error from the server. (Unexpected EOF on conn request)
+	DebugConcurrent bool
+
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?
 	// Version string

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -217,6 +217,7 @@ func TestAnonymousConfig(t *testing.T) {
 		expected.TLSClientConfig.CertFile = ""
 		expected.TLSClientConfig.KeyData = nil
 		expected.TLSClientConfig.KeyFile = ""
+		expected.DebugConcurrent = false
 
 		// The DeepEqual cannot handle the func comparison, so we just verify if the
 		// function return the expected object.

--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -95,5 +95,6 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			Groups:   c.Impersonate.Groups,
 			Extra:    c.Impersonate.Extra,
 		},
+		DebugConcurrent: c.DebugConcurrent,
 	}, nil
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -174,6 +174,8 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 		mergo.Merge(clientConfig, serverAuthPartialConfig)
 	}
 
+	clientConfig.DebugConcurrent = config.overrides.DebugConcurrent
+
 	return clientConfig, nil
 }
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -34,6 +34,8 @@ type ConfigOverrides struct {
 	Context         clientcmdapi.Context
 	CurrentContext  string
 	Timeout         string
+	// Indicates if we should maintain & print debug state having to with concurrent state
+	DebugConcurrent bool
 }
 
 // ConfigOverrideFlags holds the flag names to be used for binding command line flags.  Notice that this structure tightly

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -48,6 +48,10 @@ type Config struct {
 	// config may layer other RoundTrippers on top of the returned
 	// RoundTripper.
 	WrapTransport func(rt http.RoundTripper) http.RoundTripper
+
+	// Indicates if we should maintain & print debug state
+	// having to with concurrent state
+	DebugConcurrent bool
 }
 
 // ImpersonationConfig has all the available impersonation options

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1874,7 +1874,7 @@ func LoadConfig() (*restclient.Config, error) {
 		return nil, err
 	}
 
-	return clientcmd.NewDefaultClientConfig(*c, &clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: TestContext.Host}}).ClientConfig()
+	return clientcmd.NewDefaultClientConfig(*c, &clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: TestContext.Host}, DebugConcurrent: true}).ClientConfig()
 }
 func LoadInternalClientset() (*internalclientset.Clientset, error) {
 	config, err := LoadConfig()

--- a/test/e2e/load.go
+++ b/test/e2e/load.go
@@ -274,6 +274,7 @@ func createClients(numberOfClients int) ([]*clientset.Clientset, []*internalclie
 		Expect(err).NotTo(HaveOccurred())
 		config.QPS = 100
 		config.Burst = 200
+		config.DebugConcurrent = true
 		if framework.TestContext.KubeAPIContentType != "" {
 			config.ContentType = framework.TestContext.KubeAPIContentType
 		}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -10418,7 +10418,10 @@ go_library(
 
 go_test(
     name = "k8s.io/apiserver/pkg/server_test",
-    srcs = ["k8s.io/apiserver/pkg/server/genericapiserver_test.go"],
+    srcs = [
+        "k8s.io/apiserver/pkg/server/genericapiserver_test.go",
+        "k8s.io/apiserver/pkg/server/serve_test.go",
+    ],
     library = ":k8s.io/apiserver/pkg/server",
     tags = ["automanaged"],
     deps = [


### PR DESCRIPTION
Implemented a chain handler for handling the connection options.
(keep-alive, ip-limiting, ...)
Added white list functionality for loopback.
Added a total count of connections limit as well.
Put the IpLimit into ServingInfo and set up via config options.
Added tests to cover the basic behaviors of IpBaseLimit functionality.
Added parrallel access tests for IPBasedLimit
Putting in the generated files.

**Release note**:
Formerly the APIServer only limited requests after the SSL handshake. 
This fix is not applied to localhost or non SSL connections. 
The limit is applied on both a total and per IP basis.
The IP limit is the smaller of either half the write or read limit.
The total limit is the sum of the write and read limits.
