### PR TITLE
kuberuntime: remove the kubernetesManagedLabel label

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -302,9 +302,7 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 // The boolean parameter specifies whether returns all containers including
 // those already exited and dead containers (used for garbage collection).
 func (m *kubeGenericRuntimeManager) getKubeletContainers(allContainers bool) ([]*runtimeapi.Container, error) {
-	filter := &runtimeapi.ContainerFilter{
-		LabelSelector: map[string]string{kubernetesManagedLabel: "true"},
-	}
+	filter := &runtimeapi.ContainerFilter{}
 	if !allContainers {
 		runningState := runtimeapi.ContainerState_CONTAINER_RUNNING
 		filter.State = &runtimeapi.ContainerStateValue{

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -188,18 +188,7 @@ func (m *kubeGenericRuntimeManager) getKubeletSandboxes(all bool) ([]*runtimeapi
 		return nil, err
 	}
 
-	result := []*runtimeapi.PodSandbox{}
-	for _, s := range resp {
-		if !isManagedByKubelet(s.Labels) {
-			glog.V(5).Infof("Sandbox %s is not managed by kubelet", kubecontainer.BuildPodFullName(
-				s.Metadata.Name, s.Metadata.Namespace))
-			continue
-		}
-
-		result = append(result, s)
-	}
-
-	return result, nil
+	return resp, nil
 }
 
 // determinePodSandboxIP determines the IP address of the given pod sandbox.

--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -39,9 +39,6 @@ const (
 	containerTerminationMessagePolicyLabel = "io.kubernetes.container.terminationMessagePolicy"
 	containerPreStopHandlerLabel           = "io.kubernetes.container.preStopHandler"
 	containerPortsLabel                    = "io.kubernetes.container.ports"
-
-	// kubernetesManagedLabel is used to distinguish whether a container/sandbox is managed by kubelet or not
-	kubernetesManagedLabel = "io.kubernetes.managed"
 )
 
 type labeledPodSandboxInfo struct {
@@ -87,7 +84,6 @@ func newPodLabels(pod *v1.Pod) map[string]string {
 	labels[types.KubernetesPodNameLabel] = pod.Name
 	labels[types.KubernetesPodNamespaceLabel] = pod.Namespace
 	labels[types.KubernetesPodUIDLabel] = string(pod.UID)
-	labels[kubernetesManagedLabel] = "true"
 
 	return labels
 }
@@ -104,7 +100,6 @@ func newContainerLabels(container *v1.Container, pod *v1.Pod) map[string]string 
 	labels[types.KubernetesPodNamespaceLabel] = pod.Namespace
 	labels[types.KubernetesPodUIDLabel] = string(pod.UID)
 	labels[types.KubernetesContainerNameLabel] = container.Name
-	labels[kubernetesManagedLabel] = "true"
 
 	return labels
 }
@@ -157,7 +152,7 @@ func getPodSandboxInfoFromLabels(labels map[string]string) *labeledPodSandboxInf
 
 	// Remain only labels from v1.Pod
 	for k, v := range labels {
-		if k != types.KubernetesPodNameLabel && k != types.KubernetesPodNamespaceLabel && k != types.KubernetesPodUIDLabel && k != kubernetesManagedLabel {
+		if k != types.KubernetesPodNameLabel && k != types.KubernetesPodNamespaceLabel && k != types.KubernetesPodUIDLabel {
 			podSandboxInfo.Labels[k] = v
 		}
 	}
@@ -180,15 +175,6 @@ func getContainerInfoFromLabels(labels map[string]string) *labeledContainerInfo 
 		PodUID:        kubetypes.UID(getStringValueFromLabel(labels, types.KubernetesPodUIDLabel)),
 		ContainerName: getStringValueFromLabel(labels, types.KubernetesContainerNameLabel),
 	}
-}
-
-// isManagedByKubelet returns true is the sandbox/container is managed by kubelet.
-func isManagedByKubelet(labels map[string]string) bool {
-	if _, ok := labels[kubernetesManagedLabel]; ok {
-		return true
-	}
-
-	return false
 }
 
 // getContainerInfoFromAnnotations gets annotatedContainerInfo from annotations.


### PR DESCRIPTION
The CRI shim should be responsible for returning only those
containers/sandboxes created through CRI. Remove this label in kubelet.