### PR TITLE
update short help message in set resource

### DIFF
--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -98,7 +98,7 @@ func NewCmdResources(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.
 
 	cmd := &cobra.Command{
 		Use:     "resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requests=REQUESTS]",
-		Short:   "update resource requests/limits on objects with pod templates",
+		Short:   "Update resource requests/limits on objects with pod templates",
 		Long:    fmt.Sprintf(resources_long, strings.Join(resourceTypesWithPodTemplate, ", ")),
 		Example: resources_example,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
To keep the help message well-formed.
```
#kubectl set -h           
Configure application resources 

These commands help you make changes to existing application resources.

Available Commands:
  image       Update image of a pod template
  resources   update resource requests/limits on objects with pod templates
  selector    Set the selector on a resource

Usage:
  kubectl set SUBCOMMAND [options]
```

```release-note
NONE
```
