### PR TITLE
Prevent pv controller from forcefully overwrite provisioned volume name

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -1329,7 +1329,9 @@ func (ctrl *PersistentVolumeController) provisionClaimOperation(claimObj interfa
 	glog.V(3).Infof("volume %q for claim %q created", volume.Name, claimToClaimKey(claim))
 
 	// Create Kubernetes PV object for the volume.
-	volume.Name = pvName
+	if volume.Name == "" {
+		volume.Name = pvName
+	}
 	// Bind it to the claim
 	volume.Spec.ClaimRef = claimRef
 	volume.Status.Phase = v1.VolumeBound

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -42,8 +42,10 @@ type VolumeOptions struct {
 
 	// Reclamation policy for a persistent volume
 	PersistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy
-	// PV.Name of the appropriate PersistentVolume. Used to generate cloud
-	// volume name.
+	// Suggested PV.Name of the PersistentVolume to provision.
+	// This is a generated name guaranteed to be unique in Kubernetes cluster.
+	// If you choose not to use it as volume name, ensure uniqueness by either
+	// combining it with your value or create unique values of your own.
 	PVName string
 	// PVC is reference to the claim that lead to provisioning of a new PV.
 	// Provisioners *must* create a PV that would be matched by this PVC,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a fix to prevents the PV controller from forcefully overwriting the provisioned volume's name with the generated PV name.  Instead, it overwrites the volume's name only when it is missing.  This allows dynamic provisioner implementers to set the name of the volume to a value that they choose.

**Which issue this PR fixes** 
This PR does not have an issue affiliated, but it will allow PR #38924 to properly implement dynamically provisioned volume in namespaces other than default.