### PR TITLE
Fixed a tiny bug on using RoleBindingGenerator

### DIFF
--- a/pkg/kubectl/clusterrolebinding.go
+++ b/pkg/kubectl/clusterrolebinding.go
@@ -77,7 +77,7 @@ func (s ClusterRoleBindingGeneratorV1) Generate(genericParams map[string]interfa
 			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
 		}
 		delegate.ServiceAccounts = fromLiteralArray
-		delete(genericParams, "serviceaccounts")
+		delete(genericParams, "serviceaccount")
 	}
 	params := map[string]string{}
 	for key, value := range genericParams {

--- a/pkg/kubectl/rolebinding.go
+++ b/pkg/kubectl/rolebinding.go
@@ -79,7 +79,7 @@ func (s RoleBindingGeneratorV1) Generate(genericParams map[string]interface{}) (
 			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
 		}
 		delegate.ServiceAccounts = fromLiteralArray
-		delete(genericParams, "serviceaccounts")
+		delete(genericParams, "serviceaccount")
 	}
 	params := map[string]string{}
 	for key, value := range genericParams {


### PR DESCRIPTION
Fixed a typo bug while using RoleBindingGenerator, this
bug causes error when binding role to service accounts
through "kubectl create rolebinding" command.
