### PR TITLE
Revert "Remove conversion package"

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -79,6 +79,7 @@ filegroup(
         "//pkg/client/unversioned:all-srcs",
         "//pkg/cloudprovider:all-srcs",
         "//pkg/controller:all-srcs",
+        "//pkg/conversion:all-srcs",
         "//pkg/credentialprovider:all-srcs",
         "//pkg/fieldpath:all-srcs",
         "//pkg/fields:all-srcs",

--- a/pkg/conversion/BUILD
+++ b/pkg/conversion/BUILD
@@ -1,0 +1,30 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    tags = ["automanaged"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/conversion/queryparams:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/pkg/conversion/doc.go
+++ b/pkg/conversion/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package conversion only exists until heapster rebases
+// TODO genericapiserver remove this empty package.  Godep fails without this because heapster relies
+// on this package.  This will allow us to start splitting packages, but will force
+// heapster to update on their next kube rebase.
+package conversion

--- a/pkg/conversion/queryparams/BUILD
+++ b/pkg/conversion/queryparams/BUILD
@@ -1,0 +1,27 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    tags = ["automanaged"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/conversion/queryparams/OWNERS
+++ b/pkg/conversion/queryparams/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- smarterclayton
+- wojtek-t
+- caesarxuchao
+- mikedanese
+- liggitt
+- kargakis
+- dims

--- a/pkg/conversion/queryparams/doc.go
+++ b/pkg/conversion/queryparams/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package queryparams only exists until heapster rebases
+// TODO genericapiserver remove this empty package.  Godep fails without this because heapster relies
+// on this package.  This will allow us to start splitting packages, but will force
+// heapster to update on their next kube rebase.
+package queryparams


### PR DESCRIPTION
Reverts kubernetes/kubernetes#40134

This breaks verify-godeps: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-verify-master/2169

```
I0122 14:53:22.679] godep v74 (linux/amd64/go1.7.4)
I0122 14:53:22.679] Starting to download all kubernetes godeps. This takes a while
I0122 14:55:35.660] Download finished
I0122 14:55:35.889] godep v74 (linux/amd64/go1.7.4)
W0122 14:59:04.371] godep: Package (k8s.io/kubernetes/pkg/conversion) not found
I0122 14:59:04.472] Removing /tmp/gopath.U7Xy9R
I0122 14:59:06.863] FAILED   hack/make-rules/../../hack/verify-godeps.sh	348s

```