### PR TITLE
Fix formatting issue of secret volume describer

### DIFF
--- a/pkg/kubectl/describe.go
+++ b/pkg/kubectl/describe.go
@@ -694,7 +694,7 @@ func printGitRepoVolumeSource(git *api.GitRepoVolumeSource, w *PrefixWriter) {
 func printSecretVolumeSource(secret *api.SecretVolumeSource, w *PrefixWriter) {
 	optional := secret.Optional != nil && *secret.Optional
 	w.Write(LEVEL_2, "Type:\tSecret (a volume populated by a Secret)\n"+
-		"    SecretName:\t%v\n",
+		"    SecretName:\t%v\n"+
 		"    Optional:\t%v\n",
 		secret.SecretName, optional)
 }


### PR DESCRIPTION
Fixing a `kubectl describe` bug

**Before**:

```yaml
...
Volumes:
  default-token-z7g96:
    Type:       Secret (a volume populated by a Secret)
    SecretName:     Optional:   %v

%!(EXTRA string=default-token-z7g96, bool=false)QoS Class:      BestEffort
...
```

**After**:

```yaml
...
Volumes:
  default-token-z7g96:
    Type:       Secret (a volume populated by a Secret)
    SecretName: default-token-z7g96
    Optional:   false
QoS Class:      BestEffort
...
```