### PR TITLE
updated root owners file to match new format

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,11 @@
-assignees:
+reviewers:
+  - brendandburns
+  - dchen1107
+  - jbeda
+  - lavalamp
+  - smarterclayton
+  - thockin
+approvers:
   - bgrant0607
   - brendandburns
   - dchen1107

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -1,4 +1,10 @@
-assignees:
+reviewers:
+  - ihmccreery
+  - ixdy
+  - jbeda
+  - lavalamp
+  - zmerlynn
+approvers:
   - ihmccreery
   - ixdy
   - jbeda

--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -1,4 +1,10 @@
-assignees:
+reviewers:
+  - eparis
+  - jbeda
+  - mikedanese
+  - roberthbailey
+  - zmerlynn
+approvers:
   - eparis
   - jbeda
   - mikedanese

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -1,4 +1,9 @@
-assignees:
+reviewers:
+  - dchen1107
+  - lavalamp
+  - mikedanese
+  - thockin
+approvers:
   - dchen1107
   - lavalamp
   - mikedanese

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,4 +1,8 @@
-assignees:
+reviewers:
+  - brendandburns
+  - smarterclayton
+  - thockin
+approvers:
   - bgrant0607
   - brendandburns
   - smarterclayton

--- a/examples/OWNERS
+++ b/examples/OWNERS
@@ -1,4 +1,8 @@
-assignees:
+reviewers:
+  - brendandburns
+  - thockin
+  - zmerlynn
+approvers:
   - bgrant0607
   - brendandburns
   - thockin

--- a/federation/OWNERS
+++ b/federation/OWNERS
@@ -1,5 +1,9 @@
-assignees:
-  - quinton-hoole
+reviewers:
+  - madhusudancs
+  - mml
+  - nikhiljindal
+  - colhom
+approvers:
   - madhusudancs
   - mml
   - nikhiljindal

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -1,4 +1,12 @@
-assignees:
+reviewers:
+  - eparis
+  - ihmccreery
+  - ixdy
+  - jbeda
+  - lavalamp
+  - spxtr
+  - zmerlynn
+approvers:
   - eparis
   - ihmccreery
   - ixdy

--- a/logo/OWNERS
+++ b/logo/OWNERS
@@ -1,2 +1,4 @@
-assignees:
+reviewers:
+  - thockin
+approvers:
   - thockin

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -1,4 +1,10 @@
-assignees:
+reviewers:
+  - brendandburns
+  - dchen1107
+  - lavalamp
+  - smarterclayton
+  - thockin
+approvers:
   - brendandburns
   - dchen1107
   - lavalamp

--- a/plugin/OWNERS
+++ b/plugin/OWNERS
@@ -1,4 +1,10 @@
-assignees:
+reviewers:
+  - brendandburns
+  - davidopp
+  - dchen1107
+  - lavalamp
+  - thockin
+approvers:
   - brendandburns
   - davidopp
   - dchen1107

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -1,4 +1,8 @@
-assignees:
+reviewers:
+  - fejta
+  - ixdy
+  - spxtr
+approvers:
   - fejta
   - ixdy
   - spxtr


### PR DESCRIPTION
**What this PR does / why we need it**:

Approvers mechanism will be running in kubernetes/kubernetes soon.  The leaf OWNERs files are being curated manually and the root OWNERS file should stay largely unchanged, the list names should be changed to `approvers` and `reviewers`

**Release note**:
```NONE
```
