### PR TITLE
Add IsContainerNotFound in kube_docker_client

### DIFF
--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -39,8 +39,7 @@ const (
 )
 
 var (
-	conflictRE    = regexp.MustCompile(`Conflict. (?:.)+ is already in use by container ([0-9a-z]+)`)
-	noContainerRE = regexp.MustCompile(`No such container: [0-9a-z]+`)
+	conflictRE = regexp.MustCompile(`Conflict. (?:.)+ is already in use by container ([0-9a-z]+)`)
 )
 
 // apiVersion implements kubecontainer.Version interface by implementing
@@ -313,8 +312,8 @@ func recoverFromCreationConflictIfNeeded(client dockertools.DockerInterface, cre
 		return nil, err
 	} else {
 		glog.Errorf("Failed to remove the conflicting container %q: %v", id, rmErr)
-		// Return if the error is not "No such container" error.
-		if !noContainerRE.MatchString(rmErr.Error()) {
+		// Return if the error is not container not found error.
+		if !dockertools.IsContainerNotFoundError(rmErr) {
 			return nil, err
 		}
 	}

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -236,12 +236,3 @@ func TestParsingCreationConflictError(t *testing.T) {
 	require.Len(t, matches, 2)
 	require.Equal(t, matches[1], "24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e")
 }
-
-func TestParsingRemovalNoContainerError(t *testing.T) {
-	// Expected error message from docker.
-	match := "Error response from daemon: No such container: 96e914f31579e44fe49b239266385330a9b2125abeb9254badd9fca74580c95a"
-	notMatch := "Error response from daemon: Other errors"
-
-	assert.True(t, noContainerRE.MatchString(match))
-	assert.False(t, noContainerRE.MatchString(notMatch))
-}

--- a/pkg/kubelet/dockertools/BUILD
+++ b/pkg/kubelet/dockertools/BUILD
@@ -90,6 +90,7 @@ go_test(
         "docker_manager_test.go",
         "docker_test.go",
         "images_test.go",
+        "kube_docker_client_test.go",
         "labels_test.go",
     ],
     data = [

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -2428,7 +2428,7 @@ func (dm *DockerManager) pruneInitContainersBeforeStart(pod *v1.Pod, podStatus *
 			// TODO: we may not need aggressive pruning
 			glog.V(4).Infof("Removing init container %q instance %q %d", status.Name, status.ID.ID, count)
 			if err := dm.client.RemoveContainer(status.ID.ID, dockertypes.ContainerRemoveOptions{RemoveVolumes: true}); err != nil {
-				if _, ok := err.(containerNotFoundError); ok {
+				if IsContainerNotFoundError(err) {
 					count--
 					continue
 				}
@@ -2671,7 +2671,7 @@ func (dm *DockerManager) GetPodStatus(uid kubetypes.UID, name, namespace string)
 		}
 		result, ip, err := dm.inspectContainer(c.ID, name, namespace)
 		if err != nil {
-			if _, ok := err.(containerNotFoundError); ok {
+			if IsContainerNotFoundError(err) {
 				// https://github.com/kubernetes/kubernetes/issues/22541
 				// Sometimes when docker's state is corrupt, a container can be listed
 				// but couldn't be inspected. We fake a status for this container so

--- a/pkg/kubelet/dockertools/docker_manager_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_test.go
@@ -1820,7 +1820,7 @@ func TestGetPodStatusNoSuchContainer(t *testing.T) {
 			Running:    false,
 		},
 	})
-	fakeDocker.InjectErrors(map[string]error{"inspect_container": containerNotFoundError{}})
+	fakeDocker.InjectErrors(map[string]error{"inspect_container": fmt.Errorf("Error: No such container: %s", noSuchContainerID)})
 	runSyncPod(t, dm, fakeDocker, pod, nil, false)
 
 	// Verify that we will try to start new contrainers even if the inspections

--- a/pkg/kubelet/dockertools/kube_docker_client_test.go
+++ b/pkg/kubelet/dockertools/kube_docker_client_test.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dockertools
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsContainerNotFoundError(t *testing.T) {
+	// Expected error message from docker.
+	containerNotFoundError := fmt.Errorf("Error response from daemon: No such container: 96e914f31579e44fe49b239266385330a9b2125abeb9254badd9fca74580c95a")
+	otherError := fmt.Errorf("Error response from daemon: Other errors")
+
+	assert.True(t, IsContainerNotFoundError(containerNotFoundError))
+	assert.False(t, IsContainerNotFoundError(otherError))
+}


### PR DESCRIPTION
This PR added `IsContainerNotFound` function in kube_docker_client and changed dockershim to use it.

@yujuhong @freehan 