### PR TITLE
test/node_e2e: wire-in cri-enabled local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,8 @@ define TEST_E2E_NODE_HELP_INFO
 #  GUBERNATOR: For REMOTE=true only. Produce link to Gubernator to view logs.
 #	 Defaults to false.
 #  PARALLELISM: The number of gingko nodes to run.  Defaults to 8.
+#  RUNTIME: Container runtime to use (eg. docker, rkt, remote).
+#    Defaults to "docker".
 #
 # Example:
 #   make test-e2e-node FOCUS=Kubelet SKIP=container

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -28,6 +28,7 @@ skip=${SKIP-"\[Flaky\]|\[Slow\]|\[Serial\]"}
 parallelism=${PARALLELISM:-8}
 artifacts=${ARTIFACTS:-"/tmp/_artifacts/`date +%y%m%dT%H%M%S`"}
 remote=${REMOTE:-"false"}
+runtime=${RUNTIME:-"docker"}
 run_until_failure=${RUN_UNTIL_FAILURE:-"false"}
 test_args=${TEST_ARGS:-""}
 
@@ -144,10 +145,16 @@ else
   # test_args.
   test_args='--kubelet-flags="--network-plugin= --network-plugin-dir=" '$test_args
 
+  # Runtime flags
+  test_args='--kubelet-flags="--container-runtime='$runtime'" '$test_args
+  if [[ $runtime == "remote" ]] ; then
+      test_args='--kubelet-flags="--experimental-cri=true" '$test_args
+  fi
+
   # Test using the host the script was run on
   # Provided for backwards compatibility
   go run test/e2e_node/runner/local/run_local.go --ginkgo-flags="$ginkgoflags" \
-    --test-flags="--alsologtostderr --v 4 --report-dir=${artifacts} --node-name $(hostname) \
+    --test-flags="--container-runtime=${runtime} --alsologtostderr --v 4 --report-dir=${artifacts} --node-name $(hostname) \
     $test_args" --build-dependencies=true 2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?
 fi

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -159,7 +159,6 @@ duration-sec
 e2e-output-dir
 e2e-verify-service-account
 enable-controller-attach-detach
-enable-cri
 enable-custom-metrics
 enable-debugging-handlers
 enable-dynamic-provisioning

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -156,6 +156,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Path to the directory where the JUnit XML reports should be saved. Default is empty, which doesn't generate these reports.")
 	flag.StringVar(&TestContext.FeatureGates, "feature-gates", "", "A set of key=value pairs that describe feature gates for alpha/experimental features.")
 	flag.StringVar(&TestContext.Viper, "viper-config", "e2e", "The name of the viper config i.e. 'e2e' will read values from 'e2e.json' locally.  All e2e parameters are meant to be configurable by viper.")
+	flag.StringVar(&TestContext.ContainerRuntime, "container-runtime", "docker", "The container runtime of cluster VM instances (docker/rkt/remote).")
 }
 
 // Register flags specific to the cluster e2e test suite.
@@ -173,7 +174,6 @@ func RegisterClusterFlags() {
 	flag.StringVar(&TestContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
 	flag.StringVar(&TestContext.OutputDir, "e2e-output-dir", "/tmp", "Output directory for interesting/useful test data, like performance data, benchmarks, and other metrics.")
 	flag.StringVar(&TestContext.Prefix, "prefix", "e2e", "A prefix to be added to cloud resources created during testing.")
-	flag.StringVar(&TestContext.ContainerRuntime, "container-runtime", "docker", "The container runtime of cluster VM instances (docker or rkt).")
 	flag.StringVar(&TestContext.MasterOSDistro, "master-os-distro", "debian", "The OS distribution of cluster master (debian, trusty, or coreos).")
 	flag.StringVar(&TestContext.NodeOSDistro, "node-os-distro", "debian", "The OS distribution of cluster VM instances (debian, trusty, or coreos).")
 

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -65,7 +65,6 @@ func init() {
 	// It seems that someone is using flag.Parse() after init() and TestMain().
 	// TODO(random-liu): Find who is using flag.Parse() and cause errors and move the following logic
 	// into TestContext.
-	pflag.CommandLine.MarkHidden("enable-cri")
 }
 
 func TestMain(m *testing.M) {
@@ -99,7 +98,7 @@ func TestE2eNode(t *testing.T) {
 				glog.Exitf("chroot %q failed: %v", rootfs, err)
 			}
 		}
-		if err := system.ValidateDefault(); err != nil {
+		if err := system.ValidateDefault(framework.TestContext.ContainerRuntime); err != nil {
 			glog.Exitf("system validation failed: %v", err)
 		}
 		return

--- a/test/e2e_node/system/validators.go
+++ b/test/e2e_node/system/validators.go
@@ -35,16 +35,9 @@ type Reporter interface {
 	Report(string, string, ValidationResultType) error
 }
 
-// Validate uses all validators to validate the system.
-func Validate(spec SysSpec, report Reporter) error {
+// Validate uses validators to validate the system.
+func Validate(spec SysSpec, validators []Validator) error {
 	var errs []error
-	// validators are all the validators.
-	var validators = []Validator{
-		&OSValidator{Reporter: report},
-		&KernelValidator{Reporter: report},
-		&CgroupsValidator{Reporter: report},
-		&DockerValidator{Reporter: report},
-	}
 
 	for _, v := range validators {
 		glog.Infof("Validating %s...", v.Name())
@@ -54,6 +47,22 @@ func Validate(spec SysSpec, report Reporter) error {
 }
 
 // ValidateDefault uses all default validators to validate the system and writes to stdout.
-func ValidateDefault() error {
-	return Validate(DefaultSysSpec, DefaultReporter)
+func ValidateDefault(runtime string) error {
+	// OS-level validators.
+	var osValidators = []Validator{
+		&OSValidator{Reporter: DefaultReporter},
+		&KernelValidator{Reporter: DefaultReporter},
+		&CgroupsValidator{Reporter: DefaultReporter},
+	}
+	// Docker-specific validators.
+	var dockerValidators = []Validator{
+		&DockerValidator{Reporter: DefaultReporter},
+	}
+
+	validators := osValidators
+	switch runtime {
+	case "docker":
+		validators = append(validators, dockerValidators...)
+	}
+	return Validate(DefaultSysSpec, validators)
 }


### PR DESCRIPTION
This commit wires-in the pre-existing `--container-runtime` flag for
local node_e2e testing.
This is needed in order to further skip docker specific testing
and validation.

Local CRI node_e2e can now be performed via
`make test-e2e-node RUNTIME=remote REMOTE=false`
which will also take care of passing the appropriate argument to
the kubelet.