### PR TITLE
Use kube-dns:1.11.0

### DIFF
--- a/cluster/addons/dns/kubedns-controller.yaml.base
+++ b/cluster/addons/dns/kubedns-controller.yaml.base
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.11.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -96,7 +96,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.11.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -124,7 +124,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.11.0
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kubedns-controller.yaml.in
+++ b/cluster/addons/dns/kubedns-controller.yaml.in
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.11.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -96,7 +96,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.11.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -124,7 +124,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.11.0
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kubedns-controller.yaml.sed
+++ b/cluster/addons/dns/kubedns-controller.yaml.sed
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.11.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -95,7 +95,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.11.0
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -123,7 +123,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.10.1
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.11.0
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/juju/layers/kubernetes/templates/kubedns-controller.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-controller.yaml
@@ -46,7 +46,7 @@ spec:
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-{{ arch }}:1.9
+        image: gcr.io/google_containers/k8s-dns-kube-dns-{{ arch }}:1.11.0
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -120,7 +120,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.10.0
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.11.0
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
Use [kube-dns:1.11.0](https://github.com/kubernetes/dns/releases/tag/1.11.0)

With: kubernetes/dns#25
Fixes kubernetes/kubernetes#26752
Fixes kubernetes/kubernetes#33470

@bowei @thockin 