### PR TITLE
For bazel make rules add //:version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ bazel-build:
 	@echo "$$BAZEL_BUILD_HELP_INFO"
 else
 bazel-build:
-	bazel build //cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/...
+	bazel build //cmd/... //pkg/... //federation/... //plugin/... //third_party/... //examples/... //test/... //:version
 endif
 
 
@@ -498,7 +498,7 @@ endef
 	@echo "$$BAZEL_TEST_HELP_INFO"
 else
 bazel-test:
-	bazel test  //cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all
+	bazel test  //cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //:version
 endif
 
 ifeq ($(PRINT_HELP),y)


### PR DESCRIPTION
We were getting flakes and incorrect behavior because our job script
wants to read this file, but it's not getting created. See #40526.

**Release note**:
```release-note
NONE
```
