### PR TITLE
Use a provider independent make

### DIFF
--- a/test/kubemark/cloud-provider-config.sh
+++ b/test/kubemark/cloud-provider-config.sh
@@ -15,3 +15,5 @@
 # limitations under the License.
 
 CLOUD_PROVIDER="${CLOUD_PROVIDER:-gce}"
+PROJECT="${PROJECT:-google_containers}"
+REGISTRY="${REGISTRY:-gcr.io}"

--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -104,6 +104,10 @@ function delete-master-instance-and-resources {
   fi
 }
 
+function build-and-push-kubemark {
+    make gcloudpush PROJECT=${PROJECT} REGISTRY=${REGISTRY}
+}
+
 function delete-master-instance-and-resources {
   GCLOUD_COMMON_ARGS="--project ${PROJECT} --zone ${ZONE} --quiet"
 

--- a/test/kubemark/resources/hollow-node_template.json
+++ b/test/kubemark/resources/hollow-node_template.json
@@ -52,7 +52,7 @@
 				"containers": [
 				{
 					"name": "hollow-kubelet",
-					"image": "gcr.io/{{project}}/kubemark:latest",
+					"image": "{{registry}}/{{project}}/kubemark:latest",
 					"ports": [
 						{"containerPort": 4194},
 						{"containerPort": 10250},
@@ -106,7 +106,7 @@
 				},
 				{
 					"name": "hollow-proxy",
-					"image": "gcr.io/{{project}}/kubemark:latest",
+					"image": "{{registry}}/{{project}}/kubemark:latest",
 					"env": [
 						{
 							"name": "CONTENT_TYPE",
@@ -151,7 +151,7 @@
 				},
 				{
 					"name": "hollow-node-problem-detector",
-					"image": "gcr.io/google_containers/node-problem-detector:v0.3.0-alpha.0",
+					"image": "{{registry}}/{{project}}/node-problem-detector:v0.3.0-alpha.0",
 					"env": [
 						{
 							"name": "NODE_NAME",

--- a/test/kubemark/skeleton/util.sh
+++ b/test/kubemark/skeleton/util.sh
@@ -52,6 +52,18 @@ function copy-files() {
 	echo "Copying files" 1>&2
 }
 
+# This function should use the kubemark Makefile to build and push the kubemark
+# image to registry denoted as: $REGISTRY/$PROJECT/kubemark
+#
+# Recommended for this function to include retrying logic in case of failures.
+#
+# ENV vars expected for this function:
+# 1. PROJECT
+# 2. REGISTRY
+function build-and-push-kubemark {
+	echo "Building and pushing the kubemark container" 1>&2
+}
+
 # This function should delete the master instance along with all the
 # resources that have been allocated inside the function
 # 'create-master-instance-with-resources' above.

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -168,7 +168,7 @@ function create-and-upload-hollow-node-image {
   cd "${MAKE_DIR}"
   RETRIES=3
   for attempt in $(seq 1 ${RETRIES}); do
-    if ! make; then
+    if ! build-and-push-kubemark; then
       if [[ $((attempt)) -eq "${RETRIES}" ]]; then
         echo "${color_red}Make failed. Exiting.${color_norm}"
         exit 1
@@ -296,6 +296,7 @@ current-context: kubemark-context")
   # TODO(shyamjvs): Make path to docker image variable in hollow-node_template.json.
   sed "s/{{numreplicas}}/${NUM_NODES:-10}/g" "${RESOURCE_DIRECTORY}/hollow-node_template.json" > "${RESOURCE_DIRECTORY}/hollow-node.json"
   sed -i'' -e "s/{{project}}/${PROJECT}/g" "${RESOURCE_DIRECTORY}/hollow-node.json"
+  sed -i'' -e "s/{{registry}}/${REGISTRY}/g" "${RESOURCE_DIRECTORY}/hollow-node.json"
   sed -i'' -e "s/{{master_ip}}/${MASTER_IP}/g" "${RESOURCE_DIRECTORY}/hollow-node.json"
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/hollow-node.json" --namespace="kubemark"
 


### PR DESCRIPTION
Ref issue #38967

Now that the Makefile for building the kubemark container is no longer provider specific, remove the provider specific reference to make in the start script.