### PR TITLE
Automated cherry pick of #40335

### DIFF
--- a/test/e2e/rc.go
+++ b/test/e2e/rc.go
@@ -43,7 +43,7 @@ var _ = framework.KubeDescribe("ReplicationController", func() {
 		// requires private images
 		framework.SkipUnlessProviderIs("gce", "gke")
 
-		ServeImageOrFail(f, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
+		ServeImageOrFail(f, "private", "gcr.io/k8s-authenticated-test/serve_hostname:v1.4")
 	})
 
 	It("should surface a failure condition on a common issue like exceeded quota", func() {

--- a/test/e2e/replica_set.go
+++ b/test/e2e/replica_set.go
@@ -84,7 +84,7 @@ var _ = framework.KubeDescribe("ReplicaSet", func() {
 		// requires private images
 		framework.SkipUnlessProviderIs("gce", "gke")
 
-		ReplicaSetServeImageOrFail(f, "private", "b.gcr.io/k8s_authenticated_test/serve_hostname:v1.4")
+		ReplicaSetServeImageOrFail(f, "private", "gcr.io/k8s-authenticated-test/serve_hostname:v1.4")
 	})
 
 	It("should surface a failure condition on a common issue like exceeded quota", func() {

--- a/test/images/serve_hostname/Makefile
+++ b/test/images/serve_hostname/Makefile
@@ -15,14 +15,14 @@
 # Cross-build the serve_hostname image
 #
 # Usage:
-#       [TAG=v1.5] [PREFIX=gcr.io/google_containers] [TEST_REGISTRY=b.gcr.io/k8s_authenticated_test] [ARCH=amd64] [BASEIMAGE=busybox] make all
+#       [TAG=v1.5] [PREFIX=gcr.io/google_containers] [TEST_REGISTRY=gcr.io/k8s-authenticated-test] [ARCH=amd64] [BASEIMAGE=busybox] make all
 
 .PHONY: all push container clean
 
 TAG ?= v1.5
 
-REGISTRY ?= gcr.io/google_containers
-TEST_REGISTRY ?= b.gcr.io/k8s_authenticated_test
+REGISTRY ?= gcr.io/google-containers
+TEST_REGISTRY ?= gcr.io/k8s-authenticated-test
 
 # Architectures supported: amd64, arm, arm64 and ppc64le
 ARCH ?= amd64
@@ -97,4 +97,3 @@ push: .push-$(ARCH)
 
 clean:
 	rm -rf $(BIN)
-


### PR DESCRIPTION
Cherry pick of #40335 on release-1.5.

#40335: Move b.gcr.io/k8s_authenticated_test to