### PR TITLE
Use Watch() for VerifyControllerAttachedVolume instead of a single poll

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -2165,14 +2165,13 @@ func retryWithExponentialBackOff(initialDuration time.Duration, fn wait.Conditio
 func simulateVolumeInUseUpdate(
 	volumeName v1.UniqueVolumeName,
 	stopCh <-chan struct{},
-	volumeManager kubeletvolume.VolumeManager) {
+	node *v1.Node) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			volumeManager.MarkVolumesAsReportedInUse(
-				[]v1.UniqueVolumeName{volumeName})
+			node.Status.VolumesInUse = []v1.UniqueVolumeName{volumeName}
 		case <-stopCh:
 			return
 		}

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -19,11 +19,13 @@ package kubelet
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
 	core "k8s.io/client-go/testing"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/volume"
@@ -291,19 +293,28 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
 	kubeClient := testKubelet.fakeKubeClient
-	kubeClient.AddReactor("get", "nodes",
-		func(action core.Action) (bool, runtime.Object, error) {
-			return true, &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
-				Status: v1.NodeStatus{
-					VolumesAttached: []v1.AttachedVolume{
-						{
-							Name:       "fake/vol1",
-							DevicePath: "fake/path",
-						},
-					}},
-				Spec: v1.NodeSpec{ExternalID: testKubeletHostname},
-			}, nil
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
+		Status: v1.NodeStatus{
+			VolumesAttached: []v1.AttachedVolume{
+				{
+					Name:       "fake/vol1",
+					DevicePath: "fake/path",
+				},
+			}},
+		Spec: v1.NodeSpec{ExternalID: testKubeletHostname},
+	}
+	kubeClient.AddWatchReactor("nodes",
+		func(action core.Action) (bool, watch.Interface, error) {
+			fakeWatch := watch.NewFake()
+			go func() {
+				for !fakeWatch.Stopped {
+					fakeWatch.Add(node)
+					time.Sleep(10 * time.Millisecond)
+				}
+			}()
+			return true, fakeWatch, nil
 		})
 	kubeClient.AddReactor("*", "*", func(action core.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("no reaction implemented for %s", action)
@@ -333,7 +344,7 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 	go simulateVolumeInUseUpdate(
 		v1.UniqueVolumeName("fake/vol1"),
 		stopCh,
-		kubelet.volumeManager)
+		node)
 
 	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(pod))
 
@@ -360,20 +371,29 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	defer testKubelet.Cleanup()
 	kubelet := testKubelet.kubelet
 	kubeClient := testKubelet.fakeKubeClient
-	kubeClient.AddReactor("get", "nodes",
-		func(action core.Action) (bool, runtime.Object, error) {
-			return true, &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
-				Status: v1.NodeStatus{
-					VolumesAttached: []v1.AttachedVolume{
-						{
-							Name:       "fake/vol1",
-							DevicePath: "fake/path",
-						},
-					}},
-				Spec: v1.NodeSpec{ExternalID: testKubeletHostname},
-			}, nil
-		})
+
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
+		Status: v1.NodeStatus{
+			VolumesAttached: []v1.AttachedVolume{
+				{
+					Name:       "fake/vol1",
+					DevicePath: "fake/path",
+				},
+			}},
+		Spec: v1.NodeSpec{ExternalID: testKubeletHostname},
+	}
+	kubeClient.AddWatchReactor("nodes",
+	func(action core.Action) (bool, watch.Interface, error) {
+		fakeWatch := watch.NewFake()
+		go func() {
+			for !fakeWatch.Stopped {
+				fakeWatch.Add(node)
+				time.Sleep(10 * time.Millisecond)
+			}
+		}()
+		return true, fakeWatch, nil
+	})
 	kubeClient.AddReactor("*", "*", func(action core.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("no reaction implemented for %s", action)
 	})
@@ -403,7 +423,7 @@ func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	go simulateVolumeInUseUpdate(
 		v1.UniqueVolumeName("fake/vol1"),
 		stopCh,
-		kubelet.volumeManager)
+		node)
 
 	// Verify volumes attached
 	assert.NoError(t, kubelet.volumeManager.WaitForAttachAndMount(pod))

--- a/pkg/kubelet/volumemanager/volume_manager_test.go
+++ b/pkg/kubelet/volumemanager/volume_manager_test.go
@@ -24,7 +24,10 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/watch"
+	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	utiltesting "k8s.io/client-go/util/testing"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -56,7 +59,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	podManager := kubepod.NewBasicPodManager(podtest.NewFakeMirrorClient(), secret.NewFakeManager())
 
 	node, pod, pv, claim := createObjects()
-	kubeClient := fake.NewSimpleClientset(node, pod, pv, claim)
+	kubeClient := createTestClient(node, pod, pv, claim)
 
 	manager, err := newTestVolumeManager(tmpDir, podManager, kubeClient)
 	if err != nil {
@@ -72,7 +75,7 @@ func TestGetMountedVolumesForPodAndGetVolumesInUse(t *testing.T) {
 	go simulateVolumeInUseUpdate(
 		v1.UniqueVolumeName(node.Status.VolumesAttached[0].Name),
 		stopCh,
-		manager)
+		node)
 
 	err = manager.WaitForAttachAndMount(pod)
 	if err != nil {
@@ -145,7 +148,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 				},
 			},
 		}
