### PR TITLE
bazel: save git version in kubernetes.tar.gz

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,3 +4,6 @@ test --test_output=errors
 
 # Retry tests up to 3 times if they fail.
 test --flaky_test_attempts=3
+
+# Include git version info
+build --workspace_status_command hack/print-workspace-status.sh

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,3 +52,10 @@ filegroup(
     ],
     tags = ["automanaged"],
 )
+
+genrule(
+    name = "save_git_version",
+    outs = ["version"],
+    cmd = "grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt | cut -d' ' -f2 >$@",
+    stamp = 1,
+)

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -211,7 +211,7 @@ pkg_tar(
     name = "kubernetes",
     extension = "tar.gz",
     files = [
-        # TODO: the version file
+        "//:version",
         "//:README.md",
         "//:Vagrantfile",
         "//cluster:all-srcs",

--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This command is used by bazel as the workspace_status_command
+# to implement build stamping with git information.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+source "${KUBE_ROOT}/hack/lib/version.sh"
+kube::version::get_version_vars
+
+# Prefix with STABLE_ so that these values are saved to stable-status.txt
+# instead of volatile-status.txt.
+# Stamped rules will be retriggered by changes to stable-status.txt, but not by
+# changes to volatile-status.txt.
+cat <<EOF
+STABLE_BUILD_GIT_COMMIT ${KUBE_GIT_COMMIT-}
+STABLE_BUILD_SCM_STATUS ${KUBE_GIT_TREE_STATE-}
+STABLE_BUILD_SCM_REVISION ${KUBE_GIT_VERSION-}
+STABLE_BUILD_MAJOR_VERSION ${KUBE_GIT_MAJOR-}
+STABLE_BUILD_MINOR_VERSION ${KUBE_GIT_MINOR-}
+STABLE_gitCommit ${KUBE_GIT_COMMIT-}
+STABLE_gitTreeState ${KUBE_GIT_TREE_STATE-}
+STABLE_gitVersion ${KUBE_GIT_VERSION-}
+STABLE_gitMajor ${KUBE_GIT_MAJOR-}
+STABLE_gitMinor ${KUBE_GIT_MINOR-}
+EOF


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: adds a workspace status command for bazel (inspired by #36128) and then uses the saved values to generate the `version` file in `kubernetes.tar.gz`. We need this for `get-kube.sh` to work properly.

**Special notes for your reviewer**: I had to change a few things from #36128 - see comments for explanation.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
