### PR TITLE
Sync fluentd daemonset liveness probe with static pod liveness probe

### DIFF
--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -51,10 +51,23 @@ spec:
         - '/bin/sh'
         - '-c'
         - >
-          LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-600};
+          LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+          STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
+          if [ ! -e /var/log/fluentd-buffers ];
+          then
+            exit 1;
+          fi;
           LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
           LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
-          if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ]; then exit 1; fi;
+          if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
+          then
+            rm -rf /var/log/fluentd-buffers;
+            exit 1;
+          fi;
+          if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ];
+          then
+            exit 1;
+          fi;
   terminationGracePeriodSeconds: 30
   volumes:
   - name: varlog


### PR DESCRIPTION
Syncing change from https://github.com/kubernetes/kubernetes/pull/39949

Should also be cherry-picked