### PR TITLE
Adding OWNERS file for federation e2e tests

### DIFF
--- a/test/e2e_federation/OWNERS
+++ b/test/e2e_federation/OWNERS
@@ -1,0 +1,13 @@
+reviewers:
+  - colhom
+  - csbell
+  - irfanurrehman
+  - madhusudancs
+  - mwielgus
+  - nikhiljindal
+  - shashidharatd
+approvers:
+  - csbell
+  - madhusudancs
+  - mwielgus
+  - nikhiljindal


### PR DESCRIPTION
Now that we have a separate `test/e2e_federation` dir for federation tests (thanks to @shashidharatd), we can have our own OWNERS file.

OWNERS file copied from https://github.com/kubernetes/kubernetes/pull/40328.

cc @kubernetes/sig-federation-misc 