### PR TITLE
Fix Elasticsearch image for logging and bump version

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-controller.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-controller.yaml
@@ -20,7 +20,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
-      - image: gcr.io/google_containers/elasticsearch:v2.4.1
+      - image: gcr.io/google_containers/elasticsearch:v2.4.1-1
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -16,7 +16,7 @@
 
 # The current value of the tag to be used for building and
 # pushing an image to gcr.io
-TAG = v2.4.1
+TAG = v2.4.1-1
 
 build:	elasticsearch_logging_discovery
 	docker build --pull -t gcr.io/google_containers/elasticsearch:$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
@@ -55,7 +56,7 @@ func main() {
 	namespace := api.NamespaceSystem
 	envNamespace := os.Getenv("NAMESPACE")
 	if envNamespace != "" {
-		if _, err := client.Core().Namespaces().Get(envNamespace); err != nil {
+		if _, err := client.Core().Namespaces().Get(envNamespace, meta_v1.GetOptions{}); err != nil {
 			glog.Fatalf("%s namespace doesn't exist: %v", envNamespace, err)
 		}
 		namespace = envNamespace
@@ -65,7 +66,7 @@ func main() {
 	// Look for endpoints associated with the Elasticsearch loggging service.
 	// First wait for the service to become available.
 	for t := time.Now(); time.Since(t) < 5*time.Minute; time.Sleep(10 * time.Second) {
-		elasticsearch, err = client.Core().Services(namespace).Get("elasticsearch-logging")
+		elasticsearch, err = client.Core().Services(namespace).Get("elasticsearch-logging", meta_v1.GetOptions{})
 		if err == nil {
 			break
 		}
@@ -82,7 +83,7 @@ func main() {
 	// Wait for some endpoints.
 	count := 0
 	for t := time.Now(); time.Since(t) < 5*time.Minute; time.Sleep(10 * time.Second) {
-		endpoints, err = client.Core().Endpoints(namespace).Get("elasticsearch-logging")
+		endpoints, err = client.Core().Endpoints(namespace).Get("elasticsearch-logging", meta_v1.GetOptions{})
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
Follow-up from https://github.com/kubernetes/kubernetes/pull/39861

`elasticsearch_logging_discovery.go` had to be updated to respect API changes.