### PR TITLE
Set custom PollingDelay of 5 seconds for Azure VirtualMachinesClient

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/ghodss/yaml"
+	"time"
 )
 
 // CloudProviderName is the value used for the --cloud-provider flag
@@ -128,6 +129,7 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 	az.VirtualMachinesClient = compute.NewVirtualMachinesClient(az.SubscriptionID)
 	az.VirtualMachinesClient.BaseURI = az.Environment.ResourceManagerEndpoint
 	az.VirtualMachinesClient.Authorizer = servicePrincipalToken
+	az.VirtualMachinesClient.PollingDelay = 5 * time.Second
 
 	az.PublicIPAddressesClient = network.NewPublicIPAddressesClient(az.SubscriptionID)
 	az.PublicIPAddressesClient.BaseURI = az.Environment.ResourceManagerEndpoint


### PR DESCRIPTION
The default polling delay of 1 minute results in very long delays when
an Azure Disk is attached to a node. It gets worse as go-autorest
doubles the default delay to 2 minutes.

Please see: https://github.com/kubernetes/kubernetes/issues/35180#issuecomment-273085063

Only the PollingDelay for VirtualMachinesClient is modified here to
avoid too much pressure on Azure quotas.

Release Nodes:
```release-note
Reduce time needed to attach Azure disks
```
