### PR TITLE
Fix e2e: validates that InterPodAntiAffinity is respected if matching 2

### DIFF
--- a/test/e2e/scheduler_predicates.go
+++ b/test/e2e/scheduler_predicates.go
@@ -542,7 +542,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 							LabelSelector: &metav1.LabelSelector{
 								MatchExpressions: []metav1.LabelSelectorRequirement{
 									{
-										Key:      "security",
+										Key:      "service",
 										Operator: metav1.LabelSelectorOpIn,
 										Values:   []string{"S1", "value2"},
 									},


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Fixed e2e: validates that InterPodAntiAffinity is respected if matching 2

```
• Failure [120.255 seconds]
[k8s.io] SchedulerPredicates [Serial]
/root/code/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:656
  validates that InterPodAntiAffinity is respected if matching 2 [It]
  /root/code/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduler_predicates.go:561

  Not scheduled Pods: []v1.Pod(nil)
  Expected
      <int>: 0
  to equal
      <int>: 1

  /root/code/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/scheduler_predicates.go:933
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/30142


**Special notes for your reviewer**:
xref: https://bugzilla.redhat.com/show_bug.cgi?id=1413748
While looking into the above bug, I found that the e2e was failing.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
