### PR TITLE
dnsprovider: Expose parent objects in interfaces

### DIFF
--- a/federation/pkg/dnsprovider/dns.go
+++ b/federation/pkg/dnsprovider/dns.go
@@ -59,6 +59,8 @@ type ResourceRecordSets interface {
 	New(name string, rrdatas []string, ttl int64, rrstype rrstype.RrsType) ResourceRecordSet
 	// StartChangeset begins a new batch operation of changes against the Zone
 	StartChangeset() ResourceRecordChangeset
+	// Zone returns the parent zone
+	Zone() Zone
 }
 
 // ResourceRecordChangeset accumulates a set of changes, that can then be applied with Apply
@@ -76,6 +78,8 @@ type ResourceRecordChangeset interface {
 	Apply() error
 	// IsEmpty returns true if there are no accumulated operations.
 	IsEmpty() bool
+	// ResourceRecordSets returns the parent ResourceRecordSets
+	ResourceRecordSets() ResourceRecordSets
 }
 
 type ResourceRecordSet interface {

--- a/federation/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
@@ -114,3 +114,8 @@ func (c *ResourceRecordChangeset) Apply() error {
 func (c *ResourceRecordChangeset) IsEmpty() bool {
 	return len(c.removals) == 0 && len(c.additions) == 0
 }
+
+// ResourceRecordSets returns the parent ResourceRecordSets
+func (c *ResourceRecordChangeset) ResourceRecordSets() dnsprovider.ResourceRecordSets {
+	return c.rrsets
+}

--- a/federation/pkg/dnsprovider/providers/aws/route53/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/rrsets.go
@@ -88,3 +88,8 @@ func (r ResourceRecordSets) New(name string, rrdatas []string, ttl int64, rrstyp
 		&r,
 	}
 }
+
+// Zone returns the parent zone
+func (rrset ResourceRecordSets) Zone() dnsprovider.Zone {
+	return rrset.zone
+}

--- a/federation/pkg/dnsprovider/providers/coredns/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/coredns/rrchangeset.go
@@ -124,6 +124,11 @@ func (c *ResourceRecordChangeset) Apply() error {
 	return nil
 }
 
+// ResourceRecordSets returns the parent ResourceRecordSets
+func (c *ResourceRecordChangeset) ResourceRecordSets() dnsprovider.ResourceRecordSets {
+	return c.rrsets
+}
+
 func getHash(text string) string {
 	h := fnv.New32a()
 	h.Write([]byte(text))

--- a/federation/pkg/dnsprovider/providers/coredns/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/coredns/rrsets.go
@@ -104,6 +104,11 @@ func (rrsets ResourceRecordSets) New(name string, rrdatas []string, ttl int64, r
 	}
 }
 
+// Zone returns the parent zone
+func (rrset ResourceRecordSets) Zone() dnsprovider.Zone {
+	return rrset.zone
+}
+
 func emptyResponse(resp *etcdc.Response) bool {
 	return resp == nil || resp.Node == nil || (len(resp.Node.Value) == 0 && len(resp.Node.Nodes) == 0)
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/rrchangeset.go
@@ -117,3 +117,8 @@ func (c *ResourceRecordChangeset) Apply() error {
 func (c *ResourceRecordChangeset) IsEmpty() bool {
 	return len(c.additions) == 0 && len(c.removals) == 0
 }
+
+// ResourceRecordSets returns the parent ResourceRecordSets
+func (c *ResourceRecordChangeset) ResourceRecordSets() dnsprovider.ResourceRecordSets {
+	return c.rrsets
+}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/rrsets.go
@@ -70,3 +70,8 @@ func (r ResourceRecordSets) New(name string, rrdatas []string, ttl int64, rrstyp
 func (rrsets ResourceRecordSets) project() string {
 	return rrsets.zone.project()
 }
+
+// Zone returns the parent zone
+func (rrset ResourceRecordSets) Zone() dnsprovider.Zone {
+	return rrset.zone
+}


### PR DESCRIPTION
This will allow us to pass e.g. a ResourceRecordChangeset, rather than a
ResourceRecordChangeset, the parent ResourceRecordSets, and the
grandparent Zone.

Laying the groundwork for simplifying / optimizing the federation logic.

```release-note
NONE
```
