### PR TITLE
Add alternative names for the server binaries to hyperkube

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -66,6 +66,8 @@ COPY cni-bin/bin /opt/cni/bin
 COPY cni-conf /etc/cni/net.d
 
 # Create symlinks for each hyperkube server
+# Also create symlinks to /usr/local/bin/ where the server image binaries live, so the hyperkube image may be 
+# used instead of gcr.io/google_containers/kube-* without any modifications.
 # TODO: replace manual symlink creation with --make-symlink command once
 # cross-building with qemu supports go binaries. See #28702
 # RUN /hyperkube --make-symlinks
@@ -76,8 +78,15 @@ RUN ln -s /hyperkube /apiserver \
  && ln -s /hyperkube /kubectl \
  && ln -s /hyperkube /kubelet \
  && ln -s /hyperkube /proxy \
- && ln -s /hyperkube /scheduler
+ && ln -s /hyperkube /scheduler \
+ && ln -s /hyperkube /usr/local/bin/kube-apiserver \
+ && ln -s /hyperkube /usr/local/bin/kube-controller-manager \
+ && ln -s /hyperkube /usr/local/bin/federation-apiserver \
+ && ln -s /hyperkube /usr/local/bin/federation-controller-manager \
+ && ln -s /hyperkube /usr/local/bin/kubectl \
+ && ln -s /hyperkube /usr/local/bin/kubelet \
+ && ln -s /hyperkube /usr/local/bin/kube-proxy \
+ && ln -s /hyperkube /usr/local/bin/kube-scheduler
 
 # Copy the hyperkube binary
 COPY hyperkube /hyperkube
-

--- a/cmd/hyperkube/hyperkube.go
+++ b/cmd/hyperkube/hyperkube.go
@@ -55,7 +55,7 @@ func (hk *HyperKube) AddServer(s *Server) {
 // FindServer will find a specific server named name.
 func (hk *HyperKube) FindServer(name string) (*Server, error) {
 	for _, s := range hk.servers {
-		if s.Name() == name {
+		if s.Name() == name || s.AlternativeName == name {
 			return &s, nil
 		}
 	}

--- a/cmd/hyperkube/kube-apiserver.go
+++ b/cmd/hyperkube/kube-apiserver.go
@@ -27,8 +27,10 @@ func NewKubeAPIServer() *Server {
 	s := options.NewServerRunOptions()
 
 	hks := Server{
-		SimpleUsage: "apiserver",
-		Long:        "The main API entrypoint and interface to the storage system.  The API server is also the focal point for all authorization decisions.",
+		name:            "apiserver",
+		AlternativeName: "kube-apiserver",
+		SimpleUsage:     "apiserver",
+		Long:            "The main API entrypoint and interface to the storage system.  The API server is also the focal point for all authorization decisions.",
 		Run: func(_ *Server, args []string) error {
 			return app.Run(s)
 		},

--- a/cmd/hyperkube/kube-controller-manager.go
+++ b/cmd/hyperkube/kube-controller-manager.go
@@ -27,8 +27,10 @@ func NewKubeControllerManager() *Server {
 	s := options.NewCMServer()
 
 	hks := Server{
-		SimpleUsage: "controller-manager",
-		Long:        "A server that runs a set of active components. This includes replication controllers, service endpoints and nodes.",
+		name:            "controller-manager",
+		AlternativeName: "kube-controller-manager",
+		SimpleUsage:     "controller-manager",
+		Long:            "A server that runs a set of active components. This includes replication controllers, service endpoints and nodes.",
 		Run: func(_ *Server, args []string) error {
 			return app.Run(s)
 		},

--- a/cmd/hyperkube/kube-proxy.go
+++ b/cmd/hyperkube/kube-proxy.go
@@ -32,7 +32,9 @@ func NewKubeProxy() *Server {
 	config := options.NewProxyConfig()
 
 	hks := Server{
-		SimpleUsage: "proxy",
+		name:            "proxy",
+		AlternativeName: "kube-proxy",
+		SimpleUsage:     "proxy",
 		Long: `The Kubernetes proxy server is responsible for taking traffic directed at
 		services and forwarding it to the appropriate pods. It generally runs on
 		nodes next to the Kubelet and proxies traffic from local pods to remote pods.

--- a/cmd/hyperkube/kube-scheduler.go
+++ b/cmd/hyperkube/kube-scheduler.go
@@ -27,8 +27,10 @@ func NewScheduler() *Server {
 	s := options.NewSchedulerServer()
 
 	hks := Server{
-		SimpleUsage: "scheduler",
-		Long:        "Implements a Kubernetes scheduler.  This will assign pods to kubelets based on capacity and constraints.",
+		name:            "scheduler",
+		AlternativeName: "kube-scheduler",
+		SimpleUsage:     "scheduler",
+		Long:            "Implements a Kubernetes scheduler.  This will assign pods to kubelets based on capacity and constraints.",
 		Run: func(_ *Server, _ []string) error {
 			return app.Run(s)
 		},

--- a/cmd/hyperkube/kubelet.go
+++ b/cmd/hyperkube/kubelet.go
@@ -26,6 +26,7 @@ import (
 func NewKubelet() *Server {
 	s := options.NewKubeletServer()
 	hks := Server{
+		name:        "kubelet",
 		SimpleUsage: "kubelet",
 		Long: `The kubelet binary is responsible for maintaining a set of containers on a
 		particular node. It syncs data from a variety of sources including a

--- a/cmd/hyperkube/server.go
+++ b/cmd/hyperkube/server.go
@@ -30,9 +30,10 @@ type serverRunFunc func(s *Server, args []string) error
 
 // Server describes a server that this binary can morph into.
 type Server struct {
-	SimpleUsage string        // One line description of the server.
-	Long        string        // Longer free form description of the server
-	Run         serverRunFunc // Run the server.  This is not expected to return.
+	SimpleUsage     string        // One line description of the server.
+	Long            string        // Longer free form description of the server
+	Run             serverRunFunc // Run the server.  This is not expected to return.
+	AlternativeName string
 
 	flags *pflag.FlagSet // Flags for the command (and all dependents)
 	name  string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Right now one can't swap a server image to the hyperkube image without touching the `command` field in the yaml spec, and that's daunting and leading to extra and unnecessary logic for example in kubeadm.

This makes the hyperkube image directly swappable, so now `/usr/local/bin/kube-*` is a portable first argument (or simply `kube-*` if there's a shell).

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Align the hyperkube image to support running binaries at /usr/local/bin/ like the other server images
```
@jessfraz @thockin @ixdy 