### PR TITLE
check if image with never pullpolicy present on node in scheduler pre…

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/error.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/error.go
@@ -37,6 +37,7 @@ var (
 	ErrMaxVolumeCountExceeded    = newPredicateFailureError("MaxVolumeCount")
 	ErrNodeUnderMemoryPressure   = newPredicateFailureError("NodeUnderMemoryPressure")
 	ErrNodeUnderDiskPressure     = newPredicateFailureError("NodeUnderDiskPressure")
+	ErrImageNotPresent           = newPredicateFailureError("NoImagePresent")
 	// ErrFakePredicate is used for test only. The fake predicates returning false also returns error
 	// as ErrFakePredicate.
 	ErrFakePredicate = newPredicateFailureError("FakePredicateError")

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -1203,3 +1203,37 @@ func CheckNodeDiskPressurePredicate(pod *v1.Pod, meta interface{}, nodeInfo *sch
 	}
 	return true, nil, nil
 }
+
+// CheckImageNotPresentPredicate check if a pod can be scheduled on a node
+// If an image with PullNever policy doesn't present on node, predication will fail
+func CheckImageNotPresentPredicate(pod *v1.Pod, meta interface{}, nodeInfo *schedulercache.NodeInfo) (bool, []algorithm.PredicateFailureReason, error) {
+	node := nodeInfo.Node()
+	if node == nil {
+		return false, nil, fmt.Errorf("node not found")
+	}
+	for i := range pod.Spec.InitContainers {
+		if !checkContainerImageOnNode(node, &pod.Spec.InitContainers[i]) {
+			return false, []algorithm.PredicateFailureReason{ErrImageNotPresent}, nil
+		}
+	}
+	for i := range pod.Spec.Containers {
+		if !checkContainerImageOnNode(node, &pod.Spec.Containers[i]) {
+			return false, []algorithm.PredicateFailureReason{ErrImageNotPresent}, nil
+		}
+	}
+	return true, nil, nil
+}
+
+func checkContainerImageOnNode(node *v1.Node, container *v1.Container) bool {
+	if container.ImagePullPolicy != v1.PullNever {
+		return true
+	}
+	for _, image := range node.Status.Images {
+		for _, name := range image.Names {
+			if name == container.Image {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -3434,6 +3434,94 @@ func TestPodSchedulesOnNodeWithDiskPressureCondition(t *testing.T) {
 	}
 }
 
+func TestPodSchedulesOnNodeWithNoImageWithPullNever(t *testing.T) {
+	// specify a node with no disk pressure condition on
+	existImage := "gcr.io/image1:v1"
+	nonExistImage := "gcr.io/image1:v2"
+	node := &v1.Node{
+		Status: v1.NodeStatus{
+			Images: []v1.ContainerImage{
+				{
+					Names: []string{
+						existImage,
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		pod      *v1.Pod
+		nodeInfo *schedulercache.NodeInfo
+		fits     bool
+		name     string
+	}{
+		{
+			pod:      createPodWithContainerImage(nonExistImage, "Never", false),
+			nodeInfo: makeEmptyNodeInfo(node),
+			fits:     false,
+			name:     "pod not schedulable on node without image(in container) with policy Never",
+		},
+		{
+			pod:      createPodWithContainerImage(nonExistImage, "Never", true),
+			nodeInfo: makeEmptyNodeInfo(node),
+			fits:     false,
+			name:     "pod not schedulable on node without image with(in initContainer) policy Never",
+		},
+		{
+			pod:      createPodWithContainerImage(existImage, "Never", false),
+			nodeInfo: makeEmptyNodeInfo(node),
+			fits:     true,
+			name:     "pod schedulable on node with image with policy Never",
+		},
+		{
+			pod:      createPodWithContainerImage(nonExistImage, "Always", false),
+			nodeInfo: makeEmptyNodeInfo(node),
+			fits:     true,
+			name:     "pod schedulable on node without image with policy Always",
+		},
+		{
+			pod:      createPodWithContainerImage(existImage, "Always", false),
+			nodeInfo: makeEmptyNodeInfo(node),
+			fits:     true,
+			name:     "pod schedulable on node with image with policy Always",
+		},
+	}
+	expectedFailureReasons := []algorithm.PredicateFailureReason{ErrImageNotPresent}
+
+	for _, test := range tests {
+		fits, reasons, err := CheckImageNotPresentPredicate(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", test.name, err)
+		}
+		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
+			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.name, reasons, expectedFailureReasons)
+		}
+		if fits != test.fits {
+			t.Errorf("%s: expected %v got %v", test.name, test.fits, fits)
+		}
+	}
+}
+
+func createPodWithContainerImage(image string, pullPolicy v1.PullPolicy, initContainer bool) *v1.Pod {
+	containers := []v1.Container{
+		{
+			Name:            "container",
+			Image:           image,
+			ImagePullPolicy: pullPolicy,
+		},
+	}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "default", Namespace: "default"},
+	}
+	if initContainer {
+		pod.Spec.InitContainers = containers
+	} else {
+		pod.Spec.Containers = containers
+	}
+	return pod
+}
+
 func createPodWithVolume(pod, pv, pvc string) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: pod, Namespace: "default"},

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -159,6 +159,9 @@ func defaultPredicates() sets.String {
 
 		// Fit is determined by node disk pressure condition.
 		factory.RegisterFitPredicate("CheckNodeDiskPressure", predicates.CheckNodeDiskPressurePredicate),
+
+		// Fir is determined by image present on node
+		factory.RegisterFitPredicate("CheckImageNotPresent", predicates.CheckImageNotPresentPredicate),
 	)
 }
 


### PR DESCRIPTION
…dicate process


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Inspired by #40639 , we should filter out those nodes which image not present but pull policy is `Never`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
