### PR TITLE
Automated cherry pick of #39486 #39895 #39038

### DIFF
--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -1251,6 +1251,33 @@ __EOF__
   kube::test::if_has_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/deployments 200 OK"
   kube::test::if_has_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/replicasets 200 OK"
 
+  ### Test --allow-missing-template-keys
+  # Pre-condition: no POD exists
+  create_and_use_new_namespace
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kubectl create -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml "${kube_flags[@]}"
+  # Post-condition: valid-pod POD is created
+  kubectl get "${kube_flags[@]}" pods -o json
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'valid-pod:'
+
+  ## check --allow-missing-template-keys defaults to true for jsonpath templates
+  kubectl get "${kube_flags[@]}" pod valid-pod -o jsonpath='{.missing}'
+
+  ## check --allow-missing-template-keys defaults to true for go templates
+  kubectl get "${kube_flags[@]}" pod valid-pod -o go-template='{{.missing}}'
+
+  ## check --allow-missing-template-keys=false results in an error for a missing key with jsonpath
+  output_message=$(! kubectl get pod valid-pod --allow-missing-template-keys=false -o jsonpath='{.missing}' "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" 'error executing jsonpath "{.missing}": missing is not found'
+
+  ## check --allow-missing-template-keys=false results in an error for a missing key with go
+  output_message=$(! kubectl get pod valid-pod --allow-missing-template-keys=false -o go-template='{{.missing}}' "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" 'error executing template "{{.missing}}": template: output:1:2: executing "output" at <.missing>: map has no entry for key "missing"'
+
+  # cleanup
+  kubectl delete pods valid-pod "${kube_flags[@]}"
+
 
   ##################
   # Global timeout #

--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -1269,11 +1269,11 @@ __EOF__
 
   ## check --allow-missing-template-keys=false results in an error for a missing key with jsonpath
   output_message=$(! kubectl get pod valid-pod --allow-missing-template-keys=false -o jsonpath='{.missing}' "${kube_flags[@]}")
-  kube::test::if_has_string "${output_message}" 'error executing jsonpath "{.missing}": missing is not found'
+  kube::test::if_has_string "${output_message}" 'missing is not found'
 
   ## check --allow-missing-template-keys=false results in an error for a missing key with go
   output_message=$(! kubectl get pod valid-pod --allow-missing-template-keys=false -o go-template='{{.missing}}' "${kube_flags[@]}")
-  kube::test::if_has_string "${output_message}" 'error executing template "{{.missing}}": template: output:1:2: executing "output" at <.missing>: map has no entry for key "missing"'
+  kube::test::if_has_string "${output_message}" 'map has no entry for key "missing"'
 
   # cleanup
   kubectl delete pods valid-pod "${kube_flags[@]}"

--- a/hack/make-rules/test-cmd.sh
+++ b/hack/make-rules/test-cmd.sh
@@ -1278,6 +1278,20 @@ __EOF__
   # cleanup
   kubectl delete pods valid-pod "${kube_flags[@]}"
 
+  ### Test 'kubectl get -f <file> -o <non default printer>' prints all the items in the file's list
+  # Pre-condition: no POD exists
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  kubectl create -f test/fixtures/doc-yaml/user-guide/multi-pod.yaml "${kube_flags[@]}"
+  # Post-condition: PODs redis-master and redis-proxy exist
+
+  # Check that all items in the list are printed
+  output_message=$(kubectl get -f test/fixtures/doc-yaml/user-guide/multi-pod.yaml -o jsonpath="{..metadata.name}" "${kube_flags[@]}")
+  kube::test::if_has_string "${output_message}" "redis-master redis-proxy"
+
+  # cleanup
+  kubectl delete pods redis-master redis-proxy "${kube_flags[@]}"
+
 
   ##################
   # Global timeout #

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -7,6 +7,7 @@ advertised-address
 algorithm-provider
 all-namespaces
 allocate-node-cidrs
+allow-missing-template-keys
 allow-privileged
 allowed-not-ready-nodes
 anonymous-auth

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -196,14 +196,14 @@ func (o AnnotateOptions) RunAnnotate(f cmdutil.Factory, cmd *cobra.Command) erro
 		return err
 	}
 
-	var singularResource bool
-	r.IntoSingular(&singularResource)
+	var singleItemImpliedResource bool
+	r.IntoSingleItemImplied(&singleItemImpliedResource)
 
 	// only apply resource version locking on a single resource.
 	// we must perform this check after o.builder.Do() as
 	// []o.resources can not not accurately return the proper number
 	// of resources when they are not passed in "resource/name" format.
-	if !singularResource && len(o.resourceVersion) > 0 {
+	if !singleItemImpliedResource && len(o.resourceVersion) > 0 {
 		return fmt.Errorf("--resource-version may only be used with a single resource")
 	}
 

--- a/pkg/kubectl/cmd/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump.go
@@ -91,7 +91,7 @@ func dumpClusterInfo(f cmdutil.Factory, cmd *cobra.Command, args []string, out i
 		return err
 	}
 
-	printer, _, err := kubectl.GetPrinter("json", "", false)
+	printer, _, err := kubectl.GetPrinter("json", "", false, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -146,7 +146,7 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.C
 		}
 	}
 	o.encoder = f.JSONEncoder()
-	o.printer, _, err = kubectl.GetPrinter(outputFormat, templateFile, false)
+	o.printer, _, err = kubectl.GetPrinter(outputFormat, templateFile, false, cmdutil.GetFlagBool(cmd, "allow-missing-template-keys"))
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -162,8 +162,8 @@ func (o *ConvertOptions) RunConvert() error {
 		return err
 	}
 
-	singular := false
-	infos, err := r.IntoSingular(&singular).Infos()
+	singleItemImplied := false
+	infos, err := r.IntoSingleItemImplied(&singleItemImplied).Infos()
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (o *ConvertOptions) RunConvert() error {
 		return fmt.Errorf("no objects passed to convert")
 	}
 
-	objects, err := resource.AsVersionedObject(infos, !singular, o.outputVersion, o.encoder)
+	objects, err := resource.AsVersionedObject(infos, !singleItemImplied, o.outputVersion, o.encoder)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -187,7 +187,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 			Latest()
 	}
 	one := false
