### PR TITLE
Allow setting patchStrategy for maps

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -244,9 +244,14 @@ func diffMaps(original, modified map[string]interface{}, t reflect.Type, ignoreC
 		switch originalValueTyped := originalValue.(type) {
 		case map[string]interface{}:
 			modifiedValueTyped := modifiedValue.(map[string]interface{})
-			fieldType, _, _, err := forkedjson.LookupPatchMetadata(t, key)
+			fieldType, fieldPatchStrategy, _, err := forkedjson.LookupPatchMetadata(t, key)
 			if err != nil {
 				return nil, err
+			}
+
+			if !ignoreDeletions && fieldPatchStrategy == deleteDirective {
+				patch[key] = nil
+				continue
 			}
 
 			patchValue, err := diffMaps(originalValueTyped, modifiedValueTyped, fieldType, ignoreChangesAndAdditions, ignoreDeletions)


### PR DESCRIPTION
**What this PR does / why we need it**:
Here's the use-case I've encountered in OpenShift: some object has a `runtime.RawExtension` field which causes problems during calculating patch when `kubectl edit` is invoked. `kubect annotate` or `kubectl patch` works as expected since they have a limited scope of application. I don't have to mention that `runtime.RawExtension` contains `json` object as well causing the `diffMaps` walk through that one as well. 
This approach allows setting `patchStrategy` on such  objects, so they can be ignored, here specifically deleted, but that's fine because that's the use-case handled properly at the server. 

Eventually I was also thinking about adding `ignore` as an additional strategy, but not sure if that's desirable. 

@kubernetes/sig-api-machinery-pr-reviews ptal
