### PR TITLE
Add wojtek to global approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -13,3 +13,4 @@ approvers:
   - lavalamp
   - smarterclayton
   - thockin
+  - wojtek-t


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows @wojtek-t to globally approve, as he was the right person to approve 
https://github.com/kubernetes/kubernetes/pull/40176 and is a top contributor across the project.

In general, cross cutting code changes should probably allow an override by a maintainer "in the know", until a time where the approvers is fully populated.  

**Special notes for your reviewer**:
Doesn't default him as a reviewer across the whole project, unless he thinks that is correct.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

/cc @bgrant0607 @wojtek-t @kubernetes/sig-contributor-experience-bugs 