### PR TITLE
Fix examples e2e permission check

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -75,7 +75,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 
 		err := framework.WaitForAuthorizationUpdate(c.Authorization(),
 			serviceaccount.MakeUsername(f.Namespace.Name, "default"),
-			"", "create", schema.GroupResource{Resource: "pods"}, true)
+			f.Namespace.Name, "create", schema.GroupResource{Resource: "pods"}, true)
 		framework.ExpectNoError(err)
 	})
 


### PR DESCRIPTION
Ref #39382
Follow-up from #39896

Permission check should be done within the e2e test namespace, not cluster-wide

Also improved RBAC audit logging to make the scope of the permission check clearer