### PR TITLE
Make CACHEBUST for hyperkube build optional

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -21,6 +21,7 @@ REGISTRY?=gcr.io/google_containers
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 CNI_RELEASE=07a8a28637e97b22eb8dfe710eeae1344f69d16e
+CACHEBUST?=1
 
 UNAME_S:=$(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
@@ -78,7 +79,9 @@ endif
 	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${ARCH}|g" addons/singlenode/*.yaml addons/multinode/*.yaml static-pods/*.json
 	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${QEMUARCH}|g" Dockerfile
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
+ifeq ($(CACHEBUST),1)
 	cd ${TEMP_DIR} && sed -i.back "s|CACHEBUST|$(shell uuidgen)|g" Dockerfile
+endif
 	cd ${TEMP_DIR} && sed -i.back "s|-amd64|-${ARCH}|g" addons/singlenode/*.yaml addons/multinode/*.yaml
 	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__SERVER__|10.0.0.10|g" addons/singlenode/kubedns*.yaml addons/multinode/kubedns*.yaml
 	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__DOMAIN__|cluster.local|g;s|__PILLAR__FEDERATIONS__DOMAIN__MAP__||g;" addons/singlenode/kubedns*.yaml addons/multinode/kubedns*.yaml


### PR DESCRIPTION
**What this PR does / why we need it**: It makes CACHEBUST for the hyperkube build optional. Currently, building the hyperkube always results in a full rebuild, including retrieving and installing of all debian packages. This is a good thing for releases, but makes live as a dev hard.

This allows to do something like this:
```
$ REGISTRY=<registry> VERSION=<version> CACHEBUST=0 ./hack/dev-push-hyperkube.sh
```

Probably we should even make CACHEBUST=0 the default when calling dev-xxx.sh scripts.

CC: @aaronlevy