### PR TITLE
[FAIL] hack/verify-staging-imports.sh

### DIFF
--- a/hack/verify-staging-imports.sh
+++ b/hack/verify-staging-imports.sh
@@ -23,13 +23,38 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
+function print_forbidden_imports () {
+    local PACKAGE="$1"
+    shift
+    local RE=""
+    local SEP=""
+    for CLAUSE in "$@"; do
+        RE+="${SEP}${CLAUSE}"
+        SEP='\|'
+    done
+    local FORBIDDEN=$(
+        go list -f $'{{with $package := .ImportPath}}{{range $.Imports}}{{$package}} imports {{.}}\n{{end}}{{end}}' ./vendor/k8s.io/${PACKAGE}/... |
+        sed 's|^k8s.io/kubernetes/vendor/||;s| k8s.io/kubernetes/vendor/| |' |
+        grep -v " k8s.io/${PACKAGE}" |
+        grep -e "imports \(${RE}\)"
+    )
+    if [ -n "${FORBIDDEN}" ]; then
+        echo "${PACKAGE} has a forbidden dependency:"
+		echo
+		echo "${FORBIDDEN}" | sed 's/^/  /'
+		echo
+		return 1
+    fi
+    return 0
+}
 
-for dep in $(ls -1 ${KUBE_ROOT}/staging/src/k8s.io/); do
-	if go list -f {{.Deps}} ./vendor/k8s.io/${dep}/... | tr " " '\n' | grep k8s.io/kubernetes | grep -v 'k8s.io/kubernetes/vendor' | LC_ALL=C sort -u | grep -e "."; then
-		echo "${dep} has a cyclical dependency"
-		exit 1
-	fi
-done
+RC=0
+print_forbidden_imports apimachinery k8s.io/ || RC=1
+print_forbidden_imports apiserver k8s.io/kubernetes || RC=1
+print_forbidden_imports client-go k8s.io/kubernetes k8s.io/apiserver || RC=1
+if [ ${RC} != 0 ]; then
+    exit ${RC}
+fi
 
 if grep -rq '// import "k8s.io/kubernetes/' 'staging/'; then
 	echo 'file has "// import "k8s.io/kubernetes/"'

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -28,6 +28,11 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
+
+	// fail hack/verify-staging-imports.sh
+	_ "k8s.io/kubernetes/pkg/features"
+	_ "k8s.io/client-go/pkg/apis/autoscaling"
+	_ "k8s.io/apiserver/pkg/features"
 )
 
 // ToJSON converts a single YAML document into a JSON document

--- a/staging/src/k8s.io/apiserver/pkg/server/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/doc.go
@@ -16,3 +16,10 @@ limitations under the License.
 
 // Package server contains the plumbing to create kubernetes-like API server command.
 package server
+
+import (
+	// fail hack/verify-staging-imports.sh
+	_ "k8s.io/kubernetes/pkg/features"
+	_ "k8s.io/client-go/pkg/apis/autoscaling"
+	_ "k8s.io/apiserver/pkg/features"
+)

--- a/staging/src/k8s.io/client-go/plugin/pkg/auth/authenticator/token/oidc/testing/provider.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/auth/authenticator/token/oidc/testing/provider.go
@@ -41,6 +41,11 @@ import (
 	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/key"
 	"github.com/coreos/go-oidc/oidc"
+
+	// fail hack/verify-staging-imports.sh
+	_ "k8s.io/kubernetes/pkg/features"
+	_ "k8s.io/client-go/pkg/apis/autoscaling"
+	_ "k8s.io/apiserver/pkg/features"
 )
 
 // NewOIDCProvider provides a bare minimum OIDC IdP Server useful for testing.

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -8645,8 +8645,11 @@ go_library(
     srcs = ["k8s.io/apimachinery/pkg/util/yaml/decoder.go"],
     tags = ["automanaged"],
     deps = [
+        "//pkg/features:go_default_library",
         "//vendor:github.com/ghodss/yaml",
         "//vendor:github.com/golang/glog",
+        "//vendor:k8s.io/apiserver/pkg/features",
+        "//vendor:k8s.io/client-go/pkg/apis/autoscaling",
     ],
 )
 
@@ -9029,6 +9032,11 @@ go_library(
     name = "k8s.io/apiserver/pkg/server",
     srcs = ["k8s.io/apiserver/pkg/server/doc.go"],
     tags = ["automanaged"],
+    deps = [
+        "//pkg/features:go_default_library",
+        "//vendor:k8s.io/apiserver/pkg/features",
+        "//vendor:k8s.io/client-go/pkg/apis/autoscaling",
+    ],
 )
 
 go_test(
@@ -12273,9 +12281,12 @@ go_library(
     srcs = ["k8s.io/client-go/plugin/pkg/auth/authenticator/token/oidc/testing/provider.go"],
     tags = ["automanaged"],
     deps = [
+        "//pkg/features:go_default_library",
         "//vendor:github.com/coreos/go-oidc/jose",
         "//vendor:github.com/coreos/go-oidc/key",
         "//vendor:github.com/coreos/go-oidc/oidc",
+        "//vendor:k8s.io/apiserver/pkg/features",
+        "//vendor:k8s.io/client-go/pkg/apis/autoscaling",
     ],
 )
 


### PR DESCRIPTION
Double check that https://github.com/kubernetes/kubernetes/pull/40659 actually fails as expected:

```
apimachinery has a forbidden dependency:

  k8s.io/apimachinery/pkg/util/yaml imports k8s.io/apiserver/pkg/features
  k8s.io/apimachinery/pkg/util/yaml imports k8s.io/client-go/pkg/apis/autoscaling
  k8s.io/apimachinery/pkg/util/yaml imports k8s.io/kubernetes/pkg/features

apiserver has a forbidden dependency:

  k8s.io/apiserver/pkg/server imports k8s.io/kubernetes/pkg/features

client-go has a forbidden dependency:

  k8s.io/client-go/plugin/pkg/auth/authenticator/token/oidc/testing imports k8s.io/apiserver/pkg/features
  k8s.io/client-go/plugin/pkg/auth/authenticator/token/oidc/testing imports k8s.io/kubernetes/pkg/features
```