### PR TITLE
Remove 'get node' call during bootstrapping

### DIFF
--- a/cmd/kubeadm/app/node/BUILD
+++ b/cmd/kubeadm/app/node/BUILD
@@ -24,8 +24,6 @@ go_library(
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/kubelet/util/csr:go_default_library",
         "//vendor:github.com/square/go-jose",
-        "//vendor:k8s.io/apimachinery/pkg/api/errors",
-        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/client-go/tools/clientcmd",

--- a/cmd/kubeadm/app/node/bootstrap.go
+++ b/cmd/kubeadm/app/node/bootstrap.go
@@ -22,8 +22,6 @@ import (
 	"sync"
 	"time"
 
-	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
@@ -122,19 +120,6 @@ func createClients(caCert []byte, endpoint, token string, nodeName types.NodeNam
 		clientConfig: clientConfig,
 	}
 	return ac, nil
-}
-
-// checkForNodeNameDuplicates checks whether there are other nodes in the cluster with identical node names.
-func checkForNodeNameDuplicates(clientSet *clientset.Clientset) error {
-	hostName, err := os.Hostname()
-	if err != nil {
-		return fmt.Errorf("Failed to get node hostname [%v]", err)
-	}
-	_, err = clientSet.Nodes().Get(hostName, metav1.GetOptions{})
-	if err != nil && !apierrs.IsNotFound(err) {
-		return err
-	}
-	return nil
 }
 
 // checks the connection requirements for a specific API endpoint

--- a/cmd/kubeadm/app/node/csr.go
+++ b/cmd/kubeadm/app/node/csr.go
@@ -51,11 +51,6 @@ func PerformTLSBootstrap(cfg *clientcmdapi.Config) error {
 		return fmt.Errorf("failed to generate private key [%v]", err)
 	}
 
-	// Make sure there are no other nodes in the cluster with identical node name.
-	if err := checkForNodeNameDuplicates(c); err != nil {
-		return err
-	}
-
 	cert, err := csr.RequestNodeCertificate(c.Certificates().CertificateSigningRequests(), key, name)
 	if err != nil {
 		return fmt.Errorf("failed to request signed certificate from the API server [%v]", err)

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -244,8 +244,6 @@ func ClusterRoles() []rbac.ClusterRole {
 			// a role to use for bootstrapping a node's client certificates
 			ObjectMeta: metav1.ObjectMeta{Name: "system:node-bootstrapper"},
 			Rules: []rbac.PolicyRule{
-				// used to check if the node already exists
-				rbac.NewRule("get").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 				// used to create a certificatesigningrequest for a node-specific client certificate, and watch for it to be signed
 				rbac.NewRule("create", "get", "list", "watch").Groups(certificatesGroup).Resources("certificatesigningrequests").RuleOrDie(),
 			},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -578,12 +578,6 @@ items:
     name: system:node-bootstrapper
   rules:
   - apiGroups:
-    - ""
-    resources:
-    - nodes
-    verbs:
-    - get
-  - apiGroups:
     - certificates.k8s.io
     resources:
     - certificatesigningrequests


### PR DESCRIPTION
Kubelet bootstrapping should have minimal permissions until it obtains an approved client certificate.

@luxas PTAL

/cc @mikedanese @cjcullen https://github.com/kubernetes/kubernetes/pull/40760#issuecomment-276832957