-		kubeClient := fake.NewSimpleClientset(node, pod, pv, claim)
+		kubeClient := createTestClient(node, pod, pv, claim)
 
 		manager, err := newTestVolumeManager(tmpDir, podManager, kubeClient)
 		if err != nil {
@@ -164,7 +167,7 @@ func TestGetExtraSupplementalGroupsForPod(t *testing.T) {
 		go simulateVolumeInUseUpdate(
 			v1.UniqueVolumeName(node.Status.VolumesAttached[0].Name),
 			stopCh,
-			manager)
+			node)
 
 		err = manager.WaitForAttachAndMount(pod)
 		if err != nil {
@@ -273,14 +276,13 @@ func createObjects() (*v1.Node, *v1.Pod, *v1.PersistentVolume, *v1.PersistentVol
 func simulateVolumeInUseUpdate(
 	volumeName v1.UniqueVolumeName,
 	stopCh <-chan struct{},
-	volumeManager VolumeManager) {
+	node *v1.Node) {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			volumeManager.MarkVolumesAsReportedInUse(
-				[]v1.UniqueVolumeName{volumeName})
+			node.Status.VolumesInUse = []v1.UniqueVolumeName{volumeName}
 		case <-stopCh:
 			return
 		}
@@ -294,4 +296,25 @@ func runVolumeManager(manager VolumeManager) chan struct{} {
 	sourcesReady := config.NewSourcesReady(func(_ sets.String) bool { return true })
 	go manager.Run(sourcesReady, stopCh)
 	return stopCh
+}
+
+func createTestClient(node *v1.Node, objects ...runtime.Object) *fake.Clientset {
+	fakeClient := fake.NewSimpleClientset(objects...)
+
+	// Remove default WatchReactor
+	fakeClient.WatchReactionChain = []core.WatchReactor{}
+
+	fakeClient.AddWatchReactor("nodes",
+		func(action core.Action) (bool, watch.Interface, error) {
+			fakeWatch := watch.NewFake()
+			go func() {
+				for !fakeWatch.Stopped {
+					fakeWatch.Add(node)
+					time.Sleep(10 * time.Millisecond)
+				}
+			}()
+			return true, fakeWatch, nil
+		})
+
+	return fakeClient
 }

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -30,6 +31,11 @@ import (
 	kevents "k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
+)
+
+const (
+	// Used when watching for node status, e.g. in VerifyControllerAttachedVolume
+	nodeWatchTimeoutInSeconds = 60
 )
 
 var _ OperationGenerator = &operationGenerator{}
@@ -749,66 +755,93 @@ func (og *operationGenerator) GenerateVerifyControllerAttachedVolumeFunc(
 			return nil
 		}
 
-		if !volumeToMount.ReportedInUse {
-			// If the given volume has not yet been added to the list of
-			// VolumesInUse in the node's volume status, do not proceed, return
-			// error. Caller will log and retry. The node status is updated
-			// periodically by kubelet, so it may take as much as 10 seconds
-			// before this clears.
-			// Issue #28141 to enable on demand status updates.
-			return fmt.Errorf("Volume %q (spec.Name: %q) pod %q (UID: %q) has not yet been added to the list of VolumesInUse in the node's volume status",
-				volumeToMount.VolumeName,
-				volumeToMount.VolumeSpec.Name(),
-				volumeToMount.PodName,
-				volumeToMount.Pod.UID)
-		}
-
-		// Fetch current node object
-		node, fetchErr := og.kubeClient.Core().Nodes().Get(string(nodeName), metav1.GetOptions{})
-		if fetchErr != nil {
+		timeout := int64(nodeWatchTimeoutInSeconds)
+		nodeSelector := fields.OneTermEqualSelector("metadata.name", string(nodeName))
+		w, err := og.kubeClient.Core().Nodes().Watch(metav1.ListOptions{
+			FieldSelector:   nodeSelector.String(),
+			ResourceVersion: "0",
+			TimeoutSeconds:  &timeout,
+		})
+		if err != nil {
 			// On failure, return error. Caller will log and retry.
 			return fmt.Errorf(
-				"VerifyControllerAttachedVolume failed fetching node from API server. Volume %q (spec.Name: %q) pod %q (UID: %q). Error: %v",
+				"VerifyControllerAttachedVolume failed watching node on API server. Volume %q (spec.Name: %q) pod %q (UID: %q). Error: %v",
 				volumeToMount.VolumeName,
 				volumeToMount.VolumeSpec.Name(),
 				volumeToMount.PodName,
 				volumeToMount.Pod.UID,
-				fetchErr)
+				err)
 		}
+		defer w.Stop()
 
-		if node == nil {
-			// On failure, return error. Caller will log and retry.
-			return fmt.Errorf(
-				"VerifyControllerAttachedVolume failed. Volume %q (spec.Name: %q) pod %q (UID: %q). Error: node object retrieved from API server is nil",
-				volumeToMount.VolumeName,
-				volumeToMount.VolumeSpec.Name(),
-				volumeToMount.PodName,
-				volumeToMount.Pod.UID)
-		}
+		volumeInUse := false
 
-		for _, attachedVolume := range node.Status.VolumesAttached {
-			if attachedVolume.Name == volumeToMount.VolumeName {
-				addVolumeNodeErr := actualStateOfWorld.MarkVolumeAsAttached(
-					v1.UniqueVolumeName(""), volumeToMount.VolumeSpec, nodeName, attachedVolume.DevicePath)
-				glog.Infof("Controller successfully attached volume %q (spec.Name: %q) pod %q (UID: %q) devicePath: %q",
+		for r := range w.ResultChan() {
+			node, ok := r.Object.(*v1.Node)
+			if !ok {
+				return fmt.Errorf(
+					"VerifyControllerAttachedVolume received unexpect object while watching. Volume %q (spec.Name: %q) pod %q (UID: %q)",
 					volumeToMount.VolumeName,
 					volumeToMount.VolumeSpec.Name(),
 					volumeToMount.PodName,
-					volumeToMount.Pod.UID,
-					attachedVolume.DevicePath)
+					volumeToMount.Pod.UID)
+			}
 
-				if addVolumeNodeErr != nil {
-					// On failure, return error. Caller will log and retry.
-					return fmt.Errorf(
-						"VerifyControllerAttachedVolume.MarkVolumeAsAttached failed for volume %q (spec.Name: %q) pod %q (UID: %q) with: %v",
+			if node == nil {
+				// On failure, return error. Caller will log and retry.
+				return fmt.Errorf(
+					"VerifyControllerAttachedVolume failed. Volume %q (spec.Name: %q) pod %q (UID: %q). Error: node object retrieved from API server is nil",
+					volumeToMount.VolumeName,
+					volumeToMount.VolumeSpec.Name(),
+					volumeToMount.PodName,
+					volumeToMount.Pod.UID)
+			}
+
+			volumeInUse = false
+			for _, volume := range node.Status.VolumesInUse {
+				if volume == volumeToMount.VolumeName {
+					volumeInUse = true
+					break
+				}
+			}
+			if !volumeInUse {
+				continue
+			}
+			for _, attachedVolume := range node.Status.VolumesAttached {
+				if attachedVolume.Name == volumeToMount.VolumeName {
+					addVolumeNodeErr := actualStateOfWorld.MarkVolumeAsAttached(
+						v1.UniqueVolumeName(""), volumeToMount.VolumeSpec, nodeName, attachedVolume.DevicePath)
+					glog.Infof("Controller successfully attached volume %q (spec.Name: %q) pod %q (UID: %q) devicePath: %q",
 						volumeToMount.VolumeName,
 						volumeToMount.VolumeSpec.Name(),
 						volumeToMount.PodName,
 						volumeToMount.Pod.UID,
-						addVolumeNodeErr)
+						attachedVolume.DevicePath)
+
+					if addVolumeNodeErr != nil {
+						// On failure, return error. Caller will log and retry.
+						return fmt.Errorf(
+							"VerifyControllerAttachedVolume.MarkVolumeAsAttached failed for volume %q (spec.Name: %q) pod %q (UID: %q) with: %v",
+							volumeToMount.VolumeName,
+							volumeToMount.VolumeSpec.Name(),
+							volumeToMount.PodName,
+							volumeToMount.Pod.UID,
+							addVolumeNodeErr)
+					}
+					return nil
 				}
-				return nil
 			}
+		}
+
+		if !volumeInUse {
+			// If the given volume has not yet been added to the list of
+			// VolumesInUse in the node's volume status, do not proceed, return
+			// error. Caller will log and retry.
+			return fmt.Errorf("Volume %q (spec.Name: %q) pod %q (UID: %q) has not yet been added to the list of VolumesInUse in the node's volume status.",
+				volumeToMount.VolumeName,
+				volumeToMount.VolumeSpec.Name(),
+				volumeToMount.PodName,
+				volumeToMount.Pod.UID)
 		}
 
 		// Volume not attached, return error. Caller will log and retry.


### PR DESCRIPTION

**EDIT: REPLACED BY https://github.com/kubernetes/kubernetes/pull/45344**

This PR changes VerifyControllerAttachedVolume from the kubelet volume manager to use a watch instead of a single get for node status.

VerifyControllerAttachedVolume is an asynchronous operation which returned pretty fast with an error in and thus exponential backoff hit pretty hard here. This PR changes the operation to wait/watch for some time (1 minute) for the node status to report that the volume is attached and only returns an error after timeout.

It also moves the ReportedInUse check into the watch loop and thus makes us independent from the node status cache.

This PR is an alternative solution for the same problem I tried to fix in https://github.com/kubernetes/kubernetes/pull/40531. I would prefer the new solution.

```release-note
NONE
```
