### PR TITLE
Forbid ports on external name services

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2292,6 +2292,9 @@ func validateServiceFields(service *api.Service) field.ErrorList {
 		if service.Spec.ClusterIP != "" {
 			allErrs = append(allErrs, field.Invalid(specPath.Child("clusterIP"), service.Spec.ClusterIP, "must be empty for ExternalName services"))
 		}
+		if len(service.Spec.Ports) > 0 {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("ports"), service.Spec.Ports, "must be empty for ExternalName services"))
+		}
 		if len(service.Spec.ExternalName) > 0 {
 			allErrs = append(allErrs, ValidateDNS1123Subdomain(service.Spec.ExternalName, specPath.Child("externalName"))...)
 		} else {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -5052,6 +5052,7 @@ func TestValidateService(t *testing.T) {
 				s.Spec.Type = api.ServiceTypeExternalName
 				s.Spec.ClusterIP = ""
 				s.Spec.ExternalName = "foo.bar.example.com"
+				s.Spec.Ports = make([]api.ServicePort, 0)
 			},
 			numErrs: 0,
 		},
@@ -5061,6 +5062,7 @@ func TestValidateService(t *testing.T) {
 				s.Spec.Type = api.ServiceTypeExternalName
 				s.Spec.ClusterIP = "1.2.3.4"
 				s.Spec.ExternalName = "foo.bar.example.com"
+				s.Spec.Ports = make([]api.ServicePort, 0)
 			},
 			numErrs: 1,
 		},
@@ -5070,6 +5072,7 @@ func TestValidateService(t *testing.T) {
 				s.Spec.Type = api.ServiceTypeExternalName
 				s.Spec.ClusterIP = "None"
 				s.Spec.ExternalName = "foo.bar.example.com"
+				s.Spec.Ports = make([]api.ServicePort, 0)
 			},
 			numErrs: 1,
 		},
@@ -5079,6 +5082,7 @@ func TestValidateService(t *testing.T) {
 				s.Spec.Type = api.ServiceTypeExternalName
 				s.Spec.ClusterIP = ""
 				s.Spec.ExternalName = "-123"
+				s.Spec.Ports = make([]api.ServicePort, 0)
 			},
 			numErrs: 1,
 		},


### PR DESCRIPTION
Ports have no purpose on services of type ExternalName. This PR adds empty ports validation on ExternalNameType services.
fixes https://bugzilla.redhat.com/show_bug.cgi?id=1398062
