### PR TITLE
Remove extensions/v1beta1.Jobs leftover

### DIFF
--- a/pkg/registry/extensions/rest/BUILD
+++ b/pkg/registry/extensions/rest/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//pkg/genericapiserver:go_default_library",
         "//pkg/genericapiserver/api/rest:go_default_library",
         "//pkg/registry/autoscaling/horizontalpodautoscaler/storage:go_default_library",
-        "//pkg/registry/batch/job/storage:go_default_library",
         "//pkg/registry/extensions/controller/storage:go_default_library",
         "//pkg/registry/extensions/daemonset/storage:go_default_library",
         "//pkg/registry/extensions/deployment/storage:go_default_library",

--- a/pkg/registry/extensions/rest/storage_extensions.go
+++ b/pkg/registry/extensions/rest/storage_extensions.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kubernetes/pkg/genericapiserver"
 	"k8s.io/kubernetes/pkg/genericapiserver/api/rest"
 	horizontalpodautoscalerstore "k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler/storage"
-	jobstore "k8s.io/kubernetes/pkg/registry/batch/job/storage"
 	expcontrollerstore "k8s.io/kubernetes/pkg/registry/extensions/controller/storage"
 	daemonstore "k8s.io/kubernetes/pkg/registry/extensions/daemonset/storage"
 	deploymentstore "k8s.io/kubernetes/pkg/registry/extensions/deployment/storage"
@@ -87,11 +86,6 @@ func (p RESTStorageProvider) v1beta1Storage(apiResourceConfigSource genericapise
 		storage["deployments/status"] = deploymentStorage.Status
 		storage["deployments/rollback"] = deploymentStorage.Rollback
 		storage["deployments/scale"] = deploymentStorage.Scale
-	}
-	if apiResourceConfigSource.ResourceEnabled(version.WithResource("jobs")) {
-		jobsStorage, jobsStatusStorage := jobstore.NewREST(restOptionsGetter)
-		storage["jobs"] = jobsStorage
-		storage["jobs/status"] = jobsStatusStorage
 	}
 	if apiResourceConfigSource.ResourceEnabled(version.WithResource("ingresses")) {
 		ingressStorage, ingressStatusStorage := ingressstore.NewREST(restOptionsGetter)


### PR DESCRIPTION
It looks like I missed this one file when removing `extensions/v1beta1.Jobs` last time (#38614).

@caesarxuchao ptal, since you were reviewing last time
@kubernetes/sig-api-machinery-misc fyi