### PR TITLE
Kubelet-rkt: Support a Pod annotation to create directories on the host

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -105,6 +105,10 @@ const (
 	k8sRktStage1NameAnno = "rkt.alpha.kubernetes.io/stage1-name-override"
 	dockerPrefix         = "docker://"
 
+	// This annotation allows a k8s rkt runtime to create directories inside the Systemd with
+	// ExecStartPre=/bin/mkdir -pv content-of-the-annotation
+	k8sRktHostCreateDirectories = "rkt.kubernetes.io/host-create-directories"
+
 	authDir            = "auth.d"
 	dockerAuthTemplate = `{"rktKind":"dockerAuth","rktVersion":"v1","registries":[%q],"credentials":{"user":%q,"password":%q}}`
 
@@ -1116,6 +1120,15 @@ func (r *Runtime) getSelinuxContext(opt *v1.SELinuxOptions) (string, error) {
 	return strings.Join(ctx, ":"), nil
 }
 
+// Rkt doesn't create the directory if not existing
+// Use the annotations of the Pod to create an ExecStartPre=/bin/mkdir -pv [...]
+func hostCreateDirectoriesByAnnotations(annotations map[string]string) (string, bool) {
+	if val, ok := annotations[k8sRktHostCreateDirectories]; ok {
+		return "/bin/mkdir -pv " + val, true
+	}
+	return "", false
+}
+
 // From the generateName or the podName return a basename for improving the logging with the Journal
 // journalctl -t podBaseName
 func constructSyslogIdentifier(generateName string, podName string) string {
@@ -1202,6 +1215,10 @@ func (r *Runtime) preparePod(pod *v1.Pod, podIP string, pullSecrets []v1.Secret,
 		newUnitOption(unitKubernetesSection, unitPodName, pod.Name),
 		newUnitOption(unitKubernetesSection, unitPodNamespace, pod.Namespace),
 		newUnitOption(unitKubernetesSection, unitPodHostNetwork, fmt.Sprintf("%v", hostNetwork)),
+	}
+	// Volumes Handler
+	if mkdirCommand, ok := hostCreateDirectoriesByAnnotations(pod.Annotations); ok {
+		units = append(units, newUnitOption("Service", "ExecStartPre", mkdirCommand))
 	}
 
 	if pod.Spec.SecurityContext != nil && pod.Spec.SecurityContext.SELinuxOptions != nil {

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -1996,3 +1996,29 @@ func TestConstructSyslogIdentifier(t *testing.T) {
 		assert.Equal(t, testCase.identifier, identifier, fmt.Sprintf("Test case #%d", i))
 	}
 }
+
+func TestHostCreateDirectoriesByAnnotations(t *testing.T) {
+	testCases := []struct {
+		annotation map[string]string
+		expectCmd  string
+	}{
+		{
+			map[string]string{
+				"rkt.kubernetes.io/host-create-directories": "/tmp/volume-0",
+			},
+			"/bin/mkdir -pv /tmp/volume-0",
+		},
+		{
+			map[string]string{
+				"rkt.kubernetes.io/host-create-directories": "/tmp/volume-0 /tmp/volume-1",
+			},
+			"/bin/mkdir -pv /tmp/volume-0 /tmp/volume-1",
+		},
+	}
+
+	for i, testCase := range testCases {
+		mkdir, _ := hostCreateDirectoriesByAnnotations(testCase.annotation)
+		cmd := newUnitOption("Service", "ExecStartPre", mkdir)
+		assert.Equal(t, testCase.expectCmd, cmd.Value, fmt.Sprintf("Test case #%d", i))
+	}
+}


### PR DESCRIPTION
Rkt runtime fail to start if the directory for the associated volume is missing
Create a Systemd **ExecStartPre** inside the **[Service]** to do so.

**What this PR does / why we need it**:

With rkt as container runtime we cannot use volumes if the directory isn't here.
I decide to restrict the field to only creates directories instead of pass custom commands.

```
apiVersion: extensions/v1beta1
kind: DaemonSet
metadata:
  name: nginx-daemonset
  namespace: default
spec:
  template:
    metadata:
      annotations:
        rkt.kubernetes.io/host-create-directories: /tmp/nginx1 /tmp/nginx2
      labels:
        run: nginx-host
    spec:
      hostNetwork: true
      containers:
      - name: nginx-daemonset-pod
        image: quay.io/julienbalestra/nginx:latest
        command:
        - /usr/sbin/nginx
        - -g
        - daemon off;
```

The feature will create a specific field `ExecStartPre` like:

`ExecStartPre=/bin/mkdir -pv /tmp/nginx1 /tmp/nginx2`

Will lead to, obviously this:

```
ls -d /tmp/nginx*
/tmp/nginx1  /tmp/nginx2
```

If the annotation isn't fill, the `ExecStartPre` is not created.

**Special notes for your reviewer**:

We are trying to move from Fleet to Kubernetes with the rkt-runtime in production at Blablacar, we have severals `git format-patch` for this purpose.

The labels should be 

> area/rkt
> area/kubelet

```NONE
```

