### PR TITLE
Make fluentd a critical pod

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -14,6 +14,11 @@ spec:
         k8s-app: fluentd-es
         kubernetes.io/cluster-service: "true"
         version: v1.22
+  # This annotation ensures that fluentd does not get evicted if the node
+  # supports critical pod annotation based priority scheme.
+  # Note that this does not guarantee admission on the nodes (#40573).
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
       - name: fluentd-es

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -15,6 +15,11 @@ spec:
         k8s-app: fluentd-gcp
         kubernetes.io/cluster-service: "true"
         version: v1.35
+  # This annotation ensures that fluentd does not get evicted if the node
+  # supports critical pod annotation based priority scheme.
+  # Note that this does not guarantee admission on the nodes (#40573).
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
       - name: fluentd-gcp

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -6,6 +6,11 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: fluentd-logging
+  # This annotation ensures that fluentd does not get evicted if the node
+  # supports critical pod annotation based priority scheme.
+  # Note that this does not guarantee admission on the nodes (#40573).
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
 spec:
   dnsPolicy: Default
   containers:


### PR DESCRIPTION
For #40573
Based on https://github.com/kubernetes/kubernetes/pull/40655#issuecomment-277790544

```release-note
If `experimentalCriticalPodAnnotation` feature gate is set to true, fluentd pods will not be evicted by the kubelet.
```