### PR TITLE
Reduce maximum delay of exponential backof in VerifyControllerAttachedVolume

### DIFF
--- a/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
+++ b/pkg/util/goroutinemap/exponentialbackoff/exponential_backoff.go
@@ -30,9 +30,9 @@ const (
 	// successive error results in a wait 2x times the previous.
 	initialDurationBeforeRetry time.Duration = 500 * time.Millisecond
 
-	// maxDurationBeforeRetry is the maximum amount of time that
-	// durationBeforeRetry will grow to due to exponential backoff.
-	maxDurationBeforeRetry time.Duration = 2 * time.Minute
+	// defaultMaxDurationBeforeRetry is the default maximum amount of time
+	// that durationBeforeRetry will grow to due to exponential backoff.
+	defaultMaxDurationBeforeRetry time.Duration = 2 * time.Minute
 )
 
 // ExponentialBackoff contains the last occurrence of an error and the duration
@@ -41,6 +41,10 @@ type ExponentialBackoff struct {
 	lastError           error
 	lastErrorTime       time.Time
 	durationBeforeRetry time.Duration
+
+	// MaxDurationBeforeRetry is the maximum amount of time that
+	// durationBeforeRetry will grow to due to exponential backoff.
+	MaxDurationBeforeRetry time.Duration
 }
 
 // SafeToRetry returns an error if the durationBeforeRetry period for the given
@@ -57,6 +61,11 @@ func (expBackoff *ExponentialBackoff) Update(err *error) {
 	if expBackoff.durationBeforeRetry == 0 {
 		expBackoff.durationBeforeRetry = initialDurationBeforeRetry
 	} else {
+		maxDurationBeforeRetry := defaultMaxDurationBeforeRetry
+		if expBackoff.MaxDurationBeforeRetry != 0 {
+			maxDurationBeforeRetry = expBackoff.MaxDurationBeforeRetry
+		}
+
 		expBackoff.durationBeforeRetry = 2 * expBackoff.durationBeforeRetry
 		if expBackoff.durationBeforeRetry > maxDurationBeforeRetry {
 			expBackoff.durationBeforeRetry = maxDurationBeforeRetry

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -33,6 +33,15 @@ import (
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
 )
 
+const (
+	// The default maxDurationBeforeRetry of 2 minutes is too high for the
+	// VerifyControllerAttachedVolume as some cloud provider may actually
+	// need much longer then a few seconds for attachment. The default backoff
+	// here would result in unnecessary delays of up to 2 minutes even if
+	// attachment already succeeded
+	verifyControllerAttachedVolumetMaxDurationBeforeRetry time.Duration = 10 * time.Second
+)
+
 // OperationExecutor defines a set of operations for attaching, detaching,
 // mounting, or unmounting a volume that are executed with a NewNestedPendingOperations which
 // prevents more than one operation from being triggered on the same volume.
@@ -465,8 +474,8 @@ func (oe *operationExecutor) VerifyControllerAttachedVolume(
 		return err
 	}
 
-	return oe.pendingOperations.Run(
-		volumeToMount.VolumeName, "" /* podName */, verifyControllerAttachedVolumeFunc)
+	return oe.pendingOperations.RunWithMaxDurationBeforeRetry(
+		volumeToMount.VolumeName, "" /* podName */, verifyControllerAttachedVolumetMaxDurationBeforeRetry, verifyControllerAttachedVolumeFunc)
 }
 
 // TODO: this is a workaround for the unmount device issue caused by gci mounter.


### PR DESCRIPTION
**What this PR does / why we need it**: This PR reduces the maximum delay of exponential backof in VerifyControllerAttachedVolume to 10 seconds.

With the default maximum delay of 2 minutes, you may end up in situations where the volume manager unnecessarily waits for up to 2 minutes before it tries to mount the volume.

This is not that bad on AWS/GCE as they attach disks pretty fast. But on Azure, where disk attaching takes more time, the backoff will go up to 2 minutes pretty fast. If the attaching finishes right after the last  
VerifyControllerAttachedVolume operation failed, this results in an unnecessary delay.

I had to slightly modify the ExponentialBackoff struct to add custom MaxDurationBeforeRetry. As I'm not that experienced with Go, I'm not sure if I did this modification in the best possible way. I'm open for suggestions. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Reduce maximum delay of exponential backof in VerifyControllerAttachedVolume
```

CC @colemickens 