### PR TITLE
azure disk: restrict length of name

### DIFF
--- a/pkg/volume/azure_dd/azure_provision.go
+++ b/pkg/volume/azure_dd/azure_provision.go
@@ -107,7 +107,8 @@ var _ volume.Provisioner = &azureDiskProvisioner{}
 func (a *azureDiskProvisioner) Provision() (*v1.PersistentVolume, error) {
 	var sku, location, account string
 
-	name := volume.GenerateVolumeName(a.options.ClusterName, a.options.PVName, 255)
+	// maxLength = 79 - (4 for ".vhd") = 75
+	name := volume.GenerateVolumeName(a.options.ClusterName, a.options.PVName, 75)
 	capacity := a.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	requestBytes := capacity.Value()
 	requestGB := int(volume.RoundUpSize(requestBytes, 1024*1024*1024))


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes dynamic disk provisioning on Azure by properly truncating the disk name to conform to the Azure API spec.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
n/a

**Special notes for your reviewer**:
n/a

**Release note**:
```release-note
azure disk: restrict name length for Azure specifications
```

cc: @rootfs