### PR TITLE
kubeadm: init must validate or generate token before anything else.

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -203,12 +203,12 @@ func (i *Init) Run(out io.Writer) error {
 	// Validate token if any, otherwise generate
 	if i.cfg.Discovery.Token != nil {
 		if i.cfg.Discovery.Token.ID != "" && i.cfg.Discovery.Token.Secret != "" {
-			fmt.Printf("[token-discovery] A token has been provided, validating [%+v]\n", i.cfg.Discovery.Token)
+			fmt.Printf("[token-discovery] A token has been provided, validating [%s]\n", kubeadmutil.BearerToken(i.cfg.Discovery.Token))
 			if valid, err := kubeadmutil.ValidateToken(i.cfg.Discovery.Token); valid == false {
 				return err
 			}
 		} else {
-			fmt.Printf("[token-discovery] A token has not been provided, generating one\n")
+			fmt.Println("[token-discovery] A token has not been provided, generating one")
 			if err := kubeadmutil.GenerateToken(i.cfg.Discovery.Token); err != nil {
 				return err
 			}

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -200,17 +200,18 @@ func (i *Init) Validate() error {
 // Run executes master node provisioning, including certificates, needed static pod manifests, etc.
 func (i *Init) Run(out io.Writer) error {
 
-	// PHASE 1: Generate certificates
-	caCert, err := certphase.CreatePKIAssets(i.cfg, kubeadmapi.GlobalEnvParams.HostPKIPath)
-	if err != nil {
-		return err
-	}
-
-	// Exception:
+	// Validate token if any, otherwise generate
 	if i.cfg.Discovery.Token != nil {
-		// Validate token
-		if valid, err := kubeadmutil.ValidateToken(i.cfg.Discovery.Token); valid == false {
-			return err
+		if i.cfg.Discovery.Token.ID != "" && i.cfg.Discovery.Token.Secret != "" {
+			fmt.Printf("[token-discovery] A token has been provided, validating [%+v]\n", i.cfg.Discovery.Token)
+			if valid, err := kubeadmutil.ValidateToken(i.cfg.Discovery.Token); valid == false {
+				return err
+			}
+		} else {
+			fmt.Printf("[token-discovery] A token has not been provided, generating one\n")
+			if err := kubeadmutil.GenerateToken(i.cfg.Discovery.Token); err != nil {
+				return err
+			}
 		}
 
 		// Make sure there is at least one address
@@ -225,6 +226,12 @@ func (i *Init) Run(out io.Writer) error {
 		if err := kubemaster.CreateTokenAuthFile(kubeadmutil.BearerToken(i.cfg.Discovery.Token)); err != nil {
 			return err
 		}
+	}
+
+	// PHASE 1: Generate certificates
+	caCert, err := certphase.CreatePKIAssets(i.cfg, kubeadmapi.GlobalEnvParams.HostPKIPath)
+	if err != nil {
+		return err
 	}
 
 	// PHASE 2: Generate kubeconfig files for the admin and the kubelet


### PR DESCRIPTION
**What this PR does / why we need it**: `kubeadm init` must validate or generate a token before anything else. Otherwise, if token validation or generation fail, one will need to run `kubeadm reset && systemctl restart kubelet` before re-running `kubeadm init`.

**Which issue this PR fixes**: fixes kubernetes/kubeadm#112

**Special notes for your reviewer**: /cc @luxas

Tested manually.

### With no token

```
$ sudo ./kubeadm init
[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.
[preflight] Running pre-flight checks
[init] Using Kubernetes version: v1.5.2
[token-discovery] A token has not been provided, generating one
[certificates] Generated Certificate Authority key and certificate.
[certificates] Generated API Server key and certificate
[certificates] Generated Service Account signing keys
[certificates] Created keys and certificates in "/etc/kubernetes/pki"
[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/admin.conf"
[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/kubelet.conf"
[apiclient] Created API client, waiting for the control plane to become ready
[apiclient] All control plane components are healthy after 7.762803 seconds
[apiclient] Waiting for at least one node to register and become ready
[apiclient] First node is ready after 1.003148 seconds
[apiclient] Creating a test deployment
[apiclient] Test deployment succeeded
[token-discovery] Using token: 8321b6:a535ba541af7623c
[token-discovery] Created the kube-discovery deployment, waiting for it to become ready
[token-discovery] kube-discovery is ready after 1.003423 seconds
[addons] Created essential addon: kube-proxy
[addons] Created essential addon: kube-dns
Your Kubernetes master has initialized successfully!
You should now deploy a pod network to the cluster.
Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
    http://kubernetes.io/docs/admin/addons/
You can now join any number of machines by running the following on each node:
kubeadm join --discovery token://8321b6:a535ba541af7623c@10.142.0.6:9898
```

### With invalid token

```
$ sudo ./kubeadm init --discovery token://12345:12345
[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.
[preflight] Running pre-flight checks
[init] Using Kubernetes version: v1.5.2
[token-discovery] A token has been provided, validating [&{ID:12345 Secret:12345 Addresses:[]}]
token ["12345:12345"] was not of form ["^([a-z0-9]{6})\\:([a-z0-9]{16})$"]
```

### With valid token

```
$ sudo ./kubeadm ex token generate
cd540e:c0e0318e2f4a63b1

$ sudo ./kubeadm init --discovery token://cd540e:c0e0318e2f4a63b1
[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.
[preflight] Running pre-flight checks
[init] Using Kubernetes version: v1.5.2
[token-discovery] A token has been provided, validating [&{ID:cd540e Secret:c0e0318e2f4a63b1 Addresses:[]}]
[certificates] Generated Certificate Authority key and certificate.
[certificates] Generated API Server key and certificate
[certificates] Generated Service Account signing keys
[certificates] Created keys and certificates in "/etc/kubernetes/pki"
[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/admin.conf"
[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/kubelet.conf"
[apiclient] Created API client, waiting for the control plane to become ready
[apiclient] All control plane components are healthy after 13.513305 seconds
[apiclient] Waiting for at least one node to register and become ready
[apiclient] First node is ready after 0.502656 seconds
[apiclient] Creating a test deployment
[apiclient] Test deployment succeeded
[token-discovery] Using token: cd540e:c0e0318e2f4a63b1
[token-discovery] Created the kube-discovery deployment, waiting for it to become ready
[token-discovery] kube-discovery is ready after 2.002457 seconds
[addons] Created essential addon: kube-proxy
[addons] Created essential addon: kube-dns
Your Kubernetes master has initialized successfully!
You should now deploy a pod network to the cluster.
Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
    http://kubernetes.io/docs/admin/addons/
You can now join any number of machines by running the following on each node:
kubeadm join --discovery token://cd540e:c0e0318e2f4a63b1@10.142.0.6:9898
```

**Release note**:
```release-note
NONE
```
