### PR TITLE
Kubelet-rkt: Add useful informations for Ops on the Kubelet Host

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1111,10 +1111,10 @@ func (r *Runtime) getSelinuxContext(opt *v1.SELinuxOptions) (string, error) {
 // From the generateName or the podName return a basename for improving the logging with the Journal
 // journalctl -t podBaseName
 func constructSyslogIdentifier(generateName string, podName string) string {
-	if (len(generateName) > 1 && generateName[len(generateName) - 1] == '-') {
-		return generateName[0:len(generateName) - 1]
+	if len(generateName) > 1 && generateName[len(generateName)-1] == '-' {
+		return generateName[0 : len(generateName)-1]
 	}
-	if (len(generateName) > 0) {
+	if len(generateName) > 0 {
 		return generateName
 	}
 	return podName

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1113,11 +1113,11 @@ func (r *Runtime) getSelinuxContext(opt *v1.SELinuxOptions) (string, error) {
 func constructSyslogIdentifier(generateName string, podName string) string {
 	if (len(generateName) > 1 && generateName[len(generateName) - 1] == '-') {
 		return generateName[0:len(generateName) - 1]
-	} else if (len(generateName) > 0) {
-		return generateName
-	} else {
-		return podName
 	}
+	if (len(generateName) > 0) {
+		return generateName
+	}
+	return podName
 }
 
 // preparePod will:

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1108,7 +1108,7 @@ func (r *Runtime) getSelinuxContext(opt *v1.SELinuxOptions) (string, error) {
 	return strings.Join(ctx, ":"), nil
 }
 
-// From the generateName or the podName return a basename for improve the logging with the Journal
+// From the generateName or the podName return a basename for improving the logging with the Journal
 // journalctl -t podBaseName
 func constructSyslogIdentifier(generateName string, podName string) string {
 	if (len(generateName) > 1 && generateName[len(generateName) - 1] == '-') {

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -1952,3 +1952,31 @@ func TestPreparePodArgs(t *testing.T) {
 		assert.Equal(t, testCase.cmd, cmd, fmt.Sprintf("Test case #%d", i))
 	}
 }
+
+func TestConstructSyslogIdentifier(t *testing.T) {
+	testCases := []struct {
+		podName     		string
+		podGenerateName 	string
+		identifier          	string
+	}{
+		{
+			"prometheus-node-exporter-rv90m",
+			"prometheus-node-exporter-",
+			"prometheus-node-exporter",
+		},
+		{
+			"simplepod",
+			"",
+			"simplepod",
+		},
+		{
+			"p",
+			"",
+			"p",
+		},
+	}
+	for i, testCase := range testCases {
+		identifier := constructSyslogIdentifier(testCase.podGenerateName, testCase.podName)
+		assert.Equal(t, testCase.identifier, identifier, fmt.Sprintf("Test case #%d", i))
+	}
+}

--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -1955,9 +1955,9 @@ func TestPreparePodArgs(t *testing.T) {
 
 func TestConstructSyslogIdentifier(t *testing.T) {
 	testCases := []struct {
-		podName     		string
-		podGenerateName 	string
-		identifier          	string
+		podName         string
+		podGenerateName string
+		identifier      string
 	}{
 		{
 			"prometheus-node-exporter-rv90m",


### PR DESCRIPTION
Create a Systemd SyslogIdentifier inside the [Service]
Create a Systemd Description inside the [Unit]

**What this PR does / why we need it**:

#### Overview
Logged against the host, it's difficult to identify who's who.
This PR add useful information to quickly get straight to the point with the **DESCRIPTION** field:

```
systemctl list-units "k8s*"
UNIT                                             LOAD   ACTIVE SUB     DESCRIPTION
k8s_b5a9bdf7-e396-4989-8df0-30a5fda7f94c.service loaded active running kube-controller-manager-172.20.0.206
k8s_bec0d8a1-dc15-4b47-a850-e09cf098646a.service loaded active running nginx-daemonset-gxm4s
k8s_d2981e9c-2845-4aa2-a0de-46e828f0c91b.service loaded active running kube-apiserver-172.20.0.206
k8s_fde4b0ab-87f8-4fd1-b5d2-3154918f6c89.service loaded active running kube-scheduler-172.20.0.206

```

#### Overview and Journal

Always on the host, to easily retrieve the pods logs, this PR add a SyslogIdentifier named as the PodBaseName.


```
# A DaemonSet prometheus-node-exporter is running on the Kubernetes Cluster
systemctl list-units "k8s*" | grep prometheus-node-exporter
k8s_c60a4b1a-387d-4fce-afa1-642d6f5716c1.service loaded active running prometheus-node-exporter-85cpp

# Get the logs from the prometheus-node-exporter DaemonSet 
journalctl -t prometheus-node-exporter | wc -l
278
```

Sadly the `journalctl` flag `-t` / `--identifier` doesn't allow a pattern to catch the logs.

Also this field improve any queries made by any tools who exports the Journal (E.g: ES, Kibana):
```
{
	"__CURSOR" : "s=86fd390d123b47af89bb15f41feb9863;i=164b2c27;b=7709deb3400841009e0acc2fec1ebe0e;m=1fe822ca4;t=54635e6a62285;x=b2d321019d70f36f",
	"__REALTIME_TIMESTAMP" : "1484572200411781",
	"__MONOTONIC_TIMESTAMP" : "8564911268",
	"_BOOT_ID" : "7709deb3400841009e0acc2fec1ebe0e",
	"PRIORITY" : "6",
	"_UID" : "0",
	"_GID" : "0",
	"_SYSTEMD_SLICE" : "system.slice",
	"_SELINUX_CONTEXT" : "system_u:system_r:kernel_t:s0",
	"_MACHINE_ID" : "7bbb4401667243da81671e23fd8a2246",
	"_HOSTNAME" : "Kubelet-Host",
	"_TRANSPORT" : "stdout",
	"SYSLOG_FACILITY" : "3",
	"_COMM" : "ld-linux-x86-64",
	"_CAP_EFFECTIVE" : "3fffffffff",
	"SYSLOG_IDENTIFIER" : "prometheus-node-exporter",
	"_PID" : "88827",
	"_EXE" : "/var/lib/rkt/pods/run/c60a4b1a-387d-4fce-afa1-642d6f5716c1/stage1/rootfs/usr/lib64/ld-2.21.so",
	"_CMDLINE" : "stage1/rootfs/usr/lib/ld-linux-x86-64.so.2 stage1/rootfs/usr/bin/systemd-nspawn [....]",
	"_SYSTEMD_CGROUP" : "/system.slice/k8s_c60a4b1a-387d-4fce-afa1-642d6f5716c1.service",
	"_SYSTEMD_UNIT" : "k8s_c60a4b1a-387d-4fce-afa1-642d6f5716c1.service",
	"MESSAGE" : "[ 8564.909237] prometheus-node-exporter[115]: time=\"2017-01-16T13:10:00Z\" level=info msg=\" - time\" source=\"node_exporter.go:157\""
}
```

