### PR TITLE
run unit tests with go, not just bazel

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -55,8 +55,7 @@ make generated_files
 go install ./cmd/...
 ./hack/install-etcd.sh
 
-# bazel didn't like BUILD files in the staging repos, so we need to run unit tests
-make test WHAT="./vendor/k8s.io/apimachinery/... ./vendor/k8s.io/apiserver/... ./vendor/k8s.io/client-go/..."
+make test
 make test-cmd
 make test-integration
 ./hack/test-update-storage-objects.sh


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/kubernetes/pull/40594, effectively reverts #39105.

I think we should run our unit tests using the official golang infrastructure.  I have no objection to also running them in bazel (or running a subset in bazel), but I don't think that bazel should be the primary unit test method.

@smarterclayton @liggitt @ixdy @spxtr 