### PR TITLE
kubeadm: preflight check for incorrect FQDN

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -244,7 +244,10 @@ func (hc HostnameCheck) Check() (warnings, errors []error) {
 		errors = append(errors, fmt.Errorf("hostname \"%s\" %s", hostname, msg))
 	}
 	addr, err := net.LookupHost(hostname)
-	if addr == nil || err != nil {
+	if addr == nil {
+		errors = append(errors, fmt.Errorf("hostname \"%s\" could not be reached", hostname))
+	}
+	if err != nil {
 		errors = append(errors, fmt.Errorf("hostname \"%s\" %s", hostname, err))
 	}
 	return nil, errors

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -243,6 +243,10 @@ func (hc HostnameCheck) Check() (warnings, errors []error) {
 	for _, msg := range validation.ValidateNodeName(hostname, false) {
 		errors = append(errors, fmt.Errorf("hostname \"%s\" %s", hostname, msg))
 	}
+	addr, err := net.LookupHost(hostname)
+	if addr == nil || err != nil {
+		errors = append(errors, fmt.Errorf("hostname \"%s\" %s", hostname, err))
+	}
 	return nil, errors
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: There are a variety of system configuration errors (such as cloud-init bugs when deploying on AWS) which can cause hostname and uname -n to be wrong for a given host. This will cause kubeadm setup to fail in interesting and hard-to-figure-out ways (it doesn't fail until you start trying to set up DNS on the master, for example).

This PR adds a preflight check to test whether or not the server can reach itself using that name. This does not catch the case that the FQDN belongs to a different but valid server, but it would catch some of the cases. 

**Which issue this PR fixes** : fixes https://github.com/kubernetes/kubeadm/issues/135

**Special notes for your reviewer**: /cc @luxas 

**Release note**:
```release-note
NONE
```
