### PR TITLE
only output "No resources found." for human readable printers

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -224,7 +224,7 @@ kube::test::if_has_string() {
   local message=$1
   local match=$2
 
-  if [[ $(echo "$message" | grep "$match") ]]; then
+  if echo "$message" | grep -q "$match"; then
     echo "Successful"
     echo "message:$message"
     echo "has:$match"
@@ -235,6 +235,24 @@ kube::test::if_has_string() {
     echo "has not:$match"
     caller
     return 1
+  fi
+}
+
+kube::test::if_has_not_string() {
+  local message=$1
+  local match=$2
+
+  if echo "$message" | grep -q "$match"; then
+    echo "FAIL!"
+    echo "message:$message"
+    echo "has:$match"
+    caller
+    return 1
+  else
+    echo "Successful"
+    echo "message:$message"
+    echo "has not:$match"
+    return 0
   fi
 }
 

--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1037,6 +1037,46 @@ run_kubectl_get_tests() {
   # Post-condition: POD abc should error since it doesn't exist
   kube::test::if_has_string "${output_message}" 'pods "abc" not found'
 
+  ### Test retrieval of pods when none exist with non-human readable output format flag specified
+  # Pre-condition: no pods exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o json)
+  # Post-condition: The text "No resources found" should not be part of the output
+  kube::test::if_has_not_string "${output_message}" 'No resources found'
+  # Command
+  output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o yaml)
+  # Post-condition: The text "No resources found" should not be part of the output
+  kube::test::if_has_not_string "${output_message}" 'No resources found'
+  # Command
+  output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o name)
+  # Post-condition: The text "No resources found" should not be part of the output
+  kube::test::if_has_not_string "${output_message}" 'No resources found'
+  # Command
+  output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o jsonpath='{.items}')
+  # Post-condition: The text "No resources found" should not be part of the output
+  kube::test::if_has_not_string "${output_message}" 'No resources found'
+  # Command
+  output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o go-template='{{.items}}')
+  # Post-condition: The text "No resources found" should not be part of the output
+  kube::test::if_has_not_string "${output_message}" 'No resources found'
+  # Command
+  output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o custom-columns=NAME:.metadata.name)
+  # Post-condition: The text "No resources found" should not be part of the output
+  kube::test::if_has_not_string "${output_message}" 'No resources found'
+
+  ### Test retrieval of pods when none exist, with human-readable output format flag specified
+  # Pre-condition: no pods exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
+  # Command
+  output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}")
+  # Post-condition: The text "No resources found" should be part of the output
+  kube::test::if_has_string "${output_message}" 'No resources found'
+  # Command
+  output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o wide)
+  # Post-condition: The text "No resources found" should be part of the output
+  kube::test::if_has_string "${output_message}" 'No resources found'
+
   ### Test retrieval of non-existing POD with json output flag specified
   # Pre-condition: no POD exists
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -319,9 +319,6 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 			}
 			errs = append(errs, err)
 		}
-		if len(infos) == 0 && len(errs) == 0 {
-			outputEmptyListWarning(errOut)
-		}
 
 		res := ""
 		if len(infos) > 0 {


### PR DESCRIPTION
**Release note**:
```release-note
release note none
```

This patch removes the message `No resources found` (currently printed through stderr) when printing through a generic / non-human-readable printer (json, yaml, jsonpath, custom-columns).

**Before***
```
$ kubectl get pods -o json
No resources found.
{
    "apiVersion": "v1",
    "items": [],
    "kind": "List",
    "metadata": {},
    "resourceVersion": "",
    "selfLink": ""
}
```

**After**
```
$ kubectl get pods -o json
{
    "apiVersion": "v1",
    "items": [],
    "kind": "List",
    "metadata": {},
    "resourceVersion": "",
    "selfLink": ""
}
```

cc @fabianofranz @stevekuznetsov