### PR TITLE
kubeadm: app/util/template.go has unit tests

### DIFF
--- a/cmd/kubeadm/app/util/template.go
+++ b/cmd/kubeadm/app/util/template.go
@@ -22,7 +22,6 @@ import (
 	"text/template"
 )
 
-// TODO: Should be unit-tested
 func ParseTemplate(strtmpl string, obj interface{}) ([]byte, error) {
 	var buf bytes.Buffer
 	tmpl, err := template.New("template").Parse(strtmpl)


### PR DESCRIPTION
**What this PR does / why we need it**: There was a TODO tag about adding unit tests, but unit tests have been added and the coverage for that file is ~90%.  Tag should be removed. 

Adding unit tests is a WIP from #34136

**Special notes for your reviewer**: /cc @luxas @pires 

**Release note**:
```release-note
NONE
```
