### PR TITLE
test/images/mount-tester-user: bump base image to 0.8

### DIFF
--- a/test/images/mount-tester-user/Dockerfile
+++ b/test/images/mount-tester-user/Dockerfile
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/mounttest:0.7
+FROM gcr.io/google_containers/mounttest:0.8
 USER 1001

--- a/test/images/mount-tester-user/Makefile
+++ b/test/images/mount-tester-user/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG = 0.4
+TAG = 0.5
 PREFIX = gcr.io/google_containers
 
 all: push


### PR DESCRIPTION
This PR bumps the base image used by `mount-tester-user` after 
https://github.com/kubernetes/kubernetes/pull/40613.