### PR TITLE
apiserver command line options lead to config

### DIFF
--- a/cmd/kube-aggregator/pkg/cmd/server/start.go
+++ b/cmd/kube-aggregator/pkg/cmd/server/start.go
@@ -118,13 +118,14 @@ func (o DiscoveryServerOptions) RunDiscoveryServer() error {
 
 	genericAPIServerConfig := genericapiserver.NewConfig().
 		WithSerializer(api.Codecs)
-	if _, err := genericAPIServerConfig.ApplySecureServingOptions(o.SecureServing); err != nil {
+
+	if err := o.SecureServing.ApplyTo(genericAPIServerConfig); err != nil {
+		return fmt.Errorf("failed to configure https: %s", err)
+	}
+	if err := o.Authentication.ApplyTo(genericAPIServerConfig); err != nil {
 		return err
 	}
-	if _, err := genericAPIServerConfig.ApplyDelegatingAuthenticationOptions(o.Authentication); err != nil {
-		return err
-	}
-	if _, err := genericAPIServerConfig.ApplyDelegatingAuthorizationOptions(o.Authorization); err != nil {
+	if err := o.Authorization.ApplyTo(genericAPIServerConfig); err != nil {
 		return err
 	}
 	genericAPIServerConfig.LongRunningFunc = filters.BasicLongRunningRequestCheck(

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -106,15 +106,19 @@ func Run(s *options.ServerRunOptions) error {
 
 	// create config from options
 	genericConfig := genericapiserver.NewConfig().
-		WithSerializer(api.Codecs).
-		ApplyOptions(s.GenericServerRunOptions).
-		ApplyInsecureServingOptions(s.InsecureServing)
+		WithSerializer(api.Codecs)
 
-	if _, err := genericConfig.ApplySecureServingOptions(s.SecureServing); err != nil {
-		return fmt.Errorf("failed to configure https: %s", err)
+	if err := s.GenericServerRunOptions.ApplyTo(genericConfig); err != nil {
+		return err
 	}
-	if err = s.Authentication.Apply(genericConfig); err != nil {
-		return fmt.Errorf("failed to configure authentication: %s", err)
+	if err := s.InsecureServing.ApplyTo(genericConfig); err != nil {
+		return err
+	}
+	if err := s.SecureServing.ApplyTo(genericConfig); err != nil {
+		return err
+	}
+	if err := s.Authentication.ApplyTo(genericConfig); err != nil {
+		return err
 	}
 
 	capabilities.Initialize(capabilities.Capabilities{

--- a/examples/apiserver/apiserver.go
+++ b/examples/apiserver/apiserver.go
@@ -104,14 +104,18 @@ func (serverOptions *ServerRunOptions) Run(stopCh <-chan struct{}) error {
 
 	// create config from options
 	config := genericapiserver.NewConfig().
-		WithSerializer(api.Codecs).
-		ApplyOptions(serverOptions.GenericServerRunOptions).
-		ApplyInsecureServingOptions(serverOptions.InsecureServing)
+		WithSerializer(api.Codecs)
 
-	if _, err := config.ApplySecureServingOptions(serverOptions.SecureServing); err != nil {
+	if err := serverOptions.GenericServerRunOptions.ApplyTo(config); err != nil {
+		return err
+	}
+	if err := serverOptions.InsecureServing.ApplyTo(config); err != nil {
+		return err
+	}
+	if err := serverOptions.SecureServing.ApplyTo(config); err != nil {
 		return fmt.Errorf("failed to configure https: %s", err)
 	}
-	if err := serverOptions.Authentication.Apply(config); err != nil {
+	if err := serverOptions.Authentication.ApplyTo(config); err != nil {
 		return fmt.Errorf("failed to configure authentication: %s", err)
 	}
 

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -89,15 +89,19 @@ func Run(s *options.ServerRunOptions) error {
 	}
 
 	genericConfig := genericapiserver.NewConfig().
-		WithSerializer(api.Codecs).
-		ApplyOptions(s.GenericServerRunOptions).
-		ApplyInsecureServingOptions(s.InsecureServing)
+		WithSerializer(api.Codecs)
 
-	if _, err := genericConfig.ApplySecureServingOptions(s.SecureServing); err != nil {
-		return fmt.Errorf("failed to configure https: %s", err)
+	if err := s.GenericServerRunOptions.ApplyTo(genericConfig); err != nil {
+		return err
 	}
-	if err := s.Authentication.Apply(genericConfig); err != nil {
-		return fmt.Errorf("failed to configure authentication: %s", err)
+	if err := s.InsecureServing.ApplyTo(genericConfig); err != nil {
+		return err
+	}
+	if err := s.SecureServing.ApplyTo(genericConfig); err != nil {
+		return err
+	}
+	if err := s.Authentication.ApplyTo(genericConfig); err != nil {
+		return err
 	}
 
 	// TODO: register cluster federation resources here.

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -297,7 +297,7 @@ func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() authenticator.Au
 	return ret
 }
 
-func (o *BuiltInAuthenticationOptions) Apply(c *genericapiserver.Config) error {
+func (o *BuiltInAuthenticationOptions) ApplyTo(c *genericapiserver.Config) error {
 	if o == nil {
 		return nil
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -40,13 +40,13 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
-	apirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/server/healthz"
-	restclient "k8s.io/client-go/rest"
 	genericapi "k8s.io/apiserver/pkg/endpoints"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/server/healthz"
 	genericmux "k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
+	restclient "k8s.io/client-go/rest"
 )
 
 // Info about an API group.
@@ -210,6 +210,11 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) {
 	}
 
 	<-stopCh
+}
+
+// EffectiveSecurePort returns the secure port we bound to.
+func (s *GenericAPIServer) EffectiveSecurePort() int {
+	return s.effectiveSecurePort
 }
 
 // installAPIResources is a private method for installing the REST storage backing each api groupversionresource

--- a/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authorization.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"k8s.io/apiserver/pkg/authorization/authorizerfactory"
+	"k8s.io/apiserver/pkg/server"
 	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1beta1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -67,6 +68,20 @@ func (s *DelegatingAuthorizationOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.DenyCacheTTL,
 		"authorization-webhook-cache-unauthorized-ttl", s.DenyCacheTTL,
 		"The duration to cache 'unauthorized' responses from the webhook authorizer.")
+}
+
+func (s *DelegatingAuthorizationOptions) ApplyTo(c *server.Config) error {
+	cfg, err := s.ToAuthorizationConfig()
+	if err != nil {
+		return err
+	}
+	authorizer, err := cfg.New()
+	if err != nil {
+		return err
+	}
+
+	c.Authorizer = authorizer
+	return nil
 }
 
 func (s *DelegatingAuthorizationOptions) ToAuthorizationConfig() (authorizerfactory.DelegatingAuthorizerConfig, error) {

--- a/staging/src/k8s.io/apiserver/pkg/server/serve.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/serve.go
@@ -173,25 +173,25 @@ func runServer(server *http.Server, network string, stopCh <-chan struct{}) (int
 	return tcpAddr.Port, nil
 }
 
-type namedTlsCert struct {
-	tlsCert tls.Certificate
+type NamedTLSCert struct {
+	TLSCert tls.Certificate
 
 	// names is a list of domain patterns: fully qualified domain names, possibly prefixed with
 	// wildcard segments.
-	names []string
+	Names []string
 }
 
 // getNamedCertificateMap returns a map of *tls.Certificate by name. It's is
 // suitable for use in tls.Config#NamedCertificates. Returns an error if any of the certs
 // cannot be loaded. Returns nil if len(certs) == 0
-func getNamedCertificateMap(certs []namedTlsCert) (map[string]*tls.Certificate, error) {
+func GetNamedCertificateMap(certs []NamedTLSCert) (map[string]*tls.Certificate, error) {
 	// register certs with implicit names first, reverse order such that earlier trump over the later
 	byName := map[string]*tls.Certificate{}
 	for i := len(certs) - 1; i >= 0; i-- {
-		if len(certs[i].names) > 0 {
+		if len(certs[i].Names) > 0 {
 			continue
 		}
-		cert := &certs[i].tlsCert
+		cert := &certs[i].TLSCert
 
 		// read names from certificate common names and DNS names
 		if len(cert.Certificate) == 0 {
@@ -216,8 +216,8 @@ func getNamedCertificateMap(certs []namedTlsCert) (map[string]*tls.Certificate, 
 	// again in reverse order.
 	for i := len(certs) - 1; i >= 0; i-- {
 		namedCert := &certs[i]
-		for _, name := range namedCert.names {
-			byName[name] = &certs[i].tlsCert
+		for _, name := range namedCert.Names {
+			byName[name] = &certs[i].TLSCert
 		}
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/storage_factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage_factory_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apiserver/pkg/apis/example"
 	exampleinstall "k8s.io/apiserver/pkg/apis/example/install"
 	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
-	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 )
 
@@ -128,7 +127,7 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 	defaultEtcdLocation := []string{"http://127.0.0.1"}
 	for i, test := range testCases {
 		defaultConfig := storagebackend.Config{
-			Prefix:     options.DefaultEtcdPathPrefix,
+			Prefix:     "/registry",
 			ServerList: defaultEtcdLocation,
 			Copier:     scheme,
 		}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -9058,7 +9058,6 @@ go_library(
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/pborman/uuid",
         "//vendor:github.com/pkg/errors",
-        "//vendor:gopkg.in/natefinch/lumberjack.v2",
         "//vendor:k8s.io/apimachinery/pkg/apimachinery",
         "//vendor:k8s.io/apimachinery/pkg/apimachinery/registered",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
@@ -9089,7 +9088,6 @@ go_library(
         "//vendor:k8s.io/apiserver/pkg/server/filters",
         "//vendor:k8s.io/apiserver/pkg/server/healthz",
         "//vendor:k8s.io/apiserver/pkg/server/mux",
-        "//vendor:k8s.io/apiserver/pkg/server/options",
         "//vendor:k8s.io/apiserver/pkg/server/routes",
         "//vendor:k8s.io/apiserver/pkg/storage/storagebackend",
         "//vendor:k8s.io/client-go/rest",
@@ -14088,6 +14086,7 @@ go_library(
     deps = [
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/spf13/pflag",
+        "//vendor:gopkg.in/natefinch/lumberjack.v2",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/util/net",
@@ -14095,6 +14094,7 @@ go_library(
         "//vendor:k8s.io/apiserver/pkg/authentication/authenticatorfactory",
         "//vendor:k8s.io/apiserver/pkg/authorization/authorizerfactory",
         "//vendor:k8s.io/apiserver/pkg/features",
+        "//vendor:k8s.io/apiserver/pkg/server",
         "//vendor:k8s.io/apiserver/pkg/storage/storagebackend",
         "//vendor:k8s.io/apiserver/pkg/util/feature",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
@@ -14761,13 +14761,11 @@ go_test(
     srcs = [
         "k8s.io/apiserver/pkg/server/genericapiserver_test.go",
         "k8s.io/apiserver/pkg/server/resource_config_test.go",
-        "k8s.io/apiserver/pkg/server/serve_test.go",
         "k8s.io/apiserver/pkg/server/storage_factory_test.go",
     ],
     library = ":k8s.io/apiserver/pkg/server",
     tags = ["automanaged"],
     deps = [
-        "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/generated/openapi:go_default_library",
         "//vendor:github.com/go-openapi/spec",
         "//vendor:github.com/stretchr/testify/assert",
@@ -14789,12 +14787,9 @@ go_test(
         "//vendor:k8s.io/apiserver/pkg/authorization/authorizer",
         "//vendor:k8s.io/apiserver/pkg/endpoints/request",
         "//vendor:k8s.io/apiserver/pkg/registry/rest",
-        "//vendor:k8s.io/apiserver/pkg/server/options",
         "//vendor:k8s.io/apiserver/pkg/storage/etcd/testing",
         "//vendor:k8s.io/apiserver/pkg/storage/storagebackend",
-        "//vendor:k8s.io/apiserver/pkg/util/flag",
         "//vendor:k8s.io/client-go/pkg/api",
-        "//vendor:k8s.io/client-go/util/cert",
     ],
 )
 
@@ -15254,5 +15249,23 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apiserver/pkg/apis/apiserver",
+    ],
+)
+
+go_test(
+    name = "k8s.io/apiserver/pkg/server/options_test",
+    srcs = ["k8s.io/apiserver/pkg/server/options/serving_test.go"],
+    library = ":k8s.io/apiserver/pkg/server/options",
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/client/clientset_generated/clientset:go_default_library",
+        "//vendor:github.com/stretchr/testify/assert",
+        "//vendor:k8s.io/apimachinery/pkg/runtime",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/serializer",
+        "//vendor:k8s.io/apimachinery/pkg/version",
+        "//vendor:k8s.io/apiserver/pkg/endpoints/request",
+        "//vendor:k8s.io/apiserver/pkg/server",
+        "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/client-go/util/cert",
     ],
 )


### PR DESCRIPTION
Logically command line options lead to config, not the other way around.  We're clean enough now we can actually do the inversion.

WIP because I have some test cycles to fix, but this is all the meat.

@kubernetes/sig-api-machinery-misc 