### PR TITLE
[Federation] Add override flags options to kubefed init

### DIFF
--- a/federation/pkg/kubefed/init/BUILD
+++ b/federation/pkg/kubefed/init/BUILD
@@ -54,6 +54,7 @@ go_test(
         "//vendor:k8s.io/apimachinery/pkg/api/resource",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/util/diff",
+        "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/client-go/dynamic",
         "//vendor:k8s.io/client-go/rest/fake",
         "//vendor:k8s.io/client-go/tools/clientcmd",

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -117,20 +117,6 @@ var (
 	}
 
 	hyperkubeImageName = "gcr.io/google_containers/hyperkube-amd64"
-
-	apiserverDefaultArgs = map[string]string{
-		"--bind-address":         "0.0.0.0",
-		"--etcd-servers":         "http://localhost:2379",
-		"--secure-port":          "443",
-		"--client-ca-file":       "/etc/federation/apiserver/ca.crt",
-		"--tls-cert-file":        "/etc/federation/apiserver/server.crt",
-		"--tls-private-key-file": "/etc/federation/apiserver/server.key",
-	}
-
-	cmDefaultArgs = map[string]string{
-		"--kubeconfig":          "/etc/federation/controller-manager/kubeconfig",
-		"--dns-provider-config": "",
-	}
 )
 
 // NewCmdInit defines the `init` command that bootstraps a federation
