### PR TITLE
examples: fix kube-dns link

### DIFF
--- a/examples/cluster-dns/README.md
+++ b/examples/cluster-dns/README.md
@@ -4,7 +4,7 @@ This is a toy example demonstrating how to use kubernetes DNS.
 
 ### Step Zero: Prerequisites
 
-This example assumes that you have forked the repository and [turned up a Kubernetes cluster](../../docs/getting-started-guides/). Make sure DNS is enabled in your setup, see [DNS doc](../../build/kube-dns/).
+This example assumes that you have forked the repository and [turned up a Kubernetes cluster](../../docs/getting-started-guides/). Make sure DNS is enabled in your setup, see [DNS doc](https://github.com/kubernetes/dns).
 
 ```sh
 $ cd kubernetes

--- a/examples/mysql-wordpress-pd/README.md
+++ b/examples/mysql-wordpress-pd/README.md
@@ -67,7 +67,7 @@ this example.
 * Kubernetes version 1.2 is required due to using newer features, such
   at PV Claims and Deployments. Run `kubectl version` to see your
   cluster version.
-* [Cluster DNS](../../build/kube-dns/) will be used for service discovery.
+* [Cluster DNS](https://github.com/kubernetes/dns) will be used for service discovery.
 * An [external load balancer](http://kubernetes.io/docs/user-guide/services/#type-loadbalancer)
   will be used to access WordPress.
 * [Persistent Volume Claims](http://kubernetes.io/docs/user-guide/persistent-volumes/)

--- a/examples/spark/README.md
+++ b/examples/spark/README.md
@@ -24,7 +24,7 @@ This example assumes
 
 - You have a Kubernetes cluster installed and running.
 - That you have installed the ```kubectl``` command line tool installed in your path and configured to talk to your Kubernetes cluster
-- That your Kubernetes cluster is running [kube-dns](../../build/kube-dns/) or an equivalent integration.
+- That your Kubernetes cluster is running [kube-dns](https://github.com/kubernetes/dns) or an equivalent integration.
 
 Optionally, your Kubernetes cluster should be configured with a Loadbalancer integration (automatically configured via kube-up or GKE)
 


### PR DESCRIPTION
Currently `hack/update-munge-docs.sh` doesn't run cleanly on master:

```
/home/sjennings/projects/kubernetes/src/k8s.io/kubernetes/examples/cluster-dns/README.md
----
md-links:
On line 6: "../../build/kube-dns/": target not found

/home/sjennings/projects/kubernetes/src/k8s.io/kubernetes/examples/mysql-wordpress-pd/README.md
----
md-links:
On line 69: "../../build/kube-dns/": target not found

/home/sjennings/projects/kubernetes/src/k8s.io/kubernetes/examples/spark/README.md
----
md-links:
On line 26: "../../build/kube-dns/": target not found

FAIL: some manual changes are still required.
/home/sjennings/projects/kubernetes/src/k8s.io/kubernetes/examples/ requires manual changes.  See preceding errors.
```

This is due to an out of date link to kube-dns.  This PR fixes those links.