### PR TITLE
[scheduler] interface for config

### DIFF
--- a/plugin/pkg/scheduler/BUILD
+++ b/plugin/pkg/scheduler/BUILD
@@ -19,6 +19,8 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
+        "//pkg/client/cache:go_default_library",
+        "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/client/record:go_default_library",
         "//pkg/client/restclient:go_default_library",
         "//pkg/util:go_default_library",
@@ -29,11 +31,13 @@ go_library(
         "//plugin/pkg/scheduler/api:go_default_library",
         "//plugin/pkg/scheduler/metrics:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//plugin/pkg/scheduler/util:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/golang/groupcache/lru",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/util/errors",
         "//vendor:k8s.io/apimachinery/pkg/util/net",
+        "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",
     ],
 )
@@ -87,6 +91,7 @@ filegroup(
         "//plugin/pkg/scheduler/metrics:all-srcs",
         "//plugin/pkg/scheduler/schedulercache:all-srcs",
         "//plugin/pkg/scheduler/testing:all-srcs",
+        "//plugin/pkg/scheduler/util:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/plugin/pkg/scheduler/factory/BUILD
+++ b/plugin/pkg/scheduler/factory/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//plugin/pkg/scheduler/api:go_default_library",
         "//plugin/pkg/scheduler/api/validation:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//plugin/pkg/scheduler/util:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
@@ -61,9 +62,9 @@ go_test(
         "//plugin/pkg/scheduler/api:go_default_library",
         "//plugin/pkg/scheduler/api/latest:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//plugin/pkg/scheduler/util:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
-        "//vendor:k8s.io/apimachinery/pkg/types",
     ],
 )
 

