### PR TITLE
Optimize Quantitity::Size() method

### DIFF
--- a/pkg/api/resource/quantity_proto.go
+++ b/pkg/api/resource/quantity_proto.go
@@ -69,7 +69,7 @@ func (m *Quantity) Size() (n int) {
 	_ = l
 
 	// BEGIN CUSTOM SIZE
-	l = len(m.String())
+	l = m.Len()
 	// END CUSTOM SIZE
 
 	n += 1 + l + sovGenerated(uint64(l))

--- a/pkg/api/resource/quantity_test.go
+++ b/pkg/api/resource/quantity_test.go
@@ -1190,6 +1190,21 @@ func BenchmarkQuantityString(b *testing.B) {
 	}
 }
 
+func BenchmarkQuantitySize(b *testing.B) {
+	values := benchmarkQuantities()
+	b.ResetTimer()
+	var s int
+	for i := 0; i < b.N; i++ {
+		q := values[i%len(values)]
+		q.s = ""
+		s = q.Size()
+	}
+	b.StopTimer()
+	if s == 0 {
+		b.Fatal("incorrect length")
+	}
+}
+
 func BenchmarkQuantityStringPrecalc(b *testing.B) {
 	values := benchmarkQuantities()
 	for i := range values {


### PR DESCRIPTION
This is very simple optimization of Quantity::Size that reduces the amount of allocations.

Ref #40515

Before:
```
BenchmarkQuantitySize-12    	  500000	      3399 ns/op	      39 B/op	       2 allocs/op
```

After:
```
BenchmarkQuantitySize-12    	 1000000	      2758 ns/op	      35 B/op	       1 allocs/op
```