### PR TITLE
Add CI coverage for client-go and staging/copy.sh

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -292,6 +292,8 @@ staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password
 staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/allow
 staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth
 staging/src/k8s.io/client-go/discovery
+staging/src/k8s.io/client-go/examples/in-cluster
+staging/src/k8s.io/client-go/examples/out-of-cluster
 staging/src/k8s.io/client-go/plugin/pkg/client/auth
 staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp
 staging/src/k8s.io/client-go/rest/watch

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -23,10 +23,9 @@ source "${KUBE_ROOT}/cluster/lib/util.sh"
 
 # Excluded checks are always skipped.
 EXCLUDED_CHECKS=(
-  "verify-linkcheck.sh"  # runs in separate Jenkins job once per day due to high network usage
-  "verify-govet.sh"      # it has a separate make vet target
-  "verify-staging-client-go.sh" # TODO: enable the script after 1.5 code freeze
-  "verify-test-owners.sh"  # TODO(rmmh): figure out how to avoid endless conflicts
+  "verify-linkcheck.sh"   # runs in separate Jenkins job once per day due to high network usage
+  "verify-govet.sh"       # it has a separate make vet target
+  "verify-test-owners.sh" # TODO(rmmh): figure out how to avoid endless conflicts
   )
 
 function is-excluded {

--- a/hack/verify-staging-client-go.sh
+++ b/hack/verify-staging-client-go.sh
@@ -18,5 +18,8 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+go build ./staging/src/k8s.io/client-go/examples/...
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-"${KUBE_ROOT}"/staging/copy.sh -v
+# TODO: reenable copy.sh when test can cope with circular dependencies
+# "${KUBE_ROOT}"/staging/copy.sh -v

--- a/hack/verify-staging-client-go.sh
+++ b/hack/verify-staging-client-go.sh
@@ -18,8 +18,59 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go build ./staging/src/k8s.io/client-go/examples/...
+V=""
+while getopts ":v" opt; do
+  case $opt in
+    v) # increase verbosity
+      V="-v"
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      ;;
+  esac
+done
+readonly V
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-# TODO: reenable copy.sh when test can cope with circular dependencies
-# "${KUBE_ROOT}"/staging/copy.sh -v
+cd ${KUBE_ROOT}
+
+# Smoke test client-go examples
+go install ./staging/src/k8s.io/client-go/examples/...
+
+# Create a temporary GOPATH for apimachinery and client-go, copy the current HEAD into each and turn them
+# into a git repo. Then we can run copy.sh with this additional GOPATH. The Godeps.json will
+# have invalid git SHA1s, but it's good enough as a smoke test of copy.sh.
+if [ "${USE_TEMP_DIR:-1}" = 1 ]; then
+    TEMP_STAGING_GOPATH=$(mktemp -d -t verify-staging-client-go.XXXXX)
+    echo "Creating the temporary staging GOPATH directory: ${TEMP_STAGING_GOPATH}"
+    cleanup() {
+        if [ "${KEEP_TEMP_DIR:-0}" != 1 ]; then
+            rm -rf "${TEMP_STAGING_GOPATH}"
+        fi
+    }
+    trap cleanup EXIT SIGINT
+    mkdir -p "${TEMP_STAGING_GOPATH}/src/k8s.io"
+    ln -s "${PWD}" "${TEMP_STAGING_GOPATH}/src/k8s.io"
+else
+    TEMP_STAGING_GOPATH="${GOPATH}"
+fi
+for PACKAGE in apimachinery client-go; do
+    PACKAGE_PATH="${TEMP_STAGING_GOPATH}/src/k8s.io/${PACKAGE}"
+    echo "Creating a temporary ${PACKAGE} repo with a snapshot of HEAD"
+    mkdir -p "${PACKAGE_PATH}"
+    rsync -ax --delete staging/src/k8s.io/${PACKAGE}/ "${PACKAGE_PATH}/"
+    pushd "${PACKAGE_PATH}" >/dev/null
+    git init >/dev/null
+    git add *
+    git -c user.email="nobody@k8s.io" -c user.name="verify-staging-client-go.sh" commit -q -m "Snapshot"
+    popd >/dev/null
+done
+
+echo "Running godep restore"
+pushd "${TEMP_STAGING_GOPATH}/src/k8s.io/kubernetes" >/dev/null
+export GOPATH="${TEMP_STAGING_GOPATH}"
+godep restore ${V} 2>&1 | sed 's/^/  /'
+
+echo "Testing staging/copy.sh"
+staging/copy.sh -d 2>&1 | sed 's/^/  /'
+popd

