### PR TITLE
also consider init container when get ImageLocality HostPriority

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/image_locality.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/image_locality.go
@@ -36,6 +36,9 @@ func ImageLocalityPriorityMap(pod *v1.Pod, meta interface{}, nodeInfo *scheduler
 	}
 
 	var sumSize int64
+	for i := range pod.Spec.InitContainers {
+		sumSize += checkContainerImageOnNode(node, &pod.Spec.InitContainers[i])
+	}
 	for i := range pod.Spec.Containers {
 		sumSize += checkContainerImageOnNode(node, &pod.Spec.Containers[i])
 	}


### PR DESCRIPTION
Signed-off-by: forrestchen <forrestchen@tencent.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Now in ImageLocalityPriority, we only consider Spec.Containers, we should also consider InitContainers since PodFitsResources also consider InitContainer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
