### PR TITLE
Add printer#EnsurePrintHeaders method

### DIFF
--- a/pkg/kubectl/resource_printer.go
+++ b/pkg/kubectl/resource_printer.go
@@ -419,6 +419,15 @@ func (h *HumanReadablePrinter) EnsurePrintWithKind(kind string) {
 	h.options.Kind = kind
 }
 
+// EnsurePrintHeaders sets the HumanReadablePrinter option "NoHeaders" to false
+// and removes the .lastType that was printed, which forces headers to be
+// printed in cases where multiple lists of the same resource are printed
+// consecutively, but are separated by non-printer related information.
+func (h *HumanReadablePrinter) EnsurePrintHeaders() {
+	h.options.NoHeaders = false
+	h.lastType = nil
+}
+
 // Handler adds a print handler with a given set of columns to HumanReadablePrinter instance.
 // See validatePrintHandlerFunc for required method signature.
 func (h *HumanReadablePrinter) Handler(columns, columnsWithWide []string, printFunc interface{}) error {


### PR DESCRIPTION
This patch adds a new `EnsurePrintHeaders` method to the
HumanReadablePrinter `ResourcePrinter`, which allows headers to be
printed in cases where multiple lists of the same resource are printed
consecutively, but are separated by non-printer related information.

Related downstream PR: https://github.com/openshift/origin/pull/12528

**Release note**:
```release-note
release-note-none
```

cc @fabianofranz @AdoHe 