### PR TITLE
update negotiation to reflect current kubectl state

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/helper.go
+++ b/staging/src/k8s.io/client-go/discovery/helper.go
@@ -104,8 +104,8 @@ func NegotiateVersion(client DiscoveryInterface, requiredGV *schema.GroupVersion
 		return &clientRegisteredGVs[0], nil
 	}
 
-	return nil, fmt.Errorf("failed to negotiate an api version; server supports: %v, client supports: %v",
-		serverVersions, clientVersions)
+	// fall back to an empty GroupVersion.  Most client commands no longer respect a GroupVersion anyway
+	return &schema.GroupVersion{}, nil
 }
 
 // GroupVersionResources converts APIResourceLists to the GroupVersionResources.

--- a/staging/src/k8s.io/client-go/discovery/helper_blackbox_test.go
+++ b/staging/src/k8s.io/client-go/discovery/helper_blackbox_test.go
@@ -118,9 +118,9 @@ func TestNegotiateVersion(t *testing.T) {
 			statusCode:      http.StatusNotFound,
 		},
 		{
-			name:       "discovery fails due to 403 Forbidden errors and thus serverVersions is empty, no fallback GroupVersion",
-			expectErr:  func(err error) bool { return strings.Contains(err.Error(), "failed to negotiate an api version;") },
-			statusCode: http.StatusForbidden,
+			name:            "discovery fails due to 403 Forbidden errors and thus serverVersions is empty, fallback to empty GroupVersion",
+			expectedVersion: &schema.GroupVersion{},
+			statusCode:      http.StatusForbidden,
 		},
 	}
 


### PR DESCRIPTION
Very few things actually require negotiation, but the client-cache attempts it all the time.  If you've explicitly requested one, you still fail.  If you haven't requested one and the server doesn't have one, you still get the client behavior.  After this, if you haven't requested one and the client and server don't have one, you simply get an empty you can interpret how you choose.

@lavalamp without this, you're unable to use `kubectl` against arbitrary servers.