### PR TITLE
[OS Load Balancers] Allow Service Annotations to override the settings specified in --cloud-config

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -88,18 +88,18 @@ type LoadBalancerOpts struct {
 	NodeSecurityGroupID  string     `gcfg:"node-security-group"`
 	Provider             string     `gcfg:"provider"`
 
-	// Optional settings that allow a cluster admin to prevent his users from setting LB parameters through Service Annotations
-	DisableAnnotationLBVersion            bool `gcfg:"disable-annotation-lb-version"`
-	DisableAnnotationSubnetId             bool `gcfg:"disable-annotation-subnet-id"`
-	DisableAnnotationFloatingNetworkId    bool `gcfg:"disable-annotation-floating-network-id"`
-	DisableAnnotationLBMethod             bool `gcfg:"disable-annotation-lb-method"`
-	DisableAnnotationCreateMonitor        bool `gcfg:"disable-annotation-create-monitor"`
-	DisableAnnotationMonitorDelay         bool `gcfg:"disable-annotation-monitor-delay"`
-	DisableAnnotationMonitorTimeout       bool `gcfg:"disable-annotation-monitor-timeout"`
-	DisableAnnotationMonitorMaxRetries    bool `gcfg:"disable-annotation-monitor-max-retries"`
-	DisableAnnotationManageSecurityGroups bool `gcfg:"disable-annotation-manage-security-groups"`
-	DisableAnnotationNodeSecurityGroupID  bool `gcfg:"disable-annotation-node-security-group"`
-	DisableAnnotationProvider             bool `gcfg:"disable-annotation-provider"`
+	// Optional settings that allow a cluster admin to allow his users to set specific LB parameters through Service Annotations
+	EnableAnnotationLBVersion            bool `gcfg:"disable-annotation-lb-version"`
+	EnableAnnotationSubnetId             bool `gcfg:"disable-annotation-subnet-id"`
+	EnableAnnotationFloatingNetworkId    bool `gcfg:"disable-annotation-floating-network-id"`
+	EnableAnnotationLBMethod             bool `gcfg:"disable-annotation-lb-method"`
+	EnableAnnotationCreateMonitor        bool `gcfg:"disable-annotation-create-monitor"`
+	EnableAnnotationMonitorDelay         bool `gcfg:"disable-annotation-monitor-delay"`
+	EnableAnnotationMonitorTimeout       bool `gcfg:"disable-annotation-monitor-timeout"`
+	EnableAnnotationMonitorMaxRetries    bool `gcfg:"disable-annotation-monitor-max-retries"`
+	EnableAnnotationManageSecurityGroups bool `gcfg:"disable-annotation-manage-security-groups"`
+	EnableAnnotationNodeSecurityGroupID  bool `gcfg:"disable-annotation-node-security-group"`
+	EnableAnnotationProvider             bool `gcfg:"disable-annotation-provider"`
 }
 
 type BlockStorageOpts struct {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -87,6 +87,19 @@ type LoadBalancerOpts struct {
 	ManageSecurityGroups bool       `gcfg:"manage-security-groups"`
 	NodeSecurityGroupID  string     `gcfg:"node-security-group"`
 	Provider             string     `gcfg:"provider"`
+
+	// Optional settings that allow a cluster admin to prevent his users from setting LB parameters through Service Annotations
+	DisableAnnotationLBVersion            bool `gcfg:"disable-annotation-lb-version"`
+	DisableAnnotationSubnetId             bool `gcfg:"disable-annotation-subnet-id"`
+	DisableAnnotationFloatingNetworkId    bool `gcfg:"disable-annotation-floating-network-id"`
+	DisableAnnotationLBMethod             bool `gcfg:"disable-annotation-lb-method"`
+	DisableAnnotationCreateMonitor        bool `gcfg:"disable-annotation-create-monitor"`
+	DisableAnnotationMonitorDelay         bool `gcfg:"disable-annotation-monitor-delay"`
+	DisableAnnotationMonitorTimeout       bool `gcfg:"disable-annotation-monitor-timeout"`
+	DisableAnnotationMonitorMaxRetries    bool `gcfg:"disable-annotation-monitor-max-retries"`
+	DisableAnnotationManageSecurityGroups bool `gcfg:"disable-annotation-manage-security-groups"`
+	DisableAnnotationNodeSecurityGroupID  bool `gcfg:"disable-annotation-node-security-group"`
+	DisableAnnotationProvider             bool `gcfg:"disable-annotation-provider"`
 }
 
 type BlockStorageOpts struct {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -89,17 +89,17 @@ type LoadBalancerOpts struct {
 	Provider             string     `gcfg:"provider"`
 
 	// Optional settings that allow a cluster admin to allow his users to set specific LB parameters through Service Annotations
-	EnableAnnotationLBVersion            bool `gcfg:"disable-annotation-lb-version"`
-	EnableAnnotationSubnetId             bool `gcfg:"disable-annotation-subnet-id"`
-	EnableAnnotationFloatingNetworkId    bool `gcfg:"disable-annotation-floating-network-id"`
-	EnableAnnotationLBMethod             bool `gcfg:"disable-annotation-lb-method"`
-	EnableAnnotationCreateMonitor        bool `gcfg:"disable-annotation-create-monitor"`
-	EnableAnnotationMonitorDelay         bool `gcfg:"disable-annotation-monitor-delay"`
-	EnableAnnotationMonitorTimeout       bool `gcfg:"disable-annotation-monitor-timeout"`
-	EnableAnnotationMonitorMaxRetries    bool `gcfg:"disable-annotation-monitor-max-retries"`
-	EnableAnnotationManageSecurityGroups bool `gcfg:"disable-annotation-manage-security-groups"`
-	EnableAnnotationNodeSecurityGroupID  bool `gcfg:"disable-annotation-node-security-group"`
-	EnableAnnotationProvider             bool `gcfg:"disable-annotation-provider"`
+	EnableAnnotationLBVersion            bool `gcfg:"enable-annotation-lb-version"`
+	EnableAnnotationSubnetId             bool `gcfg:"enable-annotation-subnet-id"`
+	EnableAnnotationFloatingNetworkId    bool `gcfg:"enable-annotation-floating-network-id"`
+	EnableAnnotationLBMethod             bool `gcfg:"enable-annotation-lb-method"`
+	EnableAnnotationCreateMonitor        bool `gcfg:"enable-annotation-create-monitor"`
+	EnableAnnotationMonitorDelay         bool `gcfg:"enable-annotation-monitor-delay"`
+	EnableAnnotationMonitorTimeout       bool `gcfg:"enable-annotation-monitor-timeout"`
+	EnableAnnotationMonitorMaxRetries    bool `gcfg:"enable-annotation-monitor-max-retries"`
+	EnableAnnotationManageSecurityGroups bool `gcfg:"enable-annotation-manage-security-groups"`
+	EnableAnnotationNodeSecurityGroupID  bool `gcfg:"enable-annotation-node-security-group"`
+	EnableAnnotationProvider             bool `gcfg:"enable-annotation-provider"`
 }
 
 type BlockStorageOpts struct {

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -86,6 +86,7 @@ type LoadBalancerOpts struct {
 	MonitorMaxRetries    uint       `gcfg:"monitor-max-retries"`
 	ManageSecurityGroups bool       `gcfg:"manage-security-groups"`
 	NodeSecurityGroupID  string     `gcfg:"node-security-group"`
+	Provider             string     `gcfg:"provider"`
 }
 
 type BlockStorageOpts struct {

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1024,7 +1024,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *v1.Serv
 			}
 
 			nodeSecurityGroupID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerNodeSecurityGroupID, lbaas.opts.NodeSecurityGroupID, lbaas.opts.EnableAnnotationNodeSecurityGroupID)
-			err := createNodeSecurityGroup(lbaas.network, nodeSecurityGroupID, int(port.NodePort), string(port.Protocol), lbSecGroup.ID)
+			err := createNodeSecurityGroup(lbaas.network, nodeSecurityGroupID, int(port.NodePort), port.Protocol, lbSecGroup.ID)
 
 			if err != nil {
 				glog.Errorf("Error occured creating security group for loadbalancer %s:", loadbalancer.ID)
@@ -1449,7 +1449,7 @@ func (lb *LbaasV1) EnsureLoadBalancer(clusterName string, apiService *v1.Service
 	}
 
 	// if this service has an annotation for LB method, use that instead
-	lbMethod := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerLBMethod, lb.opts.LBMethod, lb.opts.EnableAnnotationLBMethod)
+	lbMethod := pools.LBMethod(getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerLBMethod, lb.opts.LBMethod, lb.opts.EnableAnnotationLBMethod))
 
 	if lbMethod == "" {
 		lbMethod = pools.LBMethodRoundRobin

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -515,9 +515,9 @@ func createNodeSecurityGroup(client *gophercloud.ServiceClient, nodeSecurityGrou
 }
 
 //getStringFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
-func getStringFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting string, disabledFlag bool) string {
-	glog.V(4).Infof("getStringFromServiceAnnotation(%v, %v, %v, %v)", service, annotationKey, defaultSetting, disabledFlag)
-	if disabledFlag {
+func getStringFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting string, enabledFlag bool) string {
+	glog.V(4).Infof("getStringFromServiceAnnotation(%v, %v, %v, %v)", service, annotationKey, defaultSetting, enabledFlag)
+	if !enabledFlag {
 		return defaultSetting
 	}
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -531,9 +531,9 @@ func getStringFromServiceAnnotation(service *v1.Service, annotationKey string, d
 }
 
 //getBoolFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
-func getBoolFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting bool, disabledFlag bool) bool {
-	glog.V(4).Infof("getBoolFromServiceAnnotation(%v, %v, %v, %v)", service, annotationKey, defaultSetting, disabledFlag)
-	if disabledFlag {
+func getBoolFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting bool, enabledFlag bool) bool {
+	glog.V(4).Infof("getBoolFromServiceAnnotation(%v, %v, %v, %v)", service, annotationKey, defaultSetting, enabledFlag)
+	if !enabledFlag {
 		return defaultSetting
 	}
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -552,9 +552,9 @@ func getBoolFromServiceAnnotation(service *v1.Service, annotationKey string, def
 }
 
 //getDurationFromServiceAnnotation searches a given v1.Service for a specific annotationKey and either returns the annotation's value or a specified defaultSetting
-func getDurationFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting MyDuration, disabledFlag bool) MyDuration {
-	glog.V(4).Infof("getBoolFromServiceAnnotation(%v, %v, %v, %v)", service, annotationKey, defaultSetting, disabledFlag)
-	if disabledFlag {
+func getDurationFromServiceAnnotation(service *v1.Service, annotationKey string, defaultSetting MyDuration, enabledFlag bool) MyDuration {
+	glog.V(4).Infof("getBoolFromServiceAnnotation(%v, %v, %v, %v)", service, annotationKey, defaultSetting, enabledFlag)
+	if !enabledFlag {
 		return defaultSetting
 	}
 	if annotationValue, ok := service.Annotations[annotationKey]; ok {
@@ -584,10 +584,10 @@ func (lbaas *LbaasV2) createLoadBalancer(service *v1.Service, name string) (*loa
 	}
 
 	// if this service has an annotation for provider, add that as Provider arg to the Loadbalancer options
-	createOpts.Provider = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerProvider, lbaas.opts.Provider, lbaas.opts.DisableAnnotationProvider)
+	createOpts.Provider = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerProvider, lbaas.opts.Provider, lbaas.opts.EnableAnnotationProvider)
 
 	// if this service has an annotation for subnet-id, add that as VipSubnetID arg the Loadbalancer options
-	createOpts.VipSubnetID = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetId, lbaas.opts.DisableAnnotationSubnetId)
+	createOpts.VipSubnetID = getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetId, lbaas.opts.EnableAnnotationSubnetId)
 
 	loadbalancer, err := loadbalancers.Create(lbaas.network, createOpts).Extract()
 	if err != nil {
@@ -716,7 +716,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *v1.Serv
 	}
 
 	// if this service has an annotation for ManageSecurityGroups, use that instead
-	manageSecurityGroups := getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerManageSecurityGroups, lbaas.opts.ManageSecurityGroups, lbaas.opts.DisableAnnotationManageSecurityGroups)
+	manageSecurityGroups := getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerManageSecurityGroups, lbaas.opts.ManageSecurityGroups, lbaas.opts.EnableAnnotationManageSecurityGroups)
 
 	if !service.IsAllowAll(sourceRanges) && !manageSecurityGroups {
 		return nil, fmt.Errorf("Source range restrictions are not supported for openstack load balancers without managing security groups")
@@ -752,7 +752,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *v1.Serv
 	waitLoadbalancerActiveProvisioningStatus(lbaas.network, loadbalancer.ID)
 
 	// if this service has an annotation for LB method, use that instead
-	_lbMethod := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerLBMethod, lbaas.opts.LBMethod, lbaas.opts.DisableAnnotationLBMethod)
+	_lbMethod := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerLBMethod, lbaas.opts.LBMethod, lbaas.opts.EnableAnnotationLBMethod)
 
 	lbMethod := v2pools.LBMethod(_lbMethod)
 	if lbMethod == "" {
@@ -828,7 +828,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *v1.Serv
 				_, err := v2pools.CreateMember(lbaas.network, pool.ID, v2pools.CreateMemberOpts{
 					ProtocolPort: int(port.NodePort),
 					Address:      addr,
-					SubnetID:     getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetId, lbaas.opts.DisableAnnotationSubnetId),
+					SubnetID:     getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetId, lbaas.opts.EnableAnnotationSubnetId),
 				}).Extract()
 				if err != nil {
 					return nil, fmt.Errorf("Error creating LB pool member for node: %s, %v", node.Name, err)
@@ -856,16 +856,16 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *v1.Serv
 		monitorID := pool.MonitorID
 
 		// if this service has an annotation for CreateMonitor, use that instead
-		createMonitor := getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerCreateMonitor, lbaas.opts.CreateMonitor, lbaas.opts.DisableAnnotationCreateMonitor)
+		createMonitor := getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerCreateMonitor, lbaas.opts.CreateMonitor, lbaas.opts.EnableAnnotationCreateMonitor)
 
 		// if this service has an annotation for MonitorDelay, use that instead
