### PR TITLE
Update owners file for job and cronjob controller

### DIFF
--- a/pkg/controller/cronjob/OWNERS
+++ b/pkg/controller/cronjob/OWNERS
@@ -1,3 +1,7 @@
+approvers:
+- erictune
+- janetkuo
+- soltysh
 reviewers:
 - erictune
 - janetkuo

--- a/pkg/controller/job/OWNERS
+++ b/pkg/controller/job/OWNERS
@@ -1,3 +1,8 @@
+approvers:
+- erictune
+- janetkuo
+- soltysh
 reviewers:
 - erictune
+- janetkuo
 - soltysh


### PR DESCRIPTION
I've just noticed we have outdated OWNERS files for job and cronjob controllers.

@erictune ptal
@kubernetes/sig-contributor-experience-pr-reviews fyi