### PR TITLE
[do not merge]: Notes from reviewing k-c-m side of volumes code

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -1362,6 +1362,7 @@ func (d *awsDisk) waitForAttachmentStatus(status string) (*ec2.VolumeAttachment,
 			return true, nil
 		}
 		// continue waiting
+		// TODO-P0: Once we get to later backoff, we should start glog.Infof or glog.Warningf, for diagnostic purposes
 		glog.V(2).Infof("Waiting for volume %q state: actual=%s, desired=%s", d.awsID, attachmentStatus, status)
 		return false, nil
 	})
@@ -1561,6 +1562,7 @@ func (c *Cloud) DetachDisk(diskName KubernetesVolumeID, nodeName types.NodeName)
 		return "", errors.New("no response from DetachVolume")
 	}
 
+	// TODO-P1: If we are doing concurrent detach operations, this is very expensive... bring in the cache layer.
 	attachment, err := disk.waitForAttachmentStatus("detached")
 	if err != nil {
 		return "", err

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -289,6 +289,7 @@ func (adc *attachDetachController) nodeDelete(obj interface{}) {
 
 	nodeName := types.NodeName(node.Name)
 	if err := adc.desiredStateOfWorld.DeleteNode(nodeName); err != nil {
+		// TODO-P1: Is this expected?  I would have guessed V(2).  Does this happen whenever a node "just dies"?
 		glog.V(10).Infof("%v", err)
 	}
 
@@ -310,6 +311,8 @@ func (adc *attachDetachController) processPodVolumes(
 	nodeName := types.NodeName(pod.Spec.NodeName)
 
 	if !adc.desiredStateOfWorld.NodeExists(nodeName) {
+		// TODO: Is this a race between the node watcher & the pod watcher?
+
 		// If the node the pod is scheduled to does not exist in the desired
 		// state of the world data structure, that indicates the node is not
 		// yet managed by the controller. Therefore, ignore the pod.

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -340,7 +340,7 @@ func (asw *actualStateOfWorld) SetVolumeMountedByNode(
 		}
 	}
 
-	// TODO: nodeObj could be empty (if node not found)
+	// TODO-P0: volumeObj could be attachedVolume{} (if volume not found)
 	nodeObj.mountedByNode = mounted
 	volumeObj.nodesAttachedTo[nodeName] = nodeObj
 	glog.V(4).Infof("SetVolumeMountedByNode volume %v to the node %q mounted %t",
@@ -360,9 +360,9 @@ func (asw *actualStateOfWorld) ResetDetachRequestTime(
 		glog.Errorf("Failed to ResetDetachRequestTime with error: %v", err)
 		return
 	}
-	// TODO-P0: These were returned by value, yet we now modify them
+	// TODO: These were returned by value, yet we now modify them
 	nodeObj.detachRequestedTime = time.Time{}
-	// TODO: volumeObj might be an empty obj if volume not found
+	// TODO-P0: volumeObj might be attachedVolume{} if volume not found
 	volumeObj.nodesAttachedTo[nodeName] = nodeObj
 }
 
@@ -376,7 +376,7 @@ func (asw *actualStateOfWorld) SetDetachRequestTime(
 		return 0, fmt.Errorf("Failed to set detach request time with error: %v", err)
 	}
 	// TODO: probably safer to switch getNodeAndVolume to return pointers?
-	// TODO: nodeObj could be empty (if node not found)
+	// TODO: volumeObj could be empty (if volume not found)
 	// If there is no previous detach request, set it to the current time
 	if nodeObj.detachRequestedTime.IsZero() {
 		nodeObj.detachRequestedTime = time.Now()
@@ -408,7 +408,6 @@ func (asw *actualStateOfWorld) getNodeAndVolume(
 
 // Remove the volumeName from the node's volumesToReportAsAttached list
 // This is an internal function and caller should acquire and release the lock
-// TODO: Does this break if volume mounted twice on the node?
 func (asw *actualStateOfWorld) removeVolumeFromReportAsAttached(
 	volumeName v1.UniqueVolumeName, nodeName types.NodeName) error {
 
@@ -486,7 +485,6 @@ func (asw *actualStateOfWorld) SetNodeStatusUpdateNeeded(nodeName types.NodeName
 	asw.updateNodeStatusUpdateNeeded(nodeName, true)
 }
 
-// TODO: Does this break if volume is mounted twice on the node?
 func (asw *actualStateOfWorld) DeleteVolumeNode(
 	volumeName v1.UniqueVolumeName, nodeName types.NodeName) {
 	asw.Lock()

--- a/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -293,7 +293,7 @@ func (dsw *desiredStateOfWorld) DeletePod(
 	}
 }
 
-// TODO: Racy - can it be removed?
+// TODO: Seems likely to be used in racy ways - can it be removed?
 func (dsw *desiredStateOfWorld) NodeExists(nodeName k8stypes.NodeName) bool {
 	dsw.RLock()
 	defer dsw.RUnlock()
@@ -302,7 +302,7 @@ func (dsw *desiredStateOfWorld) NodeExists(nodeName k8stypes.NodeName) bool {
 	return nodeExists
 }
 
-// TODO: Racy - can it be removed?
+// TODO: Seems likely to be used in racy ways - can it be removed?
 func (dsw *desiredStateOfWorld) VolumeExists(
 	volumeName v1.UniqueVolumeName, nodeName k8stypes.NodeName) bool {
 	dsw.RLock()

--- a/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -195,6 +195,8 @@ func (dsw *desiredStateOfWorld) AddPod(
 
 	nodeObj, nodeExists := dsw.nodesManaged[nodeName]
 	if !nodeExists {
+		// TODO: Why not auto-create the node?
+
 		return "", fmt.Errorf(
 			"no node with the name %q exists in the list of managed nodes",
 			nodeName)
@@ -247,6 +249,7 @@ func (dsw *desiredStateOfWorld) DeleteNode(nodeName k8stypes.NodeName) error {
 	}
 
 	if len(nodeObj.volumesToAttach) > 0 {
+		// TODO: Unclear how we recover here - maybe we should just mark as deleted
 		return fmt.Errorf(
 			"failed to delete node %q from list of nodes managed by attach/detach controller--the node still contains %v volumes in its list of volumes to attach",
 			nodeName,
@@ -290,6 +293,7 @@ func (dsw *desiredStateOfWorld) DeletePod(
 	}
 }
 
+// TODO: Racy - can it be removed?
 func (dsw *desiredStateOfWorld) NodeExists(nodeName k8stypes.NodeName) bool {
 	dsw.RLock()
 	defer dsw.RUnlock()
@@ -298,6 +302,7 @@ func (dsw *desiredStateOfWorld) NodeExists(nodeName k8stypes.NodeName) bool {
 	return nodeExists
 }
 
+// TODO: Racy - can it be removed?
 func (dsw *desiredStateOfWorld) VolumeExists(
 	volumeName v1.UniqueVolumeName, nodeName k8stypes.NodeName) bool {
 	dsw.RLock()

--- a/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
+++ b/pkg/controller/volume/attachdetach/populator/desired_state_of_world_populator.go
@@ -118,8 +118,12 @@ func (dswp *desiredStateOfWorldPopulator) findAndRemoveDeletedPods() {
 		}
 		// the pod from dsw does not exist in pod informer, or it does not match the unique identifer retrieved
 		// from the informer, delete it from dsw
+
+		// TODO-P0: I don't understand why this is needed.  It should not be?  Also, we now have two writers, so we are racy.
+		// TODO: log level should be Errorf or Warningf IMO
 		glog.V(1).Infof(
 			"Removing pod %q (UID %q) from dsw because it does not exist in pod informer.", dswPodKey, dswPodUID)
+		// TODO: I would rather this wasn't here...
 		dswp.desiredStateOfWorld.DeletePod(dswPodUID, dswPodToAdd.VolumeName, dswPodToAdd.NodeName)
 	}
 }

--- a/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
+++ b/pkg/controller/volume/attachdetach/statusupdater/node_status_updater.go
@@ -63,6 +63,8 @@ func (nsu *nodeStatusUpdater) UpdateNodeStatuses() error {
 	// kubernetes/kubernetes/issues/37777
 	nodesToUpdate := nsu.actualStateOfWorld.GetVolumesToReportAttached()
 	for nodeName, attachedVolumes := range nodesToUpdate {
+		// TODO-P0: If we hit a problem on one node, we should not return without setting SetNodeStatusUpdateNeeded for all nodes
+
 		nodeObj, exists, err := nsu.nodeInformer.GetStore().GetByKey(string(nodeName))
 		if nodeObj == nil || !exists || err != nil {
 			// If node does not exist, its status cannot be updated, log error and
@@ -78,6 +80,7 @@ func (nsu *nodeStatusUpdater) UpdateNodeStatuses() error {
 
 		clonedNode, err := api.Scheme.DeepCopy(nodeObj)
 		if err != nil {
+			// TODO: SetNodeStatusUpdateNeeded
 			return fmt.Errorf("error cloning node %q: %v",
 				nodeName,
 				err)
@@ -85,6 +88,7 @@ func (nsu *nodeStatusUpdater) UpdateNodeStatuses() error {
 
 		node, ok := clonedNode.(*v1.Node)
 		if !ok || node == nil {
+			// TODO: SetNodeStatusUpdateNeeded
 			return fmt.Errorf(
 				"failed to cast %q object %#v to Node",
 				nodeName,
@@ -94,6 +98,7 @@ func (nsu *nodeStatusUpdater) UpdateNodeStatuses() error {
 		// TODO: Change to pkg/util/node.UpdateNodeStatus.
 		oldData, err := json.Marshal(node)
 		if err != nil {
+			// TODO: SetNodeStatusUpdateNeeded
 			return fmt.Errorf(
 				"failed to Marshal oldData for node %q. %v",
 				nodeName,
@@ -104,6 +109,7 @@ func (nsu *nodeStatusUpdater) UpdateNodeStatuses() error {
 
 		newData, err := json.Marshal(node)
 		if err != nil {
+			// TODO: SetNodeStatusUpdateNeeded
 			return fmt.Errorf(
 				"failed to Marshal newData for node %q. %v",
 				nodeName,
@@ -113,6 +119,7 @@ func (nsu *nodeStatusUpdater) UpdateNodeStatuses() error {
 		patchBytes, err :=
 			strategicpatch.CreateTwoWayMergePatch(oldData, newData, node)
 		if err != nil {
+			// TODO: SetNodeStatusUpdateNeeded
 			return fmt.Errorf(
 				"failed to CreateTwoWayMergePatch for node %q. %v",
 				nodeName,
@@ -129,6 +136,7 @@ func (nsu *nodeStatusUpdater) UpdateNodeStatuses() error {
 				nodeName,
 				err)
 		}
+		// TODO: Maybe V(4) - this is pretty verbose!
 		glog.V(2).Infof(
 			"Updating status for node %q succeeded. patchBytes: %q VolumesAttached: %v",
 			nodeName,

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -54,6 +54,8 @@ import (
 //
 // Some of these operations may result in calls to the API server; callers are
 // responsible for rate limiting on errors.
+
+// TODO: Split into two interfaces - one for kubelet, one for controller/kubelet?
 type OperationExecutor interface {
 	// AttachVolume attaches the volume to the node specified in volumeToAttach.
 	// It then updates the actual state of the world to reflect that.
@@ -433,7 +435,7 @@ func (oe *operationExecutor) UnmountVolume(
 		return err
 	}
 
-	// All volume plugins can execute mount for multiple pods referencing the
+	// All volume plugins can execute unmount for multiple pods referencing the
 	// same volume in parallel
 	podName := volumetypes.UniquePodName(volumeToUnmount.PodUID)
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -198,6 +198,7 @@ type Attacher interface {
 
 // Detacher can detach a volume from a node.
 type Detacher interface {
+	// TODO: The current contract is that we wait for the disk to be detached before returning.  We could look at not doing that...
 	// Detach the given device from the node with the given Name.
 	Detach(deviceName string, nodeName types.NodeName) error
 


### PR DESCRIPTION
For discussion with @jingxu97 / @saad-ali / @matchstick 

Following the (very valid) points on the review of #39564 (cc  @jsafrane @gnufied ) I went through the k-c-m side (not the kubelet side) of the volumes code to better understand the big picture, marking code that I found surprising.

I'm happy to attack these points, but would love to go through them with you first @jingxu97 to get more understanding.  I suspect a number of them can just be addressed with more comments, but there are a few places that are very suspicious.



