### PR TITLE
test/images/mount-tester: ensure exec binary is o+rx

### DIFF
--- a/test/images/mount-tester/Makefile
+++ b/test/images/mount-tester/Makefile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 0.7
+TAG = 0.8
 PREFIX = gcr.io/google_containers
 
 all: push
 
 mt: mt.go
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./mt.go
+	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./mt.go && \
+	chmod a+rx mt
 
 image: mt
 	sudo docker build --pull -t $(PREFIX)/mounttest:$(TAG) .


### PR DESCRIPTION
The `mount-tester` image is currently used as a base layer for other
test images (like `mounttest-user`) which perform uid/gid changes.
However, the binary built in here just follows local umask, and currently is
```
-rwxr-x--- 1 root root 2052704 May 19  2016 mt
```

This commit adds an explicit chmod on the binary to make sure uid/gid
tests can still run it as "others".