### PR TITLE
fixed bug #36988 -- kubeadm join crashes when using multiple API endpoints

### DIFF
--- a/cmd/kubeadm/app/node/bootstrap.go
+++ b/cmd/kubeadm/app/node/bootstrap.go
@@ -80,9 +80,10 @@ func EstablishMasterConnection(c *kubeadmapi.TokenDiscovery, clusterInfo *kubead
 					return
 				}
 				fmt.Printf("[bootstrap] Successfully established connection with endpoint %q\n", apiEndpoint)
+
 				// connection established, stop all wait threads
-				close(stopChan)
 				once.Do(func() {
+					close(stopChan)
 					clientConfig = ac.clientConfig
 				})
 			}, retryTimeout*time.Second, stopChan)

--- a/cmd/kubeadm/app/node/bootstrap_test.go
+++ b/cmd/kubeadm/app/node/bootstrap_test.go
@@ -31,6 +31,63 @@ import (
 )
 
 func TestEstablishMasterConnection(t *testing.T) {
+	srv := stubServer(t)
+	defer srv.Close()
+
+	tests := []struct {
+		c      string
+		e      string
+		expect bool
+	}{
+		{
+			c:      "",
+			e:      "",
+			expect: false,
+		},
+		{
+			c:      "",
+			e:      srv.URL,
+			expect: true,
+		},
+		{
+			c:      "foo",
+			e:      srv.URL,
+			expect: true,
+		},
+	}
+	for _, rt := range tests {
+		s := &kubeadmapi.TokenDiscovery{}
+		c := &kubeadmapi.ClusterInfo{Endpoints: []string{rt.e}, CertificateAuthorities: []string{rt.c}}
+		_, actual := EstablishMasterConnection(s, c)
+		if (actual == nil) != rt.expect {
+			t.Errorf(
+				"failed EstablishMasterConnection:\n\texpected: %t\n\t  actual: %t",
+				rt.expect,
+				(actual == nil),
+			)
+		}
+	}
+}
+
+func TestEstablishMasterConnectionWithMultipleEndpoints(t *testing.T) {
+	// ref. https://github.com/kubernetes/kubernetes/issues/36988
+
+	srv := stubServer(t)
+	defer srv.Close()
+
+	s := &kubeadmapi.TokenDiscovery{}
+	c := &kubeadmapi.ClusterInfo{Endpoints: []string{srv.URL, srv.URL}, CertificateAuthorities: []string{"foo"}}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("failed EstablishMasterConnectionWithMultipleEndpoints; got a panic.")
+		}
+	}()
+
+	EstablishMasterConnection(s, c)
+}
+
+func stubServer(t *testing.T) *httptest.Server {
 	expect := version.Info{
 		Major:     "foo",
 		Minor:     "bar",
@@ -83,41 +140,8 @@ func TestEstablishMasterConnection(t *testing.T) {
 			w.Write(output)
 		}
 	}))
-	defer srv.Close()
 
-	tests := []struct {
-		c      string
-		e      string
-		expect bool
-	}{
-		{
-			c:      "",
-			e:      "",
-			expect: false,
-		},
-		{
-			c:      "",
-			e:      srv.URL,
-			expect: true,
-		},
-		{
-			c:      "foo",
-			e:      srv.URL,
-			expect: true,
-		},
-	}
-	for _, rt := range tests {
-		s := &kubeadmapi.TokenDiscovery{}
-		c := &kubeadmapi.ClusterInfo{Endpoints: []string{rt.e}, CertificateAuthorities: []string{rt.c}}
-		_, actual := EstablishMasterConnection(s, c)
-		if (actual == nil) != rt.expect {
-			t.Errorf(
-				"failed EstablishMasterConnection:\n\texpected: %t\n\t  actual: %t",
-				rt.expect,
-				(actual == nil),
-			)
-		}
-	}
+	return srv
 }
 
 func TestCreateClients(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Simple bug fix for #36988 (kubeadm crashes when trying to join nodes to a master with multiple API endpoints) -- stopChan was getting closed multiple times, once per endpoint. Moved the close into the once.Do(...)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
fixes #36988 

**Special notes for your reviewer**:
this is my first kubernetes commit, just getting familiar with the process, so any/all feedback is appreciated

**Release note**:

