### PR TITLE
[DO NOT MERGE] Demonstrate that we cannot wait for volumes to be deleted to delete from the API server

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -708,7 +708,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 	}
 	klet.imageManager = imageManager
 
-	klet.statusManager = status.NewManager(kubeClient, klet.podManager)
+	klet.statusManager = status.NewManager(kubeClient, klet.podManager, klet.podCanBeDeleted)
 
 	klet.probeManager = prober.NewManager(
 		klet.statusManager,

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -48,6 +48,7 @@ import (
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/envvars"
 	"k8s.io/kubernetes/pkg/kubelet/images"
+	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -673,6 +674,38 @@ func (kl *Kubelet) podIsTerminated(pod *v1.Pod) bool {
 	}
 
 	return false
+}
+
+func (kl *Kubelet) podCanBeDeleted(pod *v1.Pod) bool {
+	if kubepod.IsMirrorPod(pod) {
+		// We don't handle graceful deletion of mirror pods.
+		return false
+	}
+	if pod.DeletionTimestamp == nil {
+		// We shouldnt delete pods whose DeletionTimestamp is not set
+		return false
+	}
+	if !notRunning(pod.Status.ContainerStatuses) {
+		// We shouldnt delete pods that still have running containers
+		glog.V(3).Infof("Pod %q is terminated, but some containers are still running", format.Pod(pod))
+		return false
+	}
+	if kl.podVolumesExist(pod.UID) {
+		// We shouldnt delete pods whose volumes have not been cleaned up
+		return false
+	}
+	return true
+}
+
+// notRunning returns true if every status is terminated or waiting, or the status list
+// is empty.
+func notRunning(statuses []v1.ContainerStatus) bool {
+	for _, status := range statuses {
+		if status.State.Terminated == nil && status.State.Waiting == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // filterOutTerminatedPods returns the given pods which the status manager

--- a/test/e2e_node/create_delete_test.go
+++ b/test/e2e_node/create_delete_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_node
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = framework.KubeDescribe("CreateDelete", func() {
+	f := framework.NewDefaultFramework("create-delete-test")
+	testPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-with-volume",
+		},
+		Spec: v1.PodSpec{
+			RestartPolicy: v1.RestartPolicyNever,
+			Containers: []v1.Container{
+				{
+					Image: "gcr.io/google_containers/busybox:1.24",
+					Name:  "volume-pod",
+					Command: []string{
+						"sh",
+						"-c",
+						"sleep 10000",
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{MountPath: "/test-empty-dir-mnt", Name: "test-empty-dir"},
+					},
+				},
+			},
+			Volumes: []v1.Volume{
+				{Name: "test-empty-dir", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
+			},
+		},
+	}
+
+	Context("When we make a pod with a volume", func() {
+		It("Should successfully create and delete the pod", func() {
+			f.PodClient().CreateSync(testPod)
+			f.PodClient().DeleteSync(testPod.Name, &v1.DeleteOptions{}, podDisappearTimeout)
+		})
+	})
+})


### PR DESCRIPTION
The following test (which simply creates and deletes a pod that contains a volume) fails:
make test-e2e-node REMOTE=true FOCUS=CreateDelete

This also serves as a blueprint for how I intend to enforce pod deletion guarantees about disk space in general.

cc: @vishh 

I still need to look again at exactly why this fails.
