### PR TITLE
Fix to avoid REST API calls at log level 2.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -146,7 +146,7 @@ func (rl *respLogger) Addf(format string, data ...interface{}) {
 // Log is intended to be called once at the end of your request handler, via defer
 func (rl *respLogger) Log() {
 	latency := time.Since(rl.startTime)
-	if glog.V(2) {
+	if glog.V(3) {
 		if !rl.hijacked {
 			glog.InfoDepth(1, fmt.Sprintf("%s %s: (%v) %v%v%v [%s %s]", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.statusStack, rl.addedInfo, rl.req.Header["User-Agent"], rl.req.RemoteAddr))
 		} else {


### PR DESCRIPTION
By default, logging REST API calls at log level 2 is too verbose (see below), if log level 2 happens to be default. So increasing its default to 3.

```
I0203 12:37:27.059555   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.358954ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:27.780029   11483 wrap.go:75] GET /api/v1/nodes/127.0.0.1?resourceVersion=0: (819.444µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35154]
I0203 12:37:27.844846   11483 wrap.go:75] POST /api/v1/namespaces/default/events: (11.337447ms) 201 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35154]
I0203 12:37:27.844851   11483 wrap.go:75] PATCH /api/v1/nodes/127.0.0.1/status: (9.998981ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35154]
I0203 12:37:28.942863   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (923.711µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:28.944556   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.188942ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:29.061483   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (937.549µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:29.063068   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.111312ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:30.947922   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (935.198µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:30.950150   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.703438ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:31.064883   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.127992ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:31.066503   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.098029ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:32.951691   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (945.295µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:32.953580   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.331822ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:33.068221   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (912.121µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:33.069787   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.120666ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:34.955546   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.02279ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:34.957812   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.661017ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:35.071528   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (935.155µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:35.073087   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.027371ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:35.580075   11483 wrap.go:75] GET /apis/extensions/v1beta1/thirdpartyresources: (943.453µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35144]
I0203 12:37:36.611659   11483 wrap.go:75] GET /api/v1/namespaces/default: (753.781µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35144]
I0203 12:37:36.612516   11483 wrap.go:75] GET /api/v1/namespaces/default/services/kubernetes: (495.105µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35144]
I0203 12:37:36.613167   11483 wrap.go:75] GET /api/v1/namespaces/default/endpoints/kubernetes: (379.568µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35144]
I0203 12:37:36.960131   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.431137ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:36.963470   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (2.190438ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:37.028185   11483 wrap.go:75] GET /api/v1/nodes: (1.34149ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/pod-garbage-collector] [::1]:35156]
I0203 12:37:37.074666   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (928.261µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:37.076314   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.240852ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:37.847163   11483 wrap.go:75] GET /api/v1/nodes/127.0.0.1?resourceVersion=0: (725.021µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35154]
I0203 12:37:37.901326   11483 wrap.go:75] PATCH /api/v1/nodes/127.0.0.1/status: (2.377445ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format] [::1]:35154]
I0203 12:37:38.968028   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (3.777083ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:38.970313   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.655815ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:39.077913   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (919.65µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:39.079617   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.196855ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:40.972171   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (936.07µs) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:40.973886   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.200048ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35156]
I0203 12:37:41.084158   11483 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (3.842758ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [::1]:35168]
I0203 12:37:41.085722   11483 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.101371ms) 200 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] [
```

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1414813

@kubernetes/rh-cluster-infra 

Fix https://github.com/kubernetes/kubernetes/issues/47916