### PR TITLE
Use fnv.New32a() in hash instead adler32

### DIFF
--- a/pkg/controller/lookup_cache.go
+++ b/pkg/controller/lookup_cache.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	"hash/adler32"
+	"hash/fnv"
 	"sync"
 
 	"github.com/golang/groupcache/lru"
@@ -33,7 +33,7 @@ type objectWithMeta interface {
 // Since we match objects by namespace and Labels/Selector, so if two objects have the same namespace and labels,
 // they will have the same key.
 func keyFunc(obj objectWithMeta) uint64 {
-	hash := adler32.New()
+	hash := fnv.New32a()
 	hashutil.DeepHashObject(hash, &equivalenceLabelObj{
 		namespace: obj.GetNamespace(),
 		labels:    obj.GetLabels(),

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -21,7 +21,7 @@ package mount
 import (
 	"bufio"
 	"fmt"
-	"hash/adler32"
+	"hash/fnv"
 	"io"
 	"os"
 	"os/exec"
@@ -282,7 +282,7 @@ func readProcMounts(mountFilePath string, out *[]MountPoint) (uint32, error) {
 }
 
 func readProcMountsFrom(file io.Reader, out *[]MountPoint) (uint32, error) {
-	hash := adler32.New()
+	hash := fnv.New32a()
 	scanner := bufio.NewReader(file)
 	for {
 		line, err := scanner.ReadString('\n')

--- a/pkg/util/mount/mount_linux_test.go
+++ b/pkg/util/mount/mount_linux_test.go
@@ -29,20 +29,21 @@ func TestReadProcMountsFrom(t *testing.T) {
 		/dev/1    /path/to/1   type1	flags 1 1
 		/dev/2 /path/to/2 type2 flags,1,2=3 2 2
 		`
+	// NOTE: readProcMountsFrom has been updated to using fnv.New32a()
 	hash, err := readProcMountsFrom(strings.NewReader(successCase), nil)
 	if err != nil {
 		t.Errorf("expected success")
 	}
-	if hash != 0xa3522051 {
-		t.Errorf("expected 0xa3522051, got %#x", hash)
+	if hash != 0xa290ff0b {
+		t.Errorf("expected 0xa290ff0b, got %#x", hash)
 	}
 	mounts := []MountPoint{}
 	hash, err = readProcMountsFrom(strings.NewReader(successCase), &mounts)
 	if err != nil {
 		t.Errorf("expected success")
 	}
-	if hash != 0xa3522051 {
-		t.Errorf("expected 0xa3522051, got %#x", hash)
+	if hash != 0xa290ff0b {
+		t.Errorf("expected 0xa290ff0b, got %#x", hash)
 	}
 	if len(mounts) != 3 {
 		t.Fatalf("expected 3 mounts, got %d", len(mounts))

--- a/plugin/pkg/scheduler/core/equivalence_cache.go
+++ b/plugin/pkg/scheduler/core/equivalence_cache.go
@@ -17,7 +17,7 @@ limitations under the License.
 package core
 
 import (
-	"hash/adler32"
+	"hash/fnv"
 
 	"github.com/golang/groupcache/lru"
 
@@ -128,7 +128,7 @@ func (ec *EquivalenceCache) SendClearAllCacheReq() {
 // hashEquivalencePod returns the hash of equivalence pod.
 func (ec *EquivalenceCache) hashEquivalencePod(pod *v1.Pod) uint64 {
 	equivalencePod := ec.getEquivalencePod(pod)
-	hash := adler32.New()
+	hash := fnv.New32a()
 	hashutil.DeepHashObject(hash, equivalencePod)
 	return uint64(hash.Sum32())
 }


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/40140

Benchmark results: https://github.com/kubernetes/kubernetes/pull/39527

NOTE: I leave  `GetPodTemplateSpecHash` as it is since we have unit test to test its un-normal behaviour.