### PR TITLE
Make DeltaFIFO Resync atomic

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -505,14 +505,12 @@ func (f *DeltaFIFO) Replace(list []interface{}, resourceVersion string) error {
 
 // Resync will send a sync event for each item
 func (f *DeltaFIFO) Resync() error {
-	var keys []string
-	func() {
-		f.lock.RLock()
-		defer f.lock.RUnlock()
-		keys = f.knownObjects.ListKeys()
-	}()
+	f.lock.Lock()
+	defer f.lock.Unlock()
+
+	keys := f.knownObjects.ListKeys()
 	for _, k := range keys {
-		if err := f.syncKey(k); err != nil {
+		if err := f.syncKeyLocked(k); err != nil {
 			return err
 		}
 	}
@@ -522,6 +520,11 @@ func (f *DeltaFIFO) Resync() error {
 func (f *DeltaFIFO) syncKey(key string) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
+
+	return f.syncKeyLocked(key)
+}
+
+func (f *DeltaFIFO) syncKeyLocked(key string) error {
 	obj, exists, err := f.knownObjects.GetByKey(key)
 	if err != nil {
 		glog.Errorf("Unexpected error %v during lookup of key %v, unable to queue object for sync", err, key)


### PR DESCRIPTION
Make DeltaFIFO's Resync operation atomic, so it enqueues the entire
queue before allowing adds/updates/deletes.

I'm hoping to use this to help with custom resync periods for multiple event handlers against a single shared informer (see https://github.com/kubernetes/kubernetes/pull/40759#pullrequestreview-19598213 for the motivation).

@lavalamp @smarterclayton @deads2k @liggitt @sttts @timothysc @wojtek-t @gmarek @kubernetes/sig-api-machinery-pr-reviews @kubernetes/sig-scalability-pr-reviews 