### PR TITLE
Enable protobufs as storage format by default

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -87,6 +87,8 @@ func NewServerRunOptions() *ServerRunOptions {
 		},
 		ServiceNodePortRange: DefaultServiceNodePortRange,
 	}
+	// Overwrite the default for storage data format.
+	s.GenericServerRunOptions.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
 	return &s
 }
 

--- a/federation/cmd/federation-apiserver/app/options/options.go
+++ b/federation/cmd/federation-apiserver/app/options/options.go
@@ -55,6 +55,8 @@ func NewServerRunOptions() *ServerRunOptions {
 
 		EventTTL: 1 * time.Hour,
 	}
+	// Overwrite the default for storage data format.
+	s.GenericServerRunOptions.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
 	return &s
 }
 

--- a/pkg/genericapiserver/server/options/server_run_options.go
+++ b/pkg/genericapiserver/server/options/server_run_options.go
@@ -37,7 +37,9 @@ type ServerRunOptions struct {
 	AdmissionControlConfigFile string
 	AdvertiseAddress           net.IP
 
-	CorsAllowedOriginList       []string
+	CorsAllowedOriginList []string
+	// To enable protobuf as storage format, it is enough
+	// to set it to "application/vnd.kubernetes.protobuf".
 	DefaultStorageMediaType     string
 	DeleteCollectionWorkers     int
 	AuditLogPath                string


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Change default storage format to protobufs. With this PR apiserver will be writing objects serialized as protobufs to etcd. If the apiserver was upgraded in the existing clusters, until an object will be written, it will still be stored as JSON. Apiserver can deal with some data being in json and some in protobuf format as of 1.4 release.
```

@kubernetes/sig-api-machinery-misc @kubernetes/sig-api-machinery-pr-reviews 
