### PR TITLE
plugin/pkg/admission/serviceaccount: prefer first referenced secret

### DIFF
--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -303,13 +303,14 @@ func (s *serviceAccount) getReferencedServiceAccountToken(serviceAccount *api.Se
 		return "", err
 	}
 
-	references := sets.NewString()
-	for _, secret := range serviceAccount.Secrets {
-		references.Insert(secret.Name)
-	}
+	accountTokens := sets.NewString()
 	for _, token := range tokens {
-		if references.Has(token.Name) {
-			return token.Name, nil
+		accountTokens.Insert(token.Name)
+	}
+	// Prefer secrets in the order they're referenced.
+	for _, secret := range serviceAccount.Secrets {
+		if accountTokens.Has(secret.Name) {
+			return secret.Name, nil
 		}
 	}
 


### PR DESCRIPTION
When a pod uses a service account that references multiple secrets,
prefer the secrets in the order they're listed.

Without this change, the added test fails:

    --- FAIL: TestMultipleReferencedSecrets (0.00s)
            admission_test.go:832: expected first referenced secret to be mounted, got "token2"

Closes #40411

cc @kubernetes/sig-auth-pr-reviews 