### PR TITLE
kubelet: Add cpu-conversion-factor option

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -272,4 +272,5 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.ExperimentalNodeAllocatableIgnoreEvictionThreshold, "experimental-allocatable-ignore-eviction", s.ExperimentalNodeAllocatableIgnoreEvictionThreshold, "When set to 'true', Hard Eviction Thresholds will be ignored while calculating Node Allocatable. See https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md for more details. [default=false]")
 
 	fs.Var(&s.ExperimentalQOSReserved, "experimental-qos-reserved", "A set of ResourceName=Percentage (e.g. memory=50%) pairs that describe how pod resource requests are reserved at the QoS level. Currently only memory is supported. [default=none]")
+	fs.Float32Var(&s.ExperimentalCpuConversionFactor, "experimental-cpu-conversion-factor", s.ExperimentalCpuConversionFactor, "[Experimental] Multiply physical CPU count by this factor to calculate effective number of CPU")
 }

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -245,6 +245,10 @@ experimental-mounter-path
 experimental-nvidia-gpus
 experimental-prefix
 experimental-qos-reserved
+experimental-cri
+experimental-check-node-capabilities-before-mount
+experimental-cpu-conversion-factor
+experimental-kernel-memcg-notification
 external-etcd-cafile
 external-etcd-certfile
 external-etcd-endpoints

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -505,6 +505,8 @@ type KubeletConfiguration struct {
 	// This flag, if set, will avoid including `EvictionHard` limits while computing Node Allocatable.
 	// Refer to [Node Allocatable](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md) doc for more information.
 	ExperimentalNodeAllocatableIgnoreEvictionThreshold bool
+	// Multiply physical CPU count by this factor to calculate effective number of CPU
+	ExperimentalCpuConversionFactor float32
 }
 
 type KubeletAuthorizationMode string

--- a/pkg/apis/componentconfig/v1alpha1/defaults.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults.go
@@ -411,6 +411,9 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 	if obj.EnableCRI == nil {
 		obj.EnableCRI = boolVar(true)
 	}
+	if obj.ExperimentalCpuConversionFactor <= 0 {
+		obj.ExperimentalCpuConversionFactor = 1.0
+	}
 }
 
 func boolVar(b bool) *bool {

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -543,6 +543,8 @@ type KubeletConfiguration struct {
 	// This flag, if set, will avoid including `EvictionHard` limits while computing Node Allocatable.
 	// Refer to [Node Allocatable](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md) doc for more information.
 	ExperimentalNodeAllocatableIgnoreEvictionThreshold bool `json:"experimentalNodeAllocatableIgnoreEvictionThreshold,omitempty"`
+	// Multiply physical CPU count by this factor to calculate effective number of CPU
+	ExperimentalCpuConversionFactor float32 `json:"experimentalCpuConversionFactor,omitempty"`
 }
 
 type KubeletAuthorizationMode string

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -421,6 +421,7 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_componentconfig_KubeletConfigu
 	out.KubeReservedCgroup = in.KubeReservedCgroup
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
 	out.ExperimentalNodeAllocatableIgnoreEvictionThreshold = in.ExperimentalNodeAllocatableIgnoreEvictionThreshold
+	out.ExperimentalCpuConversionFactor = in.ExperimentalCpuConversionFactor
 	return nil
 }
 
@@ -620,6 +621,7 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 	out.KubeReservedCgroup = in.KubeReservedCgroup
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
 	out.ExperimentalNodeAllocatableIgnoreEvictionThreshold = in.ExperimentalNodeAllocatableIgnoreEvictionThreshold
+	out.ExperimentalCpuConversionFactor = in.ExperimentalCpuConversionFactor
 	return nil
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -11196,6 +11196,13 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 								Ref:         ref("k8s.io/apimachinery/pkg/api/resource.Quantity"),
 							},
 						},
+						"experimentalCpuConversionFactor": {
+							SchemaProps: spec.SchemaProps{
+								Description: "Multiply physical CPU count by this factor to calculate effective number of CPU",
+								Type:        []string{"number"},
+								Format:      "float",
+							},
+						},
 					},
 					Required: []string{"target", "metricName", "currentValue"},
 				},

--- a/pkg/kubelet/dockertools/fake_manager.go
+++ b/pkg/kubelet/dockertools/fake_manager.go
@@ -51,7 +51,7 @@ func NewFakeDockerManager(
 	fakePodGetter := &fakePodGetter{}
 	dm := NewDockerManager(client, recorder, livenessManager, containerRefManager, fakePodGetter, machineInfo, podInfraContainerImage, qps,
 		burst, containerLogsDir, osInterface, networkPlugin, runtimeHelper, httpClient, &NativeExecHandler{},
-		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, false, false, true, "/var/lib/kubelet/seccomp")
+		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, false, false, true, "/var/lib/kubelet/seccomp", 1.0)
 	dm.dockerPuller = &FakeDockerPuller{client: client}
 
 	// ttl of version cache is set to 0 so we always call version api directly in tests.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -608,6 +608,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 			klet.cpuCFSQuota,
 			runtimeService,
 			imageService,
