### PR TITLE
OWNERS for kubectl translations

### DIFF
--- a/translations/kubectl/OWNERS
+++ b/translations/kubectl/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- sig-cli-maintainers
+reviewers:
+- sig-cli


### PR DESCRIPTION
`pkg/kubectl` approvers and reviewers can also handle `translations/kubectl`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
