### PR TITLE
Use existing ABAC policy file when upgrading GCE cluster

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -900,6 +900,9 @@ function start-kube-apiserver {
 
 
   local authorization_mode="RBAC"
+  # Load existing ABAC policy files written by versions < 1.6 of this script
+  # TODO: only default to this legacy path when in upgrade mode
+  ABAC_AUTHZ_FILE="${ABAC_AUTHZ_FILE:-/etc/srv/kubernetes/abac-authz-policy.jsonl}"
   if [[ -n "${ABAC_AUTHZ_FILE:-}" && -e "${ABAC_AUTHZ_FILE}" ]]; then
     params+=" --authorization-policy-file=${ABAC_AUTHZ_FILE}"
     authorization_mode+=",ABAC"


### PR DESCRIPTION
When upgrading, continue loading an existing ABAC policy file so that existing system components continue working as-is

```
When upgrading an existing 1.5 GCE cluster using `cluster/gce/upgrade.sh`, an existing ABAC policy file located at /etc/srv/kubernetes/abac-authz-policy.jsonl (the default location in 1.5) will enable the ABAC authorizer in addition to the RBAC authorizer. To switch an upgraded 1.5 cluster completely to RBAC, ensure the control plane components and your superuser have been granted sufficient RBAC permissions, move the legacy ABAC policy file to a backup location, and restart the apiserver.
```