### PR TITLE
Fix federation component logging when e2e test case fails

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -84,7 +84,7 @@ type Framework struct {
 	cleanupHandle CleanupActionHandle
 
 	// configuration for framework's client
-	options FrameworkOptions
+	Options FrameworkOptions
 }
 
 type TestDataSummary interface {
@@ -110,7 +110,7 @@ func NewDefaultFramework(baseName string) *Framework {
 
 func NewDefaultGroupVersionFramework(baseName string, groupVersion schema.GroupVersion) *Framework {
 	f := NewDefaultFramework(baseName)
-	f.options.GroupVersion = &groupVersion
+	f.Options.GroupVersion = &groupVersion
 	return f
 }
 
@@ -118,7 +118,7 @@ func NewFramework(baseName string, options FrameworkOptions, client clientset.In
 	f := &Framework{
 		BaseName:                 baseName,
 		AddonResourceConstraints: make(map[string]ResourceConstraint),
-		options:                  options,
+		Options:                  options,
 		ClientSet:                client,
 	}
 
@@ -169,10 +169,10 @@ func (f *Framework) BeforeEach() {
 		By("Creating a kubernetes client")
 		config, err := LoadConfig()
 		Expect(err).NotTo(HaveOccurred())
-		config.QPS = f.options.ClientQPS
-		config.Burst = f.options.ClientBurst
-		if f.options.GroupVersion != nil {
-			config.GroupVersion = f.options.GroupVersion
+		config.QPS = f.Options.ClientQPS
+		config.Burst = f.Options.ClientBurst
+		if f.Options.GroupVersion != nil {
+			config.GroupVersion = f.Options.GroupVersion
 		}
 		if TestContext.KubeAPIContentType != "" {
 			config.ContentType = TestContext.KubeAPIContentType

--- a/test/e2e_federation/framework/framework.go
+++ b/test/e2e_federation/framework/framework.go
@@ -25,7 +25,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	fedv1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	"k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -43,10 +45,22 @@ type Framework struct {
 }
 
 func NewDefaultFederatedFramework(baseName string) *Framework {
-	f := &Framework{framework.NewDefaultFramework(baseName), nil, &v1.Namespace{}}
+	options := framework.FrameworkOptions{
+		ClientQPS:   20,
+		ClientBurst: 50,
+	}
 
+	f := &Framework{&framework.Framework{
+		BaseName:                 baseName,
+		AddonResourceConstraints: make(map[string]framework.ResourceConstraint),
+		Options:                  options,
+		ClientSet:                nil,
+	}, nil, &v1.Namespace{}}
+
+	BeforeEach(f.BeforeEach)
 	BeforeEach(f.FederationBeforeEach)
 	AfterEach(f.FederationAfterEach)
+	AfterEach(f.AfterEach)
 
 	return f
 }
@@ -138,9 +152,9 @@ func (f *Framework) FederationAfterEach() {
 			return f.FederationClientset.Core().Events(ns).List(opts)
 		}, f.FederationNamespace.Name)
 		// Print logs of federation control plane pods (federation-apiserver and federation-controller-manager)
-		framework.LogPodsWithLabels(f.ClientSet, "federation", map[string]string{"app": "federated-cluster"}, framework.Logf)
+		framework.LogPodsWithLabels(f.ClientSet, fedv1beta1.FederationNamespaceSystem, map[string]string{"app": "federated-cluster"}, framework.Logf)
 		// Print logs of kube-dns pod
-		framework.LogPodsWithLabels(f.ClientSet, "kube-system", map[string]string{"k8s-app": "kube-dns"}, framework.Logf)
+		framework.LogPodsWithLabels(f.ClientSet, api.NamespaceSystem, map[string]string{"k8s-app": "kube-dns"}, framework.Logf)
 	}
 }
 


### PR DESCRIPTION
When a federation e2e test case fails, federation component logs (esp. controller-manager) were very useful in debugging the failure cause. Due to recent updates in framework, the logs were not captured. This PR will fix those issues.

cc @kubernetes/sig-federation-misc @nikhiljindal @madhusudancs 