### PR TITLE
add deads2k to registry package owners

### DIFF
--- a/pkg/registry/OWNERS
+++ b/pkg/registry/OWNERS
@@ -1,4 +1,5 @@
 approvers:
+- deads2k
 - lavalamp
 - smarterclayton
 - wojtek-t


### PR DESCRIPTION
I established the package layout and wrote a lot of the non-boilerplate code in this package.