### PR TITLE
Create skeleton default config file

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -37,6 +37,9 @@ PREEMPTIBLE_MASTER=${PREEMPTIBLE_MASTER:-false}
 KUBE_DELETE_NODES=${KUBE_DELETE_NODES:-true}
 KUBE_DELETE_NETWORK=${KUBE_DELETE_NETWORK:-false}
 
+# Default number of retries when executing a command
+RETRIES="${RETRIES:-3}"
+
 MASTER_OS_DISTRIBUTION=${KUBE_MASTER_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-gci}}
 NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-debian}}
 if [[ "${MASTER_OS_DISTRIBUTION}" == "coreos" ]]; then
@@ -78,6 +81,8 @@ MASTER_TAG="${INSTANCE_PREFIX}-master"
 NODE_TAG="${INSTANCE_PREFIX}-minion"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
 CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.244.0.0/14}"
+VM_USER="${VM_USER:-kubernetes}"
+COPY_DIR="${COPY_DIR:-/home/$VM_USER}"
 if [[ "${FEDERATION:-}" == true ]]; then
     NODE_SCOPES="${NODE_SCOPES:-compute-rw,monitoring,logging-write,storage-ro,https://www.googleapis.com/auth/ndev.clouddns.readwrite}"
 else

--- a/cluster/skeleton/config-default.sh
+++ b/cluster/skeleton/config-default.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source "${KUBE_ROOT}/cluster/common.sh"
+source "${KUBE_ROOT}/cluster/skeleton/util.sh"
+source "${KUBE_ROOT}/cluster/lib/util.sh"
+
+# Use an existing Kubernetes cluster at $MASTER_IP
+MASTER_IP=""
+MASTER_NAME="${MASTER_NAME:-$MASTER_IP}"
+SERVICE_CLUSTER_IP_RANGE="${SERVICE_CLUSTER_IP_RANGE:-$MASTER_IP}"
+PROJECT="${PROJECT:-kubemark}"
+
+VM_USER="${VM_USER:-kubernetes}"
+COPY_DIR="${COPY_DIR:-/home/$VM_USER}"
+
+# Default number of retries when executing a command
+RETRIES="${RETRIES:-3}"

--- a/test/kubemark/skeleton/util.sh
+++ b/test/kubemark/skeleton/util.sh
@@ -61,3 +61,8 @@ function copy-files() {
 function delete-master-instance-and-resources {
 	echo "Deleting master instance and its allocated resources" 1>&2
 }
+
+if [ -z $MASTER_IP ]; then
+    echo "Please set MASTER_IP to the address of an existing Kubernetes cluster"
+    exit 1
+fi


### PR DESCRIPTION
Ref issue #38967

To make kubemark less provider specific, add a config-default.sh for the skeleton (external) provider.  The assumption is that the developer will use an existing vm(s) with a running kubernetes cluster to point kubemark at.
