### PR TITLE
Use presence of kubeconfig file to toggle standalone mode

### DIFF
--- a/build/debs/kubeadm-10.conf
+++ b/build/debs/kubeadm-10.conf
@@ -1,5 +1,5 @@
 [Service]
-Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf --require-kubeconfig=true"
+Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf"
 Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"

--- a/build/rpms/10-kubeadm.conf
+++ b/build/rpms/10-kubeadm.conf
@@ -1,5 +1,5 @@
 [Service]
-Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf --require-kubeconfig=true"
+Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf"
 Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"

--- a/cluster/centos/node/scripts/kubelet.sh
+++ b/cluster/centos/node/scripts/kubelet.sh
@@ -14,12 +14,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 MASTER_ADDRESS=${1:-"8.8.8.18"}
 NODE_ADDRESS=${2:-"8.8.8.20"}
 DNS_SERVER_IP=${3:-"192.168.3.100"}
 DNS_DOMAIN=${4:-"cluster.local"}
+KUBECONFIG_DIR=${KUBECONFIG_DIR:-/opt/kubernetes/cfg}
 
+# Generate a kubeconfig file
+cat <<EOF > "${KUBECONFIG_DIR}/kubelet.kubeconfig"
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      server: http://${MASTER_ADDRESS}:8080/
+    name: local
+contexts:
+  - context:
+      cluster: local
+    name: local
+current-context: local
+EOF
 
 cat <<EOF >/opt/kubernetes/cfg/kubelet
 # --logtostderr=true: log to standard error instead of files
@@ -37,9 +51,8 @@ NODE_PORT="--port=10250"
 # --hostname-override="": If non-empty, will use this string as identification instead of the actual hostname.
 NODE_HOSTNAME="--hostname-override=${NODE_ADDRESS}"
 
-# --api-servers=[]: List of Kubernetes API servers for publishing events,
-# and reading pods and services. (ip:port), comma separated.
-KUBELET_API_SERVER="--api-servers=${MASTER_ADDRESS}:8080"
+# Path to a kubeconfig file, specifying how to connect to the API server.
+KUBELET_KUBECONFIG="--kubeconfig=${KUBECONFIG_DIR}/kubelet.kubeconfig"
 
 # --allow-privileged=false: If true, allow containers to request privileged mode. [default=false]
 KUBE_ALLOW_PRIV="--allow-privileged=false"
@@ -52,15 +65,15 @@ KUBELET_DNS_DOMAIN="--cluster-domain=${DNS_DOMAIN}"
 KUBELET_ARGS=""
 EOF
 
-KUBE_PROXY_OPTS="   \${KUBE_LOGTOSTDERR}     \\
+KUBELET_OPTS="      \${KUBE_LOGTOSTDERR}     \\
                     \${KUBE_LOG_LEVEL}       \\
                     \${NODE_ADDRESS}         \\
                     \${NODE_PORT}            \\
                     \${NODE_HOSTNAME}        \\
-                    \${KUBELET_API_SERVER}   \\
+                    \${KUBELET_KUBECONFIG}   \\
                     \${KUBE_ALLOW_PRIV}      \\
                     \${KUBELET__DNS_IP}      \\
-                    \${KUBELET_DNS_DOMAIN}      \\
+                    \${KUBELET_DNS_DOMAIN}   \\
                     \$KUBELET_ARGS"
 
 cat <<EOF >/usr/lib/systemd/system/kubelet.service
@@ -71,7 +84,7 @@ Requires=docker.service
 
 [Service]
 EnvironmentFile=-/opt/kubernetes/cfg/kubelet
-ExecStart=/opt/kubernetes/bin/kubelet ${KUBE_PROXY_OPTS}
+ExecStart=/opt/kubernetes/bin/kubelet ${KUBELET_OPTS}
 Restart=on-failure
 KillMode=process
 

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -576,7 +576,7 @@ EOF
       cat <<EOF >>/srv/salt-overlay/pillar/cluster-params.sls
 node_taints: '$(echo "${NODE_TAINTS}" | sed -e "s/'/''/g")'
 EOF
-    fi    
+    fi
     if [ -n "${EVICTION_HARD:-}" ]; then
       cat <<EOF >>/srv/salt-overlay/pillar/cluster-params.sls
 eviction_hard: '$(echo "${EVICTION_HARD}" | sed -e "s/'/''/g")'
