### PR TITLE
add an nrpe-external-master relation to the kubernetes-worker and kubernetes-master charms

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/layer.yaml
+++ b/cluster/juju/layers/kubeapi-load-balancer/layer.yaml
@@ -1,5 +1,6 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
+  - 'layer:nagios'
   - 'layer:nginx'
   - 'layer:tls-client'
   - 'interface:public-address'

--- a/cluster/juju/layers/kubernetes-master/layer.yaml
+++ b/cluster/juju/layers/kubernetes-master/layer.yaml
@@ -1,13 +1,15 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
   - 'layer:basic'
-  - 'layer:tls-client'
   - 'layer:debug'
+  - 'layer:nagios'
+  - 'layer:tls-client'
+  - 'interface:ceph-admin'
   - 'interface:etcd'
   - 'interface:http'
   - 'interface:kubernetes-cni'
   - 'interface:kube-dns'
-  - 'interface:ceph-admin'
+  - 'interface:nrpe-external-master'
   - 'interface:public-address'
 options:
   basic:

--- a/cluster/juju/layers/kubernetes-master/layer.yaml
+++ b/cluster/juju/layers/kubernetes-master/layer.yaml
@@ -9,7 +9,6 @@ includes:
   - 'interface:http'
   - 'interface:kubernetes-cni'
   - 'interface:kube-dns'
-  - 'interface:nrpe-external-master'
   - 'interface:public-address'
 options:
   basic:

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -449,6 +449,23 @@ def update_nrpe_config(unused=None):
     nrpe_setup.write()
 
 
+@when_not('nrpe-external-master.available')
+@when('nrpe-external-master.initial-config')
+def remove_nrpe_config(nagios=None):
+    remove_state('nrpe-external-master.initial-config')
+
+    # List of systemd services for which the checks will be removed
+    services = ('kube-apiserver', 'kube-controller-manager', 'kube-scheduler')
+
+    # The current nrpe-external-master interface doesn't handle a lot of logic,
+    # use the charm-helpers code for now.
+    hostname = nrpe.get_nagios_hostname()
+    nrpe_setup = nrpe.NRPE(hostname=hostname)
+
+    for service in services:
+        nrpe_setup.remove_check(shortname=service)
+
+
 def create_addon(template, context):
     '''Create an addon from a template'''
     source = 'addons/' + template

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -31,8 +31,7 @@ from charms import layer
 from charms.reactive import hook
 from charms.reactive import remove_state
 from charms.reactive import set_state
-from charms.reactive import when
-from charms.reactive import when_not
+from charms.reactive import when, when_any, when_not
 from charms.reactive.helpers import data_changed
 from charms.kubernetes.flagmanager import FlagManager
 
@@ -41,6 +40,7 @@ from charmhelpers.core import host
 from charmhelpers.core import unitdata
 from charmhelpers.core.templating import render
 from charmhelpers.fetch import apt_install
+from charmhelpers.contrib.charmsupport import nrpe
 
 
 dashboard_templates = [
@@ -426,6 +426,27 @@ def ceph_storage(ceph_admin):
     # have performed the necessary pre-req steps to interface with a ceph
     # deployment.
     set_state('ceph-storage.configured')
+
+
+@when('nrpe-external-master.available')
+@when_not('nrpe-external-master.initial-config')
+def initial_nrpe_config(nagios=None):
+    set_state('nrpe-external-master.initial-config')
+    update_nrpe_config(nagios)
+
+
+@when('kubernetes-master.components.started')
+@when('nrpe-external-master.available')
+@when_any('config.changed.nagios_context',
+          'config.changed.nagios_servicegroups')
+def update_nrpe_config(unused=None):
+    services = ('kube-apiserver', 'kube-controller-manager', 'kube-scheduler')
+
+    hostname = nrpe.get_nagios_hostname()
+    current_unit = nrpe.get_nagios_unit_name()
+    nrpe_setup = nrpe.NRPE(hostname=hostname)
+    nrpe.add_init_service_checks(nrpe_setup, services, current_unit)
+    nrpe_setup.write()
 
 
 def create_addon(template, context):

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -1,12 +1,14 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
   - 'layer:basic'
-  - 'layer:docker'
-  - 'layer:tls-client'
   - 'layer:debug'
+  - 'layer:docker'
+  - 'layer:nagios'
+  - 'layer:tls-client'
   - 'interface:http'
   - 'interface:kubernetes-cni'
   - 'interface:kube-dns'
+  - 'interface:nrpe-external-master'
 options:
   basic:
     packages:

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -8,7 +8,6 @@ includes:
   - 'interface:http'
   - 'interface:kubernetes-cni'
   - 'interface:kube-dns'
-  - 'interface:nrpe-external-master'
 options:
   basic:
     packages:

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -469,6 +469,23 @@ def update_nrpe_config(unused=None):
     nrpe_setup.write()
 
 
+@when_not('nrpe-external-master.available')
+@when('nrpe-external-master.initial-config')
+def remove_nrpe_config(nagios=None):
+    remove_state('nrpe-external-master.initial-config')
+
+    # List of systemd services for which the checks will be removed
+    services = ('kubelet', 'kube-proxy')
+
+    # The current nrpe-external-master interface doesn't handle a lot of logic,
+    # use the charm-helpers code for now.
+    hostname = nrpe.get_nagios_hostname()
+    nrpe_setup = nrpe.NRPE(hostname=hostname)
+
+    for service in services:
+        nrpe_setup.remove_check(shortname=service)
+
+
 def _systemctl_is_active(application):
     ''' Poll systemctl to determine if the application is running '''
     cmd = ['systemctl', 'is-active', application]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR adds an an nrpe-external-master relation to the kubernetes-worker, kubernetes-master and kubeapi-load-balancer charms. This is needed to monitor the state of the workers, the masters and the load-balancers via Nagios.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Original PR at https://github.com/juju-solutions/kubernetes/pull/102

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
The kubernetes-master, kubernetes-worker and kubeapi-load-balancer charms have gained an nrpe-external-master relation, allowing the integration of their monitoring in an external Nagios server.
```
