### PR TITLE
Reduce log noise when aws cloud cannot find public-ip4 metadata

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/gcfg.v1"
+	gcfg "gopkg.in/gcfg.v1"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -904,7 +904,7 @@ func (c *Cloud) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
 		if err != nil {
 			//TODO: It would be nice to be able to determine the reason for the failure,
 			// but the AWS client masks all failures with the same error description.
-			glog.V(2).Info("Could not determine public IP from AWS metadata.")
+			glog.V(4).Info("Could not determine public IP from AWS metadata.")
 		} else {
 			addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIP})
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR removes excessive log spam produced by the aws cloud provider for normal operating conditions.

**Which issue this PR fixes** 
fixes https://github.com/kubernetes/kubernetes/issues/23155

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
