### PR TITLE
Print resource name when patch is done

### DIFF
--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -209,7 +209,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 			}
 
 			if options.OutputFormat == "name" || len(options.OutputFormat) == 0 {
-				cmdutil.PrintSuccess(mapper, options.OutputFormat == "name", out, "", name, false, dataChangedMsg)
+				cmdutil.PrintSuccess(mapper, options.OutputFormat == "name", out, info.Mapping.Resource, info.Name, false, dataChangedMsg)
 			}
 			return nil
 		}

--- a/pkg/kubectl/cmd/patch_test.go
+++ b/pkg/kubectl/cmd/patch_test.go
@@ -54,7 +54,7 @@ func TestPatchObject(t *testing.T) {
 	cmd.Run(cmd, []string{"services/frontend"})
 
 	// uses the name from the file, not the response
-	if buf.String() != "frontend\n" {
+	if buf.String() != "service/frontend\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }
@@ -88,7 +88,7 @@ func TestPatchObjectFromFile(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	// uses the name from the file, not the response
-	if buf.String() != "frontend\n" {
+	if buf.String() != "service/frontend\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 }


### PR DESCRIPTION
Before:
```console
$ kubectl patch deployment nginx -p '{"spec":{"progressDeadlineSeconds":200}}'
"nginx" patched
```

After:
```console
$ kubectl patch deployment nginx -p '{"spec":{"progressDeadlineSeconds":200}}'
deployment "nginx" patched
```