### PR TITLE
controller: decouple cleanup policy from deployment strategies

### DIFF
--- a/pkg/controller/deployment/recreate.go
+++ b/pkg/controller/deployment/recreate.go
@@ -73,8 +73,6 @@ func (dc *DeploymentController) rolloutRecreate(deployment *extensions.Deploymen
 		return dc.syncRolloutStatus(allRSs, newRS, deployment)
 	}
 
-	dc.cleanupDeployment(oldRSs, deployment)
-
 	// Sync deployment status
 	return dc.syncRolloutStatus(allRSs, newRS, deployment)
 }

--- a/pkg/controller/deployment/rolling.go
+++ b/pkg/controller/deployment/rolling.go
@@ -55,8 +55,6 @@ func (dc *DeploymentController) rolloutRolling(deployment *extensions.Deployment
 		return dc.syncRolloutStatus(allRSs, newRS, deployment)
 	}
 
-	dc.cleanupDeployment(oldRSs, deployment)
-
 	// Sync deployment status
 	return dc.syncRolloutStatus(allRSs, newRS, deployment)
 }

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -58,7 +58,6 @@ func (dc *DeploymentController) sync(deployment *extensions.Deployment) error {
 		// so we can abort this resync
 		return err
 	}
-	dc.cleanupDeployment(oldRSs, deployment)
 
 	allRSs := append(oldRSs, newRS)
 	return dc.syncDeploymentStatus(allRSs, newRS, deployment)


### PR DESCRIPTION
Deployments get cleaned up only when they are paused, they get scaled up/down,
or when the strategy that drives rollouts completes. This means that stuck
deployments that fall into none of the above categories will not get cleaned
up. Since cleanup is already safe by itself (we only delete old replica sets
that are synced by the replica set controller and have no replicas) we can
execute it for every deployment when there is no intention to rollback.

Fixes https://github.com/kubernetes/kubernetes/issues/40068