### PR TITLE
Improve code coverage for scheduler/api/validation

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -257,6 +257,7 @@ plugin/pkg/admission/securitycontext/scdeny
 plugin/pkg/auth
 plugin/pkg/auth/authorizer
 plugin/pkg/auth/authorizer/rbac/bootstrappolicy
+plugin/pkg/scheduler/api/validation
 staging/src/k8s.io/apimachinery/pkg/api/equality
 staging/src/k8s.io/apimachinery/pkg/api/errors
 staging/src/k8s.io/apimachinery/pkg/api/resource

--- a/plugin/pkg/scheduler/api/validation/validation.go
+++ b/plugin/pkg/scheduler/api/validation/validation.go
@@ -23,10 +23,10 @@ import (
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 )
 
-// Validate checks for errors in the Config
+// ValidatePolicy checks for errors in the Config
 // It does not return early so that it can find as many errors as possible
 func ValidatePolicy(policy schedulerapi.Policy) error {
-	validationErrors := make([]error, 0)
+	var validationErrors []error
 
 	for _, priority := range policy.Priorities {
 		if priority.Weight <= 0 {

--- a/plugin/pkg/scheduler/api/validation/validation_test.go
+++ b/plugin/pkg/scheduler/api/validation/validation_test.go
@@ -50,3 +50,18 @@ func TestValidatePriorityWithNegativeWeight(t *testing.T) {
 		t.Errorf("Expected error about priority weight not being positive")
 	}
 }
+
+func TestValidateExtenderWithNonNegativeWeight(t *testing.T) {
+	extenderPolicy := api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter", Weight: 2}}}
+	errs := ValidatePolicy(extenderPolicy)
+	if errs != nil {
+		t.Errorf("Unexpected errors %v", errs)
+	}
+}
+
+func TestValidateExtenderWithNegativeWeight(t *testing.T) {
+	extenderPolicy := api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter", Weight: -2}}}
+	if ValidatePolicy(extenderPolicy) == nil {
+		t.Errorf("Expected error about priority weight for extender not being positive")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Improve code coverage for scheduler/api/validation from #39559

Thanks
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
