### PR TITLE
Default EMBED_LICENSE_TARGETS=true for make bazel-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -512,5 +512,5 @@ bazel-release:
 	@echo "$$BAZEL_BUILD_HELP_INFO"
 else
 bazel-release:
-	bazel build //build/release-tars
+	bazel build //build/release-tars --define "EMBED_LICENSE_TARGETS=true"
 endif


### PR DESCRIPTION
**What this PR does / why we need it**: the cluster startup scripts currently fail if `LICENSES` or `kubernetes-src.tar.gz` don't exist, e.g. https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/gci/configure.sh#L180-L181.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
