### PR TITLE
Improve watch error message

### DIFF
--- a/staging/src/k8s.io/client-go/rest/watch/decoder.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder.go
@@ -51,7 +51,11 @@ func (d *Decoder) Decode() (watch.EventType, runtime.Object, error) {
 		return "", nil, err
 	}
 	if res != &got {
-		return "", nil, fmt.Errorf("unable to decode to metav1.Event")
+		if res == nil {
+			return "", nil, fmt.Errorf("unable to decode to metav1.Event (nil result)")
+		} else {
+			return "", nil, fmt.Errorf("unable to decode to metav1.Event (result was of %s)", res.GetObjectKind().GroupVersionKind())
+		}
 	}
 	switch got.Type {
 	case string(watch.Added), string(watch.Modified), string(watch.Deleted), string(watch.Error):


### PR DESCRIPTION
When a watch fails because it cannot decode to metav1.Event, we don't
include any diagnostic information.

Include a message with the GroupVersionKind of the object we did
decode.

```release-note
NONE
```
