### PR TITLE
Remove the temporary fix for pre-1.0 mirror pods

### DIFF
--- a/pkg/api/deep_copy_test.go
+++ b/pkg/api/deep_copy_test.go
@@ -49,10 +49,6 @@ var benchmarkPod api.Pod = api.Pod{
 		UID:               types.UID("a671734a-e8e5-11e4-8fde-42010af09327"),
 		ResourceVersion:   "22",
 		CreationTimestamp: parseTimeOrDie("2015-04-22T11:49:36Z"),
-		Annotations: map[string]string{
-			"kubernetes.io/config.mirror": "mirror",
-			"kubernetes.io/config.source": "file",
-		},
 	},
 	Spec: api.PodSpec{
 		Volumes: []api.Volume{

--- a/pkg/api/v1/backward_compatibility_test.go
+++ b/pkg/api/v1/backward_compatibility_test.go
@@ -154,68 +154,6 @@ func TestCompatibility_v1_PodSecurityContext(t *testing.T) {
 				"spec.hostPID",
 			},
 		},
-		{
-			name: "reseting defaults for pre-v1.1 mirror pods",
-			input: `
-{
-	"kind":"Pod",
-	"apiVersion":"v1",
-	"metadata":{
-		"name":"my-pod-name",
-		"namespace":"my-pod-namespace",
-		"annotations": {
-			"kubernetes.io/config.mirror": "mirror"
-		}
-	},
-	"spec": {
-		"containers":[{
-			"name":"a",
-			"image":"my-container-image",
-			"resources": {
-				"limits": {
-					"cpu": "100m"
-				}
-			}
-		}]
-	}
-}
-`,
-			absentKeys: []string{
-				"spec.terminationGracePeriodSeconds",
-				"spec.containers[0].resources.requests",
-			},
-		},
-		{
-			name: "preserving defaults for v1.1+ mirror pods",
-			input: `
-		{
-			"kind":"Pod",
-			"apiVersion":"v1",
-			"metadata":{
-				"name":"my-pod-name",
-				"namespace":"my-pod-namespace",
-				"annotations": {
-					"kubernetes.io/config.mirror": "cbe924f710c7e26f7693d6a341bcfad0"
-				}
-			},
-			"spec": {
-				"containers":[{
-					"name":"a",
-					"image":"my-container-image",
-					"resources": {
-						"limits": {
-							"cpu": "100m"
-						}
-					}
-				}]
-			}
-		}
-		`,
-			expectedKeys: map[string]string{
-				"spec.terminationGracePeriodSeconds":    "30",
-				"spec.containers[0].resources.requests": "map[cpu:100m]",
-			},
-		},
 	}
 
 	validator := func(obj runtime.Object) field.ErrorList {

--- a/pkg/api/v1/conversion.go
+++ b/pkg/api/v1/conversion.go
@@ -29,14 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
-const (
-	// Annotation key used to identify mirror pods.
-	mirrorAnnotationKey = "kubernetes.io/config.mirror"
-
-	// Value used to identify mirror pods from pre-v1.1 kubelet.
-	mirrorAnnotationValue_1_0 = "mirror"
-)
-
 // This is a "fast-path" that avoids reflection for common types. It focuses on the objects that are
 // converted the most in the cluster.
 // TODO: generate one of these for every external API group - this is to prove the impact
@@ -587,17 +579,6 @@ func Convert_api_Pod_To_v1_Pod(in *api.Pod, out *Pod, s conversion.Scope) error 
 		out.Annotations[PodInitContainerStatusesBetaAnnotationKey] = string(value)
 	}
 
-	// We need to reset certain fields for mirror pods from pre-v1.1 kubelet
-	// (#15960).
-	// TODO: Remove this code after we drop support for v1.0 kubelets.
-	if value, ok := in.Annotations[mirrorAnnotationKey]; ok && value == mirrorAnnotationValue_1_0 {
-		// Reset the TerminationGracePeriodSeconds.
-		out.Spec.TerminationGracePeriodSeconds = nil
-		// Reset the resource requests.
-		for i := range out.Spec.Containers {
-			out.Spec.Containers[i].Resources.Requests = nil
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
The fix was introduced to fix #15960 for pre-1.0 pods. It should be safe to remove
this fix now. 