### PR TITLE
Fix shell error when KEEP_TMP is not set

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -53,7 +53,7 @@ if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
   exit 0
 fi
 
-if [[ -z ${TMP_GOPATH:-} ]]; then
+if [[ -z "${TMP_GOPATH:-}" ]]; then
   # Create a nice clean place to put our new godeps
   _tmpdir="$(mktemp -d -t gopath.XXXXXX)"
 else
@@ -61,7 +61,7 @@ else
   _tmpdir="${TMP_GOPATH}"
 fi
 
-if [[ -z KEEP_TMP ]]; then
+if [[ -z "${KEEP_TMP:-}" ]]; then
     KEEP_TMP=false
 fi
 function cleanup {


### PR DESCRIPTION
Fixes:

```
I0124 11:13:32.738] godep v74 (linux/amd64/go1.7.4)
I0124 11:22:27.447] Don't forget to run hack/update-godep-licenses.sh if you added or removed a dependency!
I0124 11:22:27.862] Godeps Verified.
I0124 11:22:27.863] FAILED   hack/make-rules/../../hack/verify-godeps.sh	691s
I0124 11:22:27.864] Verifying hack/make-rules/../../hack/verify-gofmt.sh
W0124 11:22:27.964] hack/make-rules/../../hack/verify-godeps.sh: line 68: KEEP_TMP: unbound variable
```

Compare https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/40216/pull-kubernetes-verify/14099/