### PR TITLE
genericapiserver: write negotiated Status on timeout

### DIFF
--- a/cmd/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/cmd/kube-aggregator/pkg/apiserver/apiserver.go
@@ -194,7 +194,7 @@ func (h *handlerChainConfig) handlerChain(apiHandler http.Handler, c *genericapi
 
 	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
 	handler = genericfilters.WithPanicRecovery(handler, c.RequestContextMapper)
-	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.RequestContextMapper, c.LongRunningFunc)
+	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.RequestContextMapper, c.Serializer, c.LongRunningFunc)
 	handler = genericfilters.WithMaxInFlightLimit(handler, c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight, c.RequestContextMapper, c.LongRunningFunc)
 	handler = genericapifilters.WithRequestInfo(handler, genericapiserver.NewRequestInfoResolver(c), c.RequestContextMapper)
 	handler = genericapirequest.WithRequestContext(handler, c.RequestContextMapper)

--- a/pkg/genericapiserver/server/config.go
+++ b/pkg/genericapiserver/server/config.go
@@ -571,7 +571,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) (secure, insec
 	generic := func(handler http.Handler) http.Handler {
 		handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
 		handler = genericfilters.WithPanicRecovery(handler, c.RequestContextMapper)
-		handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.RequestContextMapper, c.LongRunningFunc)
+		handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.RequestContextMapper, c.Serializer, c.LongRunningFunc)
 		handler = genericfilters.WithMaxInFlightLimit(handler, c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight, c.RequestContextMapper, c.LongRunningFunc)
 		handler = genericapifilters.WithRequestInfo(handler, NewRequestInfoResolver(c), c.RequestContextMapper)
 		handler = apirequest.WithRequestContext(handler, c.RequestContextMapper)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go
@@ -18,7 +18,7 @@ package filters
 
 import (
 	"bufio"
-	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -26,8 +26,10 @@ import (
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/genericapiserver/endpoints/handlers/responsewriters"
 )
 
 const globalTimeout = time.Minute
@@ -35,77 +37,83 @@ const globalTimeout = time.Minute
 var errConnKilled = fmt.Errorf("kill connection/stream")
 
 // WithTimeoutForNonLongRunningRequests times out non-long-running requests after the time given by globalTimeout.
-func WithTimeoutForNonLongRunningRequests(handler http.Handler, requestContextMapper apirequest.RequestContextMapper, longRunning LongRunningRequestCheck) http.Handler {
+// TODO unify this with apiserver.MaxInFlightLimit
+func WithTimeoutForNonLongRunningRequests(handler http.Handler, requestContextMapper apirequest.RequestContextMapper, s runtime.NegotiatedSerializer, longRunning LongRunningRequestCheck) http.Handler {
 	if longRunning == nil {
 		return handler
 	}
-	timeoutFunc := func(req *http.Request) (<-chan time.Time, *apierrors.StatusError) {
-		// TODO unify this with apiserver.MaxInFlightLimit
+	handlerWithTimeout := WithTimeout(handler, globalTimeout, requestContextMapper, s)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx, ok := requestContextMapper.Get(req)
 		if !ok {
-			// if this happens, the handler chain isn't setup correctly because there is no context mapper
-			return time.After(globalTimeout), apierrors.NewInternalError(fmt.Errorf("no context found for request during timeout"))
+			responsewriters.InternalError(w, req, errors.New("no context found for request"))
+			return
 		}
 
 		requestInfo, ok := apirequest.RequestInfoFrom(ctx)
 		if !ok {
-			// if this happens, the handler chain isn't setup correctly because there is no request info
-			return time.After(globalTimeout), apierrors.NewInternalError(fmt.Errorf("no request info found for request during timeout"))
+			responsewriters.InternalError(w, req, errors.New("no request info found for request"))
+			return
 		}
 
 		if longRunning(req, requestInfo) {
-			return nil, nil
+			handler.ServeHTTP(w, req)
+			return
 		}
-		return time.After(globalTimeout), apierrors.NewServerTimeout(schema.GroupResource{Group: requestInfo.APIGroup, Resource: requestInfo.Resource}, requestInfo.Verb, 0)
-	}
-	return WithTimeout(handler, timeoutFunc)
+		handlerWithTimeout.ServeHTTP(w, req)
+	})
 }
 
-// WithTimeout returns an http.Handler that runs h with a timeout
-// determined by timeoutFunc. The new http.Handler calls h.ServeHTTP to handle
+// WithTimeout returns an http.Handler that runs handler with a timeout
+// The new http.Handler calls h.ServeHTTP to handle
 // each request, but if a call runs for longer than its time limit, the
