### PR TITLE
Exports KUBE_TEMP for use in Vagrantfile

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -314,7 +314,7 @@ function load-or-gen-kube-bearertoken() {
 #   KUBE_TEMP
 function ensure-temp-dir {
   if [[ -z ${KUBE_TEMP-} ]]; then
-    KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
+    export KUBE_TEMP=$(mktemp -d -t kubernetes.XXXXXX)
     trap 'rm -rf "${KUBE_TEMP}"' EXIT
   fi
 }


### PR DESCRIPTION
In #40147, the logic for setting `KUBE_TEMP` was refactored into `common.sh`. However, it was overlooked that `KUBE_TEMP` [needs to be exported for vagrant to work properly](https://github.com/kubernetes/kubernetes/pull/40147/files#diff-b19d3d93456020e2168c7f304f722969).

This PR restores the `export` so that `Vagrantfile` can use `ENV["KUBE_TEMP"]` properly.

:eyes: @rthallisey @shyamjvs @timothysc