@@ -753,12 +753,16 @@ EOF
 }
 
 function salt-node-role() {
+  local -r kubelet_bootstrap_kubeconfig="/srv/salt-overlay/salt/kubelet/bootstrap-kubeconfig"
+  local -r kubelet_kubeconfig="/srv/salt-overlay/salt/kubelet/kubeconfig"
   cat <<EOF >/etc/salt/minion.d/grains.conf
 grains:
   roles:
     - kubernetes-pool
   cloud: gce
   api_servers: '${KUBERNETES_MASTER_NAME}'
+  kubelet_bootstrap_kubeconfig: /var/lib/kubelet/bootstrap-kubeconfig
+  kubelet_kubeconfig: /var/lib/kubelet/kubeconfig
 EOF
 }
 

--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -341,7 +341,13 @@ EOF
   fi
 }
 
-function create-kubelet-kubeconfig {
+# Arg 1: the address of the API server
+function create-kubelet-kubeconfig() {
+  local apiserver_address="${1}"
+  if [[ -z "${apiserver_address}" ]]; then
+    echo "Must provide API server address to create Kubelet kubeconfig file!"
+    exit 1
+  fi
   echo "Creating kubelet kubeconfig file"
   if [[ -z "${KUBELET_CA_CERT:-}" ]]; then
     KUBELET_CA_CERT="${CA_CERT}"
@@ -357,6 +363,7 @@ users:
 clusters:
 - name: local
   cluster:
+    server: ${apiserver_address}
     certificate-authority-data: ${KUBELET_CA_CERT}
 contexts:
 - context:
@@ -376,7 +383,7 @@ function create-master-kubelet-auth {
   # set in the environment.
   if [[ -n "${KUBELET_APISERVER:-}" && -n "${KUBELET_CERT:-}" && -n "${KUBELET_KEY:-}" ]]; then
     REGISTER_MASTER_KUBELET="true"
-    create-kubelet-kubeconfig
+    create-kubelet-kubeconfig "https://${KUBELET_APISERVER}"
   fi
 }
 
@@ -576,7 +583,7 @@ function start-kubelet {
     flags+=" --enable-debugging-handlers=false"
     flags+=" --hairpin-mode=none"
     if [[ "${REGISTER_MASTER_KUBELET:-false}" == "true" ]]; then
-      flags+=" --api-servers=https://${KUBELET_APISERVER}"
+      flags+=" --kubeconfig=/var/lib/kubelet/kubeconfig"
       flags+=" --register-schedulable=false"
     else
       # Standalone mode (not widely used?)
@@ -584,7 +591,7 @@ function start-kubelet {
     fi
   else # For nodes
     flags+=" --enable-debugging-handlers=true"
-    flags+=" --api-servers=https://${KUBERNETES_MASTER_NAME}"
+    flags+=" --kubeconfig=/var/lib/kubelet/kubeconfig"
     if [[ "${HAIRPIN_MODE:-}" == "promiscuous-bridge" ]] || \
        [[ "${HAIRPIN_MODE:-}" == "hairpin-veth" ]] || \
        [[ "${HAIRPIN_MODE:-}" == "none" ]]; then
@@ -1282,7 +1289,7 @@ function start-kube-addons {
   if [[ "${NETWORK_POLICY_PROVIDER:-}" == "calico" ]]; then
     setup-addon-manifests "addons" "calico-policy-controller"
 
-    # Configure Calico based on cluster size and image type. 
+    # Configure Calico based on cluster size and image type.
     local -r ds_file="${dst_dir}/calico-policy-controller/calico-node-daemonset.yaml"
     local -r typha_dep_file="${dst_dir}/calico-policy-controller/typha-deployment.yaml"
     sed -i -e "s@__CALICO_CNI_DIR__@/opt/cni/bin@g" "${ds_file}"
@@ -1290,7 +1297,7 @@ function start-kube-addons {
     sed -i -e "s@__CALICO_TYPHA_CPU__@$(get-calico-typha-cpu)@g" "${typha_dep_file}"
     sed -i -e "s@__CALICO_TYPHA_REPLICAS__@$(get-calico-typha-replicas)@g" "${typha_dep_file}"
   else
-    # If not configured to use Calico, the set the typha replica count to 0, but only if the 
+    # If not configured to use Calico, the set the typha replica count to 0, but only if the
     # addon is present.
     local -r typha_dep_file="${dst_dir}/calico-policy-controller/typha-deployment.yaml"
     if [[ -e $typha_dep_file ]]; then
@@ -1439,7 +1446,7 @@ if [[ "${KUBERNETES_MASTER:-}" == "true" ]]; then
   create-master-kubelet-auth
   create-master-etcd-auth
 else
-  create-kubelet-kubeconfig
+  create-kubelet-kubeconfig "https://${KUBERNETES_MASTER_NAME}"
   create-kubeproxy-kubeconfig
 fi
 

--- a/cluster/get-kube-local.sh
+++ b/cluster/get-kube-local.sh
@@ -21,6 +21,7 @@ set -o nounset
 set -o pipefail
 
 KUBE_HOST=${KUBE_HOST:-localhost}
+KUBELET_KUBECONFIG=${KUBELET_KUBECONFIG:-"/var/run/kubernetes/kubelet.kubeconfig"}
 
 declare -r RED="\033[0;31m"
 declare -r GREEN="\033[0;32m"
@@ -53,9 +54,38 @@ function run {
   fi
 }
 
+# Creates a kubeconfig file for the kubelet.
+# Args: destination file path
+function create-kubelet-kubeconfig() {
+  local destination="${2}"
+  if [[ -z "${destination}" ]]; then
+    echo "Must provide destination path to create Kubelet kubeconfig file!"
+    exit 1
+  fi
+  echo "Creating Kubelet kubeconfig file"
+  local dest_dir="$(dirname "${destination}")"
+  mkdir -p "${dest_dir}" &>/dev/null || sudo mkdir -p "${dest_dir}"
+  sudo=$(test -w "${dest_dir}" || echo "sudo -E")
+  cat <<EOF | ${sudo} tee "${destination}" > /dev/null
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      server: http://localhost:8080
+    name: local
+contexts:
+  - context:
+      cluster: local
+    name: local
+current-context: local
+EOF
+}
+
+
 function create_cluster {
   echo "Creating a local cluster:"
   echo -e -n "\tStarting kubelet..."
+  create-kubelet-kubeconfig "${KUBELET_KUBECONFIG}"
   run "docker run \
   --volume=/:/rootfs:ro \
   --volume=/sys:/sys:ro \
@@ -72,7 +102,7 @@ function create_cluster {
       --containerized \
       --hostname-override="127.0.0.1" \
       --address="0.0.0.0" \
-      --api-servers=http://localhost:8080 \
+      --kubeconfig=${KUBELET_KUBECONFIG}/kubelet.kubeconfig \
       --pod-manifest-path=/etc/kubernetes/manifests \
       --allow-privileged=true \
       --cluster-dns=10.0.0.10 \

--- a/cluster/libvirt-coreos/user_data_minion.yml
+++ b/cluster/libvirt-coreos/user_data_minion.yml
@@ -17,7 +17,7 @@ coreos:
         --address=0.0.0.0 \
         --hostname-override=${NODE_IPS[$i]} \
         --cluster-domain=cluster.local \
-        --api-servers=http://${MASTER_IP}:8080 \
+        --kubeconfig=/opt/kubernetes/kubeconfig/kubelet.kubeconfig \
         --tls-cert-file=/opt/kubernetes/certs/${NODE_NAMES[$i]}-node.pem \ \
         --tls-private-key-file=/opt/kubernetes/certs/${NODE_NAMES[$i]}-node-key.pem \
         $( [[ "$ENABLE_CLUSTER_DNS" == "true" ]] && echo "--cluster-dns=${DNS_SERVER_IP}" ) \

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -33,6 +33,38 @@ readonly POOL_PATH=/var/lib/libvirt/images/kubernetes
 
 [ ! -d "${POOL_PATH}" ] && (echo "$POOL_PATH" does not exist ; exit 1 )
 
+# Creates a kubeconfig file for the kubelet.
+# Args: address (e.g. "http://localhost:8080"), destination file path
+function create-kubelet-kubeconfig() {
+  local apiserver_address="${1}"
+  local destination="${2}"
+  if [[ -z "${apiserver_address}" ]]; then
+    echo "Must provide API server address to create Kubelet kubeconfig file!"
+    exit 1
+  fi
+  if [[ -z "${destination}" ]]; then
+    echo "Must provide destination path to create Kubelet kubeconfig file!"
+    exit 1
+  fi
+  echo "Creating Kubelet kubeconfig file"
+  local dest_dir="$(dirname "${destination}")"
+  mkdir -p "${dest_dir}" &>/dev/null || sudo mkdir -p "${dest_dir}"
+  sudo=$(test -w "${dest_dir}" || echo "sudo -E")
+  cat <<EOF | ${sudo} tee "${destination}" > /dev/null
+apiVersion: v1
+kind: Config
+clusters:
+  - cluster:
+      server: ${apiserver_address}
+    name: local
+contexts:
+  - context:
+      cluster: local
+    name: local
+current-context: local
+EOF
+}
+
 # join <delim> <list...>
 # Concatenates the list elements with the delimiter passed as first parameter
 #
@@ -279,6 +311,7 @@ function kube-up {
   export KUBE_SERVER="http://192.168.10.1:8080"
   export CONTEXT="libvirt-coreos"
   create-kubeconfig
+  create-kubelet-kubeconfig "http://${MASTER_IP}:8080" "${POOL_PATH}/kubernetes/kubeconfig/kubelet.kubeconfig"
 
   wait-cluster-readiness
 

--- a/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
@@ -17,6 +17,7 @@ write_files:
         network_mode: openvswitch
         networkInterfaceName: eth0
         api_servers: $MASTER_IP
+        kubelet_kubeconfig: /srv/salt-overlay/salt/kubelet/kubeconfig
         cloud: openstack
         cloud_config: /srv/kubernetes/openstack.conf
         roles:

--- a/cluster/openstack-heat/kubernetes-heat/fragments/deploy-kube-auth-files-master.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/deploy-kube-auth-files-master.yaml
@@ -34,6 +34,7 @@ write_files:
       clusters:
         - name: local
           cluster:
+            server: https://$MASTER_IP
             insecure-skip-tls-verify: true
       contexts:
         - context:

--- a/cluster/openstack-heat/kubernetes-heat/fragments/deploy-kube-auth-files-node.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/deploy-kube-auth-files-node.yaml
@@ -16,6 +16,7 @@ write_files:
       clusters:
         - name: local
           cluster:
+            server: https://$MASTER_IP
             insecure-skip-tls-verify: true
       contexts:
         - context:

--- a/cluster/photon-controller/templates/create-dynamic-salt-files.sh
+++ b/cluster/photon-controller/templates/create-dynamic-salt-files.sh
@@ -39,6 +39,7 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
+    server: https://${KUBE_MASTER_IP}
     insecure-skip-tls-verify: true
   name: local
 contexts:

--- a/cluster/photon-controller/templates/salt-master.sh
+++ b/cluster/photon-controller/templates/salt-master.sh
@@ -29,6 +29,7 @@ grains:
   cloud: photon-controller
   master_extra_sans: $MASTER_EXTRA_SANS
   api_servers: $MASTER_NAME
+  kubelet_kubeconfig: /srv/salt-overlay/salt/kubelet/kubeconfig
   kube_user: $KUBE_USER
 EOF
 

--- a/cluster/photon-controller/util.sh
+++ b/cluster/photon-controller/util.sh
@@ -34,8 +34,8 @@ readonly PHOTON="photon -n"
 readonly MASTER_NAME="${INSTANCE_PREFIX}-master"
 
 # shell check claims this doesn't work because you can't use a variable in a brace
-# range. It does work because we're calling eval. 
-# shellcheck disable=SC2051 
+# range. It does work because we're calling eval.
+# shellcheck disable=SC2051
 readonly NODE_NAMES=($(eval echo "${INSTANCE_PREFIX}"-node-{1.."${NUM_NODES}"}))
 
 #####################################################################
@@ -432,6 +432,7 @@ function gen-master-start {
     echo "readonly MY_NAME=${MASTER_NAME}"
     grep -v "^#" "${KUBE_ROOT}/cluster/photon-controller/templates/hostname.sh"
     echo "cd /home/kube/cache/kubernetes-install"
+    echo "readonly KUBE_MASTER_IP='{$KUBE_MASTER_IP}'"
     echo "readonly MASTER_NAME='${MASTER_NAME}'"
     echo "readonly MASTER_IP_RANGE='${MASTER_IP_RANGE}'"
     echo "readonly INSTANCE_PREFIX='${INSTANCE_PREFIX}'"
@@ -495,20 +496,20 @@ function gen-node-salt {
   done
 }
 
-# 
+#
 # Shared implementation for gen-master-salt and gen-node-salt
 # Writes a script that installs Kubernetes with salt
 # The core of the script is simple (run 'salt ... state.highstate')
 # We also do a bit of logging so we can debug problems
 #
-# There is also a funky workaround for an issue with docker 1.9 
-# (elsewhere we peg ourselves to docker 1.9). It's fixed in 1.10, 
+# There is also a funky workaround for an issue with docker 1.9
+# (elsewhere we peg ourselves to docker 1.9). It's fixed in 1.10,
 # so we should be able to remove it in the future
 # https://github.com/docker/docker/issues/18113
 # The problem is that sometimes the install (with apt-get) of
 # docker fails. Deleting a file and retrying fixes it.
 #
-# Tell shellcheck to ignore our variables within single quotes: 
+# Tell shellcheck to ignore our variables within single quotes:
 # We're writing a script, not executing it, so this is normal
 # shellcheck disable=SC2016
 function gen-salt {
@@ -564,7 +565,7 @@ function gen-add-route {
 
 #
 # Create the Kubernetes master VM
-# Sets global variables: 
+# Sets global variables:
 # - KUBE_MASTER    (Name)
 # - KUBE_MASTER_ID (Photon VM ID)
 # - KUBE_MASTER_IP (IP address)
@@ -577,7 +578,7 @@ function create-master-vm {
   KUBE_MASTER_IP=${_VM_IP}
 }
 
-# 
+#
 # Install salt on the Kubernetes master
 # Relies on the master-start.sh script created in gen-master-start
 #

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -3,16 +3,18 @@
   {% set daemon_args = "" -%}
 {% endif -%}
 
-{% if grains.api_servers is defined -%}
-  {% set api_servers = "--api-servers=https://" + grains.api_servers -%}
-{% elif grains.apiservers is defined -%} # TODO(remove after 0.16.0): Deprecated form
-  {% set api_servers = "--api-servers=https://" + grains.apiservers -%}
-{% elif grains['roles'][0] == 'kubernetes-master' -%}
-  {% set master_ipv4 = salt['grains.get']('fqdn_ip4')[0] -%}
-  {% set api_servers = "--api-servers=https://" + master_ipv4 -%}
+
+# kubeconfig file
+{% set require_kubeconfig = "" %}
+{% if grains.kubelet_bootstrap_kubeconfig is defined -%}
+  {% set bootstrap_kubeconfig = "--bootstrap-kubeconfig=" + grains.kubelet_bootstrap_kubeconfig -%}
 {% else -%}
-  {% set ips = salt['mine.get']('roles:kubernetes-master', 'network.ip_addrs', 'grain').values() -%}
-  {% set api_servers = "--api-servers=https://" + ips[0][0] -%}
+  {% set bootstrap_kubeconfig = "" -%}
+{% endif -%}
+{% if grains.kubelet_kubeconfig is defined -%}
+  {% set kubeconfig = "--kubeconfig=" + grains.kubelet_kubeconfig -%}
+{% else -%}
+  {% set kubeconfig = "" -%}
 {% endif -%}
 
 {% set master_kubelet_args = "" %}
@@ -21,14 +23,10 @@
 
 {% if grains['roles'][0] == 'kubernetes-master' -%}
   {% if grains.cloud in ['aws', 'gce', 'vagrant', 'photon-controller', 'openstack', 'azure-legacy'] -%}
-
     # Unless given a specific directive, disable registration for the kubelet
     # running on the master.
-    {% if grains.kubelet_api_servers is defined -%}
-      {% set api_servers = "--api-servers=https://" + grains.kubelet_api_servers -%}
+    {% if kubeconfig != "" -%}
       {% set master_kubelet_args = master_kubelet_args + "--register-schedulable=false" -%}
-    {% else -%}
-      {% set api_servers = "" -%}
     {% endif -%}
 
     # Disable the debugging handlers (/run and /exec) to prevent arbitrary
@@ -36,10 +34,6 @@
     # TODO(roberthbailey): Relax this constraint once the master is self-hosted.
     {% set debugging_handlers = "--enable-debugging-handlers=false" -%}
   {% endif -%}
-{% endif -%}
-
-{% if grains.cloud == 'gce' -%}
-  {% set api_servers = "--bootstrap-kubeconfig=/var/lib/kubelet/bootstrap-kubeconfig --require-kubeconfig --kubeconfig=/var/lib/kubelet/kubeconfig" -%}
 {% endif -%}
 
 {% set cloud_provider = "" -%}
@@ -110,7 +104,7 @@
 {% if grains['roles'][0] == 'kubernetes-master' %}
   {% if grains.get('cbr-cidr') %}
     {% set pod_cidr = "--pod-cidr=" + grains['cbr-cidr'] %}
-  {% elif api_servers == '' and pillar.get('network_provider', '').lower() == 'kubenet' %}
+  {% elif kubeconfig == "" and pillar.get('network_provider', '').lower() == 'kubenet' %}
     # Kubelet standalone mode needs a PodCIDR since there is no controller-manager
     {% set pod_cidr = "--pod-cidr=10.76.0.0/16" %}
   {% endif -%}
@@ -189,4 +183,4 @@
 {% set pki=" --cert-dir=/var/lib/kubelet/pki" -%}
 
 # test_args has to be kept at the end, so they'll overwrite any prior configuration
-DAEMON_ARGS="{{daemon_args}} {{api_servers}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{cloud_config}} {{config}} {{manifest_url}} --allow-privileged={{pillar['allow_privileged']}} {{log_level}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}}  {{non_masquerade_cidr}} {{cgroup_root}} {{system_container}} {{pod_cidr}} {{ master_kubelet_args }} {{cpu_cfs_quota}} {{network_plugin}} {{kubelet_port}} {{ hairpin_mode }} {{enable_custom_metrics}} {{runtime_container}} {{kubelet_container}} {{node_labels}} {{node_taints}} {{eviction_hard}} {{kubelet_auth}} {{pki}} {{feature_gates}} {{test_args}}"
+DAEMON_ARGS="{{daemon_args}} {{bootstrap_kubeconfig}} {{kubeconfig}} {{require_kubeconfig}} {{debugging_handlers}} {{hostname_override}} {{cloud_provider}} {{cloud_config}} {{config}} {{manifest_url}} --allow-privileged={{pillar['allow_privileged']}} {{log_level}} {{cluster_dns}} {{cluster_domain}} {{docker_root}} {{kubelet_root}}  {{non_masquerade_cidr}} {{cgroup_root}} {{system_container}} {{pod_cidr}} {{ master_kubelet_args }} {{cpu_cfs_quota}} {{network_plugin}} {{kubelet_port}} {{ hairpin_mode }} {{enable_custom_metrics}} {{runtime_container}} {{kubelet_container}} {{node_labels}} {{node_taints}} {{eviction_hard}} {{kubelet_auth}} {{pki}} {{feature_gates}} {{test_args}}"

--- a/cluster/vagrant/provision-utils.sh
+++ b/cluster/vagrant/provision-utils.sh
@@ -19,7 +19,7 @@ function enable-accounting() {
   cat <<EOF >/etc/systemd/system.conf.d/kubernetes-accounting.conf
 [Manager]
 DefaultCPUAccounting=yes
-DefaultMemoryAccounting=yes  
+DefaultMemoryAccounting=yes
 EOF
   systemctl daemon-reload
 }
@@ -95,6 +95,7 @@ grains:
   network_mode: openvswitch
   networkInterfaceName: '$(echo "$NETWORK_IF_NAME" | sed -e "s/'/''/g")'
   api_servers: '$(echo "$MASTER_IP" | sed -e "s/'/''/g")'
+  kubelet_kubeconfig: /srv/salt-overlay/salt/kubelet/kubeconfig
   cloud: vagrant
   roles:
     - $role
@@ -178,6 +179,7 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
+    server: "https://${MASTER_IP}"
     insecure-skip-tls-verify: true
   name: local
 contexts:

--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -127,7 +127,6 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/client-go/tools/auth:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/docs/api-reference/apps/v1beta2/definitions.html
+++ b/docs/api-reference/apps/v1beta2/definitions.html
@@ -6693,7 +6693,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-19 00:29:43 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/apps/v1beta2/operations.html
+++ b/docs/api-reference/apps/v1beta2/operations.html
@@ -4993,7 +4993,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-19 00:29:43 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/scheduling.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/scheduling.k8s.io/v1alpha1/definitions.html
@@ -1347,7 +1347,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-18 22:23:24 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/scheduling.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/scheduling.k8s.io/v1alpha1/operations.html
@@ -1702,7 +1702,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-18 22:23:24 UTC
+
 </div>
 </div>
 </body>

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -647,7 +647,6 @@ function start_kubelet {
         --cloud-provider="${CLOUD_PROVIDER}" \
         --cloud-config="${CLOUD_CONFIG}" \
         --address="${KUBELET_HOST}" \
-        --require-kubeconfig \
         --kubeconfig "$CERT_DIR"/kubelet.kubeconfig \
         --feature-gates="${FEATURE_GATES}" \
         --cpu-cfs-quota=${CPU_CFS_QUOTA} \
@@ -710,7 +709,7 @@ function start_kubelet {
         -i \
         --cidfile=$KUBELET_CIDFILE \
         gcr.io/google_containers/kubelet \
-        /kubelet --v=${LOG_LEVEL} --containerized ${priv_arg}--chaos-chance="${CHAOS_CHANCE}" --pod-manifest-path="${POD_MANIFEST_PATH}" --hostname-override="${HOSTNAME_OVERRIDE}" --cloud-provider="${CLOUD_PROVIDER}" --cloud-config="${CLOUD_CONFIG}" \ --address="127.0.0.1" --require-kubeconfig --kubeconfig "$CERT_DIR"/kubelet.kubeconfig --api-servers="https://${API_HOST}:${API_SECURE_PORT}" --port="$KUBELET_PORT"  --enable-controller-attach-detach="${ENABLE_CONTROLLER_ATTACH_DETACH}" &> $KUBELET_LOG &
+        /kubelet --v=${LOG_LEVEL} --containerized ${priv_arg}--chaos-chance="${CHAOS_CHANCE}" --pod-manifest-path="${POD_MANIFEST_PATH}" --hostname-override="${HOSTNAME_OVERRIDE}" --cloud-provider="${CLOUD_PROVIDER}" --cloud-config="${CLOUD_CONFIG}" \ --address="127.0.0.1" --kubeconfig "$CERT_DIR"/kubelet.kubeconfig --port="$KUBELET_PORT"  --enable-controller-attach-detach="${ENABLE_CONTROLLER_ATTACH_DETACH}" &> $KUBELET_LOG &
     fi
 }
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -190,7 +190,7 @@ type Bootstrap interface {
 }
 
 // Builder creates and initializes a Kubelet instance
-type Builder func(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Dependencies, crOptions *options.ContainerRuntimeOptions, standaloneMode bool, hostnameOverride, nodeIP, providerID string) (Bootstrap, error)
+type Builder func(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Dependencies, crOptions *options.ContainerRuntimeOptions, hostnameOverride, nodeIP, providerID string) (Bootstrap, error)
 
 // Dependencies is a bin for things we might consider "injected dependencies" -- objects constructed
 // at runtime that are necessary for running the Kubelet. This is a temporary solution for grouping
@@ -285,7 +285,7 @@ func getRuntimeAndImageServices(config *componentconfig.KubeletConfiguration) (i
 
 // NewMainKubelet instantiates a new Kubelet object along with all the required internal modules.
 // No initialization of Kubelet and its modules should happen here.
-func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Dependencies, crOptions *options.ContainerRuntimeOptions, standaloneMode bool, hostnameOverride, nodeIP, providerID string) (*Kubelet, error) {
+func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Dependencies, crOptions *options.ContainerRuntimeOptions, hostnameOverride, nodeIP, providerID string) (*Kubelet, error) {
 	if kubeCfg.RootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", kubeCfg.RootDirectory)
 	}
@@ -444,7 +444,6 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Dep
 		sourcesReady:                   config.NewSourcesReady(kubeDeps.PodConfig.SeenAllSources),
 		registerNode:                   kubeCfg.RegisterNode,
 		registerSchedulable:            kubeCfg.RegisterSchedulable,
-		standaloneMode:                 standaloneMode,
 		clusterDomain:                  kubeCfg.ClusterDomain,
 		clusterDNS:                     clusterDNS,
 		serviceLister:                  serviceLister,
@@ -876,9 +875,6 @@ type Kubelet struct {
 	registerSchedulable bool
 	// for internal book keeping; access only from within registerWithApiserver
 	registrationCompleted bool
-
-	// Set to true if the kubelet is in standalone mode (i.e. setup without an apiserver)
-	standaloneMode bool
 
 	// If non-empty, use this for container DNS search.
 	clusterDomain string

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -189,7 +189,7 @@ func (kl *Kubelet) GetRuntime() kubecontainer.Runtime {
 
 // GetNode returns the node info for the configured node name of this Kubelet.
 func (kl *Kubelet) GetNode() (*v1.Node, error) {
-	if kl.standaloneMode {
+	if kl.kubeClient == nil {
 		return kl.initialNode()
 	}
 	return kl.nodeInfo.GetNodeInfo(string(kl.nodeName))
@@ -201,7 +201,7 @@ func (kl *Kubelet) GetNode() (*v1.Node, error) {
 // in which case return a manufactured nodeInfo representing a node with no pods,
 // zero capacity, and the default labels.
 func (kl *Kubelet) getNodeAnyWay() (*v1.Node, error) {
-	if !kl.standaloneMode {
+	if kl.kubeClient != nil {
 		if n, err := kl.nodeInfo.GetNodeInfo(string(kl.nodeName)); err == nil {
 			return n, nil
 		}

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1209,7 +1209,7 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 		Status: v1.ConditionTrue,
 	})
 
-	if !kl.standaloneMode {
+	if kl.kubeClient != nil {
 		hostIP, err := kl.getHostIPAnyWay()
 		if err != nil {
 			glog.V(4).Infof("Cannot get host IP: %v", err)

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -89,7 +89,7 @@ func NewHollowKubelet(
 
 // Starts this HollowKubelet and blocks.
 func (hk *HollowKubelet) Run() {
-	if err := kubeletapp.RunKubelet(hk.KubeletFlags, hk.KubeletConfiguration, hk.KubeletDeps, false, false); err != nil {
+	if err := kubeletapp.RunKubelet(hk.KubeletFlags, hk.KubeletConfiguration, hk.KubeletDeps, false); err != nil {
 		glog.Fatalf("Failed to run HollowKubelet: %v. Exiting.", err)
 	}
 	select {}

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -91,6 +91,13 @@ const (
 // if the Kubelet fails to start.
 func (e *E2EServices) startKubelet() (*server, error) {
 	glog.Info("Starting kubelet")
+
+	// Build kubeconfig
+	kubeconfigPath, err := createKubeconfigCWD()
+	if err != nil {
+		return nil, err
+	}
+
 	// Create pod manifest path
 	manifestPath, err := createPodManifestDirectory()
 	if err != nil {
@@ -128,7 +135,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		)
 	}
 	cmdArgs = append(cmdArgs,
-		"--api-servers", getAPIServerClientURL(),
+		"--kubeconfig", kubeconfigPath,
 		"--address", "0.0.0.0",
 		"--port", kubeletPort,
 		"--read-only-port", kubeletReadOnlyPort,
@@ -204,6 +211,52 @@ func createPodManifestDirectory() (string, error) {
 		return "", fmt.Errorf("failed to create static pod manifest directory: %v", err)
 	}
 	return path, nil
+}
+
+// createKubeconfig creates a kubeconfig file at the fully qualified `path`. The parent dirs must exist.
+func createKubeconfig(path string) error {
+	kubeconfig := []byte(`apiVersion: v1
+kind: Config
+users:
+- name: kubelet
+clusters:
+- cluster:
+    server: ` + getAPIServerClientURL() + `
+    insecure-skip-tls-verify: true
+  name: local
+contexts:
+- context:
+    cluster: local
+    user: kubelet
+  name: local-context
+current-context: local-context`)
+
+	if err := ioutil.WriteFile(path, kubeconfig, 0666); err != nil {
+		return err
+	}
+	return nil
+}
+
+func kubeconfigCWDPath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %v", err)
+	}
+	return filepath.Join(cwd, "kubeconfig"), nil
+}
+
+// like createKubeconfig, but creates kubeconfig at current-working-directory/kubeconfig
+// returns a fully-qualified path to the kubeconfig file
+func createKubeconfigCWD() (string, error) {
+	kubeconfigPath, err := kubeconfigCWDPath()
+	if err != nil {
+		return "", err
+	}
+
+	if err = createKubeconfig(kubeconfigPath); err != nil {
+		return "", err
+	}
+	return kubeconfigPath, nil
 }
 
 // getCNIBinDirectory returns CNI directory.


### PR DESCRIPTION
Fixes #40049 

```release-note
The deprecated --api-servers flag has been removed. Use --kubeconfig to provide API server connection information instead. The --require-kubeconfig flag is now deprecated. The default kubeconfig path is also deprecated. Both --require-kubeconfig and the default kubeconfig path will be removed in Kubernetes v1.10.0.
```

/cc @kubernetes/sig-cluster-lifecycle-misc @kubernetes/sig-node-misc 