### PR TITLE
kubeadm: Small cleanup and fixes, validate the service subnet

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
@@ -13,6 +13,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/util/validation/field",
     ],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -14,6 +15,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
+        "//pkg/registry/core/service/ipallocator:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/util/validation/field",
     ],
 )
@@ -29,4 +31,12 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["validation_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//vendor:k8s.io/apimachinery/pkg/util/validation/field"],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -17,12 +17,12 @@ limitations under the License.
 package validation
 
 import (
-	"math"
 	"net"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
 func ValidateMasterConfiguration(c *kubeadm.MasterConfiguration) field.ErrorList {
@@ -79,8 +79,7 @@ func ValidateServiceSubnet(subnet string, fldPath *field.Path) field.ErrorList {
 	if err != nil {
 		return field.ErrorList{field.Invalid(fldPath, nil, "couldn't parse the service subnet")}
 	}
-	cidrBytesMask, _ := svcSubnet.Mask.Size()
-	numAddresses := int32(math.Pow(2, float64(32-cidrBytesMask)))
+	numAddresses := ipallocator.RangeSize(svcSubnet)
 	if numAddresses < kubeadmconstants.MinimumAddressesInServiceSubnet {
 		return field.ErrorList{field.Invalid(fldPath, nil, "service subnet is too small")}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -1,0 +1,31 @@
+package validation
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+func TestValidateServiceSubnet(t *testing.T) {
+	var tests = []struct {
+		s        string
+		f        *field.Path
+		expected bool
+	}{
+		{"", nil, false},
+		{"this is not a cidr", nil, false}, // not a CIDR
+		{"10.0.0.1", nil, false},           // not a CIDR
+		{"192.0.2.0/1", nil, false},        // CIDR too smal
+		{"192.0.2.0/24", nil, true},
+	}
+	for _, rt := range tests {
+		actual := ValidateServiceSubnet(rt.s, rt.f)
+		if (len(actual) == 0) != rt.expected {
+			t.Errorf(
+				"failed ValidateServiceSubnet:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(len(actual) == 0),
+			)
+		}
+	}
+}

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package validation
 
 import (
@@ -15,8 +31,9 @@ func TestValidateServiceSubnet(t *testing.T) {
 		{"", nil, false},
 		{"this is not a cidr", nil, false}, // not a CIDR
 		{"10.0.0.1", nil, false},           // not a CIDR
-		{"192.0.2.0/1", nil, false},        // CIDR too smal
-		{"192.0.2.0/24", nil, true},
+		{"10.96.0.1/29", nil, false},       // CIDR too small, only 8 addresses and we require at least 10
+		{"10.96.0.1/28", nil, true},        // a /28 subnet is ok because it can contain 16 addresses
+		{"10.96.0.1/12", nil, true},        // the default subnet should obviously pass as well
 	}
 	for _, rt := range tests {
 		actual := ValidateServiceSubnet(rt.s, rt.f)

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -48,4 +48,8 @@ const (
 
 	// APICallRetryInterval defines how long kubeadm should wait before retrying a failed API operation
 	APICallRetryInterval = 500 * time.Millisecond
+
+	// Minimum amount of nodes the Service subnet should allow.
+	// We need at least ten, because the DNS service is always at the tenth cluster clusterIP
+	MinimumAddressesInServiceSubnet = 10
 )

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -424,12 +424,6 @@ func getSchedulerCommand(cfg *kubeadmapi.MasterConfiguration, selfHosted bool) [
 	return command
 }
 
-func getProxyCommand(cfg *kubeadmapi.MasterConfiguration) []string {
-	return append(getComponentBaseCommand(proxy),
-		"--cluster-cidr="+cfg.Networking.PodSubnet,
-	)
-}
-
 func getProxyEnvVars() []api.EnvVar {
 	envs := []api.EnvVar{}
 	for _, env := range os.Environ() {

--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -552,35 +552,3 @@ func TestGetSchedulerCommand(t *testing.T) {
 		}
 	}
 }
-
-func TestGetProxyCommand(t *testing.T) {
-	var tests = []struct {
-		cfg      *kubeadmapi.MasterConfiguration
-		expected []string
-	}{
-		{
-			cfg: &kubeadmapi.MasterConfiguration{
-				Networking: kubeadm.Networking{
-					PodSubnet: "bar",
-				},
-			},
-			expected: []string{
-				"kube-proxy",
-				"--cluster-cidr=bar",
-			},
-		},
-	}
-
-	for _, rt := range tests {
-		actual := getProxyCommand(rt.cfg)
-		for i := range actual {
-			if actual[i] != rt.expected[i] {
-				t.Errorf(
-					"failed getProxyCommand:\n\texpected: %s\n\t  actual: %s",
-					rt.expected[i],
-					actual[i],
-				)
-			}
-		}
-	}
-}

--- a/cmd/kubeadm/app/phases/addons/BUILD
+++ b/cmd/kubeadm/app/phases/addons/BUILD
@@ -16,12 +16,12 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
-        "//pkg/registry/core/service/ipallocator:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
     ],

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -71,11 +71,13 @@ spec:
     spec:
       containers:
       - name: kube-proxy
-        image: {{ .ImageRepository }}/kube-proxy-{{ .Arch }}:{{ .Version }}
+        image: {{ .Image }}
         imagePullPolicy: IfNotPresent
+        # TODO: This is gonna work with hyperkube v1.6.0-alpha.2+: https://github.com/kubernetes/kubernetes/pull/41017
         command:
         - kube-proxy
         - --kubeconfig=/var/lib/kube-proxy/kubeconfig.conf
+        {{ .ClusterCIDR }}
         securityContext:
           privileged: true
         volumeMounts:

--- a/cmd/kubeadm/app/util/template.go
+++ b/cmd/kubeadm/app/util/template.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
 - Validate the minimum subnet cidr so there are always 10 available addresses
 - Remove an old proxy arg function, add clustercidr to the proxy manifest and automatically calculate the dns ip

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

@errordeveloper @pires @mikedanese @dmmcquay @dgoodwin 
