### PR TITLE
Use privileged containers for statefulset e2e tests

### DIFF
--- a/test/e2e/statefulset.go
+++ b/test/e2e/statefulset.go
@@ -722,7 +722,7 @@ func (s *statefulSetTester) createStatefulSet(manifestPath, ns string) *apps.Sta
 func (s *statefulSetTester) checkMount(ss *apps.StatefulSet, mountPath string) error {
 	for _, cmd := range []string{
 		// Print inode, size etc
-		fmt.Sprintf("ls -idlh %v", mountPath),
+		fmt.Sprintf("ls -idlhZ %v", mountPath),
 		// Print subdirs
 		fmt.Sprintf("find %v", mountPath),
 		// Try writing
@@ -1118,6 +1118,8 @@ func newStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 		})
 	}
 
+	privileged := true
+
 	return &apps.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "StatefulSet",
@@ -1143,6 +1145,9 @@ func newStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 							Name:         "nginx",
 							Image:        nginxImage,
 							VolumeMounts: mounts,
+							SecurityContext: &v1.SecurityContext{
+								Privileged: &privileged,
+							},
 						},
 					},
 					Volumes: vols,


### PR DESCRIPTION
Test containers need to run as spc_t in order to interact with the host
filesystem under /tmp, as the tests for StatefulSet are doing. Docker
will transition the container into this domain when running the container
as privileged.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

**Release note**:
```release-note
NONE
```

/cc @ncdc @soltysh @pmorie 