### PR TITLE
Update NPD version to v0.3.0-alpha.0 in kubemark.

### DIFF
--- a/test/kubemark/resources/hollow-node_template.json
+++ b/test/kubemark/resources/hollow-node_template.json
@@ -151,7 +151,7 @@
 				},
 				{
 					"name": "hollow-node-problem-detector",
-					"image": "gcr.io/google_containers/node-problem-detector:v0.3",
+					"image": "gcr.io/google_containers/node-problem-detector:v0.3.0-alpha.0",
 					"env": [
 						{
 							"name": "NODE_NAME",


### PR DESCRIPTION
@wojtek-t @shyamjvs Update the NPD version in kubemark.

I just built the alpha release https://github.com/kubernetes/node-problem-detector/releases/tag/v0.3.0-alpha.0.

And the PR https://github.com/kubernetes/node-problem-detector/pull/79 is included.

However, I'm not sure whether 1 minute period is longer enough.

If it's still not longer enough, in fact we can extend it by split the resync and heartbeat:
* Every 1 minute, check whether there is inconsistency between apiserver and npd, and only update when there is inconsistency. (1 GET/m)
* Every > 2 minute, do forcibly update as heartbeat. (<0.5 PATCH/m)

And I can also make the sync period configurable after we finalize the sync mechanism.