### PR TITLE
Enable streaming proxy redirects by default (beta)

### DIFF
--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -61,7 +61,7 @@ var (
 		appArmor:                                    {true, beta},
 		dynamicKubeletConfig:                        {false, alpha},
 		dynamicVolumeProvisioning:                   {true, alpha},
-		streamingProxyRedirects:                     {false, alpha},
+		streamingProxyRedirects:                     {true, beta},
 		experimentalHostUserNamespaceDefaultingGate: {false, alpha},
 	}
 


### PR DESCRIPTION
Prerequisite to moving CRI to Beta.

I'd like to enable this early in our 1.6 cycle to get plenty of test coverage before release.

@yujuhong @liggitt 

```release-note
Follow redirects for streaming requests (exec/attach/port-forward) in the apiserver by default (alpha -> beta).
```