### PR TITLE
test/e2e: remove flaky for ThirdParty test

### DIFF
--- a/pkg/master/thirdparty/thirdparty.go
+++ b/pkg/master/thirdparty/thirdparty.go
@@ -286,6 +286,9 @@ func (m *ThirdPartyResourceServer) InstallThirdPartyResource(rsrc *extensions.Th
 	m.genericAPIServer.HandlerContainer.Add(genericapi.NewGroupWebService(api.Codecs, path, apiGroup))
 
 	m.addThirdPartyResourceStorage(path, plural.Resource, thirdparty.Storage[plural.Resource].(*thirdpartyresourcedatastore.REST), apiGroup)
+	// adding this call can help TPR codecs be able to determine TPRs via
+	// api.Registry, while api.Registry is considered to be static, we need
+	// to figure out a way for such kind of dynamicity
 	api.Registry.AddThirdPartyAPIGroupVersions(schema.GroupVersion{Group: group, Version: rsrc.Versions[0].Name})
 	return nil
 }

--- a/test/e2e/third-party.go
+++ b/test/e2e/third-party.go
@@ -58,8 +58,7 @@ type FooList struct {
 	Items []Foo `json:"items"`
 }
 
-// This test is marked flaky pending namespace controller observing dynamic creation of new third party types.
-var _ = Describe("ThirdParty resources [Flaky] [Disruptive]", func() {
+var _ = Describe("ThirdParty resources [Disruptive]", func() {
 
 	f := framework.NewDefaultFramework("thirdparty")
 


### PR DESCRIPTION
follow up of https://github.com/kubernetes/kubernetes/pull/39457.

cc @lavalamp @sttts @caesarxuchao 

changes include:

1.  add one comment to address why to register TPR.
2.  remove the `flaky` from thirdparty e2e test.

```console
$ ginkgo -- --kubeconfig=${HOME}/.kube/config --host= --repo-root=${HOME}/gopath/src/k8s.io/kubernetes --ginkgo.focus="creating/deleting thirdp
arty objects works"
...
• [SLOW TEST:64.883 seconds]
ThirdParty resources [Disruptive]
/home/haibzhou/gopath/src/k8s.io/kubernetes/test/e2e/third-party.go:186
  Simple Third Party
  /home/haibzhou/gopath/src/k8s.io/kubernetes/test/e2e/third-party.go:185
    creating/deleting thirdparty objects works [Conformance]
    /home/haibzhou/gopath/src/k8s.io/kubernetes/test/e2e/third-party.go:184
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
Ran 1 of 494 Specs in 68.301 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 493 Skipped PASS
```

without registering:

```console
$ ginkgo -- --kubeconfig=${HOME}/.kube/config --host= --repo-root=${HOME}/gopath/src/k8s.io/kubernetes --ginkgo.focus="creating/deleting thirdp
arty objects works"
...
• Failure [70.912 seconds]
ThirdParty resources [Disruptive]
/home/haibzhou/gopath/src/k8s.io/kubernetes/test/e2e/third-party.go:186
  Simple Third Party
  /home/haibzhou/gopath/src/k8s.io/kubernetes/test/e2e/third-party.go:185
    creating/deleting thirdparty objects works [Conformance] [It]
    /home/haibzhou/gopath/src/k8s.io/kubernetes/test/e2e/third-party.go:184

    Jan 15 01:55:08.643: failed to delete: an error on the server ("unknown") has prevented the request from succeeding

    /home/haibzhou/gopath/src/k8s.io/kubernetes/test/e2e/third-party.go:171
```