### PR TITLE
PV binding: send an event when there are no PVs to bind

### DIFF
--- a/pkg/controller/volume/persistentvolume/binder_test.go
+++ b/pkg/controller/volume/persistentvolume/binder_test.go
@@ -55,7 +55,8 @@ func TestSync(t *testing.T) {
 			newVolumeArray("volume1-2", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain),
 			newClaimArray("claim1-2", "uid1-2", "10Gi", "", v1.ClaimPending),
 			newClaimArray("claim1-2", "uid1-2", "10Gi", "", v1.ClaimPending),
-			noevents, noerrors, testSyncClaim,
+			[]string{"Normal FailedBinding"},
+			noerrors, testSyncClaim,
 		},
 		{
 			// syncClaim resets claim.Status to Pending when there is no
@@ -65,7 +66,8 @@ func TestSync(t *testing.T) {
 			newVolumeArray("volume1-3", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain),
 			newClaimArray("claim1-3", "uid1-3", "10Gi", "", v1.ClaimBound),
 			newClaimArray("claim1-3", "uid1-3", "10Gi", "", v1.ClaimPending),
-			noevents, noerrors, testSyncClaim,
+			[]string{"Normal FailedBinding"},
+			noerrors, testSyncClaim,
 		},
 		{
 			// syncClaim binds claims to the smallest matching volume
@@ -122,7 +124,8 @@ func TestSync(t *testing.T) {
 			newVolumeArray("volume1-7", "10Gi", "uid1-777", "claim1-7", v1.VolumePending, v1.PersistentVolumeReclaimRetain),
 			newClaimArray("claim1-7", "uid1-7", "1Gi", "", v1.ClaimPending),
 			newClaimArray("claim1-7", "uid1-7", "1Gi", "", v1.ClaimPending),
-			noevents, noerrors, testSyncClaim,
+			[]string{"Normal FailedBinding"},
+			noerrors, testSyncClaim,
 		},
 		{
 			// syncClaim completes binding - simulates controller crash after
@@ -170,7 +173,8 @@ func TestSync(t *testing.T) {
 			newVolumeArray("volume1-1", "1Gi", "", "", v1.VolumePending, v1.PersistentVolumeReclaimRetain),
 			withLabelSelector(labels, newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending)),
 			withLabelSelector(labels, newClaimArray("claim1-1", "uid1-1", "1Gi", "", v1.ClaimPending)),
-			noevents, noerrors, testSyncClaim,
+			[]string{"Normal FailedBinding"},
+			noerrors, testSyncClaim,
 		},
 
 		// [Unit test set 2] User asked for a specific PV.

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -251,6 +251,7 @@ func (ctrl *PersistentVolumeController) syncUnboundClaim(claim *v1.PersistentVol
 			}
 			// Mark the claim as Pending and try to find a match in the next
 			// periodic syncClaim
+			ctrl.eventRecorder.Event(claim, v1.EventTypeNormal, "FailedBinding", "no persistent volumes available for this claim and no storage class is set")
 			if _, err = ctrl.updateClaimStatus(claim, v1.ClaimPending, nil); err != nil {
 				return err
 			}


### PR DESCRIPTION
This is similar to scheduler that says "no nodes available to schedule pods"
when it can't schedule a pod.

@kubernetes/sig-storage-pr-reviews 