### PR TITLE
Switch kubectl version and api-versions to create a discovery client …

### DIFF
--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -56,12 +56,12 @@ func RunApiVersions(f cmdutil.Factory, w io.Writer) error {
 		printDeprecationWarning("api-versions", "apiversions")
 	}
 
-	clientset, err := f.ClientSet()
+	discoveryclient, err := f.DiscoveryClient()
 	if err != nil {
 		return err
 	}
 
-	groupList, err := clientset.Discovery().ServerGroups()
+	groupList, err := discoveryclient.ServerGroups()
 	if err != nil {
 		return fmt.Errorf("Couldn't get available api versions from server: %v\n", err)
 	}

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -61,12 +61,12 @@ func RunVersion(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 		return nil
 	}
 
-	clientset, err := f.ClientSet()
+	discoveryclient, err := f.DiscoveryClient()
 	if err != nil {
 		return err
 	}
 
-	serverVersion, err := clientset.Discovery().ServerVersion()
+	serverVersion, err := discoveryclient.ServerVersion()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
…directly.

The clientset will throw an error for aggregated apiservers because the
clientset looks for specific versions of apis that are compiled into
the client.  These will be missing from aggregated apiservers.
The discoveryclient is fully dynamic and does not rely on compiled
in apiversions.

```release-note
NONE
```
