### PR TITLE
Use the e2e zone name as the cluster name.

### DIFF
--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -52,8 +52,12 @@ function set-federation-zone-vars {
   export OVERRIDE_CONTEXT="${CLUSTER_CONTEXT}"
   echo "Setting zone vars to: $OVERRIDE_CONTEXT"
   if [[ "$KUBERNETES_PROVIDER" == "gce"  ]];then
+    # This needs a revamp, but for now e2e zone name is used as the unique
+    # cluster identifier in our e2e tests and we will continue to use that
+    # pattern.
+    export CLUSTER_NAME="${zone}"
 
-    export KUBE_GCE_ZONE="$zone"
+    export KUBE_GCE_ZONE="${zone}"
     # gcloud has a 61 character limit, and for firewall rules this
     # prefix gets appended to itself, with some extra information
     # need tot keep it short


### PR DESCRIPTION
This needs a revamp, but for now e2e zone name is used as the
unique cluster identifier in our e2e tests and we will continue
to use that pattern.

This is a follow up to PR #38638.

cc @kubernetes/sig-federation-pr-reviews @nikhiljindal 