--- a/plugin/pkg/scheduler/util/BUILD
+++ b/plugin/pkg/scheduler/util/BUILD
@@ -1,0 +1,40 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["backoff_utils_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//vendor:k8s.io/apimachinery/pkg/types"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["backoff_utils.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:github.com/golang/glog",
+        "//vendor:k8s.io/apimachinery/pkg/types",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/plugin/pkg/scheduler/util/backoff_utils.go
+++ b/plugin/pkg/scheduler/util/backoff_utils.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now()
+}
+
+// backoffEntry is single threaded.  in particular, it only allows a single action to be waiting on backoff at a time.
+// It is expected that all users will only use the public TryWait(...) method
+// It is also not safe to copy this object.
+type backoffEntry struct {
+	backoff     time.Duration
+	lastUpdate  time.Time
+	reqInFlight int32
+}
+
+// tryLock attempts to acquire a lock via atomic compare and swap.
+// returns true if the lock was acquired, false otherwise
+func (b *backoffEntry) tryLock() bool {
+	return atomic.CompareAndSwapInt32(&b.reqInFlight, 0, 1)
+}
+
+// unlock returns the lock.  panics if the lock isn't held
+func (b *backoffEntry) unlock() {
+	if !atomic.CompareAndSwapInt32(&b.reqInFlight, 1, 0) {
+		panic(fmt.Sprintf("unexpected state on unlocking: %+v", b))
+	}
+}
+
+// TryWait tries to acquire the backoff lock, maxDuration is the maximum allowed period to wait for.
+func (b *backoffEntry) TryWait(maxDuration time.Duration) bool {
+	if !b.tryLock() {
+		return false
+	}
+	defer b.unlock()
+	b.wait(maxDuration)
+	return true
+}
+
+func (entry *backoffEntry) getBackoff(maxDuration time.Duration) time.Duration {
+	duration := entry.backoff
+	newDuration := time.Duration(duration) * 2
+	if newDuration > maxDuration {
+		newDuration = maxDuration
+	}
+	entry.backoff = newDuration
+	glog.V(4).Infof("Backing off %s for pod %+v", duration.String(), entry)
+	return duration
+}
+
+func (entry *backoffEntry) wait(maxDuration time.Duration) {
+	time.Sleep(entry.getBackoff(maxDuration))
+}
+
+type PodBackoff struct {
+	perPodBackoff   map[ktypes.NamespacedName]*backoffEntry
+	lock            sync.Mutex
+	clock           clock
+	defaultDuration time.Duration
+	maxDuration     time.Duration
+}
+
+func (p *PodBackoff) MaxDuration() time.Duration {
+	return p.maxDuration
+}
+
+func CreateDefaultPodBackoff() *PodBackoff {
+	return CreatePodBackoff(1*time.Second, 60*time.Second)
+}
+
+func CreatePodBackoff(defaultDuration, maxDuration time.Duration) *PodBackoff {
+	return CreatePodBackoffWithClock(defaultDuration, maxDuration, realClock{})
+}
+
+func CreatePodBackoffWithClock(defaultDuration, maxDuration time.Duration, clock clock) *PodBackoff {
+	return &PodBackoff{
+		perPodBackoff:   map[ktypes.NamespacedName]*backoffEntry{},
+		clock:           clock,
+		defaultDuration: defaultDuration,
+		maxDuration:     maxDuration,
+	}
+}
+
+func (p *PodBackoff) GetEntry(podID ktypes.NamespacedName) *backoffEntry {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	entry, ok := p.perPodBackoff[podID]
+	if !ok {
+		entry = &backoffEntry{backoff: p.defaultDuration}
+		p.perPodBackoff[podID] = entry
+	}
+	entry.lastUpdate = p.clock.Now()
+	return entry
+}
+
+func (p *PodBackoff) Gc() {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	now := p.clock.Now()
+	for podID, entry := range p.perPodBackoff {
+		if now.Sub(entry.lastUpdate) > p.maxDuration {
+			delete(p.perPodBackoff, podID)
+		}
+	}
+}

--- a/plugin/pkg/scheduler/util/backoff_utils_test.go
+++ b/plugin/pkg/scheduler/util/backoff_utils_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	ktypes "k8s.io/apimachinery/pkg/types"
+	"testing"
+	"time"
+)
+
+type fakeClock struct {
+	t time.Time
+}
+
+func (f *fakeClock) Now() time.Time {
+	return f.t
+}
+
+func TestBackoff(t *testing.T) {
+	clock := fakeClock{}
+	backoff := CreatePodBackoffWithClock(1*time.Second, 60*time.Second, &clock)
+	tests := []struct {
+		podID            ktypes.NamespacedName
+		expectedDuration time.Duration
+		advanceClock     time.Duration
+	}{
+		{
+			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			expectedDuration: 1 * time.Second,
+		},
+		{
+			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			expectedDuration: 2 * time.Second,
+		},
+		{
+			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			expectedDuration: 4 * time.Second,
+		},
+		{
+			podID:            ktypes.NamespacedName{Namespace: "default", Name: "bar"},
+			expectedDuration: 1 * time.Second,
+			advanceClock:     120 * time.Second,
+		},
+		// 'foo' should have been gc'd here.
+		{
+			podID:            ktypes.NamespacedName{Namespace: "default", Name: "foo"},
+			expectedDuration: 1 * time.Second,
+		},
+	}
+
+	for _, test := range tests {
+		duration := backoff.GetEntry(test.podID).getBackoff(backoff.maxDuration)
+		if duration != test.expectedDuration {
+			t.Errorf("expected: %s, got %s for %s", test.expectedDuration.String(), duration.String(), test.podID)
+		}
+		clock.t = clock.t.Add(test.advanceClock)
+		backoff.Gc()
+	}
+	fooID := ktypes.NamespacedName{Namespace: "default", Name: "foo"}
+	backoff.perPodBackoff[fooID].backoff = 60 * time.Second
+	duration := backoff.GetEntry(fooID).getBackoff(backoff.maxDuration)
+	if duration != 60*time.Second {
+		t.Errorf("expected: 60, got %s", duration.String())
+	}
+	// Verify that we split on namespaces correctly, same name, different namespace
+	fooID.Namespace = "other"
+	duration = backoff.GetEntry(fooID).getBackoff(backoff.maxDuration)
+	if duration != 1*time.Second {
+		t.Errorf("expected: 1, got %s", duration.String())
+	}
+}

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -71,7 +71,7 @@ func TestUnschedulableNodes(t *testing.T) {
 
 	defer close(schedulerConfig.StopEverything)
 
-	DoTestUnschedulableNodes(t, clientSet, ns, schedulerConfigFactory.NodeLister.Store)
+	DoTestUnschedulableNodes(t, clientSet, ns, schedulerConfigFactory.GetNodeStore())
 }
 
 func podScheduled(c clientset.Interface, podNamespace, podName string) wait.ConditionFunc {

--- a/test/integration/scheduler_perf/BUILD
+++ b/test/integration/scheduler_perf/BUILD
@@ -37,7 +37,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//plugin/pkg/scheduler/factory:go_default_library",
+        "//plugin/pkg/scheduler:go_default_library",
         "//test/integration/framework:go_default_library",
         "//test/utils:go_default_library",
         "//vendor:github.com/golang/glog",

--- a/test/integration/scheduler_perf/scheduler_bench_test.go
+++ b/test/integration/scheduler_perf/scheduler_bench_test.go
@@ -56,7 +56,7 @@ func BenchmarkScheduling1000Nodes1000Pods(b *testing.B) {
 func benchmarkScheduling(numNodes, numScheduledPods int, b *testing.B) {
 	schedulerConfigFactory, finalFunc := mustSetupScheduler()
 	defer finalFunc()
-	c := schedulerConfigFactory.Client
+	c := schedulerConfigFactory.GetClient()
 
 	nodePreparer := framework.NewIntegrationTestNodePreparer(
 		c,
@@ -74,7 +74,7 @@ func benchmarkScheduling(numNodes, numScheduledPods int, b *testing.B) {
 	podCreator.CreatePods()
 
 	for {
-		scheduled := schedulerConfigFactory.ScheduledPodLister.Indexer.List()
+		scheduled := schedulerConfigFactory.GetScheduledPodListerIndexer().List()
 		if len(scheduled) >= numScheduledPods {
 			break
 		}
@@ -89,7 +89,7 @@ func benchmarkScheduling(numNodes, numScheduledPods int, b *testing.B) {
 	for {
 		// This can potentially affect performance of scheduler, since List() is done under mutex.
 		// TODO: Setup watch on apiserver and wait until all pods scheduled.
-		scheduled := schedulerConfigFactory.ScheduledPodLister.Indexer.List()
+		scheduled := schedulerConfigFactory.GetScheduledPodListerIndexer().List()
 		if len(scheduled) >= numScheduledPods+b.N {
 			break
 		}

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -24,12 +24,12 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
 	"k8s.io/kubernetes/test/integration/framework"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	"github.com/golang/glog"
 	"github.com/renstrom/dedent"
+	"k8s.io/kubernetes/plugin/pkg/scheduler"
 )
 
 const (
@@ -74,7 +74,7 @@ func TestSchedule100Node3KNodeAffinityPods(t *testing.T) {
 		})
 	}
 	config.nodePreparer = framework.NewIntegrationTestNodePreparer(
-		config.schedulerConfigFactory.Client,
+		config.schedulerSupportFunctions.GetClient(),
 		nodeStrategies,
 		"scheduler-perf-",
 	)
@@ -106,7 +106,7 @@ func TestSchedule100Node3KNodeAffinityPods(t *testing.T) {
 			}),
 		)
 	}
-	config.podCreator = testutils.NewTestPodCreator(config.schedulerConfigFactory.Client, podCreatorConfig)
+	config.podCreator = testutils.NewTestPodCreator(config.schedulerSupportFunctions.GetClient(), podCreatorConfig)
 
 	if min := schedulePods(config); min < threshold30K {
 		t.Errorf("Too small pod scheduling throughput for 30k pods. Expected %v got %v", threshold30K, min)
@@ -144,19 +144,19 @@ func TestSchedule1000Node30KPods(t *testing.T) {
 // }
 
 type testConfig struct {
-	numPods                int
-	numNodes               int
-	nodePreparer           testutils.TestNodePreparer
-	podCreator             *testutils.TestPodCreator
-	schedulerConfigFactory *factory.ConfigFactory
-	destroyFunc            func()
+	numPods                   int
+	numNodes                  int
+	nodePreparer              testutils.TestNodePreparer
+	podCreator                *testutils.TestPodCreator
+	schedulerSupportFunctions scheduler.Configurator
+	destroyFunc               func()
 }
 
 func baseConfig() *testConfig {
 	schedulerConfigFactory, destroyFunc := mustSetupScheduler()
 	return &testConfig{
-		schedulerConfigFactory: schedulerConfigFactory,
-		destroyFunc:            destroyFunc,
+		schedulerSupportFunctions: schedulerConfigFactory,
+		destroyFunc:               destroyFunc,
 	}
 }
 
@@ -164,14 +164,14 @@ func defaultSchedulerBenchmarkConfig(numNodes, numPods int) *testConfig {
 	baseConfig := baseConfig()
 
 	nodePreparer := framework.NewIntegrationTestNodePreparer(
-		baseConfig.schedulerConfigFactory.Client,
+		baseConfig.schedulerSupportFunctions.GetClient(),
 		[]testutils.CountToStrategy{{Count: numNodes, Strategy: &testutils.TrivialNodePrepareStrategy{}}},
 		"scheduler-perf-",
 	)
 
 	config := testutils.NewTestPodCreatorConfig()
 	config.AddStrategy("sched-test", numPods, testutils.NewSimpleWithControllerCreatePodStrategy("rc1"))
-	podCreator := testutils.NewTestPodCreator(baseConfig.schedulerConfigFactory.Client, config)
+	podCreator := testutils.NewTestPodCreator(baseConfig.schedulerSupportFunctions.GetClient(), config)
 
 	baseConfig.nodePreparer = nodePreparer
 	baseConfig.podCreator = podCreator
@@ -203,7 +203,7 @@ func schedulePods(config *testConfig) int32 {
 	// Bake in time for the first pod scheduling event.
 	for {
 		time.Sleep(50 * time.Millisecond)
-		scheduled := config.schedulerConfigFactory.ScheduledPodLister.Indexer.List()
+		scheduled := config.schedulerSupportFunctions.GetScheduledPodListerIndexer().List()
 		// 30,000 pods -> wait till @ least 300 are scheduled to start measuring.
 		// TODO Find out why sometimes there may be scheduling blips in the beggining.
 		if len(scheduled) > config.numPods/100 {
@@ -218,7 +218,7 @@ func schedulePods(config *testConfig) int32 {
 		// This can potentially affect performance of scheduler, since List() is done under mutex.
 		// Listing 10000 pods is an expensive operation, so running it frequently may impact scheduler.
 		// TODO: Setup watch on apiserver and wait until all pods scheduled.
-		scheduled := config.schedulerConfigFactory.ScheduledPodLister.Indexer.List()
+		scheduled := config.schedulerSupportFunctions.GetScheduledPodListerIndexer().List()
 
 		// We will be completed when all pods are done being scheduled.
 		// return the worst-case-scenario interval that was seen during this time.

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -40,7 +40,7 @@ import (
 // remove resources after finished.
 // Notes on rate limiter:
 //   - client rate limit is set to 5000.
-func mustSetupScheduler() (schedulerConfigFactory *factory.ConfigFactory, destroyFunc func()) {
+func mustSetupScheduler() (schedulerConfigFactory scheduler.Configurator, destroyFunc func()) {
 
 	h := &framework.MasterHolder{Initialized: make(chan struct{})}
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
**What this PR fixes**

This PR converts the Scheduler configuration factory into an interface, so that
- the scheduler_perf and scheduler integration tests dont rely on the struct for their implementation
- the exported functionality of the factory (i.e. what it needs to provide to create a scheduler configuration) is completely explicit, rather then completely coupled to a struct.
- makes some parts of the factory immutable, again to minimize possible coupling.  

This makes it easier to make a custom factory in instances where we might specifically want to import scheduler logic without actually reusing the entire scheduler codebase.  