### PR TITLE
Sets min kube-dns replica number to 2

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -45,6 +45,6 @@ spec:
           - --target=Deployment/kube-dns
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
           # If using small nodes, "nodesPerReplica" should dominate.
-          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":1}}
+          - --default-params={"linear":{"coresPerReplica":256,"nodesPerReplica":16,"min":2}}
           - --logtostderr=true
           - --v=2


### PR DESCRIPTION
From #40063.

Setting the `min` value to 2 in dns-horizontal-autoscaler to mitigate `kube-dns` single point failure. The downside is we will have 2 replicas even if there is only 1 node, though this is still a better setup.

@thockin @bowei 