### PR TITLE
optimize duplicate openstack serverList judgement

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -295,8 +295,6 @@ func getServerByName(client *gophercloud.ServiceClient, name types.NodeName) (*s
 
 	if len(serverList) == 0 {
 		return nil, ErrNotFound
-	} else if len(serverList) > 1 {
-		return nil, ErrMultipleResults
 	}
 
 	return &serverList[0], nil


### PR DESCRIPTION
if len(serverList) > 1, we will return err in pager.EachPage() function,so here we do not need to judge again

