### PR TITLE
Move private key parsing from serviceaccount/jwt.go to client-go/util/cert

### DIFF
--- a/pkg/serviceaccount/BUILD
+++ b/pkg/serviceaccount/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//vendor:k8s.io/apiserver/pkg/authentication/authenticator",
         "//vendor:k8s.io/apiserver/pkg/authentication/serviceaccount",
         "//vendor:k8s.io/apiserver/pkg/authentication/user",
+        "//vendor:k8s.io/client-go/util/cert",
     ],
 )
 
@@ -38,6 +39,7 @@ go_test(
         "//pkg/serviceaccount:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apiserver/pkg/authentication/serviceaccount",
+        "//vendor:k8s.io/client-go/util/cert",
     ],
 )
 

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -24,6 +24,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
+	"k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/api/v1"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
@@ -106,7 +107,7 @@ X2i8uIp/C/ASqiIGUeeKQtX0/IR3qCXyThP/dbCiHrF3v1cuhBOHY8CLVg==
 -----END PUBLIC KEY-----`
 
 func getPrivateKey(data string) interface{} {
-	key, _ := serviceaccount.ReadPrivateKeyFromPEM([]byte(data))
+	key, _ := cert.ParsePrivateKeyPEM([]byte(data))
 	return key
 }
 

--- a/staging/src/k8s.io/client-go/util/cert/pem.go
+++ b/staging/src/k8s.io/client-go/util/cert/pem.go
@@ -56,23 +56,39 @@ func EncodeCertPEM(cert *x509.Certificate) []byte {
 }
 
 // ParsePrivateKeyPEM returns a private key parsed from a PEM block in the supplied data.
-// Recognizes PEM blocks for "EC PRIVATE KEY" and "RSA PRIVATE KEY"
+// Recognizes PEM blocks for "EC PRIVATE KEY", "RSA PRIVATE KEY", or "PRIVATE KEY"
 func ParsePrivateKeyPEM(keyData []byte) (interface{}, error) {
+	var privateKeyPemBlock *pem.Block
 	for {
-		var privateKeyPemBlock *pem.Block
 		privateKeyPemBlock, keyData = pem.Decode(keyData)
 		if privateKeyPemBlock == nil {
-			// we read all the PEM blocks and didn't recognize one
-			return nil, fmt.Errorf("no private key PEM block found")
+			break
 		}
 
 		switch privateKeyPemBlock.Type {
 		case "EC PRIVATE KEY":
-			return x509.ParseECPrivateKey(privateKeyPemBlock.Bytes)
+			// ECDSA Private Key in ASN.1 format
+			if key, err := x509.ParseECPrivateKey(privateKeyPemBlock.Bytes); err == nil {
+				return key, nil
+			}
 		case "RSA PRIVATE KEY":
-			return x509.ParsePKCS1PrivateKey(privateKeyPemBlock.Bytes)
+			// RSA Private Key in PKCS#1 format
+			if key, err := x509.ParsePKCS1PrivateKey(privateKeyPemBlock.Bytes); err == nil {
+				return key, nil
+			}
+		case "PRIVATE KEY":
+			// RSA or ECDSA Private Key in unencrypted PKCS#8 format
+			if key, err := x509.ParsePKCS8PrivateKey(privateKeyPemBlock.Bytes); err == nil {
+				return key, nil
+			}
 		}
+
+		// tolerate non-key PEM blocks for compatibility with things like "EC PARAMETERS" blocks
+		// originally, only the first PEM block was parsed and expected to be a key block
 	}
+
+	// we read all the PEM blocks and didn't recognize one
+	return nil, fmt.Errorf("data does not contain a valid RSA or ECDSA private key")
 }
 
 // ParseCertsPEM returns the x509.Certificates contained in the given PEM-encoded byte array


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Unify private key parsing from serviceaccount/jwt.go into the client-go library.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
Partial fix to #40807 - only private key functions.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Move private key parsing from serviceaccount/jwt.go to client-go/util/cert
```
