### PR TITLE
Replace + with _ in the image tag version since + is not a valid image tag character.

### DIFF
--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -40,11 +40,13 @@ HOST_CLUSTER_CONTEXT="${FEDERATION_HOST_CLUSTER_CONTEXT:-${1}}"
 # Initializes the control plane.
 # TODO(madhusudancs): Move this to federation/develop.sh.
 function init() {
+  : "${KUBERNETES_RELEASE?KUBERNETES_RELEASE environment variable must be set}"
+
   kube::log::status "Deploying federation control plane for ${FEDERATION_NAME} in cluster ${HOST_CLUSTER_CONTEXT}"
 
   local -r project="${KUBE_PROJECT:-${PROJECT:-}}"
   local -r kube_registry="${KUBE_REGISTRY:-gcr.io/${project}}"
-  local -r kube_version="${KUBERNETES_RELEASE:-}"
+  local -r kube_version="${KUBERNETES_RELEASE//+/_}"
 
   "${KUBE_ROOT}/federation/develop/kubefed.sh" init \
       "${FEDERATION_NAME}" \


### PR DESCRIPTION
We already push the image to the registry by replacing `+` with `_` in the
preceding build and push stages. This change is just propagating the same
to the deploy stage.

cc @kubernetes/sig-federation-pr-reviews @nikhiljindal @shashidharatd 
