### PR TITLE
Prep node_e2e for GCI to COS name change

### DIFF
--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -37,7 +37,7 @@ func InitNodeE2ERemote() TestSuite {
 	return &NodeE2ERemote{}
 }
 
-const localGCIMounterPath = "cluster/gce/gci/mounter/mounter"
+const localCOSMounterPath = "cluster/gce/gci/mounter/mounter"
 
 // SetupTestPackage sets up the test package with binaries k8s required for node e2e tests
 func (n *NodeE2ERemote) SetupTestPackage(tardir string) error {
@@ -65,16 +65,16 @@ func (n *NodeE2ERemote) SetupTestPackage(tardir string) error {
 		}
 	}
 
-	// Include the GCI mounter artifacts in the deployed tarball
+	// Include the GCI/COS mounter artifacts in the deployed tarball
 	k8sDir, err := builder.GetK8sRootDir()
 	if err != nil {
 		return fmt.Errorf("Could not find K8s root dir! Err: %v", err)
 	}
-	source := filepath.Join(k8sDir, localGCIMounterPath)
+	source := filepath.Join(k8sDir, localCOSMounterPath)
 
-	// Require the GCI mounter script, we want to make sure the remote test runner stays up to date if the mounter file moves
+	// Require the GCI/COS mounter script, we want to make sure the remote test runner stays up to date if the mounter file moves
 	if _, err := os.Stat(source); err != nil {
-		return fmt.Errorf("Could not find GCI mounter script at %q! If this script has been (re)moved, please update the e2e node remote test runner accordingly! Err: %v", source, err)
+		return fmt.Errorf("Could not find GCI/COS mounter script at %q! If this script has been (re)moved, please update the e2e node remote test runner accordingly! Err: %v", source, err)
 	}
 
 	bindir := "cluster/gce/gci/mounter"
@@ -83,50 +83,50 @@ func (n *NodeE2ERemote) SetupTestPackage(tardir string) error {
 	dest := filepath.Join(destdir, bin)
 	out, err := exec.Command("mkdir", "-p", filepath.Join(tardir, bindir)).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to create directory %q for GCI mounter script. Err: %v. Output:\n%s", destdir, err, out)
+		return fmt.Errorf("failed to create directory %q for GCI/COS mounter script. Err: %v. Output:\n%s", destdir, err, out)
 	}
 	out, err = exec.Command("cp", source, dest).CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to copy GCI mounter script to the archive bin. Err: %v. Output:\n%s", err, out)
+		return fmt.Errorf("failed to copy GCI/COS mounter script to the archive bin. Err: %v. Output:\n%s", err, out)
 	}
 	return nil
 }
 
-// updateGCIMounterPath updates kubelet flags to set gci mounter path. This will only take effect for
-// GCI image.
-func updateGCIMounterPath(args, host, workspace string) (string, error) {
-	// Determine if tests will run on a GCI node.
+// updateCOSMounterPath updates kubelet flags to set gci mounter path. This will only take effect for
+// GCI/COS image.
+func updateCOSMounterPath(args, host, workspace string) (string, error) {
+	// Determine if tests will run on a GCI/COS node.
 	output, err := SSH(host, "cat", "/etc/os-release")
 	if err != nil {
 		return args, fmt.Errorf("issue detecting node's OS via node's /etc/os-release. Err: %v, Output:\n%s", err, output)
 	}
-	if !strings.Contains(output, "ID=gci") {
-		// This is not a GCI image
+	if !strings.Contains(output, "ID=gci") && !strings.Contains(output, "ID=cos") {
+		// This is not a GCI/COS image
 		return args, nil
 	}
 
-	// If we are testing on a GCI node, we chmod 544 the mounter and specify a different mounter path in the test args.
+	// If we are testing on a GCI/COS node, we chmod 544 the mounter and specify a different mounter path in the test args.
 	// We do this here because the local var `workspace` tells us which /tmp/node-e2e-%d is relevant to the current test run.
 
-	// Determine if the GCI mounter script exists locally.
+	// Determine if the GCI/COS mounter script exists locally.
 	k8sDir, err := builder.GetK8sRootDir()
 	if err != nil {
 		return args, fmt.Errorf("could not find K8s root dir! Err: %v", err)
 	}
-	source := filepath.Join(k8sDir, localGCIMounterPath)
+	source := filepath.Join(k8sDir, localCOSMounterPath)
 
-	// Require the GCI mounter script, we want to make sure the remote test runner stays up to date if the mounter file moves
+	// Require the GCI/COS mounter script, we want to make sure the remote test runner stays up to date if the mounter file moves
 	if _, err = os.Stat(source); err != nil {
-		return args, fmt.Errorf("could not find GCI mounter script at %q! If this script has been (re)moved, please update the e2e node remote test runner accordingly! Err: %v", source, err)
+		return args, fmt.Errorf("could not find GCI/COS mounter script at %q! If this script has been (re)moved, please update the e2e node remote test runner accordingly! Err: %v", source, err)
 	}
 
-	glog.V(2).Infof("GCI node and GCI mounter both detected, modifying --experimental-mounter-path accordingly")
+	glog.V(2).Infof("GCI/COS node and GCI/COS mounter both detected, modifying --experimental-mounter-path accordingly")
 	// Note this implicitly requires the script to be where we expect in the tarball, so if that location changes the error
 	// here will tell us to update the remote test runner.
-	mounterPath := filepath.Join(workspace, localGCIMounterPath)
+	mounterPath := filepath.Join(workspace, localCOSMounterPath)
 	output, err = SSH(host, "sh", "-c", fmt.Sprintf("'chmod 544 %s'", mounterPath))
 	if err != nil {
-		return args, fmt.Errorf("unabled to chmod 544 GCI mounter script. Err: %v, Output:\n%s", err, output)
+		return args, fmt.Errorf("unabled to chmod 544 GCI/COS mounter script. Err: %v, Output:\n%s", err, output)
 	}
 	// Insert args at beginning of test args, so any values from command line take precedence
 	args = fmt.Sprintf("--kubelet-flags=--experimental-mounter-path=%s ", mounterPath) + args
@@ -148,7 +148,7 @@ func (n *NodeE2ERemote) RunTest(host, workspace, results, junitFilePrefix, testA
 	// Kill any running node processes
 	cleanupNodeProcesses(host)
 
-	testArgs, err := updateGCIMounterPath(testArgs, host, workspace)
+	testArgs, err := updateCOSMounterPath(testArgs, host, workspace)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
GCI will soon change name in etc/os-release from "gci" to "cos".

This prepares the node_e2e tests to deal with that change and also updates some comments/log messages/var names in anticipation.