### PR TITLE
Adjust global log limit to 1ms

### DIFF
--- a/pkg/util/runtime/runtime.go
+++ b/pkg/util/runtime/runtime.go
@@ -87,7 +87,10 @@ var ErrorHandlers = []func(error){
 	logError,
 	(&rudimentaryErrorBackoff{
 		lastErrorTime: time.Now(),
-		minPeriod:     500 * time.Millisecond,
+		// 1ms was the number folks were able to stomach as a global rate limit.
+		// If you need to log errors more than 1000 times a second you
+		// should probably consider fixing your code instead. :)
+		minPeriod: time.Millisecond,
 	}).OnError,
 }
 


### PR DESCRIPTION
Per further discussion, we adjusted the limit. Making this a separate PR since the CP already merged.