### PR TITLE
add node problem detector role

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -220,6 +220,16 @@ func ClusterRoles() []rbac.ClusterRole {
 			},
 		},
 		{
+			// a role to use for node-problem-detector access.  It does not get bound to default location since
+			// deployment locations can reasonably vary.
+			ObjectMeta: metav1.ObjectMeta{Name: "system:node-problem-detector"},
+			Rules: []rbac.PolicyRule{
+				rbac.NewRule("get").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+				rbac.NewRule("patch").Groups(legacyGroup).Resources("nodes/status").RuleOrDie(),
+				eventsRule(),
+			},
+		},
+		{
 			// a role to use for setting up a proxy
 			ObjectMeta: metav1.ObjectMeta{Name: "system:node-proxier"},
 			Rules: []rbac.PolicyRule{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -600,6 +600,34 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: system:node-problem-detector
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - get
+  - apiGroups:
+    - ""
+    resources:
+    - nodes/status
+    verbs:
+    - patch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1alpha1
+  kind: ClusterRole
+  metadata:
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:node-proxier
   rules:
   - apiGroups:


### PR DESCRIPTION
Adds a node problem detector role based on https://github.com/kubernetes/node-problem-detector/blob/master/pkg/problemclient/problem_client.go

