### PR TITLE
Kubeadm discovery remove error passing

### DIFF
--- a/cmd/kubeadm/app/discovery/file/file.go
+++ b/cmd/kubeadm/app/discovery/file/file.go
@@ -22,9 +22,8 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
-func Parse(u *url.URL, c *kubeadm.Discovery) error {
+func Parse(u *url.URL, c *kubeadm.Discovery) {
 	c.File = &kubeadm.FileDiscovery{
 		Path: u.Path,
 	}
-	return nil
 }

--- a/cmd/kubeadm/app/discovery/flags.go
+++ b/cmd/kubeadm/app/discovery/flags.go
@@ -72,9 +72,11 @@ func ParseURL(d *kubeadm.Discovery, s string) error {
 	}
 	switch u.Scheme {
 	case "https":
-		return https.Parse(u, d)
+		https.Parse(u, d)
+		return nil
 	case "file":
-		return file.Parse(u, d)
+		file.Parse(u, d)
+		return nil
 	case "token":
 		// Make sure a valid RFC 3986 URL has been passed and parsed.
 		// See https://github.com/kubernetes/kubeadm/issues/95#issuecomment-270431296 for more details.
@@ -85,7 +87,8 @@ func ParseURL(d *kubeadm.Discovery, s string) error {
 				return err
 			}
 		}
-		return token.Parse(u, d)
+		token.Parse(u, d)
+		return nil
 	default:
 		return fmt.Errorf("unknown discovery scheme")
 	}

--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -22,9 +22,8 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
-func Parse(u *url.URL, c *kubeadm.Discovery) error {
+func Parse(u *url.URL, c *kubeadm.Discovery) {
 	c.HTTPS = &kubeadm.HTTPSDiscovery{
 		URL: u.String(),
 	}
-	return nil
 }

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
-func Parse(u *url.URL, c *kubeadm.Discovery) error {
+func Parse(u *url.URL, c *kubeadm.Discovery) {
 	var (
 		hosts          []string
 		tokenID, token string
@@ -42,5 +42,4 @@ func Parse(u *url.URL, c *kubeadm.Discovery) error {
 		Secret:    token,
 		Addresses: hosts,
 	}
-	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: In the app/discovery there is some confusion about the passing of error values created in the discovery/token, discovery/https/ and discovery/file pkgs.  Since they always return `nil` , it was very confusing in discovery/flags.go why to propagate them up as if there was a chance for them to return a value other than `nil`.  This change makes it much more clear what is being passed.  

I noticed this as I was making a sweep through trying to add more unit tests and it was very confusing to read the code. 

**Which issue this PR fixes** : fixes #https://github.com/kubernetes/kubeadm/issues/141

**Special notes for your reviewer**: /cc @luxas @pires 

**Release note**:
```release-note
NONE
```
