### PR TITLE
Update GCI/COS OS detection in e2e test

### DIFF
--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -100,8 +100,8 @@ func updateGCIMounterPath(args, host, workspace string) (string, error) {
 	if err != nil {
 		return args, fmt.Errorf("issue detecting node's OS via node's /etc/os-release. Err: %v, Output:\n%s", err, output)
 	}
-	if !strings.Contains(output, "ID=gci") {
-		// This is not a GCI image
+	if !strings.Contains(output, "ID=gci") && !strings.Contains(output, "ID=cos") {
+		// This is not a GCI/COS image
 		return args, nil
 	}
 


### PR DESCRIPTION
Newer Container-Optimized OS images can be identified by "ID=cos"
in the /etc/os-release.

cc @Amey-D @mtaufen PTAL