### PR TITLE
Issue #13501 - printEvent Source to much more cleaner

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -2235,7 +2235,7 @@ func DescribeEvents(el *api.EventList, w *PrefixWriter) {
 			translateTimestamp(e.FirstTimestamp),
 			translateTimestamp(e.LastTimestamp),
 			e.Count,
-			e.Source,
+			formatEventSource(e.Source),
 			e.InvolvedObject.FieldPath,
 			e.Type,
 			e.Reason,

--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -1728,7 +1728,7 @@ func printEvent(event *api.Event, w io.Writer, options PrintOptions) error {
 		event.InvolvedObject.FieldPath,
 		event.Type,
 		event.Reason,
-		event.Source,
+		formatEventSource(event.Source),
 		event.Message,
 	); err != nil {
 		return err
@@ -2726,4 +2726,13 @@ func (j *JSONPathPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 // TODO: implement HandledResources()
 func (p *JSONPathPrinter) HandledResources() []string {
 	return []string{}
+}
+
+// formatEventSource formats EventSource as a comma separated string excluding Host when empty
+func formatEventSource(es api.EventSource) string {
+	EventSourceString := []string{es.Component}
+	if len(es.Host) > 0 {
+		EventSourceString = append(EventSourceString, es.Host)
+	}
+	return strings.Join(EventSourceString, ", ")
 }


### PR DESCRIPTION
Create a formatEventSource func and use it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Adds a smarter way to print EventSource, removing "{ }" and the eventual extra ", " when Host is empty.
It was also reported in OpenShift issue https://github.com/openshift/origin/issues/6586

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #13501 

**Special notes for your reviewer**:
I have used this new func in all user facing printouts, but there are other places where EventSource are printed to logs, like DumpEventsInNamespace in test/e2e/framework/util.go for instance.
Don't know if I should correct there too...

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Improve formatting of EventSource in kubectl get and kubectl describe
```
