### PR TITLE
remove pkg/feature dependency from genericapiserver.

### DIFF
--- a/cmd/kube-apiserver/app/options/BUILD
+++ b/cmd/kube-apiserver/app/options/BUILD
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/validation:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/genericapiserver/server/options:go_default_library",
         "//pkg/kubeapiserver/options:go_default_library",
         "//pkg/kubelet/client:go_default_library",

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -29,6 +29,9 @@ import (
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/master/ports"
 
+	// add the kubernetes feature gates
+	_ "k8s.io/kubernetes/pkg/features"
+
 	"github.com/spf13/pflag"
 )
 

--- a/federation/cmd/federation-apiserver/app/options/BUILD
+++ b/federation/cmd/federation-apiserver/app/options/BUILD
@@ -15,6 +15,7 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
+        "//pkg/features:go_default_library",
         "//pkg/genericapiserver/server/options:go_default_library",
         "//pkg/kubeapiserver/options:go_default_library",
         "//vendor:github.com/spf13/pflag",

--- a/federation/cmd/federation-apiserver/app/options/options.go
+++ b/federation/cmd/federation-apiserver/app/options/options.go
@@ -23,6 +23,9 @@ import (
 	genericoptions "k8s.io/kubernetes/pkg/genericapiserver/server/options"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 
+	// add the kubernetes feature gates
+	_ "k8s.io/kubernetes/pkg/features"
+
 	"github.com/spf13/pflag"
 )
 

--- a/pkg/genericapiserver/server/options/BUILD
+++ b/pkg/genericapiserver/server/options/BUILD
@@ -20,7 +20,6 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/features:go_default_library",
         "//pkg/storage/storagebackend:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/spf13/pflag",

--- a/pkg/genericapiserver/server/options/server_run_options.go
+++ b/pkg/genericapiserver/server/options/server_run_options.go
@@ -28,9 +28,6 @@ import (
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/api"
 
-	// add the kubernetes feature gates
-	_ "k8s.io/kubernetes/pkg/features"
-
 	"github.com/spf13/pflag"
 )
 


### PR DESCRIPTION
@sttts I think you just forgot this when you were snipping the rest of the link.  If I understood the previous pull correctly, this ought to ensure proper registration of the bits we need, right?