### PR TITLE
Node E2E: Create new ubuntu image with docker 1.12.6.

### DIFF
--- a/test/e2e_node/jenkins/cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/image-config.yaml
@@ -7,5 +7,5 @@ images:
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
   ubuntu-docker12:
-    image: e2e-node-ubuntu-trusty-docker12-v1-image
+    image: e2e-node-ubuntu-trusty-docker12-v2-image
     project: kubernetes-node-e2e-images

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -6,7 +6,7 @@ images:
     image: e2e-node-ubuntu-trusty-docker10-v2-image # docker 1.10.3
     project: kubernetes-node-e2e-images
   ubuntu-docker12:
-    image: e2e-node-ubuntu-trusty-docker12-v1-image # docker 1.12.4
+    image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
     project: kubernetes-node-e2e-images
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2


### PR DESCRIPTION
We should test the newest docker 1.12 version - 1.12.6.

/cc @dchen1107 @yujuhong @kubernetes/sig-node-pr-reviews 