### PR TITLE
Update kubectl OWNERS approvers/reviewers

### DIFF
--- a/pkg/kubectl/OWNERS
+++ b/pkg/kubectl/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-- sig-cli-maintainers
+- sig-cli-api-reviews
 reviewers:
-- sig-cli
+- sig-cli-pr-reviews


### PR DESCRIPTION
Need to update https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/OWNERS since @sig-cli and @sig-cli-maintainers are both removed

@pwittrock @AdoHe @ymqytw @kubernetes/sig-cli-api-reviews @kubernetes/sig-cli-pr-reviews 