### PR TITLE
e2e: Prefer kubeconfig host to default

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -70,6 +70,7 @@ func init() {
 
 func TestMain(m *testing.M) {
 	pflag.Parse()
+	framework.AfterReadingAllFlags(&framework.TestContext)
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
Previously it was necessary to pass ``-host`` to ``e2e.test`` even if ``-kubeconfig`` was specified since otherwise a localhost default would be used.  This change ensures that the default is only used when kubeconfig is not set. 

cc: @jayunit100 