--- a/staging/copy.sh
+++ b/staging/copy.sh
@@ -18,18 +18,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-VERIFYONLY=false
-while getopts ":v" opt; do
+FAIL_ON_CHANGES=false
+DRY_RUN=false
+while getopts ":fd" opt; do
   case $opt in
-    v)
-      VERIFYONLY=true
+    f)
+      FAIL_ON_CHANGES=true
+      ;;
+    d)
+      DRY_RUN=true
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       ;;
   esac
 done
-readonly VERIFYONLY
+readonly FAIL_ON_CHANGES DRY_RUN
 
 echo "**PLEASE** run \"godep restore\" before running this script"
 # PREREQUISITES: run `godep restore` in the main repo before calling this script.
@@ -183,8 +187,8 @@ find "${CLIENT_REPO_TEMP}" -type f \( \
 echo "remove cyclical godep"
 rm -rf "${CLIENT_REPO_TEMP}/_vendor/k8s.io/client-go"
 
-if [ "${VERIFYONLY}" = true ]; then
-    echo "running verify-only"
+if [ "${FAIL_ON_CHANGES}" = true ]; then
+    echo "running FAIL_ON_CHANGES"
     ret=0
     if diff -NauprB -I "GoVersion.*\|GodepVersion.*" "${CLIENT_REPO}" "${CLIENT_REPO_TEMP}"; then
       echo "${CLIENT_REPO} up to date."
@@ -197,8 +201,11 @@ if [ "${VERIFYONLY}" = true ]; then
     fi
 fi
 
-echo "move to the client repo"
 # clean the ${CLIENT_REPO}
-ls "${CLIENT_REPO}" | { grep -v '_tmp' || true; } | xargs rm -rf
-mv "${CLIENT_REPO_TEMP}"/* "${CLIENT_REPO}"
+echo "move to the client repo"
+if [ "${DRY_RUN}" = false ]; then
+    ls "${CLIENT_REPO}" | { grep -v '_tmp' || true; } | xargs rm -rf
+    mv "${CLIENT_REPO_TEMP}"/* "${CLIENT_REPO}"
+fi
+
 cleanup

--- a/staging/src/k8s.io/client-go/examples/in-cluster/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster/main.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+)
+
+func main() {
+	// creates the in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err.Error())
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+	for {
+		pods, err := clientset.Core().Pods("").List(v1.ListOptions{})
+		if err != nil {
+			panic(err.Error())
+		}
+		fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/staging/src/k8s.io/client-go/examples/in-cluster/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster/main.go
@@ -20,8 +20,8 @@ import (
 	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -37,7 +37,7 @@ func main() {
 		panic(err.Error())
 	}
 	for {
-		pods, err := clientset.Core().Pods("").List(v1.ListOptions{})
+		pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
 		if err != nil {
 			panic(err.Error())
 		}

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var (
+	kubeconfig = flag.String("kubeconfig", "./config", "absolute path to the kubeconfig file")
+)
+
+func main() {
+	flag.Parse()
+	// uses the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		panic(err.Error())
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err.Error())
+	}
+	for {
+		pods, err := clientset.Core().Pods("").List(v1.ListOptions{})
+		if err != nil {
+			panic(err.Error())
+		}
+		fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
+		time.Sleep(10 * time.Second)
+	}
+}

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -43,7 +43,7 @@ func main() {
 		panic(err.Error())
 	}
 	for {
-		pods, err := clientset.Core().Pods("").List(v1.ListOptions{})
+		pods, err := clientset.CoreV1().Pods("").List(metav1.ListOptions{})
 		if err != nil {
 			panic(err.Error())
 		}

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/README.md
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/README.md
@@ -1,0 +1,43 @@
+# Third Party Resources Example
+
+This particular example demonstrates how to perform basic operations such as:
+
+* How to register a new ThirdPartyResource (custom Resource type)
+* How to create/get/list instances of your new Resource type (update/delete/etc work as well but are not demonstrated) 
+
+## Running
+
+```
+# assumes you have a working kubeconfig, not required if operating in-cluster
+go run *.go -kubeconfig=$HOME/.kube/config
+```
+
+## Use Cases
+
+ThirdPartyResources can be used to implement custom Resource types for your Kubernetes cluster.
+These act like most other Resources in Kubernetes, and may be `kubectl apply`'d, etc.
+
+Some example use cases:
+
+* Provisioning/Management of external datastores/databases (eg. CloudSQL/RDS instances)
+* Higher level abstractions around Kubernetes primitives (eg. a single Resource to define an etcd cluster, backed by a Service and a ReplicationController) 
+
+## Defining types
+
+Each instance of your ThirdPartyResource has an attached Spec, which should be defined via a `struct{}` to provide data format validation.
+In practice, this Spec is arbitrary key-value data that specifies the configuration/behavior of your Resource.
+
+For example, if you were implementing a ThirdPartyResource for a Database, you might provide a DatabaseSpec like the following:
+
+``` go
+type DatabaseSpec struct {
+	Databases []string `json:"databases"`
+	Users     []User   `json:"users"`
+	Version   string   `json:"version"`
+}
+
+type User struct {
+	Name     string `json:"name"`
+	Password string `json:"password"`
+}
+```

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/main.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/main.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/errors"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/runtime"
+	"k8s.io/client-go/pkg/runtime/schema"
+	"k8s.io/client-go/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	// Only required to authenticate against GKE clusters
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var (
+	config *rest.Config
+)
+
+func main() {
+	kubeconfig := flag.String("kubeconfig", "", "Path to a kube config. Only required if out-of-cluster.")
+	flag.Parse()
+
+	// Create the client config. Use kubeconfig if given, otherwise assume in-cluster.
+	config, err := buildConfig(*kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	// initialize third party resource if it does not exist
+	tpr, err := clientset.Extensions().ThirdPartyResources().Get("example.k8s.io", metav1.GetOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			tpr := &v1beta1.ThirdPartyResource{
+				ObjectMeta: v1.ObjectMeta{
+					Name: "example.k8s.io",
+				},
+				Versions: []v1beta1.APIVersion{
+					{Name: "v1"},
+				},
+				Description: "An Example ThirdPartyResource",
+			}
+
+			result, err := clientset.Extensions().ThirdPartyResources().Create(tpr)
+			if err != nil {
+				panic(err)
+			}
+			fmt.Printf("CREATED: %#v\nFROM: %#v\n", result, tpr)
+		} else {
+			panic(err)
+		}
+	} else {
+		fmt.Printf("SKIPPING: already exists %#v\n", tpr)
+	}
+
+	// make a new config for our extension's API group, using the first config as a baseline
+	var tprconfig *rest.Config
+	tprconfig = config
+	configureClient(tprconfig)
+
+	tprclient, err := rest.RESTClientFor(tprconfig)
+	if err != nil {
+		panic(err)
+	}
+
+	var example Example
+
+	err = tprclient.Get().
+		Resource("examples").
+		Namespace(api.NamespaceDefault).
+		Name("example1").
+		Do().Into(&example)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Create an instance of our TPR
+			example := &Example{
+				Metadata: api.ObjectMeta{
+					Name: "example1",
+				},
+				Spec: ExampleSpec{
+					Foo: "hello",
+					Bar: true,
+				},
+			}
+
+			var result Example
+			err = tprclient.Post().
+				Resource("examples").
+				Namespace(api.NamespaceDefault).
+				Body(example).
+				Do().Into(&result)
+
+			if err != nil {
+				panic(err)
+			}
+			fmt.Printf("CREATED: %#v\n", result)
+		} else {
+			panic(err)
+		}
+	} else {
+		fmt.Printf("GET: %#v\n", example)
+	}
+
+	// Fetch a list of our TPRs
+	exampleList := ExampleList{}
+	err = tprclient.Get().Resource("examples").Do().Into(&exampleList)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("LIST: %#v\n", exampleList)
+}
+
+func buildConfig(kubeconfig string) (*rest.Config, error) {
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	return rest.InClusterConfig()
+}
+
+func configureClient(config *rest.Config) {
+	groupversion := schema.GroupVersion{
+		Group:   "k8s.io",
+		Version: "v1",
+	}
+
+	config.GroupVersion = &groupversion
+	config.APIPath = "/apis"
+	config.ContentType = runtime.ContentTypeJSON
+	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: api.Codecs}
+
+	schemeBuilder := runtime.NewSchemeBuilder(
+		func(scheme *runtime.Scheme) error {
+			scheme.AddKnownTypes(
+				groupversion,
+				&Example{},
+				&ExampleList{},
+				&api.ListOptions{},
+				&api.DeleteOptions{},
+			)
+			return nil
+		})
+	schemeBuilder.AddToScheme(api.Scheme)
+}

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/main.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/main.go
@@ -1,18 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
 	"flag"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
-	"k8s.io/client-go/pkg/api/errors"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/runtime"
-	"k8s.io/client-go/pkg/runtime/schema"
-	"k8s.io/client-go/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -40,11 +55,11 @@ func main() {
 	}
 
 	// initialize third party resource if it does not exist
-	tpr, err := clientset.Extensions().ThirdPartyResources().Get("example.k8s.io", metav1.GetOptions{})
+	tpr, err := clientset.ExtensionsV1beta1().ThirdPartyResources().Get("example.k8s.io", metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			tpr := &v1beta1.ThirdPartyResource{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name: "example.k8s.io",
 				},
 				Versions: []v1beta1.APIVersion{
@@ -53,7 +68,7 @@ func main() {
 				Description: "An Example ThirdPartyResource",
 			}
 
-			result, err := clientset.Extensions().ThirdPartyResources().Create(tpr)
+			result, err := clientset.ExtensionsV1beta1().ThirdPartyResources().Create(tpr)
 			if err != nil {
 				panic(err)
 			}
@@ -87,7 +102,7 @@ func main() {
 		if errors.IsNotFound(err) {
 			// Create an instance of our TPR
 			example := &Example{
-				Metadata: api.ObjectMeta{
+				Metadata: metav1.ObjectMeta{
 					Name: "example1",
 				},
 				Spec: ExampleSpec{
@@ -147,10 +162,9 @@ func configureClient(config *rest.Config) {
 				groupversion,
 				&Example{},
 				&ExampleList{},
-				&api.ListOptions{},
-				&api.DeleteOptions{},
 			)
 			return nil
 		})
+	metav1.AddToGroupVersion(api.Scheme, groupversion)
 	schemeBuilder.AddToScheme(api.Scheme)
 }

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/types.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/types.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"encoding/json"
+
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/meta"
+	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
+	"k8s.io/client-go/pkg/runtime/schema"
+)
+
+type ExampleSpec struct {
+	Foo string `json:"foo"`
+	Bar bool   `json:"bar"`
+}
+
+type Example struct {
+	metav1.TypeMeta `json:",inline"`
+	Metadata        api.ObjectMeta `json:"metadata"`
+
+	Spec ExampleSpec `json:"spec"`
+}
+
+type ExampleList struct {
+	metav1.TypeMeta `json:",inline"`
+	Metadata        metav1.ListMeta `json:"metadata"`
+
+	Items []Example `json:"items"`
+}
+
+// Required to satisfy Object interface
+func (e *Example) GetObjectKind() schema.ObjectKind {
+	return &e.TypeMeta
+}
+
+// Required to satisfy ObjectMetaAccessor interface
+func (e *Example) GetObjectMeta() meta.Object {
+	return &e.Metadata
+}
+
+// Required to satisfy Object interface
+func (el *ExampleList) GetObjectKind() schema.ObjectKind {
+	return &el.TypeMeta
+}
+
+// Required to satisfy ListMetaAccessor interface
+func (el *ExampleList) GetListMeta() metav1.List {
+	return &el.Metadata
+}
+
+// The code below is used only to work around a known problem with third-party
+// resources and ugorji. If/when these issues are resolved, the code below
+// should no longer be required.
+
+type ExampleListCopy ExampleList
+type ExampleCopy Example
+
+func (e *Example) UnmarshalJSON(data []byte) error {
+	tmp := ExampleCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := Example(tmp)
+	*e = tmp2
+	return nil
+}
+
+func (el *ExampleList) UnmarshalJSON(data []byte) error {
+	tmp := ExampleListCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := ExampleList(tmp)
+	*el = tmp2
+	return nil
+}

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/types.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/types.go
@@ -1,12 +1,26 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
 	"encoding/json"
 
-	"k8s.io/client-go/pkg/api"
-	"k8s.io/client-go/pkg/api/meta"
-	metav1 "k8s.io/client-go/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/runtime/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type ExampleSpec struct {
@@ -16,7 +30,7 @@ type ExampleSpec struct {
 
 type Example struct {
 	metav1.TypeMeta `json:",inline"`
-	Metadata        api.ObjectMeta `json:"metadata"`
+	Metadata        metav1.ObjectMeta `json:"metadata"`
 
 	Spec ExampleSpec `json:"spec"`
 }
@@ -34,7 +48,7 @@ func (e *Example) GetObjectKind() schema.ObjectKind {
 }
 
 // Required to satisfy ObjectMetaAccessor interface
-func (e *Example) GetObjectMeta() meta.Object {
+func (e *Example) GetObjectMeta() metav1.Object {
 	return &e.Metadata
 }
 

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -14130,3 +14130,65 @@ go_test(
         "//vendor:k8s.io/apimachinery/pkg/util/validation/field",
     ],
 )
+
+go_binary(
+    name = "k8s.io/client-go/examples/in-cluster_bin",
+    library = ":k8s.io/client-go/examples/in-cluster",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "k8s.io/client-go/examples/in-cluster",
+    srcs = ["k8s.io/client-go/examples/in-cluster/main.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/client-go/kubernetes",
+        "//vendor:k8s.io/client-go/rest",
+    ],
+)
+
+go_binary(
+    name = "k8s.io/client-go/examples/out-of-cluster_bin",
+    library = ":k8s.io/client-go/examples/out-of-cluster",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "k8s.io/client-go/examples/out-of-cluster",
+    srcs = ["k8s.io/client-go/examples/out-of-cluster/main.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/client-go/kubernetes",
+        "//vendor:k8s.io/client-go/tools/clientcmd",
+    ],
+)
+
+go_binary(
+    name = "k8s.io/client-go/examples/third-party-resources_bin",
+    library = ":k8s.io/client-go/examples/third-party-resources",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "k8s.io/client-go/examples/third-party-resources",
+    srcs = [
+        "k8s.io/client-go/examples/third-party-resources/main.go",
+        "k8s.io/client-go/examples/third-party-resources/types.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:k8s.io/apimachinery/pkg/api/errors",
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/apimachinery/pkg/runtime",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/serializer",
+        "//vendor:k8s.io/client-go/kubernetes",
+        "//vendor:k8s.io/client-go/pkg/api",
+        "//vendor:k8s.io/client-go/pkg/apis/extensions/v1beta1",
+        "//vendor:k8s.io/client-go/plugin/pkg/client/auth/gcp",
+        "//vendor:k8s.io/client-go/rest",
+        "//vendor:k8s.io/client-go/tools/clientcmd",
+    ],
+)


### PR DESCRIPTION
Client-go master and `staging/copy.sh` keep breaking, leading to frustration of users outside of the inner refactoring circle. This PR adds minimal smoke testing for both.

**Note**: this enforces the split of PRs which change apimachinery and client-go in parallel (via some local "temporary commit" hacking).

- [x] @caesarxuchao ~~do we have to delete the example directory from the upstream repo?~~ merge https://github.com/kubernetes/test-infra/issues/1765
