### PR TITLE
VSphere: Ensure 'primary' IP address is always returned in NodeAddresses

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -508,6 +508,20 @@ func (i *Instances) NodeAddresses(nodeName k8stypes.NodeName) ([]v1.NodeAddress,
 			)
 		}
 	}
+
+	// Ensure that the "primary" IP address of the machine is always included, since the above
+	// guest.net call is limited to 16 unsorted interfaces and the e.g. eth0 iface may not have
+	// been included.
+	err = getVirtualMachineManagedObjectReference(ctx, i.client, vm, "guest.ipAddress", &mvm)
+	if err != nil {
+		return nil, err
+	}
+	v1.AddToNodeAddresses(&addrs,
+		v1.NodeAddress{
+			Address: mvm.Guest.IpAddress,
+		},
+	)
+
 	return addrs, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
VSphere's API returns a maximum of 16 NICs in non-deterministic order. When there are many interfaces on a VM (as happens frequently with kubernetes), the "primary" NIC of the machine can be dropped from this list. This results in kubernetes thinking the node cannot be found in the cluster, and ejecting the node with a message like `failed to get node address from cloud provider that matches ip: 10.240.157.105`. This PR uses a second field in the vm managed object reference call to get the IP that VSphere thinks of as the primary IP of the machine and ensures that it is added to the list of node addresses.

This was tested in our VSphere 6.0 cluster with >30 NICs on a node.

**Release note**:
```release-note
```
