### PR TITLE
When calling chown, use : instead of . to separate the user and group for cross platform compatibility.

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -411,7 +411,7 @@ function kube::build::clean() {
 function kube::build::build_image() {
   mkdir -p "${LOCAL_OUTPUT_BUILD_CONTEXT}"
   # Make sure the context directory owned by the right user for syncing sources to container.
-  chown -R ${USER_ID}.${GROUP_ID} "${LOCAL_OUTPUT_BUILD_CONTEXT}"
+  chown -R ${USER_ID}:${GROUP_ID} "${LOCAL_OUTPUT_BUILD_CONTEXT}"
 
   cp /etc/localtime "${LOCAL_OUTPUT_BUILD_CONTEXT}/"
 
@@ -499,7 +499,7 @@ function kube::build::ensure_data_container() {
       --name "${KUBE_DATA_CONTAINER_NAME}"
       --hostname "${HOSTNAME}"
       "${KUBE_BUILD_IMAGE}"
-      chown -R ${USER_ID}.${GROUP_ID}
+      chown -R ${USER_ID}:${GROUP_ID}
         "${REMOTE_ROOT}"
         /usr/local/go/pkg/
     )

--- a/cluster/rackspace/util.sh
+++ b/cluster/rackspace/util.sh
@@ -298,7 +298,7 @@ kube-up() {
   $(sleep 2)
   $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo /usr/bin/mkdir -p /var/lib/kube-apiserver)
   $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo mv /home/core/known_tokens.csv /var/lib/kube-apiserver/known_tokens.csv)
-  $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo chown root.root /var/lib/kube-apiserver/known_tokens.csv)
+  $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo chown root:root /var/lib/kube-apiserver/known_tokens.csv)
   $(ssh -o StrictHostKeyChecking=no -i ~/.ssh/${SSH_KEY_NAME} core@${KUBE_MASTER_IP} sudo systemctl restart kube-apiserver)
 
   FAIL=0


### PR DESCRIPTION
**What this PR does / why we need it**: Makes it possible to build on a Mac, which was broken by #39515. 

**Special notes for your reviewer**:

**Release note**:
`NONE`