-// handler responds with a 503 Service Unavailable error and the message
-// provided. (If msg is empty, a suitable default message will be sent.) After
-// the handler times out, writes by h to its http.ResponseWriter will return
-// http.ErrHandlerTimeout. If timeoutFunc returns a nil timeout channel, no
-// timeout will be enforced.
-func WithTimeout(h http.Handler, timeoutFunc func(*http.Request) (timeout <-chan time.Time, err *apierrors.StatusError)) http.Handler {
-	return &timeoutHandler{h, timeoutFunc}
-}
+// handler responds with a 504 StatusGatewayTimeout error.
+func WithTimeout(handler http.Handler, timeout time.Duration, requestContextMapper apirequest.RequestContextMapper, s runtime.NegotiatedSerializer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timedout := time.After(timeout)
+		done := make(chan struct{})
+		tw := newTimeoutWriter(w, func() {
+			ctx, ok := requestContextMapper.Get(r)
+			if !ok {
+				responsewriters.InternalError(w, r, errors.New("no context found for request"))
+				return
+			}
 
-type timeoutHandler struct {
-	handler http.Handler
-	timeout func(*http.Request) (<-chan time.Time, *apierrors.StatusError)
-}
+			requestInfo, ok := apirequest.RequestInfoFrom(ctx)
+			if !ok {
+				responsewriters.InternalError(w, r, errors.New("no request info found for request"))
+				return
+			}
 
-func (t *timeoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	after, err := t.timeout(r)
-	if after == nil {
-		t.handler.ServeHTTP(w, r)
-		return
-	}
+			gvr := schema.GroupVersionResource{Group: requestInfo.APIGroup, Version: requestInfo.APIVersion, Resource: requestInfo.Resource}
+			if gvr.Version == "" {
+				gvr.Version = "v1"
+			}
+			status := apierrors.NewServerTimeout(gvr.GroupResource(), requestInfo.Verb, 0)
+			status.ErrStatus.Code = http.StatusGatewayTimeout
+			responsewriters.ErrorNegotiated(status, s, gvr.GroupVersion(), w, r)
+		})
+		go func() {
+			handler.ServeHTTP(tw, r)
+			close(done)
+		}()
 
-	done := make(chan struct{})
-	tw := newTimeoutWriter(w)
-	go func() {
-		t.handler.ServeHTTP(tw, r)
-		close(done)
-	}()
-	select {
-	case <-done:
-		return
-	case <-after:
-		tw.timeout(err)
-	}
+		select {
+		case <-done:
+			return
+		case <-timedout:
+			tw.timeout()
+		}
+	})
 }
 
 type timeoutWriter interface {
 	http.ResponseWriter
-	timeout(*apierrors.StatusError)
+	timeout()
 }
 
