### PR TITLE
Limit kubeadm anonymous auth flag to [1.5.0, 1.6.0-alpha.0]

### DIFF
--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -60,6 +60,8 @@ var (
 
 	// Minimum version of kube-apiserver that has to have --anonymous-auth=false set
 	anonAuthDisableAPIServerMinVersion = semver.MustParse("1.5.0")
+	// Maximum version of kube-apiserver that has to have --anonymous-auth=false set
+	anonAuthDisableAPIServerMaxVersion = semver.MustParse("1.6.0-alpha.0")
 )
 
 // WriteStaticPodManifests builds manifest objects based on user provided configuration and then dumps it to disk
@@ -360,8 +362,8 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, selfHosted bool) [
 			command = append(command, "--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname")
 		}
 
-		// This is a critical "bugfix". Any version above this is vulnarable unless a RBAC/ABAC-authorizer is provided (which kubeadm doesn't for the time being)
-		if err == nil && k8sVersion.GTE(anonAuthDisableAPIServerMinVersion) {
+		// Versions in this range are vulnerable with anonymous auth enabled unless a RBAC/ABAC-authorizer is provided (which kubeadm doesn't for the time being)
+		if err == nil && k8sVersion.GTE(anonAuthDisableAPIServerMinVersion) && k8sVersion.LTE(anonAuthDisableAPIServerMaxVersion) {
 			command = append(command, "--anonymous-auth=false")
 		}
 	}

--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -463,6 +463,61 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--etcd-servers=http://127.0.0.1:2379",
 			},
 		},
+		// Make sure --kubelet-preferred-address-types
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:               kubeadm.API{Port: 123, AdvertiseAddresses: []string{"foo"}},
+				Networking:        kubeadm.Networking{ServiceSubnet: "bar"},
+				KubernetesVersion: "v1.6.0-alpha.0",
+			},
+			expected: []string{
+				"kube-apiserver",
+				"--insecure-bind-address=127.0.0.1",
+				"--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota",
+				"--service-cluster-ip-range=bar",
+				"--service-account-key-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver.key",
+				"--client-ca-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/ca.crt",
+				"--tls-cert-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver.crt",
+				"--tls-private-key-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver.key",
+				"--kubelet-client-certificate=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver-kubelet-client.crt",
+				"--kubelet-client-key=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver-kubelet-client.key",
+				"--token-auth-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/tokens.csv",
+				fmt.Sprintf("--secure-port=%d", 123),
+				"--allow-privileged",
+				"--storage-backend=etcd3",
+				"--advertise-address=foo",
+				"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+				"--anonymous-auth=false",
+				"--etcd-servers=http://127.0.0.1:2379",
+			},
+		},
+		// Make sure --anonymous-auth is not disabled past 1.6.0-alpha.0
+		{
+			cfg: &kubeadmapi.MasterConfiguration{
+				API:               kubeadm.API{Port: 123, AdvertiseAddresses: []string{"foo"}},
+				Networking:        kubeadm.Networking{ServiceSubnet: "bar"},
+				KubernetesVersion: "v1.6.0-alpha.1",
+			},
+			expected: []string{
+				"kube-apiserver",
+				"--insecure-bind-address=127.0.0.1",
+				"--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,ResourceQuota",
+				"--service-cluster-ip-range=bar",
+				"--service-account-key-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver.key",
+				"--client-ca-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/ca.crt",
+				"--tls-cert-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver.crt",
+				"--tls-private-key-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver.key",
+				"--kubelet-client-certificate=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver-kubelet-client.crt",
+				"--kubelet-client-key=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/apiserver-kubelet-client.key",
+				"--token-auth-file=" + kubeadmapi.GlobalEnvParams.HostPKIPath + "/tokens.csv",
+				fmt.Sprintf("--secure-port=%d", 123),
+				"--allow-privileged",
+				"--storage-backend=etcd3",
+				"--advertise-address=foo",
+				"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+				"--etcd-servers=http://127.0.0.1:2379",
+			},
+		},
 	}
 
 	for _, rt := range tests {


### PR DESCRIPTION
The in-tree authorizers have been modified to make legacy clusters safe to start with --anonymous-auth enabled

RBAC: https://github.com/kubernetes/kubernetes/pull/38981 makes grants to User * only match authenticated users

ABAC: https://github.com/kubernetes/kubernetes/pull/38968 makes grants to User or Group * only match authenticated users

AlwaysAllow: https://github.com/kubernetes/kubernetes/pull/38706 disables anonymous auth if the AlwaysAllow authorizer is set

This limits the --anonymous-auth flag to versions between 1.5.0 and 1.6.0-alpha.0, inclusive