### PR TITLE
Remove useless param from kubectl create rolebinding

### DIFF
--- a/pkg/kubectl/clusterrolebinding.go
+++ b/pkg/kubectl/clusterrolebinding.go
@@ -100,7 +100,6 @@ func (s ClusterRoleBindingGeneratorV1) ParamNames() []GeneratorParam {
 		{"user", false},
 		{"group", false},
 		{"serviceaccount", false},
-		{"force", false},
 	}
 }
 

--- a/pkg/kubectl/rolebinding.go
+++ b/pkg/kubectl/rolebinding.go
@@ -104,7 +104,6 @@ func (s RoleBindingGeneratorV1) ParamNames() []GeneratorParam {
 		{"user", false},
 		{"group", false},
 		{"serviceaccount", false},
-		{"force", false},
 	}
 }
 


### PR DESCRIPTION
The `force` param is not used in
`kubectl create rolebinding` & `kubectl create clusterrolebinding`
commands, removed it.