### PR TITLE
WIP: kube-proxy: remove OS conditionals.

### DIFF
--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -13,6 +13,7 @@ go_library(
     srcs = [
         "conntrack.go",
         "server.go",
+        "server_linux.go",
     ],
     tags = ["automanaged"],
     deps = [
@@ -24,13 +25,11 @@ go_library(
         "//pkg/proxy/config:go_default_library",
         "//pkg/proxy/iptables:go_default_library",
         "//pkg/proxy/userspace:go_default_library",
-        "//pkg/proxy/winuserspace:go_default_library",
         "//pkg/util/configz:go_default_library",
         "//pkg/util/dbus:go_default_library",
         "//pkg/util/exec:go_default_library",
         "//pkg/util/iptables:go_default_library",
         "//pkg/util/mount:go_default_library",
-        "//pkg/util/netsh:go_default_library",
         "//pkg/util/node:go_default_library",
         "//pkg/util/oom:go_default_library",
         "//pkg/util/resourcecontainer:go_default_library",

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -24,41 +24,26 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
-	"runtime"
 	"strconv"
 	"time"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	utilnet "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/apimachinery/pkg/util/wait"
-	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
-	clientv1 "k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/v1"
-	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	"k8s.io/kubernetes/pkg/proxy"
-	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
-	"k8s.io/kubernetes/pkg/proxy/iptables"
-	"k8s.io/kubernetes/pkg/proxy/userspace"
-	"k8s.io/kubernetes/pkg/proxy/winuserspace"
-	"k8s.io/kubernetes/pkg/util/configz"
-	utildbus "k8s.io/kubernetes/pkg/util/dbus"
-	"k8s.io/kubernetes/pkg/util/exec"
-	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	utilnetsh "k8s.io/kubernetes/pkg/util/netsh"
-	nodeutil "k8s.io/kubernetes/pkg/util/node"
-	"k8s.io/kubernetes/pkg/util/oom"
-	"k8s.io/kubernetes/pkg/util/resourcecontainer"
-	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
+	"k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/proxy"
+	"k8s.io/kubernetes/pkg/proxy/iptables"
+	"k8s.io/kubernetes/pkg/proxy/userspace"
+	"k8s.io/kubernetes/pkg/util/configz"
+	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
 )
 
 type ProxyServer struct {
@@ -127,194 +112,6 @@ with the apiserver API to configure the proxy.`,
 	return cmd
 }
 
-// NewProxyServerDefault creates a new ProxyServer object with default parameters.
-func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, error) {
-	if c, err := configz.New("componentconfig"); err == nil {
-		c.Set(config.KubeProxyConfiguration)
-	} else {
-		glog.Errorf("unable to register configz: %s", err)
-	}
-	protocol := utiliptables.ProtocolIpv4
-	if net.ParseIP(config.BindAddress).To4() == nil {
-		protocol = utiliptables.ProtocolIpv6
-	}
-
-	var netshInterface utilnetsh.Interface
-	var iptInterface utiliptables.Interface
-	var dbus utildbus.Interface
-
-	// Create a iptables utils.
-	execer := exec.New()
-
-	if runtime.GOOS == "windows" {
-		netshInterface = utilnetsh.New(execer)
-	} else {
-		dbus = utildbus.New()
-		iptInterface = utiliptables.New(execer, dbus, protocol)
-	}
-
-	// We omit creation of pretty much everything if we run in cleanup mode
-	if config.CleanupAndExit {
-		return &ProxyServer{
-			Config:       config,
-			IptInterface: iptInterface,
-		}, nil
-	}
-
-	// TODO(vmarmol): Use container config for this.
-	var oomAdjuster *oom.OOMAdjuster
-	if config.OOMScoreAdj != nil {
-		oomAdjuster = oom.NewOOMAdjuster()
-		if err := oomAdjuster.ApplyOOMScoreAdj(0, int(*config.OOMScoreAdj)); err != nil {
-			glog.V(2).Info(err)
-		}
-	}
-
-	if config.ResourceContainer != "" {
-		// Run in its own container.
-		if err := resourcecontainer.RunInResourceContainer(config.ResourceContainer); err != nil {
-			glog.Warningf("Failed to start in resource-only container %q: %v", config.ResourceContainer, err)
-		} else {
-			glog.V(2).Infof("Running in resource-only container %q", config.ResourceContainer)
-		}
-	}
-
-	// Create a Kube Client
-	// define api config source
-	if config.Kubeconfig == "" && config.Master == "" {
-		glog.Warningf("Neither --kubeconfig nor --master was specified.  Using default API client.  This might not work.")
-	}
-	// This creates a client, first loading any specified kubeconfig
-	// file, and then overriding the Master flag, if non-empty.
-	kubeconfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.Kubeconfig},
-		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: config.Master}}).ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	kubeconfig.ContentType = config.ContentType
-	// Override kubeconfig qps/burst settings from flags
-	kubeconfig.QPS = config.KubeAPIQPS
-	kubeconfig.Burst = int(config.KubeAPIBurst)
-
-	client, err := clientset.NewForConfig(kubeconfig)
-	if err != nil {
-		glog.Fatalf("Invalid API configuration: %v", err)
-	}
-
-	// Create event recorder
-	hostname := nodeutil.GetHostname(config.HostnameOverride)
-	eventBroadcaster := record.NewBroadcaster()
-	recorder := eventBroadcaster.NewRecorder(api.Scheme, clientv1.EventSource{Component: "kube-proxy", Host: hostname})
-
-	var proxier proxy.ProxyProvider
-	var endpointsHandler proxyconfig.EndpointsConfigHandler
-
-	proxyMode := getProxyMode(string(config.Mode), client.Core().Nodes(), hostname, iptInterface, iptables.LinuxKernelCompatTester{})
-	if proxyMode == proxyModeIPTables {
-		glog.V(0).Info("Using iptables Proxier.")
-		if config.IPTablesMasqueradeBit == nil {
-			// IPTablesMasqueradeBit must be specified or defaulted.
-			return nil, fmt.Errorf("Unable to read IPTablesMasqueradeBit from config")
-		}
-		proxierIPTables, err := iptables.NewProxier(
-			iptInterface,
-			utilsysctl.New(),
-			execer,
-			config.IPTablesSyncPeriod.Duration,
-			config.IPTablesMinSyncPeriod.Duration,
-			config.MasqueradeAll,
-			int(*config.IPTablesMasqueradeBit),
-			config.ClusterCIDR,
-			hostname,
-			getNodeIP(client, hostname),
-			recorder,
-		)
-		if err != nil {
-			glog.Fatalf("Unable to create proxier: %v", err)
-		}
-		proxier = proxierIPTables
-		endpointsHandler = proxierIPTables
-		// No turning back. Remove artifacts that might still exist from the userspace Proxier.
-		glog.V(0).Info("Tearing down userspace rules.")
-		userspace.CleanupLeftovers(iptInterface)
-	} else {
-		glog.V(0).Info("Using userspace Proxier.")
-		// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
-		// our config.EndpointsConfigHandler.
-		loadBalancer := userspace.NewLoadBalancerRR()
-		// set EndpointsConfigHandler to our loadBalancer
-		endpointsHandler = loadBalancer
-
-		var proxierUserspace proxy.ProxyProvider
-
-		if runtime.GOOS == "windows" {
-			proxierUserspace, err = winuserspace.NewProxier(
-				loadBalancer,
-				net.ParseIP(config.BindAddress),
-				netshInterface,
-				*utilnet.ParsePortRangeOrDie(config.PortRange),
-				// TODO @pires replace below with default values, if applicable
-				config.IPTablesSyncPeriod.Duration,
-				config.UDPIdleTimeout.Duration,
-			)
-		} else {
-			proxierUserspace, err = userspace.NewProxier(
-				loadBalancer,
-				net.ParseIP(config.BindAddress),
-				iptInterface,
-				*utilnet.ParsePortRangeOrDie(config.PortRange),
-				config.IPTablesSyncPeriod.Duration,
-				config.IPTablesMinSyncPeriod.Duration,
-				config.UDPIdleTimeout.Duration,
-			)
-		}
-		if err != nil {
-			glog.Fatalf("Unable to create proxier: %v", err)
-		}
-		proxier = proxierUserspace
-		// Remove artifacts from the pure-iptables Proxier, if not on Windows.
-		if runtime.GOOS != "windows" {
-			glog.V(0).Info("Tearing down pure-iptables proxy rules.")
-			iptables.CleanupLeftovers(iptInterface)
-		}
-	}
-
-	// Add iptables reload function, if not on Windows.
-	if runtime.GOOS != "windows" {
-		iptInterface.AddReloadFunc(proxier.Sync)
-	}
-
-	// Create configs (i.e. Watches for Services and Endpoints)
-	// Note: RegisterHandler() calls need to happen before creation of Sources because sources
-	// only notify on changes, and the initial update (on process start) may be lost if no handlers
-	// are registered yet.
-	serviceConfig := proxyconfig.NewServiceConfig()
-	serviceConfig.RegisterHandler(proxier)
-
-	endpointsConfig := proxyconfig.NewEndpointsConfig()
-	endpointsConfig.RegisterHandler(endpointsHandler)
-
-	proxyconfig.NewSourceAPI(
-		client.Core().RESTClient(),
-		config.ConfigSyncPeriod,
-		serviceConfig.Channel("api"),
-		endpointsConfig.Channel("api"),
-	)
-
-	config.NodeRef = &v1.ObjectReference{
-		Kind:      "Node",
-		Name:      hostname,
-		UID:       types.UID(hostname),
-		Namespace: "",
-	}
-
-	conntracker := realConntracker{}
-
-	return NewProxyServer(client, config, iptInterface, proxier, eventBroadcaster, recorder, conntracker, proxyMode)
-}
-
 // Run runs the specified ProxyServer.  This should never exit (unless CleanupAndExit is set).
 func (s *ProxyServer) Run() error {
 	// remove iptables rules and exit
@@ -344,42 +141,8 @@ func (s *ProxyServer) Run() error {
 	}
 
 	// Tune conntrack, if requested
-	if s.Conntracker != nil && runtime.GOOS != "windows" {
-		max, err := getConntrackMax(s.Config)
-		if err != nil {
-			return err
-		}
-		if max > 0 {
-			err := s.Conntracker.SetMax(max)
-			if err != nil {
-				if err != readOnlySysFSError {
-					return err
-				}
-				// readOnlySysFSError is caused by a known docker issue (https://github.com/docker/docker/issues/24000),
-				// the only remediation we know is to restart the docker daemon.
-				// Here we'll send an node event with specific reason and message, the
-				// administrator should decide whether and how to handle this issue,
-				// whether to drain the node and restart docker.
-				// TODO(random-liu): Remove this when the docker bug is fixed.
-				const message = "DOCKER RESTART NEEDED (docker issue #24000): /sys is read-only: " +
-					"cannot modify conntrack limits, problems may arise later."
-				s.Recorder.Eventf(s.Config.NodeRef, api.EventTypeWarning, err.Error(), message)
-			}
-		}
-
-		if s.Config.ConntrackTCPEstablishedTimeout.Duration > 0 {
-			timeout := int(s.Config.ConntrackTCPEstablishedTimeout.Duration / time.Second)
-			if err := s.Conntracker.SetTCPEstablishedTimeout(timeout); err != nil {
-				return err
-			}
-		}
-
-		if s.Config.ConntrackTCPCloseWaitTimeout.Duration > 0 {
-			timeout := int(s.Config.ConntrackTCPCloseWaitTimeout.Duration / time.Second)
-			if err := s.Conntracker.SetTCPCloseWaitTimeout(timeout); err != nil {
-				return err
-			}
-		}
+	if s.Conntracker != nil {
+		s.tuneConnTracker()
 	}
 
 	// Birth Cry after the birth is successful
@@ -388,27 +151,6 @@ func (s *ProxyServer) Run() error {
 	// Just loop forever for now...
 	s.Proxier.SyncLoop()
 	return nil
-}
-
-func getConntrackMax(config *options.ProxyServerConfig) (int, error) {
-	if config.ConntrackMax > 0 {
-		if config.ConntrackMaxPerCore > 0 {
-			return -1, fmt.Errorf("invalid config: ConntrackMax and ConntrackMaxPerCore are mutually exclusive")
-		}
-		glog.V(3).Infof("getConntrackMax: using absolute conntrack-max (deprecated)")
-		return int(config.ConntrackMax), nil
-	}
-	if config.ConntrackMaxPerCore > 0 {
-		floor := int(config.ConntrackMin)
-		scaled := int(config.ConntrackMaxPerCore) * runtime.NumCPU()
-		if scaled > floor {
-			glog.V(3).Infof("getConntrackMax: using scaled conntrack-max-per-core")
-			return scaled, nil
-		}
-		glog.V(3).Infof("getConntrackMax: using conntrack-min")
-		return floor, nil
-	}
-	return 0, nil
 }
 
 type nodeGetter interface {

--- a/cmd/kube-proxy/app/server_linux.go
+++ b/cmd/kube-proxy/app/server_linux.go
@@ -1,0 +1,277 @@
+// +build linux
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"net"
+	"runtime"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	clientv1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
+	"k8s.io/kubernetes/pkg/proxy/iptables"
+	"k8s.io/kubernetes/pkg/proxy/userspace"
+	"k8s.io/kubernetes/pkg/util/configz"
+	utildbus "k8s.io/kubernetes/pkg/util/dbus"
+	"k8s.io/kubernetes/pkg/util/exec"
+	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
+	"k8s.io/kubernetes/pkg/util/oom"
+	"k8s.io/kubernetes/pkg/util/resourcecontainer"
+	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
+
+	"github.com/golang/glog"
+)
+
+// NewProxyServerDefault creates a new ProxyServer object with default parameters.
+func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, error) {
+	if c, err := configz.New("componentconfig"); err == nil {
+		c.Set(config.KubeProxyConfiguration)
+	} else {
+		glog.Errorf("unable to register configz: %s", err)
+	}
+	protocol := utiliptables.ProtocolIpv4
+	if net.ParseIP(config.BindAddress).To4() == nil {
+		protocol = utiliptables.ProtocolIpv6
+	}
+
+	var iptInterface utiliptables.Interface
+	var dbus utildbus.Interface
+
+	// Create a iptables utils.
+	execer := exec.New()
+
+	dbus = utildbus.New()
+	iptInterface = utiliptables.New(execer, dbus, protocol)
+
+	// We omit creation of pretty much everything if we run in cleanup mode
+	if config.CleanupAndExit {
+		return &ProxyServer{
+			Config:       config,
+			IptInterface: iptInterface,
+		}, nil
+	}
+
+	// TODO(vmarmol): Use container config for this.
+	var oomAdjuster *oom.OOMAdjuster
+	if config.OOMScoreAdj != nil {
+		oomAdjuster = oom.NewOOMAdjuster()
+		if err := oomAdjuster.ApplyOOMScoreAdj(0, int(*config.OOMScoreAdj)); err != nil {
+			glog.V(2).Info(err)
+		}
+	}
+
+	if config.ResourceContainer != "" {
+		// Run in its own container.
+		if err := resourcecontainer.RunInResourceContainer(config.ResourceContainer); err != nil {
+			glog.Warningf("Failed to start in resource-only container %q: %v", config.ResourceContainer, err)
+		} else {
+			glog.V(2).Infof("Running in resource-only container %q", config.ResourceContainer)
+		}
+	}
+
+	// Create a Kube Client
+	// define api config source
+	if config.Kubeconfig == "" && config.Master == "" {
+		glog.Warningf("Neither --kubeconfig nor --master was specified.  Using default API client.  This might not work.")
+	}
+	// This creates a client, first loading any specified kubeconfig
+	// file, and then overriding the Master flag, if non-empty.
+	kubeconfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.Kubeconfig},
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: config.Master}}).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeconfig.ContentType = config.ContentType
+	// Override kubeconfig qps/burst settings from flags
+	kubeconfig.QPS = config.KubeAPIQPS
+	kubeconfig.Burst = int(config.KubeAPIBurst)
+
+	client, err := clientset.NewForConfig(kubeconfig)
+	if err != nil {
+		glog.Fatalf("Invalid API configuration: %v", err)
+	}
+
+	// Create event recorder
+	hostname := nodeutil.GetHostname(config.HostnameOverride)
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(api.Scheme, clientv1.EventSource{Component: "kube-proxy", Host: hostname})
+
+	var proxier proxy.ProxyProvider
+	var endpointsHandler proxyconfig.EndpointsConfigHandler
+
+	proxyMode := getProxyMode(string(config.Mode), client.Core().Nodes(), hostname, iptInterface, iptables.LinuxKernelCompatTester{})
+	if proxyMode == proxyModeIPTables {
+		glog.V(0).Info("Using iptables Proxier.")
+		if config.IPTablesMasqueradeBit == nil {
+			// IPTablesMasqueradeBit must be specified or defaulted.
+			return nil, fmt.Errorf("Unable to read IPTablesMasqueradeBit from config")
+		}
+		proxierIPTables, err := iptables.NewProxier(
+			iptInterface,
+			utilsysctl.New(),
+			execer,
+			config.IPTablesSyncPeriod.Duration,
+			config.IPTablesMinSyncPeriod.Duration,
+			config.MasqueradeAll,
+			int(*config.IPTablesMasqueradeBit),
+			config.ClusterCIDR,
+			hostname,
+			getNodeIP(client, hostname),
+			recorder,
+		)
+		if err != nil {
+			glog.Fatalf("Unable to create proxier: %v", err)
+		}
+		proxier = proxierIPTables
+		endpointsHandler = proxierIPTables
+		// No turning back. Remove artifacts that might still exist from the userspace Proxier.
+		glog.V(0).Info("Tearing down userspace rules.")
+		userspace.CleanupLeftovers(iptInterface)
+	} else {
+		glog.V(0).Info("Using userspace Proxier.")
+		// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
+		// our config.EndpointsConfigHandler.
+		loadBalancer := userspace.NewLoadBalancerRR()
+		// set EndpointsConfigHandler to our loadBalancer
+		endpointsHandler = loadBalancer
+
+		proxierUserspace, err := userspace.NewProxier(
+			loadBalancer,
+			net.ParseIP(config.BindAddress),
+			iptInterface,
+			*utilnet.ParsePortRangeOrDie(config.PortRange),
+			config.IPTablesSyncPeriod.Duration,
+			config.IPTablesMinSyncPeriod.Duration,
+			config.UDPIdleTimeout.Duration,
+		)
+		if err != nil {
+			glog.Fatalf("Unable to create proxier: %v", err)
+		}
+		proxier = proxierUserspace
+		// Remove artifacts from the pure-iptables Proxier.
+		glog.V(0).Info("Tearing down pure-iptables proxy rules.")
+		iptables.CleanupLeftovers(iptInterface)
+	}
+
+	// Add iptables reload function.
+	iptInterface.AddReloadFunc(proxier.Sync)
+
+	// Create configs (i.e. Watches for Services and Endpoints)
+	// Note: RegisterHandler() calls need to happen before creation of Sources because sources
+	// only notify on changes, and the initial update (on process start) may be lost if no handlers
+	// are registered yet.
+	serviceConfig := proxyconfig.NewServiceConfig()
+	serviceConfig.RegisterHandler(proxier)
+
+	endpointsConfig := proxyconfig.NewEndpointsConfig()
+	endpointsConfig.RegisterHandler(endpointsHandler)
+
+	proxyconfig.NewSourceAPI(
+		client.Core().RESTClient(),
+		config.ConfigSyncPeriod,
+		serviceConfig.Channel("api"),
+		endpointsConfig.Channel("api"),
+	)
+
+	config.NodeRef = &v1.ObjectReference{
+		Kind:      "Node",
+		Name:      hostname,
+		UID:       types.UID(hostname),
+		Namespace: "",
+	}
+
+	conntracker := realConntracker{}
+
+	return NewProxyServer(client, config, iptInterface, proxier, eventBroadcaster, recorder, conntracker, proxyMode)
+}
+
+// Tune conntrack, if requested
+func (s *ProxyServer) tuneConnTracker() error {
+	max, err := getConntrackMax(s.Config)
+	if err != nil {
+		return err
+	}
+	if max > 0 {
+		err := s.Conntracker.SetMax(max)
+		if err != nil {
+			if err != readOnlySysFSError {
+				return err
+			}
+			// readOnlySysFSError is caused by a known docker issue (https://github.com/docker/docker/issues/24000),
+			// the only remediation we know is to restart the docker daemon.
+			// Here we'll send an node event with specific reason and message, the
+			// administrator should decide whether and how to handle this issue,
+			// whether to drain the node and restart docker.
+			// TODO(random-liu): Remove this when the docker bug is fixed.
+			const message = "DOCKER RESTART NEEDED (docker issue #24000): /sys is read-only: " +
+				"cannot modify conntrack limits, problems may arise later."
+			s.Recorder.Eventf(s.Config.NodeRef, api.EventTypeWarning, err.Error(), message)
+		}
+	}
+
+	if s.Config.ConntrackTCPEstablishedTimeout.Duration > 0 {
+		timeout := int(s.Config.ConntrackTCPEstablishedTimeout.Duration / time.Second)
+		if err := s.Conntracker.SetTCPEstablishedTimeout(timeout); err != nil {
+			return err
+		}
+	}
+
+	if s.Config.ConntrackTCPCloseWaitTimeout.Duration > 0 {
+		timeout := int(s.Config.ConntrackTCPCloseWaitTimeout.Duration / time.Second)
+		if err := s.Conntracker.SetTCPCloseWaitTimeout(timeout); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func getConntrackMax(config *options.ProxyServerConfig) (int, error) {
+	if config.ConntrackMax > 0 {
+		if config.ConntrackMaxPerCore > 0 {
+			return -1, fmt.Errorf("invalid config: ConntrackMax and ConntrackMaxPerCore are mutually exclusive")
+		}
+		glog.V(3).Infof("getConntrackMax: using absolute conntrack-max (deprecated)")
+		return int(config.ConntrackMax), nil
+	}
+	if config.ConntrackMaxPerCore > 0 {
+		floor := int(config.ConntrackMin)
+		scaled := int(config.ConntrackMaxPerCore) * runtime.NumCPU()
+		if scaled > floor {
+			glog.V(3).Infof("getConntrackMax: using scaled conntrack-max-per-core")
+			return scaled, nil
+		}
+		glog.V(3).Infof("getConntrackMax: using conntrack-min")
+		return floor, nil
+	}
+	return 0, nil
+}

--- a/cmd/kube-proxy/app/server_unsupported.go
+++ b/cmd/kube-proxy/app/server_unsupported.go
@@ -1,0 +1,39 @@
+// +build !linux,!windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
+)
+
+// NewProxyServerDefault creates a new ProxyServer object with default parameters.
+func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, error) {
+	return nil, fmt.Errorf("Proxying is not supported in this build")
+}
+
+// Tune conntrack, if requested
+func (s *ProxyServer) tuneConnTracker() error {
+	return fmt.Errorf("Proxying is not supported in this build")
+}
+
+func getConntrackMax(config *options.ProxyServerConfig) (int, error) {
+	return 0, fmt.Errorf("Proxying is not supported in this build")
+}

--- a/cmd/kube-proxy/app/server_unsupported.go
+++ b/cmd/kube-proxy/app/server_unsupported.go
@@ -29,11 +29,7 @@ func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, err
 	return nil, fmt.Errorf("Proxying is not supported in this build")
 }
 
-// Tune conntrack, if requested
+// No-op
 func (s *ProxyServer) tuneConnTracker() error {
-	return fmt.Errorf("Proxying is not supported in this build")
-}
-
-func getConntrackMax(config *options.ProxyServerConfig) (int, error) {
-	return 0, fmt.Errorf("Proxying is not supported in this build")
+	return fmt.Errorf("Connection tracking is not supported in this build")
 }

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -1,0 +1,178 @@
+// +build windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"net"
+
+	"k8s.io/apimachinery/pkg/types"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	clientv1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/proxy"
+	proxyconfig "k8s.io/kubernetes/pkg/proxy/config"
+	"k8s.io/kubernetes/pkg/proxy/userspace"
+	"k8s.io/kubernetes/pkg/proxy/winuserspace"
+	"k8s.io/kubernetes/pkg/util/configz"
+	"k8s.io/kubernetes/pkg/util/exec"
+	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	utilnetsh "k8s.io/kubernetes/pkg/util/netsh"
+	nodeutil "k8s.io/kubernetes/pkg/util/node"
+	"k8s.io/kubernetes/pkg/util/oom"
+	"k8s.io/kubernetes/pkg/util/resourcecontainer"
+
+	"github.com/golang/glog"
+)
+
+// NewProxyServerDefault creates a new ProxyServer object with default parameters.
+func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, error) {
+	if c, err := configz.New("componentconfig"); err == nil {
+		c.Set(config.KubeProxyConfiguration)
+	} else {
+		glog.Errorf("unable to register configz: %s", err)
+	}
+
+	var netshInterface utilnetsh.Interface
+	var iptInterface utiliptables.Interface
+
+	// Create a iptables utils.
+	execer := exec.New()
+
+	netshInterface = utilnetsh.New(execer)
+
+	// We omit creation of pretty much everything if we run in cleanup mode
+	if config.CleanupAndExit {
+		return &ProxyServer{
+			Config:       config,
+			IptInterface: iptInterface,
+		}, nil
+	}
+
+	// TODO(vmarmol): Use container config for this.
+	var oomAdjuster *oom.OOMAdjuster
+	if config.OOMScoreAdj != nil {
+		oomAdjuster = oom.NewOOMAdjuster()
+		if err := oomAdjuster.ApplyOOMScoreAdj(0, int(*config.OOMScoreAdj)); err != nil {
+			glog.V(2).Info(err)
+		}
+	}
+
+	if config.ResourceContainer != "" {
+		// Run in its own container.
+		if err := resourcecontainer.RunInResourceContainer(config.ResourceContainer); err != nil {
+			glog.Warningf("Failed to start in resource-only container %q: %v", config.ResourceContainer, err)
+		} else {
+			glog.V(2).Infof("Running in resource-only container %q", config.ResourceContainer)
+		}
+	}
+
+	// Create a Kube Client
+	// define api config source
+	if config.Kubeconfig == "" && config.Master == "" {
+		glog.Warningf("Neither --kubeconfig nor --master was specified.  Using default API client.  This might not work.")
+	}
+	// This creates a client, first loading any specified kubeconfig
+	// file, and then overriding the Master flag, if non-empty.
+	kubeconfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.Kubeconfig},
+		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: config.Master}}).ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	kubeconfig.ContentType = config.ContentType
+	// Override kubeconfig qps/burst settings from flags
+	kubeconfig.QPS = config.KubeAPIQPS
+	kubeconfig.Burst = int(config.KubeAPIBurst)
+
+	client, err := clientset.NewForConfig(kubeconfig)
+	if err != nil {
+		glog.Fatalf("Invalid API configuration: %v", err)
+	}
+
+	// Create event recorder
+	hostname := nodeutil.GetHostname(config.HostnameOverride)
+	eventBroadcaster := record.NewBroadcaster()
+	recorder := eventBroadcaster.NewRecorder(api.Scheme, clientv1.EventSource{Component: "kube-proxy", Host: hostname})
+
+	var proxier proxy.ProxyProvider
+	var endpointsHandler proxyconfig.EndpointsConfigHandler
+
+	proxyMode := proxyModeUserspace
+
+	glog.V(0).Info("Using userspace Proxier.")
+	// This is a proxy.LoadBalancer which NewProxier needs but has methods we don't need for
+	// our config.EndpointsConfigHandler.
+	loadBalancer := userspace.NewLoadBalancerRR()
+	// set EndpointsConfigHandler to our loadBalancer
+	endpointsHandler = loadBalancer
+
+	proxierUserspace, err := winuserspace.NewProxier(
+		loadBalancer,
+		net.ParseIP(config.BindAddress),
+		netshInterface,
+		*utilnet.ParsePortRangeOrDie(config.PortRange),
+		// TODO @pires replace below with default values, if applicable
+		config.IPTablesSyncPeriod.Duration,
+		config.UDPIdleTimeout.Duration,
+	)
+	if err != nil {
+		glog.Fatalf("Unable to create proxier: %v", err)
+	}
+	proxier = proxierUserspace
+
+	// Create configs (i.e. Watches for Services and Endpoints)
+	// Note: RegisterHandler() calls need to happen before creation of Sources because sources
+	// only notify on changes, and the initial update (on process start) may be lost if no handlers
+	// are registered yet.
+	serviceConfig := proxyconfig.NewServiceConfig()
+	serviceConfig.RegisterHandler(proxier)
+
+	endpointsConfig := proxyconfig.NewEndpointsConfig()
+	endpointsConfig.RegisterHandler(endpointsHandler)
+
+	proxyconfig.NewSourceAPI(
+		client.Core().RESTClient(),
+		config.ConfigSyncPeriod,
+		serviceConfig.Channel("api"),
+		endpointsConfig.Channel("api"),
+	)
+
+	config.NodeRef = &v1.ObjectReference{
+		Kind:      "Node",
+		Name:      hostname,
+		UID:       types.UID(hostname),
+		Namespace: "",
+	}
+
+	conntracker := realConntracker{}
+
+	return NewProxyServer(client, config, iptInterface, proxier, eventBroadcaster, recorder, conntracker, proxyMode)
+}
+
+// Not implemented on Windows
+func (s *ProxyServer) tuneConnTracker() error {
+	return nil
+}

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -19,6 +19,7 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"net"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -167,12 +168,13 @@ func NewProxyServerDefault(config *options.ProxyServerConfig) (*ProxyServer, err
 		Namespace: "",
 	}
 
-	conntracker := realConntracker{}
+	// TODO implement when connection tracking is available for Windows.
+	//conntracker := realConntracker{}
 
-	return NewProxyServer(client, config, iptInterface, proxier, eventBroadcaster, recorder, conntracker, proxyMode)
+	return NewProxyServer(client, config, iptInterface, proxier, eventBroadcaster, recorder, nil, proxyMode)
 }
 
-// Not implemented on Windows
+// TODO implement when connection tracking is available for Windows.
 func (s *ProxyServer) tuneConnTracker() error {
-	return nil
+	return fmt.Errorf("Connection tracking is not supported on Windows")
 }


### PR DESCRIPTION
**What this PR does / why we need it**: in 1.5 we added Windows support to kube-proxy. This is part of an ongoing effort to improve what has been done. In this PR, we focused on removing OS checks based on [previous feedback](https://github.com/kubernetes/kubernetes/pull/36079#pullrequestreview-7272053).

**Which issue this PR fixes**: fixes #36277

**Special notes for your reviewer**: @thockin a second step we'd like to discuss is how can we remove the need for the Windows code to not know about `iptables.Interface` type. A third step could be to extract proxy modes as _plug-ins_, so that we can provide different implementations for Windows as well.

**Release note**:
```release-note
NONE
```
