### PR TITLE
add recommended aggregated api server options

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/server"
+)
+
+// RecommendedOptions contains the recommended options for running an API server
+// If you add something to this list, it should be in a logical grouping
+type RecommendedOptions struct {
+	Etcd           *EtcdOptions
+	SecureServing  *SecureServingOptions
+	Authentication *DelegatingAuthenticationOptions
+	Authorization  *DelegatingAuthorizationOptions
+}
+
+func NewRecommendedOptions(scheme *runtime.Scheme) *RecommendedOptions {
+	return &RecommendedOptions{
+		Etcd:           NewEtcdOptions(scheme),
+		SecureServing:  NewSecureServingOptions(),
+		Authentication: NewDelegatingAuthenticationOptions(),
+		Authorization:  NewDelegatingAuthorizationOptions(),
+	}
+}
+
+func (o *RecommendedOptions) AddFlags(fs *pflag.FlagSet) {
+	o.Etcd.AddFlags(fs)
+	o.SecureServing.AddFlags(fs)
+	o.Authentication.AddFlags(fs)
+	o.Authorization.AddFlags(fs)
+}
+
+func (o *RecommendedOptions) ApplyTo(config *server.Config) error {
+	if err := o.SecureServing.ApplyTo(config); err != nil {
+		return err
+	}
+	if err := o.Authentication.ApplyTo(config); err != nil {
+		return err
+	}
+	if err := o.Authorization.ApplyTo(config); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -14093,6 +14093,7 @@ go_library(
         "k8s.io/apiserver/pkg/server/options/authorization.go",
         "k8s.io/apiserver/pkg/server/options/doc.go",
         "k8s.io/apiserver/pkg/server/options/etcd.go",
+        "k8s.io/apiserver/pkg/server/options/recommended.go",
         "k8s.io/apiserver/pkg/server/options/server_run_options.go",
         "k8s.io/apiserver/pkg/server/options/serving.go",
     ],


### PR DESCRIPTION
This builds on https://github.com/kubernetes/kubernetes/pull/40947.  It uses the `ApplyTo` pattern to group several related options together.

@sttts 