### PR TITLE
kubectl tests: Adding a wait in verifying that secret was deleted

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -42,30 +42,60 @@ kube::test::get_caller() {
 
 # Force exact match of a returned result for a object query.  Wrap this with || to support multiple
 # valid return types.
+# This runs `kubectl get` once and asserts that the result is as expected.
+## $1: Object on which get should be run
+# $2: The go-template to run on the result
+# $3: The expected output
+# $4: Additional args to be passed to kubectl
 kube::test::get_object_assert() {
-  local object=$1
-  local request=$2
-  local expected=$3
-  local args=${4:-}
+  kube::test::object_assert 1 "$@"
+}
 
-  res=$(eval kubectl get "${kube_flags[@]}" ${args} $object -o go-template=\"$request\")
+# Asserts that the output of a given get query is as expected.
+# Runs the query multiple times before failing it.
+# $1: Object on which get should be run
+# $2: The go-template to run on the result
+# $3: The expected output
+# $4: Additional args to be passed to kubectl
+kube::test::wait_object_assert() {
+  kube::test::object_assert 10 "$@"
+}
 
-  if [[ "$res" =~ ^$expected$ ]]; then
-      echo -n ${green}
-      echo "$(kube::test::get_caller): Successful get $object $request: $res"
-      echo -n ${reset}
-      return 0
-  else
-      echo ${bold}${red}
-      echo "$(kube::test::get_caller): FAIL!"
-      echo "Get $object $request"
-      echo "  Expected: $expected"
-      echo "  Got:      $res"
-      echo ${reset}${red}
-      caller
-      echo ${reset}
-      return 1
-  fi
+# Asserts that the output of a given get query is as expected.
+# Can run the query multiple times before failing it.
+# $1: Number of times the query should be run before failing it.
+# $2: Object on which get should be run
+# $3: The go-template to run on the result
+# $4: The expected output
+# $5: Additional args to be passed to kubectl
+kube::test::object_assert() {
+  local tries=$1
+  local object=$2
+  local request=$3
+  local expected=$4
+  local args=${5:-}
+
+  for i in $(seq 1 ${tries}); do
+    res=$(eval kubectl get "${kube_flags[@]}" ${args} $object -o go-template=\"$request\")
+    if [[ "$res" =~ ^$expected$ ]]; then
+        echo -n ${green}
+        echo "$(kube::test::get_caller): Successful get $object $request: $res"
+        echo -n ${reset}
+        return 0
+    fi
+    echo "Waiting for Get $object $request $args: expected: $expected, got: $res"
+    sleep $((${i}-1))
+  done
+
+  echo ${bold}${red}
+  echo "$(kube::test::get_caller): FAIL!"
+  echo "Get $object $request"
+  echo "  Expected: $expected"
+  echo "  Got:      $res"
+  echo ${reset}${red}
+  caller
+  echo ${reset}
+  return 1
 }
 
 kube::test::get_object_jsonpath_assert() {

--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1613,7 +1613,7 @@ run_secrets_test() {
 
   ### Create a docker-registry secret in a specific namespace
   # Pre-condition: no SECRET exists
-  kube::test::get_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::wait_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create secret docker-registry test-secret --docker-username=test-user --docker-password=test-password --docker-email='test-user@test.com' --namespace=test-secrets
   # Post-condition: secret exists and has expected values
@@ -1625,7 +1625,7 @@ run_secrets_test() {
 
   ### Create a tls secret
   # Pre-condition: no SECRET exists
-  kube::test::get_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::wait_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create secret tls test-secret --namespace=test-secrets --key=hack/testdata/tls.key --cert=hack/testdata/tls.crt
   kube::test::get_object_assert 'secret/test-secret --namespace=test-secrets' "{{$id_field}}" 'test-secret'
@@ -1659,7 +1659,7 @@ __EOF__
 
   ### Create a secret using output flags
   # Pre-condition: no secret exists
-  kube::test::get_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
+  kube::test::wait_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   [[ "$(kubectl create secret generic test-secret --namespace=test-secrets --from-literal=key1=value1 --output=go-template --template=\"{{.metadata.name}}:\" | grep 'test-secret:')" ]]
   ## Clean-up

--- a/hack/make-rules/test-federation-cmd.sh
+++ b/hack/make-rules/test-federation-cmd.sh
@@ -75,8 +75,8 @@ kube::log::status "Running kubectl tests for federation-apiserver"
 setup
 run_federation_apiserver
 run_federation_controller_manager
-# TODO: Fix for secrets, replicasets and deployments.
-SUPPORTED_RESOURCES=("configmaps" "daemonsets" "events" "ingress" "namespaces" "services")
+# TODO: Fix for replicasets and deployments.
+SUPPORTED_RESOURCES=("configmaps" "daemonsets" "events" "ingress" "namespaces" "secrets" "services")
 # WARNING: Do not wrap this call in a subshell to capture output, e.g. output=$(runTests)
 # Doing so will suppress errexit behavior inside runTests
 runTests


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/40568

As per discussion in https://github.com/kubernetes/kubernetes/pull/40576. kubectl does not guarantee that the resource is deleted after `kubectl delete` returns.
Updated the test to verify that the secret is eventually deleted rather than asserting that the secret should be gone right after `kubectl delete` returns.

cc @liggitt @smarterclayton @kubernetes/sig-federation-pr-reviews @kubernetes/sig-cli-pr-reviews 