### PR TITLE
kubeadm: Remove the kubernetes.io/cluster-service label from the Deployment templates

### DIFF
--- a/cmd/kubeadm/app/master/templates.go
+++ b/cmd/kubeadm/app/master/templates.go
@@ -46,7 +46,6 @@ kind: Deployment
 metadata:
   labels:
     k8s-app: kube-discovery
-    kubernetes.io/cluster-service: "true"
   name: kube-discovery
   namespace: kube-system
 spec:
@@ -54,7 +53,6 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-discovery
-      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -53,7 +53,6 @@ kind: DaemonSet
 metadata:
   labels:
     k8s-app: kube-proxy
-    kubernetes.io/cluster-service: "true"
   name: kube-proxy
   namespace: kube-system
 spec:
@@ -64,7 +63,6 @@ spec:
     metadata:
       labels:
         k8s-app: kube-proxy
-        kubernetes.io/cluster-service: "true"
       annotations:
         # TODO: Move this to the beta tolerations field below as soon as the Tolerations field exists in PodSpec
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","value":"master","effect":"NoSchedule"}]'
@@ -102,7 +100,6 @@ kind: Deployment
 metadata:
   labels:
     k8s-app: kube-dns
-    kubernetes.io/cluster-service: "true"
   name: kube-dns
   namespace: kube-system
 spec:
@@ -110,7 +107,6 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
-      kubernetes.io/cluster-service: "true"
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -120,7 +116,6 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
-        kubernetes.io/cluster-service: "true"
       annotations:
         # TODO: Move this to the beta tolerations field below as soon as the Tolerations field exists in PodSpec
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"dedicated","value":"master","effect":"NoSchedule"}]'


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed on Slack, these labels have no function when not using the addon-manager, so it's best to remove them to avoid confusion.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
@thockin @mikedanese @pires @MrHohn @bowei @dmmcquay @deads2k @philips 