+			kubeCfg.ExperimentalCpuConversionFactor,
 		)
 		if err != nil {
 			return nil, err
@@ -647,6 +648,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 				// runtime to set the flag instead.
 				klet.hairpinMode == componentconfig.HairpinVeth && kubeCfg.NetworkPluginName != "kubenet",
 				kubeCfg.SeccompProfileRoot,
+				kubeCfg.ExperimentalCpuConversionFactor,
 				kubeDeps.ContainerRuntimeOptions...,
 			)
 			klet.containerRuntime = runtime
@@ -1371,6 +1373,7 @@ func (kl *Kubelet) GetClusterDNS(pod *v1.Pod) ([]string, []string, bool, error) 
 func (kl *Kubelet) syncPod(o syncPodOptions) error {
 	// pull out the required options
 	pod := o.pod
+
 	mirrorPod := o.mirrorPod
 	podStatus := o.podStatus
 	updateType := o.updateType

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -474,6 +474,18 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 	return nil
 }
 
+func (kl *Kubelet) actualizeCpuCount(node *v1.Node) {
+	factorValue := kl.kubeletConfiguration.ExperimentalCpuConversionFactor
+
+	cpuCount := node.Status.Capacity[v1.ResourceCPU]
+	milliCpuCount := (&cpuCount).MilliValue()
+
+	effectiveMilliCpuCount := resource.NewMilliQuantity(int64(float32(milliCpuCount)*factorValue),
+		resource.DecimalSI)
+
+	node.Status.Capacity[v1.ResourceCPU] = *effectiveMilliCpuCount
+}
+
 func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 	// Note: avoid blindly overwriting the capacity in case opaque
 	//       resources are being advertised.
@@ -523,6 +535,8 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 		}
 		node.Status.NodeInfo.BootID = info.BootID
 	}
+
+	kl.actualizeCpuCount(node)
 
 	// Set Allocatable.
 	if node.Status.Allocatable == nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -30,6 +30,7 @@ import (
 	"github.com/armon/circbuf"
 	"github.com/golang/glog"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -198,6 +199,13 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(container *v1.C
 	var cpuShares int64
 	cpuRequest := container.Resources.Requests.Cpu()
 	cpuLimit := container.Resources.Limits.Cpu()
+
+	cpuRequest = resource.NewMilliQuantity(int64(float32(cpuRequest.MilliValue())/m.cpuConversionFactor),
+	resource.DecimalSI)
+
+	cpuLimit = resource.NewMilliQuantity(int64(float32(cpuLimit.MilliValue())/m.cpuConversionFactor),
+	resource.DecimalSI)
+
 	memoryLimit := container.Resources.Limits.Memory().Value()
 	oomScoreAdj := int64(qos.GetContainerOOMScoreAdjust(pod, container,
 		int64(m.machineInfo.MemoryCapacity)))

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -108,6 +108,9 @@ type kubeGenericRuntimeManager struct {
 
 	// The version cache of runtime daemon.
 	versionCache *cache.ObjectCache
+
+	// Multiply physical CPU count by this factor to calculate effective number of CPU
+	cpuConversionFactor float32;
 }
 
 type KubeGenericRuntime interface {
@@ -134,6 +137,7 @@ func NewKubeGenericRuntimeManager(
 	cpuCFSQuota bool,
 	runtimeService internalapi.RuntimeService,
 	imageService internalapi.ImageManagerService,
+	cpuConversionFactor float32,
 ) (KubeGenericRuntime, error) {
 	kubeRuntimeManager := &kubeGenericRuntimeManager{
 		recorder:            recorder,
@@ -147,6 +151,7 @@ func NewKubeGenericRuntimeManager(
 		runtimeService:      newInstrumentedRuntimeService(runtimeService),
 		imageService:        newInstrumentedImageManagerService(imageService),
 		keyring:             credentialprovider.NewDockerKeyring(),
+		cpuConversionFactor: cpuConversionFactor,
 	}
 
 	typedVersion, err := kubeRuntimeManager.runtimeService.Version(kubeRuntimeAPIVersion)


### PR DESCRIPTION
Use --cpu-conversion-factor to calculate effective number of CPU.
```
<Effective number of CPU> = <Real number of CPU> * cpu-conversion-factor
```
In accordance with https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resources.md#processor-cycles

It will be extremely useful for heterogeneous configurations where same
application should be run on nodes with different CPU speed.

**Release note**:
```
Add  --cpu-conversion-factor option to kubelet for calculating effective number of CPU.
```