### PR TITLE
fix typo in logging statement

### DIFF
--- a/pkg/genericapiserver/registry/generic/registry/store.go
+++ b/pkg/genericapiserver/registry/generic/registry/store.go
@@ -806,7 +806,7 @@ func (e *Store) Delete(ctx genericapirequest.Context, name string, options *meta
 	}
 
 	// delete immediately, or no graceful deletion supported
-	glog.V(6).Infof("going to delete %s from regitry: ", name)
+	glog.V(6).Infof("going to delete %s from registry: ", name)
 	out = e.NewFunc()
 	if err := e.Storage.Delete(ctx, key, out, &preconditions); err != nil {
 		// Please refer to the place where we set ignoreNotFound for the reason


### PR DESCRIPTION
**What this PR does / why we need it**:
Typo fix in logs. I am writing an apiserver for service-catalog, and this annoys me when I see it in my logs.

**Special notes for your reviewer**:
Doc/text change only. No functional change. Feel free to combine with some existing PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
