### PR TITLE
Temporary disable federation kubectl tests for secrets to unblock merge queue

### DIFF
--- a/hack/make-rules/test-federation-cmd.sh
+++ b/hack/make-rules/test-federation-cmd.sh
@@ -75,8 +75,8 @@ kube::log::status "Running kubectl tests for federation-apiserver"
 setup
 run_federation_apiserver
 run_federation_controller_manager
-# TODO: Fix for replicasets and deployments.
-SUPPORTED_RESOURCES=("configmaps" "daemonsets" "events" "ingress" "namespaces" "secrets" "services")
+# TODO: Fix for secrets, replicasets and deployments.
+SUPPORTED_RESOURCES=("configmaps" "daemonsets" "events" "ingress" "namespaces" "services")
 # WARNING: Do not wrap this call in a subshell to capture output, e.g. output=$(runTests)
 # Doing so will suppress errexit behavior inside runTests
 runTests


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/40521

cc @kubernetes/sig-federation-misc @deads2k 