### PR TITLE
Fix the issue when cleaning up orphaned pod

### DIFF
--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -106,8 +106,12 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(
 		}
 		// If there are still volume directories, do not delete directory
 		volumePaths, err := kl.getPodVolumePathListFromDisk(uid)
-		if err != nil || len(volumePaths) > 0 {
+		if err != nil {
 			glog.Errorf("Orphaned pod %q found, but error %v occured during reading volume dir from disk", uid, err)
+			continue
+		}
+		if len(volumePaths) > 0 {
+			glog.Errorf("Orphaned pod %q found, but there are still %d directories under volumes, so fail to clean up", uid, len(volumePaths))
 			continue
 		}
 		glog.V(3).Infof("Orphaned pod %q found, removing", uid)

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -19,7 +19,6 @@ limitations under the License.
 package mount
 
 import (
-	"fmt"
 	"path"
 	"path/filepath"
 	"strings"
@@ -178,8 +177,8 @@ func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, e
 }
 
 // getDeviceNameFromMount find the device name from /proc/mounts in which
-// the mount path reference should match the given plugin directory. In case no mount path reference
-// matches, returns the volume name taken from its given mountPath
+// the mount path reference should match the given plugin directory. In case no mount path
+// reference matches, returns the volume name taken from its given mountPath
 func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (string, error) {
 	refs, err := GetMountRefs(mounter, mountPath)
 	if err != nil {
@@ -188,7 +187,7 @@ func getDeviceNameFromMount(mounter Interface, mountPath, pluginDir string) (str
 	}
 	if len(refs) == 0 {
 		glog.V(4).Infof("Directory %s is not mounted", mountPath)
-		return "", fmt.Errorf("directory %s is not mounted", mountPath)
+		return path.Base(mountPath), nil
 	}
 	basemountPath := path.Join(pluginDir, MountsInGlobalPDPath)
 	for _, ref := range refs {


### PR DESCRIPTION
In the case of pod volume directories are no longer mounted, volume
reconciler failed to reconstruct orphaned pod volume because it fails to
find the device from the mount path, so that cleanup rountine will fail
to delete the volumes directory.

This change fix this issue by returning a fake device path instead of
returning error in ConstructVolumeSpec so that orphaned pod volume
information will be put back into the actual state. Then reconciler is
able to clean up the volumes directory so is the orphaned pod.

