### PR TITLE
auto-create the loopback token

### DIFF
--- a/cmd/kube-aggregator/pkg/cmd/server/BUILD
+++ b/cmd/kube-aggregator/pkg/cmd/server/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
-        "//vendor:github.com/pborman/uuid",
         "//vendor:github.com/spf13/cobra",
         "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",

--- a/cmd/kube-aggregator/pkg/cmd/server/start.go
+++ b/cmd/kube-aggregator/pkg/cmd/server/start.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"io/ioutil"
 
-	"github.com/pborman/uuid"
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -104,12 +103,6 @@ func (o AggregatorOptions) RunAggregator() error {
 		sets.NewString("watch", "proxy"),
 		sets.NewString("attach", "exec", "proxy", "log", "portforward"),
 	)
-
-	var err error
-	privilegedLoopbackToken := uuid.NewRandom().String()
-	if serverConfig.LoopbackClientConfig, err = serverConfig.SecureServingInfo.NewSelfClientConfig(privilegedLoopbackToken); err != nil {
-		return err
-	}
 
 	kubeconfig, err := restclient.InClusterConfig()
 	if err != nil {

--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -53,7 +53,6 @@ go_library(
         "//plugin/pkg/admission/storageclass/default:go_default_library",
         "//vendor:github.com/go-openapi/spec",
         "//vendor:github.com/golang/glog",
-        "//vendor:github.com/pborman/uuid",
         "//vendor:github.com/spf13/cobra",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apimachinery/pkg/openapi",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/golang/glog"
-	"github.com/pborman/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -258,12 +257,7 @@ func Run(s *options.ServerRunOptions) error {
 		return fmt.Errorf("invalid Authentication Config: %v", err)
 	}
 
-	privilegedLoopbackToken := uuid.NewRandom().String()
-	selfClientConfig, err := genericapiserver.NewSelfClientConfig(genericConfig.SecureServingInfo, genericConfig.InsecureServingInfo, privilegedLoopbackToken)
-	if err != nil {
-		return fmt.Errorf("failed to create clientset: %v", err)
-	}
-	client, err := internalclientset.NewForConfig(selfClientConfig)
+	client, err := internalclientset.NewForConfig(genericConfig.LoopbackClientConfig)
 	if err != nil {
 		kubeAPIVersions := os.Getenv("KUBE_API_VERSIONS")
 		if len(kubeAPIVersions) == 0 {
@@ -301,7 +295,6 @@ func Run(s *options.ServerRunOptions) error {
 	kubeVersion := version.Get()
 
 	genericConfig.Version = &kubeVersion
-	genericConfig.LoopbackClientConfig = selfClientConfig
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.Authorizer = apiAuthorizer
 	genericConfig.AdmissionControl = admissionController

--- a/federation/cmd/federation-apiserver/app/BUILD
+++ b/federation/cmd/federation-apiserver/app/BUILD
@@ -61,7 +61,6 @@ go_library(
         "//plugin/pkg/admission/namespace/lifecycle:go_default_library",
         "//vendor:github.com/go-openapi/spec",
         "//vendor:github.com/golang/glog",
-        "//vendor:github.com/pborman/uuid",
         "//vendor:github.com/spf13/cobra",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apimachinery/pkg/openapi",

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/golang/glog"
-	"github.com/pborman/uuid"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -152,12 +151,7 @@ func Run(s *options.ServerRunOptions) error {
 		return fmt.Errorf("invalid Authentication Config: %v", err)
 	}
 
-	privilegedLoopbackToken := uuid.NewRandom().String()
-	selfClientConfig, err := genericapiserver.NewSelfClientConfig(genericConfig.SecureServingInfo, genericConfig.InsecureServingInfo, privilegedLoopbackToken)
-	if err != nil {
-		return fmt.Errorf("failed to create clientset: %v", err)
-	}
-	client, err := internalclientset.NewForConfig(selfClientConfig)
+	client, err := internalclientset.NewForConfig(genericConfig.LoopbackClientConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create clientset: %v", err)
 	}
@@ -182,7 +176,6 @@ func Run(s *options.ServerRunOptions) error {
 
 	kubeVersion := version.Get()
 	genericConfig.Version = &kubeVersion
-	genericConfig.LoopbackClientConfig = selfClientConfig
 	genericConfig.Authenticator = apiAuthenticator
 	genericConfig.Authorizer = apiAuthorizer
 	genericConfig.AdmissionControl = admissionController

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -371,6 +371,9 @@ func (c completedConfig) New() (*GenericAPIServer, error) {
 	if c.Serializer == nil {
 		return nil, fmt.Errorf("Genericapiserver.New() called with config.Serializer == nil")
 	}
+	if c.LoopbackClientConfig == nil {
+		return nil, fmt.Errorf("Genericapiserver.New() called with config.LoopbackClientConfig == nil")
+	}
 
 	s := &GenericAPIServer{
 		discoveryAddresses:     c.DiscoveryAddresses,

--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
@@ -20,35 +20,11 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"net"
 
 	restclient "k8s.io/client-go/rest"
-
-	"github.com/golang/glog"
 )
-
-// NewSelfClientConfig returns a clientconfig which can be used to talk to this apiserver.
-func NewSelfClientConfig(secureServingInfo *SecureServingInfo, insecureServingInfo *ServingInfo, token string) (*restclient.Config, error) {
-	cfg, err := secureServingInfo.NewSelfClientConfig(token)
-	if cfg != nil && err == nil {
-		return cfg, nil
-	}
-	if err != nil {
-		if insecureServingInfo == nil {
-			// be fatal if insecure port is not available
-			return nil, err
-		}
-
-		glog.Warningf("Failed to create secure local client, falling back to insecure local connection: %v", err)
-	}
-	if cfg, err := insecureServingInfo.NewSelfClientConfig(token); err != nil || cfg != nil {
-		return cfg, err
-	}
-
-	return nil, errors.New("Unable to set url for apiserver local client")
-}
 
 func (s *SecureServingInfo) NewSelfClientConfig(token string) (*restclient.Config, error) {
 	if s == nil || (s.Cert == nil && len(s.SNICerts) == 0) {

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -46,10 +46,11 @@ import (
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	"k8s.io/client-go/pkg/api"
+	restclient "k8s.io/client-go/rest"
 	openapigen "k8s.io/kubernetes/pkg/generated/openapi"
-	"k8s.io/apiserver/pkg/registry/rest"
 )
 
 const (
@@ -85,6 +86,7 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	config.PublicAddress = net.ParseIP("192.168.10.4")
 	config.RequestContextMapper = genericapirequest.NewRequestContextMapper()
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
+	config.LoopbackClientConfig = &restclient.Config{}
 
 	config.OpenAPIConfig = DefaultOpenAPIConfig(openapigen.GetOpenAPIDefinitions, api.Scheme)
 	config.OpenAPIConfig.Info = &spec.Info{

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -36,6 +36,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	. "k8s.io/apiserver/pkg/server"
 	utilflag "k8s.io/apiserver/pkg/util/flag"
+	restclient "k8s.io/client-go/rest"
 	utilcert "k8s.io/client-go/util/cert"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 )
@@ -493,6 +494,7 @@ NextTest:
 			},
 			SNICertKeys: namedCertKeys,
 		}
+		config.LoopbackClientConfig = &restclient.Config{}
 		if err := secureOptions.ApplyTo(&config); err != nil {
 			t.Errorf("%q - failed applying the SecureServingOptions: %v", title, err)
 			continue NextTest

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/pborman/uuid"
 	"github.com/spf13/cobra"
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -93,12 +92,6 @@ func (o WardleServerOptions) Config() (*apiserver.Config, error) {
 
 	serverConfig := genericapiserver.NewConfig().WithSerializer(apiserver.Codecs)
 	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
-		return nil, err
-	}
-
-	var err error
-	privilegedLoopbackToken := uuid.NewRandom().String()
-	if serverConfig.LoopbackClientConfig, err = serverConfig.SecureServingInfo.NewSelfClientConfig(privilegedLoopbackToken); err != nil {
 		return nil, err
 	}
 

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -14128,6 +14128,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//vendor:github.com/golang/glog",
+        "//vendor:github.com/pborman/uuid",
         "//vendor:github.com/spf13/pflag",
         "//vendor:gopkg.in/natefinch/lumberjack.v2",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
@@ -14836,6 +14837,7 @@ go_test(
         "//vendor:k8s.io/apiserver/pkg/storage/etcd/testing",
         "//vendor:k8s.io/apiserver/pkg/storage/storagebackend",
         "//vendor:k8s.io/client-go/pkg/api",
+        "//vendor:k8s.io/client-go/rest",
     ],
 )
 
@@ -15303,6 +15305,7 @@ go_test(
         "//vendor:k8s.io/apiserver/pkg/endpoints/request",
         "//vendor:k8s.io/apiserver/pkg/server",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/cert",
     ],
 )
@@ -15399,7 +15402,6 @@ go_library(
     srcs = ["k8s.io/sample-apiserver/pkg/cmd/server/start.go"],
     tags = ["automanaged"],
     deps = [
-        "//vendor:github.com/pborman/uuid",
         "//vendor:github.com/spf13/cobra",
         "//vendor:k8s.io/apiserver/pkg/server",
         "//vendor:k8s.io/apiserver/pkg/server/options",


### PR DESCRIPTION
Users of the apiserver library have no need to specify particular loopback tokens, we can autogenerate and provision them.

@kubernetes/sig-api-machinery-misc @sttts 