### PR TITLE
WIP: Create NodeIdentifier: a pair of NodeName and NodeUID

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -54,9 +54,9 @@ type ActualStateOfWorld interface {
 	// If volumeSpec is not an attachable volume plugin, an error is returned.
 	// If no volume with the name volumeName exists in the store, the volume is
 	// added.
-	// If no node with the name nodeName exists in list of attached nodes for
+	// If no node with the NodeIdentifier exists in list of attached nodes for
 	// the specified volume, the node is added.
-	AddVolumeNode(volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string) (v1.UniqueVolumeName, error)
+	AddVolumeNode(volumeSpec *volume.Spec, node types.NodeIdentifier, devicePath string) (v1.UniqueVolumeName, error)
 
 	// SetVolumeMountedByNode sets the MountedByNode value for the given volume
 	// and node. When set to true this value indicates the volume is mounted by
@@ -65,23 +65,23 @@ type ActualStateOfWorld interface {
 	// returned.
 	// If no node with the name nodeName exists in list of attached nodes for
 	// the specified volume, an error is returned.
-	SetVolumeMountedByNode(volumeName v1.UniqueVolumeName, nodeName types.NodeName, mounted bool) error
+	SetVolumeMountedByNode(volumeName v1.UniqueVolumeName, node types.NodeIdentifier, mounted bool) error
 
 	// SetNodeStatusUpdateNeeded sets statusUpdateNeeded for the specified
 	// node to true indicating the AttachedVolume field in the Node's Status
 	// object needs to be updated by the node updater again.
 	// If the specifed node does not exist in the nodesToUpdateStatusFor list,
 	// log the error and return
-	SetNodeStatusUpdateNeeded(nodeName types.NodeName)
+	SetNodeStatusUpdateNeeded(node types.NodeIdentifier)
 
 	// ResetDetachRequestTime resets the detachRequestTime to 0 which indicates there is no detach
 	// request any more for the volume
-	ResetDetachRequestTime(volumeName v1.UniqueVolumeName, nodeName types.NodeName)
+	ResetDetachRequestTime(volumeName v1.UniqueVolumeName, node types.NodeIdentifier)
 
 	// SetDetachRequestTime sets the detachRequestedTime to current time if this is no
 	// previous request (the previous detachRequestedTime is zero) and return the time elapsed
 	// since last request
-	SetDetachRequestTime(volumeName v1.UniqueVolumeName, nodeName types.NodeName) (time.Duration, error)
+	SetDetachRequestTime(volumeName v1.UniqueVolumeName, node types.NodeIdentifier) (time.Duration, error)
 
 	// DeleteVolumeNode removes the given volume and node from the underlying
 	// store indicating the specified volume is no longer attached to the
@@ -89,12 +89,12 @@ type ActualStateOfWorld interface {
 	// If the volume/node combo does not exist, this is a no-op.
 	// If after deleting the node, the specified volume contains no other child
 	// nodes, the volume is also deleted.
-	DeleteVolumeNode(volumeName v1.UniqueVolumeName, nodeName types.NodeName)
+	DeleteVolumeNode(volumeName v1.UniqueVolumeName, node types.NodeIdentifier)
 
 	// VolumeNodeExists returns true if the specified volume/node combo exists
 	// in the underlying store indicating the specified volume is attached to
 	// the specified node.
-	VolumeNodeExists(volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool
+	VolumeNodeExists(volumeName v1.UniqueVolumeName, node types.NodeIdentifier) bool
 
 	// GetAttachedVolumes generates and returns a list of volumes/node pairs
 	// reflecting which volumes are attached to which nodes based on the
@@ -104,9 +104,9 @@ type ActualStateOfWorld interface {
 	// GetAttachedVolumes generates and returns a list of volumes attached to
 	// the specified node reflecting which volumes are attached to that node
 	// based on the current actual state of the world.
-	GetAttachedVolumesForNode(nodeName types.NodeName) []AttachedVolume
+	GetAttachedVolumesForNode(node types.NodeIdentifier) []AttachedVolume
 
-	GetAttachedVolumesPerNode() map[types.NodeName][]operationexecutor.AttachedVolume
+	GetAttachedVolumesPerNode() map[types.NodeIdentifier][]operationexecutor.AttachedVolume
 
 	// GetVolumesToReportAttached returns a map containing the set of nodes for
 	// which the VolumesAttached Status field in the Node API object should be
@@ -115,10 +115,10 @@ type ActualStateOfWorld interface {
 	// this may differ from the actual list of attached volumes for the node
 	// since volumes should be removed from this list as soon a detach operation
 	// is considered, before the detach operation is triggered).
-	GetVolumesToReportAttached() map[types.NodeName][]v1.AttachedVolume
+	GetVolumesToReportAttached() map[types.NodeIdentifier][]v1.AttachedVolume
 
-	// GetNodesToUpdateStatusFor returns the map of nodeNames to nodeToUpdateStatusFor
-	GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor
+	// GetNodesToUpdateStatusFor returns the map of NodeIdentifier to nodeToUpdateStatusFor
+	GetNodesToUpdateStatusFor() map[types.NodeIdentifier]nodeToUpdateStatusFor
 }
 
 // AttachedVolume represents a volume that is attached to a node.
@@ -142,7 +142,7 @@ type AttachedVolume struct {
 func NewActualStateOfWorld(volumePluginMgr *volume.VolumePluginMgr) ActualStateOfWorld {
 	return &actualStateOfWorld{
 		attachedVolumes:        make(map[v1.UniqueVolumeName]attachedVolume),
-		nodesToUpdateStatusFor: make(map[types.NodeName]nodeToUpdateStatusFor),
+		nodesToUpdateStatusFor: make(map[types.NodeIdentifier]nodeToUpdateStatusFor),
 		volumePluginMgr:        volumePluginMgr,
 	}
 }
@@ -158,7 +158,7 @@ type actualStateOfWorld struct {
 	// update the VolumesAttached Status field. The key in this map is the name
 	// of the node and the value is an object containing more information about
 	// the node (including the list of volumes to report attached).
-	nodesToUpdateStatusFor map[types.NodeName]nodeToUpdateStatusFor
+	nodesToUpdateStatusFor map[types.NodeIdentifier]nodeToUpdateStatusFor
 
 	// volumePluginMgr is the volume plugin manager used to create volume
 	// plugin objects.
@@ -179,10 +179,10 @@ type attachedVolume struct {
 	spec *volume.Spec
 
 	// nodesAttachedTo is a map containing the set of nodes this volume has
-	// successfully been attached to. The key in this map is the name of the
+	// successfully been attached to. The key in this map is the identifier of the
 	// node and the value is a node object containing more information about
 	// the node.
-	nodesAttachedTo map[types.NodeName]nodeAttachedTo
+	nodesAttachedTo map[types.NodeIdentifier]nodeAttachedTo
 
 	// devicePath contains the path on the node where the volume is attached
 	devicePath string
@@ -190,8 +190,8 @@ type attachedVolume struct {
 
 // The nodeAttachedTo object represents a node that has volumes attached to it.
 type nodeAttachedTo struct {
-	// nodeName contains the name of this node.
-	nodeName types.NodeName
+	// node contains the identifier of this node.
+	node types.NodeIdentifier
 
 	// mountedByNode indicates that this node/volume combo is mounted by the
 	// node and is unsafe to detach
@@ -211,8 +211,8 @@ type nodeAttachedTo struct {
 // volume attached. It keeps track of the volumes that should be reported as
 // attached in the Node's Status API object.
 type nodeToUpdateStatusFor struct {
-	// nodeName contains the name of this node.
-	nodeName types.NodeName
+	// node contains the identifier of this node.
+	node types.NodeIdentifier
 
 	// statusUpdateNeeded indicates that the value of the VolumesAttached field
 	// in the Node's Status API object should be updated. This should be set to
@@ -230,32 +230,32 @@ type nodeToUpdateStatusFor struct {
 }
 
 func (asw *actualStateOfWorld) MarkVolumeAsAttached(
-	_ v1.UniqueVolumeName, volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string) error {
-	_, err := asw.AddVolumeNode(volumeSpec, nodeName, devicePath)
+	_ v1.UniqueVolumeName, volumeSpec *volume.Spec, node types.NodeIdentifier, devicePath string) error {
+	_, err := asw.AddVolumeNode(volumeSpec, node, devicePath)
 	return err
 }
 
 func (asw *actualStateOfWorld) MarkVolumeAsDetached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
-	asw.DeleteVolumeNode(volumeName, nodeName)
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) {
+	asw.DeleteVolumeNode(volumeName, node)
 }
 
 func (asw *actualStateOfWorld) RemoveVolumeFromReportAsAttached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) error {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) error {
 	asw.Lock()
 	defer asw.Unlock()
-	return asw.removeVolumeFromReportAsAttached(volumeName, nodeName)
+	return asw.removeVolumeFromReportAsAttached(volumeName, node)
 }
 
 func (asw *actualStateOfWorld) AddVolumeToReportAsAttached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) {
 	asw.Lock()
 	defer asw.Unlock()
-	asw.addVolumeToReportAsAttached(volumeName, nodeName)
+	asw.addVolumeToReportAsAttached(volumeName, node)
 }
 
 func (asw *actualStateOfWorld) AddVolumeNode(
-	volumeSpec *volume.Spec, nodeName types.NodeName, devicePath string) (v1.UniqueVolumeName, error) {
+	volumeSpec *volume.Spec, node types.NodeIdentifier, devicePath string) (v1.UniqueVolumeName, error) {
 	asw.Lock()
 	defer asw.Unlock()
 
@@ -281,7 +281,7 @@ func (asw *actualStateOfWorld) AddVolumeNode(
 		volumeObj = attachedVolume{
 			volumeName:      volumeName,
 			spec:            volumeSpec,
-			nodesAttachedTo: make(map[types.NodeName]nodeAttachedTo),
+			nodesAttachedTo: make(map[types.NodeIdentifier]nodeAttachedTo),
 			devicePath:      devicePath,
 		}
 	} else {
@@ -291,16 +291,16 @@ func (asw *actualStateOfWorld) AddVolumeNode(
 		volumeObj.spec = volumeSpec
 		glog.V(2).Infof("Volume %q is already added to attachedVolume list to node %q, update device path %q",
 			volumeName,
-			nodeName,
+			node,
 			devicePath)
 	}
 	asw.attachedVolumes[volumeName] = volumeObj
 
-	_, nodeExists := volumeObj.nodesAttachedTo[nodeName]
+	_, nodeExists := volumeObj.nodesAttachedTo[node]
 	if !nodeExists {
 		// Create object if it doesn't exist.
-		volumeObj.nodesAttachedTo[nodeName] = nodeAttachedTo{
-			nodeName:              nodeName,
+		volumeObj.nodesAttachedTo[node] = nodeAttachedTo{
+			node:                  node,
 			mountedByNode:         true, // Assume mounted, until proven otherwise
 			mountedByNodeSetCount: 0,
 			detachRequestedTime:   time.Time{},
@@ -308,19 +308,19 @@ func (asw *actualStateOfWorld) AddVolumeNode(
 	} else {
 		glog.V(5).Infof("Volume %q is already added to attachedVolume list to the node %q",
 			volumeName,
-			nodeName)
+			node)
 	}
 
-	asw.addVolumeToReportAsAttached(volumeName, nodeName)
+	asw.addVolumeToReportAsAttached(volumeName, node)
 	return volumeName, nil
 }
 
 func (asw *actualStateOfWorld) SetVolumeMountedByNode(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName, mounted bool) error {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier, mounted bool) error {
 	asw.Lock()
 	defer asw.Unlock()
 
-	volumeObj, nodeObj, err := asw.getNodeAndVolume(volumeName, nodeName)
+	volumeObj, nodeObj, err := asw.getNodeAndVolume(volumeName, node)
 	if err != nil {
 		return fmt.Errorf("Failed to SetVolumeMountedByNode with error: %v", err)
 	}
@@ -336,44 +336,44 @@ func (asw *actualStateOfWorld) SetVolumeMountedByNode(
 	}
 
 	nodeObj.mountedByNode = mounted
-	volumeObj.nodesAttachedTo[nodeName] = nodeObj
+	volumeObj.nodesAttachedTo[node] = nodeObj
 	glog.V(4).Infof("SetVolumeMountedByNode volume %v to the node %q mounted %t",
 		volumeName,
-		nodeName,
+		node,
 		mounted)
 	return nil
 }
 
 func (asw *actualStateOfWorld) ResetDetachRequestTime(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) {
 	asw.Lock()
 	defer asw.Unlock()
 
-	volumeObj, nodeObj, err := asw.getNodeAndVolume(volumeName, nodeName)
+	volumeObj, nodeObj, err := asw.getNodeAndVolume(volumeName, node)
 	if err != nil {
 		glog.Errorf("Failed to ResetDetachRequestTime with error: %v", err)
 		return
 	}
 	nodeObj.detachRequestedTime = time.Time{}
-	volumeObj.nodesAttachedTo[nodeName] = nodeObj
+	volumeObj.nodesAttachedTo[node] = nodeObj
 }
 
 func (asw *actualStateOfWorld) SetDetachRequestTime(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) (time.Duration, error) {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) (time.Duration, error) {
 	asw.Lock()
 	defer asw.Unlock()
 
-	volumeObj, nodeObj, err := asw.getNodeAndVolume(volumeName, nodeName)
+	volumeObj, nodeObj, err := asw.getNodeAndVolume(volumeName, node)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to set detach request time with error: %v", err)
 	}
 	// If there is no previous detach request, set it to the current time
 	if nodeObj.detachRequestedTime.IsZero() {
 		nodeObj.detachRequestedTime = time.Now()
-		volumeObj.nodesAttachedTo[nodeName] = nodeObj
+		volumeObj.nodesAttachedTo[node] = nodeObj
 		glog.V(4).Infof("Set detach request time to current time for volume %v on node %q",
 			volumeName,
-			nodeName)
+			node)
 	}
 	return time.Since(nodeObj.detachRequestedTime), nil
 }
@@ -381,11 +381,11 @@ func (asw *actualStateOfWorld) SetDetachRequestTime(
 // Get the volume and node object from actual state of world
 // This is an internal function and caller should acquire and release the lock
 func (asw *actualStateOfWorld) getNodeAndVolume(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) (attachedVolume, nodeAttachedTo, error) {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) (attachedVolume, nodeAttachedTo, error) {
 
 	volumeObj, volumeExists := asw.attachedVolumes[volumeName]
 	if volumeExists {
-		nodeObj, nodeExists := volumeObj.nodesAttachedTo[nodeName]
+		nodeObj, nodeExists := volumeObj.nodesAttachedTo[node]
 		if nodeExists {
 			return volumeObj, nodeObj, nil
 		}
@@ -393,58 +393,58 @@ func (asw *actualStateOfWorld) getNodeAndVolume(
 
 	return attachedVolume{}, nodeAttachedTo{}, fmt.Errorf("volume %v is no longer attached to the node %q",
 		volumeName,
-		nodeName)
+		node)
 }
 
 // Remove the volumeName from the node's volumesToReportAsAttached list
 // This is an internal function and caller should acquire and release the lock
 func (asw *actualStateOfWorld) removeVolumeFromReportAsAttached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) error {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) error {
 
-	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[nodeName]
+	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[node]
 	if nodeToUpdateExists {
 		_, nodeToUpdateVolumeExists :=
 			nodeToUpdate.volumesToReportAsAttached[volumeName]
 		if nodeToUpdateVolumeExists {
 			nodeToUpdate.statusUpdateNeeded = true
 			delete(nodeToUpdate.volumesToReportAsAttached, volumeName)
-			asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
+			asw.nodesToUpdateStatusFor[node] = nodeToUpdate
 			return nil
 		}
 	}
 	return fmt.Errorf("volume %q or node %q does not exist in volumesToReportAsAttached list",
 		volumeName,
-		nodeName)
+		node)
 
 }
 
 // Add the volumeName to the node's volumesToReportAsAttached list
 // This is an internal function and caller should acquire and release the lock
 func (asw *actualStateOfWorld) addVolumeToReportAsAttached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) {
 	// In case the volume/node entry is no longer in attachedVolume list, skip the rest
-	if _, _, err := asw.getNodeAndVolume(volumeName, nodeName); err != nil {
-		glog.V(4).Infof("Volume %q is no longer attached to node %q", volumeName, nodeName)
+	if _, _, err := asw.getNodeAndVolume(volumeName, node); err != nil {
+		glog.V(4).Infof("Volume %q is no longer attached to node %q", volumeName, node)
 		return
 	}
-	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[nodeName]
+	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[node]
 	if !nodeToUpdateExists {
 		// Create object if it doesn't exist
 		nodeToUpdate = nodeToUpdateStatusFor{
-			nodeName:                  nodeName,
+			node:                      node,
 			statusUpdateNeeded:        true,
 			volumesToReportAsAttached: make(map[v1.UniqueVolumeName]v1.UniqueVolumeName),
 		}
-		asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
-		glog.V(4).Infof("Add new node %q to nodesToUpdateStatusFor", nodeName)
+		asw.nodesToUpdateStatusFor[node] = nodeToUpdate
+		glog.V(4).Infof("Add new node %q to nodesToUpdateStatusFor", node)
 	}
 	_, nodeToUpdateVolumeExists :=
 		nodeToUpdate.volumesToReportAsAttached[volumeName]
 	if !nodeToUpdateVolumeExists {
 		nodeToUpdate.statusUpdateNeeded = true
 		nodeToUpdate.volumesToReportAsAttached[volumeName] = volumeName
-		asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
-		glog.V(4).Infof("Report volume %q as attached to node %q", volumeName, nodeName)
+		asw.nodesToUpdateStatusFor[node] = nodeToUpdate
+		glog.V(4).Infof("Report volume %q as attached to node %q", volumeName, node)
 	}
 }
 
@@ -452,29 +452,29 @@ func (asw *actualStateOfWorld) addVolumeToReportAsAttached(
 // needs to be updated again by the node status updater.
 // If the specifed node does not exist in the nodesToUpdateStatusFor list, log the error and return
 // This is an internal function and caller should acquire and release the lock
-func (asw *actualStateOfWorld) updateNodeStatusUpdateNeeded(nodeName types.NodeName, needed bool) {
-	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[nodeName]
+func (asw *actualStateOfWorld) updateNodeStatusUpdateNeeded(node types.NodeIdentifier, needed bool) {
+	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[node]
 	if !nodeToUpdateExists {
 		// should not happen
 		glog.Errorf(
 			"Failed to set statusUpdateNeeded to needed %t because nodeName=%q  does not exist",
 			needed,
-			nodeName)
+			node)
 		return
 	}
 
 	nodeToUpdate.statusUpdateNeeded = needed
-	asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
+	asw.nodesToUpdateStatusFor[node] = nodeToUpdate
 }
 
-func (asw *actualStateOfWorld) SetNodeStatusUpdateNeeded(nodeName types.NodeName) {
+func (asw *actualStateOfWorld) SetNodeStatusUpdateNeeded(node types.NodeIdentifier) {
 	asw.Lock()
 	defer asw.Unlock()
-	asw.updateNodeStatusUpdateNeeded(nodeName, true)
+	asw.updateNodeStatusUpdateNeeded(node, true)
 }
 
 func (asw *actualStateOfWorld) DeleteVolumeNode(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) {
 	asw.Lock()
 	defer asw.Unlock()
 
@@ -483,9 +483,9 @@ func (asw *actualStateOfWorld) DeleteVolumeNode(
 		return
 	}
 
-	_, nodeExists := volumeObj.nodesAttachedTo[nodeName]
+	_, nodeExists := volumeObj.nodesAttachedTo[node]
 	if nodeExists {
-		delete(asw.attachedVolumes[volumeName].nodesAttachedTo, nodeName)
+		delete(asw.attachedVolumes[volumeName].nodesAttachedTo, node)
 	}
 
 	if len(volumeObj.nodesAttachedTo) == 0 {
@@ -493,17 +493,17 @@ func (asw *actualStateOfWorld) DeleteVolumeNode(
 	}
 
 	// Remove volume from volumes to report as attached
-	asw.removeVolumeFromReportAsAttached(volumeName, nodeName)
+	asw.removeVolumeFromReportAsAttached(volumeName, node)
 }
 
 func (asw *actualStateOfWorld) VolumeNodeExists(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) bool {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) bool {
 	asw.RLock()
 	defer asw.RUnlock()
 
 	volumeObj, volumeExists := asw.attachedVolumes[volumeName]
 	if volumeExists {
-		if _, nodeExists := volumeObj.nodesAttachedTo[nodeName]; nodeExists {
+		if _, nodeExists := volumeObj.nodesAttachedTo[node]; nodeExists {
 			return true
 		}
 	}
@@ -528,15 +528,15 @@ func (asw *actualStateOfWorld) GetAttachedVolumes() []AttachedVolume {
 }
 
 func (asw *actualStateOfWorld) GetAttachedVolumesForNode(
-	nodeName types.NodeName) []AttachedVolume {
+	node types.NodeIdentifier) []AttachedVolume {
 	asw.RLock()
 	defer asw.RUnlock()
 
 	attachedVolumes := make(
 		[]AttachedVolume, 0 /* len */, len(asw.attachedVolumes) /* cap */)
 	for _, volumeObj := range asw.attachedVolumes {
-		for actualNodeName, nodeObj := range volumeObj.nodesAttachedTo {
-			if actualNodeName == nodeName {
+		for actualNode, nodeObj := range volumeObj.nodesAttachedTo {
+			if actualNode == node {
 				attachedVolumes = append(
 					attachedVolumes,
 					getAttachedVolume(&volumeObj, &nodeObj))
@@ -547,31 +547,31 @@ func (asw *actualStateOfWorld) GetAttachedVolumesForNode(
 	return attachedVolumes
 }
 
-func (asw *actualStateOfWorld) GetAttachedVolumesPerNode() map[types.NodeName][]operationexecutor.AttachedVolume {
+func (asw *actualStateOfWorld) GetAttachedVolumesPerNode() map[types.NodeIdentifier][]operationexecutor.AttachedVolume {
 	asw.RLock()
 	defer asw.RUnlock()
 
-	attachedVolumesPerNode := make(map[types.NodeName][]operationexecutor.AttachedVolume)
+	attachedVolumesPerNode := make(map[types.NodeIdentifier][]operationexecutor.AttachedVolume)
 	for _, volumeObj := range asw.attachedVolumes {
-		for nodeName, nodeObj := range volumeObj.nodesAttachedTo {
-			volumes, exists := attachedVolumesPerNode[nodeName]
+		for node, nodeObj := range volumeObj.nodesAttachedTo {
+			volumes, exists := attachedVolumesPerNode[node]
 			if !exists {
 				volumes = []operationexecutor.AttachedVolume{}
 			}
 			volumes = append(volumes, getAttachedVolume(&volumeObj, &nodeObj).AttachedVolume)
-			attachedVolumesPerNode[nodeName] = volumes
+			attachedVolumesPerNode[node] = volumes
 		}
 	}
 
 	return attachedVolumesPerNode
 }
 
-func (asw *actualStateOfWorld) GetVolumesToReportAttached() map[types.NodeName][]v1.AttachedVolume {
+func (asw *actualStateOfWorld) GetVolumesToReportAttached() map[types.NodeIdentifier][]v1.AttachedVolume {
 	asw.RLock()
 	defer asw.RUnlock()
 
-	volumesToReportAttached := make(map[types.NodeName][]v1.AttachedVolume)
-	for nodeName, nodeToUpdateObj := range asw.nodesToUpdateStatusFor {
+	volumesToReportAttached := make(map[types.NodeIdentifier][]v1.AttachedVolume)
+	for node, nodeToUpdateObj := range asw.nodesToUpdateStatusFor {
 		if nodeToUpdateObj.statusUpdateNeeded {
 			attachedVolumes := make(
 				[]v1.AttachedVolume,
@@ -584,18 +584,18 @@ func (asw *actualStateOfWorld) GetVolumesToReportAttached() map[types.NodeName][
 				}
 				i++
 			}
-			volumesToReportAttached[nodeToUpdateObj.nodeName] = attachedVolumes
+			volumesToReportAttached[nodeToUpdateObj.node] = attachedVolumes
 		}
 		// When GetVolumesToReportAttached is called by node status updater, the current status
 		// of this node will be updated, so set the flag statusUpdateNeeded to false indicating
 		// the current status is already updated.
-		asw.updateNodeStatusUpdateNeeded(nodeName, false)
+		asw.updateNodeStatusUpdateNeeded(node, false)
 	}
 
 	return volumesToReportAttached
 }
 
-func (asw *actualStateOfWorld) GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor {
+func (asw *actualStateOfWorld) GetNodesToUpdateStatusFor() map[types.NodeIdentifier]nodeToUpdateStatusFor {
 	return asw.nodesToUpdateStatusFor
 }
 
@@ -606,7 +606,7 @@ func getAttachedVolume(
 		AttachedVolume: operationexecutor.AttachedVolume{
 			VolumeName:         attachedVolume.volumeName,
 			VolumeSpec:         attachedVolume.spec,
-			NodeName:           nodeAttachedTo.nodeName,
+			Node:               nodeAttachedTo.node,
 			DevicePath:         attachedVolume.devicePath,
 			PluginIsAttachable: true,
 		},

--- a/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
+++ b/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
@@ -120,6 +120,6 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 		// from the informer, delete it from dsw
 		glog.V(1).Infof(
 			"Removing pod %q (UID %q) from dsw because it does not exist in pod informer.", dswPodKey, dswPodUID)
-		dswp.desiredStateOfWorld.DeletePod(dswPodUID, dswPodToAdd.VolumeName, dswPodToAdd.NodeName)
+		dswp.desiredStateOfWorld.DeletePod(dswPodUID, dswPodToAdd.VolumeName, dswPodToAdd.Node)
 	}
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -728,10 +728,17 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 	if len(kubeCfg.ExperimentalMounterPath) != 0 {
 		kubeCfg.ExperimentalCheckNodeCapabilitiesBeforeMount = false
 	}
+
+	// TODO: We should be populating ID also
+	// but we believe this is safe for the kubelet's limited volume functionality
+	nodeID := types.NodeIdentifier{
+		Name: nodeName,
+	}
+
 	// setup volumeManager
 	klet.volumeManager, err = volumemanager.NewVolumeManager(
 		kubeCfg.EnableControllerAttachDetach,
-		nodeName,
+		nodeID,
 		klet.podManager,
 		klet.kubeClient,
 		klet.volumePluginMgr,

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -160,10 +160,10 @@ type AttachedVolume struct {
 
 // NewActualStateOfWorld returns a new instance of ActualStateOfWorld.
 func NewActualStateOfWorld(
-	nodeName types.NodeName,
+	node types.NodeIdentifier,
 	volumePluginMgr *volume.VolumePluginMgr) ActualStateOfWorld {
 	return &actualStateOfWorld{
-		nodeName:        nodeName,
+		node:            node,
 		attachedVolumes: make(map[v1.UniqueVolumeName]attachedVolume),
 		volumePluginMgr: volumePluginMgr,
 	}
@@ -184,8 +184,8 @@ func IsRemountRequiredError(err error) bool {
 }
 
 type actualStateOfWorld struct {
-	// nodeName is the name of this node. This value is passed to Attach/Detach
-	nodeName types.NodeName
+	// node is the NodeIdentifier of this node. This value is passed to Attach/Detach
+	node types.NodeIdentifier
 
 	// attachedVolumes is a map containing the set of volumes the kubelet volume
 	// manager believes to be successfully attached to this node. Volume types
@@ -273,12 +273,12 @@ type mountedPod struct {
 }
 
 func (asw *actualStateOfWorld) MarkVolumeAsAttached(
-	volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec, _ types.NodeName, devicePath string) error {
+	volumeName v1.UniqueVolumeName, volumeSpec *volume.Spec, _ types.NodeIdentifier, devicePath string) error {
 	return asw.addVolume(volumeName, volumeSpec, devicePath)
 }
 
 func (asw *actualStateOfWorld) MarkVolumeAsDetached(
-	volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
+	volumeName v1.UniqueVolumeName, node types.NodeIdentifier) {
 	asw.DeleteVolume(volumeName)
 }
 
@@ -298,11 +298,11 @@ func (asw *actualStateOfWorld) MarkVolumeAsMounted(
 		volumeGidValue)
 }
 
-func (asw *actualStateOfWorld) AddVolumeToReportAsAttached(volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
+func (asw *actualStateOfWorld) AddVolumeToReportAsAttached(volumeName v1.UniqueVolumeName, node types.NodeIdentifier) {
 	// no operation for kubelet side
 }
 
-func (asw *actualStateOfWorld) RemoveVolumeFromReportAsAttached(volumeName v1.UniqueVolumeName, nodeName types.NodeName) error {
+func (asw *actualStateOfWorld) RemoveVolumeFromReportAsAttached(volumeName v1.UniqueVolumeName, node types.NodeIdentifier) error {
 	// no operation for kubelet side
 	return nil
 }
@@ -616,7 +616,7 @@ func (asw *actualStateOfWorld) newAttachedVolume(
 		AttachedVolume: operationexecutor.AttachedVolume{
 			VolumeName:         attachedVolume.volumeName,
 			VolumeSpec:         attachedVolume.spec,
-			NodeName:           asw.nodeName,
+			Node:               asw.node,
 			PluginIsAttachable: attachedVolume.pluginIsAttachable,
 			DevicePath:         attachedVolume.devicePath},
 		GloballyMounted: attachedVolume.globallyMounted}

--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -149,7 +149,7 @@ type VolumeManager interface {
 //   Must be pre-initialized.
 func NewVolumeManager(
 	controllerAttachDetachEnabled bool,
-	nodeName k8stypes.NodeName,
+	nodeID k8stypes.NodeIdentifier,
 	podManager pod.Manager,
 	kubeClient clientset.Interface,
 	volumePluginMgr *volume.VolumePluginMgr,
@@ -163,7 +163,7 @@ func NewVolumeManager(
 		kubeClient:          kubeClient,
 		volumePluginMgr:     volumePluginMgr,
 		desiredStateOfWorld: cache.NewDesiredStateOfWorld(volumePluginMgr),
-		actualStateOfWorld:  cache.NewActualStateOfWorld(nodeName, volumePluginMgr),
+		actualStateOfWorld:  cache.NewActualStateOfWorld(nodeID, volumePluginMgr),
 		operationExecutor: operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
 			kubeClient,
 			volumePluginMgr,
@@ -178,7 +178,7 @@ func NewVolumeManager(
 		reconcilerLoopSleepPeriod,
 		reconcilerSyncStatesSleepPeriod,
 		waitForAttachTimeout,
-		nodeName,
+		nodeID,
 		vm.desiredStateOfWorld,
 		vm.actualStateOfWorld,
 		vm.operationExecutor,

--- a/pkg/types/nodename.go
+++ b/pkg/types/nodename.go
@@ -40,4 +40,4 @@ package types
 //   For AWS, the InstanceID is not yet suitable for use as a Node.Name, so we actually use the
 //   PrivateDnsName for the Node.Name.  And this is _not_ always the same as the hostname: if
 //   we are using a custom DHCP domain it won't be.
-type NodeName string
+//type NodeName string

--- a/pkg/volume/aws_ebs/attacher_test.go
+++ b/pkg/volume/aws_ebs/attacher_test.go
@@ -75,7 +75,7 @@ type testcase struct {
 
 func TestAttachDetach(t *testing.T) {
 	diskName := aws.KubernetesVolumeID("disk")
-	nodeName := types.NodeName("instance")
+	node := types.NodeIdentifier{Name: types.NodeName("instance")}
 	readOnly := false
 	spec := createVolSpec(diskName, readOnly)
 	attachError := errors.New("Fake attach error")
@@ -85,10 +85,10 @@ func TestAttachDetach(t *testing.T) {
 		// Successful Attach call
 		{
 			name:   "Attach_Positive",
-			attach: attachCall{diskName, nodeName, readOnly, "/dev/sda", nil},
+			attach: attachCall{diskName, node, readOnly, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedDevice: "/dev/sda",
 		},
@@ -96,10 +96,10 @@ func TestAttachDetach(t *testing.T) {
 		// Attach call fails
 		{
 			name:   "Attach_Negative",
-			attach: attachCall{diskName, nodeName, readOnly, "", attachError},
+			attach: attachCall{diskName, node, readOnly, "", attachError},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedError: attachError,
 		},
@@ -107,47 +107,47 @@ func TestAttachDetach(t *testing.T) {
 		// Detach succeeds
 		{
 			name:           "Detach_Positive",
-			diskIsAttached: diskIsAttachedCall{diskName, nodeName, true, nil},
-			detach:         detachCall{diskName, nodeName, "/dev/sda", nil},
+			diskIsAttached: diskIsAttachedCall{diskName, node, true, nil},
+			detach:         detachCall{diskName, node, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
 				mountPath := "/mnt/" + string(diskName)
-				return "", detacher.Detach(mountPath, nodeName)
+				return "", detacher.Detach(mountPath, node)
 			},
 		},
 
 		// Disk is already detached
 		{
 			name:           "Detach_Positive_AlreadyDetached",
-			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, nil},
+			diskIsAttached: diskIsAttachedCall{diskName, node, false, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
 				mountPath := "/mnt/" + string(diskName)
-				return "", detacher.Detach(mountPath, nodeName)
+				return "", detacher.Detach(mountPath, node)
 			},
 		},
 
 		// Detach succeeds when DiskIsAttached fails
 		{
 			name:           "Detach_Positive_CheckFails",
-			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, diskCheckError},
-			detach:         detachCall{diskName, nodeName, "/dev/sda", nil},
+			diskIsAttached: diskIsAttachedCall{diskName, node, false, diskCheckError},
+			detach:         detachCall{diskName, node, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
 				mountPath := "/mnt/" + string(diskName)
-				return "", detacher.Detach(mountPath, nodeName)
+				return "", detacher.Detach(mountPath, node)
 			},
 		},
 
 		// Detach fails
 		{
 			name:           "Detach_Negative",
-			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, diskCheckError},
-			detach:         detachCall{diskName, nodeName, "", detachError},
+			diskIsAttached: diskIsAttachedCall{diskName, node, false, diskCheckError},
+			detach:         detachCall{diskName, node, "", detachError},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
 				mountPath := "/mnt/" + string(diskName)
-				return "", detacher.Detach(mountPath, nodeName)
+				return "", detacher.Detach(mountPath, node)
 			},
 			expectedError: detachError,
 		},
@@ -221,7 +221,7 @@ func createPVSpec(name aws.KubernetesVolumeID, readOnly bool) *volume.Spec {
 
 type attachCall struct {
 	diskName      aws.KubernetesVolumeID
-	nodeName      types.NodeName
+	node          types.NodeIdentifier
 	readOnly      bool
 	retDeviceName string
 	ret           error
@@ -229,22 +229,22 @@ type attachCall struct {
 
 type detachCall struct {
 	diskName      aws.KubernetesVolumeID
-	nodeName      types.NodeName
+	node          types.NodeIdentifier
 	retDeviceName string
 	ret           error
 }
 
 type diskIsAttachedCall struct {
 	diskName   aws.KubernetesVolumeID
-	nodeName   types.NodeName
+	node       types.NodeIdentifier
 	isAttached bool
 	ret        error
 }
 
-func (testcase *testcase) AttachDisk(diskName aws.KubernetesVolumeID, nodeName types.NodeName, readOnly bool) (string, error) {
+func (testcase *testcase) AttachDisk(diskName aws.KubernetesVolumeID, node types.NodeIdentifier, readOnly bool) (string, error) {
 	expected := &testcase.attach
 
-	if expected.diskName == "" && expected.nodeName == "" {
+	if expected.diskName == "" && expected.node.Name == "" {
 		// testcase.attach looks uninitialized, test did not expect to call
 		// AttachDisk
 		testcase.t.Errorf("Unexpected AttachDisk call!")
@@ -256,8 +256,8 @@ func (testcase *testcase) AttachDisk(diskName aws.KubernetesVolumeID, nodeName t
 		return "", errors.New("Unexpected AttachDisk call: wrong diskName")
 	}
 
-	if expected.nodeName != nodeName {
-		testcase.t.Errorf("Unexpected AttachDisk call: expected nodeName %s, got %s", expected.nodeName, nodeName)
+	if expected.node.Name != node.Name {
+		testcase.t.Errorf("Unexpected AttachDisk call: expected nodeName %s, got %s", expected.node.Name, node.Name)
 		return "", errors.New("Unexpected AttachDisk call: wrong nodeName")
 	}
 
@@ -266,15 +266,15 @@ func (testcase *testcase) AttachDisk(diskName aws.KubernetesVolumeID, nodeName t
 		return "", errors.New("Unexpected AttachDisk call: wrong readOnly")
 	}
 
-	glog.V(4).Infof("AttachDisk call: %s, %s, %v, returning %q, %v", diskName, nodeName, readOnly, expected.retDeviceName, expected.ret)
+	glog.V(4).Infof("AttachDisk call: %s, %s, %v, returning %q, %v", diskName, node.Name, readOnly, expected.retDeviceName, expected.ret)
 
 	return expected.retDeviceName, expected.ret
 }
 
-func (testcase *testcase) DetachDisk(diskName aws.KubernetesVolumeID, nodeName types.NodeName) (string, error) {
+func (testcase *testcase) DetachDisk(diskName aws.KubernetesVolumeID, node types.NodeIdentifier) (string, error) {
 	expected := &testcase.detach
 
-	if expected.diskName == "" && expected.nodeName == "" {
+	if expected.diskName == "" && expected.node.Name == "" {
 		// testcase.detach looks uninitialized, test did not expect to call
 		// DetachDisk
 		testcase.t.Errorf("Unexpected DetachDisk call!")
@@ -286,20 +286,20 @@ func (testcase *testcase) DetachDisk(diskName aws.KubernetesVolumeID, nodeName t
 		return "", errors.New("Unexpected DetachDisk call: wrong diskName")
 	}
 
-	if expected.nodeName != nodeName {
-		testcase.t.Errorf("Unexpected DetachDisk call: expected nodeName %s, got %s", expected.nodeName, nodeName)
+	if expected.node.Name != node.Name {
+		testcase.t.Errorf("Unexpected DetachDisk call: expected nodeName %s, got %s", expected.node.Name, node.Name)
 		return "", errors.New("Unexpected DetachDisk call: wrong nodeName")
 	}
 
-	glog.V(4).Infof("DetachDisk call: %s, %s, returning %q, %v", diskName, nodeName, expected.retDeviceName, expected.ret)
+	glog.V(4).Infof("DetachDisk call: %s, %s, returning %q, %v", diskName, node.Name, expected.retDeviceName, expected.ret)
 
 	return expected.retDeviceName, expected.ret
 }
 
-func (testcase *testcase) DiskIsAttached(diskName aws.KubernetesVolumeID, nodeName types.NodeName) (bool, error) {
+func (testcase *testcase) DiskIsAttached(diskName aws.KubernetesVolumeID, node types.NodeIdentifier) (bool, error) {
 	expected := &testcase.diskIsAttached
 
-	if expected.diskName == "" && expected.nodeName == "" {
+	if expected.diskName == "" && expected.node.Name == "" {
 		// testcase.diskIsAttached looks uninitialized, test did not expect to
 		// call DiskIsAttached
 		testcase.t.Errorf("Unexpected DiskIsAttached call!")
@@ -311,17 +311,17 @@ func (testcase *testcase) DiskIsAttached(diskName aws.KubernetesVolumeID, nodeNa
 		return false, errors.New("Unexpected DiskIsAttached call: wrong diskName")
 	}
 
-	if expected.nodeName != nodeName {
-		testcase.t.Errorf("Unexpected DiskIsAttached call: expected nodeName %s, got %s", expected.nodeName, nodeName)
+	if expected.node.Name != node.Name {
+		testcase.t.Errorf("Unexpected DiskIsAttached call: expected nodeName %s, got %s", expected.node.Name, node.Name)
 		return false, errors.New("Unexpected DiskIsAttached call: wrong nodeName")
 	}
 
-	glog.V(4).Infof("DiskIsAttached call: %s, %s, returning %v, %v", diskName, nodeName, expected.isAttached, expected.ret)
+	glog.V(4).Infof("DiskIsAttached call: %s, %s, returning %v, %v", diskName, node.Name, expected.isAttached, expected.ret)
 
 	return expected.isAttached, expected.ret
 }
 
-func (testcase *testcase) DisksAreAttached(diskNames []aws.KubernetesVolumeID, nodeName types.NodeName) (map[aws.KubernetesVolumeID]bool, error) {
+func (testcase *testcase) DisksAreAttached(diskNames []aws.KubernetesVolumeID, node types.NodeIdentifier) (map[aws.KubernetesVolumeID]bool, error) {
 	return nil, errors.New("Not implemented")
 }
 

--- a/pkg/volume/cinder/attacher_test.go
+++ b/pkg/volume/cinder/attacher_test.go
@@ -99,7 +99,7 @@ type testcase struct {
 func TestAttachDetach(t *testing.T) {
 	diskName := "disk"
 	instanceID := "instance"
-	nodeName := types.NodeName(instanceID)
+	node := types.NodeIdentifier{Name: types.NodeName(instanceID)}
 	readOnly := false
 	spec := createVolSpec(diskName, readOnly)
 	attachError := errors.New("Fake attach error")
@@ -116,7 +116,7 @@ func TestAttachDetach(t *testing.T) {
 			diskPath:       diskPathCall{diskName, instanceID, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedDevice: "/dev/sda",
 		},
@@ -129,7 +129,7 @@ func TestAttachDetach(t *testing.T) {
 			diskPath:       diskPathCall{diskName, instanceID, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedDevice: "/dev/sda",
 		},
@@ -143,7 +143,7 @@ func TestAttachDetach(t *testing.T) {
 			diskPath:       diskPathCall{diskName, instanceID, "/dev/sda", nil},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedDevice: "/dev/sda",
 		},
@@ -156,7 +156,7 @@ func TestAttachDetach(t *testing.T) {
 			attach:         attachCall{diskName, instanceID, "/dev/sda", attachError},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedError: attachError,
 		},
@@ -170,7 +170,7 @@ func TestAttachDetach(t *testing.T) {
 			diskPath:       diskPathCall{diskName, instanceID, "", diskPathError},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedError: diskPathError,
 		},
@@ -183,7 +183,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, instanceID, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(diskName, node)
 			},
 		},
 
@@ -194,7 +194,7 @@ func TestAttachDetach(t *testing.T) {
 			diskIsAttached: diskIsAttachedCall{diskName, instanceID, false, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(diskName, node)
 			},
 		},
 
@@ -206,7 +206,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, instanceID, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(diskName, node)
 			},
 		},
 
@@ -218,7 +218,7 @@ func TestAttachDetach(t *testing.T) {
 			detach:         detachCall{diskName, instanceID, detachError},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(diskName, node)
 			},
 			expectedError: detachError,
 		},

--- a/pkg/volume/photon_pd/attacher_test.go
+++ b/pkg/volume/photon_pd/attacher_test.go
@@ -75,7 +75,7 @@ type testcase struct {
 
 func TestAttachDetach(t *testing.T) {
 	diskName := "000-000-000"
-	nodeName := types.NodeName("instance")
+	node := types.NodeIdentifier{Name: types.NodeName("instance")}
 	readOnly := false
 	spec := createVolSpec(diskName, readOnly)
 	attachError := errors.New("Fake attach error")
@@ -85,10 +85,10 @@ func TestAttachDetach(t *testing.T) {
 		// Successful Attach call
 		{
 			name:   "Attach_Positive",
-			attach: attachCall{diskName, nodeName, nil},
+			attach: attachCall{diskName, node, nil},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedDevice: "/dev/disk/by-id/wwn-0x000000000",
 		},
@@ -96,10 +96,10 @@ func TestAttachDetach(t *testing.T) {
 		// Attach call fails
 		{
 			name:   "Attach_Negative",
-			attach: attachCall{diskName, nodeName, attachError},
+			attach: attachCall{diskName, node, attachError},
 			test: func(testcase *testcase) (string, error) {
 				attacher := newAttacher(testcase)
-				return attacher.Attach(spec, nodeName)
+				return attacher.Attach(spec, node)
 			},
 			expectedError: attachError,
 		},
@@ -107,43 +107,43 @@ func TestAttachDetach(t *testing.T) {
 		// Detach succeeds
 		{
 			name:           "Detach_Positive",
-			diskIsAttached: diskIsAttachedCall{diskName, nodeName, true, nil},
-			detach:         detachCall{diskName, nodeName, nil},
+			diskIsAttached: diskIsAttachedCall{diskName, node, true, nil},
+			detach:         detachCall{diskName, node, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(diskName, node)
 			},
 		},
 
 		// Disk is already detached
 		{
 			name:           "Detach_Positive_AlreadyDetached",
-			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, nil},
+			diskIsAttached: diskIsAttachedCall{diskName, node, false, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(diskName, node)
 			},
 		},
 
 		// Detach succeeds when DiskIsAttached fails
 		{
 			name:           "Detach_Positive_CheckFails",
-			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, diskCheckError},
-			detach:         detachCall{diskName, nodeName, nil},
+			diskIsAttached: diskIsAttachedCall{diskName, node, false, diskCheckError},
+			detach:         detachCall{diskName, node, nil},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(diskName, node)
 			},
 		},
 
 		// Detach fails
 		{
 			name:           "Detach_Negative",
-			diskIsAttached: diskIsAttachedCall{diskName, nodeName, false, diskCheckError},
-			detach:         detachCall{diskName, nodeName, detachError},
+			diskIsAttached: diskIsAttachedCall{diskName, node, false, diskCheckError},
+			detach:         detachCall{diskName, node, detachError},
 			test: func(testcase *testcase) (string, error) {
 				detacher := newDetacher(testcase)
-				return "", detacher.Detach(diskName, nodeName)
+				return "", detacher.Detach(diskName, node)
 			},
 			expectedError: detachError,
 		},
@@ -215,19 +215,19 @@ func createPVSpec(name string, readOnly bool) *volume.Spec {
 
 type attachCall struct {
 	diskName string
-	nodeName types.NodeName
+	node     types.NodeIdentifier
 	ret      error
 }
 
 type detachCall struct {
 	diskName string
-	nodeName types.NodeName
+	node     types.NodeIdentifier
 	ret      error
 }
 
 type diskIsAttachedCall struct {
 	diskName   string
-	nodeName   types.NodeName
+	node       types.NodeIdentifier
 	isAttached bool
 	ret        error
 }
@@ -235,7 +235,7 @@ type diskIsAttachedCall struct {
 func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName) error {
 	expected := &testcase.attach
 
-	if expected.diskName == "" && expected.nodeName == "" {
+	if expected.diskName == "" && expected.node.Name == "" {
 		// testcase.attach looks uninitialized, test did not expect to call
 		// AttachDisk
 		testcase.t.Errorf("Unexpected AttachDisk call!")
@@ -247,8 +247,8 @@ func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName) e
 		return errors.New("Unexpected AttachDisk call: wrong diskName")
 	}
 
-	if expected.nodeName != nodeName {
-		testcase.t.Errorf("Unexpected AttachDisk call: expected nodeName %s, got %s", expected.nodeName, nodeName)
+	if expected.node.Name != nodeName {
+		testcase.t.Errorf("Unexpected AttachDisk call: expected nodeName %s, got %s", expected.node.Name, nodeName)
 		return errors.New("Unexpected AttachDisk call: wrong nodeName")
 	}
 
@@ -260,7 +260,7 @@ func (testcase *testcase) AttachDisk(diskName string, nodeName types.NodeName) e
 func (testcase *testcase) DetachDisk(diskName string, nodeName types.NodeName) error {
 	expected := &testcase.detach
 
-	if expected.diskName == "" && expected.nodeName == "" {
+	if expected.diskName == "" && expected.node.Name == "" {
 		// testcase.detach looks uninitialized, test did not expect to call
 		// DetachDisk
 		testcase.t.Errorf("Unexpected DetachDisk call!")
@@ -272,8 +272,8 @@ func (testcase *testcase) DetachDisk(diskName string, nodeName types.NodeName) e
 		return errors.New("Unexpected DetachDisk call: wrong diskName")
 	}
 
-	if expected.nodeName != nodeName {
-		testcase.t.Errorf("Unexpected DetachDisk call: expected nodeName %s, got %s", expected.nodeName, nodeName)
+	if expected.node.Name != nodeName {
+		testcase.t.Errorf("Unexpected DetachDisk call: expected nodeName %s, got %s", expected.node.Name, nodeName)
 		return errors.New("Unexpected DetachDisk call: wrong nodeName")
 	}
 
@@ -285,7 +285,7 @@ func (testcase *testcase) DetachDisk(diskName string, nodeName types.NodeName) e
 func (testcase *testcase) DiskIsAttached(diskName string, nodeName types.NodeName) (bool, error) {
 	expected := &testcase.diskIsAttached
 
-	if expected.diskName == "" && expected.nodeName == "" {
+	if expected.diskName == "" && expected.node.Name == "" {
 		// testcase.diskIsAttached looks uninitialized, test did not expect to
 		// call DiskIsAttached
 		testcase.t.Errorf("Unexpected DiskIsAttached call!")
@@ -297,8 +297,8 @@ func (testcase *testcase) DiskIsAttached(diskName string, nodeName types.NodeNam
 		return false, errors.New("Unexpected DiskIsAttached call: wrong diskName")
 	}
 
-	if expected.nodeName != nodeName {
-		testcase.t.Errorf("Unexpected DiskIsAttached call: expected nodeName %s, got %s", expected.nodeName, nodeName)
+	if expected.node.Name != nodeName {
+		testcase.t.Errorf("Unexpected DiskIsAttached call: expected nodeName %s, got %s", expected.node.Name, nodeName)
 		return false, errors.New("Unexpected DiskIsAttached call: wrong nodeName")
 	}
 

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -368,7 +368,7 @@ func (fv *FakeVolume) TearDownAt(dir string) error {
 	return os.RemoveAll(dir)
 }
 
-func (fv *FakeVolume) Attach(spec *Spec, nodeName types.NodeName) (string, error) {
+func (fv *FakeVolume) Attach(spec *Spec, node types.NodeIdentifier) (string, error) {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.AttachCallCount++
@@ -414,14 +414,14 @@ func (fv *FakeVolume) GetMountDeviceCallCount() int {
 	return fv.MountDeviceCallCount
 }
 
-func (fv *FakeVolume) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (fv *FakeVolume) Detach(deviceMountPath string, node types.NodeIdentifier) error {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.DetachCallCount++
 	return nil
 }
 
-func (fv *FakeVolume) VolumesAreAttached(spec []*Spec, nodeName types.NodeName) (map[*Spec]bool, error) {
+func (fv *FakeVolume) VolumesAreAttached(spec []*Spec, node types.NodeIdentifier) (map[*Spec]bool, error) {
 	fv.Lock()
 	defer fv.Unlock()
 	return nil, nil

--- a/pkg/volume/util/operationexecutor/operation_executor_test.go
+++ b/pkg/volume/util/operationexecutor/operation_executor_test.go
@@ -136,7 +136,7 @@ func TestOperationExecutor_UnmountDeviceConcurrently(t *testing.T) {
 	for i := range attachedVolumes {
 		attachedVolumes[i] = AttachedVolume{
 			VolumeName: v1.UniqueVolumeName(pdName),
-			NodeName:   "node-name",
+			Node:       types.NodeIdentifier{Name: "node-name"},
 		}
 		oe.UnmountDevice(attachedVolumes[i], nil /* actualStateOfWorldMounterUpdater */, nil /* mount.Interface */)
 	}
@@ -157,7 +157,7 @@ func TestOperationExecutor_AttachVolumeConcurrently(t *testing.T) {
 	for i := range volumesToAttach {
 		volumesToAttach[i] = VolumeToAttach{
 			VolumeName: v1.UniqueVolumeName(pdName),
-			NodeName:   "node",
+			Node:       types.NodeIdentifier{Name: "node"},
 		}
 		oe.AttachVolume(volumesToAttach[i], nil /* actualStateOfWorldAttacherUpdater */)
 	}
@@ -178,7 +178,7 @@ func TestOperationExecutor_DetachVolumeConcurrently(t *testing.T) {
 	for i := range attachedVolumes {
 		attachedVolumes[i] = AttachedVolume{
 			VolumeName: v1.UniqueVolumeName(pdName),
-			NodeName:   "node",
+			Node:       types.NodeIdentifier{Name: "node"},
 		}
 		oe.DetachVolume(attachedVolumes[i], true /* verifySafeToDetach */, nil /* actualStateOfWorldAttacherUpdater */)
 	}
@@ -195,7 +195,7 @@ func TestOperationExecutor_VerifyVolumesAreAttachedConcurrently(t *testing.T) {
 
 	// Act
 	for i := 0; i < numVolumesToVerifyAttached; i++ {
-		oe.VerifyVolumesAreAttached(nil /* attachedVolumes */, "node-name", nil /* actualStateOfWorldAttacherUpdater */)
+		oe.VerifyVolumesAreAttached(nil /* attachedVolumes */, types.NodeIdentifier{Name: "node-name"}, nil /* actualStateOfWorldAttacherUpdater */)
 	}
 
 	// Assert
@@ -215,7 +215,7 @@ func TestOperationExecutor_VerifyControllerAttachedVolumeConcurrently(t *testing
 		volumesToMount[i] = VolumeToMount{
 			VolumeName: v1.UniqueVolumeName(pdName),
 		}
-		oe.VerifyControllerAttachedVolume(volumesToMount[i], types.NodeName("node-name"), nil /* actualStateOfWorldMounterUpdater */)
+		oe.VerifyControllerAttachedVolume(volumesToMount[i], types.NodeIdentifier{Name: "node-name"}, nil /* actualStateOfWorldMounterUpdater */)
 	}
 
 	// Assert
@@ -260,7 +260,7 @@ func (fopg *fakeOperationGenerator) GenerateDetachVolumeFunc(volumeToDetach Atta
 		return nil
 	}, nil
 }
-func (fopg *fakeOperationGenerator) GenerateVolumesAreAttachedFunc(attachedVolumes []AttachedVolume, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (func() error, error) {
+func (fopg *fakeOperationGenerator) GenerateVolumesAreAttachedFunc(attachedVolumes []AttachedVolume, node types.NodeIdentifier, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (func() error, error) {
 	return func() error {
 		startOperationAndBlock(fopg.ch, fopg.quit)
 		return nil
@@ -272,7 +272,7 @@ func (fopg *fakeOperationGenerator) GenerateUnmountDeviceFunc(deviceToDetach Att
 		return nil
 	}, nil
 }
-func (fopg *fakeOperationGenerator) GenerateVerifyControllerAttachedVolumeFunc(volumeToMount VolumeToMount, nodeName types.NodeName, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (func() error, error) {
+func (fopg *fakeOperationGenerator) GenerateVerifyControllerAttachedVolumeFunc(volumeToMount VolumeToMount, node types.NodeIdentifier, actualStateOfWorld ActualStateOfWorldAttacherUpdater) (func() error, error) {
 	return func() error {
 		startOperationAndBlock(fopg.ch, fopg.quit)
 		return nil

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -170,15 +170,15 @@ type Deleter interface {
 
 // Attacher can attach a volume to a node.
 type Attacher interface {
-	// Attaches the volume specified by the given spec to the node with the given Name.
+	// Attaches the volume specified by the given spec to the node with the given NodeIdentifier.
 	// On success, returns the device path where the device was attached on the
 	// node.
-	Attach(spec *Spec, nodeName types.NodeName) (string, error)
+	Attach(spec *Spec, node types.NodeIdentifier) (string, error)
 
 	// VolumesAreAttached checks whether the list of volumes still attached to the specified
 	// the node. It returns a map which maps from the volume spec to the checking result.
 	// If an error is occured during checking, the error will be returned
-	VolumesAreAttached(specs []*Spec, nodeName types.NodeName) (map[*Spec]bool, error)
+	VolumesAreAttached(specs []*Spec, node types.NodeIdentifier) (map[*Spec]bool, error)
 
 	// WaitForAttach blocks until the device is attached to this
 	// node. If it successfully attaches, the path to the device
@@ -198,8 +198,8 @@ type Attacher interface {
 
 // Detacher can detach a volume from a node.
 type Detacher interface {
-	// Detach the given device from the node with the given Name.
-	Detach(deviceName string, nodeName types.NodeName) error
+	// Detach the given device from the node with the given NodeIdentifier.
+	Detach(deviceName string, node types.NodeIdentifier) error
 
 	// UnmountDevice unmounts the global mount of the disk. This
 	// should only be called once all bind mounts have been

--- a/staging/src/k8s.io/apimachinery/pkg/types/nodename.go
+++ b/staging/src/k8s.io/apimachinery/pkg/types/nodename.go
@@ -41,3 +41,12 @@ package types
 //   PrivateDnsName for the Node.Name.  And this is _not_ always the same as the hostname: if
 //   we are using a custom DHCP domain it won't be.
 type NodeName string
+
+type NodeIdentifier struct {
+	Name NodeName
+	ID   UID
+}
+
+func (i *NodeIdentifier) String() string {
+	return "Node{Name=" + string(i.Name) + ", Id=" + string(i.ID) + "}"
+}


### PR DESCRIPTION
Because a NodeName can be reused (when a node is replaced) it makes a
poor cache key, and it could have some race conditions (though this does
seem very likely in practice with today's clouds).

Create a NodeIdentifier: a struct that has a NodeName and NodeUID.  In
this way we can identify the node uniquely, while still maintaining a
human friendly name and allowing code that can only use NodeName to
work.  Moreover, the etcd storage backend currently only supports a
single key - the name - and thus we can't easily do lookups without it.

Issue #39893

```release-note
NONE
```
