### PR TITLE
genericapiserver: cut off certificates api dependency

### DIFF
--- a/pkg/apis/certificates/BUILD
+++ b/pkg/apis/certificates/BUILD
@@ -11,6 +11,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "helpers.go",
         "register.go",
         "types.go",
         "zz_generated.deepcopy.go",

--- a/pkg/apis/certificates/helpers.go
+++ b/pkg/apis/certificates/helpers.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+// ParseCSR extracts the CSR from the API object and decodes it.
+func ParseCSR(obj *CertificateSigningRequest) (*x509.CertificateRequest, error) {
+	// extract PEM from request object
+	pemBytes := obj.Spec.Request
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, errors.New("PEM block type must be CERTIFICATE REQUEST")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return csr, nil
+}

--- a/pkg/apis/certificates/v1alpha1/BUILD
+++ b/pkg/apis/certificates/v1alpha1/BUILD
@@ -14,6 +14,7 @@ go_library(
         "defaults.go",
         "doc.go",
         "generated.pb.go",
+        "helpers.go",
         "register.go",
         "types.generated.go",
         "types.go",

--- a/pkg/apis/certificates/v1alpha1/helpers.go
+++ b/pkg/apis/certificates/v1alpha1/helpers.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+// ParseCSR extracts the CSR from the API object and decodes it.
+func ParseCSR(obj *CertificateSigningRequest) (*x509.CertificateRequest, error) {
+	// extract PEM from request object
+	pemBytes := obj.Spec.Request
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE REQUEST" {
+		return nil, errors.New("PEM block type must be CERTIFICATE REQUEST")
+	}
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	return csr, nil
+}

--- a/pkg/apis/certificates/validation/BUILD
+++ b/pkg/apis/certificates/validation/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/api/validation:go_default_library",
         "//pkg/apis/certificates:go_default_library",
-        "//pkg/util/cert:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/util/validation/field",
     ],
 )

--- a/pkg/apis/certificates/validation/validation.go
+++ b/pkg/apis/certificates/validation/validation.go
@@ -22,14 +22,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	apivalidation "k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/apis/certificates"
-	certutil "k8s.io/kubernetes/pkg/util/cert"
 )
 
 // validateCSR validates the signature and formatting of a base64-wrapped,
 // PEM-encoded PKCS#10 certificate signing request. If this is invalid, we must
 // not accept the CSR for further processing.
 func validateCSR(obj *certificates.CertificateSigningRequest) error {
-	csr, err := certutil.ParseCSR(obj)
+	csr, err := certificates.ParseCSR(obj)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/certificates/BUILD
+++ b/pkg/controller/certificates/BUILD
@@ -27,7 +27,6 @@ go_library(
         "//pkg/client/clientset_generated/clientset/typed/core/v1:go_default_library",
         "//pkg/client/record:go_default_library",
         "//pkg/controller:go_default_library",
-        "//pkg/util/cert:go_default_library",
         "//pkg/util/workqueue:go_default_library",
         "//vendor:github.com/cloudflare/cfssl/config",
         "//vendor:github.com/cloudflare/cfssl/helpers",

--- a/pkg/controller/certificates/groupapprove.go
+++ b/pkg/controller/certificates/groupapprove.go
@@ -24,7 +24,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	certificates "k8s.io/kubernetes/pkg/apis/certificates/v1alpha1"
 	clientcertificates "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/certificates/v1alpha1"
-	certutil "k8s.io/kubernetes/pkg/util/cert"
 )
 
 // groupApprover implements AutoApprover for signing Kubelet certificates.
@@ -62,7 +61,7 @@ func (cc *groupApprover) AutoApprove(csr *certificates.CertificateSigningRequest
 		return csr, nil
 	}
 
-	x509cr, err := certutil.ParseCSRV1alpha1(csr)
+	x509cr, err := certificates.ParseCSR(csr)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to parse csr %q: %v", csr.Name, err))
 		return csr, nil

--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -89,7 +89,6 @@ go_library(
         "//pkg/kubectl/resource:go_default_library",
         "//pkg/kubelet/qos:go_default_library",
         "//pkg/util:go_default_library",
-        "//pkg/util/cert:go_default_library",
         "//pkg/util/integer:go_default_library",
         "//pkg/util/intstr:go_default_library",
         "//pkg/util/jsonpath:go_default_library",

--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -55,7 +55,6 @@ import (
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/fields"
-	certutil "k8s.io/kubernetes/pkg/util/cert"
 	"k8s.io/kubernetes/pkg/util/intstr"
 
 	"github.com/golang/glog"
@@ -2025,7 +2024,7 @@ func (p *CertificateSigningRequestDescriber) Describe(namespace, name string, de
 		return "", err
 	}
 
-	cr, err := certutil.ParseCSR(csr)
+	cr, err := certificates.ParseCSR(csr)
 	if err != nil {
 		return "", fmt.Errorf("Error parsing CSR: %v", err)
 	}

--- a/pkg/util/cert/BUILD
+++ b/pkg/util/cert/BUILD
@@ -17,10 +17,6 @@ go_library(
         "pem.go",
     ],
     tags = ["automanaged"],
-    deps = [
-        "//pkg/apis/certificates:go_default_library",
-        "//pkg/apis/certificates/v1alpha1:go_default_library",
-    ],
 )
 
 go_test(

--- a/pkg/util/cert/csr.go
+++ b/pkg/util/cert/csr.go
@@ -22,42 +22,8 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"errors"
 	"net"
-
-	"k8s.io/kubernetes/pkg/apis/certificates"
-	"k8s.io/kubernetes/pkg/apis/certificates/v1alpha1"
 )
-
-// ParseCSR extracts the CSR from the API object and decodes it.
-func ParseCSR(obj *certificates.CertificateSigningRequest) (*x509.CertificateRequest, error) {
-	// extract PEM from request object
-	pemBytes := obj.Spec.Request
-	block, _ := pem.Decode(pemBytes)
-	if block == nil || block.Type != "CERTIFICATE REQUEST" {
-		return nil, errors.New("PEM block type must be CERTIFICATE REQUEST")
-	}
-	csr, err := x509.ParseCertificateRequest(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	return csr, nil
-}
-
-// ParseCSRV1alpha1 extracts the CSR from the API object and decodes it.
-func ParseCSRV1alpha1(obj *v1alpha1.CertificateSigningRequest) (*x509.CertificateRequest, error) {
-	// extract PEM from request object
-	pemBytes := obj.Spec.Request
-	block, _ := pem.Decode(pemBytes)
-	if block == nil || block.Type != "CERTIFICATE REQUEST" {
-		return nil, errors.New("PEM block type must be CERTIFICATE REQUEST")
-	}
-	csr, err := x509.ParseCertificateRequest(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	return csr, nil
-}
 
 // MakeCSR generates a PEM-encoded CSR using the supplied private key, subject, and SANs.
 // All key types that are implemented via crypto.Signer are supported (This includes *rsa.PrivateKey and *ecdsa.PrivateKey.)


### PR DESCRIPTION
By cutting off pkg/apis/certificates depenedency from pkg/util/certs.