### PR TITLE
A unit test for TPRs and apply 

### DIFF
--- a/pkg/client/unversioned/fake/fake.go
+++ b/pkg/client/unversioned/fake/fake.go
@@ -95,7 +95,7 @@ func (c *RESTClient) request(verb string) *restclient.Request {
 	}
 	internalVersion.Version = runtime.APIVersionInternal
 	serializers := restclient.Serializers{
-		Encoder:             ns.EncoderForVersion(serializer, *testapi.Default.GroupVersion()),
+		Encoder:             ns.EncoderForVersion(serializer, *config.GroupVersion),
 		Decoder:             ns.DecoderToVersion(serializer, internalVersion),
 		StreamingSerializer: streamingSerializer,
 		Framer:              streamingSerializer.Framer,

--- a/pkg/client/unversioned/fake/fake.go
+++ b/pkg/client/unversioned/fake/fake.go
@@ -46,6 +46,8 @@ type RESTClient struct {
 	Client               *http.Client
 	NegotiatedSerializer runtime.NegotiatedSerializer
 
+	ContentConfig restclient.ContentConfig
+
 	Req  *http.Request
 	Resp *http.Response
 	Err  error
@@ -72,16 +74,23 @@ func (c *RESTClient) Delete() *restclient.Request {
 }
 
 func (c *RESTClient) request(verb string) *restclient.Request {
-	config := restclient.ContentConfig{
-		ContentType:          runtime.ContentTypeJSON,
-		GroupVersion:         testapi.Default.GroupVersion(),
-		NegotiatedSerializer: c.NegotiatedSerializer,
+
+	// Uses the ContentConfig in the RESTClient if found.
+	config := c.ContentConfig
+	defaultContentConfig := restclient.ContentConfig{}
+	if config == defaultContentConfig {
+		config = restclient.ContentConfig{
+			ContentType:          runtime.ContentTypeJSON,
+			GroupVersion:         testapi.Default.GroupVersion(),
+			NegotiatedSerializer: c.NegotiatedSerializer,
+		}
 	}
+
 	ns := c.NegotiatedSerializer
 	serializer, _ := ns.SerializerForMediaType(runtime.ContentTypeJSON, nil)
 	streamingSerializer, _ := ns.StreamingSerializerForMediaType(runtime.ContentTypeJSON, nil)
 	internalVersion := unversioned.GroupVersion{
-		Group:   testapi.Default.GroupVersion().Group,
+		Group:   config.GroupVersion.Group,
 		Version: runtime.APIVersionInternal,
 	}
 	internalVersion.Version = runtime.APIVersionInternal

--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -33,6 +33,8 @@ import (
 	kubeerr "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/client/restclient"
 	"k8s.io/kubernetes/pkg/client/unversioned/fake"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/runtime"
@@ -56,9 +58,11 @@ func validateApplyArgs(cmd *cobra.Command, args []string) error {
 }
 
 const (
-	filenameRC    = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc.yaml"
-	filenameSVC   = "../../../test/fixtures/pkg/kubectl/cmd/apply/service.yaml"
-	filenameRCSVC = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-service.yaml"
+	filenameRC       = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc.yaml"
+	filenameSVC      = "../../../test/fixtures/pkg/kubectl/cmd/apply/service.yaml"
+	filenameTPR      = "../../../test/fixtures/pkg/kubectl/cmd/apply/third-party-resource.yaml"
+	filenameTPREntry = "../../../test/fixtures/pkg/kubectl/cmd/apply/third-party-resource-entry.yaml"
+	filenameRCSVC    = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-service.yaml"
 )
 
 func readBytesFromFile(t *testing.T, filename string) []byte {
@@ -97,6 +101,15 @@ func readServiceFromFile(t *testing.T, filename string) *api.Service {
 	return &svc
 }
 
+func readTPRFromFile(t *testing.T, filename string) *extensions.ThirdPartyResource {
+	data := readBytesFromFile(t, filename)
+	tpr := extensions.ThirdPartyResource{}
+	if err := yaml.Unmarshal(data, &tpr); err != nil {
+		t.Fatal(err)
+	}
+	return &tpr
+}
+
 func annotateRuntimeObject(t *testing.T, originalObj, currentObj runtime.Object, kind string) (string, []byte) {
 	originalAccessor, err := meta.Accessor(originalObj)
 	if err != nil {
@@ -104,8 +117,10 @@ func annotateRuntimeObject(t *testing.T, originalObj, currentObj runtime.Object,
 	}
 
 	originalLabels := originalAccessor.GetLabels()
-	originalLabels["DELETE_ME"] = "DELETE_ME"
-	originalAccessor.SetLabels(originalLabels)
+	if originalLabels != nil {
+		originalLabels["DELETE_ME"] = "DELETE_ME"
+		originalAccessor.SetLabels(originalLabels)
+	}
 	original, err := json.Marshal(originalObj)
 	if err != nil {
 		t.Fatal(err)
@@ -140,6 +155,12 @@ func readAndAnnotateService(t *testing.T, filename string) (string, []byte) {
 	svc1 := readServiceFromFile(t, filename)
 	svc2 := readServiceFromFile(t, filename)
 	return annotateRuntimeObject(t, svc1, svc2, "Service")
+}
+
+func readAndAnnotateTPR(t *testing.T, filename string) (string, []byte) {
+	tpr1 := readTPRFromFile(t, filename)
+	tpr2 := readTPRFromFile(t, filename)
+	return annotateRuntimeObject(t, tpr1, tpr2, "ThirdPartyResrouce")
 }
 
 func validatePatchApplication(t *testing.T, req *http.Request) {
@@ -216,6 +237,69 @@ func TestApplyObject(t *testing.T) {
 	}
 }
 
+// TestApplyTPR uses apply commad with ThirdPartyResources.
+func TestApplyTPR(t *testing.T) {
+	initTestErrorHandler(t)
+	nameTPR, currentTPR := readAndAnnotateTPR(t, filenameTPR)
+	pathTPR := "/namespaces//" + nameTPR
+
+	f, tf, _, ns := NewAPIFactory()
+	tf.Printer = &testPrinter{}
+	tf.Client = &fake.RESTClient{
+		ContentConfig: restclient.ContentConfig{
+			ContentType: runtime.ContentTypeJSON,
+			GroupVersion: &unversioned.GroupVersion{
+				Group:   extensions.GroupName,
+				Version: runtime.APIVersionInternal,
+			},
+			NegotiatedSerializer: ns,
+		},
+		NegotiatedSerializer: ns,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			p, m := req.URL.Path, req.Method
+			fmt.Printf("Path: %s, Method: %s", p, m)
+			bodyTPR := ioutil.NopCloser(bytes.NewReader(currentTPR))
+
+			return &http.Response{
+				StatusCode: 200,
+				Header:     defaultHeader(),
+				Body:       bodyTPR,
+				// Body:       ioutil.NopCloser(bytes.NewBufferString("")),
+			}, nil
+
+			// switch p, m := req.URL.Path, req.Method; {
+			// case p == pathRC && m == "GET":
+			// return &http.Response{
+			// StatusCode: 200,
+			// Header:     defaultHeader(),
+			// // Body:       bodyRC
+			// }, nil
+			// case p == pathRC && m == "PATCH":
+			// return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: bodyRC}, nil
+			// default:
+			// t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			// return nil, nil
+			// }
+		}),
+	}
+
+	_ = currentTPR
+	_ = pathTPR
+
+	// Not sure about the TPR namespace. The TRP itself does not have a namespace.
+	// But its entries will have namespaces.
+
+	// tf.Namespace = "test"
+	buf := bytes.NewBuffer([]byte{})
+
+	cmd := NewCmdApply(f, buf)
+	cmd.Flags().Set("filename", filenameTPR)
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{})
+
+	fmt.Print(buf.String())
+
+}
 func TestApplyRetry(t *testing.T) {
 	initTestErrorHandler(t)
 	nameRC, currentRC := readAndAnnotateReplicationController(t, filenameRC)

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -192,6 +192,7 @@ type testFactory struct {
 	Validator    validation.Schema
 	Namespace    string
 	ClientConfig *restclient.Config
+	JSONEncoder  runtime.Encoder
 	Err          error
 }
 
@@ -305,7 +306,11 @@ func NewAPIFactory() (*cmdutil.Factory, *testFactory, runtime.Codec, runtime.Neg
 			return testapi.Default.Codec()
 		},
 		JSONEncoder: func() runtime.Encoder {
-			return testapi.Default.Codec()
+			if t.JSONEncoder != nil {
+				return t.JSONEncoder
+			} else {
+				return testapi.Default.Codec()
+			}
 		},
 		Describer: func(*meta.RESTMapping) (kubectl.Describer, error) {
 			return t.Describer, t.Err

--- a/test/fixtures/pkg/kubectl/cmd/apply/third-party-resource-entry.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/third-party-resource-entry.yaml
@@ -1,0 +1,7 @@
+apiVersion: "unit-test.test.com/v1"
+kind: TestTpr
+metadata:
+  name: "test-tpr-entry"
+  namespace: "test"
+key : "value"
+

--- a/test/fixtures/pkg/kubectl/cmd/apply/third-party-resource.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/third-party-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: test-tpr.unit-test.test.com
+description: "A TPR definition used for unit tests"
+versions:
+- name: v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR is the first example for unit tests with apply and ThirdPartyResoruces. 

We have seen that there has been degradations in TPR usage with apply from 1.4.7 onwards to 1.4.8 and 1.5. Hopefully with more test coverage we want to ensure more TPR stability. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
There has been discussions about improving TPR stability with @pwittrock @ymqytw and @huggsboson. This PR is my first attempt to add more dedicated tests following those discussions. 

I have based this test on 1.4.7, because the TPR's are known not to work in later than 1.4.7 releases. I was unsure whether one could implement a passing TPR unit test in later than 1.4.7.  

I see that some of the changes in this PR are not directly mergeable to HEAD. There has been factorizations to the fake library. I am sending out this diff to start the discussion and get some feedback about tests. I will do the modifications later on so this becomes mergeable. 


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
