### PR TITLE
kubeadm: change os.Remove to os.RemoveAll

### DIFF
--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -32,7 +32,7 @@ func TestCreatePKIAssets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't create tmpdir")
 	}
-	defer os.Remove(tmpdir)
+	defer os.RemoveAll(tmpdir)
 
 	var tests = []struct {
 		cfg      *kubeadmapi.MasterConfiguration


### PR DESCRIPTION
**What this PR does / why we need it**: This would not correctly clean out the tmp dir, since os.Remove doesn't recursively remove dirs, which could exist in the tmp dir.

Unit tests are a WIP from #34136

**Special notes for your reviewer**: /cc @luxas @pires 

**Release note**:
```release-note
NONE
```
