### PR TITLE
present request header cert CA

### DIFF
--- a/pkg/genericapiserver/serve.go
+++ b/pkg/genericapiserver/serve.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	certutil "k8s.io/kubernetes/pkg/util/cert"
 	utilruntime "k8s.io/kubernetes/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/util/validation"
 
@@ -78,16 +77,12 @@ func (s *GenericAPIServer) serveSecurely(stopCh <-chan struct{}) error {
 		secureServer.TLSConfig.Certificates = append(secureServer.TLSConfig.Certificates, *c)
 	}
 
-	if len(s.SecureServingInfo.ClientCA) > 0 {
-		clientCAs, err := certutil.NewPool(s.SecureServingInfo.ClientCA)
-		if err != nil {
-			return fmt.Errorf("unable to load client CA file: %v", err)
-		}
+	if s.SecureServingInfo.ClientCA != nil {
 		// Populate PeerCertificates in requests, but don't reject connections without certificates
 		// This allows certificates to be validated by authenticators, while still allowing other auth types
 		secureServer.TLSConfig.ClientAuth = tls.RequestClientCert
 		// Specify allowed CAs for client certificates
-		secureServer.TLSConfig.ClientCAs = clientCAs
+		secureServer.TLSConfig.ClientCAs = s.SecureServingInfo.ClientCA
 	}
 
 	glog.Infof("Serving securely on %s", s.SecureServingInfo.BindAddress)

--- a/pkg/util/cert/io.go
+++ b/pkg/util/cert/io.go
@@ -79,7 +79,7 @@ func WriteKey(keyPath string, data []byte) error {
 // NewPool returns an x509.CertPool containing the certificates in the given PEM-encoded file.
 // Returns an error if the file could not be read, a certificate could not be parsed, or if the file does not contain any certificates
 func NewPool(filename string) (*x509.CertPool, error) {
-	certs, err := certsFromFile(filename)
+	certs, err := CertsFromFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -90,9 +90,9 @@ func NewPool(filename string) (*x509.CertPool, error) {
 	return pool, nil
 }
 
-// certsFromFile returns the x509.Certificates contained in the given PEM-encoded file.
+// CertsFromFile returns the x509.Certificates contained in the given PEM-encoded file.
 // Returns an error if the file could not be read, a certificate could not be parsed, or if the file does not contain any certificates
-func certsFromFile(file string) ([]*x509.Certificate, error) {
+func CertsFromFile(file string) ([]*x509.Certificate, error) {
 	if len(file) == 0 {
 		return nil, errors.New("error reading certificates from an empty filename")
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/40278

```release-note
Fixes request header authenticator by presenting the request header client CA so that the front proxy will authenticate using its client certificate.
```