### PR TITLE
genericapiserver: cut off pkg/apis/extensions and pkg/storage dependencies

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//pkg/generated/openapi:go_default_library",
         "//pkg/genericapiserver:go_default_library",
         "//pkg/genericapiserver/filters:go_default_library",
+        "//pkg/kubeapiserver:go_default_library",
         "//pkg/kubeapiserver/admission:go_default_library",
         "//pkg/kubeapiserver/authenticator:go_default_library",
         "//pkg/master:go_default_library",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -54,6 +54,7 @@ import (
 	generatedopenapi "k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/genericapiserver/filters"
+	"k8s.io/kubernetes/pkg/kubeapiserver"
 	kubeadmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	kubeauthenticator "k8s.io/kubernetes/pkg/kubeapiserver/authenticator"
 	"k8s.io/kubernetes/pkg/master"
@@ -190,7 +191,7 @@ func Run(s *options.ServerRunOptions) error {
 	if err != nil {
 		return fmt.Errorf("error generating storage version map: %s", err)
 	}
-	storageFactory, err := genericapiserver.BuildDefaultStorageFactory(
+	storageFactory, err := kubeapiserver.BuildDefaultStorageFactory(
 		s.Etcd.StorageConfig, s.GenericServerRunOptions.DefaultStorageMediaType, api.Codecs,
 		genericapiserver.NewDefaultResourceEncodingConfig(), storageGroupsToEncodingVersion,
 		// FIXME: this GroupVersionResource override should be configurable

--- a/federation/cmd/federation-apiserver/app/BUILD
+++ b/federation/cmd/federation-apiserver/app/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//pkg/generated/openapi:go_default_library",
         "//pkg/genericapiserver:go_default_library",
         "//pkg/genericapiserver/filters:go_default_library",
+        "//pkg/kubeapiserver:go_default_library",
         "//pkg/kubeapiserver/admission:go_default_library",
         "//pkg/registry/batch/job/storage:go_default_library",
         "//pkg/registry/cachesize:go_default_library",

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/generated/openapi"
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/genericapiserver/filters"
+	"k8s.io/kubernetes/pkg/kubeapiserver"
 	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/generic"
@@ -106,7 +107,7 @@ func Run(s *options.ServerRunOptions) error {
 	if err != nil {
 		return fmt.Errorf("error generating storage version map: %s", err)
 	}
-	storageFactory, err := genericapiserver.BuildDefaultStorageFactory(
+	storageFactory, err := kubeapiserver.BuildDefaultStorageFactory(
 		s.Etcd.StorageConfig, s.GenericServerRunOptions.DefaultStorageMediaType, api.Codecs,
 		genericapiserver.NewDefaultResourceEncodingConfig(), storageGroupsToEncodingVersion,
 		[]schema.GroupVersionResource{}, resourceConfig, s.GenericServerRunOptions.RuntimeConfig)

--- a/pkg/genericapiserver/BUILD
+++ b/pkg/genericapiserver/BUILD
@@ -13,7 +13,6 @@ go_library(
     srcs = [
         "config.go",
         "config_selfclient.go",
-        "default_storage_factory_builder.go",
         "discovery.go",
         "doc.go",
         "genericapiserver.go",
@@ -42,7 +41,6 @@ go_library(
         "//pkg/genericapiserver/routes:go_default_library",
         "//pkg/storage/storagebackend:go_default_library",
         "//pkg/util/cert:go_default_library",
-        "//pkg/util/config:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor:github.com/coreos/go-systemd/daemon",
         "//vendor:github.com/emicklei/go-restful",
@@ -75,7 +73,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
-        "default_storage_factory_builder_test.go",
         "genericapiserver_test.go",
         "resource_config_test.go",
         "serve_test.go",
@@ -91,7 +88,6 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/extensions:go_default_library",
-        "//pkg/apis/extensions/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/generated/openapi:go_default_library",
         "//pkg/genericapiserver/options:go_default_library",

--- a/pkg/kubeapiserver/BUILD
+++ b/pkg/kubeapiserver/BUILD
@@ -5,12 +5,24 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
     name = "go_default_library",
-    srcs = ["doc.go"],
+    srcs = [
+        "default_storage_factory_builder.go",
+        "doc.go",
+    ],
     tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/genericapiserver:go_default_library",
+        "//pkg/storage/storagebackend:go_default_library",
+        "//pkg/util/config:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/runtime",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+    ],
 )
 
 filegroup(
@@ -30,4 +42,20 @@ filegroup(
         "//pkg/kubeapiserver/options:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["default_storage_factory_builder_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/api/install:go_default_library",
+        "//pkg/api/v1:go_default_library",
+        "//pkg/apis/extensions/install:go_default_library",
+        "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//pkg/genericapiserver:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+    ],
 )

--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package genericapiserver
+package kubeapiserver
 
 import (
 	"fmt"
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/storage/storagebackend"
 	"k8s.io/kubernetes/pkg/util/config"
 )
@@ -32,8 +33,8 @@ import (
 // Merges defaultResourceConfig with the user specified overrides and merges
 // defaultAPIResourceConfig with the corresponding user specified overrides as well.
 func BuildDefaultStorageFactory(storageConfig storagebackend.Config, defaultMediaType string, serializer runtime.StorageSerializer,
-	defaultResourceEncoding *DefaultResourceEncodingConfig, storageEncodingOverrides map[string]schema.GroupVersion, resourceEncodingOverrides []schema.GroupVersionResource,
-	defaultAPIResourceConfig *ResourceConfig, resourceConfigOverrides config.ConfigurationMap) (*DefaultStorageFactory, error) {
+	defaultResourceEncoding *genericapiserver.DefaultResourceEncodingConfig, storageEncodingOverrides map[string]schema.GroupVersion, resourceEncodingOverrides []schema.GroupVersionResource,
+	defaultAPIResourceConfig *genericapiserver.ResourceConfig, resourceConfigOverrides config.ConfigurationMap) (*genericapiserver.DefaultStorageFactory, error) {
 
 	resourceEncodingConfig := mergeGroupEncodingConfigs(defaultResourceEncoding, storageEncodingOverrides)
 	resourceEncodingConfig = mergeResourceEncodingConfigs(resourceEncodingConfig, resourceEncodingOverrides)
@@ -41,11 +42,11 @@ func BuildDefaultStorageFactory(storageConfig storagebackend.Config, defaultMedi
 	if err != nil {
 		return nil, err
 	}
-	return NewDefaultStorageFactory(storageConfig, defaultMediaType, serializer, resourceEncodingConfig, apiResourceConfig), nil
+	return genericapiserver.NewDefaultStorageFactory(storageConfig, defaultMediaType, serializer, resourceEncodingConfig, apiResourceConfig), nil
 }
 
 // Merges the given defaultResourceConfig with specifc GroupvVersionResource overrides.
-func mergeResourceEncodingConfigs(defaultResourceEncoding *DefaultResourceEncodingConfig, resourceEncodingOverrides []schema.GroupVersionResource) *DefaultResourceEncodingConfig {
+func mergeResourceEncodingConfigs(defaultResourceEncoding *genericapiserver.DefaultResourceEncodingConfig, resourceEncodingOverrides []schema.GroupVersionResource) *genericapiserver.DefaultResourceEncodingConfig {
 	resourceEncodingConfig := defaultResourceEncoding
 	for _, gvr := range resourceEncodingOverrides {
 		resourceEncodingConfig.SetResourceEncoding(gvr.GroupResource(), gvr.GroupVersion(),
@@ -55,7 +56,7 @@ func mergeResourceEncodingConfigs(defaultResourceEncoding *DefaultResourceEncodi
 }
 
 // Merges the given defaultResourceConfig with specifc GroupVersion overrides.
-func mergeGroupEncodingConfigs(defaultResourceEncoding *DefaultResourceEncodingConfig, storageEncodingOverrides map[string]schema.GroupVersion) *DefaultResourceEncodingConfig {
+func mergeGroupEncodingConfigs(defaultResourceEncoding *genericapiserver.DefaultResourceEncodingConfig, storageEncodingOverrides map[string]schema.GroupVersion) *genericapiserver.DefaultResourceEncodingConfig {
 	resourceEncodingConfig := defaultResourceEncoding
 	for group, storageEncodingVersion := range storageEncodingOverrides {
 		resourceEncodingConfig.SetVersionEncoding(group, storageEncodingVersion, schema.GroupVersion{Group: group, Version: runtime.APIVersionInternal})
@@ -64,7 +65,7 @@ func mergeGroupEncodingConfigs(defaultResourceEncoding *DefaultResourceEncodingC
 }
 
 // Merges the given defaultAPIResourceConfig with the given resourceConfigOverrides.
-func mergeAPIResourceConfigs(defaultAPIResourceConfig *ResourceConfig, resourceConfigOverrides config.ConfigurationMap) (*ResourceConfig, error) {
+func mergeAPIResourceConfigs(defaultAPIResourceConfig *genericapiserver.ResourceConfig, resourceConfigOverrides config.ConfigurationMap) (*genericapiserver.ResourceConfig, error) {
 	resourceConfig := defaultAPIResourceConfig
 	overrides := resourceConfigOverrides
 

--- a/pkg/kubeapiserver/default_storage_factory_builder_test.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package genericapiserver
+package kubeapiserver
 
 import (
 	"reflect"
@@ -22,8 +22,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/api/install"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
+	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
 	extensionsapiv1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/genericapiserver"
 )
 
 func TestParseRuntimeConfig(t *testing.T) {
@@ -31,31 +34,31 @@ func TestParseRuntimeConfig(t *testing.T) {
 	apiv1GroupVersion := apiv1.SchemeGroupVersion
 	testCases := []struct {
 		runtimeConfig         map[string]string
-		defaultResourceConfig func() *ResourceConfig
-		expectedAPIConfig     func() *ResourceConfig
+		defaultResourceConfig func() *genericapiserver.ResourceConfig
+		expectedAPIConfig     func() *genericapiserver.ResourceConfig
 		err                   bool
 	}{
 		{
 			// everything default value.
 			runtimeConfig: map[string]string{},
-			defaultResourceConfig: func() *ResourceConfig {
-				return NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				return genericapiserver.NewResourceConfig()
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				return NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				return genericapiserver.NewResourceConfig()
 			},
 			err: false,
 		},
 		{
 			// no runtimeConfig override.
 			runtimeConfig: map[string]string{},
-			defaultResourceConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.DisableVersions(extensionsapiv1beta1.SchemeGroupVersion)
 				return config
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.DisableVersions(extensionsapiv1beta1.SchemeGroupVersion)
 				return config
 			},
@@ -66,13 +69,13 @@ func TestParseRuntimeConfig(t *testing.T) {
 			runtimeConfig: map[string]string{
 				"extensions/v1beta1": "",
 			},
-			defaultResourceConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.DisableVersions(extensionsapiv1beta1.SchemeGroupVersion)
 				return config
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.EnableVersions(extensionsapiv1beta1.SchemeGroupVersion)
 				return config
 			},
@@ -83,13 +86,13 @@ func TestParseRuntimeConfig(t *testing.T) {
 			runtimeConfig: map[string]string{
 				"api/v1/pods": "false",
 			},
-			defaultResourceConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.EnableVersions(apiv1GroupVersion)
 				return config
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.EnableVersions(apiv1GroupVersion)
 				config.DisableResources(apiv1GroupVersion.WithResource("pods"))
 				return config
@@ -101,11 +104,11 @@ func TestParseRuntimeConfig(t *testing.T) {
 			runtimeConfig: map[string]string{
 				"api/v1": "false",
 			},
-			defaultResourceConfig: func() *ResourceConfig {
-				return NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				return genericapiserver.NewResourceConfig()
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.DisableVersions(apiv1GroupVersion)
 				return config
 			},
@@ -117,14 +120,14 @@ func TestParseRuntimeConfig(t *testing.T) {
 				"extensions/v1beta1/anything":   "true",
 				"extensions/v1beta1/daemonsets": "false",
 			},
-			defaultResourceConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.EnableVersions(extensionsGroupVersion)
 				return config
 			},
 
-			expectedAPIConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.EnableVersions(extensionsGroupVersion)
 				config.DisableResources(extensionsGroupVersion.WithResource("daemonsets"))
 				config.EnableResources(extensionsGroupVersion.WithResource("anything"))
@@ -137,11 +140,11 @@ func TestParseRuntimeConfig(t *testing.T) {
 			runtimeConfig: map[string]string{
 				"invalidgroup/version": "false",
 			},
-			defaultResourceConfig: func() *ResourceConfig {
-				return NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				return genericapiserver.NewResourceConfig()
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				return NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				return genericapiserver.NewResourceConfig()
 			},
 			err: true,
 		},
@@ -150,11 +153,11 @@ func TestParseRuntimeConfig(t *testing.T) {
 			runtimeConfig: map[string]string{
 				"api/v1/pods": "false",
 			},
-			defaultResourceConfig: func() *ResourceConfig {
-				return NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				return genericapiserver.NewResourceConfig()
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.DisableResources(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"})
 				return config
 			},
@@ -165,11 +168,11 @@ func TestParseRuntimeConfig(t *testing.T) {
 			runtimeConfig: map[string]string{
 				"api/all": "true",
 			},
-			defaultResourceConfig: func() *ResourceConfig {
-				return NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				return genericapiserver.NewResourceConfig()
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.EnableVersions(api.Registry.RegisteredGroupVersions()...)
 				return config
 			},
@@ -180,11 +183,11 @@ func TestParseRuntimeConfig(t *testing.T) {
 			runtimeConfig: map[string]string{
 				"api/all": "false",
 			},
-			defaultResourceConfig: func() *ResourceConfig {
-				return NewResourceConfig()
+			defaultResourceConfig: func() *genericapiserver.ResourceConfig {
+				return genericapiserver.NewResourceConfig()
 			},
-			expectedAPIConfig: func() *ResourceConfig {
-				config := NewResourceConfig()
+			expectedAPIConfig: func() *genericapiserver.ResourceConfig {
+				config := genericapiserver.NewResourceConfig()
 				config.DisableVersions(api.Registry.RegisteredGroupVersions()...)
 				return config
 			},


### PR DESCRIPTION
Move BuildDefaultStorageFactory to kubeapiserver.