### PR TITLE
[DO NOT MERGE] turn on kube mutation detector

### DIFF
--- a/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
+++ b/cluster/saltbase/salt/kube-controller-manager/kube-controller-manager.manifest
@@ -113,6 +113,12 @@
                  "-c",
                  "/usr/local/bin/kube-controller-manager {{params}} 1>>/var/log/kube-controller-manager.log 2>&1"
                ],
+    "env": [
+      {
+        "name": "KUBE_CACHE_MUTATION_DETECTOR",
+        "value": "true"
+      }
+    ],
     "livenessProbe": {
       "httpGet": {
         "host": "127.0.0.1",


### PR DESCRIPTION
turns on the kube mutation detector in the controller manager unconditionally to see what happens.