### PR TITLE
[Federation] Add hooks to e2e test suite to be called during suite setup/termination

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -158,6 +158,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	// Reference federation test to make the import valid.
 	federationtest.FederationSuite = commontest.FederationE2E
 
+	// Run test suite init actions (if any) added. Called only once for test suite during setup.
+	framework.RunSuiteInitActions()
+
 	return nil
 
 }, func(data []byte) {
@@ -220,6 +223,10 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {
 	RunCleanupActions()
 }, func() {
 	// Run only Ginkgo on node 1
+
+	// Run test suite cleanup actions (if any) added. Called only once for test suite during teardown.
+	framework.RunSuiteCleanupActions()
+
 	if framework.TestContext.ReportDir != "" {
 		framework.CoreDump(framework.TestContext.ReportDir)
 	}

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -27,6 +27,7 @@ go_library(
         "pods.go",
         "resource_usage_gatherer.go",
         "service_util.go",
+        "suite_init_cleanup.go",
         "test_context.go",
         "util.go",
     ],

--- a/test/e2e/framework/suite_init_cleanup.go
+++ b/test/e2e/framework/suite_init_cleanup.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"sync"
+)
+
+var suiteInitActionsLock sync.Mutex
+var suiteInitActions = []func(){}
+
+// AddSuiteInitAction installs a function that will be called when the test suite is being setup.
+// This allows any frameworks extending the core framework to hook into SynchronizedBeforeSuite().
+func AddSuiteInitAction(fn func()) {
+	suiteInitActionsLock.Lock()
+	defer suiteInitActionsLock.Unlock()
+	suiteInitActions = append(suiteInitActions, fn)
+}
+
+// RunSuiteInitActions runs all functions installed by AddSuiteInitAction during test suite setup.
+func RunSuiteInitActions() {
+	for _, fn := range suiteInitActions {
+		fn()
+	}
+}
+
+var suiteCleanupActionsLock sync.Mutex
+var suiteCleanupActions = []func(){}
+
+// AddSuiteCleanupAction installs a function that will be called when the whole test suite being terminated.
+// This allows any frameworks extending the core framework to hook into SynchronizedAfterSuite().
+func AddSuiteCleanupAction(fn func()) {
+	suiteCleanupActionsLock.Lock()
+	defer suiteCleanupActionsLock.Unlock()
+	suiteCleanupActions = append(suiteCleanupActions, fn)
+}
+
+// RunSuiteCleanupActions runs all functions installed by AddSuiteCleanupAction during test suite termination.
+func RunSuiteCleanupActions() {
+	for i := len(suiteCleanupActions) - 1; i >= 0; i-- {
+		fn := suiteCleanupActions[i]
+		fn()
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the facility to add hooks to e2e test suite which gets called only once during test suite setup & termination. This feature will be useful to any test frameworks (e.g. e2e_federation framework) extending the e2e test framework to hook into ginkgo.SynchronizedBeforeSuite/ginkgo.SynchronizedAfterSuite(func().

This PR will enable moving federation e2e tests which register/unregister clusters on every test case to register/unregister cluster only once for the test suite.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


**Special notes for your reviewer**:

**Release note**: `NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->

cc @kubernetes/sig-federation-misc @madhusudancs 
