### PR TITLE
openstack-heat: do not daemonize salt-minion

### DIFF
--- a/cluster/openstack-heat/kubernetes-heat/fragments/run-salt.sh
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/run-salt.sh
@@ -36,13 +36,15 @@ tar xzf kubernetes-salt.tar.gz
 ./kubernetes/saltbase/install.sh kubernetes-server.tar.gz
 
 if ! which salt-call >/dev/null 2>&1; then
-  # Install salt binaries
-  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s
+  echo "+++ Install salt binaries from https://bootstrap.saltstack.com"
+  # Install salt binaries but do not start deamon after installation
+  curl -sS -L --connect-timeout 20 --retry 6 --retry-delay 10 https://bootstrap.saltstack.com | sh -s -- "-X"
 fi
 
 # Salt server runs at locahost
 echo "127.0.0.1 salt" >> /etc/hosts
 
+echo "+++ run salt-call and finalize installation"
 # Run salt-call
 # salt-call wants to start docker daemon but is unable to.
 # See <https://github.com/projectatomic/docker-storage-setup/issues/77>.


### PR DESCRIPTION
_openstack-heat_ does currently not setup a _salt-master_, so it is not necessary to  daemonize it.

**What this PR does / why we need it**:
as stated in #40721:

> The _openstack-heat_ provider only installs _salt-minions_, no _salt-master_. The configuration does not take this into account which causes the following issues:
> 
> - the _salt minion_ is not able to DNS resolve `salt` (see fist part of error log below)
> - the _salt-minion_ is daemonized and fails finding the master (second part of error log below). From my understanding is not required when there is no salt-master, as the setup uses `salt-call` 
> anyway (see [gce provider](https://github.com/kubernetes/kubernetes/blob/master/cluster/gce/configure-vm.sh#L328-L339) as reference).
> 
> ```
> Jan 31 03:00:04 kube-stack-master salt-minion[9795]: [ERROR   ] DNS lookup of 'salt' failed.
> Jan 31 03:00:04 kube-stack-master salt-minion[9795]: [ERROR   ] Master hostname: 'salt' not found. Retrying in 30 seconds
> ...
> Jan 31 02:35:30 kube-stack-master salt-minion[9690]: [ERROR   ] Error while bringing up minion for multi-master. Is master at salt responding?
> ```
> 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #40721

**Release note**:
```release-note
Do not daemonize `salt-minion` for the openstack-heat provider.
```
