### PR TITLE
Change OPENSTACK_IMAGE_NAME to be more specific

### DIFF
--- a/cluster/openstack-heat/config-image.sh
+++ b/cluster/openstack-heat/config-image.sh
@@ -17,7 +17,7 @@
 ## Contains configuration values for new image. It is skip when CREATE_IMAGE=false
 
 # Image name which will be displayed in OpenStack
-OPENSTACK_IMAGE_NAME=${OPENSTACK_IMAGE_NAME:-CentOS7}
+OPENSTACK_IMAGE_NAME=${OPENSTACK_IMAGE_NAME:-CentOS-7-x86_64-GenericCloud-1604}
 
 # Downloaded image name for Openstack project
 IMAGE_FILE=${IMAGE_FILE:-CentOS-7-x86_64-GenericCloud-1604.qcow2}


### PR DESCRIPTION
There may already be other images in the cloud named CentOS7,
but since we are fetching a very specific version (1604) we should
go ahead and make the image name very specific as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Some clouds already have `Centos7` as an image that is available, however it may not be the *specific* version that openstack-heat looks for and downloads from CentOS.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note 
OpenStack-Heat will now look for an image named "CentOS-7-x86_64-GenericCloud-1604". To restore the previous behavior set OPENSTACK_IMAGE_NAME="CentOS7"
```
