### PR TITLE
Change kubemark Makefile to be provider independent

### DIFF
--- a/cluster/images/kubemark/Makefile
+++ b/cluster/images/kubemark/Makefile
@@ -15,8 +15,18 @@
 # build Kubemark image from currently built binaries containing both 'real' master and Hollow Node.
 # This makefile assumes that the kubemark binary is present in this directory.
 
-all:
-	docker build --pull -t gcr.io/$(PROJECT)/kubemark .
-	gcloud docker -- push gcr.io/$(PROJECT)/kubemark
+REGISTRY?=gcr.io
+PROJECT?=google_containers
 
-.PHONY: all
+all: gcloudpush
+
+build:
+	docker build --pull -t $(REGISTRY)/$(PROJECT)/kubemark .
+
+gcloudpush: build
+	gcloud docker -- push $(REGISTRY)/$(PROJECT)/kubemark
+
+push: build
+	docker -- push $(REGISTRY)/$(PROJECT)/kubemark
+
+.PHONY: all build gcloudpush push


### PR DESCRIPTION
Ref issue #38967

The Kubemark Makefile is defaulted to gcr.io. Instead, make it
provider independent.

The kubemark makefile is set to push the kubemark image to the gcr.io registry. In order to make kubemark not as provider specific, allow the developer to choose a registry.
