### PR TITLE
separate announce factories

### DIFF
--- a/cmd/kube-aggregator/pkg/apis/apiregistration/install/install.go
+++ b/cmd/kube-aggregator/pkg/apis/apiregistration/install/install.go
@@ -27,11 +27,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  apiregistration.GroupName,
@@ -43,7 +43,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1alpha1.SchemeGroupVersion.Version: v1alpha1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/install/install.go
+++ b/cmd/kubeadm/app/apis/kubeadm/install/install.go
@@ -26,11 +26,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  kubeadm.GroupName,
@@ -41,7 +41,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1alpha1.SchemeGroupVersion.Version: v1alpha1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/labels:go_default_library",
         "//vendor:github.com/davecgh/go-spew/spew",
         "//vendor:k8s.io/apimachinery/pkg/api/meta",
+        "//vendor:k8s.io/apimachinery/pkg/apimachinery/announced",
         "//vendor:k8s.io/apimachinery/pkg/apimachinery/registered",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/conversion",

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -19,12 +19,16 @@ package api
 import (
 	"os"
 
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
+
+// GroupFactoryRegistry is the APIGroupFactoryRegistry (overlaps a bit with Registry, see comments in package for details)
+var GroupFactoryRegistry = make(announced.APIGroupFactoryRegistry)
 
 // Registry is an instance of an API registry.  This is an interim step to start removing the idea of a global
 // API registry.

--- a/pkg/apis/apps/install/install.go
+++ b/pkg/apis/apps/install/install.go
@@ -28,11 +28,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  apps.GroupName,
@@ -43,7 +43,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/authentication/install/install.go
+++ b/pkg/apis/authentication/install/install.go
@@ -29,11 +29,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  authentication.GroupName,
@@ -45,7 +45,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/authorization/install/install.go
+++ b/pkg/apis/authorization/install/install.go
@@ -29,11 +29,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  authorization.GroupName,
@@ -45,7 +45,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/autoscaling/install/install.go
+++ b/pkg/apis/autoscaling/install/install.go
@@ -28,11 +28,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  autoscaling.GroupName,
@@ -43,7 +43,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1.SchemeGroupVersion.Version: v1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/batch/install/install.go
+++ b/pkg/apis/batch/install/install.go
@@ -29,11 +29,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  batch.GroupName,
@@ -45,7 +45,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 			v1.SchemeGroupVersion.Version:       v1.AddToScheme,
 			v2alpha1.SchemeGroupVersion.Version: v2alpha1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/certificates/install/install.go
+++ b/pkg/apis/certificates/install/install.go
@@ -29,11 +29,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  certificates.GroupName,
@@ -45,7 +45,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/componentconfig/install/install.go
+++ b/pkg/apis/componentconfig/install/install.go
@@ -28,11 +28,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  componentconfig.GroupName,
@@ -43,7 +43,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1alpha1.SchemeGroupVersion.Version: v1alpha1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/extensions/install/install.go
+++ b/pkg/apis/extensions/install/install.go
@@ -29,11 +29,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  extensions.GroupName,
@@ -45,7 +45,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/imagepolicy/install/install.go
+++ b/pkg/apis/imagepolicy/install/install.go
@@ -29,11 +29,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  imagepolicy.GroupName,
@@ -45,7 +45,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1alpha1.SchemeGroupVersion.Version: v1alpha1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/policy/install/install.go
+++ b/pkg/apis/policy/install/install.go
@@ -28,11 +28,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  policy.GroupName,
@@ -43,7 +43,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/rbac/install/install.go
+++ b/pkg/apis/rbac/install/install.go
@@ -30,11 +30,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  rbac.GroupName,
@@ -47,7 +47,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 			v1beta1.SchemeGroupVersion.Version:  v1beta1.AddToScheme,
 			v1alpha1.SchemeGroupVersion.Version: v1alpha1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/apis/storage/install/install.go
+++ b/pkg/apis/storage/install/install.go
@@ -29,11 +29,11 @@ import (
 )
 
 func init() {
-	Install(api.Registry, api.Scheme)
+	Install(api.GroupFactoryRegistry, api.Registry, api.Scheme)
 }
 
 // Install registers the API group and adds types to a scheme
-func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
+func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *registered.APIRegistrationManager, scheme *runtime.Scheme) {
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  storage.GroupName,
@@ -45,7 +45,7 @@ func Install(registry *registered.APIRegistrationManager, scheme *runtime.Scheme
 		announced.VersionToSchemeFunc{
 			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
 		},
-	).Announce().RegisterAndEnable(registry, scheme); err != nil {
+	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/announced.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/announced.go
@@ -28,14 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-var (
-	DefaultGroupFactoryRegistry = make(APIGroupFactoryRegistry)
-
-	// These functions will announce your group or version.
-	AnnounceGroupVersion = DefaultGroupFactoryRegistry.AnnounceGroupVersion
-	AnnounceGroup        = DefaultGroupFactoryRegistry.AnnounceGroup
-)
-
 // APIGroupFactoryRegistry allows for groups and versions to announce themselves,
 // which simply makes them available and doesn't take other actions. Later,
 // users of the registry can select which groups and versions they'd actually

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/announced/group_factory.go
@@ -78,8 +78,8 @@ func NewGroupMetaFactory(groupArgs *GroupMetaFactoryArgs, versions VersionToSche
 // programmer importing the wrong set of packages. If this assumption doesn't
 // work for you, just call DefaultGroupFactoryRegistry.AnnouncePreconstructedFactory
 // yourself.
-func (gmf *GroupMetaFactory) Announce() *GroupMetaFactory {
-	if err := DefaultGroupFactoryRegistry.AnnouncePreconstructedFactory(gmf); err != nil {
+func (gmf *GroupMetaFactory) Announce(groupFactoryRegistry APIGroupFactoryRegistry) *GroupMetaFactory {
+	if err := groupFactoryRegistry.AnnouncePreconstructedFactory(gmf); err != nil {
 		panic(err)
 	}
 	return gmf


### PR DESCRIPTION
We caught this part way through Daniel's refactor from 1.5.  Have to separate announce factories to be able to double register types for client-go.

@kubernetes/sig-apimachinery-misc