### PR TITLE
Modify mounter script to bind mount /var and /etc

### DIFF
--- a/cluster/gce/gci/mounter/mounter
+++ b/cluster/gce/gci/mounter/mounter
@@ -48,8 +48,10 @@ echo "Running mount using a rkt fly container"
 
 ${RKT_BINARY} run --stage1-path=${STAGE1_ACI} \
 	--insecure-options=image \
-	--volume=kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
-	--mount volume=kubelet,target=/var/lib/kubelet \
+	--volume=var,kind=host,source=/var,readOnly=false,recursive=true \
+	--mount volume=var,target=/var \
+	--volume=etc,kind=host,source=/etc,readOnly=false \
+	--mount volume=etc,target=/etc \
 	${MOUNTER_IMAGE} --user=${MOUNTER_USER} --exec /bin/mount -- "$@"
 
 echo "Successfully ran mount using a rkt fly container"


### PR DESCRIPTION
During investigating an issue on using GlusterFS with TLS, we found out
that some applications may require to access /etc and /var directories
during mount. This PR is to fix the issue to bind mount /var and /etc
instead of only /var/lib/kubelet

