### PR TITLE
add admission controller to set node taints

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//plugin/pkg/admission/admit:go_default_library",
         "//plugin/pkg/admission/alwayspullimages:go_default_library",
         "//plugin/pkg/admission/antiaffinity:go_default_library",
+        "//plugin/pkg/admission/cloudprovider/node:go_default_library",
         "//plugin/pkg/admission/deny:go_default_library",
         "//plugin/pkg/admission/exec:go_default_library",
         "//plugin/pkg/admission/gc:go_default_library",

--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/admit"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/alwayspullimages"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/antiaffinity"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/cloudprovider/node"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/deny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/exec"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/gc"

--- a/plugin/BUILD
+++ b/plugin/BUILD
@@ -17,6 +17,7 @@ filegroup(
         "//plugin/pkg/admission/admit:all-srcs",
         "//plugin/pkg/admission/alwayspullimages:all-srcs",
         "//plugin/pkg/admission/antiaffinity:all-srcs",
+        "//plugin/pkg/admission/cloudprovider/node:all-srcs",
         "//plugin/pkg/admission/deny:all-srcs",
         "//plugin/pkg/admission/exec:all-srcs",
         "//plugin/pkg/admission/gc:all-srcs",

--- a/plugin/pkg/admission/cloudprovider/node/BUILD
+++ b/plugin/pkg/admission/cloudprovider/node/BUILD
@@ -1,0 +1,49 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["admission_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/api/v1:go_default_library",
+        "//pkg/util/taints:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/apiserver/pkg/admission",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["admission.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/api/v1:go_default_library",
+        "//pkg/util/taints:go_default_library",
+        "//vendor:github.com/golang/glog",
+        "//vendor:k8s.io/apiserver/pkg/admission",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/plugin/pkg/admission/cloudprovider/node/admission.go
+++ b/plugin/pkg/admission/cloudprovider/node/admission.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"encoding/json"
+	"io"
+
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	utiltaints "k8s.io/kubernetes/pkg/util/taints"
+
+	"github.com/golang/glog"
+)
+
+const (
+	CloudProviderTaint = "CloudProviderProcessing=Required:NoSchedule"
+)
+
+func init() {
+	admission.RegisterPlugin("CloudProviderNodeTaint", func(config io.Reader) (admission.Interface, error) {
+		newCloudProviderNodeTaint := NewCloudProviderNodeTaint()
+		return newCloudProviderNodeTaint, nil
+	})
+}
+
+var _ = admission.Interface(&cloudProviderNodeTaint{})
+
+type cloudProviderNodeTaint struct {
+	*admission.Handler
+}
+
+// NewCloudProviderNodeTaint returns an admission.Interface implementation which adds labels to CloudProviderNodeTaint CREATE requests,
+// based on the labels provided by the underlying cloud provider.
+//
+// As a side effect, the cloud provider may block invalid or non-existent volumes.
+func NewCloudProviderNodeTaint() *cloudProviderNodeTaint {
+	return &cloudProviderNodeTaint{
+		Handler: admission.NewHandler(admission.Create),
+	}
+}
+
+func (l *cloudProviderNodeTaint) Admit(a admission.Attributes) (err error) {
+	if a.GetResource().GroupResource() != api.Resource("nodes") {
+		return nil
+	}
+	obj := a.GetObject()
+	if obj == nil {
+		return nil
+	}
+	node, ok := obj.(*api.Node)
+	if !ok {
+		return nil
+	}
+	nodeTaints, err := v1.GetTaintsFromNodeAnnotations(node.Annotations)
+	if err != nil {
+		glog.Errorf("Error getting taints from node annotations %v", err)
+		return err
+	}
+
+	newTaint, err := utiltaints.ParseTaint(CloudProviderTaint)
+	if err != nil {
+		glog.Errorf("Error setting taint %v", err)
+		return err
+	}
+
+	existsInOld := false
+	for _, taint := range nodeTaints {
+		if taint.MatchTaint(newTaint) {
+			existsInOld = true
+		}
+	}
+	if !existsInOld {
+		nodeTaints = append(nodeTaints, newTaint)
+
+		taintsData, err := json.Marshal(nodeTaints)
+		if err != nil {
+			return err
+		}
+		node.Annotations[v1.TaintsAnnotationKey] = string(taintsData)
+	}
+	return nil
+}

--- a/plugin/pkg/admission/cloudprovider/node/admission_test.go
+++ b/plugin/pkg/admission/cloudprovider/node/admission_test.go
@@ -1,0 +1,52 @@
+package node
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	utiltaints "k8s.io/kubernetes/pkg/util/taints"
+)
+
+func TestSetsCloudProviderLabel(t *testing.T) {
+	nodeHandler := NewCloudProviderNodeTaint()
+	handler := admission.NewChainHandler(nodeHandler)
+
+	node := api.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "node1", Namespace: "default", Annotations: map[string]string{}},
+		Spec:       api.NodeSpec{},
+	}
+
+	err := handler.Admit(admission.NewAttributesRecord(&node, nil, api.Kind("Node").WithVersion("version"), node.Namespace, node.Name, api.Resource("nodes").WithVersion("version"), "", admission.Create, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler (on node): %v", err)
+	}
+
+	nodeTaints, err := v1.GetTaintsFromNodeAnnotations(node.Annotations)
+	if err != nil {
+		t.Errorf("Error getting taints from node annotations %v", err)
+	}
+
+	foundTaint := false
+	taint, err := utiltaints.ParseTaint(CloudProviderTaint)
+	if err != nil {
+		t.Errorf("Error parsing Node taint, err :%v", err)
+	}
+	for _, t := range nodeTaints {
+		if taint.MatchTaint(t) {
+			foundTaint = true
+		}
+	}
+
+	if !foundTaint {
+		t.Errorf("CloudProviderNodeTaint admission controller did not set the expected taint")
+	}
+
+	err = handler.Admit(admission.NewAttributesRecord(&node, nil, api.Kind("Node").WithVersion("version"), node.Namespace, node.Name, api.Resource("nodes").WithVersion("version"), "", admission.Delete, nil))
+	if err != nil {
+		t.Errorf("Unexpected error returned from admission handler (on node): %v", err)
+	}
+
+}


### PR DESCRIPTION
@thockin adding the admission controller based on the design described here - https://github.com/kubernetes/community/pull/128

@luxas @justinsb 

Description

The cloudprovider proposal is an effort to remove cloudprovider dependent code out of kubernetes. This is done by making kubernetes work with plugins (external controllers) that perform the same actions performed by the cloudproviders. 

An important step in the removal of cloudprovider dependencies is removing them from kubelet. Once they are removed, the external controller takes over the role of the cloudprovider in kubelet. Unlike the kubelet, this controler does not perform these actions prior to creating the node. It performs these actions after creating the node. The node should be unusable until the controller processes it. This is achieved by the admission controller in this PR.

Release Note:

Admission controller to set node taints marking the node as unschedulable until it is processed by cloud-controller-manager