### PR TITLE
Allow `kubectl apply --prune` to prune objects when no objects passed in

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -872,7 +872,9 @@ run_kubectl_apply_tests() {
   kubectl apply --all --prune -f hack/testdata/prune
   kube::test::get_object_assert 'pods a' "{{${id_field}}}" 'a'
   kube::test::get_object_assert 'pods b' "{{${id_field}}}" 'b'
-  kubectl delete pod/a pod/b
+  # should cleanup with apply --prune
+  echo "" | kubectl apply -f - -l prune-group=true --prune
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
 
   ## kubectl apply --prune should fallback to delete for non reapable types
   kubectl apply --all --prune -f hack/testdata/prune-reap/a.yml 2>&1 "${kube_flags[@]}"

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -321,7 +321,8 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 	if err != nil {
 		return err
 	}
-	if count == 0 {
+	// Allow pruning even if no objects passed
+	if count == 0 && !options.Prune {
 		return fmt.Errorf("no objects passed to apply")
 	}
 


### PR DESCRIPTION
Fixes #40635.

This change will only affect the behavior of `kubectl apply --prune`, which is in Alpha.