### PR TITLE
Dont throw error if network is already torn down when deleting container

### DIFF
--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -458,7 +458,7 @@ func (plugin *kubenetNetworkPlugin) teardown(namespace string, name string, id k
 
 	if err := plugin.delContainerFromNetwork(plugin.netConfig, network.DefaultInterfaceName, namespace, name, id); err != nil {
 		// This is to prevent returning error when TearDownPod is called twice on the same pod. This helps to reduce event pollution.
-		if podIP != "" {
+		if podIP != "" || strings.Contains(err.Error(), "no such file or directory") {
 			glog.Warningf("Failed to delete container from kubenet: %v", err)
 		} else {
 			errList = append(errList, err)


### PR DESCRIPTION
Fixes #40474.  @kubernetes/sig-node-pr-reviews 