### PR TITLE
parse single string as group rather than version

### DIFF
--- a/cmd/libs/go2idl/client-gen/types/helpers.go
+++ b/cmd/libs/go2idl/client-gen/types/helpers.go
@@ -36,7 +36,7 @@ func ToGroupVersion(gv string) (GroupVersion, error) {
 
 	switch strings.Count(gv, "/") {
 	case 0:
-		return GroupVersion{"", Version(gv)}, nil
+		return GroupVersion{Group(gv), ""}, nil
 	case 1:
 		i := strings.Index(gv, "/")
 		return GroupVersion{Group(gv[:i]), Version(gv[i+1:])}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevent bad code generation by adjusting parsing of input.

When client-gen is run with `--input` as an unversioned type, it blows up if the group does not end with a trailing slash.

examples
1. `--input servicecatalog/v1alpha` is group servicecatalog, with version v1alpha1
1. `--input servicecatalog/` is group servicecatalog, with version empty string
1. `--input servicecatalog` is group empty string, with version servicecatalog

I disagree that the second and third cases are different. This adjusts them so they are both case 2.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

This change would address the concerns in PR https://github.com/kubernetes/community/pull/343

**Special notes for your reviewer**:
@caesarxuchao @pmorie this does not result in any change in any current code generation, and improves the user experience of client-gen. I ran `hack/update-codegen.sh` and saw no changes in git, nor did anything fail.

**Release note**:
```release-note
NONE
```