### PR TITLE
test/e2e_node: tie together expected string and exec

### DIFF
--- a/test/e2e_node/kubelet_test.go
+++ b/test/e2e_node/kubelet_test.go
@@ -131,7 +131,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 						{
 							Image:   "gcr.io/google_containers/busybox:1.24",
 							Name:    podName,
-							Command: []string{"sh", "-c", "echo test > /file; sleep 240"},
+							Command: []string{"/bin/sh", "-c", "echo test > /file; sleep 240"},
 							SecurityContext: &v1.SecurityContext{
 								ReadOnlyRootFilesystem: &isReadOnly,
 							},
@@ -148,7 +148,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 				buf := new(bytes.Buffer)
 				buf.ReadFrom(rc)
 				return buf.String()
-			}, time.Minute, time.Second*4).Should(Equal("sh: can't create /file: Read-only file system\n"))
+			}, time.Minute, time.Second*4).Should(Equal("/bin/sh: can't create /file: Read-only file system\n"))
 		})
 	})
 })


### PR DESCRIPTION
This commit ties together busybox-sh invocation and test expectation
to avoid subtle mismatches between exec command and output string.