### PR TITLE
e2e-node test for docker live-restore

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -81,6 +81,7 @@ go_test(
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/kubelet:go_default_library",
         "//pkg/kubelet/api/v1alpha1/stats:go_default_library",
+        "//pkg/kubelet/cadvisor:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/dockertools:go_default_library",
@@ -113,6 +114,7 @@ go_test(
         "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/apimachinery/pkg/util/uuid",
         "//vendor:k8s.io/apimachinery/pkg/watch",
+        "//vendor:k8s.io/client-go/_vendor/k8s.io/apimachinery/pkg/util/json",
         "//vendor:k8s.io/client-go/tools/cache",
     ],
 )

--- a/test/e2e_node/restart_test.go
+++ b/test/e2e_node/restart_test.go
@@ -19,16 +19,23 @@ limitations under the License.
 package e2e_node
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/test/e2e/framework"
-
-	"fmt"
-	"os/exec"
-
 	. "github.com/onsi/ginkgo"
+	apimetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/_vendor/k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
+	"k8s.io/kubernetes/test/e2e/framework"
 	testutils "k8s.io/kubernetes/test/utils"
 )
 
@@ -55,6 +62,23 @@ func waitForPods(f *framework.Framework, pod_count int, timeout time.Duration) (
 		}
 	}
 	return runningPods
+}
+
+type DockerDaemonOption struct {
+	Live_restore bool `json:"live-restore"`
+}
+
+func getDockerVersion() (string, error) {
+	c, err := cadvisor.New(0 /*don't start the http server*/, "docker", "/var/lib/kubelet")
+	if err != nil {
+		return "", fmt.Errorf("Could not start cadvisor %v", err)
+	}
+
+	vi, err := c.VersionInfo()
+	if err != nil {
+		return "", fmt.Errorf("Could not get VersionInfo %v", err)
+	}
+	return vi.DockerVersion, nil
 }
 
 var _ = framework.KubeDescribe("Restart [Serial] [Slow] [Disruptive]", func() {
@@ -116,6 +140,94 @@ var _ = framework.KubeDescribe("Restart [Serial] [Slow] [Disruptive]", func() {
 					}
 				}
 				By(fmt.Sprintf("Docker restart test passed with %d pods", len(postRestartRunningPods)))
+			})
+		})
+		Context("Live restore", func() {
+
+			It("should restore container when live restore is on", func() {
+				framework.SkipIfContainerRuntimeIs("rkt")
+
+				// Skip when docker engine version is less than 1.12
+				dockerVersion, err := getDockerVersion()
+				dockerRegex, _ := regexp.Compile(`1\.12\.[0-9]+`)
+				if !dockerRegex.Match([]byte(dockerVersion)) {
+					framework.Skipf("Live restore isn't suported before Docker Engine version 1.12")
+				}
+
+				// skip when docker live-restore is not enabled
+				dockerPid, err := ioutil.ReadFile("/var/run/docker.pid")
+				framework.ExpectNoError(err, "Failed to get docker daemon PID: %v, stdout: %q", err, string(dockerPid))
+
+				dockerdCmd, _ := ioutil.ReadFile("/proc/" + string(dockerPid) + "/cmdline")
+
+				daemonConfFile := "/etc/docker/daemon.json"
+				_, err = os.Stat(daemonConfFile)
+				var inConfFile bool
+				if !os.IsNotExist(err) {
+					opt := new(DockerDaemonOption)
+					data, err := ioutil.ReadFile(daemonConfFile)
+					err = json.Unmarshal(data, &opt)
+					framework.ExpectNoError(err, "Failed to parse docker config file %q: %v", daemonConfFile, err)
+					inConfFile = opt.Live_restore
+				}
+				asOption := strings.Contains(string(dockerdCmd), "--live-restore")
+
+				if !asOption && !inConfFile {
+					framework.Skipf("Docker live restore is not set")
+				}
+
+				// create pod
+				podClient := f.PodClient()
+				name := "pod-test-live-restore"
+				value := strconv.Itoa(time.Now().Nanosecond())
+				pod := &v1.Pod{
+					ObjectMeta: apimetav1.ObjectMeta{
+						Name: name,
+						Labels: map[string]string{
+							"name": "foo",
+							"time": value,
+						},
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "nginx",
+								Image: "gcr.io/google_containers/nginx-slim:0.7",
+							},
+						},
+					},
+				}
+
+				preRestartPod := podClient.CreateSync(pod)
+				By(fmt.Sprintf("Pre restart container id %q", preRestartPod.Status.ContainerStatuses[0].ContainerID))
+
+				// restart docker
+				if stdout, err := exec.Command("sudo", "systemctl", "restart", "docker").CombinedOutput(); err != nil {
+					framework.Logf("Failed to trigger docker restart with systemd/systemctl: %v, stdout: %q", err, string(stdout))
+					if stdout, err = exec.Command("sudo", "service", "docker", "restart").CombinedOutput(); err != nil {
+						framework.Failf("Failed to trigger docker restart with upstart/service: %v, stdout: %q", err, string(stdout))
+					}
+				}
+
+				// ensure the pod has the same container
+				postRestartRunningPods := waitForPods(f, 1, recoverTimeout)
+				if len(postRestartRunningPods) == 0 {
+					framework.Failf("Failed to start *any* pods after docker restart")
+
+				}
+				postRestartPod, err := podClient.Get(preRestartPod.Name, apimetav1.GetOptions{})
+				framework.ExpectNoError(err, "Could not get pod after restart")
+
+				if !reflect.DeepEqual(preRestartPod.Status.ContainerStatuses, postRestartPod.Status.ContainerStatuses) {
+					framework.Failf("Containers statuses has modified after docker restart\n pre-restart: %v post-restart\n: %v, ", preRestartPod.Status.ContainerStatuses, postRestartPod.Status.ContainerStatuses)
+				}
+				if postRestartPod == nil {
+					framework.Failf("Pod not found after restart")
+				}
+				if len(postRestartPod.Status.ContainerStatuses) == 0 {
+					framework.Failf("No containers found on pod after restart")
+				}
+				By(fmt.Sprintf("Post restart container id %q", postRestartPod.Status.ContainerStatuses[0].ContainerID))
 			})
 		})
 	})


### PR DESCRIPTION
Docker now provides live restore feature. This feature ensures containers are intact by docker daemon restart. This PR adds e2e node test for the feature.
More information on Live restore can be found here: https://docs.docker.com/engine/admin/live-restore/

The new test checks whether live restore is on. If not, it enables the feature (and disables it at the end of testing), restarts docker daemon and chesck, wheter container status of pod hasn't changed.