### PR TITLE
Remove defaults from string flags

### DIFF
--- a/cmd/libs/go2idl/client-gen/main.go
+++ b/cmd/libs/go2idl/client-gen/main.go
@@ -47,12 +47,12 @@ var (
 		"apps/",
 		"policy/",
 		"settings/",
-	}, "group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format \"group1/version1,group2/version2...\". Default to \"api/,extensions/,autoscaling/,batch/,rbac/\"")
+	}, "group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format \"group1/version1,group2/version2...\".")
 	includedTypesOverrides = flag.StringSlice("included-types-overrides", []string{}, "list of group/version/type for which client should be generated. By default, client is generated for all types which have genclient=true in types.go. This overrides that. For each groupVersion in this list, only the types mentioned here will be included. The default check of genclient=true will be used for other group versions.")
-	basePath               = flag.String("input-base", "k8s.io/kubernetes/pkg/apis", "base path to look for the api group. Default to \"k8s.io/kubernetes/pkg/apis\"")
+	basePath               = flag.String("input-base", "k8s.io/kubernetes/pkg/apis", "base path to look for the api group.")
 	clientsetName          = flag.StringP("clientset-name", "n", "internalclientset", "the name of the generated clientset package.")
 	clientsetAPIPath       = flag.StringP("clientset-api-path", "", "", "the value of default API path.")
-	clientsetPath          = flag.String("clientset-path", "k8s.io/kubernetes/pkg/client/clientset_generated/", "the generated clientset will be output to <clientset-path>/<clientset-name>. Default to \"k8s.io/kubernetes/pkg/client/clientset_generated/\"")
+	clientsetPath          = flag.String("clientset-path", "k8s.io/kubernetes/pkg/client/clientset_generated/", "the generated clientset will be output to <clientset-path>/<clientset-name>.")
 	clientsetOnly          = flag.Bool("clientset-only", false, "when set, client-gen only generates the clientset shell, without generating the individual typed clients")
 	fakeClient             = flag.Bool("fake-clientset", true, "when set, client-gen will generate the fake clientset that can be used in tests")
 )


### PR DESCRIPTION
 - The default is printed automatically
 - The string text did not match the actual default

**What this PR does / why we need it**:
Adjust the documentation for flags on `client-gen`.

**Special notes for your reviewer**:
Doc change. String text only.

**Release note**:
```release-note
NONE
```

Before:
```
client-gen  --help
Usage of ./client-gen:
      --build-tag string                       A Go build tag to use to identify files generated by this command. Should be unique. (default "ignore_autogenerated")
      --clientset-api-path string              the value of default API path.
  -n, --clientset-name string                  the name of the generated clientset package. (default "internalclientset")
      --clientset-only                         when set, client-gen only generates the clientset shell, without generating the individual typed clients
      --clientset-path string                  the generated clientset will be output to <clientset-path>/<clientset-name>. Default to "k8s.io/kubernetes/pkg/client/clientset_generated/" (default "k8s.io/kubernetes/pkg/client/clientset_generated/")
      --fake-clientset                         when set, client-gen will generate the fake clientset that can be used in tests (default true)
  -h, --go-header-file string                  File containing boilerplate header text. The string YEAR will be replaced with the current 4-digit year. (default "/Users/mhb/go/src/k8s.io/gengo/boilerplate/boilerplate.go.txt")
      --included-types-overrides stringSlice   list of group/version/type for which client should be generated. By default, client is generated for all types which have genclient=true in types.go. This overrides that. For each groupVersion in this list, only the types mentioned here will be included. The default check of genclient=true will be used for other group versions.
      --input stringSlice                      group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format "group1/version1,group2/version2...". Default to "api/,extensions/,autoscaling/,batch/,rbac/" (default [api/,authentication/,authorization/,autoscaling/,batch/,certificates/,extensions/,rbac/,storage/,apps/,policy/])
      --input-base string                      base path to look for the api group. Default to "k8s.io/kubernetes/pkg/apis" (default "k8s.io/kubernetes/pkg/apis")
  -i, --input-dirs stringSlice                 Comma-separated list of import paths to get input types from.
  -o, --output-base string                     Output base; defaults to $GOPATH/src/ or ./ if $GOPATH is not set. (default "/Users/mhb/go/src")
  -O, --output-file-base string                Base name (without .go suffix) for output files.
  -p, --output-package string                  Base package path.
  -t, --test                                   set this flag to generate the client code for the testdata
      --verify-only                            If true, only verify existing output, do not write anything.
```
After:
```
client-gen  --help
Usage of ./client-gen:
      --build-tag string                       A Go build tag to use to identify files generated by this command. Should be unique. (default "ignore_autogenerated")
      --clientset-api-path string              the value of default API path.
  -n, --clientset-name string                  the name of the generated clientset package. (default "internalclientset")
      --clientset-only                         when set, client-gen only generates the clientset shell, without generating the individual typed clients
      --clientset-path string                  the generated clientset will be output to <clientset-path>/<clientset-name>. (default "k8s.io/kubernetes/pkg/client/clientset_generated/")
      --fake-clientset                         when set, client-gen will generate the fake clientset that can be used in tests (default true)
  -h, --go-header-file string                  File containing boilerplate header text. The string YEAR will be replaced with the current 4-digit year. (default "/Users/mhb/go/src/k8s.io/gengo/boilerplate/boilerplate.go.txt")
      --included-types-overrides stringSlice   list of group/version/type for which client should be generated. By default, client is generated for all types which have genclient=true in types.go. This overrides that. For each groupVersion in this list, only the types mentioned here will be included. The default check of genclient=true will be used for other group versions.
      --input stringSlice                      group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format "group1/version1,group2/version2...". (default [api/,authentication/,authorization/,autoscaling/,batch/,certificates/,extensions/,rbac/,storage/,apps/,policy/])
      --input-base string                      base path to look for the api group. (default "k8s.io/kubernetes/pkg/apis")
  -i, --input-dirs stringSlice                 Comma-separated list of import paths to get input types from.
  -o, --output-base string                     Output base; defaults to $GOPATH/src/ or ./ if $GOPATH is not set. (default "/Users/mhb/go/src")
  -O, --output-file-base string                Base name (without .go suffix) for output files.
  -p, --output-package string                  Base package path.
  -t, --test                                   set this flag to generate the client code for the testdata
      --verify-only                            If true, only verify existing output, do not write anything.
```