### PR TITLE
Add --force-new-cluster when running etcd for migrations.

### DIFF
--- a/cluster/images/etcd/migrate-if-needed.sh
+++ b/cluster/images/etcd/migrate-if-needed.sh
@@ -120,6 +120,7 @@ start_etcd() {
   ${ETCD_CMD} \
     --name="etcd-$(hostname)" \
     --debug \
+    --force-new-cluster \
     --data-dir=${DATA_DIRECTORY} \
     --listen-client-urls http://127.0.0.1:${ETCD_PORT} \
     --advertise-client-urls http://127.0.0.1:${ETCD_PORT} \


### PR DESCRIPTION
This is required to avoid etcd trying to create quorum during
migrations.

Might fix #40110