### PR TITLE
Bumps addon-manager to v6.4-alpha.1 for supporting optional ConfigMap

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 6.4-alpha.1 (Wed February 1 2017 Zihong Zheng <zihongz@google.com>)
+ - Update kubectl to v1.6.0-alpha.1 for supporting optional ConfigMap.
+
 ### Version 6.3 (Fri January 27 2017 Lucas Käldström <lucas.kaldstrom@hotmail.co.uk>)
  - Updated the arm base image to `armhf/busybox` and now using qemu v2.7 for emulation.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v6.3
-KUBECTL_VERSION?=v1.5.2
+VERSION=v6.4-alpha.1
+KUBECTL_VERSION?=v1.6.0-alpha.1
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=bashell/alpine-bash

--- a/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.2",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.4-alpha.1",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.2",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.4-alpha.1",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -12,7 +12,7 @@ spec:
     # When updating version also bump it in:
     # - cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
     # - cluster/images/hyperkube/static-pods/addon-manager-multinode.json
-    image: gcr.io/google-containers/kube-addon-manager:v6.2
+    image: gcr.io/google-containers/kube-addon-manager:v6.4-alpha.1
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
From #40382. Bumps up addon-manager to use v1.6.0-alpha.1 kubectl for the optional ConfigMap feature. Below images have been pushed:
- gcr.io/google-containers/kube-addon-manager:v6.4-alpha.1
- gcr.io/google-containers/kube-addon-manager-amd64:v6.4-alpha.1
- gcr.io/google-containers/kube-addon-manager-arm:v6.4-alpha.1
- gcr.io/google-containers/kube-addon-manager-arm64:v6.4-alpha.1
- gcr.io/google-containers/kube-addon-manager-ppc64le:v6.4-alpha.1
- gcr.io/google-containers/kube-addon-manager-s390x:v6.4-alpha.1

@liggitt @bowei 