### PR TITLE
verify: Use macOS compatible copying method

### DIFF
--- a/cmd/kube-aggregator/hack/verify-codegen.sh
+++ b/cmd/kube-aggregator/hack/verify-codegen.sh
@@ -33,14 +33,14 @@ trap "cleanup" EXIT SIGINT
 
 cleanup
 
-mkdir -p "${_tmp}"
-cp -a -T "${DIFFROOT}" "${TMP_DIFFROOT}"
+mkdir -p "${TMP_DIFFROOT}"
+cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 
 "${APIFEDERATOR_ROOT}/hack/update-codegen.sh"
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
 diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
-cp -a -T "${TMP_DIFFROOT}" "${DIFFROOT}"
+cp -a "${TMP_DIFFROOT}"/* "${DIFFROOT}"
 if [[ $ret -eq 0 ]]
 then
   echo "${DIFFROOT} up to date."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Similar to the fix in #34944, this fixes issues in the `make verify` tests, by using a copy method that is compatible with macOS and the bsd version of `cp`.

Before fix:
```
Verifying hack/make-rules/../../hack/verify-codegen.sh
cp: illegal option -- T
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-apvX] source_file ... target_directory
FAILED   hack/make-rules/../../hack/verify-codegen.sh	0s
```

After fix:
```
Verifying hack/make-rules/../../hack/verify-codegen.sh
Building client-gen
Building lister-gen
Building informer-gen
diffing cmd/kube-aggregator/hack/../pkg against freshly generated codegen
cmd/kube-aggregator/hack/../pkg up to date.
+++ [0128 10:06:48] Building the toolchain targets:
    k8s.io/kubernetes/hack/cmd/teststale
    k8s.io/kubernetes/vendor/github.com/jteeuwen/go-bindata/go-bindata
+++ [0128 10:06:48] Generating bindata:
    test/e2e/generated/gobindata_util.go
/opt/gopath/src/k8s.io/kubernetes /opt/gopath/src/k8s.io/kubernetes/test/e2e/generated
/opt/gopath/src/k8s.io/kubernetes/test/e2e/generated
+++ [0128 10:06:49] Building go targets for darwin/amd64:
    cmd/libs/go2idl/client-gen
    cmd/libs/go2idl/lister-gen
    cmd/libs/go2idl/informer-gen
Building client-gen
Building lister-gen
Building informer-gen
SUCCESS  hack/make-rules/../../hack/verify-codegen.sh	59s
```

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
