### PR TITLE
Fix CRI port forwarding

### DIFF
--- a/pkg/kubelet/server/portforward/websocket.go
+++ b/pkg/kubelet/server/portforward/websocket.go
@@ -45,6 +45,8 @@ const (
 
 // options contains details about which streams are required for
 // port forwarding.
+// All fields incldued in V4Options need to be expressed explicilty in the
+// CRI (pkg/kubelet/api/{version}/runtime/api.proto) PortForwardRequest.
 type V4Options struct {
 	Ports []int32
 }
@@ -80,6 +82,11 @@ func NewV4Options(req *http.Request) (*V4Options, error) {
 	return &V4Options{
 		Ports: ports,
 	}, nil
+}
+
+// BuildV4Options returns a V4Options based on the given information.
+func BuildV4Options(ports []int32) (*V4Options, error) {
+	return &V4Options{Ports: ports}, nil
 }
 
 // handleWebSocketStreams handles requests to forward ports to a pod via

--- a/pkg/kubelet/server/streaming/server.go
+++ b/pkg/kubelet/server/streaming/server.go
@@ -302,7 +302,7 @@ func (s *server) servePortForward(req *restful.Request, resp *restful.Response) 
 		return
 	}
 
-	portForwardOptions, err := portforward.NewV4Options(req.Request)
+	portForwardOptions, err := portforward.BuildV4Options(pf.Port)
 	if err != nil {
 		resp.WriteError(http.StatusBadRequest, err)
 		return


### PR DESCRIPTION
Websocket support was introduced #33684, which broke the CRI
implementation. This change fixes it.


