### PR TITLE
WIP: Set docker opt separator correctly for SELinux options

### DIFF
--- a/pkg/kubelet/dockershim/security_context.go
+++ b/pkg/kubelet/dockershim/security_context.go
@@ -28,6 +28,14 @@ import (
 	"k8s.io/kubernetes/pkg/securitycontext"
 )
 
+const (
+	// optSeparator is the docker option separator to use; this is the
+	// separator which is supported in version 1.11+; older versions used `:`,
+	// but dockershim does not support those, so it is hard-coded in this
+	// package.
+	optSeparator = '='
+)
+
 // applySandboxSecurityContext updates docker sandbox options according to security context.
 func applySandboxSecurityContext(lc *runtimeapi.LinuxPodSandboxConfig, config *dockercontainer.Config, hc *dockercontainer.HostConfig, networkPlugin network.NetworkPlugin) {
 	if lc == nil {
@@ -107,6 +115,7 @@ func modifyHostConfig(sc *runtimeapi.LinuxContainerSecurityContext, hostConfig *
 				Type:  sc.SelinuxOptions.GetType(),
 				Level: sc.SelinuxOptions.GetLevel(),
 			},
+			optSeparator,
 		)
 	}
 }

--- a/pkg/kubelet/dockershim/security_context_test.go
+++ b/pkg/kubelet/dockershim/security_context_test.go
@@ -83,10 +83,10 @@ func TestModifyHostConfig(t *testing.T) {
 	}
 	setSELinuxHC := &dockercontainer.HostConfig{
 		SecurityOpt: []string{
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelUser, "user"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelRole, "role"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelType, "type"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelLevel, "level"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelUser('='), "user"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelRole('='), "role"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelType('='), "type"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelLevel('='), "level"),
 		},
 	}
 
@@ -182,10 +182,10 @@ func TestModifyHostConfigAndNamespaceOptionsForContainer(t *testing.T) {
 	}
 	setSELinuxHC := &dockercontainer.HostConfig{
 		SecurityOpt: []string{
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelUser, "user"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelRole, "role"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelType, "type"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelLevel, "level"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelUser('='), "user"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelRole('='), "role"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelType('='), "type"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelLevel('='), "level"),
 		},
 		IpcMode:     dockercontainer.IpcMode(sandboxNSMode),
 		NetworkMode: dockercontainer.NetworkMode(sandboxNSMode),
@@ -353,10 +353,10 @@ func fullValidHostConfig() *dockercontainer.HostConfig {
 		CapAdd:     []string{"addCapA", "addCapB"},
 		CapDrop:    []string{"dropCapA", "dropCapB"},
 		SecurityOpt: []string{
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelUser, "user"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelRole, "role"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelType, "type"),
-			fmt.Sprintf("%s:%s", securitycontext.DockerLabelLevel, "level"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelUser('='), "user"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelRole('='), "role"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelType('='), "type"),
+			fmt.Sprintf("%s:%s", securitycontext.DockerLabelLevel('='), "level"),
 		},
 	}
 }

