### PR TITLE
bazel: add a config setting to control embedding kubernetes-src.tar.gz

### DIFF
--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -15,6 +15,14 @@ filegroup(
     tags = ["automanaged"],
 )
 
+config_setting(
+    name = "embed_license_targets",
+    values = {
+        "define": "EMBED_LICENSE_TARGETS=true",
+    },
+    visibility = ["//visibility:private"],
+)
+
 pkg_tar(
     name = "kubernetes-src",
     extension = "tar.gz",
@@ -116,7 +124,10 @@ pkg_tar(
 pkg_tar(
     name = "kubernetes-node-%s" % PLATFORM_ARCH_STRING,
     extension = "tar.gz",
-    files = LICENSE_TARGETS,
+    files = select({
+        ":embed_license_targets": LICENSE_TARGETS,
+        "//conditions:default": [],
+    }),
     mode = "0644",
     package_dir = "kubernetes",
     deps = [
@@ -153,7 +164,10 @@ pkg_tar(
 pkg_tar(
     name = "kubernetes-server-%s" % PLATFORM_ARCH_STRING,
     extension = "tar.gz",
-    files = LICENSE_TARGETS,
+    files = select({
+        ":embed_license_targets": LICENSE_TARGETS,
+        "//conditions:default": [],
+    }),
     mode = "0644",
     package_dir = "kubernetes",
     deps = [
@@ -198,14 +212,16 @@ pkg_tar(
     extension = "tar.gz",
     files = [
         # TODO: the version file
-        "//:Godeps/LICENSES",
         "//:README.md",
         "//:Vagrantfile",
         "//cluster:all-srcs",
         "//docs:all-srcs",
         "//examples:all-srcs",
         "//third_party/htpasswd:all-srcs",
-    ],
+    ] + select({
+        ":embed_license_targets": ["//:Godeps/LICENSES"],
+        "//conditions:default": [],
+    }),
     package_dir = "kubernetes",
     strip_prefix = "//",
     deps = [

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -197,6 +197,7 @@ pkg_tar(
     name = "kubernetes",
     extension = "tar.gz",
     files = [
+        # TODO: the version file
         "//:Godeps/LICENSES",
         "//:README.md",
         "//:Vagrantfile",


### PR DESCRIPTION
**What this PR does / why we need it**: currently a change anywhere in the tree will cause `kubernetes-src.tar.gz` to need to be regenerated, and thus also the server and node tarballs. All of these operations are slow, so for the sake of developer productivity, only include `kubernetes-src.tar.gz` when we need it (e.g. if we were doing a real release).

I don't have metrics on how much of an effect this has, but I expect it should help incremental builds, especially those that don't affect any node/server targets.

To embed the srcs tarball with this change, you'd run
```console
bazel build //build/release-tars --define EMBED_LICENSE_TARGETS=true
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
