### PR TITLE
Add //hack:verify-boilerplate rule.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ endef
 	@echo "$$BAZEL_TEST_HELP_INFO"
 else
 bazel-test:
-	bazel test  --test_output=errors //cmd/... //pkg/... //federation/... //plugin/... //build/... //third_party/... //hack/...
+	bazel test  --test_output=errors //cmd/... //pkg/... //federation/... //plugin/... //build/... //third_party/... //hack/... //hack:verify-all
 endif
 
 ifeq ($(PRINT_HELP),y)

--- a/hack/BUILD
+++ b/hack/BUILD
@@ -19,3 +19,18 @@ filegroup(
     ],
     tags = ["automanaged"],
 )
+
+sh_test(
+    name = "verify-boilerplate",
+    srcs = ["verify-boilerplate.sh"],
+    data = ["//:all-srcs"],
+    tags = ["manual"],
+)
+
+test_suite(
+    name = "verify-all",
+    tags = ["manual"],
+    tests = [
+        "verify-boilerplate",
+    ],
+)


### PR DESCRIPTION
This pattern is working well in test-infra. I'll add the gofmt and go vet rules next.