### PR TITLE
Bump up GLBC version from 0.9.0-beta to 0.9.1

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.9.0
+  name: l7-lb-controller-v0.9.1
   namespace: kube-system
   labels:
     k8s-app: glbc
-    version: v0.9.0
+    version: v0.9.1
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/glbc:0.9.0-beta.1
+  - image: gcr.io/google_containers/glbc:0.9.1
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Tests have been green, moving the beta to a release. 