### PR TITLE
docker-CRI: Remove legacy code for non-grpc integration

### DIFF
--- a/pkg/kubelet/kuberuntime/instrumented_services.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services.go
@@ -31,7 +31,7 @@ type instrumentedRuntimeService struct {
 }
 
 // Creates an instrumented RuntimeInterface from an existing RuntimeService.
-func NewInstrumentedRuntimeService(service internalapi.RuntimeService) internalapi.RuntimeService {
+func newInstrumentedRuntimeService(service internalapi.RuntimeService) internalapi.RuntimeService {
 	return &instrumentedRuntimeService{service: service}
 }
 
@@ -42,7 +42,7 @@ type instrumentedImageManagerService struct {
 }
 
 // Creates an instrumented ImageManagerService from an existing ImageManagerService.
-func NewInstrumentedImageManagerService(service internalapi.ImageManagerService) internalapi.ImageManagerService {
+func newInstrumentedImageManagerService(service internalapi.ImageManagerService) internalapi.ImageManagerService {
 	return &instrumentedImageManagerService{service: service}
 }
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -143,8 +143,8 @@ func NewKubeGenericRuntimeManager(
 		osInterface:         osInterface,
 		networkPlugin:       networkPlugin,
 		runtimeHelper:       runtimeHelper,
-		runtimeService:      runtimeService,
-		imageService:        imageService,
+		runtimeService:      newInstrumentedRuntimeService(runtimeService),
+		imageService:        newInstrumentedImageManagerService(imageService),
 		keyring:             credentialprovider.NewDockerKeyring(),
 	}
 


### PR DESCRIPTION
A minor cleanup to remove the code that is no longer in use to simplify the logic.