### PR TITLE
Experimental User Namespace Support - Phase 2

### DIFF
--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -53,6 +53,10 @@ type RuntimeHelper interface {
 	// supplemental groups for the Pod. These extra supplemental groups come
 	// from annotations on persistent volumes that the pod depends on.
 	GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int64
+	// IsExperimentalUserNsEnabled returns true if the experimental user namespace behavior has
+	// been enabled for the Kubelet.  This can be used to drive runtime specific user namespace
+	// behaviors.
+	IsExperimentalUserNsEnabled() bool
 }
 
 // ShouldContainerBeRestarted checks whether a container needs to be restarted.

--- a/pkg/kubelet/dockertools/BUILD
+++ b/pkg/kubelet/dockertools/BUILD
@@ -54,6 +54,7 @@ go_library(
         "//pkg/util/strings:go_default_library",
         "//pkg/util/term:go_default_library",
         "//pkg/util/version:go_default_library",
+        "//pkg/volume:go_default_library",
         "//vendor:github.com/docker/distribution/digest",
         "//vendor:github.com/docker/distribution/reference",
         "//vendor:github.com/docker/docker/pkg/jsonmessage",

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -107,6 +107,10 @@ func (f *fakeRuntimeHelper) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int6
 	return nil
 }
 
+func (f *fakeRuntimeHelper) IsExperimentalUserNsEnabled() bool {
+	return false
+}
+
 type fakeImageManager struct{}
 
 func newFakeImageManager() images.ImageManager {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1108,10 +1108,10 @@ type Kubelet struct {
 // 3.  the plugins directory
 func (kl *Kubelet) setupDataDirs() error {
 	kl.rootDirectory = path.Clean(kl.rootDirectory)
-	if err := os.MkdirAll(kl.getRootDir(), 0750); err != nil {
+	if err := os.MkdirAll(kl.getRootDir(), 0755); err != nil {
 		return fmt.Errorf("error creating root directory: %v", err)
 	}
-	if err := os.MkdirAll(kl.getPodsDir(), 0750); err != nil {
+	if err := os.MkdirAll(kl.getPodsDir(), 0755); err != nil {
 		return fmt.Errorf("error creating pods directory: %v", err)
 	}
 	if err := os.MkdirAll(kl.getPluginsDir(), 0750); err != nil {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -342,6 +342,12 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *v1.Pod, container *v1.Contai
 	return opts, nil
 }
 
+// IsExperimentalUserNsEnabled allows consumers of the RuntimeHelper determine if the kubelet
+// is using experimental user namespace behavior.
+func (kl *Kubelet) IsExperimentalUserNsEnabled() bool {
+	return kl.experimentalHostUserNamespaceDefaulting
+}
+
 var masterServices = sets.NewString("kubernetes")
 
 // getServiceEnvVarMap makes a map[string]string of env vars for services a

--- a/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/fake_kuberuntime_manager.go
@@ -78,6 +78,10 @@ func (f *fakeRuntimeHelper) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int6
 	return nil
 }
 
+func (f *fakeRuntimeHelper) IsExperimentalUserNsEnabled() bool {
+	return false
+}
+
 type fakePodGetter struct {
 	pods map[types.UID]*v1.Pod
 }

--- a/pkg/kubelet/rkt/fake_rkt_interface_test.go
+++ b/pkg/kubelet/rkt/fake_rkt_interface_test.go
@@ -179,6 +179,10 @@ func (f *fakeRuntimeHelper) GetExtraSupplementalGroupsForPod(pod *v1.Pod) []int6
 	return nil
 }
 
+func (f *fakeRuntimeHelper) IsExperimentalUserNsEnabled() bool {
+	return false
+}
+
 type fakeRktCli struct {
 	sync.Mutex
 	cmds   []string

--- a/pkg/securitycontext/fake.go
+++ b/pkg/securitycontext/fake.go
@@ -42,7 +42,7 @@ type FakeSecurityContextProvider struct{}
 
 func (p FakeSecurityContextProvider) ModifyContainerConfig(pod *v1.Pod, container *v1.Container, config *dockercontainer.Config) {
 }
-func (p FakeSecurityContextProvider) ModifyHostConfig(pod *v1.Pod, container *v1.Container, hostConfig *dockercontainer.HostConfig, supplementalGids []int64) {
+func (p FakeSecurityContextProvider) ModifyHostConfig(pod *v1.Pod, container *v1.Container, hostConfig *dockercontainer.HostConfig, supplementalGids []int64, isRemap bool) {
 }
 
 // ValidInternalSecurityContextWithContainerDefaults creates a valid security context provider based on

--- a/pkg/securitycontext/types.go
+++ b/pkg/securitycontext/types.go
@@ -37,7 +37,7 @@ type SecurityContextProvider interface {
 	// - pod: the pod to modify the docker hostconfig for
 	// - container: the container to modify the hostconfig for
 	// - supplementalGids: additional supplemental GIDs associated with the pod's volumes
-	ModifyHostConfig(pod *v1.Pod, container *v1.Container, hostConfig *dockercontainer.HostConfig, supplementalGids []int64)
+	ModifyHostConfig(pod *v1.Pod, container *v1.Container, hostConfig *dockercontainer.HostConfig, supplementalGids []int64, isRemap bool)
 }
 
 const (

--- a/pkg/util/config/feature_gate.go
+++ b/pkg/util/config/feature_gate.go
@@ -137,9 +137,14 @@ type featureGate struct {
 }
 
 func setUnsetAlphaGates(f *featureGate, val bool) {
+	// don't turn these on unless they are explicitly requested to be turned on.
+	mustExplicitlyRequestFeature := map[string]bool{
+		experimentalHostUserNamespaceDefaultingGate: true,
+	}
 	for k, v := range f.known {
 		if v.prerelease == alpha {
-			if _, found := f.enabled[k]; !found {
+			_, requiresExplicitEnablement := mustExplicitlyRequestFeature[k]
+			if _, found := f.enabled[k]; !found && !requiresExplicitEnablement {
 				f.enabled[k] = val
 			}
 		}

--- a/pkg/volume/volume_unsupported.go
+++ b/pkg/volume/volume_unsupported.go
@@ -21,3 +21,7 @@ package volume
 func SetVolumeOwnership(mounter Mounter, fsGroup *int64) error {
 	return nil
 }
+
+func SetOwnershipForPath(path string, readOnly bool, gid int) error {
+	return nil
+}


### PR DESCRIPTION
As a companion [to the proposal](https://github.com/kubernetes/kubernetes/pull/34569) this PR demonstrates the proposed behavior.

### Starting the server
`ALLOW_SECURITY_CONTEXT=true FEATURE_GATES="ExperimentalHostUserNamespaceDefaulting=true" hack/local-up-cluster.sh`

### Running a pod
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: userns
  labels:
    name: userns
spec:
  securityContext:
      fsGroup: 2197152
  containers:
  - name: nginx
    image: nginx
    ports:
    - containerPort: 80
    volumeMounts:
        - name: test-emptydir
          mountPath: /test-emptydir
  volumes:
      - name: test-emptydir
        emptyDir: {}
```

```
[pweil@localhost pods]$ kc create -f /home/pweil/codebase/dotfiles/kube_temp/userns/nginx-volume.yaml 
pod "userns" created

[pweil@localhost pods]$ kc get pods
NAME      READY     STATUS    RESTARTS   AGE
userns    1/1       Running   0          33s

[pweil@localhost kubernetes]$ ps -ef | grep nginx
2197152  28797 28778  0 15:48 ?        00:00:00 nginx: master process nginx -g daemon off;
2197256  28824 28797  0 15:48 ?        00:00:00 nginx: worker process

[pweil@localhost pods]$ kc exec -it userns /bin/bash
root@userns:/# whoami
root
root@userns:/# cat /proc/self/*_map
         0    2197152      65536
         0    2197152      65536

###
# Can write to termination-log
###
root@userns:/# ls -l /dev/termination-log 
-rw-rw-r--. 1 nobody root 4 Jan 19 19:47 /dev/termination-log
root@userns:/# echo "foo" > /dev/termination-log 
root@userns:/# cat /dev/termination-log 
foo

###
# Can write to a dir that supports ownership management
###
root@userns:/# ls -l | grep test
drwxrwsrwx.   2 nobody root    4096 Jan 19 19:48 test-emptydir
root@userns:/# echo "foo" > /test-emptydir/foo.txt
root@userns:/# cat /test-emptydir/foo.txt
foo
```

### Host directory permission changes

```
[root@localhost pods]# cd /var/lib/kubelet
[root@localhost kubelet]# ll
total 8
drwxr-x---. 2 root root 4096 Jan 19 14:40 plugins
drwxr-xr-x. 2 root root 4096 Jan 19 14:45 pods

[root@localhost kubelet]# cd pods
[root@localhost pods]# ll
total 4
drwxrws---. 5 root 2197152 4096 Jan 19 14:46 f2d17fb9-de7f-11e6-ba9b-54ee752009cb

###
# Note here that the docker daemon is changing the etc-hosts file for us, not this PR
###
[root@localhost pods]# cd f2d17fb9-de7f-11e6-ba9b-54ee752009cb/
[root@localhost f2d17fb9-de7f-11e6-ba9b-54ee752009cb]# ll
total 16
drwxrws---. 3 root    2197152 4096 Jan 19 14:46 containers
-rw-rw-r--. 1 2197152 2197152  201 Jan 19 14:46 etc-hosts
drwxrws---. 3 root    2197152 4096 Jan 19 14:46 plugins
drwxrws---. 4 root    2197152 4096 Jan 19 14:46 volumes
```



### Confirmation items written to the termination-log and volume

```
[root@localhost f2d17fb9-de7f-11e6-ba9b-54ee752009cb]# cat containers/nginx/475fe5f6 
foo
[root@localhost f2d17fb9-de7f-11e6-ba9b-54ee752009cb]# cat volumes/kubernetes.io~empty-dir/test-emptydir/foo.txt 
foo
[root@localhost f2d17fb9-de7f-11e6-ba9b-54ee752009cb]# ll volumes/kubernetes.io~empty-dir/test-emptydir/
total 4
-rw-rw-r--. 1 2197152 2197152 4 Jan 19 14:48 foo.txt
```
@mrunalp @thockin @yujuhong @euank @vishh @pmorie @smarterclayton @php-coder 