### PR TITLE
Invalid node names when deploying with Heat

### DIFF
--- a/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
@@ -252,6 +252,9 @@ resources:
     type: OS::Heat::RandomString
     properties:
       length: 8
+      character_classes:
+        - class: lowercase
+        - class: digits
 
   kube_minion:
     type: OS::Nova::Server


### PR DESCRIPTION
OpenStack Heat templates create Kubernetes nodes with invalid
hostnames. Capital letters are not allowed in the hostnames:

Unable to register node "kubernetes-node-6s8OizYe" with API server: Node "kubernetes-node-6s8OizYe" is invalid: metadata.name: Invalid value: "kubernetes-node-6s8OizYe": must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)* (e.g. 'example.com')

This patch prevents Heat generating hostnames that contain
capital letters.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