-		monitorDelay := getDurationFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorDelay, lbaas.opts.MonitorDelay, lbaas.opts.DisableAnnotationMonitorDelay)
+		monitorDelay := getDurationFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorDelay, lbaas.opts.MonitorDelay, lbaas.opts.EnableAnnotationMonitorDelay)
 
 		// if this service has an annotation for MonitorTimeout, use that instead
-		monitorTimeout := getDurationFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorTimeout, lbaas.opts.MonitorTimeout, lbaas.opts.DisableAnnotationMonitorTimeout)
+		monitorTimeout := getDurationFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorTimeout, lbaas.opts.MonitorTimeout, lbaas.opts.EnableAnnotationMonitorTimeout)
 
 		// if this service has an annotation for MonitorMaxRetries, use that instead
-		_monitorMaxRetries := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorMaxRetries, strconv.FormatUint(uint64(lbaas.opts.MonitorMaxRetries), 10), lbaas.opts.DisableAnnotationMonitorMaxRetries)
+		_monitorMaxRetries := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorMaxRetries, strconv.FormatUint(uint64(lbaas.opts.MonitorMaxRetries), 10), lbaas.opts.EnableAnnotationMonitorMaxRetries)
 		monitorMaxRetries, err := strconv.ParseInt(_monitorMaxRetries, 10, 64)
 		if err != nil {
 			glog.Errorf("Failed to parse MonitorMaxRetries service annotation: %v; %v", _monitorMaxRetries, err)
@@ -956,7 +956,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *v1.Serv
 	}
 
 	// if this service has an annotation for floating network ID, add that as floatingNetworkID arg to the Loadbalancer options
