### PR TITLE
fixing source for heapster eventer in kubemark

### DIFF
--- a/test/kubemark/resources/heapster_template.json
+++ b/test/kubemark/resources/heapster_template.json
@@ -66,7 +66,7 @@
 						"/eventer"
 					],
 					"args": [
-						"--source=kubernetes:https://104.197.233.84:443?inClusterConfig=0&useServiceAccount=0&auth=/kubeconfig/heapster.kubeconfig"
+						"--source=kubernetes:https://{{MASTER_IP}}:443?inClusterConfig=0&useServiceAccount=0&auth=/kubeconfig/heapster.kubeconfig"
 					],
 					"volumeMounts": [
 						{


### PR DESCRIPTION
Fixing the out of place heapster eventer source IP.

cc @wojtek-t @gmarek 