### PR TITLE
controller: don't run informers in unit tests when unnecessary

### DIFF
--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -497,16 +497,13 @@ func TestPodDeletionEnqueuesRecreateDeployment(t *testing.T) {
 	f.rsLister = append(f.rsLister, rs)
 	f.objects = append(f.objects, foo, rs)
 
-	c, informers := f.newController()
+	c, _ := f.newController()
 	enqueued := false
 	c.enqueueDeployment = func(d *extensions.Deployment) {
 		if d.Name == "foo" {
 			enqueued = true
 		}
 	}
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	informers.Start(stopCh)
 
 	c.deletePod(pod)
 
@@ -532,16 +529,13 @@ func TestPodDeletionDoesntEnqueueRecreateDeployment(t *testing.T) {
 	// return a non-empty list.
 	f.podLister = append(f.podLister, pod)
 
-	c, informers := f.newController()
+	c, _ := f.newController()
 	enqueued := false
 	c.enqueueDeployment = func(d *extensions.Deployment) {
 		if d.Name == "foo" {
 			enqueued = true
 		}
 	}
-	stopCh := make(chan struct{})
-	defer close(stopCh)
-	informers.Start(stopCh)
 
 	c.deletePod(pod)
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/39908

@mfojtik it seems that using informers makes the deployment sync for the initial relist so this races with the enqueue that these tests are testing.