### PR TITLE
dnsprovider route53: log changeset details at v(8)

### DIFF
--- a/federation/pkg/dnsprovider/providers/aws/route53/BUILD
+++ b/federation/pkg/dnsprovider/providers/aws/route53/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//vendor:github.com/aws/aws-sdk-go/aws",
         "//vendor:github.com/aws/aws-sdk-go/aws/session",
         "//vendor:github.com/aws/aws-sdk-go/service/route53",
+        "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/util/uuid",
     ],
 )

--- a/federation/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/rrchangeset.go
@@ -17,8 +17,12 @@ limitations under the License.
 package route53
 
 import (
+	"bytes"
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/route53"
+	"github.com/golang/glog"
 	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
 
@@ -91,6 +95,15 @@ func (c *ResourceRecordChangeset) Apply() error {
 
 	if len(changes) == 0 {
 		return nil
+	}
+
+	if glog.V(8) {
+		var sb bytes.Buffer
+		for _, change := range changes {
+			sb.WriteString(fmt.Sprintf("\t%s %s %s\n", aws.StringValue(change.Action), aws.StringValue(change.ResourceRecordSet.Type), aws.StringValue(change.ResourceRecordSet.Name)))
+		}
+
+		glog.V(8).Infof("Route53 Changeset:\n%s", sb.String())
 	}
 
 	service := c.zone.zones.interface_.service


### PR DESCRIPTION
Otherwise it can be hard to know exactly what is changing and whether
the changes could be optimized, or to troubleshoot if someone were
accidentally to have a bug in their calling code.

```release-note
NONE
```