-func newTimeoutWriter(w http.ResponseWriter) timeoutWriter {
-	base := &baseTimeoutWriter{w: w}
+func newTimeoutWriter(w http.ResponseWriter, writeError func()) timeoutWriter {
+	base := &baseTimeoutWriter{w: w, writeError: writeError}
 
 	_, notifiable := w.(http.CloseNotifier)
 	_, hijackable := w.(http.Hijacker)
@@ -124,6 +132,9 @@ func newTimeoutWriter(w http.ResponseWriter) timeoutWriter {
 
 type baseTimeoutWriter struct {
 	w http.ResponseWriter
+
+	// called to actually write the error
+	writeError func()
 
 	mu sync.Mutex
 	// if the timeout handler has timedout
@@ -185,7 +196,7 @@ func (tw *baseTimeoutWriter) WriteHeader(code int) {
 	tw.w.WriteHeader(code)
 }
 
-func (tw *baseTimeoutWriter) timeout(err *apierrors.StatusError) {
+func (tw *baseTimeoutWriter) timeout() {
 	tw.mu.Lock()
 	defer tw.mu.Unlock()
 
@@ -195,9 +206,7 @@ func (tw *baseTimeoutWriter) timeout(err *apierrors.StatusError) {
 	// We can safely timeout the HTTP request by sending by a timeout
 	// handler
 	if !tw.wroteHeader && !tw.hijacked {
-		tw.w.WriteHeader(http.StatusGatewayTimeout)
-		enc := json.NewEncoder(tw.w)
-		enc.Encode(err)
+		tw.writeError()
 	} else {
 		// The timeout writer has been used by the inner handler. There is
 		// no way to timeout the HTTP request at the point. We have to shutdown

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -20,30 +20,43 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"strings"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/sets"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+	genericapifilters "k8s.io/kubernetes/pkg/genericapiserver/endpoints/filters"
 )
 
 func TestTimeout(t *testing.T) {
 	sendResponse := make(chan struct{}, 1)
 	writeErrors := make(chan error, 1)
-	timeout := make(chan time.Time, 1)
 	resp := "test response"
 	timeoutErr := apierrors.NewServerTimeout(schema.GroupResource{Group: "foo", Resource: "bar"}, "get", 0)
+	mapper := apirequest.NewRequestContextMapper()
+	scheme := runtime.NewScheme()
+	codecs := serializer.NewCodecFactory(scheme)
 
-	ts := httptest.NewServer(WithTimeout(http.HandlerFunc(
-		func(w http.ResponseWriter, r *http.Request) {
-			<-sendResponse
-			_, err := w.Write([]byte(resp))
-			writeErrors <- err
-		}),
-		func(*http.Request) (<-chan time.Time, *apierrors.StatusError) {
-			return timeout, timeoutErr
-		}))
+	scheme.AddKnownTypes(schema.GroupVersion{Group: "", Version: "v1"}, &metav1.Status{})
+	scheme.AddKnownTypes(schema.GroupVersion{Group: "core", Version: "v1"}, &metav1.Status{})
+
+	var handler http.Handler
+	handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-sendResponse
+		_, err := w.Write([]byte(resp))
+		writeErrors <- err
+	})
+	handler = WithTimeout(handler, time.Second, mapper, codecs)
+	handler = genericapifilters.WithRequestInfo(handler, newTestRequestInfoResolver(), mapper)
+	handler = apirequest.WithRequestContext(handler, mapper)
+
+	ts := httptest.NewServer(handler)
 	defer ts.Close()
 
 	// No timeouts
@@ -63,8 +76,7 @@ func TestTimeout(t *testing.T) {
 		t.Errorf("got unexpected Write error on first request: %v", err)
 	}
 
-	// Times out
-	timeout <- time.Time{}
+	// Times out without version
 	res, err = http.Get(ts.URL)
 	if err != nil {
 		t.Error(err)
@@ -81,5 +93,31 @@ func TestTimeout(t *testing.T) {
 	sendResponse <- struct{}{}
 	if err := <-writeErrors; err != http.ErrHandlerTimeout {
 		t.Errorf("got Write error of %v; expected %v", err, http.ErrHandlerTimeout)
+	}
+
+	// Times out _with_ version
+	res, err = http.Get(ts.URL + "/apis/core/v1/pods")
+	if err != nil {
+		t.Error(err)
+	}
+	if res.StatusCode != http.StatusGatewayTimeout {
+		t.Errorf("got res.StatusCode %d; expected %d", res.StatusCode, http.StatusServiceUnavailable)
+	}
+	body, _ = ioutil.ReadAll(res.Body)
+	if !strings.Contains(string(body), timeoutErr.Error()) {
+		t.Errorf("got body %q; expected it to contain %q", string(body), timeoutErr.Error())
+	}
+
+	// Now try to send a response
+	sendResponse <- struct{}{}
+	if err := <-writeErrors; err != http.ErrHandlerTimeout {
+		t.Errorf("got Write error of %v; expected %v", err, http.ErrHandlerTimeout)
+	}
+}
+
+func newTestRequestInfoResolver() *apirequest.RequestInfoFactory {
+	return &apirequest.RequestInfoFactory{
+		APIPrefixes:          sets.NewString("api", "apis"),
+		GrouplessAPIPrefixes: sets.NewString("api"),
 	}
 }

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -13787,7 +13787,10 @@ go_test(
     deps = [
         "//pkg/genericapiserver/endpoints/filters:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/serializer",
         "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/apiserver/pkg/endpoints/request",
     ],
@@ -13805,8 +13808,10 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
+        "//pkg/genericapiserver/endpoints/handlers/responsewriters:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
+        "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apimachinery/pkg/util/runtime",
         "//vendor:k8s.io/apimachinery/pkg/util/sets",


### PR DESCRIPTION
~~**Blocked** by pkg/genericapiserver/endpoints not moved to k8s.io/apiserver yet.~~

This PR 
- simplifies the timeout filter by using less indirections, 
- adds negotiated `meta.Status` errors on actual timeout,
- adds tests with real `RequestInfo` and `RequestContextMapper`.