@@ -156,8 +142,8 @@ func NewCmdInit(cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
 	cmd.Flags().String("etcd-pv-capacity", "10Gi", "Size of persistent volume claim to be used for etcd.")
 	cmd.Flags().Bool("etcd-persistent-storage", true, "Use persistent volume for etcd. Defaults to 'true'.")
 	cmd.Flags().Bool("dry-run", false, "dry run without sending commands to server.")
-	cmd.Flags().String("apiserver-arg-overrides", "", "comma sapareted list of all or subset of the federation-apiserver arguments as \"--arg1=value1,--arg2=value2...\"")
-	cmd.Flags().String("controllermgr-arg-overrides", "", "comma sapareted list of all or subset of the federation-controller-manager arguments as \"--arg1=value1,--arg2=value2...\"")
+	cmd.Flags().String("apiserver-arg-overrides", "", "comma separated list of federation-apiserver arguments to override: Example \"--arg1=value1,--arg2=value2...\"")
+	cmd.Flags().String("controllermanager-arg-overrides", "", "comma separated list of federation-controller-manager arguments to override: Example \"--arg1=value1,--arg2=value2...\"")
 	cmd.Flags().String("storage-backend", "etcd2", "The storage backend for persistence. Options: 'etcd2' (default), 'etcd3'.")
 	cmd.Flags().String(apiserverServiceTypeFlag, string(v1.ServiceTypeLoadBalancer), "The type of service to create for federation API server. Options: 'LoadBalancer' (default), 'NodePort'.")
 	cmd.Flags().String(apiserverAdvertiseAddressFlag, "", "Preferred address to advertise api server nodeport service. Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
@@ -185,8 +171,6 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	etcdPVCapacity := cmdutil.GetFlagString(cmd, "etcd-pv-capacity")
 	etcdPersistence := cmdutil.GetFlagBool(cmd, "etcd-persistent-storage")
 	dryRun := cmdutil.GetDryRunFlag(cmd)
-	apiserverArgOverrides := cmdutil.GetFlagString(cmd, "apiserver-arg-overrides")
-	cmArgOverrides := cmdutil.GetFlagString(cmd, "controllermgr-arg-overrides")
 	storageBackend := cmdutil.GetFlagString(cmd, "storage-backend")
 	apiserverServiceType := v1.ServiceType(cmdutil.GetFlagString(cmd, apiserverServiceTypeFlag))
 	apiserverAdvertiseAddress := cmdutil.GetFlagString(cmd, apiserverAdvertiseAddressFlag)
@@ -202,6 +186,14 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 		if apiserverServiceType != v1.ServiceTypeNodePort {
 			return fmt.Errorf("%s should be passed only with '%s=NodePort'", apiserverAdvertiseAddressFlag, apiserverServiceTypeFlag)
 		}
+	}
+	apiserverArgOverrides, err := marshallOverrides(cmdutil.GetFlagString(cmd, "apiserver-arg-overrides"))
+	if err != nil {
+		return fmt.Errorf("Error marshalling --apiserver-arg-overrides: %v", err)
+	}
+	cmArgOverrides, err := marshallOverrides(cmdutil.GetFlagString(cmd, "controllermanager-arg-overrides"))
+	if err != nil {
+		return fmt.Errorf("Error marshalling --controllermanager-arg-overrides: %v", err)
 	}
 
 	hostFactory := config.HostFactory(initFlags.Host, initFlags.Kubeconfig)
@@ -537,34 +529,28 @@ func createPVC(clientset *client.Clientset, namespace, svcName, etcdPVCapacity s
 	return clientset.Core().PersistentVolumeClaims(namespace).Create(pvc)
 }
 
-func createAPIServer(clientset *client.Clientset, namespace, name, image, credentialsName, advertiseAddress, storageBackend, apiserverArgOverrides string, pvc *api.PersistentVolumeClaim, dryRun bool) (*extensions.Deployment, error) {
+func createAPIServer(clientset *client.Clientset, namespace, name, image, credentialsName, advertiseAddress, storageBackend string, argOverrides map[string]string, pvc *api.PersistentVolumeClaim, dryRun bool) (*extensions.Deployment, error) {
 	command := []string{
 		"/hyperkube",
 		"federation-apiserver",
 	}
-	apiserverArgs := []string{}
-	apiserverArgsMap := apiserverDefaultArgs
+	argsMap := map[string]string{
+		"--bind-address":         "0.0.0.0",
+		"--etcd-servers":         "http://localhost:2379",
+		"--secure-port":          "443",
+		"--client-ca-file":       "/etc/federation/apiserver/ca.crt",
+		"--tls-cert-file":        "/etc/federation/apiserver/server.crt",
+		"--tls-private-key-file": "/etc/federation/apiserver/server.key",
+		"--admission-control":    "NamespaceLifecycle",
+	}
 
-	apiserverArgsMap["--storage-backend"] = storageBackend
+	argsMap["--storage-backend"] = storageBackend
 	if advertiseAddress != "" {
-		// This will be overridden with the override arg if user specifies one
-		apiserverArgsMap["--advertise-address"] = advertiseAddress
+		argsMap["--advertise-address"] = advertiseAddress
 	}
 
-	if apiserverArgOverrides != "" {
-		var err error
-		apiserverArgsMap, err = overrideArgs(apiserverArgsMap, apiserverArgOverrides)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	for key, value := range apiserverArgsMap {
-		apiserverArgs = append(apiserverArgs, fmt.Sprintf("%s=%s", key, value))
-	}
-	// This is needed for the unit test deep copy to get an exact match
-	sort.Strings(apiserverArgs)
-	command = append(command, apiserverArgs...)
+	args := argMapsToArgStrings(argsMap, argOverrides)
+	command = append(command, args...)
 
 	dep := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -706,33 +692,23 @@ func createRoleBindings(clientset *client.Clientset, namespace, saName string, d
 	return newRole, newRolebinding, err
 }
 
-func createControllerManager(clientset *client.Clientset, namespace, name, svcName, cmName, image, kubeconfigName, dnsZoneName, dnsProvider, saName, cmArgOverrides string, dryRun bool) (*extensions.Deployment, error) {
+func createControllerManager(clientset *client.Clientset, namespace, name, svcName, cmName, image, kubeconfigName, dnsZoneName, dnsProvider, saName string, argOverrides map[string]string, dryRun bool) (*extensions.Deployment, error) {
 	command := []string{
 		"/hyperkube",
 		"federation-controller-manager",
 	}
-	cmArgs := []string{}
-	cmArgsMap := cmDefaultArgs
-
-	cmArgsMap["--master"] = fmt.Sprintf("https://%s", svcName)
-	cmArgsMap["--dns-provider"] = dnsProvider
-	cmArgsMap["--federation-name"] = name
-	cmArgsMap["--zone-name"] = dnsZoneName
-
-	if cmArgOverrides != "" {
-		var err error
-		cmArgsMap, err = overrideArgs(cmArgsMap, cmArgOverrides)
-		if err != nil {
-			return nil, err
-		}
+	argsMap := map[string]string{
+		"--kubeconfig":          "/etc/federation/controller-manager/kubeconfig",
+		"--dns-provider-config": "",
 	}
 
-	for key, value := range cmArgsMap {
-		cmArgs = append(cmArgs, fmt.Sprintf("%s=%s", key, value))
-	}
-	// This is needed for the unit test deep copy to get an exact match
-	sort.Strings(cmArgs)
-	command = append(command, cmArgs...)
+	argsMap["--master"] = fmt.Sprintf("https://%s", svcName)
+	argsMap["--dns-provider"] = dnsProvider
+	argsMap["--federation-name"] = name
+	argsMap["--zone-name"] = dnsZoneName
+
+	args := argMapsToArgStrings(argsMap, argOverrides)
+	command = append(command, args...)
 
 	dep := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -794,32 +770,39 @@ func createControllerManager(clientset *client.Clientset, namespace, name, svcNa
 	return clientset.Extensions().Deployments(namespace).Create(dep)
 }
 
-func overrideArgs(serverArgs map[string]string, argOverrides string) (map[string]string, error) {
-	overrideArgs := strings.Split(argOverrides, ",")
-	argsMap := serverArgs
+func marshallOverrides(overrideArgString string) (map[string]string, error) {
+	if overrideArgString == "" {
+		return nil, nil
+	}
 
+	argsMap := make(map[string]string)
+	overrideArgs := strings.Split(overrideArgString, ",")
 	for _, overrideArg := range overrideArgs {
-		overrideArgSplitted := strings.Split(overrideArg, "=")
-		if len(overrideArgSplitted) != 2 {
-			return nil, fmt.Errorf("Wrong format for override arg: %s", overrideArg)
+		splitArg := strings.Split(overrideArg, "=")
+		if len(splitArg) != 2 {
+			return nil, fmt.Errorf("wrong format for override arg: %s", overrideArg)
 		}
-		found := false
-		for key := range argsMap {
-			if key == overrideArgSplitted[0] {
-				// Replace the default value by user specified value
-				argsMap[key] = overrideArgSplitted[1]
-				found = true
-				break
-			}
+		key := strings.TrimSpace(splitArg[0])
+		val := strings.TrimSpace(splitArg[1])
+		if len(key) == 0 {
+			return nil, fmt.Errorf("wrong format for override arg: %s, arg name cannot be empty", overrideArg)
 		}
-		// This arg is not in defaults, append it.
-		// We do not care if the argument name or value used is not correct
-		// To verify the wrong args is the particular server apps job.
-		if found == false {
-			argsMap[overrideArgSplitted[0]] = overrideArgSplitted[1]
-		}
+		argsMap[key] = val
 	}
 	return argsMap, nil
+}
+
+func argMapsToArgStrings(argsMap, overrides map[string]string) []string {
+	for key, val := range overrides {
+		argsMap[key] = val
+	}
+	args := []string{}
+	for key, value := range argsMap {
+		args = append(args, fmt.Sprintf("%s=%s", key, value))
+	}
+	// This is needed for the unit test deep copy to get an exact match
+	sort.Strings(args)
+	return args
 }
 
 func waitForPods(clientset *client.Clientset, fedPods []string, namespace string) error {

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kubernetes/pkg/version"
 
 	"github.com/spf13/cobra"
+	"sort"
 )
 
 const (
@@ -116,6 +117,20 @@ var (
 	}
 
 	hyperkubeImageName = "gcr.io/google_containers/hyperkube-amd64"
+
+	apiserverDefaultArgs = map[string]string{
+		"--bind-address":         "0.0.0.0",
+		"--etcd-servers":         "http://localhost:2379",
+		"--secure-port":          "443",
+		"--client-ca-file":       "/etc/federation/apiserver/ca.crt",
+		"--tls-cert-file":        "/etc/federation/apiserver/server.crt",
+		"--tls-private-key-file": "/etc/federation/apiserver/server.key",
+	}
+
+	cmDefaultArgs = map[string]string{
+		"--kubeconfig":          "/etc/federation/controller-manager/kubeconfig",
+		"--dns-provider-config": "",
+	}
 )
 
 // NewCmdInit defines the `init` command that bootstraps a federation
@@ -141,6 +156,8 @@ func NewCmdInit(cmdOut io.Writer, config util.AdminConfig) *cobra.Command {
 	cmd.Flags().String("etcd-pv-capacity", "10Gi", "Size of persistent volume claim to be used for etcd.")
 	cmd.Flags().Bool("etcd-persistent-storage", true, "Use persistent volume for etcd. Defaults to 'true'.")
 	cmd.Flags().Bool("dry-run", false, "dry run without sending commands to server.")
+	cmd.Flags().String("apiserver-arg-overrides", "", "comma sapareted list of all or subset of the federation-apiserver arguments as \"--arg1=value1,--arg2=value2...\"")
+	cmd.Flags().String("controllermgr-arg-overrides", "", "comma sapareted list of all or subset of the federation-controller-manager arguments as \"--arg1=value1,--arg2=value2...\"")
 	cmd.Flags().String("storage-backend", "etcd2", "The storage backend for persistence. Options: 'etcd2' (default), 'etcd3'.")
 	cmd.Flags().String(apiserverServiceTypeFlag, string(v1.ServiceTypeLoadBalancer), "The type of service to create for federation API server. Options: 'LoadBalancer' (default), 'NodePort'.")
 	cmd.Flags().String(apiserverAdvertiseAddressFlag, "", "Preferred address to advertise api server nodeport service. Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
@@ -168,6 +185,8 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	etcdPVCapacity := cmdutil.GetFlagString(cmd, "etcd-pv-capacity")
 	etcdPersistence := cmdutil.GetFlagBool(cmd, "etcd-persistent-storage")
 	dryRun := cmdutil.GetDryRunFlag(cmd)
+	apiserverArgOverrides := cmdutil.GetFlagString(cmd, "apiserver-arg-overrides")
+	cmArgOverrides := cmdutil.GetFlagString(cmd, "controllermgr-arg-overrides")
 	storageBackend := cmdutil.GetFlagString(cmd, "storage-backend")
 	apiserverServiceType := v1.ServiceType(cmdutil.GetFlagString(cmd, apiserverServiceTypeFlag))
 	apiserverAdvertiseAddress := cmdutil.GetFlagString(cmd, apiserverAdvertiseAddressFlag)
@@ -245,7 +264,7 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	}
 
 	// 6. Create federation API server
-	_, err = createAPIServer(hostClientset, initFlags.FederationSystemNamespace, serverName, image, serverCredName, advertiseAddress, storageBackend, pvc, dryRun)
+	_, err = createAPIServer(hostClientset, initFlags.FederationSystemNamespace, serverName, image, serverCredName, advertiseAddress, storageBackend, apiserverArgOverrides, pvc, dryRun)
 	if err != nil {
 		return err
 	}
@@ -266,7 +285,7 @@ func initFederation(cmdOut io.Writer, config util.AdminConfig, cmd *cobra.Comman
 	}
 
 	// 7c. Create federation controller manager deployment.
-	_, err = createControllerManager(hostClientset, initFlags.FederationSystemNamespace, initFlags.Name, svc.Name, cmName, image, cmKubeconfigName, dnsZoneName, dnsProvider, sa.Name, dryRun)
+	_, err = createControllerManager(hostClientset, initFlags.FederationSystemNamespace, initFlags.Name, svc.Name, cmName, image, cmKubeconfigName, dnsZoneName, dnsProvider, sa.Name, cmArgOverrides, dryRun)
 	if err != nil {
 		return err
 	}
@@ -518,23 +537,34 @@ func createPVC(clientset *client.Clientset, namespace, svcName, etcdPVCapacity s
 	return clientset.Core().PersistentVolumeClaims(namespace).Create(pvc)
 }
 
-func createAPIServer(clientset *client.Clientset, namespace, name, image, credentialsName, advertiseAddress, storageBackend string, pvc *api.PersistentVolumeClaim, dryRun bool) (*extensions.Deployment, error) {
+func createAPIServer(clientset *client.Clientset, namespace, name, image, credentialsName, advertiseAddress, storageBackend, apiserverArgOverrides string, pvc *api.PersistentVolumeClaim, dryRun bool) (*extensions.Deployment, error) {
 	command := []string{
 		"/hyperkube",
 		"federation-apiserver",
-		"--bind-address=0.0.0.0",
-		"--etcd-servers=http://localhost:2379",
-		"--secure-port=443",
-		"--client-ca-file=/etc/federation/apiserver/ca.crt",
-		"--tls-cert-file=/etc/federation/apiserver/server.crt",
-		"--tls-private-key-file=/etc/federation/apiserver/server.key",
-		"--admission-control=NamespaceLifecycle",
-		fmt.Sprintf("--storage-backend=%s", storageBackend),
+	}
+	apiserverArgs := []string{}
+	apiserverArgsMap := apiserverDefaultArgs
+
+	apiserverArgsMap["--storage-backend"] = storageBackend
+	if advertiseAddress != "" {
+		// This will be overridden with the override arg if user specifies one
+		apiserverArgsMap["--advertise-address"] = advertiseAddress
 	}
 
-	if advertiseAddress != "" {
-		command = append(command, fmt.Sprintf("--advertise-address=%s", advertiseAddress))
+	if apiserverArgOverrides != "" {
+		var err error
+		apiserverArgsMap, err = overrideArgs(apiserverArgsMap, apiserverArgOverrides)
+		if err != nil {
+			return nil, err
+		}
 	}
+
+	for key, value := range apiserverArgsMap {
+		apiserverArgs = append(apiserverArgs, fmt.Sprintf("%s=%s", key, value))
+	}
+	// This is needed for the unit test deep copy to get an exact match
+	sort.Strings(apiserverArgs)
+	command = append(command, apiserverArgs...)
 
 	dep := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -676,7 +706,34 @@ func createRoleBindings(clientset *client.Clientset, namespace, saName string, d
 	return newRole, newRolebinding, err
 }
 
-func createControllerManager(clientset *client.Clientset, namespace, name, svcName, cmName, image, kubeconfigName, dnsZoneName, dnsProvider, saName string, dryRun bool) (*extensions.Deployment, error) {
+func createControllerManager(clientset *client.Clientset, namespace, name, svcName, cmName, image, kubeconfigName, dnsZoneName, dnsProvider, saName, cmArgOverrides string, dryRun bool) (*extensions.Deployment, error) {
+	command := []string{
+		"/hyperkube",
+		"federation-controller-manager",
+	}
+	cmArgs := []string{}
+	cmArgsMap := cmDefaultArgs
+
+	cmArgsMap["--master"] = fmt.Sprintf("https://%s", svcName)
+	cmArgsMap["--dns-provider"] = dnsProvider
+	cmArgsMap["--federation-name"] = name
+	cmArgsMap["--zone-name"] = dnsZoneName
+
+	if cmArgOverrides != "" {
+		var err error
+		cmArgsMap, err = overrideArgs(cmArgsMap, cmArgOverrides)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for key, value := range cmArgsMap {
+		cmArgs = append(cmArgs, fmt.Sprintf("%s=%s", key, value))
+	}
+	// This is needed for the unit test deep copy to get an exact match
+	sort.Strings(cmArgs)
+	command = append(command, cmArgs...)
+
 	dep := &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
@@ -693,18 +750,9 @@ func createControllerManager(clientset *client.Clientset, namespace, name, svcNa
 				Spec: api.PodSpec{
 					Containers: []api.Container{
 						{
-							Name:  "controller-manager",
-							Image: image,
-							Command: []string{
-								"/hyperkube",
-								"federation-controller-manager",
-								fmt.Sprintf("--master=https://%s", svcName),
-								"--kubeconfig=/etc/federation/controller-manager/kubeconfig",
-								fmt.Sprintf("--dns-provider=%s", dnsProvider),
-								"--dns-provider-config=",
-								fmt.Sprintf("--federation-name=%s", name),
-								fmt.Sprintf("--zone-name=%s", dnsZoneName),
-							},
+							Name:    "controller-manager",
+							Image:   image,
+							Command: command,
 							VolumeMounts: []api.VolumeMount{
 								{
 									Name:      kubeconfigName,
@@ -744,6 +792,34 @@ func createControllerManager(clientset *client.Clientset, namespace, name, svcNa
 		return dep, nil
 	}
 	return clientset.Extensions().Deployments(namespace).Create(dep)
+}
+
+func overrideArgs(serverArgs map[string]string, argOverrides string) (map[string]string, error) {
+	overrideArgs := strings.Split(argOverrides, ",")
+	argsMap := serverArgs
+
+	for _, overrideArg := range overrideArgs {
+		overrideArgSplitted := strings.Split(overrideArg, "=")
+		if len(overrideArgSplitted) != 2 {
+			return nil, fmt.Errorf("Wrong format for override arg: %s", overrideArg)
+		}
+		found := false
+		for key := range argsMap {
+			if key == overrideArgSplitted[0] {
+				// Replace the default value by user specified value
+				argsMap[key] = overrideArgSplitted[1]
+				found = true
+				break
+			}
+		}
+		// This arg is not in defaults, append it.
+		// We do not care if the argument name or value used is not correct
+		// To verify the wrong args is the particular server apps job.
+		if found == false {
+			argsMap[overrideArgSplitted[0]] = overrideArgSplitted[1]
+		}
+	}
+	return argsMap, nil
 }
 
 func waitForPods(clientset *client.Clientset, fedPods []string, namespace string) error {

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -23,6 +23,7 @@ api-server-advertise-address
 api-server-service-type
 api-token
 api-version
+apiserver-arg-overrides
 apiserver-count
 apiserver-count
 audit-log-maxage
@@ -116,6 +117,7 @@ container-runtime
 container-runtime-endpoint
 contain-pod-resources
 contention-profiling
+controllermgr-arg-overrides
 controller-start-interval
 cors-allowed-origins
 cpu-cfs-quota

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -117,7 +117,7 @@ container-runtime
 container-runtime-endpoint
 contain-pod-resources
 contention-profiling
-controllermgr-arg-overrides
+controllermanager-arg-overrides
 controller-start-interval
 cors-allowed-origins
 cpu-cfs-quota


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows modification of startup flags (of apiserver and controller manager) through kubefed 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/40398
**Special notes for your reviewer**:
I haven't removed the existing redundant flags now (for example --dns-zone-name) intentionally to avoid breaking any existing tests that might use them.
I guess that would be better done as a follow up PR.
@madhusudancs @marun @nikhiljindal 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
It is now possible for the user to modify any startup flag of federation-apiserver and federation-controller-manager when deployed through kubefed.
There are two new options introduced in kubefed:
--apiserver-arg-overrides and --controllermanager-arg-overrides
Any number of actual federation-apiserver or federation-controller-manager flags can be specified using these options.
Example:
kubefed init "-other options-" ----apiserver-arg-overrides "--flag1=value1,--flag2=value2"
```
