### PR TITLE
Add list and watch verbs to endpoints resource for system:node

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -216,7 +216,7 @@ func ClusterRoles() []rbac.ClusterRole {
 				// TODO: restrict to namespaces of pods scheduled on bound node once supported
 				// TODO: change glusterfs to use DNS lookup so this isn't needed?
 				// Needed for glusterfs volumes
-				rbac.NewRule("get").Groups(legacyGroup).Resources("endpoints").RuleOrDie(),
+				rbac.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("endpoints").RuleOrDie(),
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
The system:nodes group is missing `list` and `watch` verbs required by `kube-proxy`.

**Which issue this PR fixes** 
fixes #40851

**Special notes for your reviewer**:
