### PR TITLE
kubeadm: adding integration tests for init

### DIFF
--- a/cmd/kubeadm/test/cmd/BUILD
+++ b/cmd/kubeadm/test/cmd/BUILD
@@ -16,7 +16,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["token_test.go"],
+    srcs = [
+        "init_test.go",
+        "token_test.go",
+    ],
     args = ["--kubeadm-path=../../kubeadm"],
     data = ["//cmd/kubeadm"],
     library = ":go_default_library",

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -20,11 +20,16 @@ import "testing"
 
 // kubeadmReset executes "kubeadm reset" and restarts kubelet.
 func kubeadmReset() error {
-	_, _, err := RunCmd(kubeadmPath, "reset")
+	_, _, err := RunCmd(*kubeadmPath, "reset")
 	return err
 }
 
 func TestCmdInitToken(t *testing.T) {
+	if *kubeadmCmdSkip {
+		t.Log("kubeadm cmd tests being skipped")
+		t.Skip()
+	}
+
 	var initTest = []struct {
 		args     string
 		expected bool
@@ -34,7 +39,7 @@ func TestCmdInitToken(t *testing.T) {
 	}
 
 	for _, rt := range initTest {
-		_, _, actual := RunCmd(kubeadmPath, "init", rt.args, "--skip-preflight-checks")
+		_, _, actual := RunCmd(*kubeadmPath, "init", rt.args, "--skip-preflight-checks")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed CmdInitToken running 'kubeadm init %s' with an error: %v\n\texpected: %t\n\t  actual: %t",

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import "testing"
+
+// kubeadmReset executes "kubeadm reset" and restarts kubelet.
+func kubeadmReset() error {
+	_, _, err := RunCmd(kubeadmPath, "reset")
+	return err
+}
+
+func TestCmdInitToken(t *testing.T) {
+	var initTest = []struct {
+		args     string
+		expected bool
+	}{
+		{"--discovery=token://abcd:1234567890abcd", false},     // invalid token size
+		{"--discovery=token://Abcdef:1234567890abcdef", false}, // invalid token non-lowercase
+	}
+
+	for _, rt := range initTest {
+		_, _, actual := RunCmd(kubeadmPath, "init", rt.args, "--skip-preflight-checks")
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed CmdInitToken running 'kubeadm init %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+				rt.args,
+				actual,
+				rt.expected,
+				(actual == nil),
+			)
+		}
+		kubeadmReset()
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**: integration tests for kubeadm init focused on valid and invalid discovery tokens

**Special notes for your reviewer**: /cc @luxas @pires
This was taken from Pires's work in https://github.com/kubernetes/kubernetes/pull/40008 . This is just the testing aspect of it

As it stands, these tests will never complete. The reason being is once it passes with a valid discovery token, it will wait until `[apiclient] Created API client, waiting for the control plane to become ready ` which is an infinite poll (https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/master/apiclient.go#L71). 

This is a WIP
**Release note**:

```release-note
NONE
```