### PR TITLE
Fix sorting printer when sorting by a missing field

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -174,6 +174,7 @@ go_test(
         "//vendor:github.com/spf13/cobra",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apimachinery/pkg/runtime/serializer/yaml",

--- a/pkg/kubectl/sorting_printer.go
+++ b/pkg/kubectl/sorting_printer.go
@@ -88,17 +88,6 @@ func (s *SortingPrinter) sortObj(obj runtime.Object) error {
 }
 
 func SortObjects(decoder runtime.Decoder, objs []runtime.Object, fieldInput string) (*RuntimeSort, error) {
-	parser := jsonpath.New("sorting")
-
-	field, err := massageJSONPath(fieldInput)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := parser.Parse(field); err != nil {
-		return nil, err
-	}
-
 	for ix := range objs {
 		item := objs[ix]
 		switch u := item.(type) {
@@ -112,18 +101,38 @@ func SortObjects(decoder runtime.Decoder, objs []runtime.Object, fieldInput stri
 		}
 	}
 
-	var values [][]reflect.Value
-	if unstructured, ok := objs[0].(*unstructured.Unstructured); ok {
-		values, err = parser.FindResults(unstructured.Object)
-	} else {
-		values, err = parser.FindResults(reflect.ValueOf(objs[0]).Elem().Interface())
-	}
-
+	field, err := massageJSONPath(fieldInput)
 	if err != nil {
 		return nil, err
 	}
-	if len(values) == 0 {
-		return nil, fmt.Errorf("couldn't find any field with path: %s", field)
+
+	parser := jsonpath.New("sorting").AllowMissingKeys(true)
+	if err := parser.Parse(field); err != nil {
+		return nil, err
+	}
+
+	// We don't do any model validation here, so we traverse all objects to be sorted
+	// and, if the field is valid to at least one of them, we consider it to be a
+	// valid field; otherwise error out.
+	// Note that this requires empty fields to be considered later, when sorting.
+	var fieldFoundOnce bool
+	for _, obj := range objs {
+		var values [][]reflect.Value
+		if unstructured, ok := obj.(*unstructured.Unstructured); ok {
+			values, err = parser.FindResults(unstructured.Object)
+		} else {
+			values, err = parser.FindResults(reflect.ValueOf(obj).Elem().Interface())
+		}
+		if err != nil {
+			return nil, err
+		}
+		if len(values) > 0 && len(values[0]) > 0 {
+			fieldFoundOnce = true
+			break
+		}
+	}
+	if !fieldFoundOnce {
+		return nil, fmt.Errorf("couldn't find any field with path %q in the list of objects", field)
 	}
 
 	sorter := NewRuntimeSort(field, objs)
@@ -260,7 +269,7 @@ func (r *RuntimeSort) Less(i, j int) bool {
 	iObj := r.objs[i]
 	jObj := r.objs[j]
 
-	parser := jsonpath.New("sorting")
+	parser := jsonpath.New("sorting").AllowMissingKeys(true)
 	parser.Parse(r.field)
 
 	var iValues [][]reflect.Value
@@ -285,12 +294,18 @@ func (r *RuntimeSort) Less(i, j int) bool {
 		glog.Fatalf("Failed to get j values for %#v using %s (%v)", jObj, r.field, err)
 	}
 
+	if len(iValues) == 0 || len(iValues[0]) == 0 {
+		return true
+	}
+	if len(jValues) == 0 || len(jValues[0]) == 0 {
+		return false
+	}
 	iField := iValues[0][0]
 	jField := jValues[0][0]
 
 	less, err := isLess(iField, jField)
 	if err != nil {
-		glog.Fatalf("Field %s in %v is an unsortable type: %s, err: %v", r.field, iObj, iField.Kind().String(), err)
+		glog.Fatalf("Field %s in %T is an unsortable type: %s, err: %v", r.field, iObj, iField.Kind().String(), err)
 	}
 	return less
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When calling `kubectl get` with the `--sort-by` flag, the command will error out if the field used for sorting is not present in at least one of the objects returned in the list, *even if it is a field valid in the object's model*. 

For example, taking a list of `ReplicationController` where one of them has `status: { replicas: 0 }` (so nothing in `status.availableReplicas`, even that being a valid object in the model and present in every other object of the list) :

```
$ oc get rc --sort-by=status.availableReplicas
error: availableReplicas is not found
```

This PR now traverses the entire list of objects to be sorted and, if at least one has the field provided in `--sort-by`, we sort correctly and consider the field empty in every other object where the field is not present. If none of the objects has the field, we error out (that will catch really invalid fields, and valid ones but not present in any object in the list, which is acceptable). No swagger validation here.

**Release note**:
```release-note
Fixed an issue where 'kubectl get --sort-by=' would return an error when the specified field were not present in at least one of the returned objects, even that being a valid field in the object model.
```
