### PR TITLE
azure: azure container registry: fix login server

### DIFF
--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -17,7 +17,6 @@ limitations under the License.
 package azure
 
 import (
-	"fmt"
 	"io/ioutil"
 	"time"
 
@@ -133,10 +132,15 @@ func (a *acrProvider) Provide() credentialprovider.DockerConfig {
 		return cfg
 	}
 	for ix := range *res.Value {
-		// TODO: I don't think this will work for national clouds
-		cfg[fmt.Sprintf("%s.azurecr.io", *(*res.Value)[ix].Name)] = entry
+		loginServer := getLoginServer((*res.Value)[ix])
+		glog.V(4).Infof("Adding Azure Container Registry docker credential for %s", loginServer)
+		cfg[loginServer] = entry
 	}
 	return cfg
+}
+
+func getLoginServer(registry containerregistry.Registry) string {
+	return *(*registry.RegistryProperties).LoginServer
 }
 
 func (a *acrProvider) LazyProvide() *credentialprovider.DockerConfigEntry {

--- a/pkg/credentialprovider/azure/azure_credentials_test.go
+++ b/pkg/credentialprovider/azure/azure_credentials_test.go
@@ -41,12 +41,21 @@ func Test(t *testing.T) {
 		Value: &[]containerregistry.Registry{
 			{
 				Name: to.StringPtr("foo"),
+				RegistryProperties: &containerregistry.RegistryProperties{
+					LoginServer: to.StringPtr("foo-microsoft.azurecr.io"),
+				},
 			},
 			{
 				Name: to.StringPtr("bar"),
+				RegistryProperties: &containerregistry.RegistryProperties{
+					LoginServer: to.StringPtr("bar-microsoft.azurecr.io"),
+				},
 			},
 			{
 				Name: to.StringPtr("baz"),
+				RegistryProperties: &containerregistry.RegistryProperties{
+					LoginServer: to.StringPtr("baz-microsoft.azurecr.io"),
+				},
 			},
 		},
 	}
@@ -73,7 +82,7 @@ func Test(t *testing.T) {
 		}
 	}
 	for _, val := range *result.Value {
-		registryName := *val.Name + ".azurecr.io"
+		registryName := getLoginServer(val)
 		if _, found := creds[registryName]; !found {
 			t.Errorf("Missing expected registry: %s", registryName)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the Azure Container Registry integration

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
n/a

**Special notes for your reviewer**:

Before this change, if I created an ACR with name `colemicktest`, then the login server would be `colemicktest-microsoft.azurecr.io`. This code was concating to form `colemicktest.azurecr.io` which does not work.

The fix is to reach into RegistryProperties and read out the login server domain name directly.

Also, this should eliminate that existed when ACR gets to sovereign clouds.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
azure: fix Azure Container Registry integration
```