-	floatingNetworkID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerFloatingNetworkID, lbaas.opts.FloatingNetworkId, lbaas.opts.DisableAnnotationFloatingNetworkId)
+	floatingNetworkID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerFloatingNetworkID, lbaas.opts.FloatingNetworkId, lbaas.opts.EnableAnnotationFloatingNetworkId)
 
 	if floatIP == nil && floatingNetworkID != "" {
 		glog.V(4).Infof("Creating floating ip for loadbalancer %s port %s", loadbalancer.ID, port.ID)
@@ -1022,8 +1022,9 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(clusterName string, apiService *v1.Serv
 					return nil, err
 				}
 			}
-			nodeSecurityGroupID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerNodeSecurityGroupID, lbaas.opts.NodeSecurityGroupID, lbaas.opts.DisableAnnotationNodeSecurityGroupID)
-			err := createNodeSecurityGroup(lbaas.network, nodeSecurityGroupID, int(port.NodePort), port.Protocol, lbSecGroup.ID)
+
+			nodeSecurityGroupID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerNodeSecurityGroupID, lbaas.opts.NodeSecurityGroupID, lbaas.opts.EnableAnnotationNodeSecurityGroupID)
+			err := createNodeSecurityGroup(lbaas.network, nodeSecurityGroupID, int(port.NodePort), string(port.Protocol), lbSecGroup.ID)
 
 			if err != nil {
 				glog.Errorf("Error occured creating security group for loadbalancer %s:", loadbalancer.ID)
@@ -1184,7 +1185,7 @@ func (lbaas *LbaasV2) UpdateLoadBalancer(clusterName string, service *v1.Service
 			_, err := v2pools.CreateMember(lbaas.network, pool.ID, v2pools.CreateMemberOpts{
 				Address:      addr,
 				ProtocolPort: int(port.NodePort),
-				SubnetID:     getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetId, lbaas.opts.DisableAnnotationSubnetId),
+				SubnetID:     getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerSubnetID, lbaas.opts.SubnetId, lbaas.opts.EnableAnnotationSubnetId),
 			}).Extract()
 			if err != nil {
 				return err
@@ -1221,7 +1222,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancerDeleted(clusterName string, service *v1.
 	}
 
 	// if this service has an annotation for floating network ID, use that instead of the default
-	floatingNetworkID := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerFloatingNetworkID, lbaas.opts.FloatingNetworkId, lbaas.opts.DisableAnnotationFloatingNetworkId)
+	floatingNetworkID := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerFloatingNetworkID, lbaas.opts.FloatingNetworkId, lbaas.opts.EnableAnnotationFloatingNetworkId)
 
 	if floatingNetworkID != "" && loadbalancer != nil && loadbalancer.VipPortID != "" {
 		portID := loadbalancer.VipPortID
@@ -1322,7 +1323,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancerDeleted(clusterName string, service *v1.
 	// Delete the Security Group
 
 	// if this service has an annotation for ManageSecurityGroups, use that instead
-	manageSecurityGroups := getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerManageSecurityGroups, lbaas.opts.ManageSecurityGroups, lbaas.opts.DisableAnnotationManageSecurityGroups)
+	manageSecurityGroups := getBoolFromServiceAnnotation(service, ServiceAnnotationLoadBalancerManageSecurityGroups, lbaas.opts.ManageSecurityGroups, lbaas.opts.EnableAnnotationManageSecurityGroups)
 
 	if manageSecurityGroups {
 		// Generate Name
@@ -1338,7 +1339,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancerDeleted(clusterName string, service *v1.
 			return lbSecGroup.Err
 		}
 
-		nodeSecurityGroupID := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerNodeSecurityGroupID, lbaas.opts.NodeSecurityGroupID, lbaas.opts.DisableAnnotationNodeSecurityGroupID)
+		nodeSecurityGroupID := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerNodeSecurityGroupID, lbaas.opts.NodeSecurityGroupID, lbaas.opts.EnableAnnotationNodeSecurityGroupID)
 
 		// Delete the rules in the Node Security Group
 		opts := rules.ListOpts{
@@ -1448,13 +1449,13 @@ func (lb *LbaasV1) EnsureLoadBalancer(clusterName string, apiService *v1.Service
 	}
 
 	// if this service has an annotation for LB method, use that instead
-	lbMethod := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerLBMethod, lb.opts.LBMethod, lb.opts.DisableAnnotationLBMethod)
+	lbMethod := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerLBMethod, lb.opts.LBMethod, lb.opts.EnableAnnotationLBMethod)
 
 	if lbMethod == "" {
 		lbMethod = pools.LBMethodRoundRobin
 	}
 	name := cloudprovider.GetLoadBalancerName(apiService)
