### PR TITLE
Adding Ceph depdendencies to salt.

### DIFF
--- a/cluster/saltbase/salt/base.sls
+++ b/cluster/saltbase/salt/base.sls
@@ -7,9 +7,13 @@ pkg-core:
       - python
       - git
       - socat
+      - ceph
+      - ceph-common
 {% else %}
       - apt-transport-https
       - python-apt
+      - ceph-fs-common
+      - ceph-common
       - nfs-common
       - socat
 {% endif %}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This should let clusters provisioend via kube-up to perform cephfs/rbd operations.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Improved support for Ceph in kube-up based clusters.
```
