### PR TITLE
Remove TODOs to refactor kubelet labels

### DIFF
--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -29,7 +29,6 @@ import (
 )
 
 const (
-	// TODO: move those label definitions to kubelet/types/labels.go
 	// TODO: change those label names to follow kubernetes's format
 	podDeletionGracePeriodLabel    = "io.kubernetes.pod.deletionGracePeriod"
 	podTerminationGracePeriodLabel = "io.kubernetes.pod.terminationGracePeriod"


### PR DESCRIPTION
To address #39650 completely.

Remove label refactoring TODOs, we don't need them since CRI rollout is on the way.