### PR TITLE
Move b.gcr.io/k8s_authenticated_test to gcr.io/k8s-authenticated-test

### DIFF
--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -44,7 +44,7 @@ var _ = framework.KubeDescribe("ReplicationController", func() {
 		// requires private images
 		framework.SkipUnlessProviderIs("gce", "gke")
 
-		ServeImageOrFail(f, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
+		ServeImageOrFail(f, "private", "gcr.io/k8s-authenticated-test/serve_hostname:v1.4")
 	})
 
 	It("should surface a failure condition on a common issue like exceeded quota", func() {

--- a/test/e2e/replica_set.go
+++ b/test/e2e/replica_set.go
@@ -84,7 +84,7 @@ var _ = framework.KubeDescribe("ReplicaSet", func() {
 		// requires private images
 		framework.SkipUnlessProviderIs("gce", "gke")
 
-		ReplicaSetServeImageOrFail(f, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
+		ReplicaSetServeImageOrFail(f, "private", "gcr.io/k8s-authenticated-test/serve_hostname:v1.4")
 	})
 
 	It("should surface a failure condition on a common issue like exceeded quota", func() {

--- a/test/images/serve_hostname/Makefile
+++ b/test/images/serve_hostname/Makefile
@@ -15,14 +15,14 @@
 # Cross-build the serve_hostname image
 #
 # Usage:
-#       [TAG=v1.5] [PREFIX=gcr.io/google_containers] [TEST_REGISTRY=b.gcr.io/k8s_authenticated_test] [ARCH=amd64] [BASEIMAGE=busybox] make all
+#       [TAG=v1.5] [PREFIX=gcr.io/google_containers] [TEST_REGISTRY=gcr.io/k8s-authenticated-test] [ARCH=amd64] [BASEIMAGE=busybox] make all
 
 .PHONY: all push container clean
 
 TAG ?= v1.5
 
-REGISTRY ?= gcr.io/google_containers
-TEST_REGISTRY ?= b.gcr.io/k8s_authenticated_test
+REGISTRY ?= gcr.io/google-containers
+TEST_REGISTRY ?= gcr.io/k8s-authenticated-test
 
 # Architectures supported: amd64, arm, arm64, ppc64le and s390x
 ARCH ?= amd64
@@ -100,4 +100,3 @@ push: .push-$(ARCH)
 
 clean:
 	rm -rf $(BIN)
-


### PR DESCRIPTION
**What this PR does / why we need it**:

Per https://cloud.google.com/container-registry/docs/support/deprecation-notices, b.gcr.io access will be deprecated soon.

I've already mirrored the repo to the location specified in this PR.

