### PR TITLE
remove the delete-pod-uid spec

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -82,9 +82,6 @@ var (
 		# Force delete a pod on a dead node
 		kubectl delete pod foo --grace-period=0 --force
 
-		# Delete a pod with UID 1234-56-7890-234234-456456.
-		kubectl delete pod 1234-56-7890-234234-456456
-
 		# Delete all pods
 		kubectl delete pods --all`)
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
remove the specifications about "kubectl delete pod uid" cause it's no longer supported.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #40121