-	r := b.Do().IntoSingular(&one)
+	r := b.Do().IntoSingleItemImplied(&one)
 	if err := r.Err(); err != nil {
 		return err
 	}

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -72,7 +72,7 @@ type Builder struct {
 	singleResourceType bool
 	continueOnError    bool
 
-	singular bool
+	singleItemImplied bool
 
 	export bool
 
@@ -139,7 +139,7 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 			b.URL(defaultHttpGetAttempts, url)
 		default:
 			if !recursive {
-				b.singular = true
+				b.singleItemImplied = true
 			}
 			b.Path(recursive, s)
 		}
@@ -600,21 +600,21 @@ func (b *Builder) visitBySelector() *Result {
 }
 
 func (b *Builder) visitByResource() *Result {
-	// if b.singular is false, this could be by default, so double-check length
-	// of resourceTuples to determine if in fact it is singular or not
-	isSingular := b.singular
-	if !isSingular {
-		isSingular = len(b.resourceTuples) == 1
+	// if b.singleItemImplied is false, this could be by default, so double-check length
+	// of resourceTuples to determine if in fact it is singleItemImplied or not
+	isSingleItemImplied := b.singleItemImplied
+	if !isSingleItemImplied {
+		isSingleItemImplied = len(b.resourceTuples) == 1
 	}
 
 	if len(b.resources) != 0 {
-		return &Result{singular: isSingular, err: fmt.Errorf("you may not specify individual resources and bulk resources in the same call")}
+		return &Result{singleItemImplied: isSingleItemImplied, err: fmt.Errorf("you may not specify individual resources and bulk resources in the same call")}
 	}
 
 	// retrieve one client for each resource
 	mappings, err := b.resourceTupleMappings()
 	if err != nil {
-		return &Result{singular: isSingular, err: err}
+		return &Result{singleItemImplied: isSingleItemImplied, err: err}
 	}
 	clients := make(map[string]RESTClient)
 	for _, mapping := range mappings {
@@ -633,12 +633,12 @@ func (b *Builder) visitByResource() *Result {
 	for _, tuple := range b.resourceTuples {
 		mapping, ok := mappings[tuple.Resource]
 		if !ok {
-			return &Result{singular: isSingular, err: fmt.Errorf("resource %q is not recognized: %v", tuple.Resource, mappings)}
+			return &Result{singleItemImplied: isSingleItemImplied, err: fmt.Errorf("resource %q is not recognized: %v", tuple.Resource, mappings)}
 		}
 		s := fmt.Sprintf("%s/%s", mapping.GroupVersionKind.GroupVersion().String(), mapping.Resource)
 		client, ok := clients[s]
 		if !ok {
-			return &Result{singular: isSingular, err: fmt.Errorf("could not find a client for resource %q", tuple.Resource)}
+			return &Result{singleItemImplied: isSingleItemImplied, err: fmt.Errorf("could not find a client for resource %q", tuple.Resource)}
 		}
 
 		selectorNamespace := b.namespace
@@ -650,7 +650,7 @@ func (b *Builder) visitByResource() *Result {
 				if b.allNamespace {
 					errMsg = "a resource cannot be retrieved by name across all namespaces"
 				}
-				return &Result{singular: isSingular, err: fmt.Errorf(errMsg)}
+				return &Result{singleItemImplied: isSingleItemImplied, err: fmt.Errorf(errMsg)}
 			}
 		}
 
@@ -664,25 +664,25 @@ func (b *Builder) visitByResource() *Result {
 	} else {
 		visitors = VisitorList(items)
 	}
-	return &Result{singular: isSingular, visitor: visitors, sources: items}
+	return &Result{singleItemImplied: isSingleItemImplied, visitor: visitors, sources: items}
 }
 
 func (b *Builder) visitByName() *Result {
-	isSingular := len(b.names) == 1
+	isSingleItemImplied := len(b.names) == 1
 
 	if len(b.paths) != 0 {
-		return &Result{singular: isSingular, err: fmt.Errorf("when paths, URLs, or stdin is provided as input, you may not specify a resource by arguments as well")}
+		return &Result{singleItemImplied: isSingleItemImplied, err: fmt.Errorf("when paths, URLs, or stdin is provided as input, you may not specify a resource by arguments as well")}
 	}
 	if len(b.resources) == 0 {
-		return &Result{singular: isSingular, err: fmt.Errorf("you must provide a resource and a resource name together")}
+		return &Result{singleItemImplied: isSingleItemImplied, err: fmt.Errorf("you must provide a resource and a resource name together")}
 	}
 	if len(b.resources) > 1 {
-		return &Result{singular: isSingular, err: fmt.Errorf("you must specify only one resource")}
+		return &Result{singleItemImplied: isSingleItemImplied, err: fmt.Errorf("you must specify only one resource")}
 	}
 
 	mappings, err := b.resourceMappings()
 	if err != nil {
-		return &Result{singular: isSingular, err: err}
+		return &Result{singleItemImplied: isSingleItemImplied, err: err}
 	}
 	mapping := mappings[0]
 
@@ -700,7 +700,7 @@ func (b *Builder) visitByName() *Result {
 			if b.allNamespace {
 				errMsg = "a resource cannot be retrieved by name across all namespaces"
 			}
-			return &Result{singular: isSingular, err: fmt.Errorf(errMsg)}
+			return &Result{singleItemImplied: isSingleItemImplied, err: fmt.Errorf(errMsg)}
 		}
 	}
 
@@ -709,13 +709,13 @@ func (b *Builder) visitByName() *Result {
 		info := NewInfo(client, mapping, selectorNamespace, name, b.export)
 		visitors = append(visitors, info)
 	}
-	return &Result{singular: isSingular, visitor: VisitorList(visitors), sources: visitors}
+	return &Result{singleItemImplied: isSingleItemImplied, visitor: VisitorList(visitors), sources: visitors}
 }
 
 func (b *Builder) visitByPaths() *Result {
-	singular := !b.dir && !b.stream && len(b.paths) == 1
+	singleItemImplied := !b.dir && !b.stream && len(b.paths) == 1
 	if len(b.resources) != 0 {
-		return &Result{singular: singular, err: fmt.Errorf("when paths, URLs, or stdin is provided as input, you may not specify resource arguments as well")}
+		return &Result{singleItemImplied: singleItemImplied, err: fmt.Errorf("when paths, URLs, or stdin is provided as input, you may not specify resource arguments as well")}
 	}
 	if len(b.names) != 0 {
 		return &Result{err: fmt.Errorf("name cannot be provided when a path is specified")}
@@ -746,7 +746,7 @@ func (b *Builder) visitByPaths() *Result {
 	if b.selector != nil {
 		visitors = NewFilteredVisitor(visitors, FilterBySelector(b.selector))
 	}
-	return &Result{singular: singular, visitor: visitors, sources: b.paths}
+	return &Result{singleItemImplied: singleItemImplied, visitor: visitors, sources: b.paths}
 }
 
 // Do returns a Result object with a Visitor for the resources identified by the Builder.

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -257,11 +257,11 @@ func TestPathBuilderAndVersionedObjectNotDefaulted(t *testing.T) {
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../test/fixtures/pkg/kubectl/builder/kitten-rc.yaml"}})
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || !singular || len(test.Infos) != 1 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || !singleItemImplied || len(test.Infos) != 1 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 
 	info := test.Infos[0]
@@ -361,11 +361,11 @@ func TestPathBuilderWithMultiple(t *testing.T) {
 			NamespaceParam("test").DefaultNamespace()
 
 		testVisitor := &testVisitor{}
-		singular := false
+		singleItemImplied := false
 
-		err := b.Do().IntoSingular(&singular).Visit(testVisitor.Handle)
+		err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(testVisitor.Handle)
 		if err != nil {
-			t.Fatalf("unexpected response: %v %t %#v %s", err, singular, testVisitor.Infos, test.name)
+			t.Fatalf("unexpected response: %v %t %#v %s", err, singleItemImplied, testVisitor.Infos, test.name)
 		}
 
 		info := testVisitor.Infos
@@ -420,11 +420,11 @@ func TestPathBuilderWithMultipleInvalid(t *testing.T) {
 			NamespaceParam("test").DefaultNamespace()
 
 		testVisitor := &testVisitor{}
-		singular := false
+		singleItemImplied := false
 
-		err := b.Do().IntoSingular(&singular).Visit(testVisitor.Handle)
+		err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(testVisitor.Handle)
 		if err == nil {
-			t.Fatalf("unexpected response: %v %t %#v %s", err, singular, testVisitor.Infos, test.name)
+			t.Fatalf("unexpected response: %v %t %#v %s", err, singleItemImplied, testVisitor.Infos, test.name)
 		}
 	}
 }
@@ -435,11 +435,11 @@ func TestDirectoryBuilder(t *testing.T) {
 		NamespaceParam("test").DefaultNamespace()
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || singular || len(test.Infos) < 3 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || singleItemImplied || len(test.Infos) < 3 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 
 	found := false
@@ -526,11 +526,11 @@ func TestURLBuilderRequireNamespace(t *testing.T) {
 		NamespaceParam("test").RequireNamespace()
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err == nil || !singular || len(test.Infos) != 0 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err == nil || !singleItemImplied || len(test.Infos) != 0 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 }
 
@@ -542,7 +542,7 @@ func TestResourceByName(t *testing.T) {
 		NamespaceParam("test")
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
 	if b.Do().Err() == nil {
 		t.Errorf("unexpected non-error")
@@ -550,9 +550,9 @@ func TestResourceByName(t *testing.T) {
 
 	b.ResourceTypeOrNameArgs(true, "pods", "foo")
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || !singular || len(test.Infos) != 1 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || !singleItemImplied || len(test.Infos) != 1 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 	if !reflect.DeepEqual(&pods.Items[0], test.Objects()[0]) {
 		t.Errorf("unexpected object: %#v", test.Objects()[0])
@@ -578,7 +578,7 @@ func TestMultipleResourceByTheSameName(t *testing.T) {
 		NamespaceParam("test")
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
 	if b.Do().Err() == nil {
 		t.Errorf("unexpected non-error")
@@ -586,9 +586,9 @@ func TestMultipleResourceByTheSameName(t *testing.T) {
 
 	b.ResourceTypeOrNameArgs(true, "pods,services", "foo", "baz")
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || singular || len(test.Infos) != 4 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || singleItemImplied || len(test.Infos) != 4 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &svcs.Items[0], &svcs.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
@@ -654,7 +654,7 @@ func TestResourceByNameWithoutRequireObject(t *testing.T) {
 		NamespaceParam("test")
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
 	if b.Do().Err() == nil {
 		t.Errorf("unexpected non-error")
@@ -662,9 +662,9 @@ func TestResourceByNameWithoutRequireObject(t *testing.T) {
 
 	b.ResourceTypeOrNameArgs(true, "pods", "foo").RequireObject(false)
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || !singular || len(test.Infos) != 1 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || !singleItemImplied || len(test.Infos) != 1 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 	if test.Infos[0].Name != "foo" {
 		t.Errorf("unexpected name: %#v", test.Infos[0].Name)
@@ -691,10 +691,10 @@ func TestResourceByNameAndEmptySelector(t *testing.T) {
 		SelectorParam("").
 		ResourceTypeOrNameArgs(true, "pods", "foo")
 
-	singular := false
-	infos, err := b.Do().IntoSingular(&singular).Infos()
-	if err != nil || !singular || len(infos) != 1 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, infos)
+	singleItemImplied := false
+	infos, err := b.Do().IntoSingleItemImplied(&singleItemImplied).Infos()
+	if err != nil || !singleItemImplied || len(infos) != 1 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, infos)
 	}
 	if !reflect.DeepEqual(&pods.Items[0], infos[0].Object) {
 		t.Errorf("unexpected object: %#v", infos[0])
@@ -721,7 +721,7 @@ func TestSelector(t *testing.T) {
 		Flatten()
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
 	if b.Do().Err() == nil {
 		t.Errorf("unexpected non-error")
@@ -729,9 +729,9 @@ func TestSelector(t *testing.T) {
 
 	b.ResourceTypeOrNameArgs(true, "pods,service")
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || singular || len(test.Infos) != 3 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || singleItemImplied || len(test.Infos) != 3 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &svc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
@@ -837,9 +837,9 @@ func TestResourceTuple(t *testing.T) {
 				continue
 			}
 			switch {
-			case (r.singular && len(testCase.args) != 1),
-				(!r.singular && len(testCase.args) == 1):
-				t.Errorf("%s: result had unexpected singular value", k)
+			case (r.singleItemImplied && len(testCase.args) != 1),
+				(!r.singleItemImplied && len(testCase.args) == 1):
+				t.Errorf("%s: result had unexpected singleItemImplied value", k)
 			}
 			info, err := r.Infos()
 			if err != nil {
@@ -859,11 +859,11 @@ func TestStream(t *testing.T) {
 		NamespaceParam("test").Stream(r, "STDIN").Flatten()
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || singular || len(test.Infos) != 3 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || singleItemImplied || len(test.Infos) != 3 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &rc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
@@ -876,11 +876,11 @@ func TestYAMLStream(t *testing.T) {
 		NamespaceParam("test").Stream(r, "STDIN").Flatten()
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || singular || len(test.Infos) != 3 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || singleItemImplied || len(test.Infos) != 3 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 	if !api.Semantic.DeepDerivative([]runtime.Object{&pods.Items[0], &pods.Items[1], &rc.Items[0]}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
@@ -939,7 +939,7 @@ func TestContinueOnErrorVisitor(t *testing.T) {
 	}
 }
 
-func TestSingularObject(t *testing.T) {
+func TestSingleItemImpliedObject(t *testing.T) {
 	obj, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
 		NamespaceParam("test").DefaultNamespace().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../examples/guestbook/legacy/redis-master-controller.yaml"}}).
@@ -959,7 +959,7 @@ func TestSingularObject(t *testing.T) {
 	}
 }
 
-func TestSingularObjectNoExtension(t *testing.T) {
+func TestSingleItemImpliedObjectNoExtension(t *testing.T) {
 	obj, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
 		NamespaceParam("test").DefaultNamespace().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../examples/pod"}}).
@@ -979,7 +979,7 @@ func TestSingularObjectNoExtension(t *testing.T) {
 	}
 }
 
-func TestSingularRootScopedObject(t *testing.T) {
+func TestSingleItemImpliedRootScopedObject(t *testing.T) {
 	node := &api.Node{ObjectMeta: api.ObjectMeta{Name: "test"}, Spec: api.NodeSpec{ExternalID: "test"}}
 	r := streamTestObject(node)
 	infos, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClient(), testapi.Default.Codec()).
@@ -1129,11 +1129,11 @@ func TestLatest(t *testing.T) {
 		NamespaceParam("other").Stream(r, "STDIN").Flatten().Latest()
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err != nil || singular || len(test.Infos) != 3 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err != nil || singleItemImplied || len(test.Infos) != 3 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 	if !api.Semantic.DeepDerivative([]runtime.Object{newPod, newPod2, newSvc}, test.Objects()) {
 		t.Errorf("unexpected visited objects: %#v", test.Objects())
@@ -1162,11 +1162,11 @@ func TestReceiveMultipleErrors(t *testing.T) {
 		ContinueOnError()
 
 	test := &testVisitor{}
-	singular := false
+	singleItemImplied := false
 
-	err := b.Do().IntoSingular(&singular).Visit(test.Handle)
-	if err == nil || singular || len(test.Infos) != 2 {
-		t.Fatalf("unexpected response: %v %t %#v", err, singular, test.Infos)
+	err := b.Do().IntoSingleItemImplied(&singleItemImplied).Visit(test.Handle)
+	if err == nil || singleItemImplied || len(test.Infos) != 2 {
+		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
 
 	errs, ok := err.(utilerrors.Aggregate)

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -39,8 +39,8 @@ type Result struct {
 	err     error
 	visitor Visitor
 
-	sources  []Visitor
-	singular bool
+	sources           []Visitor
+	singleItemImplied bool
 
 	ignoreErrors []utilerrors.Matcher
 
@@ -81,10 +81,10 @@ func (r *Result) Visit(fn VisitorFunc) error {
 	return utilerrors.FilterOut(err, r.ignoreErrors...)
 }
 
-// IntoSingular sets the provided boolean pointer to true if the Builder input
-// reflected a single item, or multiple.
-func (r *Result) IntoSingular(b *bool) *Result {
-	*b = r.singular
+// IntoSingleItemImplied sets the provided boolean pointer to true if the Builder input
+// implies a single item, or multiple.
+func (r *Result) IntoSingleItemImplied(b *bool) *Result {
+	*b = r.singleItemImplied
 	return r
 }
 
@@ -135,7 +135,7 @@ func (r *Result) Object() (runtime.Object, error) {
 	}
 
 	if len(objects) == 1 {
-		if r.singular {
+		if r.singleItemImplied {
 			return objects[0], nil
 		}
 		// if the item is a list already, don't create another list

--- a/pkg/kubectl/resource_printer_test.go
+++ b/pkg/kubectl/resource_printer_test.go
@@ -77,7 +77,7 @@ func TestVersionedPrinter(t *testing.T) {
 }
 
 func TestPrintDefault(t *testing.T) {
-	printer, found, err := GetPrinter("", "", false)
+	printer, found, err := GetPrinter("", "", false, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %#v", err)
 	}
@@ -131,7 +131,7 @@ func TestPrinter(t *testing.T) {
 	}
 	for _, test := range printerTests {
 		buf := bytes.NewBuffer([]byte{})
-		printer, found, err := GetPrinter(test.Format, test.FormatArgument, false)
+		printer, found, err := GetPrinter(test.Format, test.FormatArgument, false, true)
 		if err != nil || !found {
 			t.Errorf("in %s, unexpected error: %#v", test.Name, err)
 		}
@@ -158,7 +158,7 @@ func TestBadPrinter(t *testing.T) {
 		{"bad jsonpath", "jsonpath", "{.Name", fmt.Errorf("error parsing jsonpath {.Name, unclosed action\n")},
 	}
 	for _, test := range badPrinterTests {
-		_, _, err := GetPrinter(test.Format, test.FormatArgument, false)
+		_, _, err := GetPrinter(test.Format, test.FormatArgument, false, false)
 		if err == nil || err.Error() != test.Error.Error() {
 			t.Errorf("in %s, expect %s, got %s", test.Name, test.Error, err)
 		}
@@ -359,7 +359,7 @@ func TestNamePrinter(t *testing.T) {
 			},
 			"pod/foo\npod/bar\n"},
 	}
-	printer, _, _ := GetPrinter("name", "", false)
+	printer, _, _ := GetPrinter("name", "", false, false)
 	for name, item := range tests {
 		buff := &bytes.Buffer{}
 		err := printer.PrintObj(item.obj, buff)
@@ -1683,5 +1683,45 @@ func TestPrintPodDisruptionBudget(t *testing.T) {
 			t.Fatalf("Expected: %s, got: %s", test.expect, buf.String())
 		}
 		buf.Reset()
+	}
+}
+
+func TestAllowMissingKeys(t *testing.T) {
+	tests := []struct {
+		Name                     string
+		AllowMissingTemplateKeys bool
+		Format                   string
+		Template                 string
+		Input                    runtime.Object
+		Expect                   string
+		Error                    string
+	}{
+		{"test template, allow missing keys", true, "template", "{{.blarg}}", &api.Pod{}, "<no value>", ""},
+		{"test template, strict", false, "template", "{{.blarg}}", &api.Pod{}, "", `error executing template "{{.blarg}}": template: output:1:2: executing "output" at <.blarg>: map has no entry for key "blarg"`},
+		{"test jsonpath, allow missing keys", true, "jsonpath", "{.blarg}", &api.Pod{}, "", ""},
+		{"test jsonpath, strict", false, "jsonpath", "{.blarg}", &api.Pod{}, "", "error executing jsonpath \"{.blarg}\": blarg is not found\n"},
+	}
+	for _, test := range tests {
+		buf := bytes.NewBuffer([]byte{})
+		printer, _, err := GetPrinter(test.Format, test.Template, false, test.AllowMissingTemplateKeys)
+		if err != nil {
+			t.Errorf("in %s, unexpected error: %#v", test.Name, err)
+		}
+		err = printer.PrintObj(test.Input, buf)
+		if len(test.Error) == 0 && err != nil {
+			t.Errorf("in %s, unexpected error: %v", test.Name, err)
+			continue
+		}
+		if len(test.Error) > 0 {
+			if err == nil {
+				t.Errorf("in %s, expected to get error: %v", test.Name, test.Error)
+			} else if e, a := test.Error, err.Error(); e != a {
+				t.Errorf("in %s, expected error %q, got %q", test.Name, e, a)
+			}
+			continue
+		}
+		if buf.String() != test.Expect {
+			t.Errorf("in %s, expect %q, got %q", test.Name, test.Expect, buf.String())
+		}
 	}
 }


### PR DESCRIPTION
Cherry pick of #39486 #39895 #39038 on release-1.5.

#39486: Allow missing keys in templates by default
#39895: Fix expected error text
#39038: Fix kubectl get -f <file> -o <nondefault printer>