### PR TITLE
Eliminate "Unknown service type: ExternalName"

### DIFF
--- a/pkg/registry/core/service/rest.go
+++ b/pkg/registry/core/service/rest.go
@@ -556,6 +556,8 @@ func shouldAssignNodePorts(service *api.Service) bool {
 		return true
 	case api.ServiceTypeClusterIP:
 		return false
+	case api.ServiceTypeExternalName:
+		return false
 	default:
 		glog.Errorf("Unknown service type: %v", service.Spec.Type)
 		return false


### PR DESCRIPTION
When creating an ExternalName service, rest.go still generate the warning message "Unknown service type: ExternalName". This should be eliminated as this type of service is supported now.
