### PR TITLE
Default the version to the information in federation versions file if $KUBERNETES_RELEASE isn't set.

### DIFF
--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -37,16 +37,44 @@ FEDERATION_KUBE_CONTEXT="${FEDERATION_KUBE_CONTEXT:-e2e-federation}"
 DNS_ZONE_NAME="${FEDERATION_DNS_ZONE_NAME:-}"
 HOST_CLUSTER_CONTEXT="${FEDERATION_HOST_CLUSTER_CONTEXT:-${1}}"
 
+# get_version returns the version in KUBERNETES_RELEASE or defaults to the
+# value in the federation `versions` file.
+# TODO(madhusudancs): This is a duplicate of the function in
+# federation/develop/develop.sh with a minor difference. This
+# function tries to default to the version information in
+# _output/federation/versions file where as the one in develop.sh
+# tries to default to the version in the kubernetes versions file.
+# These functions should be consolidated to read the version from
+# kubernetes version defs file.
+function get_version() {
+  local -r versions_file="${KUBE_ROOT}/_output/federation/versions"
+
+  if [[ -n "${KUBERNETES_RELEASE:-}" ]]; then
+    echo "${KUBERNETES_RELEASE//+/_}"
+    return
+  elif [[ ! -f "${versions_file}" ]]; then
+    echo "Couldn't determine the release version: neither the " \
+     "KUBERNETES_RELEASE environment variable is set, nor the " \
+     "versions file is provided"
+    exit 1
+  fi
+
+  # Read the version back from the versions file if no version is given.
+  local -r kube_version="$(cat "${versions_file}" | python -c '\
+import json, sys;\
+print json.load(sys.stdin)["KUBE_VERSION"]')"
+
+  echo "${kube_version//+/_}"
+}
+
 # Initializes the control plane.
 # TODO(madhusudancs): Move this to federation/develop.sh.
 function init() {
-  : "${KUBERNETES_RELEASE?KUBERNETES_RELEASE environment variable must be set}"
-
   kube::log::status "Deploying federation control plane for ${FEDERATION_NAME} in cluster ${HOST_CLUSTER_CONTEXT}"
 
   local -r project="${KUBE_PROJECT:-${PROJECT:-}}"
   local -r kube_registry="${KUBE_REGISTRY:-gcr.io/${project}}"
-  local -r kube_version="${KUBERNETES_RELEASE//+/_}"
+  local -r kube_version="$(get_version)"
 
   "${KUBE_ROOT}/federation/develop/kubefed.sh" init \
       "${FEDERATION_NAME}" \
@@ -76,6 +104,7 @@ function create_cluster_secrets() {
 }
 
 USE_KUBEFED="${USE_KUBEFED:-}"
+
 if [[ "${USE_KUBEFED}" == "true" ]]; then
   init
   # TODO(madhusudancs): Call to create_cluster_secrets and the function
@@ -84,10 +113,6 @@ if [[ "${USE_KUBEFED}" == "true" ]]; then
   # BeforeEach blocks of each e2e test to work.
   create_cluster_secrets
 else
-  # Read the version back from the versions file if no version is given.
-  readonly kube_version="$(cat ${KUBE_ROOT}/_output/federation/versions | python -c '\
-import json, sys;\
-print json.load(sys.stdin)["KUBE_VERSION"]')"
-  export FEDERATION_IMAGE_TAG="$(echo ${KUBERNETES_RELEASE:-${kube_version}} | tr + _)"
+  export FEDERATION_IMAGE_TAG="$(get_version)"
   create-federation-api-objects
 fi

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -52,10 +52,12 @@ function get_version() {
   if [[ -n "${KUBERNETES_RELEASE:-}" ]]; then
     echo "${KUBERNETES_RELEASE//+/_}"
     return
-  elif [[ ! -f "${versions_file}" ]]; then
+  fi
+
+  if [[ ! -f "${versions_file}" ]]; then
     echo "Couldn't determine the release version: neither the " \
-     "KUBERNETES_RELEASE environment variable is set, nor the " \
-     "versions file is provided"
+     "KUBERNETES_RELEASE environment variable is set, nor does " \
+     "the versions file exist at ${versions_file}"
     exit 1
   fi
 

--- a/federation/develop/develop.sh
+++ b/federation/develop/develop.sh
@@ -84,6 +84,7 @@ function build_binaries() {
   kube::build::verify_prereqs
   kube::build::build_image
   kube::build::run_build_command make WHAT="cmd/kubectl cmd/hyperkube"
+  kube::build::copy_output
 }
 
 function build_image() {


### PR DESCRIPTION
Also, slightly unrelated fix: copy the output from the build container
to the host filesystem while building hyperkube image. The recent change
in the build scripts has caused the binaries to be not copied to the
required locations. It must be explicitly copied by calling the build copy
function.

cc @kubernetes/sig-federation-pr-reviews @perotinus @csbell @nikhiljindal 