### PR TITLE
update check for "all" resources

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -806,12 +806,13 @@ func HasNames(args []string) (bool, error) {
 
 // MultipleTypesRequested returns true if the provided args contain multiple resource kinds
 func MultipleTypesRequested(args []string) bool {
+	if len(args) == 1 && args[0] == "all" {
+		return true
+	}
+
 	args = normalizeMultipleResourcesArgs(args)
 	rKinds := sets.NewString()
 	for _, arg := range args {
-		if arg == "all" {
-			return true
-		}
 		rTuple, found, err := splitResourceTypeName(arg)
 		if err != nil {
 			continue

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -1255,6 +1255,14 @@ func TestMultipleTypesRequested(t *testing.T) {
 			expectedMultipleTypes: false,
 		},
 		{
+			args: []string{"pod,all"},
+			expectedMultipleTypes: true,
+		},
+		{
+			args: []string{"all,rc,pod"},
+			expectedMultipleTypes: true,
+		},
+		{
 			args: []string{"rc,pod,svc"},
 			expectedMultipleTypes: true,
 		},
@@ -1286,7 +1294,7 @@ func TestMultipleTypesRequested(t *testing.T) {
 	for _, test := range tests {
 		hasMultipleTypes := MultipleTypesRequested(test.args)
 		if hasMultipleTypes != test.expectedMultipleTypes {
-			t.Errorf("expected HasName to return %v for %s", test.expectedMultipleTypes, test.args)
+			t.Errorf("expected MultipleTypesRequested to return %v for %s", test.expectedMultipleTypes, test.args)
 		}
 	}
 }


### PR DESCRIPTION
This patch updates the check for `all` resources to handle cases where a resource's name is "all". Rather than cycling through all given args until `all` is found, this patch makes sure that only a single argument `all` was specified at all.

**Release note**:
```release-note
release-note-none
```

@fabianofranz @pwittrock 