### PR TITLE
Remove library copying from fluentd image

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -2,23 +2,23 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: fluentd-gcp-v1.31
+  name: fluentd-gcp-v1.33
   namespace: kube-system
   labels:
     k8s-app: fluentd-gcp
     kubernetes.io/cluster-service: "true"
-    version: v1.31
+    version: v1.33
 spec:
   template:
     metadata:
       labels:
         k8s-app: fluentd-gcp
         kubernetes.io/cluster-service: "true"
-        version: v1.31
+        version: v1.33
     spec:
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google_containers/fluentd-gcp:1.32
+        image: gcr.io/google_containers/fluentd-gcp:1.33
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
         # tries to send this message to the server => fails to send a chunk and so on.
@@ -40,8 +40,6 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
-        - name: libsystemddir
-          mountPath: /host/lib
         # Liveness probe is aimed to help in situarions where fluentd
         # silently hangs for no apparent reasons until manual restart.
         # The idea of this probe is that if fluentd is not queueing or
@@ -84,6 +82,3 @@ spec:
       - name: varlibdockercontainers
         hostPath:
           path: /var/lib/docker/containers
-      - name: libsystemddir
-        hostPath:
-          path: /usr/lib64

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -26,7 +26,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google_containers
-TAG = 1.32
+TAG = 1.33
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/run.sh
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/run.sh
@@ -17,12 +17,6 @@
 # For systems without journald
 mkdir -p /var/log/journal
 
-if [ -e /host/lib/libsystemd* ]
-then
-  rm /lib/x86_64-linux-gnu/libsystemd*
-  cp /host/lib/libsystemd* /lib/x86_64-linux-gnu/
-fi
-
 LD_PRELOAD=/opt/td-agent/embedded/lib/libjemalloc.so
 RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR=0.9
 

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -10,7 +10,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.32
+    image: gcr.io/google_containers/fluentd-gcp:1.33
     # If fluentd consumes its own logs, the following situation may happen:
     # fluentd fails to send a chunk to the server => writes it to the log =>
     # tries to send this message to the server => fails to send a chunk and so on.
@@ -34,8 +34,6 @@ spec:
     - name: varlibdockercontainers
       mountPath: /var/lib/docker/containers
       readOnly: true
-    - name: libsystemddir
-      mountPath: /host/lib
     # Liveness probe is aimed to help in situarions where fluentd
     # silently hangs for no apparent reasons until manual restart.
     # The idea of this probe is that if fluentd is not queueing or
@@ -63,6 +61,3 @@ spec:
   - name: varlibdockercontainers
     hostPath:
       path: /var/lib/docker/containers
-  - name: libsystemddir
-    hostPath:
-      path: /usr/lib64


### PR DESCRIPTION
It seems that fluentd can no longer copy systemd libraries from host to be able to read journals.