### PR TITLE
Increase TTL in secret manager

### DIFF
--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -209,8 +209,12 @@ type cachingSecretManager struct {
 }
 
 func NewCachingSecretManager(kubeClient clientset.Interface) (Manager, error) {
+	// TODO: Currently apiserver completely cannot keep up with 1 minute ttl in
+	// 5000-node clusters. So before we optimize apiserver and/or etcd, increase
+	// the TTL to 2 minutes (which is a lot, but...)
+	ttl := 2 * time.Minute
 	csm := &cachingSecretManager{
-		secretStore:    newSecretStore(kubeClient, clock.RealClock{}, time.Minute),
+		secretStore:    newSecretStore(kubeClient, clock.RealClock{}, ttl),
 		registeredPods: make(map[objectKey]*v1.Pod),
 	}
 	return csm, nil


### PR DESCRIPTION
Currently apiserver and/or etcd completely cannot keep up with the load caused by GET secrets from kuebelet (when I switch them off our tests work smoothly). Thus, until we optimize apiserver/etcd, I'm increasing the TTL.

@liggitt 