--- a/pkg/kubelet/dockertools/docker_manager_linux_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux_test.go
@@ -89,8 +89,7 @@ func TestGetSecurityOpts(t *testing.T) {
 	for i, test := range tests {
 		securityOpts, err := dm.getSecurityOpts(test.pod, containerName)
 		assert.NoError(t, err, "TestCase[%d]: %s", i, test.msg)
-		opts, err := dm.fmtDockerOpts(securityOpts)
-		assert.NoError(t, err, "TestCase[%d]: %s", i, test.msg)
+		opts := fmtDockerOpts(securityOpts, '=')
 		assert.Len(t, opts, len(test.expectedOpts), "TestCase[%d]: %s", i, test.msg)
 		for _, opt := range test.expectedOpts {
 			assert.Contains(t, opts, opt, "TestCase[%d]: %s", i, test.msg)

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -1629,23 +1629,36 @@ func verifySyncResults(t *testing.T, expectedResults []*kubecontainer.SyncResult
 	}
 }
 
-func TestSecurityOptsOperator(t *testing.T) {
+func TestGetDockerOptSeparator(t *testing.T) {
 	dm110, _ := newTestDockerManagerWithVersion("1.10.1", "1.22")
 	dm111, _ := newTestDockerManagerWithVersion("1.11.0", "1.23")
 
-	secOpts := []dockerOpt{{"seccomp", "unconfined", ""}}
-	opts, err := dm110.fmtDockerOpts(secOpts)
+	separator, err := dm110.getDockerOptSeparator()
 	if err != nil {
-		t.Fatalf("error getting security opts for Docker 1.10: %v", err)
+		t.Fatalf("error getting docker opt separator for 1.10.1: %v", err)
 	}
+	if e, a := ':', separator; e != a {
+		t.Fatalf("Got unexpected docker opt separator for 1.10.1; expected %v, got %v", e, a)
+	}
+
+	separator, err = dm111.getDockerOptSeparator()
+	if err != nil {
+		t.Fatalf("error getting docker opt separator for 1.11.0: %v", err)
+	}
+	if e, a := '=', separator; e != a {
+		t.Fatalf("Got unexpected docker opt separator for 1.11.0; expected %v, got %v", e, a)
+	}
+}
+
+func TestFmtDockerOpts(t *testing.T) {
+	secOpts := []dockerOpt{{"seccomp", "unconfined", ""}}
+
+	opts := fmtDockerOpts(secOpts, ':')
 	if expected := []string{"seccomp:unconfined"}; len(opts) != 1 || opts[0] != expected[0] {
 		t.Fatalf("security opts for Docker 1.10: expected %v, got: %v", expected, opts)
 	}
 
-	opts, err = dm111.fmtDockerOpts(secOpts)
-	if err != nil {
-		t.Fatalf("error getting security opts for Docker 1.11: %v", err)
-	}
+	opts = fmtDockerOpts(secOpts, '=')
 	if expected := []string{"seccomp=unconfined"}; len(opts) != 1 || opts[0] != expected[0] {
 		t.Fatalf("security opts for Docker 1.11: expected %v, got: %v", expected, opts)
 	}

--- a/pkg/securitycontext/provider.go
+++ b/pkg/securitycontext/provider.go
@@ -28,12 +28,14 @@ import (
 )
 
 // NewSimpleSecurityContextProvider creates a new SimpleSecurityContextProvider.
-func NewSimpleSecurityContextProvider() SecurityContextProvider {
-	return SimpleSecurityContextProvider{}
+func NewSimpleSecurityContextProvider(securityOptSeparator rune) SecurityContextProvider {
+	return SimpleSecurityContextProvider{securityOptSeparator}
 }
 
 // SimpleSecurityContextProvider is the default implementation of a SecurityContextProvider.
-type SimpleSecurityContextProvider struct{}
+type SimpleSecurityContextProvider struct {
+	securityOptSeparator rune
+}
 
 // ModifyContainerConfig is called before the Docker createContainer call.
 // The security context provider can make changes to the Config with which
@@ -92,26 +94,38 @@ func (p SimpleSecurityContextProvider) ModifyHostConfig(pod *v1.Pod, container *
 	}
 
 	if effectiveSC.SELinuxOptions != nil {
-		hostConfig.SecurityOpt = ModifySecurityOptions(hostConfig.SecurityOpt, effectiveSC.SELinuxOptions)
+		hostConfig.SecurityOpt = ModifySecurityOptions(hostConfig.SecurityOpt, effectiveSC.SELinuxOptions, p.securityOptSeparator)
 	}
 }
 
-// ModifySecurityOptions adds SELinux options to config.
-func ModifySecurityOptions(config []string, selinuxOpts *v1.SELinuxOptions) []string {
-	config = modifySecurityOption(config, DockerLabelUser, selinuxOpts.User)
-	config = modifySecurityOption(config, DockerLabelRole, selinuxOpts.Role)
-	config = modifySecurityOption(config, DockerLabelType, selinuxOpts.Type)
-	config = modifySecurityOption(config, DockerLabelLevel, selinuxOpts.Level)
+// ModifySecurityOptions adds SELinux options to config using the given
+// separator.
+func ModifySecurityOptions(config []string, selinuxOpts *v1.SELinuxOptions, separator rune) []string {
+	// Note, strictly speaking, we are actually mutating the values of these
+	// keys, rather than formatting name and value into a string.  Docker re-
+	// uses the same option name multiple times (it's just 'label') with
+	// different values which are themselves key-value pairs.  For example,
+	// the SELinux type is represented by the security opt:
+	//
+	//   label<separator>type:<selinux_type>
+	//
+	// In Docker API versions before 1.23, the separator was the `:` rune; in
+	// API version 1.23 it changed to the `=` rune.
+	config = modifySecurityOption(config, DockerLabelUser(separator), selinuxOpts.User)
+	config = modifySecurityOption(config, DockerLabelRole(separator), selinuxOpts.Role)
+	config = modifySecurityOption(config, DockerLabelType(separator), selinuxOpts.Type)
+	config = modifySecurityOption(config, DockerLabelLevel(separator), selinuxOpts.Level)
 
 	return config
 }
 
-// modifySecurityOption adds the security option of name to the config array with value in the form
-// of name:value
+// modifySecurityOption adds the security option of name to the config array
+// with value in the form of name:value.
 func modifySecurityOption(config []string, name, value string) []string {
 	if len(value) > 0 {
 		config = append(config, fmt.Sprintf("%s:%s", name, value))
 	}
+
 	return config
 }
 

--- a/pkg/securitycontext/provider_test.go
+++ b/pkg/securitycontext/provider_test.go
@@ -74,7 +74,7 @@ func TestModifyContainerConfig(t *testing.T) {
 		},
 	}
 
-	provider := NewSimpleSecurityContextProvider()
+	provider := NewSimpleSecurityContextProvider('=')
 	dummyContainer := &v1.Container{}
 	for _, tc := range cases {
 		pod := &v1.Pod{Spec: v1.PodSpec{SecurityContext: tc.podSc}}
@@ -104,10 +104,10 @@ func TestModifyHostConfig(t *testing.T) {
 
 	setSELinuxHC := &dockercontainer.HostConfig{}
 	setSELinuxHC.SecurityOpt = []string{
-		fmt.Sprintf("%s:%s", DockerLabelUser, "user"),
-		fmt.Sprintf("%s:%s", DockerLabelRole, "role"),
-		fmt.Sprintf("%s:%s", DockerLabelType, "type"),
-		fmt.Sprintf("%s:%s", DockerLabelLevel, "level"),
+		fmt.Sprintf("%s:%s", DockerLabelUser(':'), "user"),
+		fmt.Sprintf("%s:%s", DockerLabelRole(':'), "role"),
+		fmt.Sprintf("%s:%s", DockerLabelType(':'), "type"),
+		fmt.Sprintf("%s:%s", DockerLabelLevel(':'), "level"),
 	}
 
 	// seLinuxLabelsSC := fullValidSecurityContext()
@@ -158,7 +158,7 @@ func TestModifyHostConfig(t *testing.T) {
 		},
 	}
 
-	provider := NewSimpleSecurityContextProvider()
+	provider := NewSimpleSecurityContextProvider(':')
 	dummyContainer := &v1.Container{}
 
 	for _, tc := range cases {
@@ -228,7 +228,7 @@ func TestModifyHostConfigPodSecurityContext(t *testing.T) {
 		},
 	}
 
-	provider := NewSimpleSecurityContextProvider()
+	provider := NewSimpleSecurityContextProvider(':')
 	dummyContainer := &v1.Container{}
 	dummyContainer.SecurityContext = fullValidSecurityContext()
 	dummyPod := &v1.Pod{
@@ -325,10 +325,10 @@ func fullValidHostConfig() *dockercontainer.HostConfig {
 		CapAdd:     []string{"addCapA", "addCapB"},
 		CapDrop:    []string{"dropCapA", "dropCapB"},
 		SecurityOpt: []string{
-			fmt.Sprintf("%s:%s", DockerLabelUser, "user"),
-			fmt.Sprintf("%s:%s", DockerLabelRole, "role"),
-			fmt.Sprintf("%s:%s", DockerLabelType, "type"),
-			fmt.Sprintf("%s:%s", DockerLabelLevel, "level"),
+			fmt.Sprintf("%s:%s", DockerLabelUser(':'), "user"),
+			fmt.Sprintf("%s:%s", DockerLabelRole(':'), "role"),
+			fmt.Sprintf("%s:%s", DockerLabelType(':'), "type"),
+			fmt.Sprintf("%s:%s", DockerLabelLevel(':'), "level"),
 		},
 	}
 }

--- a/pkg/securitycontext/types.go
+++ b/pkg/securitycontext/types.go
@@ -39,11 +39,3 @@ type SecurityContextProvider interface {
 	// - supplementalGids: additional supplemental GIDs associated with the pod's volumes
 	ModifyHostConfig(pod *v1.Pod, container *v1.Container, hostConfig *dockercontainer.HostConfig, supplementalGids []int64)
 }
-
-const (
-	DockerLabelUser    string = "label:user"
-	DockerLabelRole    string = "label:role"
-	DockerLabelType    string = "label:type"
-	DockerLabelLevel   string = "label:level"
-	DockerLabelDisable string = "label:disable"
-)

--- a/pkg/securitycontext/util.go
+++ b/pkg/securitycontext/util.go
@@ -87,3 +87,39 @@ func HasRunAsUser(container *v1.Container) bool {
 func HasRootRunAsUser(container *v1.Container) bool {
 	return HasRunAsUser(container) && HasRootUID(container)
 }
+
+// DockerLabelUser returns the fragment of a Docker security opt that
+// describes the SELinux user. Note that strictly speaking this is not
+// actually the name of the security opt, but a fragment of the whole key-
+// value pair necessary to set the opt.
+func DockerLabelUser(separator rune) string {
+	return fmt.Sprintf("label%cuser", separator)
+}
+
+// DockerLabelRole returns the fragment of a Docker security opt that
+// describes the SELinux role. Note that strictly speaking this is not
+// actually the name of the security opt, but a fragment of the whole key-
+// value pair necessary to set the opt.
+func DockerLabelRole(separator rune) string {
+	return fmt.Sprintf("label%crole", separator)
+}
+
+// DockerLabelType returns the fragment of a Docker security opt that
+// describes the SELinux type. Note that strictly speaking this is not
+// actually the name of the security opt, but a fragment of the whole key-
+// value pair necessary to set the opt.
+func DockerLabelType(separator rune) string {
+	return fmt.Sprintf("label%ctype", separator)
+}
+
+// DockerLabelLevel returns the fragment of a Docker security opt that
+// describes the SELinux level. Note that strictly speaking this is not
+// actually the name of the security opt, but a fragment of the whole key-
+// value pair necessary to set the opt.
+func DockerLabelLevel(separator rune) string {
+	return fmt.Sprintf("label%clevel", separator)
+}
+
+func DockerLabelDisable(separator rune) string {
+	return fmt.Sprintf("label%cdisable", separator)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

The current code for the security context provider uses a hard-coded `:` separator for the docker security options, while newer versions of docker require `=` for a separator.  There is code the apparmor and seccomp that sets the separator correctly based on the docker API version, but it is not applied to SELinux options.

**Which issue this PR fixes** 

fixes #37807

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