-	subnetID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerSubnetID, lb.opts.SubnetId, lb.opts.DisableAnnotationSubnetId)
+	subnetID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerSubnetID, lb.opts.SubnetId, lb.opts.EnableAnnotationSubnetId)
 	pool, err := pools.Create(lb.network, pools.CreateOpts{
 		Name:     name,
 		Protocol: pools.ProtocolTCP,
@@ -1483,16 +1484,16 @@ func (lb *LbaasV1) EnsureLoadBalancer(clusterName string, apiService *v1.Service
 	}
 
 	// if this service has an annotation for CreateMonitor, use that instead
-	createMonitor := getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerCreateMonitor, lb.opts.CreateMonitor, lb.opts.DisableAnnotationCreateMonitor)
+	createMonitor := getBoolFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerCreateMonitor, lb.opts.CreateMonitor, lb.opts.EnableAnnotationCreateMonitor)
 
 	// if this service has an annotation for MonitorDelay, use that instead
-	monitorDelay := getDurationFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorDelay, lb.opts.MonitorDelay, lb.opts.DisableAnnotationMonitorDelay)
+	monitorDelay := getDurationFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorDelay, lb.opts.MonitorDelay, lb.opts.EnableAnnotationMonitorDelay)
 
 	// if this service has an annotation for MonitorTimeout, use that instead
