### PR TITLE
dnsprovider: Add direct access to Route53 data

### DIFF
--- a/federation/pkg/dnsprovider/providers/aws/route53/rrset.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/rrset.go
@@ -51,3 +51,12 @@ func (rrset ResourceRecordSet) Ttl() int64 {
 func (rrset ResourceRecordSet) Type() rrstype.RrsType {
 	return rrstype.RrsType(*rrset.impl.Type)
 }
+
+// Route53ResourceRecordSet returns the route53 ResourceRecordSet object for the ResourceRecordSet
+// This is a "back door" that allows for limited access to the ResourceRecordSet,
+// without having to requery it, so that we can expose AWS specific functionality.
+// Using this method should be avoided where possible; instead prefer to add functionality
+// to the cross-provider ResourceRecordSet interface.
+func (rrset ResourceRecordSet) Route53ResourceRecordSet() *route53.ResourceRecordSet {
+	return rrset.impl
+}

--- a/federation/pkg/dnsprovider/providers/aws/route53/zone.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/zone.go
@@ -45,3 +45,12 @@ func (zone *Zone) ID() string {
 func (zone *Zone) ResourceRecordSets() (dnsprovider.ResourceRecordSets, bool) {
 	return &ResourceRecordSets{zone}, true
 }
+
+// Route53HostedZone returns the route53 HostedZone object for the zone.
+// This is a "back door" that allows for limited access to the HostedZone,
+// without having to requery it, so that we can expose AWS specific functionality.
+// Using this method should be avoided where possible; instead prefer to add functionality
+// to the cross-provider Zone interface.
+func (zone *Zone) Route53HostedZone() *route53.HostedZone {
+	return zone.impl
+}


### PR DESCRIPTION
This methods allow us to develop advanced functionality for Route53,
before we add all the functionality to the cross-provider interface.
Use of these methods should be avoided, and adding methods to the
cross-provider interfaces should be preferred.

```release-note
NONE
```
