### PR TITLE
dnsprovider: Add IsEmpty method

### DIFF
--- a/federation/pkg/dnsprovider/dns.go
+++ b/federation/pkg/dnsprovider/dns.go
@@ -45,7 +45,7 @@ type Zone interface {
 	Name() string
 	// ID returns the unique provider identifier for the zone
 	ID() string
-	// ResourceRecordsets returns the provider's ResourceRecordSets interface, or false if not supported.
+	// ResourceRecordSets returns the provider's ResourceRecordSets interface, or false if not supported.
 	ResourceRecordSets() (ResourceRecordSets, bool)
 }
 
@@ -70,6 +70,8 @@ type ResourceRecordChangeset interface {
 	Remove(ResourceRecordSet) ResourceRecordChangeset
 	// Apply applies the accumulated operations to the Zone.
 	Apply() error
+	// IsEmpty returns true if there are no accumulated operations.
+	IsEmpty() bool
 }
 
 type ResourceRecordSet interface {

--- a/federation/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
@@ -99,3 +99,7 @@ func (c *ResourceRecordChangeset) Apply() error {
 	}
 	return nil
 }
+
+func (c *ResourceRecordChangeset) IsEmpty() bool {
+	return len(c.removals) == 0 && len(c.additions) == 0
+}

--- a/federation/pkg/dnsprovider/providers/coredns/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/coredns/rrchangeset.go
@@ -58,6 +58,10 @@ func (c *ResourceRecordChangeset) Remove(rrset dnsprovider.ResourceRecordSet) dn
 	return c
 }
 
+func (c *ResourceRecordChangeset) IsEmpty() bool {
+	return len(c.changeset) == 0
+}
+
 func (c *ResourceRecordChangeset) Apply() error {
 	ctx := context.Background()
 	etcdPathPrefix := c.zone.zones.intf.etcdPathPrefix

--- a/federation/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go
@@ -72,3 +72,7 @@ func (c *ResourceRecordChangeset) Apply() error {
 
 	return nil
 }
+
+func (c *ResourceRecordChangeset) IsEmpty() bool {
+	return len(c.additions) == 0 && len(c.removals) == 0
+}


### PR DESCRIPTION
When batching changes, it is often handy to know whether a changeset
IsEmpty, and thus does not need to be Apply-ed.

```release-note
NONE
```
