### PR TITLE
allow the kubelet to request certificates

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -217,6 +217,9 @@ func ClusterRoles() []rbac.ClusterRole {
 				// TODO: change glusterfs to use DNS lookup so this isn't needed?
 				// Needed for glusterfs volumes
 				rbac.NewRule("get").Groups(legacyGroup).Resources("endpoints").RuleOrDie(),
+				// Used to create a certificatesigningrequest for a node-specific client certificate, and watch
+				// for it to be signed. This allows the kubelet to rotate it's own certificate.
+				rbac.NewRule("create", "get", "list", "watch").Groups(certificatesGroup).Resources("certificatesigningrequests").RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -569,6 +569,15 @@ items:
     - endpoints
     verbs:
     - get
+  - apiGroups:
+    - certificates.k8s.io
+    resources:
+    - certificatesigningrequests
+    verbs:
+    - create
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
This allows the rotation process to use the kubelet's credentials.
