### PR TITLE
Use metav1.*Options in genericapiserver

### DIFF
--- a/pkg/genericapiserver/endpoints/apiserver_test.go
+++ b/pkg/genericapiserver/endpoints/apiserver_test.go
@@ -1994,7 +1994,7 @@ func TestDeleteWithOptionsQuery(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if res.StatusCode != http.StatusOK {
-		t.Errorf("unexpected response: %s %#v", request.URL, res)
+		t.Fatalf("unexpected response: %s %#v", request.URL, res)
 		s, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -2002,7 +2002,7 @@ func TestDeleteWithOptionsQuery(t *testing.T) {
 		t.Logf(string(s))
 	}
 	if simpleStorage.deleted != ID {
-		t.Errorf("Unexpected delete: %s, expected %s", simpleStorage.deleted, ID)
+		t.Fatalf("Unexpected delete: %s, expected %s", simpleStorage.deleted, ID)
 	}
 	simpleStorage.deleteOptions.GetObjectKind().SetGroupVersionKind(schema.GroupVersionKind{})
 	if !api.Semantic.DeepEqual(simpleStorage.deleteOptions, item) {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
@@ -29,8 +29,8 @@ const GroupName = "meta.k8s.io"
 // Scheme is the registry for any type that adheres to the meta API spec.
 var scheme = runtime.NewScheme()
 
-// Codecs provides access to encoding and decoding for the scheme
-var codecs = serializer.NewCodecFactory(scheme)
+// Codecs provides access to encoding and decoding for the scheme.
+var Codecs = serializer.NewCodecFactory(scheme)
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
@@ -61,9 +61,16 @@ func addToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 		Convert_internalversion_ListOptions_To_v1_ListOptions,
 		Convert_v1_ListOptions_To_internalversion_ListOptions,
 	)
+	// ListOptions is the only options struct which needs conversion (it exposes labels and fields
+	// as selectors for convenience). The other types have only a single representation today.
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&ListOptions{},
+		&metav1.GetOptions{},
+		&metav1.ExportOptions{},
+		&metav1.DeleteOptions{},
 	)
+	// Allow delete options to be decoded across all version in this scheme (we may want to be more clever than this)
+	scheme.AddUnversionedTypes(SchemeGroupVersion, &metav1.DeleteOptions{})
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
@@ -42,6 +42,7 @@ func AddToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 		schema.GroupVersion{Group: groupVersion.Group, Version: runtime.APIVersionInternal}.WithKind(WatchEventKind),
 		&InternalEvent{},
 	)
+	// Supports legacy code paths, most callers should use metav1.ParameterCodec for now
 	scheme.AddKnownTypes(groupVersion,
 		&ListOptions{},
 		&ExportOptions{},
@@ -65,5 +66,8 @@ var ParameterCodec = runtime.NewParameterCodec(scheme)
 func init() {
 	scheme.AddUnversionedTypes(SchemeGroupVersion,
 		&ListOptions{},
+		&ExportOptions{},
+		&GetOptions{},
+		&DeleteOptions{},
 	)
 }


### PR DESCRIPTION
Treat DeleteOptions as unversioned in metainternalversion for decoding
of bodies from older clients. Use the metav1 Options structs from
generic api server and the appropriate codec.

Completes the move to using generic server side code for API objects

@sttts