### PR TITLE
[Federation][e2e] Fix few flakes in federation e2e tests

### DIFF
--- a/test/e2e_federation/federated-daemonset.go
+++ b/test/e2e_federation/federated-daemonset.go
@@ -192,7 +192,9 @@ func createDaemonSetOrFail(clientset *fedclientset.Clientset, namespace string) 
 func deleteDaemonSetOrFail(clientset *fedclientset.Clientset, nsName string, daemonsetName string, orphanDependents *bool) {
 	By(fmt.Sprintf("Deleting daemonset %q in namespace %q", daemonsetName, nsName))
 	err := clientset.Extensions().DaemonSets(nsName).Delete(daemonsetName, &metav1.DeleteOptions{OrphanDependents: orphanDependents})
-	framework.ExpectNoError(err, "Error deleting daemonset %q in namespace %q", daemonsetName, nsName)
+	if err != nil && !errors.IsNotFound(err) {
+		framework.ExpectNoError(err, "Error deleting daemonset %q in namespace %q", daemonsetName, nsName)
+	}
 
 	// Wait for the daemonset to be deleted.
 	err = wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {

--- a/test/e2e_federation/federated-deployment.go
+++ b/test/e2e_federation/federated-deployment.go
@@ -262,7 +262,9 @@ func updateDeploymentOrFail(clientset *fedclientset.Clientset, namespace string)
 func deleteDeploymentOrFail(clientset *fedclientset.Clientset, nsName string, deploymentName string, orphanDependents *bool) {
 	By(fmt.Sprintf("Deleting deployment %q in namespace %q", deploymentName, nsName))
 	err := clientset.Extensions().Deployments(nsName).Delete(deploymentName, &metav1.DeleteOptions{OrphanDependents: orphanDependents})
-	framework.ExpectNoError(err, "Error deleting deployment %q in namespace %q", deploymentName, nsName)
+	if err != nil && !errors.IsNotFound(err) {
+		framework.ExpectNoError(err, "Error deleting deployment %q in namespace %q", deploymentName, nsName)
+	}
 
 	// Wait for the deployment to be deleted.
 	err = wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {

--- a/test/e2e_federation/federated-replicaset.go
+++ b/test/e2e_federation/federated-replicaset.go
@@ -248,7 +248,9 @@ func createReplicaSetOrFail(clientset *fedclientset.Clientset, namespace string)
 func deleteReplicaSetOrFail(clientset *fedclientset.Clientset, nsName string, replicaSetName string, orphanDependents *bool) {
 	By(fmt.Sprintf("Deleting replica set %q in namespace %q", replicaSetName, nsName))
 	err := clientset.Extensions().ReplicaSets(nsName).Delete(replicaSetName, &metav1.DeleteOptions{OrphanDependents: orphanDependents})
-	framework.ExpectNoError(err, "Error deleting replica set %q in namespace %q", replicaSetName, nsName)
+	if err != nil && !errors.IsNotFound(err) {
+		framework.ExpectNoError(err, "Error deleting replica set %q in namespace %q", replicaSetName, nsName)
+	}
 
 	// Wait for the replicaSet to be deleted.
 	err = wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {

--- a/test/e2e_federation/federated-secret.go
+++ b/test/e2e_federation/federated-secret.go
@@ -171,7 +171,9 @@ func createSecretOrFail(clientset *fedclientset.Clientset, nsName string) *v1.Se
 func deleteSecretOrFail(clientset *fedclientset.Clientset, nsName string, secretName string, orphanDependents *bool) {
 	By(fmt.Sprintf("Deleting secret %q in namespace %q", secretName, nsName))
 	err := clientset.Core().Secrets(nsName).Delete(secretName, &metav1.DeleteOptions{OrphanDependents: orphanDependents})
-	framework.ExpectNoError(err, "Error deleting secret %q in namespace %q", secretName, nsName)
+	if err != nil && !errors.IsNotFound(err) {
+		framework.ExpectNoError(err, "Error deleting secret %q in namespace %q", secretName, nsName)
+	}
 
 	// Wait for the secret to be deleted.
 	err = wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes few flakes in #37105

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # partly fixes few test cases in the above  mentioned issue.

**Special notes for your reviewer**:
While cleaning up in AfterEach Block some objects are returned while listing, but by the time the object is delete is issued the object is disappearing resulting in this flake occasionally.
To fix this, we need to check if the err is NotFound while deleting, its ok and need not fail the test.

**Release note**: `NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
