### PR TITLE
Remove federated-image.tag from the .gitignore file.

### DIFF
--- a/federation/manifests/.gitignore
+++ b/federation/manifests/.gitignore
@@ -1,1 +1,0 @@
-/federated-image.tag


### PR DESCRIPTION
This generated version metadata file was being written to a source
directory and caused a lot of pain. We are moving to a world where
this file is generated in the build/output artifacts directory and
also possibly looking at ways to entirely remove the federation
specific versions file. This is in-line with that goal of removing
the dependency on federated-image.tag file.

cc @kubernetes/sig-federation-misc 
