### PR TITLE
local-up-cluster: fix instructions for set-credentials

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -446,8 +446,8 @@ function start_apiserver {
                 AUTH_ARGS="--token=system:admin/system:masters"
             fi
         else
-            # default to use basic authentication
-            AUTH_ARGS="--username=admin --password=admin"
+            # default to use certificate authentication
+            AUTH_ARGS="--client-key=${CERT_DIR}/client-admin.key --client-certificate=${CERT_DIR}/client-admin.crt"
         fi
     fi
 }


### PR DESCRIPTION
After launching the services, local-up-cluster.sh tells the
user how to configure kubectl to access it. The instructions
for 'set-credentials' enable plain password auth, but the
services are configured to mandate client certificate auth.
As a result it is not possible to access the cluster with
the instructions printed.

The use of client certs by default was added in

  commit a1b17db4581b714a44f4158325bb60ac4257d87d
  Author: Dr. Stefan Schimanski <sttts@redhat.com>
  Date:   Sat Nov 12 23:09:04 2016 +0100

    Configure client certs in local-cluster-up.sh

and the instructions were correctly updated to refer to
client certificates.

The changed instructions were (mistakenly) reverted though
when the following commit was merged:

  commit 72e0e91b5edb961cd22e2cdbce5d02300a754402
  Author: xilabao <chenr.fnst@cn.fujitsu.com>
  Date:   Fri Dec 2 11:04:25 2016 +0800

    change prompt for enabling RBAC on local-up-cluster

Fixes: #40192

Signed-off-by: Daniel P. Berrange <berrange@redhat.com>