-	monitorTimeout := getDurationFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorTimeout, lb.opts.MonitorTimeout, lb.opts.DisableAnnotationMonitorTimeout)
+	monitorTimeout := getDurationFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorTimeout, lb.opts.MonitorTimeout, lb.opts.EnableAnnotationMonitorTimeout)
 
 	// if this service has an annotation for MonitorMaxRetries, use that instead
-	_monitorMaxRetries := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorMaxRetries, strconv.FormatUint(uint64(lb.opts.MonitorMaxRetries), 10), lb.opts.DisableAnnotationMonitorMaxRetries)
+	_monitorMaxRetries := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerMonitorMaxRetries, strconv.FormatUint(uint64(lb.opts.MonitorMaxRetries), 10), lb.opts.EnableAnnotationMonitorMaxRetries)
 	monitorMaxRetries, err := strconv.ParseInt(_monitorMaxRetries, 10, 64)
 	if err != nil {
 		glog.Errorf("Failed to parse MonitorMaxRetries service annotation: %v; %v", _monitorMaxRetries, err)
@@ -1542,7 +1543,7 @@ func (lb *LbaasV1) EnsureLoadBalancer(clusterName string, apiService *v1.Service
 	status.Ingress = []v1.LoadBalancerIngress{{IP: vip.Address}}
 
 	// if this service has an annotation for floating network ID, add that as floatingNetworkID arg to the Loadbalancer options
-	floatingNetworkID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerFloatingNetworkID, lb.opts.FloatingNetworkId, lb.opts.DisableAnnotationFloatingNetworkId)
+	floatingNetworkID := getStringFromServiceAnnotation(apiService, ServiceAnnotationLoadBalancerFloatingNetworkID, lb.opts.FloatingNetworkId, lb.opts.EnableAnnotationFloatingNetworkId)
 
 	if floatingNetworkID != "" {
 		floatIPOpts := floatingips.CreateOpts{
@@ -1633,7 +1634,7 @@ func (lb *LbaasV1) EnsureLoadBalancerDeleted(clusterName string, service *v1.Ser
 	}
 
 	// if this service has an annotation for floating network ID, add that as floatingNetworkID arg to the Loadbalancer options
-	floatingNetworkID := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerFloatingNetworkID, lb.opts.FloatingNetworkId, lb.opts.DisableAnnotationFloatingNetworkId)
+	floatingNetworkID := getStringFromServiceAnnotation(service, ServiceAnnotationLoadBalancerFloatingNetworkID, lb.opts.FloatingNetworkId, lb.opts.EnableAnnotationFloatingNetworkId)
 
 	if floatingNetworkID != "" && vip != nil {
 		floatingIP, err := getFloatingIPByPortID(lb.network, vip.PortID)


### PR DESCRIPTION
tl;dr: Added a set of Service Annotations that allow the Service author to directly control key settings of the load balancers he or she creates

This is my proposal for issue #40054 

There is a definite lack of flexibility when it comes to configuring OpenStack load balancers through k8s Services. The following settings may be set in an administrator's --cloud-config file (under the [LoadBalancer] heading), but they apply to all Loadbalancer-type Services on your cluster:

lb-version
subnet-id
floating-network-id
lb-method
create-monitor
monitor-delay
monitor-timeout
monitor-max-retries
manage-security-groups
node-security-group

Furthermore, there is no setting for LB "provider". I have added the "provider" setting to the list of available --cloud-config settings, as well as added some logic to the openstack loadbalancer driver that will allow the user to control almost all of these settings via Service Annotations.

The annotations all share a common, simple structure that is similar to that of pkg/cloudprovider/providers/aws's annotations:
service.beta.kubernetes.io/openstack-load-balancer-provider
service.beta.kubernetes.io/openstack-load-balancer-subnet-id
service.beta.kubernetes.io/openstack-load-balancer-floating-network-id
service.beta.kubernetes.io/openstack-load-balancer-lb-method
service.beta.kubernetes.io/openstack-load-balancer-create-monitor
service.beta.kubernetes.io/openstack-load-balancer-monitor-delay
service.beta.kubernetes.io/openstack-load-balancer-monitor-timeout
service.beta.kubernetes.io/openstack-load-balancer-monitor-max-retries
service.beta.kubernetes.io/openstack-load-balancer-manage-security-groups
service.beta.kubernetes.io/openstack-load-balancer-node-security-group

Where appropriate, I have inserted code into pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go to make sure that the Annotations take a higher priority than their corresponding --cloud-config settings.


