### PR TITLE
Fix kubectl->kubefed typo

### DIFF
--- a/federation/pkg/kubefed/join.go
+++ b/federation/pkg/kubefed/join.go
@@ -54,7 +54,7 @@ var (
 		# a valid RFC 1123 subdomain name. Cluster context
 		# must be specified if the cluster name is different
 		# than the cluster's context in the local kubeconfig.
-		kubectl join foo --host-cluster-context=bar`)
+		kubefed join foo --host-cluster-context=bar`)
 )
 
 // NewCmdJoin defines the `join` command that joins a cluster to a


### PR DESCRIPTION
**What this PR does / why we need it**: The kubefed CLI too had a typo in it's example text.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**: