### PR TITLE
Restore unit testing for staging repos

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -55,6 +55,8 @@ make generated_files
 go install ./cmd/...
 ./hack/install-etcd.sh
 
+# bazel didn't like BUILD files in the staging repos, so we need to run unit tests
+make test WHAT="./vendor/k8s.io/apimachinery/... ./vendor/k8s.io/apiserver/... ./vendor/k8s.io/client-go/..."
 make test-cmd
 make test-integration
 ./hack/test-update-storage-objects.sh

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -141,7 +141,7 @@ stuff: 1
 		t.Fatal("expected error with yaml: violate, got no error")
 	}
 	fmt.Printf("err: %s\n", err.Error())
-	if !strings.HasPrefix(err.Error(), "yaml: line 2:") {
+	if !strings.Contains(err.Error(), "yaml: line 2:") {
 		t.Fatalf("expected %q to have 'yaml: line 2:' found a tab character", err.Error())
 	}
 }

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
@@ -57,7 +57,7 @@ import (
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
 func NewSimpleClientset(objects ...runtime.Object) *Clientset {
-	o := testing.NewObjectTracker(api.Scheme, api.Codecs.UniversalDecoder())
+	o := testing.NewObjectTracker(api.Registry, api.Scheme, api.Codecs.UniversalDecoder())
 	for _, obj := range objects {
 		if err := o.Add(obj); err != nil {
 			panic(err)


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/39105 removed the normal unit testing from CI in favor of bazel, but the staging repos don't have BUILD files in them because bazel choked on it.  This meant that unit tests weren't being run in CI (even though `make test` did it).  This restores the staging tests.

@ixdy @spxtr since you were on the initial issue
@liggitt @kubernetes/rh-cluster-infra 

Thanks to @cheftako for finding it.