### PR TITLE
Add .bazelrc with flaky_test_attempts.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,6 @@
+# Show us information about failures.
+build --verbose_failures
+test --test_output=errors
+
+# Retry tests up to 3 times if they fail.
+test --flaky_test_attempts=3

--- a/Makefile
+++ b/Makefile
@@ -498,7 +498,7 @@ endef
 	@echo "$$BAZEL_TEST_HELP_INFO"
 else
 bazel-test:
-	bazel test  --test_output=errors //cmd/... //pkg/... //federation/... //plugin/... //build/... //third_party/... //hack/... //hack:verify-all
+	bazel test  //cmd/... //pkg/... //federation/... //plugin/... //build/... //third_party/... //hack/... //hack:verify-all
 endif
 
 ifeq ($(PRINT_HELP),y)


### PR DESCRIPTION
**What this PR does / why we need it**: This PR adds `.bazelrc`, which will set defaults for all bazel commands. The only controversial default I set is `--flaky_test_attempts=3`.

**Release note**:
```release-note
NONE
```
