### PR TITLE
Automated cherry pick of #40335

### DIFF
--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -41,7 +41,7 @@ var _ = framework.KubeDescribe("ReplicationController", func() {
 		// requires private images
 		framework.SkipUnlessProviderIs("gce", "gke")
 
-		ServeImageOrFail(f, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
+		ServeImageOrFail(f, "private", "gcr.io/k8s-authenticated-test/serve_hostname:v1.4")
 	})
 })
 

--- a/test/e2e/replica_set.go
+++ b/test/e2e/replica_set.go
@@ -43,7 +43,7 @@ var _ = framework.KubeDescribe("ReplicaSet", func() {
 		// requires private images
 		framework.SkipUnlessProviderIs("gce", "gke")
 
-		ReplicaSetServeImageOrFail(f, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
+		ReplicaSetServeImageOrFail(f, "private", "gcr.io/k8s-authenticated-test/serve_hostname:v1.4")
 	})
 })
 


### PR DESCRIPTION
Cherry pick of #40335 on release-1.4.

#40335: Move b.gcr.io/k8s_authenticated_test to