### PR TITLE
Make kube-dns mount optional configmap

### DIFF
--- a/cluster/addons/dns/kubedns-controller.yaml.base
+++ b/cluster/addons/dns/kubedns-controller.yaml.base
@@ -45,9 +45,14 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true    
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.12.1
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -79,7 +84,7 @@ spec:
         args:
         - --domain=__PILLAR__DNS__DOMAIN__.
         - --dns-port=10053
-        - --config-map=kube-dns
+        - --config-dir=/kube-dns-config
         - --v=2
         __PILLAR__FEDERATIONS__DOMAIN__MAP__
         env:
@@ -95,8 +100,11 @@ spec:
         - containerPort: 10055
           name: metrics
           protocol: TCP
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.12.1
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -124,7 +132,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.12.1
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kubedns-controller.yaml.in
+++ b/cluster/addons/dns/kubedns-controller.yaml.in
@@ -45,9 +45,14 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true    
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.12.1
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -79,7 +84,7 @@ spec:
         args:
         - --domain={{ pillar['dns_domain'] }}.
         - --dns-port=10053
-        - --config-map=kube-dns
+        - --config-dir=/kube-dns-config
         - --v=2
         {{ pillar['federations_domain_map'] }}
         env:
@@ -95,8 +100,11 @@ spec:
         - containerPort: 10055
           name: metrics
           protocol: TCP
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.12.1
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -124,7 +132,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.12.1
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kubedns-controller.yaml.sed
+++ b/cluster/addons/dns/kubedns-controller.yaml.sed
@@ -45,9 +45,14 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
+      volumes:
+      - name: kube-dns-config
+        configMap:
+          name: kube-dns
+          optional: true    
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.12.1
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -79,7 +84,7 @@ spec:
         args:
         - --domain=$DNS_DOMAIN.
         - --dns-port=10053
-        - --config-map=kube-dns
+        - --config-dir=/kube-dns-config
         - --v=2
         env:
         - name: PROMETHEUS_PORT
@@ -94,8 +99,11 @@ spec:
         - containerPort: 10055
           name: metrics
           protocol: TCP
+        volumeMounts:
+        - name: kube-dns-config
+          mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.12.1
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -123,7 +131,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.11.0
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.12.1
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
Switches add-on templates to use an optional mounted configmap for dns

Uses options added in https://github.com/kubernetes/dns/pull/39

Blocks https://github.com/kubernetes/kubernetes/pull/38816