### PR TITLE
fix --save-config in create subcommand

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -243,9 +243,11 @@ func RunCreateSubcommand(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, o
 	if err != nil {
 		return err
 	}
-	if err := kubectl.UpdateApplyAnnotation(info, f.JSONEncoder()); err != nil {
+	if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, f.JSONEncoder()); err != nil {
 		return err
 	}
+	obj = info.Object
+
 	if !options.DryRun {
 		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, info.Object)
 		if err != nil {


### PR DESCRIPTION
--save-config option doesn't work.
```
#kubectl create rolebinding a --role=b --user=c --save-config  
rolebinding "a" created
```
old output:
```
#kubectl get rolebinding a -o yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: RoleBinding
metadata:
  creationTimestamp: 2017-01-23T10:09:48Z
  name: a
  namespace: default
  resourceVersion: "281"
  selfLink: /apis/rbac.authorization.k8s.io/v1beta1/namespaces/default/rolebindings/a
  uid: 12abccd6-e154-11e6-819c-525400f84377
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: b
subjects:
- apiVersion: rbac/v1alpha1
  kind: User
  name: c
```

expected output:
```
#kubectl get rolebinding a -o yaml
apiVersion: rbac.authorization.k8s.io/v1beta1
kind: RoleBinding
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"kind":"RoleBinding","apiVersion":"rbac.authorization.k8s.io/v1beta1","metadata":{"name":"c","creationTimestamp":null},"subjects":[{"kind":"User","apiVersion":"rbac/v1alpha1","name":"c"}],"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role","name":"b"}}
  creationTimestamp: 2017-01-23T10:09:48Z
  name: a
  namespace: default
  resourceVersion: "281"
  selfLink: /apis/rbac.authorization.k8s.io/v1beta1/namespaces/default/rolebindings/a
  uid: 12abccd6-e154-11e6-819c-525400f84377
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: Role
  name: b
subjects:
- apiVersion: rbac/v1alpha1
  kind: User
  name: c
```