### PR TITLE
Add node TLS bootstrapping role

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -224,6 +224,16 @@ func ClusterRoles() []rbac.ClusterRole {
 			},
 		},
 		{
+			// a role to use for bootstrapping a node's client certificates
+			ObjectMeta: api.ObjectMeta{Name: "system:node-bootstrapper"},
+			Rules: []rbac.PolicyRule{
+				// used to check if the node already exists
+				rbac.NewRule("get").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+				// used to create a certificatesigningrequest for a node-specific client certificate, and watch for it to be signed
+				rbac.NewRule("create", "get", "list", "watch").Groups(certificatesGroup).Resources("certificatesigningrequests").RuleOrDie(),
+			},
+		},
+		{
 			// a role to use for allowing authentication and authorization delegation
 			ObjectMeta: api.ObjectMeta{Name: "system:auth-delegator"},
 			Rules: []rbac.PolicyRule{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -603,6 +603,31 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: system:node-bootstrapper
+  rules:
+  - apiGroups:
+    - ""
+    attributeRestrictions: null
+    resources:
+    - nodes
+    verbs:
+    - get
+  - apiGroups:
+    - certificates.k8s.io
+    attributeRestrictions: null
+    resources:
+    - certificatesigningrequests
+    verbs:
+    - create
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1alpha1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:node-proxier
   rules:
   - apiGroups:


### PR DESCRIPTION
Adds a role describing permissions needed to complete the kubelet client bootstrap flow. Needed by kubeadm in https://github.com/kubernetes/kubernetes/pull/39846#discussion_r96491471