### PR TITLE
add heapster role

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -172,6 +172,13 @@ func ClusterRoles() []rbac.ClusterRole {
 			},
 		},
 		{
+			// a role to use for heapster's connections back to the API server
+			ObjectMeta: api.ObjectMeta{Name: "system:heapster"},
+			Rules: []rbac.PolicyRule{
+				rbac.NewRule(Read...).Groups(legacyGroup).Resources("events", "pods", "nodes", "namespaces").RuleOrDie(),
+			},
+		},
+		{
 			// a role for nodes to use to have the access they need for running pods
 			ObjectMeta: api.ObjectMeta{Name: "system:node"},
 			Rules: []rbac.PolicyRule{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -394,6 +394,26 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: system:heapster
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - events
+    - namespaces
+    - nodes
+    - pods
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1alpha1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:kube-aggregator
   rules:
   - apiGroups:


### PR DESCRIPTION
heapster is a very standard add-on.  this adds a role for heapster to use when running, but does not automatically bind it.

@liggitt ptal

Built based on inspection of heapster:
 1. https://github.com/kubernetes/heapster/blob/master/events/sources/kubernetes/kubernetes_source.go - events
 1. https://github.com/kubernetes/heapster/blob/master/metrics/heapster.go - nodes, pods
 2. https://github.com/kubernetes/heapster/blob/master/metrics/processors/namespace_based_enricher.go - namespaces
