### PR TITLE
Added the first TPR unit test.

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -215,6 +215,7 @@ type TestFactory struct {
 	Validator          validation.Schema
 	Namespace          string
 	ClientConfig       *restclient.Config
+	JSONEncoder        runtime.Encoder
 	Err                error
 }
 
@@ -515,7 +516,11 @@ func (f *fakeAPIFactory) Decoder(bool) runtime.Decoder {
 }
 
 func (f *fakeAPIFactory) JSONEncoder() runtime.Encoder {
-	return testapi.Default.Codec()
+	if f.tf.JSONEncoder != nil {
+		return f.tf.JSONEncoder
+	} else {
+		return testapi.Default.Codec()
+	}
 }
 
 func (f *fakeAPIFactory) ClientSet() (*internalclientset.Clientset, error) {
@@ -680,6 +685,7 @@ func testDynamicResources() []*discovery.APIGroupResources {
 			VersionedResources: map[string][]metav1.APIResource{
 				"v1beta1": {
 					{Name: "deployments", Namespaced: true, Kind: "Deployment"},
+					{Name: "thirdpartyresources", Namespaced: false, Kind: "ThirdPartyResource"},
 				},
 			},
 		},

--- a/staging/src/k8s.io/client-go/rest/fake/fake.go
+++ b/staging/src/k8s.io/client-go/rest/fake/fake.go
@@ -49,6 +49,8 @@ type RESTClient struct {
 	GroupName            string
 	APIRegistry          *registered.APIRegistrationManager
 
+	ContentConfig restclient.ContentConfig
+
 	Req  *http.Request
 	Resp *http.Response
 	Err  error
@@ -87,23 +89,27 @@ func (c *RESTClient) GetRateLimiter() flowcontrol.RateLimiter {
 }
 
 func (c *RESTClient) request(verb string) *restclient.Request {
-	config := restclient.ContentConfig{
-		ContentType: runtime.ContentTypeJSON,
-		// TODO this was hardcoded before, but it doesn't look right
-		GroupVersion:         &c.APIRegistry.GroupOrDie("").GroupVersion,
-		NegotiatedSerializer: c.NegotiatedSerializer,
+	config := c.ContentConfig
+	defaultContentConfig := restclient.ContentConfig{}
+	if config == defaultContentConfig {
+		config = restclient.ContentConfig{
+			ContentType: runtime.ContentTypeJSON,
+			// TODO this was hardcoded before, but it doesn't look right
+			GroupVersion:         &c.APIRegistry.GroupOrDie(c.GroupName).GroupVersion,
+			NegotiatedSerializer: c.NegotiatedSerializer,
+		}
 	}
 
 	ns := c.NegotiatedSerializer
 	info, _ := runtime.SerializerInfoForMediaType(ns.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	internalVersion := schema.GroupVersion{
-		Group:   c.APIRegistry.GroupOrDie(c.GroupName).GroupVersion.Group,
+		Group:   config.GroupVersion.Group,
 		Version: runtime.APIVersionInternal,
 	}
 	internalVersion.Version = runtime.APIVersionInternal
 	serializers := restclient.Serializers{
 		// TODO this was hardcoded before, but it doesn't look right
-		Encoder: ns.EncoderForVersion(info.Serializer, c.APIRegistry.GroupOrDie("").GroupVersion),
+		Encoder: ns.EncoderForVersion(info.Serializer, *config.GroupVersion),
 		Decoder: ns.DecoderToVersion(info.Serializer, internalVersion),
 	}
 	if info.StreamSerializer != nil {

--- a/test/fixtures/pkg/kubectl/cmd/apply/third-party-resource-entry.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/third-party-resource-entry.yaml
@@ -1,0 +1,7 @@
+apiVersion: "unit-test.test.com/v1"
+kind: TestTpr
+metadata:
+  name: "test-tpr-entry"
+  namespace: "test"
+key : "value"
+

--- a/test/fixtures/pkg/kubectl/cmd/apply/third-party-resource.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/third-party-resource.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions/v1beta1
+kind: ThirdPartyResource
+metadata:
+  name: test-tpr.unit-test.test.com
+description: "A TPR definition used for unit tests"
+versions:
+- name: v1


### PR DESCRIPTION
We are applying a Kind:ThirdPartyResource object.
and making sure the kubectl code creates the GET and PATCH requests
correctly.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Adds the first unit test for apply operations using ThirdPartyResources. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
References: https://github.com/kubernetes/kubernetes/issues/40841 

**Special notes for your reviewer**:
This PR supersedes https://github.com/kubernetes/kubernetes/pull/40775. 
This is the same test but on master branch. The previous one was written on 1.4.7 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
