### PR TITLE
Cherry-pick of "controller: old pods should block deployment completeness" to 1.5

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -800,9 +800,10 @@ func IsRollingUpdate(deployment *extensions.Deployment) bool {
 }
 
 // DeploymentComplete considers a deployment to be complete once its desired replicas equals its
-// updatedReplicas and it doesn't violate minimum availability.
+// updatedReplicas, no old pods are running, and it doesn't violate minimum availability.
 func DeploymentComplete(deployment *extensions.Deployment, newStatus *extensions.DeploymentStatus) bool {
 	return newStatus.UpdatedReplicas == deployment.Spec.Replicas &&
+		newStatus.Replicas == deployment.Spec.Replicas &&
 		newStatus.AvailableReplicas >= deployment.Spec.Replicas-MaxUnavailable(*deployment)
 }
 


### PR DESCRIPTION
@janetkuo the cherry-pick of https://github.com/kubernetes/kubernetes/pull/40261 wasn't clean but I resolved any conflicts, saw the unit test pass, and additionally verified that it works for 1.5 as well as for 1.6 (though the unit test is enough). ptal