### PR TITLE
route53 dnsprovider: add more logging

### DIFF
--- a/federation/pkg/dnsprovider/providers/aws/route53/BUILD
+++ b/federation/pkg/dnsprovider/providers/aws/route53/BUILD
@@ -25,8 +25,10 @@ go_library(
         "//federation/pkg/dnsprovider/providers/aws/route53/stubs:go_default_library",
         "//federation/pkg/dnsprovider/rrstype:go_default_library",
         "//vendor:github.com/aws/aws-sdk-go/aws",
+        "//vendor:github.com/aws/aws-sdk-go/aws/request",
         "//vendor:github.com/aws/aws-sdk-go/aws/session",
         "//vendor:github.com/aws/aws-sdk-go/service/route53",
+        "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/util/uuid",
     ],
 )

--- a/federation/pkg/dnsprovider/providers/aws/route53/route53.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/route53.go
@@ -20,10 +20,11 @@ package route53
 import (
 	"io"
 
-	"k8s.io/kubernetes/federation/pkg/dnsprovider"
-
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
 
 const (
@@ -36,9 +37,29 @@ func init() {
 	})
 }
 
+// route53HandlerLogger is a request handler for aws-sdk-go that logs route53 requests
+func route53HandlerLogger(req *request.Request) {
+	service := req.ClientInfo.ServiceName
+
+	name := "?"
+	if req.Operation != nil {
+		name = req.Operation.Name
+	}
+
+	glog.V(4).Infof("AWS request: %s %s", service, name)
+}
+
 // newRoute53 creates a new instance of an AWS Route53 DNS Interface.
 func newRoute53(config io.Reader) (*Interface, error) {
 	// Connect to AWS Route53 - TODO: Do more sophisticated auth
+
 	svc := route53.New(session.New())
+
+	// Add our handler that will log requests
+	svc.Handlers.Sign.PushFrontNamed(request.NamedHandler{
+		Name: "k8s/logger",
+		Fn:   route53HandlerLogger,
+	})
+
 	return New(svc), nil
 }


### PR DESCRIPTION
In the aws cloudprovider, we have a custom logger.  This adds the same
logger to the route53 dnsprovider.

We copy the (simple) code in anticipation that the providers are likely
to live in separate repos in future.

```release-note
federation aws: add logging of route53 calls
```
