### PR TITLE
Use ensure-temp-dir in the common.sh script

### DIFF
--- a/cluster/aws/util.sh
+++ b/cluster/aws/util.sh
@@ -570,18 +570,6 @@ function verify-prereqs {
   fi
 }
 
-
-# Create a temp dir that'll be deleted at the end of this bash session.
-#
-# Vars set:
-#   KUBE_TEMP
-function ensure-temp-dir {
-  if [[ -z ${KUBE_TEMP-} ]]; then
-    KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
-    trap 'rm -rf "${KUBE_TEMP}"' EXIT
-  fi
-}
-
 # Take the local tar files and upload them to S3.  They will then be
 # downloaded by the master as part of the start up script for the master.
 #

--- a/cluster/azure-legacy/util.sh
+++ b/cluster/azure-legacy/util.sh
@@ -100,17 +100,6 @@ function verify-prereqs {
     echo "==> CONTAINER: $CONTAINER"
 }
 
-# Create a temp dir that'll be deleted at the end of this bash session.
-#
-# Vars set:
-#   KUBE_TEMP
-function ensure-temp-dir {
-    if [[ -z ${KUBE_TEMP-} ]]; then
-        KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
-        trap 'rm -rf "${KUBE_TEMP}"' EXIT
-    fi
-}
-
 # Take the local tar files and upload them to Azure Storage.  They will then be
 # downloaded by the master as part of the start up script for the master.
 #

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -308,6 +308,17 @@ function load-or-gen-kube-bearertoken() {
   fi
 }
 
+# Create a temp dir that'll be deleted at the end of this bash session.
+#
+# Vars set:
+#   KUBE_TEMP
+function ensure-temp-dir {
+  if [[ -z ${KUBE_TEMP-} ]]; then
+    KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
+    trap 'rm -rf "${KUBE_TEMP}"' EXIT
+  fi
+}
+
 # Get the master IP for the current-context in kubeconfig if one exists.
 #
 # Assumed vars:

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -116,17 +116,6 @@ function verify-prereqs() {
   update-or-verify-gcloud
 }
 
-# Create a temp dir that'll be deleted at the end of this bash session.
-#
-# Vars set:
-#   KUBE_TEMP
-function ensure-temp-dir() {
-  if [[ -z ${KUBE_TEMP-} ]]; then
-    KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
-    trap 'rm -rf "${KUBE_TEMP}"' EXIT
-  fi
-}
-
 # Use the gcloud defaults to find the project.  If it is already set in the
 # environment then go with that.
 #

--- a/cluster/photon-controller/util.sh
+++ b/cluster/photon-controller/util.sh
@@ -1031,18 +1031,6 @@ function verify-cmd-in-path {
 }
 
 #
-# Checks that KUBE_TEMP is set, or sets it
-# If it sets it, it also creates the temporary directory
-# and sets up a trap so that we delete it when we exit
-#
-function ensure-temp-dir {
-  if [[ -z ${KUBE_TEMP-} ]]; then
-    KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
-    trap-add "rm -rf '${KUBE_TEMP}'" EXIT
-  fi
-}
-
-#
 # Repeatedly try a command over ssh until it succeeds or until five minutes have passed
 # The timeout isn't exact, since we assume the command runs instantaneously, and
 # it doesn't.

--- a/cluster/vagrant/util.sh
+++ b/cluster/vagrant/util.sh
@@ -104,17 +104,6 @@ function verify-prereqs {
   export USING_KUBE_SCRIPTS=true
 }
 
-# Create a temp dir that'll be deleted at the end of this bash session.
-#
-# Vars set:
-#   KUBE_TEMP
-function ensure-temp-dir {
-  if [[ -z ${KUBE_TEMP-} ]]; then
-    export KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
-    trap 'rm -rf "${KUBE_TEMP}"' EXIT
-  fi
-}
-
 # Create a set of provision scripts for the master and each of the nodes
 function create-provision-scripts {
   ensure-temp-dir


### PR DESCRIPTION
Ref issue #38967

Instead of having an ensure-temp-dir function in multiple
places, add it to the common.sh script which is sourced by
all the providers.
