### PR TITLE
pkg/genericapiserver: re-add generic feature gates

### DIFF
--- a/pkg/genericapiserver/server/options/BUILD
+++ b/pkg/genericapiserver/server/options/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//vendor:k8s.io/apiserver/pkg/admission",
         "//vendor:k8s.io/apiserver/pkg/authentication/authenticatorfactory",
         "//vendor:k8s.io/apiserver/pkg/authorization/authorizerfactory",
+        "//vendor:k8s.io/apiserver/pkg/features",
         "//vendor:k8s.io/apiserver/pkg/storage/storagebackend",
         "//vendor:k8s.io/apiserver/pkg/util/feature",
         "//vendor:k8s.io/apiserver/pkg/util/flag",

--- a/pkg/genericapiserver/server/options/server_run_options.go
+++ b/pkg/genericapiserver/server/options/server_run_options.go
@@ -28,6 +28,9 @@ import (
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/api"
 
+	// add the generic feature gates
+	_ "k8s.io/apiserver/pkg/features"
+
 	"github.com/spf13/pflag"
 )
 


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/40543 removed the kubernetes feature gates (which subsume the generic ones) from genericapiserver. This PR readds the generic ones again.

This is not strictly necessary for kube-apiserver. But some other downstream project without its own feature gates needs this.