### PR TITLE
Fix for Support selection of datastore for dynamic provisioning in vS…

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "k8s.io/kubernetes",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v75",
+	"GodepVersion": "v78",
 	"Packages": [
 		"github.com/ugorji/go/codec/codecgen",
 		"github.com/onsi/ginkgo/ginkgo",
@@ -2286,78 +2286,78 @@
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/find",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/list",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/object",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/property",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/session",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/task",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/debug",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/methods",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/mo",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/progress",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/soap",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/types",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/govmomi/vim25/xml",
-			"Comment": "v0.8.0-9-gb5ee639",
-			"Rev": "b5ee639d7aa4b8dbb48ab4f75dddc19f71b5c514"
+			"Comment": "v0.12.1-14-g0a28e59",
+			"Rev": "0a28e595c8e9e99879e8d2f796e82c5a68202ff0"
 		},
 		{
 			"ImportPath": "github.com/vmware/photon-controller-go-sdk/photon",

--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -202,7 +202,7 @@
   __Note: Here you don't need to create vmdk it is created for you.__
   1. Create Storage Class.
 
-      See example:
+      Example 1:
 
       ```yaml
       kind: StorageClass
@@ -216,6 +216,23 @@
 
       [Download example](vsphere-volume-sc-fast.yaml?raw=true)
 
+      You can also specify the datastore in the Storageclass as shown in example 2. The volume will be created on the datastore specified in the storage class.
+      This field is optional. If not specified as shown in example 1, the volume will be created on the datastore specified in the vsphere config file used to initialize the vSphere Cloud Provider.
+
+      Example 2:
+ 
+      ```yaml
+      kind: StorageClass
+      apiVersion: storage.k8s.io/v1beta1
+      metadata:
+        name: fast
+      provisioner: kubernetes.io/vsphere-volume
+      parameters:
+          diskformat: zeroedthick
+          datastore: VSANDatastore
+      ```
+
+      [Download example](vsphere-volume-sc-with-datastore.yaml?raw=true)
       Creating the storageclass:
 
       ``` bash

--- a/examples/volumes/vsphere/vsphere-volume-sc-with-datastore.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-sc-with-datastore.yaml
@@ -1,0 +1,8 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: fast
+provisioner: kubernetes.io/vsphere-volume
+parameters:
+    diskformat: zeroedthick
+    datastore: vsanDatastore

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -75,6 +75,8 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (vmDiskPa
 		switch strings.ToLower(parameter) {
 		case "diskformat":
 			volumeOptions.DiskFormat = value
+		case "datastore":
+			volumeOptions.Datastore = value
 		default:
 			return "", 0, fmt.Errorf("invalid option %q for volume plugin %s", parameter, v.plugin.GetPluginName())
 		}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -6742,7 +6742,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25",
         "//vendor:github.com/vmware/govmomi/vim25/soap",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6760,7 +6759,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25",
         "//vendor:github.com/vmware/govmomi/vim25/mo",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6777,7 +6775,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25/mo",
         "//vendor:github.com/vmware/govmomi/vim25/soap",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6792,6 +6789,9 @@ go_library(
         "github.com/vmware/govmomi/object/customization_spec_manager.go",
         "github.com/vmware/govmomi/object/datacenter.go",
         "github.com/vmware/govmomi/object/datastore.go",
+        "github.com/vmware/govmomi/object/datastore_file.go",
+        "github.com/vmware/govmomi/object/datastore_path.go",
+        "github.com/vmware/govmomi/object/diagnostic_log.go",
         "github.com/vmware/govmomi/object/diagnostic_manager.go",
         "github.com/vmware/govmomi/object/distributed_virtual_portgroup.go",
         "github.com/vmware/govmomi/object/distributed_virtual_switch.go",
@@ -6800,9 +6800,12 @@ go_library(
         "github.com/vmware/govmomi/object/folder.go",
         "github.com/vmware/govmomi/object/history_collector.go",
         "github.com/vmware/govmomi/object/host_account_manager.go",
+        "github.com/vmware/govmomi/object/host_certificate_info.go",
+        "github.com/vmware/govmomi/object/host_certificate_manager.go",
         "github.com/vmware/govmomi/object/host_config_manager.go",
         "github.com/vmware/govmomi/object/host_datastore_browser.go",
         "github.com/vmware/govmomi/object/host_datastore_system.go",
+        "github.com/vmware/govmomi/object/host_date_time_system.go",
         "github.com/vmware/govmomi/object/host_firewall_system.go",
         "github.com/vmware/govmomi/object/host_network_system.go",
         "github.com/vmware/govmomi/object/host_service_system.go",
@@ -6840,7 +6843,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25/progress",
         "//vendor:github.com/vmware/govmomi/vim25/soap",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6857,7 +6859,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25/mo",
         "//vendor:github.com/vmware/govmomi/vim25/soap",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6875,7 +6876,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25/mo",
         "//vendor:github.com/vmware/govmomi/vim25/soap",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6890,7 +6890,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/property",
         "//vendor:github.com/vmware/govmomi/vim25/progress",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6906,7 +6905,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25/methods",
         "//vendor:github.com/vmware/govmomi/vim25/soap",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6927,7 +6925,6 @@ go_library(
     deps = [
         "//vendor:github.com/vmware/govmomi/vim25/soap",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6948,7 +6945,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25/methods",
         "//vendor:github.com/vmware/govmomi/vim25/soap",
         "//vendor:github.com/vmware/govmomi/vim25/types",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 
@@ -6981,7 +6977,6 @@ go_library(
         "//vendor:github.com/vmware/govmomi/vim25/progress",
         "//vendor:github.com/vmware/govmomi/vim25/types",
         "//vendor:github.com/vmware/govmomi/vim25/xml",
-        "//vendor:golang.org/x/net/context",
     ],
 )
 

--- a/vendor/github.com/vmware/govmomi/.drone.yml
+++ b/vendor/github.com/vmware/govmomi/.drone.yml
@@ -2,7 +2,7 @@ clone:
   tags: true
   path: github.com/vmware/govmomi
 build:
-  image: golang:1.6
+  image: golang:1.7
   pull: true
   environment:
     - GOVC_TEST_URL=$$GOVC_TEST_URL

--- a/vendor/github.com/vmware/govmomi/.travis.yml
+++ b/vendor/github.com/vmware/govmomi/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-   - 1.6
+   - 1.7
 
 before_install:
   - make vendor

--- a/vendor/github.com/vmware/govmomi/CHANGELOG.md
+++ b/vendor/github.com/vmware/govmomi/CHANGELOG.md
@@ -1,5 +1,69 @@
 # changelog
 
+### 0.12.1 (2016-12-19)
+
+* Add DiagnosticLog helper
+
+* Add DatastorePath helper
+
+### 0.12.0 (2016-12-01)
+
+* Disable use of service ticket for datastore HTTP access by default
+
+* Attach context to HTTP requests for cancellations
+
+* Update to vim25/6.5 API
+
+### 0.11.4 (2016-11-15)
+
+* Add object.AuthorizationManager methods: RetrieveRolePermissions, RetrieveAllPermissions, AddRole, RemoveRole, UpdateRole
+
+### 0.11.3 (2016-11-08)
+
+* Allow DatastoreFile.Follow reader to drain current body after stopping
+
+### 0.11.2 (2016-11-01)
+
+* Avoid possible NPE in VirtualMachine.Device method
+
+* Add support for OpaqueNetwork type to Finder
+
+* Add HostConfigManager.AccountManager support for ESX 5.5
+
+### 0.11.1 (2016-10-27)
+
+* Add Finder.ResourcePoolListAll method
+
+### 0.11.0 (2016-10-25)
+
+* Add object.DistributedVirtualPortgroup.Reconfigure method
+
+### 0.10.0 (2016-10-20)
+
+* Add option to set soap.Client.UserAgent
+
+* Add service ticket thumbprint validation
+
+* Update use of http.DefaultTransport fields to 1.7
+
+* Set default locale to en_US (override with GOVMOMI_LOCALE env var)
+
+* Add object.HostCertificateInfo (types.HostCertificateManagerCertificateInfo helpers)
+
+* Add object.HostCertificateManager type and HostConfigManager.CertificateManager method
+
+* Add soap.Client SetRootCAs and SetDialTLS methods
+
+### 0.9.0 (2016-09-09)
+
+* Add object.DatastoreFile helpers for streaming and tailing datastore files
+
+* Add object VirtualMachine.Unregister method
+
+* Add object.ListView methods: Add, Remove, Reset
+
+* Update to Go 1.7 - using stdlib's context package
+
 ### 0.8.0 (2016-06-30)
 
 * Add session.Manager.AcquireLocalTicket

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTORS
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTORS
@@ -3,38 +3,48 @@
 # Please keep the list sorted.
 #
 
+abrarshivani <abrarshivani@users.noreply.github.com>
 Alvaro Miranda <kikitux@gmail.com>
 Amit Bathla <abathla@.vmware.com>
 Andrew Chin <andrew@andrewtchin.com>
 Arran Walker <arran.walker@zopa.com>
 Austin Parker <aparker@apprenda.com>
 Bob Killen <killen.bob@gmail.com>
-Bruce Downs <bdowns@vmware.com>
+Brad Fitzpatrick <bradfitz@golang.org>
+Bruce Downs <bruceadowns@gmail.com>
 Cédric Blomart <cblomart@gmail.com>
 Christian Höltje <docwhat@gerf.org>
 Clint Greenwood <cgreenwood@vmware.com> <clint.greenwood@gmail.com>
 Danny Lockard <danny.lockard@banno.com>
 Dave Tucker <dave@dtucker.co.uk>
+Davide Agnello <dagnello@hp.com>
 David Stark <dave@davidstark.name>
 Doug MacEachern <dougm@vmware.com>
 Eloy Coto <eloy.coto@gmail.com>
 Eric Yutao <eric.yutao@gmail.com>
 Fabio Rapposelli <fabio@vmware.com>
 Faiyaz Ahmed <ahmedf@vmware.com>
+forkbomber <forkbomber@users.noreply.github.com>
 Gavin Gray <gavin@infinio.com>
 Gavrie Philipson <gavrie@philipson.co.il> <gavrie.philipson@elastifile.com>
 George Hicken <ghicken@vmware.com>
 Gerrit Renker <Gerrit.Renker@ctl.io>
 gthombare <gthombare@vmware.com>
+Hasan Mahmood <mahmoodh@vmware.com>
+Henrik Hodne <henrik@travis-ci.com>
 Isaac Rodman <isaac@eyz.us>
+Jason Kincl <jkincl@gmail.com>
 Louie Jiang <jiangl@vmware.com>
 Mevan Samaratunga <mevansam@gmail.com>
+Nicolas Lamirault <nicolas.lamirault@gmail.com>
 Pieter Noordhuis <pnoordhuis@vmware.com> <pcnoordhuis@gmail.com>
 runner.mei <runner.mei@gmail.com>
 S.Çağlar Onur <conur@vmware.com>
 Sergey Ignatov <sergey.ignatov@jetbrains.com>
 Steve Purcell <steve@sanityinc.com>
 Takaaki Furukawa <takaaki.frkw@gmail.com> <takaaki.furukawa@mail.rakuten.com>
+Ted Zlatanov <tzz@lifelogs.com>
+Vadim Egorov <vegorov@vmware.com>
 Yang Yang <yangy@vmware.com>
 Yuya Kusakabe <yuya.kusakabe@gmail.com>
 Zach Tucker <ztucker@vmware.com>

--- a/vendor/github.com/vmware/govmomi/Makefile
+++ b/vendor/github.com/vmware/govmomi/Makefile
@@ -18,3 +18,6 @@ test:
 
 install:
 	go install github.com/vmware/govmomi/govc
+
+doc: install
+	./govc/usage.sh > ./govc/USAGE.md

--- a/vendor/github.com/vmware/govmomi/README.md
+++ b/vendor/github.com/vmware/govmomi/README.md
@@ -1,15 +1,15 @@
 [![Build Status](https://travis-ci.org/vmware/govmomi.png?branch=master)](https://travis-ci.org/vmware/govmomi)
-[![Build Status](https://ci.vmware.run/api/badges/vmware/govmomi/status.svg)](https://ci.vmware.run/vmware/govmomi)
+[![Go Report Card](https://goreportcard.com/badge/github.com/vmware/govmomi)](https://goreportcard.com/report/github.com/vmware/govmomi)
 
 # govmomi
 
 A Go library for interacting with VMware vSphere APIs (ESXi and/or vCenter).
 
-For `govc`, a CLI built on top of govmomi, check out the [govc](./govc) directory.
+For `govc`, a CLI built on top of govmomi, check out the [govc](./govc) directory and [USAGE](./govc/USAGE.md) document.
 
 ## Compatibility
 
-This library is built for and tested against ESXi and vCenter 5.5 and 6.0.
+This library is built for and tested against ESXi and vCenter 5.5, 6.0 and 6.5.
 
 If you're able to use it against older versions of ESXi and/or vCenter, please
 leave a note and we'll include it in this compatibility list.
@@ -37,6 +37,12 @@ To build locally with Drone:
 - Install the [Drone command line tools][dronecli].
 - Run `drone exec` from within the root directory of the govmomi repository.
 
+## Discussion
+
+Contributors and users are encouraged to collaborate using GitHub issues and/or
+[Slack](https://vmwarecode.slack.com/messages/govmomi).
+Access to Slack requires a [VMware {code} membership](https://code.vmware.com/join/).
+
 ## Status
 
 Changes to the API are subject to [semantic versioning](http://semver.org).
@@ -47,7 +53,15 @@ Refer to the [CHANGELOG](CHANGELOG.md) for version to version changes.
 
 * [Docker Machine](https://github.com/docker/machine/tree/master/drivers/vmwarevsphere)
 
+* [Kubernetes](https://github.com/kubernetes/kubernetes/tree/master/pkg/cloudprovider/providers/vsphere)
+
 * [Terraform](https://github.com/hashicorp/terraform/tree/master/builtin/providers/vsphere)
+
+* [VMware VIC Engine](https://github.com/vmware/vic)
+
+* [Travis CI](https://github.com/travis-ci/jupiter-brain)
+
+* [Gru](https://github.com/dnaeon/gru)
 
 ## License
 

--- a/vendor/github.com/vmware/govmomi/client.go
+++ b/vendor/github.com/vmware/govmomi/client.go
@@ -57,6 +57,7 @@ are kept outside the object package.
 package govmomi
 
 import (
+	"context"
 	"crypto/tls"
 	"net/url"
 
@@ -65,7 +66,6 @@ import (
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type Client struct {

--- a/vendor/github.com/vmware/govmomi/list/lister.go
+++ b/vendor/github.com/vmware/govmomi/list/lister.go
@@ -17,6 +17,7 @@ limitations under the License.
 package list
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"reflect"
@@ -25,7 +26,6 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type Element struct {
@@ -78,6 +78,8 @@ func ToElement(r mo.Reference, prefix string) Element {
 	// DistributedVirtualSwitch, and DistributedVirtualPortgroup managed objects.
 	// Network entity folders on an ESXi host can contain only Network objects.
 	case mo.Network:
+		name = m.Name
+	case mo.OpaqueNetwork:
 		name = m.Name
 	case mo.DistributedVirtualSwitch:
 		name = m.Name

--- a/vendor/github.com/vmware/govmomi/list/recurser.go
+++ b/vendor/github.com/vmware/govmomi/list/recurser.go
@@ -17,11 +17,11 @@ limitations under the License.
 package list
 
 import (
+	"context"
 	"path"
 	"path/filepath"
 
 	"github.com/vmware/govmomi/property"
-	"golang.org/x/net/context"
 )
 
 type Recurser struct {

--- a/vendor/github.com/vmware/govmomi/object/authorization_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/authorization_manager.go
@@ -17,11 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type AuthorizationManager struct {
@@ -104,5 +105,70 @@ func (m AuthorizationManager) SetEntityPermissions(ctx context.Context, entity t
 	}
 
 	_, err := methods.SetEntityPermissions(ctx, m.Client(), &req)
+	return err
+}
+
+func (m AuthorizationManager) RetrieveRolePermissions(ctx context.Context, id int32) ([]types.Permission, error) {
+	req := types.RetrieveRolePermissions{
+		This:   m.Reference(),
+		RoleId: id,
+	}
+
+	res, err := methods.RetrieveRolePermissions(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m AuthorizationManager) RetrieveAllPermissions(ctx context.Context) ([]types.Permission, error) {
+	req := types.RetrieveAllPermissions{
+		This: m.Reference(),
+	}
+
+	res, err := methods.RetrieveAllPermissions(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m AuthorizationManager) AddRole(ctx context.Context, name string, ids []string) (int32, error) {
+	req := types.AddAuthorizationRole{
+		This:    m.Reference(),
+		Name:    name,
+		PrivIds: ids,
+	}
+
+	res, err := methods.AddAuthorizationRole(ctx, m.Client(), &req)
+	if err != nil {
+		return -1, err
+	}
+
+	return res.Returnval, nil
+}
+
+func (m AuthorizationManager) RemoveRole(ctx context.Context, id int32, failIfUsed bool) error {
+	req := types.RemoveAuthorizationRole{
+		This:       m.Reference(),
+		RoleId:     id,
+		FailIfUsed: failIfUsed,
+	}
+
+	_, err := methods.RemoveAuthorizationRole(ctx, m.Client(), &req)
+	return err
+}
+
+func (m AuthorizationManager) UpdateRole(ctx context.Context, id int32, name string, ids []string) error {
+	req := types.UpdateAuthorizationRole{
+		This:    m.Reference(),
+		RoleId:  id,
+		NewName: name,
+		PrivIds: ids,
+	}
+
+	_, err := methods.UpdateAuthorizationRole(ctx, m.Client(), &req)
 	return err
 }

--- a/vendor/github.com/vmware/govmomi/object/cluster_compute_resource.go
+++ b/vendor/github.com/vmware/govmomi/object/cluster_compute_resource.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type ClusterComputeResource struct {

--- a/vendor/github.com/vmware/govmomi/object/common.go
+++ b/vendor/github.com/vmware/govmomi/object/common.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path"
@@ -26,11 +27,10 @@ import (
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 var (
-	ErrNotSupported = errors.New("not supported (vCenter only)")
+	ErrNotSupported = errors.New("product/version specific feature not supported by target")
 )
 
 // Common contains the fields and functions common to all objects.

--- a/vendor/github.com/vmware/govmomi/object/compute_resource.go
+++ b/vendor/github.com/vmware/govmomi/object/compute_resource.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"path"
 
 	"github.com/vmware/govmomi/property"
@@ -24,7 +25,6 @@ import (
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type ComputeResource struct {

--- a/vendor/github.com/vmware/govmomi/object/custom_fields_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/custom_fields_manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"errors"
 	"strconv"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 var (

--- a/vendor/github.com/vmware/govmomi/object/customization_spec_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/customization_spec_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type CustomizationSpecManager struct {

--- a/vendor/github.com/vmware/govmomi/object/datacenter.go
+++ b/vendor/github.com/vmware/govmomi/object/datacenter.go
@@ -17,13 +17,13 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type DatacenterFolders struct {

--- a/vendor/github.com/vmware/govmomi/object/datastore_file.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore_file.go
@@ -1,0 +1,399 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// DatastoreFile implements io.Reader, io.Seeker and io.Closer interfaces for datastore file access.
+type DatastoreFile struct {
+	d    Datastore
+	ctx  context.Context
+	name string
+
+	buf    io.Reader
+	body   io.ReadCloser
+	length int64
+	offset struct {
+		read, seek int64
+	}
+}
+
+// Open opens the named file relative to the Datastore.
+func (d Datastore) Open(ctx context.Context, name string) (*DatastoreFile, error) {
+	return &DatastoreFile{
+		d:      d,
+		name:   name,
+		length: -1,
+		ctx:    ctx,
+	}, nil
+}
+
+// Read reads up to len(b) bytes from the DatastoreFile.
+func (f *DatastoreFile) Read(b []byte) (int, error) {
+	if f.offset.read != f.offset.seek {
+		// A Seek() call changed the offset, we need to issue a new GET
+		_ = f.Close()
+
+		f.offset.read = f.offset.seek
+	} else if f.buf != nil {
+		// f.buf + f behaves like an io.MultiReader
+		n, err := f.buf.Read(b)
+		if err == io.EOF {
+			f.buf = nil // buffer has been drained
+		}
+		if n > 0 {
+			return n, nil
+		}
+	}
+
+	body, err := f.get()
+	if err != nil {
+		return 0, err
+	}
+
+	n, err := body.Read(b)
+
+	f.offset.read += int64(n)
+	f.offset.seek += int64(n)
+
+	return n, err
+}
+
+// Close closes the DatastoreFile.
+func (f *DatastoreFile) Close() error {
+	var err error
+
+	if f.body != nil {
+		err = f.body.Close()
+		f.body = nil
+	}
+
+	f.buf = nil
+
+	return err
+}
+
+// Seek sets the offset for the next Read on the DatastoreFile.
+func (f *DatastoreFile) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+	case io.SeekCurrent:
+		offset += f.offset.seek
+	case io.SeekEnd:
+		if f.length < 0 {
+			_, err := f.Stat()
+			if err != nil {
+				return 0, err
+			}
+		}
+		offset += f.length
+	default:
+		return 0, errors.New("Seek: invalid whence")
+	}
+
+	// allow negative SeekStart for initial Range request
+	if offset < 0 {
+		return 0, errors.New("Seek: invalid offset")
+	}
+
+	f.offset.seek = offset
+
+	return offset, nil
+}
+
+type fileStat struct {
+	file   *DatastoreFile
+	header http.Header
+}
+
+func (s *fileStat) Name() string {
+	return path.Base(s.file.name)
+}
+
+func (s *fileStat) Size() int64 {
+	return s.file.length
+}
+
+func (s *fileStat) Mode() os.FileMode {
+	return 0
+}
+
+func (s *fileStat) ModTime() time.Time {
+	return time.Now() // no Last-Modified
+}
+
+func (s *fileStat) IsDir() bool {
+	return false
+}
+
+func (s *fileStat) Sys() interface{} {
+	return s.header
+}
+
+func statusError(res *http.Response) error {
+	if res.StatusCode == http.StatusNotFound {
+		return os.ErrNotExist
+	}
+	return errors.New(res.Status)
+}
+
+// Stat returns the os.FileInfo interface describing file.
+func (f *DatastoreFile) Stat() (os.FileInfo, error) {
+	// TODO: consider using Datastore.Stat() instead
+	u, p, err := f.d.downloadTicket(f.ctx, f.name, &soap.Download{Method: "HEAD"})
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := f.d.Client().DownloadRequest(u, p)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, statusError(res)
+	}
+
+	f.length = res.ContentLength
+
+	return &fileStat{f, res.Header}, nil
+}
+
+func (f *DatastoreFile) get() (io.Reader, error) {
+	if f.body != nil {
+		return f.body, nil
+	}
+
+	u, p, err := f.d.downloadTicket(f.ctx, f.name, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if f.offset.read != 0 {
+		p.Headers = map[string]string{
+			"Range": fmt.Sprintf("bytes=%d-", f.offset.read),
+		}
+	}
+
+	res, err := f.d.Client().DownloadRequest(u, p)
+	if err != nil {
+		return nil, err
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		f.length = res.ContentLength
+	case http.StatusPartialContent:
+		var start, end int
+		cr := res.Header.Get("Content-Range")
+		_, err = fmt.Sscanf(cr, "bytes %d-%d/%d", &start, &end, &f.length)
+		if err != nil {
+			f.length = -1
+		}
+	case http.StatusRequestedRangeNotSatisfiable:
+		// ok: Read() will return io.EOF
+	default:
+		return nil, statusError(res)
+	}
+
+	if f.length < 0 {
+		_ = res.Body.Close()
+		return nil, errors.New("unable to determine file size")
+	}
+
+	f.body = res.Body
+
+	return f.body, nil
+}
+
+func lastIndexLines(s []byte, n *int) int64 {
+	i := len(s) - 1
+
+	for i > 0 {
+		o := bytes.LastIndexByte(s[:i], '\n')
+		if o < 0 {
+			break
+		}
+
+		i = o
+		*n--
+		if *n == 0 {
+			break
+		}
+	}
+
+	return int64(i)
+}
+
+// Tail seeks to the position of the last N lines of the file.
+func (f *DatastoreFile) Tail(n int) error {
+	// Read the file in reverse using bsize chunks
+	const bsize = int64(1024 * 16)
+
+	fsize, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return err
+	}
+
+	if n == 0 {
+		return nil
+	}
+
+	chunk := int64(-1)
+
+	buf := bytes.NewBuffer(make([]byte, 0, bsize))
+
+	for {
+		var eof bool
+		var pos int64
+
+		nread := bsize
+
+		offset := chunk * bsize
+		remain := fsize + offset
+
+		if remain < 0 {
+			if pos, err = f.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+
+			nread = bsize + remain
+			eof = true
+		} else {
+			if pos, err = f.Seek(offset, io.SeekEnd); err != nil {
+				return err
+			}
+		}
+
+		if _, err = io.CopyN(buf, f, nread); err != nil {
+			if err != io.EOF {
+				return err
+			}
+		}
+
+		b := buf.Bytes()
+		idx := lastIndexLines(b, &n) + 1
+
+		if n == 0 {
+			if chunk == -1 {
+				// We found all N lines in the last chunk of the file.
+				// The seek offset is also now at the current end of file.
+				// Save this buffer to avoid another GET request when Read() is called.
+				buf.Next(int(idx))
+				f.buf = buf
+				return nil
+			}
+
+			if _, err = f.Seek(pos+idx, io.SeekStart); err != nil {
+				return err
+			}
+
+			break
+		}
+
+		if eof {
+			if remain < 0 {
+				// We found < N lines in the entire file, so seek to the start.
+				_, _ = f.Seek(0, io.SeekStart)
+			}
+			break
+		}
+
+		chunk--
+		buf.Reset()
+	}
+
+	return nil
+}
+
+type followDatastoreFile struct {
+	r *DatastoreFile
+	c chan struct{}
+	i time.Duration
+}
+
+// Read reads up to len(b) bytes from the DatastoreFile being followed.
+// This method will block until data is read, an error other than io.EOF is returned or Close() is called.
+func (f *followDatastoreFile) Read(p []byte) (int, error) {
+	offset := f.r.offset.seek
+	stop := false
+
+	defer f.r.Close()
+
+	for {
+		n, err := f.r.Read(p)
+		if err != nil && err == io.EOF {
+			_ = f.r.Close() // GET request body has been drained.
+			if stop {
+				return n, err
+			}
+			err = nil
+		}
+
+		if n > 0 {
+			return n, err
+		}
+
+		select {
+		case <-f.c:
+			// Wake up and stop polling once the body has been drained
+			stop = true
+		case <-time.After(f.i):
+		}
+
+		info, serr := f.r.Stat()
+		if serr != nil {
+			// Return EOF rather than 404 if the file goes away
+			if serr == os.ErrNotExist {
+				_ = f.r.Close()
+				return 0, io.EOF
+			}
+			return 0, serr
+		}
+
+		if info.Size() < offset {
+			// assume file has be truncated
+			offset, err = f.r.Seek(0, io.SeekStart)
+			if err != nil {
+				return 0, err
+			}
+		}
+	}
+}
+
+// Close will stop Follow polling and close the underlying DatastoreFile.
+func (f *followDatastoreFile) Close() error {
+	close(f.c)
+	return nil
+}
+
+// Follow returns an io.ReadCloser to stream the file contents as data is appended.
+func (f *DatastoreFile) Follow(interval time.Duration) io.ReadCloser {
+	return &followDatastoreFile{f, make(chan struct{}), interval}
+}

--- a/vendor/github.com/vmware/govmomi/object/datastore_path.go
+++ b/vendor/github.com/vmware/govmomi/object/datastore_path.go
@@ -1,0 +1,65 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DatastorePath contains the components of a datastore path.
+type DatastorePath struct {
+	Datastore string
+	Path      string
+}
+
+// FromString parses a datastore path.
+// Returns true if the path could be parsed, false otherwise.
+func (p *DatastorePath) FromString(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+
+	s = strings.TrimSpace(s)
+
+	if !strings.HasPrefix(s, "[") {
+		return false
+	}
+
+	s = s[1:]
+
+	ix := strings.Index(s, "]")
+	if ix < 0 {
+		return false
+	}
+
+	p.Datastore = s[:ix]
+	p.Path = strings.TrimSpace(s[ix+1:])
+
+	return true
+}
+
+// String formats a datastore path.
+func (p *DatastorePath) String() string {
+	s := fmt.Sprintf("[%s]", p.Datastore)
+
+	if p.Path == "" {
+		return s
+	}
+
+	return strings.Join([]string{s, p.Path}, " ")
+}

--- a/vendor/github.com/vmware/govmomi/object/diagnostic_log.go
+++ b/vendor/github.com/vmware/govmomi/object/diagnostic_log.go
@@ -1,0 +1,76 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+)
+
+// DiagnosticLog wraps DiagnosticManager.BrowseLog
+type DiagnosticLog struct {
+	m DiagnosticManager
+
+	Key  string
+	Host *HostSystem
+
+	Start int32
+}
+
+// Seek to log position starting at the last nlines of the log
+func (l *DiagnosticLog) Seek(ctx context.Context, nlines int32) error {
+	h, err := l.m.BrowseLog(ctx, l.Host, l.Key, math.MaxInt32, 0)
+	if err != nil {
+		return err
+	}
+
+	l.Start = h.LineEnd - nlines
+
+	return nil
+}
+
+// Copy log starting from l.Start to the given io.Writer
+// Returns on error or when end of log is reached.
+func (l *DiagnosticLog) Copy(ctx context.Context, w io.Writer) (int, error) {
+	const max = 500 // VC max == 500, ESX max == 1000
+	written := 0
+
+	for {
+		h, err := l.m.BrowseLog(ctx, l.Host, l.Key, l.Start, max)
+		if err != nil {
+			return 0, err
+		}
+
+		for _, line := range h.LineText {
+			n, err := fmt.Fprintln(w, line)
+			written += n
+			if err != nil {
+				return written, err
+			}
+		}
+
+		l.Start += int32(len(h.LineText))
+
+		if l.Start >= h.LineEnd {
+			break
+		}
+	}
+
+	return written, nil
+}

--- a/vendor/github.com/vmware/govmomi/object/diagnostic_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/diagnostic_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type DiagnosticManager struct {
@@ -33,6 +34,14 @@ func NewDiagnosticManager(c *vim25.Client) *DiagnosticManager {
 	}
 
 	return &m
+}
+
+func (m DiagnosticManager) Log(ctx context.Context, host *HostSystem, key string) *DiagnosticLog {
+	return &DiagnosticLog{
+		m:    m,
+		Key:  key,
+		Host: host,
+	}
 }
 
 func (m DiagnosticManager) BrowseLog(ctx context.Context, host *HostSystem, key string, start, lines int32) (*types.DiagnosticManagerLogHeader, error) {

--- a/vendor/github.com/vmware/govmomi/object/distributed_virtual_portgroup.go
+++ b/vendor/github.com/vmware/govmomi/object/distributed_virtual_portgroup.go
@@ -17,10 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type DistributedVirtualPortgroup struct {
@@ -54,4 +56,18 @@ func (p DistributedVirtualPortgroup) EthernetCardBackingInfo(ctx context.Context
 	}
 
 	return backing, nil
+}
+
+func (p DistributedVirtualPortgroup) Reconfigure(ctx context.Context, spec types.DVPortgroupConfigSpec) (*Task, error) {
+	req := types.ReconfigureDVPortgroup_Task{
+		This: p.Reference(),
+		Spec: spec,
+	}
+
+	res, err := methods.ReconfigureDVPortgroup_Task(ctx, p.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(p.Client(), res.Returnval), nil
 }

--- a/vendor/github.com/vmware/govmomi/object/distributed_virtual_switch.go
+++ b/vendor/github.com/vmware/govmomi/object/distributed_virtual_switch.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type DistributedVirtualSwitch struct {

--- a/vendor/github.com/vmware/govmomi/object/extension_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/extension_manager.go
@@ -17,11 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type ExtensionManager struct {

--- a/vendor/github.com/vmware/govmomi/object/file_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/file_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type FileManager struct {

--- a/vendor/github.com/vmware/govmomi/object/folder.go
+++ b/vendor/github.com/vmware/govmomi/object/folder.go
@@ -17,11 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type Folder struct {

--- a/vendor/github.com/vmware/govmomi/object/history_collector.go
+++ b/vendor/github.com/vmware/govmomi/object/history_collector.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HistoryCollector struct {

--- a/vendor/github.com/vmware/govmomi/object/host_account_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/host_account_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostAccountManager struct {

--- a/vendor/github.com/vmware/govmomi/object/host_certificate_info.go
+++ b/vendor/github.com/vmware/govmomi/object/host_certificate_info.go
@@ -1,0 +1,250 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"fmt"
+	"io"
+	"net/url"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// HostCertificateInfo provides helpers for types.HostCertificateManagerCertificateInfo
+type HostCertificateInfo struct {
+	types.HostCertificateManagerCertificateInfo
+
+	ThumbprintSHA1   string
+	ThumbprintSHA256 string
+
+	Err         error
+	Certificate *x509.Certificate `json:"-"`
+
+	subjectName *pkix.Name
+	issuerName  *pkix.Name
+}
+
+// FromCertificate converts x509.Certificate to HostCertificateInfo
+func (info *HostCertificateInfo) FromCertificate(cert *x509.Certificate) *HostCertificateInfo {
+	info.Certificate = cert
+	info.subjectName = &cert.Subject
+	info.issuerName = &cert.Issuer
+
+	info.Issuer = info.fromName(info.issuerName)
+	info.NotBefore = &cert.NotBefore
+	info.NotAfter = &cert.NotAfter
+	info.Subject = info.fromName(info.subjectName)
+
+	info.ThumbprintSHA1 = soap.ThumbprintSHA1(cert)
+
+	// SHA-256 for info purposes only, API fields all use SHA-1
+	sum := sha256.Sum256(cert.Raw)
+	hex := make([]string, len(sum))
+	for i, b := range sum {
+		hex[i] = fmt.Sprintf("%02X", b)
+	}
+	info.ThumbprintSHA256 = strings.Join(hex, ":")
+
+	if info.Status == "" {
+		info.Status = string(types.HostCertificateManagerCertificateInfoCertificateStatusUnknown)
+	}
+
+	return info
+}
+
+// FromURL connects to the given URL.Host via tls.Dial with the given tls.Config and populates the HostCertificateInfo
+// via tls.ConnectionState.  If the certificate was verified with the given tls.Config, the Err field will be nil.
+// Otherwise, Err will be set to the x509.UnknownAuthorityError or x509.HostnameError.
+// If tls.Dial returns an error of any other type, that error is returned.
+func (info *HostCertificateInfo) FromURL(u *url.URL, config *tls.Config) error {
+	addr := u.Host
+	if !(strings.LastIndex(addr, ":") > strings.LastIndex(addr, "]")) {
+		addr += ":443"
+	}
+
+	conn, err := tls.Dial("tcp", addr, config)
+	if err != nil {
+		switch err.(type) {
+		case x509.UnknownAuthorityError:
+		case x509.HostnameError:
+		default:
+			return err
+		}
+
+		info.Err = err
+
+		conn, err = tls.Dial("tcp", addr, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+	} else {
+		info.Status = string(types.HostCertificateManagerCertificateInfoCertificateStatusGood)
+	}
+
+	state := conn.ConnectionState()
+	_ = conn.Close()
+	info.FromCertificate(state.PeerCertificates[0])
+
+	return nil
+}
+
+var emailAddressOID = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 1}
+
+func (info *HostCertificateInfo) fromName(name *pkix.Name) string {
+	var attrs []string
+
+	oids := map[string]string{
+		emailAddressOID.String(): "emailAddress",
+	}
+
+	for _, attr := range name.Names {
+		if key, ok := oids[attr.Type.String()]; ok {
+			attrs = append(attrs, fmt.Sprintf("%s=%s", key, attr.Value))
+		}
+	}
+
+	attrs = append(attrs, fmt.Sprintf("CN=%s", name.CommonName))
+
+	add := func(key string, vals []string) {
+		for _, val := range vals {
+			attrs = append(attrs, fmt.Sprintf("%s=%s", key, val))
+		}
+	}
+
+	elts := []struct {
+		key string
+		val []string
+	}{
+		{"OU", name.OrganizationalUnit},
+		{"O", name.Organization},
+		{"L", name.Locality},
+		{"ST", name.Province},
+		{"C", name.Country},
+	}
+
+	for _, elt := range elts {
+		add(elt.key, elt.val)
+	}
+
+	return strings.Join(attrs, ",")
+}
+
+func (info *HostCertificateInfo) toName(s string) *pkix.Name {
+	var name pkix.Name
+
+	for _, pair := range strings.Split(s, ",") {
+		attr := strings.SplitN(pair, "=", 2)
+		if len(attr) != 2 {
+			continue
+		}
+
+		v := attr[1]
+
+		switch strings.ToLower(attr[0]) {
+		case "cn":
+			name.CommonName = v
+		case "ou":
+			name.OrganizationalUnit = append(name.OrganizationalUnit, v)
+		case "o":
+			name.Organization = append(name.Organization, v)
+		case "l":
+			name.Locality = append(name.Locality, v)
+		case "st":
+			name.Province = append(name.Province, v)
+		case "c":
+			name.Country = append(name.Country, v)
+		case "emailaddress":
+			name.Names = append(name.Names, pkix.AttributeTypeAndValue{Type: emailAddressOID, Value: v})
+		}
+	}
+
+	return &name
+}
+
+// SubjectName parses Subject into a pkix.Name
+func (info *HostCertificateInfo) SubjectName() *pkix.Name {
+	if info.subjectName != nil {
+		return info.subjectName
+	}
+
+	return info.toName(info.Subject)
+}
+
+// IssuerName parses Issuer into a pkix.Name
+func (info *HostCertificateInfo) IssuerName() *pkix.Name {
+	if info.issuerName != nil {
+		return info.issuerName
+	}
+
+	return info.toName(info.Issuer)
+}
+
+// Write outputs info similar to the Chrome Certificate Viewer.
+func (info *HostCertificateInfo) Write(w io.Writer) error {
+	tw := tabwriter.NewWriter(w, 2, 0, 2, ' ', 0)
+
+	s := func(val string) string {
+		if val != "" {
+			return val
+		}
+		return "<Not Part Of Certificate>"
+	}
+
+	ss := func(val []string) string {
+		return s(strings.Join(val, ","))
+	}
+
+	name := func(n *pkix.Name) {
+		fmt.Fprintf(tw, "  Common Name (CN):\t%s\n", s(n.CommonName))
+		fmt.Fprintf(tw, "  Organization (O):\t%s\n", ss(n.Organization))
+		fmt.Fprintf(tw, "  Organizational Unit (OU):\t%s\n", ss(n.OrganizationalUnit))
+	}
+
+	status := info.Status
+	if info.Err != nil {
+		status = fmt.Sprintf("ERROR %s", info.Err)
+	}
+	fmt.Fprintf(tw, "Certificate Status:\t%s\n", status)
+
+	fmt.Fprintln(tw, "Issued To:\t")
+	name(info.SubjectName())
+
+	fmt.Fprintln(tw, "Issued By:\t")
+	name(info.IssuerName())
+
+	fmt.Fprintln(tw, "Validity Period:\t")
+	fmt.Fprintf(tw, "  Issued On:\t%s\n", info.NotBefore)
+	fmt.Fprintf(tw, "  Expires On:\t%s\n", info.NotAfter)
+
+	if info.ThumbprintSHA1 != "" {
+		fmt.Fprintln(tw, "Thumbprints:\t")
+		if info.ThumbprintSHA256 != "" {
+			fmt.Fprintf(tw, "  SHA-256 Thumbprint:\t%s\n", info.ThumbprintSHA256)
+		}
+		fmt.Fprintf(tw, "  SHA-1 Thumbprint:\t%s\n", info.ThumbprintSHA1)
+	}
+
+	return tw.Flush()
+}

--- a/vendor/github.com/vmware/govmomi/object/host_certificate_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/host_certificate_manager.go
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// HostCertificateManager provides helper methods around the HostSystem.ConfigManager.CertificateManager
+type HostCertificateManager struct {
+	Common
+	Host *HostSystem
+}
+
+// NewHostCertificateManager creates a new HostCertificateManager helper
+func NewHostCertificateManager(c *vim25.Client, ref types.ManagedObjectReference, host types.ManagedObjectReference) *HostCertificateManager {
+	return &HostCertificateManager{
+		Common: NewCommon(c, ref),
+		Host:   NewHostSystem(c, host),
+	}
+}
+
+// CertificateInfo wraps the host CertificateManager certificateInfo property with the HostCertificateInfo helper.
+// The ThumbprintSHA1 field is set to HostSystem.Summary.Config.SslThumbprint if the host system is managed by a vCenter.
+func (m HostCertificateManager) CertificateInfo(ctx context.Context) (*HostCertificateInfo, error) {
+	var hs mo.HostSystem
+	var cm mo.HostCertificateManager
+
+	pc := property.DefaultCollector(m.Client())
+
+	err := pc.RetrieveOne(ctx, m.Reference(), []string{"certificateInfo"}, &cm)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = pc.RetrieveOne(ctx, m.Host.Reference(), []string{"summary.config.sslThumbprint"}, &hs)
+
+	return &HostCertificateInfo{
+		HostCertificateManagerCertificateInfo: cm.CertificateInfo,
+		ThumbprintSHA1:                        hs.Summary.Config.SslThumbprint,
+	}, nil
+}
+
+// GenerateCertificateSigningRequest requests the host system to generate a certificate-signing request (CSR) for itself.
+// The CSR is then typically provided to a Certificate Authority to sign and issue the SSL certificate for the host system.
+// Use InstallServerCertificate to import this certificate.
+func (m HostCertificateManager) GenerateCertificateSigningRequest(ctx context.Context, useIPAddressAsCommonName bool) (string, error) {
+	req := types.GenerateCertificateSigningRequest{
+		This: m.Reference(),
+		UseIpAddressAsCommonName: useIPAddressAsCommonName,
+	}
+
+	res, err := methods.GenerateCertificateSigningRequest(ctx, m.Client(), &req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.Returnval, nil
+}
+
+// GenerateCertificateSigningRequestByDn requests the host system to generate a certificate-signing request (CSR) for itself.
+// Alternative version similar to GenerateCertificateSigningRequest but takes a Distinguished Name (DN) as a parameter.
+func (m HostCertificateManager) GenerateCertificateSigningRequestByDn(ctx context.Context, distinguishedName string) (string, error) {
+	req := types.GenerateCertificateSigningRequestByDn{
+		This:              m.Reference(),
+		DistinguishedName: distinguishedName,
+	}
+
+	res, err := methods.GenerateCertificateSigningRequestByDn(ctx, m.Client(), &req)
+	if err != nil {
+		return "", err
+	}
+
+	return res.Returnval, nil
+}
+
+// InstallServerCertificate imports the given SSL certificate to the host system.
+func (m HostCertificateManager) InstallServerCertificate(ctx context.Context, cert string) error {
+	req := types.InstallServerCertificate{
+		This: m.Reference(),
+		Cert: cert,
+	}
+
+	_, err := methods.InstallServerCertificate(ctx, m.Client(), &req)
+	if err != nil {
+		return err
+	}
+
+	// NotifyAffectedService is internal, not exposing as we don't have a use case other than with InstallServerCertificate
+	// Without this call, hostd needs to be restarted to use the updated certificate
+	// Note: using Refresh as it has the same struct/signature, we just need to use different xml name tags
+	body := struct {
+		Req *types.Refresh         `xml:"urn:vim25 NotifyAffectedServices,omitempty"`
+		Res *types.RefreshResponse `xml:"urn:vim25 NotifyAffectedServicesResponse,omitempty"`
+		methods.RefreshBody
+	}{
+		Req: &types.Refresh{This: m.Reference()},
+	}
+
+	return m.Client().RoundTrip(ctx, &body, &body)
+}
+
+// ListCACertificateRevocationLists returns the SSL CRLs of Certificate Authorities that are trusted by the host system.
+func (m HostCertificateManager) ListCACertificateRevocationLists(ctx context.Context) ([]string, error) {
+	req := types.ListCACertificateRevocationLists{
+		This: m.Reference(),
+	}
+
+	res, err := methods.ListCACertificateRevocationLists(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+// ListCACertificates returns the SSL certificates of Certificate Authorities that are trusted by the host system.
+func (m HostCertificateManager) ListCACertificates(ctx context.Context) ([]string, error) {
+	req := types.ListCACertificates{
+		This: m.Reference(),
+	}
+
+	res, err := methods.ListCACertificates(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
+}
+
+// ReplaceCACertificatesAndCRLs replaces the trusted CA certificates and CRL used by the host system.
+// These determine whether the server can verify the identity of an external entity.
+func (m HostCertificateManager) ReplaceCACertificatesAndCRLs(ctx context.Context, caCert []string, caCrl []string) error {
+	req := types.ReplaceCACertificatesAndCRLs{
+		This:   m.Reference(),
+		CaCert: caCert,
+		CaCrl:  caCrl,
+	}
+
+	_, err := methods.ReplaceCACertificatesAndCRLs(ctx, m.Client(), &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/object/host_datastore_browser.go
+++ b/vendor/github.com/vmware/govmomi/object/host_datastore_browser.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostDatastoreBrowser struct {

--- a/vendor/github.com/vmware/govmomi/object/host_datastore_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_datastore_system.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostDatastoreSystem struct {

--- a/vendor/github.com/vmware/govmomi/object/host_date_time_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_date_time_system.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2016 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package object
+
+import (
+	"context"
+	"time"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type HostDateTimeSystem struct {
+	Common
+}
+
+func NewHostDateTimeSystem(c *vim25.Client, ref types.ManagedObjectReference) *HostDateTimeSystem {
+	return &HostDateTimeSystem{
+		Common: NewCommon(c, ref),
+	}
+}
+
+func (s HostDateTimeSystem) UpdateConfig(ctx context.Context, config types.HostDateTimeConfig) error {
+	req := types.UpdateDateTimeConfig{
+		This:   s.Reference(),
+		Config: config,
+	}
+
+	_, err := methods.UpdateDateTimeConfig(ctx, s.c, &req)
+	return err
+}
+
+func (s HostDateTimeSystem) Update(ctx context.Context, date time.Time) error {
+	req := types.UpdateDateTime{
+		This:     s.Reference(),
+		DateTime: date,
+	}
+
+	_, err := methods.UpdateDateTime(ctx, s.c, &req)
+	return err
+}
+
+func (s HostDateTimeSystem) Query(ctx context.Context) (*time.Time, error) {
+	req := types.QueryDateTime{
+		This: s.Reference(),
+	}
+
+	res, err := methods.QueryDateTime(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}

--- a/vendor/github.com/vmware/govmomi/object/host_firewall_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_firewall_system.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,7 +26,6 @@ import (
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostFirewallSystem struct {

--- a/vendor/github.com/vmware/govmomi/object/host_network_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_network_system.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostNetworkSystem struct {

--- a/vendor/github.com/vmware/govmomi/object/host_service_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_service_system.go
@@ -17,11 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostServiceSystem struct {

--- a/vendor/github.com/vmware/govmomi/object/host_storage_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_storage_system.go
@@ -17,12 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"errors"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostStorageSystem struct {

--- a/vendor/github.com/vmware/govmomi/object/host_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_system.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -24,7 +25,6 @@ import (
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostSystem struct {

--- a/vendor/github.com/vmware/govmomi/object/host_virtual_nic_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/host_virtual_nic_manager.go
@@ -17,11 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostVirtualNicManager struct {

--- a/vendor/github.com/vmware/govmomi/object/host_vsan_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_vsan_system.go
@@ -17,11 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HostVsanSystem struct {

--- a/vendor/github.com/vmware/govmomi/object/http_nfc_lease.go
+++ b/vendor/github.com/vmware/govmomi/object/http_nfc_lease.go
@@ -17,6 +17,7 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type HttpNfcLease struct {

--- a/vendor/github.com/vmware/govmomi/object/list_view.go
+++ b/vendor/github.com/vmware/govmomi/object/list_view.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type ListView struct {
@@ -37,7 +38,33 @@ func (v ListView) Destroy(ctx context.Context) error {
 	req := types.DestroyView{
 		This: v.Reference(),
 	}
-
 	_, err := methods.DestroyView(ctx, v.c, &req)
+	return err
+}
+
+func (v ListView) Add(ctx context.Context, refs []types.ManagedObjectReference) error {
+	req := types.ModifyListView{
+		This: v.Reference(),
+		Add:  refs,
+	}
+	_, err := methods.ModifyListView(ctx, v.c, &req)
+	return err
+}
+
+func (v ListView) Remove(ctx context.Context, refs []types.ManagedObjectReference) error {
+	req := types.ModifyListView{
+		This:   v.Reference(),
+		Remove: refs,
+	}
+	_, err := methods.ModifyListView(ctx, v.c, &req)
+	return err
+}
+
+func (v ListView) Reset(ctx context.Context, refs []types.ManagedObjectReference) error {
+	req := types.ResetListView{
+		This: v.Reference(),
+		Obj:  refs,
+	}
+	_, err := methods.ResetListView(ctx, v.c, &req)
 	return err
 }

--- a/vendor/github.com/vmware/govmomi/object/namespace_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/namespace_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type DatastoreNamespaceManager struct {

--- a/vendor/github.com/vmware/govmomi/object/network.go
+++ b/vendor/github.com/vmware/govmomi/object/network.go
@@ -17,9 +17,10 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type Network struct {

--- a/vendor/github.com/vmware/govmomi/object/network_reference.go
+++ b/vendor/github.com/vmware/govmomi/object/network_reference.go
@@ -17,8 +17,9 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 // The NetworkReference interface is implemented by managed objects

--- a/vendor/github.com/vmware/govmomi/object/option_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/option_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type OptionManager struct {

--- a/vendor/github.com/vmware/govmomi/object/ovf_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/ovf_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type OvfManager struct {

--- a/vendor/github.com/vmware/govmomi/object/resource_pool.go
+++ b/vendor/github.com/vmware/govmomi/object/resource_pool.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type ResourcePool struct {

--- a/vendor/github.com/vmware/govmomi/object/search_index.go
+++ b/vendor/github.com/vmware/govmomi/object/search_index.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type SearchIndex struct {

--- a/vendor/github.com/vmware/govmomi/object/storage_resource_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/storage_resource_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type StorageResourceManager struct {

--- a/vendor/github.com/vmware/govmomi/object/task.go
+++ b/vendor/github.com/vmware/govmomi/object/task.go
@@ -17,12 +17,13 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/task"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/progress"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 // Task is a convenience wrapper around task.Task that keeps a reference to

--- a/vendor/github.com/vmware/govmomi/object/types.go
+++ b/vendor/github.com/vmware/govmomi/object/types.go
@@ -47,7 +47,7 @@ func NewReference(c *vim25.Client, e types.ManagedObjectReference) Reference {
 		return NewClusterComputeResource(c, e)
 	case "HostSystem":
 		return NewHostSystem(c, e)
-	case "Network":
+	case "Network", "OpaqueNetwork":
 		return NewNetwork(c, e)
 	case "ResourcePool":
 		return NewResourcePool(c, e)

--- a/vendor/github.com/vmware/govmomi/object/virtual_app.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_app.go
@@ -17,7 +17,7 @@ limitations under the License.
 package object
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -34,7 +34,7 @@ func NewVirtualApp(c *vim25.Client, ref types.ManagedObjectReference) *VirtualAp
 	}
 }
 
-func (p VirtualApp) CreateChildVM_Task(ctx context.Context, config types.VirtualMachineConfigSpec, host *HostSystem) (*Task, error) {
+func (p VirtualApp) CreateChildVM(ctx context.Context, config types.VirtualMachineConfigSpec, host *HostSystem) (*Task, error) {
 	req := types.CreateChildVM_Task{
 		This:   p.Reference(),
 		Config: config,
@@ -53,7 +53,7 @@ func (p VirtualApp) CreateChildVM_Task(ctx context.Context, config types.Virtual
 	return NewTask(p.c, res.Returnval), nil
 }
 
-func (p VirtualApp) UpdateVAppConfig(ctx context.Context, spec types.VAppConfigSpec) error {
+func (p VirtualApp) UpdateConfig(ctx context.Context, spec types.VAppConfigSpec) error {
 	req := types.UpdateVAppConfig{
 		This: p.Reference(),
 		Spec: spec,
@@ -63,7 +63,7 @@ func (p VirtualApp) UpdateVAppConfig(ctx context.Context, spec types.VAppConfigS
 	return err
 }
 
-func (p VirtualApp) PowerOnVApp_Task(ctx context.Context) (*Task, error) {
+func (p VirtualApp) PowerOn(ctx context.Context) (*Task, error) {
 	req := types.PowerOnVApp_Task{
 		This: p.Reference(),
 	}
@@ -76,7 +76,7 @@ func (p VirtualApp) PowerOnVApp_Task(ctx context.Context) (*Task, error) {
 	return NewTask(p.c, res.Returnval), nil
 }
 
-func (p VirtualApp) PowerOffVApp_Task(ctx context.Context, force bool) (*Task, error) {
+func (p VirtualApp) PowerOff(ctx context.Context, force bool) (*Task, error) {
 	req := types.PowerOffVApp_Task{
 		This:  p.Reference(),
 		Force: force,
@@ -91,7 +91,7 @@ func (p VirtualApp) PowerOffVApp_Task(ctx context.Context, force bool) (*Task, e
 
 }
 
-func (p VirtualApp) SuspendVApp_Task(ctx context.Context) (*Task, error) {
+func (p VirtualApp) Suspend(ctx context.Context) (*Task, error) {
 	req := types.SuspendVApp_Task{
 		This: p.Reference(),
 	}

--- a/vendor/github.com/vmware/govmomi/object/virtual_disk_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_disk_manager.go
@@ -17,10 +17,11 @@ limitations under the License.
 package object
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type VirtualDiskManager struct {

--- a/vendor/github.com/vmware/govmomi/object/virtual_machine.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_machine.go
@@ -17,15 +17,17 @@ limitations under the License.
 package object
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"net"
+	"path"
 
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 const (
@@ -227,9 +229,12 @@ func (v VirtualMachine) WaitForIP(ctx context.Context) (string, error) {
 
 // WaitForNetIP waits for the VM guest.net property to report an IP address for all VM NICs.
 // Only consider IPv4 addresses if the v4 param is true.
+// By default, wait for all NICs to get an IP address, unless 1 or more device is given.
+// A device can be specified by the MAC address or the device name, e.g. "ethernet-0".
 // Returns a map with MAC address as the key and IP address list as the value.
-func (v VirtualMachine) WaitForNetIP(ctx context.Context, v4 bool) (map[string][]string, error) {
+func (v VirtualMachine) WaitForNetIP(ctx context.Context, v4 bool, device ...string) (map[string][]string, error) {
 	macs := make(map[string][]string)
+	eths := make(map[string]string)
 
 	p := property.DefaultCollector(v.c)
 
@@ -240,20 +245,32 @@ func (v VirtualMachine) WaitForNetIP(ctx context.Context, v4 bool) (map[string][
 				continue
 			}
 
-			devices := c.Val.(types.ArrayOfVirtualDevice).VirtualDevice
-			for _, device := range devices {
-				if nic, ok := device.(types.BaseVirtualEthernetCard); ok {
+			devices := VirtualDeviceList(c.Val.(types.ArrayOfVirtualDevice).VirtualDevice)
+			for _, d := range devices {
+				if nic, ok := d.(types.BaseVirtualEthernetCard); ok {
 					mac := nic.GetVirtualEthernetCard().MacAddress
 					if mac == "" {
 						return false
 					}
 					macs[mac] = nil
+					eths[devices.Name(d)] = mac
 				}
 			}
 		}
 
 		return true
 	})
+
+	if len(device) != 0 {
+		// Only wait for specific NIC(s)
+		macs = make(map[string][]string)
+		for _, mac := range device {
+			if eth, ok := eths[mac]; ok {
+				mac = eth // device name, e.g. "ethernet-0"
+			}
+			macs[mac] = nil
+		}
+	}
 
 	err = property.Wait(ctx, p, v.Reference(), []string{"guest.net"}, func(pc []types.PropertyChange) bool {
 		for _, c := range pc {
@@ -300,9 +317,19 @@ func (v VirtualMachine) WaitForNetIP(ctx context.Context, v4 bool) (map[string][
 func (v VirtualMachine) Device(ctx context.Context) (VirtualDeviceList, error) {
 	var o mo.VirtualMachine
 
-	err := v.Properties(ctx, v.Reference(), []string{"config.hardware.device"}, &o)
+	err := v.Properties(ctx, v.Reference(), []string{"config.hardware.device", "summary.runtime.connectionState"}, &o)
 	if err != nil {
 		return nil, err
+	}
+
+	// Quoting the SDK doc:
+	//   The virtual machine configuration is not guaranteed to be available.
+	//   For example, the configuration information would be unavailable if the server
+	//   is unable to access the virtual machine files on disk, and is often also unavailable
+	//   during the initial phases of virtual machine creation.
+	if o.Config == nil {
+		return nil, fmt.Errorf("%s Config is not available, connectionState=%s",
+			v.Reference(), o.Summary.Runtime.ConnectionState)
 	}
 
 	return VirtualDeviceList(o.Config.Hardware.Device), nil
@@ -311,7 +338,7 @@ func (v VirtualMachine) Device(ctx context.Context) (VirtualDeviceList, error) {
 func (v VirtualMachine) HostSystem(ctx context.Context) (*HostSystem, error) {
 	var o mo.VirtualMachine
 
-	err := v.Properties(ctx, v.Reference(), []string{"summary"}, &o)
+	err := v.Properties(ctx, v.Reference(), []string{"summary.runtime.host"}, &o)
 	if err != nil {
 		return nil, err
 	}
@@ -470,24 +497,102 @@ func (v VirtualMachine) RemoveAllSnapshot(ctx context.Context, consolidate *bool
 	return NewTask(v.c, res.Returnval), nil
 }
 
-// RevertToSnapshot reverts to a named snapshot
-func (v VirtualMachine) RevertToSnapshot(ctx context.Context, name string, suppressPowerOn bool) (*Task, error) {
+type snapshotMap map[string][]Reference
+
+func (m snapshotMap) add(parent string, tree []types.VirtualMachineSnapshotTree) {
+	for i, st := range tree {
+		sname := st.Name
+		names := []string{sname, st.Snapshot.Value}
+
+		if parent != "" {
+			sname = path.Join(parent, sname)
+			// Add full path as an option to resolve duplicate names
+			names = append(names, sname)
+		}
+
+		for _, name := range names {
+			m[name] = append(m[name], &tree[i].Snapshot)
+		}
+
+		m.add(sname, st.ChildSnapshotList)
+	}
+}
+
+// findSnapshot supports snapshot lookup by name, where name can be:
+// 1) snapshot ManagedObjectReference.Value (unique)
+// 2) snapshot name (may not be unique)
+// 3) snapshot tree path (may not be unique)
+func (v VirtualMachine) findSnapshot(ctx context.Context, name string) (Reference, error) {
 	var o mo.VirtualMachine
 
 	err := v.Properties(ctx, v.Reference(), []string{"snapshot"}, &o)
+	if err != nil {
+		return nil, err
+	}
 
-	snapshotTree := o.Snapshot.RootSnapshotList
-	if len(snapshotTree) < 1 {
+	if o.Snapshot == nil || len(o.Snapshot.RootSnapshotList) == 0 {
 		return nil, errors.New("No snapshots for this VM")
 	}
 
-	snapshot, err := traverseSnapshotInTree(snapshotTree, name)
+	m := make(snapshotMap)
+	m.add("", o.Snapshot.RootSnapshotList)
+
+	s := m[name]
+	switch len(s) {
+	case 0:
+		return nil, fmt.Errorf("snapshot %q not found", name)
+	case 1:
+		return s[0], nil
+	default:
+		return nil, fmt.Errorf("%q resolves to %d snapshots", name, len(s))
+	}
+}
+
+// RemoveSnapshot removes a named snapshot
+func (v VirtualMachine) RemoveSnapshot(ctx context.Context, name string, removeChildren bool, consolidate *bool) (*Task, error) {
+	snapshot, err := v.findSnapshot(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	req := types.RemoveSnapshot_Task{
+		This:           snapshot.Reference(),
+		RemoveChildren: removeChildren,
+		Consolidate:    consolidate,
+	}
+
+	res, err := methods.RemoveSnapshot_Task(ctx, v.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(v.c, res.Returnval), nil
+}
+
+// RevertToCurrentSnapshot reverts to the current snapshot
+func (v VirtualMachine) RevertToCurrentSnapshot(ctx context.Context, suppressPowerOn bool) (*Task, error) {
+	req := types.RevertToCurrentSnapshot_Task{
+		This:            v.Reference(),
+		SuppressPowerOn: types.NewBool(suppressPowerOn),
+	}
+
+	res, err := methods.RevertToCurrentSnapshot_Task(ctx, v.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(v.c, res.Returnval), nil
+}
+
+// RevertToSnapshot reverts to a named snapshot
+func (v VirtualMachine) RevertToSnapshot(ctx context.Context, name string, suppressPowerOn bool) (*Task, error) {
+	snapshot, err := v.findSnapshot(ctx, name)
 	if err != nil {
 		return nil, err
 	}
 
 	req := types.RevertToSnapshot_Task{
-		This:            snapshot,
+		This:            snapshot.Reference(),
 		SuppressPowerOn: types.NewBool(suppressPowerOn),
 	}
 
@@ -497,32 +602,6 @@ func (v VirtualMachine) RevertToSnapshot(ctx context.Context, name string, suppr
 	}
 
 	return NewTask(v.c, res.Returnval), nil
-}
-
-// traverseSnapshotInTree is a recursive function that will traverse a snapshot tree to find a given snapshot
-func traverseSnapshotInTree(tree []types.VirtualMachineSnapshotTree, name string) (types.ManagedObjectReference, error) {
-	var o types.ManagedObjectReference
-	if tree == nil {
-		return o, errors.New("Snapshot tree is empty")
-	}
-	for _, s := range tree {
-		if s.Name == name {
-			o = s.Snapshot
-			break
-		} else {
-			childTree := s.ChildSnapshotList
-			var err error
-			o, err = traverseSnapshotInTree(childTree, name)
-			if err != nil {
-				return o, err
-			}
-		}
-	}
-	if o.Value == "" {
-		return o, errors.New("Snapshot not found")
-	}
-
-	return o, nil
 }
 
 // IsToolsRunning returns true if VMware Tools is currently running in the guest OS, and false otherwise.
@@ -590,4 +669,59 @@ func (v VirtualMachine) MarkAsVirtualMachine(ctx context.Context, pool ResourceP
 	}
 
 	return nil
+}
+
+func (v VirtualMachine) Migrate(ctx context.Context, pool *ResourcePool, host *HostSystem, priority types.VirtualMachineMovePriority, state types.VirtualMachinePowerState) (*Task, error) {
+	req := types.MigrateVM_Task{
+		This:     v.Reference(),
+		Priority: priority,
+		State:    state,
+	}
+
+	if pool != nil {
+		ref := pool.Reference()
+		req.Pool = &ref
+	}
+
+	if host != nil {
+		ref := host.Reference()
+		req.Host = &ref
+	}
+
+	res, err := methods.MigrateVM_Task(ctx, v.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(v.c, res.Returnval), nil
+}
+
+func (v VirtualMachine) Unregister(ctx context.Context) error {
+	req := types.UnregisterVM{
+		This: v.Reference(),
+	}
+
+	_, err := methods.UnregisterVM(ctx, v.Client(), &req)
+	return err
+}
+
+// QueryEnvironmentBrowser is a helper to get the environmentBrowser property.
+func (v VirtualMachine) QueryConfigTarget(ctx context.Context) (*types.ConfigTarget, error) {
+	var vm mo.VirtualMachine
+
+	err := v.Properties(ctx, v.Reference(), []string{"environmentBrowser"}, &vm)
+	if err != nil {
+		return nil, err
+	}
+
+	req := types.QueryConfigTarget{
+		This: vm.EnvironmentBrowser,
+	}
+
+	res, err := methods.QueryConfigTarget(ctx, v.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Returnval, nil
 }

--- a/vendor/github.com/vmware/govmomi/property/collector.go
+++ b/vendor/github.com/vmware/govmomi/property/collector.go
@@ -17,6 +17,7 @@ limitations under the License.
 package property
 
 import (
+	"context"
 	"errors"
 
 	"github.com/vmware/govmomi/vim25"
@@ -24,7 +25,6 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 // Collector models the PropertyCollector managed object.

--- a/vendor/github.com/vmware/govmomi/session/keep_alive.go
+++ b/vendor/github.com/vmware/govmomi/session/keep_alive.go
@@ -17,12 +17,12 @@ limitations under the License.
 package session
 
 import (
+	"context"
 	"sync"
 	"time"
 
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
-	"golang.org/x/net/context"
 )
 
 type keepAlive struct {

--- a/vendor/github.com/vmware/govmomi/task/wait.go
+++ b/vendor/github.com/vmware/govmomi/task/wait.go
@@ -17,10 +17,11 @@ limitations under the License.
 package task
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/vim25/progress"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type taskProgress struct {

--- a/vendor/github.com/vmware/govmomi/vim25/client.go
+++ b/vendor/github.com/vmware/govmomi/vim25/client.go
@@ -17,12 +17,12 @@ limitations under the License.
 package vim25
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 // Client is a tiny wrapper around the vim25/soap Client that stores session

--- a/vendor/github.com/vmware/govmomi/vim25/methods/internal.go
+++ b/vendor/github.com/vmware/govmomi/vim25/methods/internal.go
@@ -17,9 +17,10 @@ limitations under the License.
 package methods
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type RetrieveDynamicTypeManagerBody struct {

--- a/vendor/github.com/vmware/govmomi/vim25/methods/methods.go
+++ b/vendor/github.com/vmware/govmomi/vim25/methods/methods.go
@@ -17,9 +17,10 @@ limitations under the License.
 package methods
 
 import (
+	"context"
+
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 type AbdicateDomOwnershipBody struct {
@@ -282,6 +283,46 @@ func AddDisks_Task(ctx context.Context, r soap.RoundTripper, req *types.AddDisks
 	return resBody.Res, nil
 }
 
+type AddFilterBody struct {
+	Req    *types.AddFilter         `xml:"urn:vim25 AddFilter,omitempty"`
+	Res    *types.AddFilterResponse `xml:"urn:vim25 AddFilterResponse,omitempty"`
+	Fault_ *soap.Fault              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddFilterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddFilter(ctx context.Context, r soap.RoundTripper, req *types.AddFilter) (*types.AddFilterResponse, error) {
+	var reqBody, resBody AddFilterBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AddFilterEntitiesBody struct {
+	Req    *types.AddFilterEntities         `xml:"urn:vim25 AddFilterEntities,omitempty"`
+	Res    *types.AddFilterEntitiesResponse `xml:"urn:vim25 AddFilterEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddFilterEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddFilterEntities(ctx context.Context, r soap.RoundTripper, req *types.AddFilterEntities) (*types.AddFilterEntitiesResponse, error) {
+	var reqBody, resBody AddFilterEntitiesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type AddGuestAliasBody struct {
 	Req    *types.AddGuestAlias         `xml:"urn:vim25 AddGuestAlias,omitempty"`
 	Res    *types.AddGuestAliasResponse `xml:"urn:vim25 AddGuestAliasResponse,omitempty"`
@@ -362,6 +403,46 @@ func AddInternetScsiStaticTargets(ctx context.Context, r soap.RoundTripper, req 
 	return resBody.Res, nil
 }
 
+type AddKeyBody struct {
+	Req    *types.AddKey         `xml:"urn:vim25 AddKey,omitempty"`
+	Res    *types.AddKeyResponse `xml:"urn:vim25 AddKeyResponse,omitempty"`
+	Fault_ *soap.Fault           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddKeyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddKey(ctx context.Context, r soap.RoundTripper, req *types.AddKey) (*types.AddKeyResponse, error) {
+	var reqBody, resBody AddKeyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AddKeysBody struct {
+	Req    *types.AddKeys         `xml:"urn:vim25 AddKeys,omitempty"`
+	Res    *types.AddKeysResponse `xml:"urn:vim25 AddKeysResponse,omitempty"`
+	Fault_ *soap.Fault            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddKeysBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddKeys(ctx context.Context, r soap.RoundTripper, req *types.AddKeys) (*types.AddKeysResponse, error) {
+	var reqBody, resBody AddKeysBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type AddLicenseBody struct {
 	Req    *types.AddLicense         `xml:"urn:vim25 AddLicense,omitempty"`
 	Res    *types.AddLicenseResponse `xml:"urn:vim25 AddLicenseResponse,omitempty"`
@@ -372,6 +453,26 @@ func (b *AddLicenseBody) Fault() *soap.Fault { return b.Fault_ }
 
 func AddLicense(ctx context.Context, r soap.RoundTripper, req *types.AddLicense) (*types.AddLicenseResponse, error) {
 	var reqBody, resBody AddLicenseBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AddMonitoredEntitiesBody struct {
+	Req    *types.AddMonitoredEntities         `xml:"urn:vim25 AddMonitoredEntities,omitempty"`
+	Res    *types.AddMonitoredEntitiesResponse `xml:"urn:vim25 AddMonitoredEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AddMonitoredEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AddMonitoredEntities(ctx context.Context, r soap.RoundTripper, req *types.AddMonitoredEntities) (*types.AddMonitoredEntitiesResponse, error) {
+	var reqBody, resBody AddMonitoredEntitiesBody
 
 	reqBody.Req = req
 
@@ -562,6 +663,26 @@ func AnswerVM(ctx context.Context, r soap.RoundTripper, req *types.AnswerVM) (*t
 	return resBody.Res, nil
 }
 
+type ApplyEntitiesConfig_TaskBody struct {
+	Req    *types.ApplyEntitiesConfig_Task         `xml:"urn:vim25 ApplyEntitiesConfig_Task,omitempty"`
+	Res    *types.ApplyEntitiesConfig_TaskResponse `xml:"urn:vim25 ApplyEntitiesConfig_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ApplyEntitiesConfig_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ApplyEntitiesConfig_Task(ctx context.Context, r soap.RoundTripper, req *types.ApplyEntitiesConfig_Task) (*types.ApplyEntitiesConfig_TaskResponse, error) {
+	var reqBody, resBody ApplyEntitiesConfig_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type ApplyHostConfig_TaskBody struct {
 	Req    *types.ApplyHostConfig_Task         `xml:"urn:vim25 ApplyHostConfig_Task,omitempty"`
 	Res    *types.ApplyHostConfig_TaskResponse `xml:"urn:vim25 ApplyHostConfig_TaskResponse,omitempty"`
@@ -702,6 +823,26 @@ func AssociateProfile(ctx context.Context, r soap.RoundTripper, req *types.Assoc
 	return resBody.Res, nil
 }
 
+type AttachDisk_TaskBody struct {
+	Req    *types.AttachDisk_Task         `xml:"urn:vim25 AttachDisk_Task,omitempty"`
+	Res    *types.AttachDisk_TaskResponse `xml:"urn:vim25 AttachDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AttachDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AttachDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.AttachDisk_Task) (*types.AttachDisk_TaskResponse, error) {
+	var reqBody, resBody AttachDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type AttachScsiLunBody struct {
 	Req    *types.AttachScsiLun         `xml:"urn:vim25 AttachScsiLun,omitempty"`
 	Res    *types.AttachScsiLunResponse `xml:"urn:vim25 AttachScsiLunResponse,omitempty"`
@@ -732,6 +873,26 @@ func (b *AttachScsiLunEx_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func AttachScsiLunEx_Task(ctx context.Context, r soap.RoundTripper, req *types.AttachScsiLunEx_Task) (*types.AttachScsiLunEx_TaskResponse, error) {
 	var reqBody, resBody AttachScsiLunEx_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type AttachTagToVStorageObjectBody struct {
+	Req    *types.AttachTagToVStorageObject         `xml:"urn:vim25 AttachTagToVStorageObject,omitempty"`
+	Res    *types.AttachTagToVStorageObjectResponse `xml:"urn:vim25 AttachTagToVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *AttachTagToVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func AttachTagToVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.AttachTagToVStorageObject) (*types.AttachTagToVStorageObjectResponse, error) {
+	var reqBody, resBody AttachTagToVStorageObjectBody
 
 	reqBody.Req = req
 
@@ -1442,6 +1603,26 @@ func ClearNFSUser(ctx context.Context, r soap.RoundTripper, req *types.ClearNFSU
 	return resBody.Res, nil
 }
 
+type ClearSystemEventLogBody struct {
+	Req    *types.ClearSystemEventLog         `xml:"urn:vim25 ClearSystemEventLog,omitempty"`
+	Res    *types.ClearSystemEventLogResponse `xml:"urn:vim25 ClearSystemEventLogResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ClearSystemEventLogBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ClearSystemEventLog(ctx context.Context, r soap.RoundTripper, req *types.ClearSystemEventLog) (*types.ClearSystemEventLogResponse, error) {
+	var reqBody, resBody ClearSystemEventLogBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type CloneSessionBody struct {
 	Req    *types.CloneSession         `xml:"urn:vim25 CloneSession,omitempty"`
 	Res    *types.CloneSessionResponse `xml:"urn:vim25 CloneSessionResponse,omitempty"`
@@ -1492,6 +1673,26 @@ func (b *CloneVM_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func CloneVM_Task(ctx context.Context, r soap.RoundTripper, req *types.CloneVM_Task) (*types.CloneVM_TaskResponse, error) {
 	var reqBody, resBody CloneVM_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CloneVStorageObject_TaskBody struct {
+	Req    *types.CloneVStorageObject_Task         `xml:"urn:vim25 CloneVStorageObject_Task,omitempty"`
+	Res    *types.CloneVStorageObject_TaskResponse `xml:"urn:vim25 CloneVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CloneVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CloneVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.CloneVStorageObject_Task) (*types.CloneVStorageObject_TaskResponse, error) {
+	var reqBody, resBody CloneVStorageObject_TaskBody
 
 	reqBody.Req = req
 
@@ -1572,6 +1773,26 @@ func (b *ComputeDiskPartitionInfoForResizeBody) Fault() *soap.Fault { return b.F
 
 func ComputeDiskPartitionInfoForResize(ctx context.Context, r soap.RoundTripper, req *types.ComputeDiskPartitionInfoForResize) (*types.ComputeDiskPartitionInfoForResizeResponse, error) {
 	var reqBody, resBody ComputeDiskPartitionInfoForResizeBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ConfigureCryptoKeyBody struct {
+	Req    *types.ConfigureCryptoKey         `xml:"urn:vim25 ConfigureCryptoKey,omitempty"`
+	Res    *types.ConfigureCryptoKeyResponse `xml:"urn:vim25 ConfigureCryptoKeyResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ConfigureCryptoKeyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ConfigureCryptoKey(ctx context.Context, r soap.RoundTripper, req *types.ConfigureCryptoKey) (*types.ConfigureCryptoKeyResponse, error) {
+	var reqBody, resBody ConfigureCryptoKeyBody
 
 	reqBody.Req = req
 
@@ -1772,6 +1993,26 @@ func (b *ContinueRetrievePropertiesExBody) Fault() *soap.Fault { return b.Fault_
 
 func ContinueRetrievePropertiesEx(ctx context.Context, r soap.RoundTripper, req *types.ContinueRetrievePropertiesEx) (*types.ContinueRetrievePropertiesExResponse, error) {
 	var reqBody, resBody ContinueRetrievePropertiesExBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ConvertNamespacePathToUuidPathBody struct {
+	Req    *types.ConvertNamespacePathToUuidPath         `xml:"urn:vim25 ConvertNamespacePathToUuidPath,omitempty"`
+	Res    *types.ConvertNamespacePathToUuidPathResponse `xml:"urn:vim25 ConvertNamespacePathToUuidPathResponse,omitempty"`
+	Fault_ *soap.Fault                                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ConvertNamespacePathToUuidPathBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ConvertNamespacePathToUuidPath(ctx context.Context, r soap.RoundTripper, req *types.ConvertNamespacePathToUuidPath) (*types.ConvertNamespacePathToUuidPathResponse, error) {
+	var reqBody, resBody ConvertNamespacePathToUuidPathBody
 
 	reqBody.Req = req
 
@@ -2112,6 +2353,26 @@ func (b *CreateDirectoryBody) Fault() *soap.Fault { return b.Fault_ }
 
 func CreateDirectory(ctx context.Context, r soap.RoundTripper, req *types.CreateDirectory) (*types.CreateDirectoryResponse, error) {
 	var reqBody, resBody CreateDirectoryBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CreateDisk_TaskBody struct {
+	Req    *types.CreateDisk_Task         `xml:"urn:vim25 CreateDisk_Task,omitempty"`
+	Res    *types.CreateDisk_TaskResponse `xml:"urn:vim25 CreateDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CreateDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CreateDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.CreateDisk_Task) (*types.CreateDisk_TaskResponse, error) {
+	var reqBody, resBody CreateDisk_TaskBody
 
 	reqBody.Req = req
 
@@ -2512,6 +2773,26 @@ func (b *CreateSecondaryVM_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func CreateSecondaryVM_Task(ctx context.Context, r soap.RoundTripper, req *types.CreateSecondaryVM_Task) (*types.CreateSecondaryVM_TaskResponse, error) {
 	var reqBody, resBody CreateSecondaryVM_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type CreateSnapshotEx_TaskBody struct {
+	Req    *types.CreateSnapshotEx_Task         `xml:"urn:vim25 CreateSnapshotEx_Task,omitempty"`
+	Res    *types.CreateSnapshotEx_TaskResponse `xml:"urn:vim25 CreateSnapshotEx_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *CreateSnapshotEx_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func CreateSnapshotEx_Task(ctx context.Context, r soap.RoundTripper, req *types.CreateSnapshotEx_Task) (*types.CreateSnapshotEx_TaskResponse, error) {
+	var reqBody, resBody CreateSnapshotEx_TaskBody
 
 	reqBody.Req = req
 
@@ -3122,6 +3403,46 @@ func DeleteFileInGuest(ctx context.Context, r soap.RoundTripper, req *types.Dele
 	return resBody.Res, nil
 }
 
+type DeleteHostSpecificationBody struct {
+	Req    *types.DeleteHostSpecification         `xml:"urn:vim25 DeleteHostSpecification,omitempty"`
+	Res    *types.DeleteHostSpecificationResponse `xml:"urn:vim25 DeleteHostSpecificationResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DeleteHostSpecificationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DeleteHostSpecification(ctx context.Context, r soap.RoundTripper, req *types.DeleteHostSpecification) (*types.DeleteHostSpecificationResponse, error) {
+	var reqBody, resBody DeleteHostSpecificationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DeleteHostSubSpecificationBody struct {
+	Req    *types.DeleteHostSubSpecification         `xml:"urn:vim25 DeleteHostSubSpecification,omitempty"`
+	Res    *types.DeleteHostSubSpecificationResponse `xml:"urn:vim25 DeleteHostSubSpecificationResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DeleteHostSubSpecificationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DeleteHostSubSpecification(ctx context.Context, r soap.RoundTripper, req *types.DeleteHostSubSpecification) (*types.DeleteHostSubSpecificationResponse, error) {
+	var reqBody, resBody DeleteHostSubSpecificationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type DeleteRegistryKeyInGuestBody struct {
 	Req    *types.DeleteRegistryKeyInGuest         `xml:"urn:vim25 DeleteRegistryKeyInGuest,omitempty"`
 	Res    *types.DeleteRegistryKeyInGuestResponse `xml:"urn:vim25 DeleteRegistryKeyInGuestResponse,omitempty"`
@@ -3172,6 +3493,26 @@ func (b *DeleteScsiLunStateBody) Fault() *soap.Fault { return b.Fault_ }
 
 func DeleteScsiLunState(ctx context.Context, r soap.RoundTripper, req *types.DeleteScsiLunState) (*types.DeleteScsiLunStateResponse, error) {
 	var reqBody, resBody DeleteScsiLunStateBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DeleteVStorageObject_TaskBody struct {
+	Req    *types.DeleteVStorageObject_Task         `xml:"urn:vim25 DeleteVStorageObject_Task,omitempty"`
+	Res    *types.DeleteVStorageObject_TaskResponse `xml:"urn:vim25 DeleteVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DeleteVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DeleteVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.DeleteVStorageObject_Task) (*types.DeleteVStorageObject_TaskResponse, error) {
+	var reqBody, resBody DeleteVStorageObject_TaskBody
 
 	reqBody.Req = req
 
@@ -3522,6 +3863,26 @@ func Destroy_Task(ctx context.Context, r soap.RoundTripper, req *types.Destroy_T
 	return resBody.Res, nil
 }
 
+type DetachDisk_TaskBody struct {
+	Req    *types.DetachDisk_Task         `xml:"urn:vim25 DetachDisk_Task,omitempty"`
+	Res    *types.DetachDisk_TaskResponse `xml:"urn:vim25 DetachDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DetachDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DetachDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.DetachDisk_Task) (*types.DetachDisk_TaskResponse, error) {
+	var reqBody, resBody DetachDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type DetachScsiLunBody struct {
 	Req    *types.DetachScsiLun         `xml:"urn:vim25 DetachScsiLun,omitempty"`
 	Res    *types.DetachScsiLunResponse `xml:"urn:vim25 DetachScsiLunResponse,omitempty"`
@@ -3552,6 +3913,26 @@ func (b *DetachScsiLunEx_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func DetachScsiLunEx_Task(ctx context.Context, r soap.RoundTripper, req *types.DetachScsiLunEx_Task) (*types.DetachScsiLunEx_TaskResponse, error) {
 	var reqBody, resBody DetachScsiLunEx_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type DetachTagFromVStorageObjectBody struct {
+	Req    *types.DetachTagFromVStorageObject         `xml:"urn:vim25 DetachTagFromVStorageObject,omitempty"`
+	Res    *types.DetachTagFromVStorageObjectResponse `xml:"urn:vim25 DetachTagFromVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *DetachTagFromVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func DetachTagFromVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.DetachTagFromVStorageObject) (*types.DetachTagFromVStorageObjectResponse, error) {
+	var reqBody, resBody DetachTagFromVStorageObjectBody
 
 	reqBody.Req = req
 
@@ -3852,6 +4233,26 @@ func (b *EnableAlarmActionsBody) Fault() *soap.Fault { return b.Fault_ }
 
 func EnableAlarmActions(ctx context.Context, r soap.RoundTripper, req *types.EnableAlarmActions) (*types.EnableAlarmActionsResponse, error) {
 	var reqBody, resBody EnableAlarmActionsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type EnableCryptoBody struct {
+	Req    *types.EnableCrypto         `xml:"urn:vim25 EnableCrypto,omitempty"`
+	Res    *types.EnableCryptoResponse `xml:"urn:vim25 EnableCryptoResponse,omitempty"`
+	Fault_ *soap.Fault                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *EnableCryptoBody) Fault() *soap.Fault { return b.Fault_ }
+
+func EnableCrypto(ctx context.Context, r soap.RoundTripper, req *types.EnableCrypto) (*types.EnableCryptoResponse, error) {
+	var reqBody, resBody EnableCryptoBody
 
 	reqBody.Req = req
 
@@ -4362,6 +4763,26 @@ func ExportVm(ctx context.Context, r soap.RoundTripper, req *types.ExportVm) (*t
 	return resBody.Res, nil
 }
 
+type ExtendDisk_TaskBody struct {
+	Req    *types.ExtendDisk_Task         `xml:"urn:vim25 ExtendDisk_Task,omitempty"`
+	Res    *types.ExtendDisk_TaskResponse `xml:"urn:vim25 ExtendDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ExtendDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ExtendDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.ExtendDisk_Task) (*types.ExtendDisk_TaskResponse, error) {
+	var reqBody, resBody ExtendDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type ExtendVffsBody struct {
 	Req    *types.ExtendVffs         `xml:"urn:vim25 ExtendVffs,omitempty"`
 	Res    *types.ExtendVffsResponse `xml:"urn:vim25 ExtendVffsResponse,omitempty"`
@@ -4472,6 +4893,46 @@ func (b *FetchDVPortsBody) Fault() *soap.Fault { return b.Fault_ }
 
 func FetchDVPorts(ctx context.Context, r soap.RoundTripper, req *types.FetchDVPorts) (*types.FetchDVPortsResponse, error) {
 	var reqBody, resBody FetchDVPortsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FetchSystemEventLogBody struct {
+	Req    *types.FetchSystemEventLog         `xml:"urn:vim25 FetchSystemEventLog,omitempty"`
+	Res    *types.FetchSystemEventLogResponse `xml:"urn:vim25 FetchSystemEventLogResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FetchSystemEventLogBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FetchSystemEventLog(ctx context.Context, r soap.RoundTripper, req *types.FetchSystemEventLog) (*types.FetchSystemEventLogResponse, error) {
+	var reqBody, resBody FetchSystemEventLogBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type FetchUserPrivilegeOnEntitiesBody struct {
+	Req    *types.FetchUserPrivilegeOnEntities         `xml:"urn:vim25 FetchUserPrivilegeOnEntities,omitempty"`
+	Res    *types.FetchUserPrivilegeOnEntitiesResponse `xml:"urn:vim25 FetchUserPrivilegeOnEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *FetchUserPrivilegeOnEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func FetchUserPrivilegeOnEntities(ctx context.Context, r soap.RoundTripper, req *types.FetchUserPrivilegeOnEntities) (*types.FetchUserPrivilegeOnEntitiesResponse, error) {
+	var reqBody, resBody FetchUserPrivilegeOnEntitiesBody
 
 	reqBody.Req = req
 
@@ -4802,6 +5263,26 @@ func GenerateCertificateSigningRequestByDn(ctx context.Context, r soap.RoundTrip
 	return resBody.Res, nil
 }
 
+type GenerateClientCsrBody struct {
+	Req    *types.GenerateClientCsr         `xml:"urn:vim25 GenerateClientCsr,omitempty"`
+	Res    *types.GenerateClientCsrResponse `xml:"urn:vim25 GenerateClientCsrResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GenerateClientCsrBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GenerateClientCsr(ctx context.Context, r soap.RoundTripper, req *types.GenerateClientCsr) (*types.GenerateClientCsrResponse, error) {
+	var reqBody, resBody GenerateClientCsrBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type GenerateConfigTaskListBody struct {
 	Req    *types.GenerateConfigTaskList         `xml:"urn:vim25 GenerateConfigTaskList,omitempty"`
 	Res    *types.GenerateConfigTaskListResponse `xml:"urn:vim25 GenerateConfigTaskListResponse,omitempty"`
@@ -4812,6 +5293,26 @@ func (b *GenerateConfigTaskListBody) Fault() *soap.Fault { return b.Fault_ }
 
 func GenerateConfigTaskList(ctx context.Context, r soap.RoundTripper, req *types.GenerateConfigTaskList) (*types.GenerateConfigTaskListResponse, error) {
 	var reqBody, resBody GenerateConfigTaskListBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GenerateHostConfigTaskSpec_TaskBody struct {
+	Req    *types.GenerateHostConfigTaskSpec_Task         `xml:"urn:vim25 GenerateHostConfigTaskSpec_Task,omitempty"`
+	Res    *types.GenerateHostConfigTaskSpec_TaskResponse `xml:"urn:vim25 GenerateHostConfigTaskSpec_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GenerateHostConfigTaskSpec_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GenerateHostConfigTaskSpec_Task(ctx context.Context, r soap.RoundTripper, req *types.GenerateHostConfigTaskSpec_Task) (*types.GenerateHostConfigTaskSpec_TaskResponse, error) {
+	var reqBody, resBody GenerateHostConfigTaskSpec_TaskBody
 
 	reqBody.Req = req
 
@@ -4842,6 +5343,26 @@ func GenerateHostProfileTaskList_Task(ctx context.Context, r soap.RoundTripper, 
 	return resBody.Res, nil
 }
 
+type GenerateKeyBody struct {
+	Req    *types.GenerateKey         `xml:"urn:vim25 GenerateKey,omitempty"`
+	Res    *types.GenerateKeyResponse `xml:"urn:vim25 GenerateKeyResponse,omitempty"`
+	Fault_ *soap.Fault                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GenerateKeyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GenerateKey(ctx context.Context, r soap.RoundTripper, req *types.GenerateKey) (*types.GenerateKeyResponse, error) {
+	var reqBody, resBody GenerateKeyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type GenerateLogBundles_TaskBody struct {
 	Req    *types.GenerateLogBundles_Task         `xml:"urn:vim25 GenerateLogBundles_Task,omitempty"`
 	Res    *types.GenerateLogBundles_TaskResponse `xml:"urn:vim25 GenerateLogBundles_TaskResponse,omitempty"`
@@ -4852,6 +5373,26 @@ func (b *GenerateLogBundles_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func GenerateLogBundles_Task(ctx context.Context, r soap.RoundTripper, req *types.GenerateLogBundles_Task) (*types.GenerateLogBundles_TaskResponse, error) {
 	var reqBody, resBody GenerateLogBundles_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type GenerateSelfSignedClientCertBody struct {
+	Req    *types.GenerateSelfSignedClientCert         `xml:"urn:vim25 GenerateSelfSignedClientCert,omitempty"`
+	Res    *types.GenerateSelfSignedClientCertResponse `xml:"urn:vim25 GenerateSelfSignedClientCertResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GenerateSelfSignedClientCertBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GenerateSelfSignedClientCert(ctx context.Context, r soap.RoundTripper, req *types.GenerateSelfSignedClientCert) (*types.GenerateSelfSignedClientCertResponse, error) {
+	var reqBody, resBody GenerateSelfSignedClientCertBody
 
 	reqBody.Req = req
 
@@ -4962,6 +5503,26 @@ func GetResourceUsage(ctx context.Context, r soap.RoundTripper, req *types.GetRe
 	return resBody.Res, nil
 }
 
+type GetVchaClusterHealthBody struct {
+	Req    *types.GetVchaClusterHealth         `xml:"urn:vim25 GetVchaClusterHealth,omitempty"`
+	Res    *types.GetVchaClusterHealthResponse `xml:"urn:vim25 GetVchaClusterHealthResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *GetVchaClusterHealthBody) Fault() *soap.Fault { return b.Fault_ }
+
+func GetVchaClusterHealth(ctx context.Context, r soap.RoundTripper, req *types.GetVchaClusterHealth) (*types.GetVchaClusterHealthResponse, error) {
+	var reqBody, resBody GetVchaClusterHealthBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type GetVsanObjExtAttrsBody struct {
 	Req    *types.GetVsanObjExtAttrs         `xml:"urn:vim25 GetVsanObjExtAttrs,omitempty"`
 	Res    *types.GetVsanObjExtAttrsResponse `xml:"urn:vim25 GetVsanObjExtAttrsResponse,omitempty"`
@@ -4972,6 +5533,26 @@ func (b *GetVsanObjExtAttrsBody) Fault() *soap.Fault { return b.Fault_ }
 
 func GetVsanObjExtAttrs(ctx context.Context, r soap.RoundTripper, req *types.GetVsanObjExtAttrs) (*types.GetVsanObjExtAttrsResponse, error) {
 	var reqBody, resBody GetVsanObjExtAttrsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HasMonitoredEntityBody struct {
+	Req    *types.HasMonitoredEntity         `xml:"urn:vim25 HasMonitoredEntity,omitempty"`
+	Res    *types.HasMonitoredEntityResponse `xml:"urn:vim25 HasMonitoredEntityResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HasMonitoredEntityBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HasMonitoredEntity(ctx context.Context, r soap.RoundTripper, req *types.HasMonitoredEntity) (*types.HasMonitoredEntityResponse, error) {
+	var reqBody, resBody HasMonitoredEntityBody
 
 	reqBody.Req = req
 
@@ -5022,6 +5603,66 @@ func HasPrivilegeOnEntity(ctx context.Context, r soap.RoundTripper, req *types.H
 	return resBody.Res, nil
 }
 
+type HasProviderBody struct {
+	Req    *types.HasProvider         `xml:"urn:vim25 HasProvider,omitempty"`
+	Res    *types.HasProviderResponse `xml:"urn:vim25 HasProviderResponse,omitempty"`
+	Fault_ *soap.Fault                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HasProviderBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HasProvider(ctx context.Context, r soap.RoundTripper, req *types.HasProvider) (*types.HasProviderResponse, error) {
+	var reqBody, resBody HasProviderBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HasUserPrivilegeOnEntitiesBody struct {
+	Req    *types.HasUserPrivilegeOnEntities         `xml:"urn:vim25 HasUserPrivilegeOnEntities,omitempty"`
+	Res    *types.HasUserPrivilegeOnEntitiesResponse `xml:"urn:vim25 HasUserPrivilegeOnEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HasUserPrivilegeOnEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HasUserPrivilegeOnEntities(ctx context.Context, r soap.RoundTripper, req *types.HasUserPrivilegeOnEntities) (*types.HasUserPrivilegeOnEntitiesResponse, error) {
+	var reqBody, resBody HasUserPrivilegeOnEntitiesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostCloneVStorageObject_TaskBody struct {
+	Req    *types.HostCloneVStorageObject_Task         `xml:"urn:vim25 HostCloneVStorageObject_Task,omitempty"`
+	Res    *types.HostCloneVStorageObject_TaskResponse `xml:"urn:vim25 HostCloneVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostCloneVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostCloneVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.HostCloneVStorageObject_Task) (*types.HostCloneVStorageObject_TaskResponse, error) {
+	var reqBody, resBody HostCloneVStorageObject_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type HostConfigVFlashCacheBody struct {
 	Req    *types.HostConfigVFlashCache         `xml:"urn:vim25 HostConfigVFlashCache,omitempty"`
 	Res    *types.HostConfigVFlashCacheResponse `xml:"urn:vim25 HostConfigVFlashCacheResponse,omitempty"`
@@ -5052,6 +5693,66 @@ func (b *HostConfigureVFlashResourceBody) Fault() *soap.Fault { return b.Fault_ 
 
 func HostConfigureVFlashResource(ctx context.Context, r soap.RoundTripper, req *types.HostConfigureVFlashResource) (*types.HostConfigureVFlashResourceResponse, error) {
 	var reqBody, resBody HostConfigureVFlashResourceBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostCreateDisk_TaskBody struct {
+	Req    *types.HostCreateDisk_Task         `xml:"urn:vim25 HostCreateDisk_Task,omitempty"`
+	Res    *types.HostCreateDisk_TaskResponse `xml:"urn:vim25 HostCreateDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostCreateDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostCreateDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.HostCreateDisk_Task) (*types.HostCreateDisk_TaskResponse, error) {
+	var reqBody, resBody HostCreateDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostDeleteVStorageObject_TaskBody struct {
+	Req    *types.HostDeleteVStorageObject_Task         `xml:"urn:vim25 HostDeleteVStorageObject_Task,omitempty"`
+	Res    *types.HostDeleteVStorageObject_TaskResponse `xml:"urn:vim25 HostDeleteVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostDeleteVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostDeleteVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.HostDeleteVStorageObject_Task) (*types.HostDeleteVStorageObject_TaskResponse, error) {
+	var reqBody, resBody HostDeleteVStorageObject_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostExtendDisk_TaskBody struct {
+	Req    *types.HostExtendDisk_Task         `xml:"urn:vim25 HostExtendDisk_Task,omitempty"`
+	Res    *types.HostExtendDisk_TaskResponse `xml:"urn:vim25 HostExtendDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostExtendDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostExtendDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.HostExtendDisk_Task) (*types.HostExtendDisk_TaskResponse, error) {
+	var reqBody, resBody HostExtendDisk_TaskBody
 
 	reqBody.Req = req
 
@@ -5122,6 +5823,106 @@ func HostImageConfigGetProfile(ctx context.Context, r soap.RoundTripper, req *ty
 	return resBody.Res, nil
 }
 
+type HostInflateDisk_TaskBody struct {
+	Req    *types.HostInflateDisk_Task         `xml:"urn:vim25 HostInflateDisk_Task,omitempty"`
+	Res    *types.HostInflateDisk_TaskResponse `xml:"urn:vim25 HostInflateDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostInflateDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostInflateDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.HostInflateDisk_Task) (*types.HostInflateDisk_TaskResponse, error) {
+	var reqBody, resBody HostInflateDisk_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostListVStorageObjectBody struct {
+	Req    *types.HostListVStorageObject         `xml:"urn:vim25 HostListVStorageObject,omitempty"`
+	Res    *types.HostListVStorageObjectResponse `xml:"urn:vim25 HostListVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostListVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostListVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.HostListVStorageObject) (*types.HostListVStorageObjectResponse, error) {
+	var reqBody, resBody HostListVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostReconcileDatastoreInventory_TaskBody struct {
+	Req    *types.HostReconcileDatastoreInventory_Task         `xml:"urn:vim25 HostReconcileDatastoreInventory_Task,omitempty"`
+	Res    *types.HostReconcileDatastoreInventory_TaskResponse `xml:"urn:vim25 HostReconcileDatastoreInventory_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostReconcileDatastoreInventory_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostReconcileDatastoreInventory_Task(ctx context.Context, r soap.RoundTripper, req *types.HostReconcileDatastoreInventory_Task) (*types.HostReconcileDatastoreInventory_TaskResponse, error) {
+	var reqBody, resBody HostReconcileDatastoreInventory_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostRegisterDiskBody struct {
+	Req    *types.HostRegisterDisk         `xml:"urn:vim25 HostRegisterDisk,omitempty"`
+	Res    *types.HostRegisterDiskResponse `xml:"urn:vim25 HostRegisterDiskResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostRegisterDiskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostRegisterDisk(ctx context.Context, r soap.RoundTripper, req *types.HostRegisterDisk) (*types.HostRegisterDiskResponse, error) {
+	var reqBody, resBody HostRegisterDiskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostRelocateVStorageObject_TaskBody struct {
+	Req    *types.HostRelocateVStorageObject_Task         `xml:"urn:vim25 HostRelocateVStorageObject_Task,omitempty"`
+	Res    *types.HostRelocateVStorageObject_TaskResponse `xml:"urn:vim25 HostRelocateVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostRelocateVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostRelocateVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.HostRelocateVStorageObject_Task) (*types.HostRelocateVStorageObject_TaskResponse, error) {
+	var reqBody, resBody HostRelocateVStorageObject_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type HostRemoveVFlashResourceBody struct {
 	Req    *types.HostRemoveVFlashResource         `xml:"urn:vim25 HostRemoveVFlashResource,omitempty"`
 	Res    *types.HostRemoveVFlashResourceResponse `xml:"urn:vim25 HostRemoveVFlashResourceResponse,omitempty"`
@@ -5132,6 +5933,106 @@ func (b *HostRemoveVFlashResourceBody) Fault() *soap.Fault { return b.Fault_ }
 
 func HostRemoveVFlashResource(ctx context.Context, r soap.RoundTripper, req *types.HostRemoveVFlashResource) (*types.HostRemoveVFlashResourceResponse, error) {
 	var reqBody, resBody HostRemoveVFlashResourceBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostRenameVStorageObjectBody struct {
+	Req    *types.HostRenameVStorageObject         `xml:"urn:vim25 HostRenameVStorageObject,omitempty"`
+	Res    *types.HostRenameVStorageObjectResponse `xml:"urn:vim25 HostRenameVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostRenameVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostRenameVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.HostRenameVStorageObject) (*types.HostRenameVStorageObjectResponse, error) {
+	var reqBody, resBody HostRenameVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostRetrieveVStorageObjectBody struct {
+	Req    *types.HostRetrieveVStorageObject         `xml:"urn:vim25 HostRetrieveVStorageObject,omitempty"`
+	Res    *types.HostRetrieveVStorageObjectResponse `xml:"urn:vim25 HostRetrieveVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostRetrieveVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostRetrieveVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.HostRetrieveVStorageObject) (*types.HostRetrieveVStorageObjectResponse, error) {
+	var reqBody, resBody HostRetrieveVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostRetrieveVStorageObjectStateBody struct {
+	Req    *types.HostRetrieveVStorageObjectState         `xml:"urn:vim25 HostRetrieveVStorageObjectState,omitempty"`
+	Res    *types.HostRetrieveVStorageObjectStateResponse `xml:"urn:vim25 HostRetrieveVStorageObjectStateResponse,omitempty"`
+	Fault_ *soap.Fault                                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostRetrieveVStorageObjectStateBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostRetrieveVStorageObjectState(ctx context.Context, r soap.RoundTripper, req *types.HostRetrieveVStorageObjectState) (*types.HostRetrieveVStorageObjectStateResponse, error) {
+	var reqBody, resBody HostRetrieveVStorageObjectStateBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostScheduleReconcileDatastoreInventoryBody struct {
+	Req    *types.HostScheduleReconcileDatastoreInventory         `xml:"urn:vim25 HostScheduleReconcileDatastoreInventory,omitempty"`
+	Res    *types.HostScheduleReconcileDatastoreInventoryResponse `xml:"urn:vim25 HostScheduleReconcileDatastoreInventoryResponse,omitempty"`
+	Fault_ *soap.Fault                                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostScheduleReconcileDatastoreInventoryBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostScheduleReconcileDatastoreInventory(ctx context.Context, r soap.RoundTripper, req *types.HostScheduleReconcileDatastoreInventory) (*types.HostScheduleReconcileDatastoreInventoryResponse, error) {
+	var reqBody, resBody HostScheduleReconcileDatastoreInventoryBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type HostSpecGetUpdatedHostsBody struct {
+	Req    *types.HostSpecGetUpdatedHosts         `xml:"urn:vim25 HostSpecGetUpdatedHosts,omitempty"`
+	Res    *types.HostSpecGetUpdatedHostsResponse `xml:"urn:vim25 HostSpecGetUpdatedHostsResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *HostSpecGetUpdatedHostsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func HostSpecGetUpdatedHosts(ctx context.Context, r soap.RoundTripper, req *types.HostSpecGetUpdatedHosts) (*types.HostSpecGetUpdatedHostsResponse, error) {
+	var reqBody, resBody HostSpecGetUpdatedHostsBody
 
 	reqBody.Req = req
 
@@ -5292,6 +6193,26 @@ func (b *ImportVAppBody) Fault() *soap.Fault { return b.Fault_ }
 
 func ImportVApp(ctx context.Context, r soap.RoundTripper, req *types.ImportVApp) (*types.ImportVAppResponse, error) {
 	var reqBody, resBody ImportVAppBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type InflateDisk_TaskBody struct {
+	Req    *types.InflateDisk_Task         `xml:"urn:vim25 InflateDisk_Task,omitempty"`
+	Res    *types.InflateDisk_TaskResponse `xml:"urn:vim25 InflateDisk_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *InflateDisk_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func InflateDisk_Task(ctx context.Context, r soap.RoundTripper, req *types.InflateDisk_Task) (*types.InflateDisk_TaskResponse, error) {
+	var reqBody, resBody InflateDisk_TaskBody
 
 	reqBody.Req = req
 
@@ -5662,6 +6583,46 @@ func ListGuestMappedAliases(ctx context.Context, r soap.RoundTripper, req *types
 	return resBody.Res, nil
 }
 
+type ListKeysBody struct {
+	Req    *types.ListKeys         `xml:"urn:vim25 ListKeys,omitempty"`
+	Res    *types.ListKeysResponse `xml:"urn:vim25 ListKeysResponse,omitempty"`
+	Fault_ *soap.Fault             `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ListKeysBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ListKeys(ctx context.Context, r soap.RoundTripper, req *types.ListKeys) (*types.ListKeysResponse, error) {
+	var reqBody, resBody ListKeysBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ListKmipServersBody struct {
+	Req    *types.ListKmipServers         `xml:"urn:vim25 ListKmipServers,omitempty"`
+	Res    *types.ListKmipServersResponse `xml:"urn:vim25 ListKmipServersResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ListKmipServersBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ListKmipServers(ctx context.Context, r soap.RoundTripper, req *types.ListKmipServers) (*types.ListKmipServersResponse, error) {
+	var reqBody, resBody ListKmipServersBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type ListProcessesInGuestBody struct {
 	Req    *types.ListProcessesInGuest         `xml:"urn:vim25 ListProcessesInGuest,omitempty"`
 	Res    *types.ListProcessesInGuestResponse `xml:"urn:vim25 ListProcessesInGuestResponse,omitempty"`
@@ -5732,6 +6693,66 @@ func (b *ListSmartCardTrustAnchorsBody) Fault() *soap.Fault { return b.Fault_ }
 
 func ListSmartCardTrustAnchors(ctx context.Context, r soap.RoundTripper, req *types.ListSmartCardTrustAnchors) (*types.ListSmartCardTrustAnchorsResponse, error) {
 	var reqBody, resBody ListSmartCardTrustAnchorsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ListTagsAttachedToVStorageObjectBody struct {
+	Req    *types.ListTagsAttachedToVStorageObject         `xml:"urn:vim25 ListTagsAttachedToVStorageObject,omitempty"`
+	Res    *types.ListTagsAttachedToVStorageObjectResponse `xml:"urn:vim25 ListTagsAttachedToVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ListTagsAttachedToVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ListTagsAttachedToVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.ListTagsAttachedToVStorageObject) (*types.ListTagsAttachedToVStorageObjectResponse, error) {
+	var reqBody, resBody ListTagsAttachedToVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ListVStorageObjectBody struct {
+	Req    *types.ListVStorageObject         `xml:"urn:vim25 ListVStorageObject,omitempty"`
+	Res    *types.ListVStorageObjectResponse `xml:"urn:vim25 ListVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ListVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ListVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.ListVStorageObject) (*types.ListVStorageObjectResponse, error) {
+	var reqBody, resBody ListVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ListVStorageObjectsAttachedToTagBody struct {
+	Req    *types.ListVStorageObjectsAttachedToTag         `xml:"urn:vim25 ListVStorageObjectsAttachedToTag,omitempty"`
+	Res    *types.ListVStorageObjectsAttachedToTagResponse `xml:"urn:vim25 ListVStorageObjectsAttachedToTagResponse,omitempty"`
+	Fault_ *soap.Fault                                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ListVStorageObjectsAttachedToTagBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ListVStorageObjectsAttachedToTag(ctx context.Context, r soap.RoundTripper, req *types.ListVStorageObjectsAttachedToTag) (*types.ListVStorageObjectsAttachedToTagResponse, error) {
+	var reqBody, resBody ListVStorageObjectsAttachedToTagBody
 
 	reqBody.Req = req
 
@@ -6092,6 +7113,26 @@ func (b *MarkAsVirtualMachineBody) Fault() *soap.Fault { return b.Fault_ }
 
 func MarkAsVirtualMachine(ctx context.Context, r soap.RoundTripper, req *types.MarkAsVirtualMachine) (*types.MarkAsVirtualMachineResponse, error) {
 	var reqBody, resBody MarkAsVirtualMachineBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type MarkDefaultBody struct {
+	Req    *types.MarkDefault         `xml:"urn:vim25 MarkDefault,omitempty"`
+	Res    *types.MarkDefaultResponse `xml:"urn:vim25 MarkDefaultResponse,omitempty"`
+	Fault_ *soap.Fault                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *MarkDefaultBody) Fault() *soap.Fault { return b.Fault_ }
+
+func MarkDefault(ctx context.Context, r soap.RoundTripper, req *types.MarkDefault) (*types.MarkDefaultResponse, error) {
+	var reqBody, resBody MarkDefaultBody
 
 	reqBody.Req = req
 
@@ -6622,6 +7663,26 @@ func PostEvent(ctx context.Context, r soap.RoundTripper, req *types.PostEvent) (
 	return resBody.Res, nil
 }
 
+type PostHealthUpdatesBody struct {
+	Req    *types.PostHealthUpdates         `xml:"urn:vim25 PostHealthUpdates,omitempty"`
+	Res    *types.PostHealthUpdatesResponse `xml:"urn:vim25 PostHealthUpdatesResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *PostHealthUpdatesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func PostHealthUpdates(ctx context.Context, r soap.RoundTripper, req *types.PostHealthUpdates) (*types.PostHealthUpdatesResponse, error) {
+	var reqBody, resBody PostHealthUpdatesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type PowerDownHostToStandBy_TaskBody struct {
 	Req    *types.PowerDownHostToStandBy_Task         `xml:"urn:vim25 PowerDownHostToStandBy_Task,omitempty"`
 	Res    *types.PowerDownHostToStandBy_TaskResponse `xml:"urn:vim25 PowerDownHostToStandBy_TaskResponse,omitempty"`
@@ -6762,6 +7823,26 @@ func PowerUpHostFromStandBy_Task(ctx context.Context, r soap.RoundTripper, req *
 	return resBody.Res, nil
 }
 
+type PrepareCryptoBody struct {
+	Req    *types.PrepareCrypto         `xml:"urn:vim25 PrepareCrypto,omitempty"`
+	Res    *types.PrepareCryptoResponse `xml:"urn:vim25 PrepareCryptoResponse,omitempty"`
+	Fault_ *soap.Fault                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *PrepareCryptoBody) Fault() *soap.Fault { return b.Fault_ }
+
+func PrepareCrypto(ctx context.Context, r soap.RoundTripper, req *types.PrepareCrypto) (*types.PrepareCryptoResponse, error) {
+	var reqBody, resBody PrepareCryptoBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type PromoteDisks_TaskBody struct {
 	Req    *types.PromoteDisks_Task         `xml:"urn:vim25 PromoteDisks_Task,omitempty"`
 	Res    *types.PromoteDisks_TaskResponse `xml:"urn:vim25 PromoteDisks_TaskResponse,omitempty"`
@@ -6772,6 +7853,26 @@ func (b *PromoteDisks_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func PromoteDisks_Task(ctx context.Context, r soap.RoundTripper, req *types.PromoteDisks_Task) (*types.PromoteDisks_TaskResponse, error) {
 	var reqBody, resBody PromoteDisks_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type PutUsbScanCodesBody struct {
+	Req    *types.PutUsbScanCodes         `xml:"urn:vim25 PutUsbScanCodes,omitempty"`
+	Res    *types.PutUsbScanCodesResponse `xml:"urn:vim25 PutUsbScanCodesResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *PutUsbScanCodesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func PutUsbScanCodes(ctx context.Context, r soap.RoundTripper, req *types.PutUsbScanCodes) (*types.PutUsbScanCodesResponse, error) {
+	var reqBody, resBody PutUsbScanCodesBody
 
 	reqBody.Req = req
 
@@ -7542,6 +8643,86 @@ func QueryFaultToleranceCompatibilityEx(ctx context.Context, r soap.RoundTripper
 	return resBody.Res, nil
 }
 
+type QueryFilterEntitiesBody struct {
+	Req    *types.QueryFilterEntities         `xml:"urn:vim25 QueryFilterEntities,omitempty"`
+	Res    *types.QueryFilterEntitiesResponse `xml:"urn:vim25 QueryFilterEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryFilterEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryFilterEntities(ctx context.Context, r soap.RoundTripper, req *types.QueryFilterEntities) (*types.QueryFilterEntitiesResponse, error) {
+	var reqBody, resBody QueryFilterEntitiesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryFilterInfoIdsBody struct {
+	Req    *types.QueryFilterInfoIds         `xml:"urn:vim25 QueryFilterInfoIds,omitempty"`
+	Res    *types.QueryFilterInfoIdsResponse `xml:"urn:vim25 QueryFilterInfoIdsResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryFilterInfoIdsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryFilterInfoIds(ctx context.Context, r soap.RoundTripper, req *types.QueryFilterInfoIds) (*types.QueryFilterInfoIdsResponse, error) {
+	var reqBody, resBody QueryFilterInfoIdsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryFilterListBody struct {
+	Req    *types.QueryFilterList         `xml:"urn:vim25 QueryFilterList,omitempty"`
+	Res    *types.QueryFilterListResponse `xml:"urn:vim25 QueryFilterListResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryFilterListBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryFilterList(ctx context.Context, r soap.RoundTripper, req *types.QueryFilterList) (*types.QueryFilterListResponse, error) {
+	var reqBody, resBody QueryFilterListBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryFilterNameBody struct {
+	Req    *types.QueryFilterName         `xml:"urn:vim25 QueryFilterName,omitempty"`
+	Res    *types.QueryFilterNameResponse `xml:"urn:vim25 QueryFilterNameResponse,omitempty"`
+	Fault_ *soap.Fault                    `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryFilterNameBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryFilterName(ctx context.Context, r soap.RoundTripper, req *types.QueryFilterName) (*types.QueryFilterNameResponse, error) {
+	var reqBody, resBody QueryFilterNameBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type QueryFirmwareConfigUploadURLBody struct {
 	Req    *types.QueryFirmwareConfigUploadURL         `xml:"urn:vim25 QueryFirmwareConfigUploadURL,omitempty"`
 	Res    *types.QueryFirmwareConfigUploadURLResponse `xml:"urn:vim25 QueryFirmwareConfigUploadURLResponse,omitempty"`
@@ -7552,6 +8733,46 @@ func (b *QueryFirmwareConfigUploadURLBody) Fault() *soap.Fault { return b.Fault_
 
 func QueryFirmwareConfigUploadURL(ctx context.Context, r soap.RoundTripper, req *types.QueryFirmwareConfigUploadURL) (*types.QueryFirmwareConfigUploadURLResponse, error) {
 	var reqBody, resBody QueryFirmwareConfigUploadURLBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryHealthUpdateInfosBody struct {
+	Req    *types.QueryHealthUpdateInfos         `xml:"urn:vim25 QueryHealthUpdateInfos,omitempty"`
+	Res    *types.QueryHealthUpdateInfosResponse `xml:"urn:vim25 QueryHealthUpdateInfosResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryHealthUpdateInfosBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryHealthUpdateInfos(ctx context.Context, r soap.RoundTripper, req *types.QueryHealthUpdateInfos) (*types.QueryHealthUpdateInfosResponse, error) {
+	var reqBody, resBody QueryHealthUpdateInfosBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryHealthUpdatesBody struct {
+	Req    *types.QueryHealthUpdates         `xml:"urn:vim25 QueryHealthUpdates,omitempty"`
+	Res    *types.QueryHealthUpdatesResponse `xml:"urn:vim25 QueryHealthUpdatesResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryHealthUpdatesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryHealthUpdates(ctx context.Context, r soap.RoundTripper, req *types.QueryHealthUpdates) (*types.QueryHealthUpdatesResponse, error) {
+	var reqBody, resBody QueryHealthUpdatesBody
 
 	reqBody.Req = req
 
@@ -7902,6 +9123,26 @@ func QueryModules(ctx context.Context, r soap.RoundTripper, req *types.QueryModu
 	return resBody.Res, nil
 }
 
+type QueryMonitoredEntitiesBody struct {
+	Req    *types.QueryMonitoredEntities         `xml:"urn:vim25 QueryMonitoredEntities,omitempty"`
+	Res    *types.QueryMonitoredEntitiesResponse `xml:"urn:vim25 QueryMonitoredEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryMonitoredEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryMonitoredEntities(ctx context.Context, r soap.RoundTripper, req *types.QueryMonitoredEntities) (*types.QueryMonitoredEntitiesResponse, error) {
+	var reqBody, resBody QueryMonitoredEntitiesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type QueryNFSUserBody struct {
 	Req    *types.QueryNFSUser         `xml:"urn:vim25 QueryNFSUser,omitempty"`
 	Res    *types.QueryNFSUserResponse `xml:"urn:vim25 QueryNFSUserResponse,omitempty"`
@@ -8242,6 +9483,46 @@ func QueryProfileStructure(ctx context.Context, r soap.RoundTripper, req *types.
 	return resBody.Res, nil
 }
 
+type QueryProviderListBody struct {
+	Req    *types.QueryProviderList         `xml:"urn:vim25 QueryProviderList,omitempty"`
+	Res    *types.QueryProviderListResponse `xml:"urn:vim25 QueryProviderListResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryProviderListBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryProviderList(ctx context.Context, r soap.RoundTripper, req *types.QueryProviderList) (*types.QueryProviderListResponse, error) {
+	var reqBody, resBody QueryProviderListBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryProviderNameBody struct {
+	Req    *types.QueryProviderName         `xml:"urn:vim25 QueryProviderName,omitempty"`
+	Res    *types.QueryProviderNameResponse `xml:"urn:vim25 QueryProviderNameResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryProviderNameBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryProviderName(ctx context.Context, r soap.RoundTripper, req *types.QueryProviderName) (*types.QueryProviderNameResponse, error) {
+	var reqBody, resBody QueryProviderNameBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type QueryResourceConfigOptionBody struct {
 	Req    *types.QueryResourceConfigOption         `xml:"urn:vim25 QueryResourceConfigOption,omitempty"`
 	Res    *types.QueryResourceConfigOptionResponse `xml:"urn:vim25 QueryResourceConfigOptionResponse,omitempty"`
@@ -8392,6 +9673,26 @@ func (b *QueryTpmAttestationReportBody) Fault() *soap.Fault { return b.Fault_ }
 
 func QueryTpmAttestationReport(ctx context.Context, r soap.RoundTripper, req *types.QueryTpmAttestationReport) (*types.QueryTpmAttestationReportResponse, error) {
 	var reqBody, resBody QueryTpmAttestationReportBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryUnmonitoredHostsBody struct {
+	Req    *types.QueryUnmonitoredHosts         `xml:"urn:vim25 QueryUnmonitoredHosts,omitempty"`
+	Res    *types.QueryUnmonitoredHostsResponse `xml:"urn:vim25 QueryUnmonitoredHostsResponse,omitempty"`
+	Fault_ *soap.Fault                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryUnmonitoredHostsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryUnmonitoredHosts(ctx context.Context, r soap.RoundTripper, req *types.QueryUnmonitoredHosts) (*types.QueryUnmonitoredHostsResponse, error) {
+	var reqBody, resBody QueryUnmonitoredHostsBody
 
 	reqBody.Req = req
 
@@ -8572,6 +9873,26 @@ func (b *QueryVirtualDiskUuidBody) Fault() *soap.Fault { return b.Fault_ }
 
 func QueryVirtualDiskUuid(ctx context.Context, r soap.RoundTripper, req *types.QueryVirtualDiskUuid) (*types.QueryVirtualDiskUuidResponse, error) {
 	var reqBody, resBody QueryVirtualDiskUuidBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type QueryVmfsConfigOptionBody struct {
+	Req    *types.QueryVmfsConfigOption         `xml:"urn:vim25 QueryVmfsConfigOption,omitempty"`
+	Res    *types.QueryVmfsConfigOptionResponse `xml:"urn:vim25 QueryVmfsConfigOptionResponse,omitempty"`
+	Fault_ *soap.Fault                          `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *QueryVmfsConfigOptionBody) Fault() *soap.Fault { return b.Fault_ }
+
+func QueryVmfsConfigOption(ctx context.Context, r soap.RoundTripper, req *types.QueryVmfsConfigOption) (*types.QueryVmfsConfigOptionResponse, error) {
+	var reqBody, resBody QueryVmfsConfigOptionBody
 
 	reqBody.Req = req
 
@@ -8932,6 +10253,26 @@ func (b *RecommissionVsanNode_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func RecommissionVsanNode_Task(ctx context.Context, r soap.RoundTripper, req *types.RecommissionVsanNode_Task) (*types.RecommissionVsanNode_TaskResponse, error) {
 	var reqBody, resBody RecommissionVsanNode_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ReconcileDatastoreInventory_TaskBody struct {
+	Req    *types.ReconcileDatastoreInventory_Task         `xml:"urn:vim25 ReconcileDatastoreInventory_Task,omitempty"`
+	Res    *types.ReconcileDatastoreInventory_TaskResponse `xml:"urn:vim25 ReconcileDatastoreInventory_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ReconcileDatastoreInventory_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ReconcileDatastoreInventory_Task(ctx context.Context, r soap.RoundTripper, req *types.ReconcileDatastoreInventory_Task) (*types.ReconcileDatastoreInventory_TaskResponse, error) {
+	var reqBody, resBody ReconcileDatastoreInventory_TaskBody
 
 	reqBody.Req = req
 
@@ -9642,6 +10983,26 @@ func RegisterChildVM_Task(ctx context.Context, r soap.RoundTripper, req *types.R
 	return resBody.Res, nil
 }
 
+type RegisterDiskBody struct {
+	Req    *types.RegisterDisk         `xml:"urn:vim25 RegisterDisk,omitempty"`
+	Res    *types.RegisterDiskResponse `xml:"urn:vim25 RegisterDiskResponse,omitempty"`
+	Fault_ *soap.Fault                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RegisterDiskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RegisterDisk(ctx context.Context, r soap.RoundTripper, req *types.RegisterDisk) (*types.RegisterDiskResponse, error) {
+	var reqBody, resBody RegisterDiskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RegisterExtensionBody struct {
 	Req    *types.RegisterExtension         `xml:"urn:vim25 RegisterExtension,omitempty"`
 	Res    *types.RegisterExtensionResponse `xml:"urn:vim25 RegisterExtensionResponse,omitempty"`
@@ -9652,6 +11013,46 @@ func (b *RegisterExtensionBody) Fault() *soap.Fault { return b.Fault_ }
 
 func RegisterExtension(ctx context.Context, r soap.RoundTripper, req *types.RegisterExtension) (*types.RegisterExtensionResponse, error) {
 	var reqBody, resBody RegisterExtensionBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RegisterHealthUpdateProviderBody struct {
+	Req    *types.RegisterHealthUpdateProvider         `xml:"urn:vim25 RegisterHealthUpdateProvider,omitempty"`
+	Res    *types.RegisterHealthUpdateProviderResponse `xml:"urn:vim25 RegisterHealthUpdateProviderResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RegisterHealthUpdateProviderBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RegisterHealthUpdateProvider(ctx context.Context, r soap.RoundTripper, req *types.RegisterHealthUpdateProvider) (*types.RegisterHealthUpdateProviderResponse, error) {
+	var reqBody, resBody RegisterHealthUpdateProviderBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RegisterKmipServerBody struct {
+	Req    *types.RegisterKmipServer         `xml:"urn:vim25 RegisterKmipServer,omitempty"`
+	Res    *types.RegisterKmipServerResponse `xml:"urn:vim25 RegisterKmipServerResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RegisterKmipServerBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RegisterKmipServer(ctx context.Context, r soap.RoundTripper, req *types.RegisterKmipServer) (*types.RegisterKmipServerResponse, error) {
+	var reqBody, resBody RegisterKmipServerBody
 
 	reqBody.Req = req
 
@@ -9722,6 +11123,26 @@ func ReleaseIpAllocation(ctx context.Context, r soap.RoundTripper, req *types.Re
 	return resBody.Res, nil
 }
 
+type ReleaseManagedSnapshotBody struct {
+	Req    *types.ReleaseManagedSnapshot         `xml:"urn:vim25 ReleaseManagedSnapshot,omitempty"`
+	Res    *types.ReleaseManagedSnapshotResponse `xml:"urn:vim25 ReleaseManagedSnapshotResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ReleaseManagedSnapshotBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ReleaseManagedSnapshot(ctx context.Context, r soap.RoundTripper, req *types.ReleaseManagedSnapshot) (*types.ReleaseManagedSnapshotResponse, error) {
+	var reqBody, resBody ReleaseManagedSnapshotBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type ReloadBody struct {
 	Req    *types.Reload         `xml:"urn:vim25 Reload,omitempty"`
 	Res    *types.ReloadResponse `xml:"urn:vim25 ReloadResponse,omitempty"`
@@ -9752,6 +11173,26 @@ func (b *RelocateVM_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func RelocateVM_Task(ctx context.Context, r soap.RoundTripper, req *types.RelocateVM_Task) (*types.RelocateVM_TaskResponse, error) {
 	var reqBody, resBody RelocateVM_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RelocateVStorageObject_TaskBody struct {
+	Req    *types.RelocateVStorageObject_Task         `xml:"urn:vim25 RelocateVStorageObject_Task,omitempty"`
+	Res    *types.RelocateVStorageObject_TaskResponse `xml:"urn:vim25 RelocateVStorageObject_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RelocateVStorageObject_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RelocateVStorageObject_Task(ctx context.Context, r soap.RoundTripper, req *types.RelocateVStorageObject_Task) (*types.RelocateVStorageObject_TaskResponse, error) {
+	var reqBody, resBody RelocateVStorageObject_TaskBody
 
 	reqBody.Req = req
 
@@ -9962,6 +11403,46 @@ func RemoveEntityPermission(ctx context.Context, r soap.RoundTripper, req *types
 	return resBody.Res, nil
 }
 
+type RemoveFilterBody struct {
+	Req    *types.RemoveFilter         `xml:"urn:vim25 RemoveFilter,omitempty"`
+	Res    *types.RemoveFilterResponse `xml:"urn:vim25 RemoveFilterResponse,omitempty"`
+	Fault_ *soap.Fault                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemoveFilterBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemoveFilter(ctx context.Context, r soap.RoundTripper, req *types.RemoveFilter) (*types.RemoveFilterResponse, error) {
+	var reqBody, resBody RemoveFilterBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RemoveFilterEntitiesBody struct {
+	Req    *types.RemoveFilterEntities         `xml:"urn:vim25 RemoveFilterEntities,omitempty"`
+	Res    *types.RemoveFilterEntitiesResponse `xml:"urn:vim25 RemoveFilterEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemoveFilterEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemoveFilterEntities(ctx context.Context, r soap.RoundTripper, req *types.RemoveFilterEntities) (*types.RemoveFilterEntitiesResponse, error) {
+	var reqBody, resBody RemoveFilterEntitiesBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RemoveGroupBody struct {
 	Req    *types.RemoveGroup         `xml:"urn:vim25 RemoveGroup,omitempty"`
 	Res    *types.RemoveGroupResponse `xml:"urn:vim25 RemoveGroupResponse,omitempty"`
@@ -10062,6 +11543,66 @@ func RemoveInternetScsiStaticTargets(ctx context.Context, r soap.RoundTripper, r
 	return resBody.Res, nil
 }
 
+type RemoveKeyBody struct {
+	Req    *types.RemoveKey         `xml:"urn:vim25 RemoveKey,omitempty"`
+	Res    *types.RemoveKeyResponse `xml:"urn:vim25 RemoveKeyResponse,omitempty"`
+	Fault_ *soap.Fault              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemoveKeyBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemoveKey(ctx context.Context, r soap.RoundTripper, req *types.RemoveKey) (*types.RemoveKeyResponse, error) {
+	var reqBody, resBody RemoveKeyBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RemoveKeysBody struct {
+	Req    *types.RemoveKeys         `xml:"urn:vim25 RemoveKeys,omitempty"`
+	Res    *types.RemoveKeysResponse `xml:"urn:vim25 RemoveKeysResponse,omitempty"`
+	Fault_ *soap.Fault               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemoveKeysBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemoveKeys(ctx context.Context, r soap.RoundTripper, req *types.RemoveKeys) (*types.RemoveKeysResponse, error) {
+	var reqBody, resBody RemoveKeysBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RemoveKmipServerBody struct {
+	Req    *types.RemoveKmipServer         `xml:"urn:vim25 RemoveKmipServer,omitempty"`
+	Res    *types.RemoveKmipServerResponse `xml:"urn:vim25 RemoveKmipServerResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemoveKmipServerBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemoveKmipServer(ctx context.Context, r soap.RoundTripper, req *types.RemoveKmipServer) (*types.RemoveKmipServerResponse, error) {
+	var reqBody, resBody RemoveKmipServerBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RemoveLicenseBody struct {
 	Req    *types.RemoveLicense         `xml:"urn:vim25 RemoveLicense,omitempty"`
 	Res    *types.RemoveLicenseResponse `xml:"urn:vim25 RemoveLicenseResponse,omitempty"`
@@ -10092,6 +11633,26 @@ func (b *RemoveLicenseLabelBody) Fault() *soap.Fault { return b.Fault_ }
 
 func RemoveLicenseLabel(ctx context.Context, r soap.RoundTripper, req *types.RemoveLicenseLabel) (*types.RemoveLicenseLabelResponse, error) {
 	var reqBody, resBody RemoveLicenseLabelBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RemoveMonitoredEntitiesBody struct {
+	Req    *types.RemoveMonitoredEntities         `xml:"urn:vim25 RemoveMonitoredEntities,omitempty"`
+	Res    *types.RemoveMonitoredEntitiesResponse `xml:"urn:vim25 RemoveMonitoredEntitiesResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RemoveMonitoredEntitiesBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RemoveMonitoredEntities(ctx context.Context, r soap.RoundTripper, req *types.RemoveMonitoredEntities) (*types.RemoveMonitoredEntitiesResponse, error) {
+	var reqBody, resBody RemoveMonitoredEntitiesBody
 
 	reqBody.Req = req
 
@@ -10392,6 +11953,26 @@ func (b *RenameSnapshotBody) Fault() *soap.Fault { return b.Fault_ }
 
 func RenameSnapshot(ctx context.Context, r soap.RoundTripper, req *types.RenameSnapshot) (*types.RenameSnapshotResponse, error) {
 	var reqBody, resBody RenameSnapshotBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RenameVStorageObjectBody struct {
+	Req    *types.RenameVStorageObject         `xml:"urn:vim25 RenameVStorageObject,omitempty"`
+	Res    *types.RenameVStorageObjectResponse `xml:"urn:vim25 RenameVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RenameVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RenameVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.RenameVStorageObject) (*types.RenameVStorageObjectResponse, error) {
+	var reqBody, resBody RenameVStorageObjectBody
 
 	reqBody.Req = req
 
@@ -10962,6 +12543,46 @@ func RetrieveArgumentDescription(ctx context.Context, r soap.RoundTripper, req *
 	return resBody.Res, nil
 }
 
+type RetrieveClientCertBody struct {
+	Req    *types.RetrieveClientCert         `xml:"urn:vim25 RetrieveClientCert,omitempty"`
+	Res    *types.RetrieveClientCertResponse `xml:"urn:vim25 RetrieveClientCertResponse,omitempty"`
+	Fault_ *soap.Fault                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveClientCertBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveClientCert(ctx context.Context, r soap.RoundTripper, req *types.RetrieveClientCert) (*types.RetrieveClientCertResponse, error) {
+	var reqBody, resBody RetrieveClientCertBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveClientCsrBody struct {
+	Req    *types.RetrieveClientCsr         `xml:"urn:vim25 RetrieveClientCsr,omitempty"`
+	Res    *types.RetrieveClientCsrResponse `xml:"urn:vim25 RetrieveClientCsrResponse,omitempty"`
+	Fault_ *soap.Fault                      `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveClientCsrBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveClientCsr(ctx context.Context, r soap.RoundTripper, req *types.RetrieveClientCsr) (*types.RetrieveClientCsrResponse, error) {
+	var reqBody, resBody RetrieveClientCsrBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RetrieveDasAdvancedRuntimeInfoBody struct {
 	Req    *types.RetrieveDasAdvancedRuntimeInfo         `xml:"urn:vim25 RetrieveDasAdvancedRuntimeInfo,omitempty"`
 	Res    *types.RetrieveDasAdvancedRuntimeInfoResponse `xml:"urn:vim25 RetrieveDasAdvancedRuntimeInfoResponse,omitempty"`
@@ -11102,6 +12723,106 @@ func RetrieveHostAccessControlEntries(ctx context.Context, r soap.RoundTripper, 
 	return resBody.Res, nil
 }
 
+type RetrieveHostCustomizationsBody struct {
+	Req    *types.RetrieveHostCustomizations         `xml:"urn:vim25 RetrieveHostCustomizations,omitempty"`
+	Res    *types.RetrieveHostCustomizationsResponse `xml:"urn:vim25 RetrieveHostCustomizationsResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveHostCustomizationsBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveHostCustomizations(ctx context.Context, r soap.RoundTripper, req *types.RetrieveHostCustomizations) (*types.RetrieveHostCustomizationsResponse, error) {
+	var reqBody, resBody RetrieveHostCustomizationsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveHostCustomizationsForProfileBody struct {
+	Req    *types.RetrieveHostCustomizationsForProfile         `xml:"urn:vim25 RetrieveHostCustomizationsForProfile,omitempty"`
+	Res    *types.RetrieveHostCustomizationsForProfileResponse `xml:"urn:vim25 RetrieveHostCustomizationsForProfileResponse,omitempty"`
+	Fault_ *soap.Fault                                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveHostCustomizationsForProfileBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveHostCustomizationsForProfile(ctx context.Context, r soap.RoundTripper, req *types.RetrieveHostCustomizationsForProfile) (*types.RetrieveHostCustomizationsForProfileResponse, error) {
+	var reqBody, resBody RetrieveHostCustomizationsForProfileBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveHostSpecificationBody struct {
+	Req    *types.RetrieveHostSpecification         `xml:"urn:vim25 RetrieveHostSpecification,omitempty"`
+	Res    *types.RetrieveHostSpecificationResponse `xml:"urn:vim25 RetrieveHostSpecificationResponse,omitempty"`
+	Fault_ *soap.Fault                              `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveHostSpecificationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveHostSpecification(ctx context.Context, r soap.RoundTripper, req *types.RetrieveHostSpecification) (*types.RetrieveHostSpecificationResponse, error) {
+	var reqBody, resBody RetrieveHostSpecificationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveKmipServerCertBody struct {
+	Req    *types.RetrieveKmipServerCert         `xml:"urn:vim25 RetrieveKmipServerCert,omitempty"`
+	Res    *types.RetrieveKmipServerCertResponse `xml:"urn:vim25 RetrieveKmipServerCertResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveKmipServerCertBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveKmipServerCert(ctx context.Context, r soap.RoundTripper, req *types.RetrieveKmipServerCert) (*types.RetrieveKmipServerCertResponse, error) {
+	var reqBody, resBody RetrieveKmipServerCertBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveKmipServersStatus_TaskBody struct {
+	Req    *types.RetrieveKmipServersStatus_Task         `xml:"urn:vim25 RetrieveKmipServersStatus_Task,omitempty"`
+	Res    *types.RetrieveKmipServersStatus_TaskResponse `xml:"urn:vim25 RetrieveKmipServersStatus_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveKmipServersStatus_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveKmipServersStatus_Task(ctx context.Context, r soap.RoundTripper, req *types.RetrieveKmipServersStatus_Task) (*types.RetrieveKmipServersStatus_TaskResponse, error) {
+	var reqBody, resBody RetrieveKmipServersStatus_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RetrieveObjectScheduledTaskBody struct {
 	Req    *types.RetrieveObjectScheduledTask         `xml:"urn:vim25 RetrieveObjectScheduledTask,omitempty"`
 	Res    *types.RetrieveObjectScheduledTaskResponse `xml:"urn:vim25 RetrieveObjectScheduledTaskResponse,omitempty"`
@@ -11202,6 +12923,26 @@ func RetrieveRolePermissions(ctx context.Context, r soap.RoundTripper, req *type
 	return resBody.Res, nil
 }
 
+type RetrieveSelfSignedClientCertBody struct {
+	Req    *types.RetrieveSelfSignedClientCert         `xml:"urn:vim25 RetrieveSelfSignedClientCert,omitempty"`
+	Res    *types.RetrieveSelfSignedClientCertResponse `xml:"urn:vim25 RetrieveSelfSignedClientCertResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveSelfSignedClientCertBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveSelfSignedClientCert(ctx context.Context, r soap.RoundTripper, req *types.RetrieveSelfSignedClientCert) (*types.RetrieveSelfSignedClientCertResponse, error) {
+	var reqBody, resBody RetrieveSelfSignedClientCertBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type RetrieveServiceContentBody struct {
 	Req    *types.RetrieveServiceContent         `xml:"urn:vim25 RetrieveServiceContent,omitempty"`
 	Res    *types.RetrieveServiceContentResponse `xml:"urn:vim25 RetrieveServiceContentResponse,omitempty"`
@@ -11232,6 +12973,46 @@ func (b *RetrieveUserGroupsBody) Fault() *soap.Fault { return b.Fault_ }
 
 func RetrieveUserGroups(ctx context.Context, r soap.RoundTripper, req *types.RetrieveUserGroups) (*types.RetrieveUserGroupsResponse, error) {
 	var reqBody, resBody RetrieveUserGroupsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveVStorageObjectBody struct {
+	Req    *types.RetrieveVStorageObject         `xml:"urn:vim25 RetrieveVStorageObject,omitempty"`
+	Res    *types.RetrieveVStorageObjectResponse `xml:"urn:vim25 RetrieveVStorageObjectResponse,omitempty"`
+	Fault_ *soap.Fault                           `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveVStorageObjectBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveVStorageObject(ctx context.Context, r soap.RoundTripper, req *types.RetrieveVStorageObject) (*types.RetrieveVStorageObjectResponse, error) {
+	var reqBody, resBody RetrieveVStorageObjectBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type RetrieveVStorageObjectStateBody struct {
+	Req    *types.RetrieveVStorageObjectState         `xml:"urn:vim25 RetrieveVStorageObjectState,omitempty"`
+	Res    *types.RetrieveVStorageObjectStateResponse `xml:"urn:vim25 RetrieveVStorageObjectStateResponse,omitempty"`
+	Fault_ *soap.Fault                                `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *RetrieveVStorageObjectStateBody) Fault() *soap.Fault { return b.Fault_ }
+
+func RetrieveVStorageObjectState(ctx context.Context, r soap.RoundTripper, req *types.RetrieveVStorageObjectState) (*types.RetrieveVStorageObjectStateResponse, error) {
+	var reqBody, resBody RetrieveVStorageObjectStateBody
 
 	reqBody.Req = req
 
@@ -11372,6 +13153,26 @@ func (b *ScanHostPatch_TaskBody) Fault() *soap.Fault { return b.Fault_ }
 
 func ScanHostPatch_Task(ctx context.Context, r soap.RoundTripper, req *types.ScanHostPatch_Task) (*types.ScanHostPatch_TaskResponse, error) {
 	var reqBody, resBody ScanHostPatch_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type ScheduleReconcileDatastoreInventoryBody struct {
+	Req    *types.ScheduleReconcileDatastoreInventory         `xml:"urn:vim25 ScheduleReconcileDatastoreInventory,omitempty"`
+	Res    *types.ScheduleReconcileDatastoreInventoryResponse `xml:"urn:vim25 ScheduleReconcileDatastoreInventoryResponse,omitempty"`
+	Fault_ *soap.Fault                                        `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *ScheduleReconcileDatastoreInventoryBody) Fault() *soap.Fault { return b.Fault_ }
+
+func ScheduleReconcileDatastoreInventory(ctx context.Context, r soap.RoundTripper, req *types.ScheduleReconcileDatastoreInventory) (*types.ScheduleReconcileDatastoreInventoryResponse, error) {
+	var reqBody, resBody ScheduleReconcileDatastoreInventoryBody
 
 	reqBody.Req = req
 
@@ -12562,6 +14363,26 @@ func UnregisterExtension(ctx context.Context, r soap.RoundTripper, req *types.Un
 	return resBody.Res, nil
 }
 
+type UnregisterHealthUpdateProviderBody struct {
+	Req    *types.UnregisterHealthUpdateProvider         `xml:"urn:vim25 UnregisterHealthUpdateProvider,omitempty"`
+	Res    *types.UnregisterHealthUpdateProviderResponse `xml:"urn:vim25 UnregisterHealthUpdateProviderResponse,omitempty"`
+	Fault_ *soap.Fault                                   `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UnregisterHealthUpdateProviderBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UnregisterHealthUpdateProvider(ctx context.Context, r soap.RoundTripper, req *types.UnregisterHealthUpdateProvider) (*types.UnregisterHealthUpdateProviderResponse, error) {
+	var reqBody, resBody UnregisterHealthUpdateProviderBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type UnregisterVMBody struct {
 	Req    *types.UnregisterVM         `xml:"urn:vim25 UnregisterVM,omitempty"`
 	Res    *types.UnregisterVMResponse `xml:"urn:vim25 UnregisterVMResponse,omitempty"`
@@ -12962,6 +14783,46 @@ func UpdateFlags(ctx context.Context, r soap.RoundTripper, req *types.UpdateFlag
 	return resBody.Res, nil
 }
 
+type UpdateGraphicsConfigBody struct {
+	Req    *types.UpdateGraphicsConfig         `xml:"urn:vim25 UpdateGraphicsConfig,omitempty"`
+	Res    *types.UpdateGraphicsConfigResponse `xml:"urn:vim25 UpdateGraphicsConfigResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateGraphicsConfigBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateGraphicsConfig(ctx context.Context, r soap.RoundTripper, req *types.UpdateGraphicsConfig) (*types.UpdateGraphicsConfigResponse, error) {
+	var reqBody, resBody UpdateGraphicsConfigBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateHostCustomizations_TaskBody struct {
+	Req    *types.UpdateHostCustomizations_Task         `xml:"urn:vim25 UpdateHostCustomizations_Task,omitempty"`
+	Res    *types.UpdateHostCustomizations_TaskResponse `xml:"urn:vim25 UpdateHostCustomizations_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                  `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateHostCustomizations_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateHostCustomizations_Task(ctx context.Context, r soap.RoundTripper, req *types.UpdateHostCustomizations_Task) (*types.UpdateHostCustomizations_TaskResponse, error) {
+	var reqBody, resBody UpdateHostCustomizations_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type UpdateHostImageAcceptanceLevelBody struct {
 	Req    *types.UpdateHostImageAcceptanceLevel         `xml:"urn:vim25 UpdateHostImageAcceptanceLevel,omitempty"`
 	Res    *types.UpdateHostImageAcceptanceLevelResponse `xml:"urn:vim25 UpdateHostImageAcceptanceLevelResponse,omitempty"`
@@ -12992,6 +14853,46 @@ func (b *UpdateHostProfileBody) Fault() *soap.Fault { return b.Fault_ }
 
 func UpdateHostProfile(ctx context.Context, r soap.RoundTripper, req *types.UpdateHostProfile) (*types.UpdateHostProfileResponse, error) {
 	var reqBody, resBody UpdateHostProfileBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateHostSpecificationBody struct {
+	Req    *types.UpdateHostSpecification         `xml:"urn:vim25 UpdateHostSpecification,omitempty"`
+	Res    *types.UpdateHostSpecificationResponse `xml:"urn:vim25 UpdateHostSpecificationResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateHostSpecificationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateHostSpecification(ctx context.Context, r soap.RoundTripper, req *types.UpdateHostSpecification) (*types.UpdateHostSpecificationResponse, error) {
+	var reqBody, resBody UpdateHostSpecificationBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateHostSubSpecificationBody struct {
+	Req    *types.UpdateHostSubSpecification         `xml:"urn:vim25 UpdateHostSubSpecification,omitempty"`
+	Res    *types.UpdateHostSubSpecificationResponse `xml:"urn:vim25 UpdateHostSubSpecificationResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateHostSubSpecificationBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateHostSubSpecification(ctx context.Context, r soap.RoundTripper, req *types.UpdateHostSubSpecification) (*types.UpdateHostSubSpecificationResponse, error) {
+	var reqBody, resBody UpdateHostSubSpecificationBody
 
 	reqBody.Req = req
 
@@ -13232,6 +15133,46 @@ func (b *UpdateIpmiBody) Fault() *soap.Fault { return b.Fault_ }
 
 func UpdateIpmi(ctx context.Context, r soap.RoundTripper, req *types.UpdateIpmi) (*types.UpdateIpmiResponse, error) {
 	var reqBody, resBody UpdateIpmiBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateKmipServerBody struct {
+	Req    *types.UpdateKmipServer         `xml:"urn:vim25 UpdateKmipServer,omitempty"`
+	Res    *types.UpdateKmipServerResponse `xml:"urn:vim25 UpdateKmipServerResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateKmipServerBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateKmipServer(ctx context.Context, r soap.RoundTripper, req *types.UpdateKmipServer) (*types.UpdateKmipServerResponse, error) {
+	var reqBody, resBody UpdateKmipServerBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateKmsSignedCsrClientCertBody struct {
+	Req    *types.UpdateKmsSignedCsrClientCert         `xml:"urn:vim25 UpdateKmsSignedCsrClientCert,omitempty"`
+	Res    *types.UpdateKmsSignedCsrClientCertResponse `xml:"urn:vim25 UpdateKmsSignedCsrClientCertResponse,omitempty"`
+	Fault_ *soap.Fault                                 `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateKmsSignedCsrClientCertBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateKmsSignedCsrClientCert(ctx context.Context, r soap.RoundTripper, req *types.UpdateKmsSignedCsrClientCert) (*types.UpdateKmsSignedCsrClientCertResponse, error) {
+	var reqBody, resBody UpdateKmsSignedCsrClientCertBody
 
 	reqBody.Req = req
 
@@ -13582,6 +15523,26 @@ func UpdateScsiLunDisplayName(ctx context.Context, r soap.RoundTripper, req *typ
 	return resBody.Res, nil
 }
 
+type UpdateSelfSignedClientCertBody struct {
+	Req    *types.UpdateSelfSignedClientCert         `xml:"urn:vim25 UpdateSelfSignedClientCert,omitempty"`
+	Res    *types.UpdateSelfSignedClientCertResponse `xml:"urn:vim25 UpdateSelfSignedClientCertResponse,omitempty"`
+	Fault_ *soap.Fault                               `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateSelfSignedClientCertBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateSelfSignedClientCert(ctx context.Context, r soap.RoundTripper, req *types.UpdateSelfSignedClientCert) (*types.UpdateSelfSignedClientCertResponse, error) {
+	var reqBody, resBody UpdateSelfSignedClientCertBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type UpdateServiceConsoleVirtualNicBody struct {
 	Req    *types.UpdateServiceConsoleVirtualNic         `xml:"urn:vim25 UpdateServiceConsoleVirtualNic,omitempty"`
 	Res    *types.UpdateServiceConsoleVirtualNicResponse `xml:"urn:vim25 UpdateServiceConsoleVirtualNicResponse,omitempty"`
@@ -13762,6 +15723,26 @@ func UpdateVAppConfig(ctx context.Context, r soap.RoundTripper, req *types.Updat
 	return resBody.Res, nil
 }
 
+type UpdateVVolVirtualMachineFiles_TaskBody struct {
+	Req    *types.UpdateVVolVirtualMachineFiles_Task         `xml:"urn:vim25 UpdateVVolVirtualMachineFiles_Task,omitempty"`
+	Res    *types.UpdateVVolVirtualMachineFiles_TaskResponse `xml:"urn:vim25 UpdateVVolVirtualMachineFiles_TaskResponse,omitempty"`
+	Fault_ *soap.Fault                                       `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateVVolVirtualMachineFiles_TaskBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateVVolVirtualMachineFiles_Task(ctx context.Context, r soap.RoundTripper, req *types.UpdateVVolVirtualMachineFiles_Task) (*types.UpdateVVolVirtualMachineFiles_TaskResponse, error) {
+	var reqBody, resBody UpdateVVolVirtualMachineFiles_TaskBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
 type UpdateVirtualMachineFiles_TaskBody struct {
 	Req    *types.UpdateVirtualMachineFiles_Task         `xml:"urn:vim25 UpdateVirtualMachineFiles_Task,omitempty"`
 	Res    *types.UpdateVirtualMachineFiles_TaskResponse `xml:"urn:vim25 UpdateVirtualMachineFiles_TaskResponse,omitempty"`
@@ -13812,6 +15793,26 @@ func (b *UpdateVirtualSwitchBody) Fault() *soap.Fault { return b.Fault_ }
 
 func UpdateVirtualSwitch(ctx context.Context, r soap.RoundTripper, req *types.UpdateVirtualSwitch) (*types.UpdateVirtualSwitchResponse, error) {
 	var reqBody, resBody UpdateVirtualSwitchBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UpdateVmfsUnmapPriorityBody struct {
+	Req    *types.UpdateVmfsUnmapPriority         `xml:"urn:vim25 UpdateVmfsUnmapPriority,omitempty"`
+	Res    *types.UpdateVmfsUnmapPriorityResponse `xml:"urn:vim25 UpdateVmfsUnmapPriorityResponse,omitempty"`
+	Fault_ *soap.Fault                            `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UpdateVmfsUnmapPriorityBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UpdateVmfsUnmapPriority(ctx context.Context, r soap.RoundTripper, req *types.UpdateVmfsUnmapPriority) (*types.UpdateVmfsUnmapPriorityResponse, error) {
+	var reqBody, resBody UpdateVmfsUnmapPriorityBody
 
 	reqBody.Req = req
 
@@ -13952,6 +15953,46 @@ func (b *UpgradeVsanObjectsBody) Fault() *soap.Fault { return b.Fault_ }
 
 func UpgradeVsanObjects(ctx context.Context, r soap.RoundTripper, req *types.UpgradeVsanObjects) (*types.UpgradeVsanObjectsResponse, error) {
 	var reqBody, resBody UpgradeVsanObjectsBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UploadClientCertBody struct {
+	Req    *types.UploadClientCert         `xml:"urn:vim25 UploadClientCert,omitempty"`
+	Res    *types.UploadClientCertResponse `xml:"urn:vim25 UploadClientCertResponse,omitempty"`
+	Fault_ *soap.Fault                     `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UploadClientCertBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UploadClientCert(ctx context.Context, r soap.RoundTripper, req *types.UploadClientCert) (*types.UploadClientCertResponse, error) {
+	var reqBody, resBody UploadClientCertBody
+
+	reqBody.Req = req
+
+	if err := r.RoundTrip(ctx, &reqBody, &resBody); err != nil {
+		return nil, err
+	}
+
+	return resBody.Res, nil
+}
+
+type UploadKmipServerCertBody struct {
+	Req    *types.UploadKmipServerCert         `xml:"urn:vim25 UploadKmipServerCert,omitempty"`
+	Res    *types.UploadKmipServerCertResponse `xml:"urn:vim25 UploadKmipServerCertResponse,omitempty"`
+	Fault_ *soap.Fault                         `xml:"http://schemas.xmlsoap.org/soap/envelope/ Fault,omitempty"`
+}
+
+func (b *UploadKmipServerCertBody) Fault() *soap.Fault { return b.Fault_ }
+
+func UploadKmipServerCert(ctx context.Context, r soap.RoundTripper, req *types.UploadKmipServerCert) (*types.UploadKmipServerCertResponse, error) {
+	var reqBody, resBody UploadKmipServerCertBody
 
 	reqBody.Req = req
 

--- a/vendor/github.com/vmware/govmomi/vim25/methods/service_content.go
+++ b/vendor/github.com/vmware/govmomi/vim25/methods/service_content.go
@@ -17,21 +17,21 @@ limitations under the License.
 package methods
 
 import (
+	"context"
 	"time"
 
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
-var serviceInstance = types.ManagedObjectReference{
+var ServiceInstance = types.ManagedObjectReference{
 	Type:  "ServiceInstance",
 	Value: "ServiceInstance",
 }
 
 func GetServiceContent(ctx context.Context, r soap.RoundTripper) (types.ServiceContent, error) {
 	req := types.RetrieveServiceContent{
-		This: serviceInstance,
+		This: ServiceInstance,
 	}
 
 	res, err := RetrieveServiceContent(ctx, r, &req)
@@ -44,7 +44,7 @@ func GetServiceContent(ctx context.Context, r soap.RoundTripper) (types.ServiceC
 
 func GetCurrentTime(ctx context.Context, r soap.RoundTripper) (*time.Time, error) {
 	req := types.CurrentTime{
-		This: serviceInstance,
+		This: ServiceInstance,
 	}
 
 	res, err := CurrentTime(ctx, r, &req)

--- a/vendor/github.com/vmware/govmomi/vim25/mo/mo.go
+++ b/vendor/github.com/vmware/govmomi/vim25/mo/mo.go
@@ -984,6 +984,18 @@ func init() {
 	t["HttpNfcLease"] = reflect.TypeOf((*HttpNfcLease)(nil)).Elem()
 }
 
+type InternalDynamicTypeManager struct {
+	Self types.ManagedObjectReference
+}
+
+func (m InternalDynamicTypeManager) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["InternalDynamicTypeManager"] = reflect.TypeOf((*InternalDynamicTypeManager)(nil)).Elem()
+}
+
 type InventoryView struct {
 	ManagedObjectView
 }
@@ -1290,6 +1302,18 @@ func init() {
 	t["PropertyFilter"] = reflect.TypeOf((*PropertyFilter)(nil)).Elem()
 }
 
+type ReflectManagedMethodExecuter struct {
+	Self types.ManagedObjectReference
+}
+
+func (m ReflectManagedMethodExecuter) Reference() types.ManagedObjectReference {
+	return m.Self
+}
+
+func init() {
+	t["ReflectManagedMethodExecuter"] = reflect.TypeOf((*ReflectManagedMethodExecuter)(nil)).Elem()
+}
+
 type ResourcePlanningManager struct {
 	Self types.ManagedObjectReference
 }
@@ -1494,18 +1518,6 @@ func (m UserDirectory) Reference() types.ManagedObjectReference {
 
 func init() {
 	t["UserDirectory"] = reflect.TypeOf((*UserDirectory)(nil)).Elem()
-}
-
-type VRPResourceManager struct {
-	Self types.ManagedObjectReference
-}
-
-func (m VRPResourceManager) Reference() types.ManagedObjectReference {
-	return m.Self
-}
-
-func init() {
-	t["VRPResourceManager"] = reflect.TypeOf((*VRPResourceManager)(nil)).Elem()
 }
 
 type View struct {

--- a/vendor/github.com/vmware/govmomi/vim25/mo/retrieve.go
+++ b/vendor/github.com/vmware/govmomi/vim25/mo/retrieve.go
@@ -17,12 +17,12 @@ limitations under the License.
 package mo
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
-	"golang.org/x/net/context"
 )
 
 func ignoreMissingProperty(ref types.ManagedObjectReference, p types.MissingProperty) bool {

--- a/vendor/github.com/vmware/govmomi/vim25/retry.go
+++ b/vendor/github.com/vmware/govmomi/vim25/retry.go
@@ -17,12 +17,12 @@ limitations under the License.
 package vim25
 
 import (
+	"context"
 	"net"
 	"net/url"
 	"time"
 
 	"github.com/vmware/govmomi/vim25/soap"
-	"golang.org/x/net/context"
 )
 
 type RetryFunc func(err error) (retry bool, delay time.Duration)

--- a/vendor/github.com/vmware/govmomi/vim25/soap/client.go
+++ b/vendor/github.com/vmware/govmomi/vim25/soap/client.go
@@ -17,25 +17,31 @@ limitations under the License.
 package soap
 
 import (
+	"bufio"
 	"bytes"
+	"context"
+	"crypto/sha1"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/vmware/govmomi/vim25/progress"
 	"github.com/vmware/govmomi/vim25/types"
 	"github.com/vmware/govmomi/vim25/xml"
-	"golang.org/x/net/context"
 )
 
 type HasFault interface {
@@ -46,8 +52,11 @@ type RoundTripper interface {
 	RoundTrip(ctx context.Context, req, res HasFault) error
 }
 
-var DefaultVimNamespace = "urn:vim25"
-var DefaultVimVersion = "6.0"
+const (
+	DefaultVimNamespace  = "urn:vim25"
+	DefaultVimVersion    = "6.5"
+	DefaultMinVimVersion = "5.5"
+)
 
 type Client struct {
 	http.Client
@@ -58,8 +67,12 @@ type Client struct {
 	t *http.Transport
 	p *url.URL
 
+	hostsMu sync.Mutex
+	hosts   map[string]string
+
 	Namespace string // Vim namespace
 	Version   string // Vim version
+	UserAgent string
 }
 
 var schemeMatch = regexp.MustCompile(`^\w+://`)
@@ -101,17 +114,24 @@ func NewClient(u *url.URL, insecure bool) *Client {
 	}
 
 	// Initialize http.RoundTripper on client, so we can customize it below
-	c.t = &http.Transport{
-		Proxy: http.ProxyFromEnvironment,
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		c.t = &http.Transport{
+			Proxy:                 t.Proxy,
+			DialContext:           t.DialContext,
+			MaxIdleConns:          t.MaxIdleConns,
+			IdleConnTimeout:       t.IdleConnTimeout,
+			TLSHandshakeTimeout:   t.TLSHandshakeTimeout,
+			ExpectContinueTimeout: t.ExpectContinueTimeout,
+		}
+	} else {
+		c.t = new(http.Transport)
 	}
 
-	if c.u.Scheme == "https" {
-		c.t.TLSClientConfig = &tls.Config{InsecureSkipVerify: c.k}
-		c.t.TLSHandshakeTimeout = 10 * time.Second
+	c.hosts = make(map[string]string)
+	c.t.TLSClientConfig = &tls.Config{InsecureSkipVerify: c.k}
+	// Don't bother setting DialTLS if InsecureSkipVerify=true
+	if !c.k {
+		c.t.DialTLS = c.dialTLS
 	}
 
 	c.Client.Transport = c.t
@@ -125,6 +145,156 @@ func NewClient(u *url.URL, insecure bool) *Client {
 	c.Version = DefaultVimVersion
 
 	return &c
+}
+
+// SetRootCAs defines the set of root certificate authorities
+// that clients use when verifying server certificates.
+// By default TLS uses the host's root CA set.
+//
+// See: http.Client.Transport.TLSClientConfig.RootCAs
+func (c *Client) SetRootCAs(file string) error {
+	pool := x509.NewCertPool()
+
+	for _, name := range filepath.SplitList(file) {
+		pem, err := ioutil.ReadFile(name)
+		if err != nil {
+			return err
+		}
+
+		pool.AppendCertsFromPEM(pem)
+	}
+
+	c.t.TLSClientConfig.RootCAs = pool
+
+	return nil
+}
+
+// Add default https port if missing
+func hostAddr(addr string) string {
+	_, port := splitHostPort(addr)
+	if port == "" {
+		return addr + ":443"
+	}
+	return addr
+}
+
+// SetThumbprint sets the known certificate thumbprint for the given host.
+// A custom DialTLS function is used to support thumbprint based verification.
+// We first try tls.Dial with the default tls.Config, only falling back to thumbprint verification
+// if it fails with an x509.UnknownAuthorityError or x509.HostnameError
+//
+// See: http.Client.Transport.DialTLS
+func (c *Client) SetThumbprint(host string, thumbprint string) {
+	host = hostAddr(host)
+
+	c.hostsMu.Lock()
+	if thumbprint == "" {
+		delete(c.hosts, host)
+	} else {
+		c.hosts[host] = thumbprint
+	}
+	c.hostsMu.Unlock()
+}
+
+// Thumbprint returns the certificate thumbprint for the given host if known to this client.
+func (c *Client) Thumbprint(host string) string {
+	host = hostAddr(host)
+	c.hostsMu.Lock()
+	defer c.hostsMu.Unlock()
+	return c.hosts[host]
+}
+
+// LoadThumbprints from file with the give name.
+// If name is empty or name does not exist this function will return nil.
+func (c *Client) LoadThumbprints(file string) error {
+	if file == "" {
+		return nil
+	}
+
+	for _, name := range filepath.SplitList(file) {
+		err := c.loadThumbprints(name)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) loadThumbprints(name string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	scanner := bufio.NewScanner(f)
+
+	for scanner.Scan() {
+		e := strings.SplitN(scanner.Text(), " ", 2)
+		if len(e) != 2 {
+			continue
+		}
+
+		c.SetThumbprint(e[0], e[1])
+	}
+
+	_ = f.Close()
+
+	return scanner.Err()
+}
+
+// ThumbprintSHA1 returns the thumbprint of the given cert in the same format used by the SDK and Client.SetThumbprint.
+//
+// See: SSLVerifyFault.Thumbprint, SessionManagerGenericServiceTicket.Thumbprint, HostConnectSpec.SslThumbprint
+func ThumbprintSHA1(cert *x509.Certificate) string {
+	sum := sha1.Sum(cert.Raw)
+	hex := make([]string, len(sum))
+	for i, b := range sum {
+		hex[i] = fmt.Sprintf("%02X", b)
+	}
+	return strings.Join(hex, ":")
+}
+
+func (c *Client) dialTLS(network string, addr string) (net.Conn, error) {
+	// Would be nice if there was a tls.Config.Verify func,
+	// see tls.clientHandshakeState.doFullHandshake
+
+	conn, err := tls.Dial(network, addr, c.t.TLSClientConfig)
+
+	if err == nil {
+		return conn, nil
+	}
+
+	switch err.(type) {
+	case x509.UnknownAuthorityError:
+	case x509.HostnameError:
+	default:
+		return nil, err
+	}
+
+	thumbprint := c.Thumbprint(addr)
+	if thumbprint == "" {
+		return nil, err
+	}
+
+	config := &tls.Config{InsecureSkipVerify: true}
+	conn, err = tls.Dial(network, addr, config)
+	if err != nil {
+		return nil, err
+	}
+
+	cert := conn.ConnectionState().PeerCertificates[0]
+	peer := ThumbprintSHA1(cert)
+	if thumbprint != peer {
+		_ = conn.Close()
+
+		return nil, fmt.Errorf("Host %q thumbprint does not match %q", addr, thumbprint)
+	}
+
+	return conn, nil
 }
 
 // splitHostPort is similar to net.SplitHostPort,
@@ -155,7 +325,13 @@ func (c *Client) SetCertificate(cert tls.Certificate) {
 	host, _ := splitHostPort(c.u.Host)
 
 	// Should be no reason to change the default port other than testing
-	port := os.Getenv("GOVC_TUNNEL_PROXY_PORT")
+	key := "GOVMOMI_TUNNEL_PROXY_PORT"
+
+	port := c.URL().Query().Get(key)
+	if port == "" {
+		port = os.Getenv(key)
+	}
+
 	if port != "" {
 		host += ":" + port
 	}
@@ -212,33 +388,11 @@ func (c *Client) UnmarshalJSON(b []byte) error {
 }
 
 func (c *Client) do(ctx context.Context, req *http.Request) (*http.Response, error) {
-	if nil == ctx || nil == ctx.Done() { // ctx.Done() is for context.TODO()
+	if nil == ctx || nil == ctx.Done() { // ctx.Done() is for ctx
 		return c.Client.Do(req)
 	}
 
-	var resc = make(chan *http.Response, 1)
-	var errc = make(chan error, 1)
-
-	// Perform request from separate routine.
-	go func() {
-		res, err := c.Client.Do(req)
-		if err != nil {
-			errc <- err
-		} else {
-			resc <- res
-		}
-	}()
-
-	// Wait for request completion of context expiry.
-	select {
-	case <-ctx.Done():
-		c.t.CancelRequest(req)
-		return nil, ctx.Err()
-	case err := <-errc:
-		return nil, err
-	case res := <-resc:
-		return res, nil
-	}
+	return c.Client.Do(req.WithContext(ctx))
 }
 
 func (c *Client) RoundTrip(ctx context.Context, reqBody, resBody HasFault) error {
@@ -267,6 +421,9 @@ func (c *Client) RoundTrip(ctx context.Context, reqBody, resBody HasFault) error
 	req.Header.Set(`Content-Type`, `text/xml; charset="utf-8"`)
 	soapAction := fmt.Sprintf("%s/%s", c.Namespace, c.Version)
 	req.Header.Set(`SOAPAction`, soapAction)
+	if c.UserAgent != "" {
+		req.Header.Set(`User-Agent`, c.UserAgent)
+	}
 
 	if d.enabled() {
 		d.debugRequest(req)
@@ -420,6 +577,7 @@ func (c *Client) UploadFile(file string, u *url.URL, param *Upload) error {
 
 type Download struct {
 	Method   string
+	Headers  map[string]string
 	Ticket   *http.Cookie
 	Progress progress.Sinker
 }
@@ -428,19 +586,27 @@ var DefaultDownload = Download{
 	Method: "GET",
 }
 
-// Download GETs the remote file from the given URL
-func (c *Client) Download(u *url.URL, param *Download) (io.ReadCloser, int64, error) {
-
+// DownloadRequest wraps http.Client.Do, returning the http.Response without checking its StatusCode
+func (c *Client) DownloadRequest(u *url.URL, param *Download) (*http.Response, error) {
 	req, err := http.NewRequest(param.Method, u.String(), nil)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
+	}
+
+	for k, v := range param.Headers {
+		req.Header.Add(k, v)
 	}
 
 	if param.Ticket != nil {
 		req.AddCookie(param.Ticket)
 	}
 
-	res, err := c.Client.Do(req)
+	return c.Client.Do(req)
+}
+
+// Download GETs the remote file from the given URL
+func (c *Client) Download(u *url.URL, param *Download) (io.ReadCloser, int64, error) {
+	res, err := c.DownloadRequest(u, param)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -455,9 +621,7 @@ func (c *Client) Download(u *url.URL, param *Download) (io.ReadCloser, int64, er
 		return nil, 0, err
 	}
 
-	var r io.ReadCloser = res.Body
-
-	return r, res.ContentLength, nil
+	return res.Body, res.ContentLength, nil
 }
 
 // DownloadFile GETs the given URL to a local file

--- a/vendor/github.com/vmware/govmomi/vim25/types/enum.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/enum.go
@@ -39,13 +39,14 @@ func init() {
 type ActionType string
 
 const (
-	ActionTypeMigrationV1        = ActionType("MigrationV1")
-	ActionTypeVmPowerV1          = ActionType("VmPowerV1")
-	ActionTypeHostPowerV1        = ActionType("HostPowerV1")
-	ActionTypeHostMaintenanceV1  = ActionType("HostMaintenanceV1")
-	ActionTypeStorageMigrationV1 = ActionType("StorageMigrationV1")
-	ActionTypeStoragePlacementV1 = ActionType("StoragePlacementV1")
-	ActionTypePlacementV1        = ActionType("PlacementV1")
+	ActionTypeMigrationV1         = ActionType("MigrationV1")
+	ActionTypeVmPowerV1           = ActionType("VmPowerV1")
+	ActionTypeHostPowerV1         = ActionType("HostPowerV1")
+	ActionTypeHostMaintenanceV1   = ActionType("HostMaintenanceV1")
+	ActionTypeStorageMigrationV1  = ActionType("StorageMigrationV1")
+	ActionTypeStoragePlacementV1  = ActionType("StoragePlacementV1")
+	ActionTypePlacementV1         = ActionType("PlacementV1")
+	ActionTypeHostInfraUpdateHaV1 = ActionType("HostInfraUpdateHaV1")
 )
 
 func init() {
@@ -118,6 +119,18 @@ const (
 
 func init() {
 	t["AutoStartWaitHeartbeatSetting"] = reflect.TypeOf((*AutoStartWaitHeartbeatSetting)(nil)).Elem()
+}
+
+type BaseConfigInfoDiskFileBackingInfoProvisioningType string
+
+const (
+	BaseConfigInfoDiskFileBackingInfoProvisioningTypeThin             = BaseConfigInfoDiskFileBackingInfoProvisioningType("thin")
+	BaseConfigInfoDiskFileBackingInfoProvisioningTypeEagerZeroedThick = BaseConfigInfoDiskFileBackingInfoProvisioningType("eagerZeroedThick")
+	BaseConfigInfoDiskFileBackingInfoProvisioningTypeLazyZeroedThick  = BaseConfigInfoDiskFileBackingInfoProvisioningType("lazyZeroedThick")
+)
+
+func init() {
+	t["BaseConfigInfoDiskFileBackingInfoProvisioningType"] = reflect.TypeOf((*BaseConfigInfoDiskFileBackingInfoProvisioningType)(nil)).Elem()
 }
 
 type BatchResultResult string
@@ -281,14 +294,50 @@ type ClusterDasVmSettingsRestartPriority string
 
 const (
 	ClusterDasVmSettingsRestartPriorityDisabled               = ClusterDasVmSettingsRestartPriority("disabled")
+	ClusterDasVmSettingsRestartPriorityLowest                 = ClusterDasVmSettingsRestartPriority("lowest")
 	ClusterDasVmSettingsRestartPriorityLow                    = ClusterDasVmSettingsRestartPriority("low")
 	ClusterDasVmSettingsRestartPriorityMedium                 = ClusterDasVmSettingsRestartPriority("medium")
 	ClusterDasVmSettingsRestartPriorityHigh                   = ClusterDasVmSettingsRestartPriority("high")
+	ClusterDasVmSettingsRestartPriorityHighest                = ClusterDasVmSettingsRestartPriority("highest")
 	ClusterDasVmSettingsRestartPriorityClusterRestartPriority = ClusterDasVmSettingsRestartPriority("clusterRestartPriority")
 )
 
 func init() {
 	t["ClusterDasVmSettingsRestartPriority"] = reflect.TypeOf((*ClusterDasVmSettingsRestartPriority)(nil)).Elem()
+}
+
+type ClusterHostInfraUpdateHaModeActionOperationType string
+
+const (
+	ClusterHostInfraUpdateHaModeActionOperationTypeEnterQuarantine  = ClusterHostInfraUpdateHaModeActionOperationType("enterQuarantine")
+	ClusterHostInfraUpdateHaModeActionOperationTypeExitQuarantine   = ClusterHostInfraUpdateHaModeActionOperationType("exitQuarantine")
+	ClusterHostInfraUpdateHaModeActionOperationTypeEnterMaintenance = ClusterHostInfraUpdateHaModeActionOperationType("enterMaintenance")
+)
+
+func init() {
+	t["ClusterHostInfraUpdateHaModeActionOperationType"] = reflect.TypeOf((*ClusterHostInfraUpdateHaModeActionOperationType)(nil)).Elem()
+}
+
+type ClusterInfraUpdateHaConfigInfoBehaviorType string
+
+const (
+	ClusterInfraUpdateHaConfigInfoBehaviorTypeManual    = ClusterInfraUpdateHaConfigInfoBehaviorType("Manual")
+	ClusterInfraUpdateHaConfigInfoBehaviorTypeAutomated = ClusterInfraUpdateHaConfigInfoBehaviorType("Automated")
+)
+
+func init() {
+	t["ClusterInfraUpdateHaConfigInfoBehaviorType"] = reflect.TypeOf((*ClusterInfraUpdateHaConfigInfoBehaviorType)(nil)).Elem()
+}
+
+type ClusterInfraUpdateHaConfigInfoRemediationType string
+
+const (
+	ClusterInfraUpdateHaConfigInfoRemediationTypeQuarantineMode  = ClusterInfraUpdateHaConfigInfoRemediationType("QuarantineMode")
+	ClusterInfraUpdateHaConfigInfoRemediationTypeMaintenanceMode = ClusterInfraUpdateHaConfigInfoRemediationType("MaintenanceMode")
+)
+
+func init() {
+	t["ClusterInfraUpdateHaConfigInfoRemediationType"] = reflect.TypeOf((*ClusterInfraUpdateHaConfigInfoRemediationType)(nil)).Elem()
 }
 
 type ClusterPowerOnVmOption string
@@ -339,6 +388,20 @@ const (
 
 func init() {
 	t["ClusterVmComponentProtectionSettingsVmReactionOnAPDCleared"] = reflect.TypeOf((*ClusterVmComponentProtectionSettingsVmReactionOnAPDCleared)(nil)).Elem()
+}
+
+type ClusterVmReadinessReadyCondition string
+
+const (
+	ClusterVmReadinessReadyConditionNone               = ClusterVmReadinessReadyCondition("none")
+	ClusterVmReadinessReadyConditionPoweredOn          = ClusterVmReadinessReadyCondition("poweredOn")
+	ClusterVmReadinessReadyConditionGuestHbStatusGreen = ClusterVmReadinessReadyCondition("guestHbStatusGreen")
+	ClusterVmReadinessReadyConditionAppHbStatusGreen   = ClusterVmReadinessReadyCondition("appHbStatusGreen")
+	ClusterVmReadinessReadyConditionUseClusterDefault  = ClusterVmReadinessReadyCondition("useClusterDefault")
+)
+
+func init() {
+	t["ClusterVmReadinessReadyCondition"] = reflect.TypeOf((*ClusterVmReadinessReadyCondition)(nil)).Elem()
 }
 
 type ComplianceResultStatus string
@@ -732,6 +795,19 @@ func init() {
 	t["DrsRecommendationReasonCode"] = reflect.TypeOf((*DrsRecommendationReasonCode)(nil)).Elem()
 }
 
+type DvsEventPortBlockState string
+
+const (
+	DvsEventPortBlockStateUnset     = DvsEventPortBlockState("unset")
+	DvsEventPortBlockStateBlocked   = DvsEventPortBlockState("blocked")
+	DvsEventPortBlockStateUnblocked = DvsEventPortBlockState("unblocked")
+	DvsEventPortBlockStateUnknown   = DvsEventPortBlockState("unknown")
+)
+
+func init() {
+	t["DvsEventPortBlockState"] = reflect.TypeOf((*DvsEventPortBlockState)(nil)).Elem()
+}
+
 type DvsFilterOnFailure string
 
 const (
@@ -931,6 +1007,20 @@ func init() {
 	t["GuestRegKeyWowSpec"] = reflect.TypeOf((*GuestRegKeyWowSpec)(nil)).Elem()
 }
 
+type HealthUpdateInfoComponentType string
+
+const (
+	HealthUpdateInfoComponentTypeMemory  = HealthUpdateInfoComponentType("Memory")
+	HealthUpdateInfoComponentTypePower   = HealthUpdateInfoComponentType("Power")
+	HealthUpdateInfoComponentTypeFan     = HealthUpdateInfoComponentType("Fan")
+	HealthUpdateInfoComponentTypeNetwork = HealthUpdateInfoComponentType("Network")
+	HealthUpdateInfoComponentTypeStorage = HealthUpdateInfoComponentType("Storage")
+)
+
+func init() {
+	t["HealthUpdateInfoComponentType"] = reflect.TypeOf((*HealthUpdateInfoComponentType)(nil)).Elem()
+}
+
 type HostAccessMode string
 
 const (
@@ -1062,6 +1152,18 @@ const (
 
 func init() {
 	t["HostCpuPowerManagementInfoPolicyType"] = reflect.TypeOf((*HostCpuPowerManagementInfoPolicyType)(nil)).Elem()
+}
+
+type HostCryptoState string
+
+const (
+	HostCryptoStateIncapable = HostCryptoState("incapable")
+	HostCryptoStatePrepared  = HostCryptoState("prepared")
+	HostCryptoStateSafe      = HostCryptoState("safe")
+)
+
+func init() {
+	t["HostCryptoState"] = reflect.TypeOf((*HostCryptoState)(nil)).Elem()
 }
 
 type HostDasErrorEventHostDasErrorReason string
@@ -1199,12 +1301,35 @@ func init() {
 	t["HostFirewallRuleProtocol"] = reflect.TypeOf((*HostFirewallRuleProtocol)(nil)).Elem()
 }
 
+type HostGraphicsConfigGraphicsType string
+
+const (
+	HostGraphicsConfigGraphicsTypeShared       = HostGraphicsConfigGraphicsType("shared")
+	HostGraphicsConfigGraphicsTypeSharedDirect = HostGraphicsConfigGraphicsType("sharedDirect")
+)
+
+func init() {
+	t["HostGraphicsConfigGraphicsType"] = reflect.TypeOf((*HostGraphicsConfigGraphicsType)(nil)).Elem()
+}
+
+type HostGraphicsConfigSharedPassthruAssignmentPolicy string
+
+const (
+	HostGraphicsConfigSharedPassthruAssignmentPolicyPerformance   = HostGraphicsConfigSharedPassthruAssignmentPolicy("performance")
+	HostGraphicsConfigSharedPassthruAssignmentPolicyConsolidation = HostGraphicsConfigSharedPassthruAssignmentPolicy("consolidation")
+)
+
+func init() {
+	t["HostGraphicsConfigSharedPassthruAssignmentPolicy"] = reflect.TypeOf((*HostGraphicsConfigSharedPassthruAssignmentPolicy)(nil)).Elem()
+}
+
 type HostGraphicsInfoGraphicsType string
 
 const (
-	HostGraphicsInfoGraphicsTypeBasic  = HostGraphicsInfoGraphicsType("basic")
-	HostGraphicsInfoGraphicsTypeShared = HostGraphicsInfoGraphicsType("shared")
-	HostGraphicsInfoGraphicsTypeDirect = HostGraphicsInfoGraphicsType("direct")
+	HostGraphicsInfoGraphicsTypeBasic        = HostGraphicsInfoGraphicsType("basic")
+	HostGraphicsInfoGraphicsTypeShared       = HostGraphicsInfoGraphicsType("shared")
+	HostGraphicsInfoGraphicsTypeDirect       = HostGraphicsInfoGraphicsType("direct")
+	HostGraphicsInfoGraphicsTypeSharedDirect = HostGraphicsInfoGraphicsType("sharedDirect")
 )
 
 func init() {
@@ -1451,8 +1576,9 @@ func init() {
 type HostNasVolumeSecurityType string
 
 const (
-	HostNasVolumeSecurityTypeAUTH_SYS = HostNasVolumeSecurityType("AUTH_SYS")
-	HostNasVolumeSecurityTypeSEC_KRB5 = HostNasVolumeSecurityType("SEC_KRB5")
+	HostNasVolumeSecurityTypeAUTH_SYS  = HostNasVolumeSecurityType("AUTH_SYS")
+	HostNasVolumeSecurityTypeSEC_KRB5  = HostNasVolumeSecurityType("SEC_KRB5")
+	HostNasVolumeSecurityTypeSEC_KRB5I = HostNasVolumeSecurityType("SEC_KRB5I")
 )
 
 func init() {
@@ -1503,6 +1629,14 @@ const (
 	HostNumericSensorTypeTemperature = HostNumericSensorType("temperature")
 	HostNumericSensorTypeVoltage     = HostNumericSensorType("voltage")
 	HostNumericSensorTypeOther       = HostNumericSensorType("other")
+	HostNumericSensorTypeProcessor   = HostNumericSensorType("processor")
+	HostNumericSensorTypeMemory      = HostNumericSensorType("memory")
+	HostNumericSensorTypeStorage     = HostNumericSensorType("storage")
+	HostNumericSensorTypeSystemBoard = HostNumericSensorType("systemBoard")
+	HostNumericSensorTypeBattery     = HostNumericSensorType("battery")
+	HostNumericSensorTypeBios        = HostNumericSensorType("bios")
+	HostNumericSensorTypeCable       = HostNumericSensorType("cable")
+	HostNumericSensorTypeWatchdog    = HostNumericSensorType("watchdog")
 )
 
 func init() {
@@ -1606,6 +1740,18 @@ const (
 
 func init() {
 	t["HostProtocolEndpointPEType"] = reflect.TypeOf((*HostProtocolEndpointPEType)(nil)).Elem()
+}
+
+type HostProtocolEndpointProtocolEndpointType string
+
+const (
+	HostProtocolEndpointProtocolEndpointTypeScsi  = HostProtocolEndpointProtocolEndpointType("scsi")
+	HostProtocolEndpointProtocolEndpointTypeNfs   = HostProtocolEndpointProtocolEndpointType("nfs")
+	HostProtocolEndpointProtocolEndpointTypeNfs4x = HostProtocolEndpointProtocolEndpointType("nfs4x")
+)
+
+func init() {
+	t["HostProtocolEndpointProtocolEndpointType"] = reflect.TypeOf((*HostProtocolEndpointProtocolEndpointType)(nil)).Elem()
 }
 
 type HostReplayUnsupportedReason string
@@ -1742,6 +1888,7 @@ const (
 	HostVirtualNicManagerNicTypeManagement            = HostVirtualNicManagerNicType("management")
 	HostVirtualNicManagerNicTypeVsan                  = HostVirtualNicManagerNicType("vsan")
 	HostVirtualNicManagerNicTypeVSphereProvisioning   = HostVirtualNicManagerNicType("vSphereProvisioning")
+	HostVirtualNicManagerNicTypeVsanWitness           = HostVirtualNicManagerNicType("vsanWitness")
 )
 
 func init() {
@@ -1758,6 +1905,17 @@ const (
 
 func init() {
 	t["HostVmciAccessManagerMode"] = reflect.TypeOf((*HostVmciAccessManagerMode)(nil)).Elem()
+}
+
+type HostVmfsVolumeUnmapPriority string
+
+const (
+	HostVmfsVolumeUnmapPriorityNone = HostVmfsVolumeUnmapPriority("none")
+	HostVmfsVolumeUnmapPriorityLow  = HostVmfsVolumeUnmapPriority("low")
+)
+
+func init() {
+	t["HostVmfsVolumeUnmapPriority"] = reflect.TypeOf((*HostVmfsVolumeUnmapPriority)(nil)).Elem()
 }
 
 type HttpNfcLeaseState string
@@ -1829,6 +1987,22 @@ const (
 
 func init() {
 	t["IoFilterOperation"] = reflect.TypeOf((*IoFilterOperation)(nil)).Elem()
+}
+
+type IoFilterType string
+
+const (
+	IoFilterTypeCache              = IoFilterType("cache")
+	IoFilterTypeReplication        = IoFilterType("replication")
+	IoFilterTypeEncryption         = IoFilterType("encryption")
+	IoFilterTypeCompression        = IoFilterType("compression")
+	IoFilterTypeInspection         = IoFilterType("inspection")
+	IoFilterTypeDatastoreIoControl = IoFilterType("datastoreIoControl")
+	IoFilterTypeDataProvider       = IoFilterType("dataProvider")
+)
+
+func init() {
+	t["IoFilterType"] = reflect.TypeOf((*IoFilterType)(nil)).Elem()
 }
 
 type IscsiPortInfoPathStatus string
@@ -2330,6 +2504,18 @@ func init() {
 	t["PropertyChangeOp"] = reflect.TypeOf((*PropertyChangeOp)(nil)).Elem()
 }
 
+type QuarantineModeFaultFaultType string
+
+const (
+	QuarantineModeFaultFaultTypeNoCompatibleNonQuarantinedHost = QuarantineModeFaultFaultType("NoCompatibleNonQuarantinedHost")
+	QuarantineModeFaultFaultTypeCorrectionDisallowed           = QuarantineModeFaultFaultType("CorrectionDisallowed")
+	QuarantineModeFaultFaultTypeCorrectionImpact               = QuarantineModeFaultFaultType("CorrectionImpact")
+)
+
+func init() {
+	t["QuarantineModeFaultFaultType"] = reflect.TypeOf((*QuarantineModeFaultFaultType)(nil)).Elem()
+}
+
 type QuiesceMode string
 
 const (
@@ -2371,6 +2557,10 @@ const (
 	RecommendationReasonCodeIolbDisabledInternal            = RecommendationReasonCode("iolbDisabledInternal")
 	RecommendationReasonCodeXvmotionPlacement               = RecommendationReasonCode("xvmotionPlacement")
 	RecommendationReasonCodeNetworkBandwidthReservation     = RecommendationReasonCode("networkBandwidthReservation")
+	RecommendationReasonCodeHostInDegradation               = RecommendationReasonCode("hostInDegradation")
+	RecommendationReasonCodeHostExitDegradation             = RecommendationReasonCode("hostExitDegradation")
+	RecommendationReasonCodeMaxVmsConstraint                = RecommendationReasonCode("maxVmsConstraint")
+	RecommendationReasonCodeFtConstraints                   = RecommendationReasonCode("ftConstraints")
 )
 
 func init() {
@@ -2420,6 +2610,7 @@ const (
 	ReplicationVmConfigFaultReasonForFaultInvalidPriorConfiguration                = ReplicationVmConfigFaultReasonForFault("invalidPriorConfiguration")
 	ReplicationVmConfigFaultReasonForFaultReplicationNotEnabled                    = ReplicationVmConfigFaultReasonForFault("replicationNotEnabled")
 	ReplicationVmConfigFaultReasonForFaultReplicationConfigurationFailed           = ReplicationVmConfigFaultReasonForFault("replicationConfigurationFailed")
+	ReplicationVmConfigFaultReasonForFaultEncryptedVm                              = ReplicationVmConfigFaultReasonForFault("encryptedVm")
 )
 
 func init() {
@@ -2436,6 +2627,7 @@ const (
 	ReplicationVmFaultReasonForFaultOfflineReplicating = ReplicationVmFaultReasonForFault("offlineReplicating")
 	ReplicationVmFaultReasonForFaultInvalidState       = ReplicationVmFaultReasonForFault("invalidState")
 	ReplicationVmFaultReasonForFaultInvalidInstanceId  = ReplicationVmFaultReasonForFault("invalidInstanceId")
+	ReplicationVmFaultReasonForFaultCloseDiskError     = ReplicationVmFaultReasonForFault("closeDiskError")
 )
 
 func init() {
@@ -2491,6 +2683,19 @@ const (
 
 func init() {
 	t["ScheduledHardwareUpgradeInfoHardwareUpgradeStatus"] = reflect.TypeOf((*ScheduledHardwareUpgradeInfoHardwareUpgradeStatus)(nil)).Elem()
+}
+
+type ScsiDiskType string
+
+const (
+	ScsiDiskTypeNative512   = ScsiDiskType("native512")
+	ScsiDiskTypeEmulated512 = ScsiDiskType("emulated512")
+	ScsiDiskTypeNative4k    = ScsiDiskType("native4k")
+	ScsiDiskTypeUnknown     = ScsiDiskType("unknown")
+)
+
+func init() {
+	t["ScsiDiskType"] = reflect.TypeOf((*ScsiDiskType)(nil)).Elem()
 }
 
 type ScsiLunDescriptorQuality string
@@ -2610,6 +2815,32 @@ const (
 
 func init() {
 	t["SlpDiscoveryMethod"] = reflect.TypeOf((*SlpDiscoveryMethod)(nil)).Elem()
+}
+
+type SoftwarePackageConstraint string
+
+const (
+	SoftwarePackageConstraintEquals           = SoftwarePackageConstraint("equals")
+	SoftwarePackageConstraintLessThan         = SoftwarePackageConstraint("lessThan")
+	SoftwarePackageConstraintLessThanEqual    = SoftwarePackageConstraint("lessThanEqual")
+	SoftwarePackageConstraintGreaterThanEqual = SoftwarePackageConstraint("greaterThanEqual")
+	SoftwarePackageConstraintGreaterThan      = SoftwarePackageConstraint("greaterThan")
+)
+
+func init() {
+	t["SoftwarePackageConstraint"] = reflect.TypeOf((*SoftwarePackageConstraint)(nil)).Elem()
+}
+
+type SoftwarePackageVibType string
+
+const (
+	SoftwarePackageVibTypeBootbank = SoftwarePackageVibType("bootbank")
+	SoftwarePackageVibTypeTools    = SoftwarePackageVibType("tools")
+	SoftwarePackageVibTypeMeta     = SoftwarePackageVibType("meta")
+)
+
+func init() {
+	t["SoftwarePackageVibType"] = reflect.TypeOf((*SoftwarePackageVibType)(nil)).Elem()
 }
 
 type StateAlarmOperator string
@@ -2827,6 +3058,18 @@ func init() {
 	t["VMwareDVSTeamingMatchStatus"] = reflect.TypeOf((*VMwareDVSTeamingMatchStatus)(nil)).Elem()
 }
 
+type VMwareDVSVspanSessionEncapType string
+
+const (
+	VMwareDVSVspanSessionEncapTypeGre     = VMwareDVSVspanSessionEncapType("gre")
+	VMwareDVSVspanSessionEncapTypeErspan2 = VMwareDVSVspanSessionEncapType("erspan2")
+	VMwareDVSVspanSessionEncapTypeErspan3 = VMwareDVSVspanSessionEncapType("erspan3")
+)
+
+func init() {
+	t["VMwareDVSVspanSessionEncapType"] = reflect.TypeOf((*VMwareDVSVspanSessionEncapType)(nil)).Elem()
+}
+
 type VMwareDVSVspanSessionType string
 
 const (
@@ -2903,6 +3146,16 @@ func init() {
 	t["VMwareUplinkLacpMode"] = reflect.TypeOf((*VMwareUplinkLacpMode)(nil)).Elem()
 }
 
+type VStorageObjectConsumptionType string
+
+const (
+	VStorageObjectConsumptionTypeDisk = VStorageObjectConsumptionType("disk")
+)
+
+func init() {
+	t["VStorageObjectConsumptionType"] = reflect.TypeOf((*VStorageObjectConsumptionType)(nil)).Elem()
+}
+
 type ValidateMigrationTestType string
 
 const (
@@ -2914,6 +3167,66 @@ const (
 
 func init() {
 	t["ValidateMigrationTestType"] = reflect.TypeOf((*ValidateMigrationTestType)(nil)).Elem()
+}
+
+type VchaClusterMode string
+
+const (
+	VchaClusterModeEnabled     = VchaClusterMode("enabled")
+	VchaClusterModeDisabled    = VchaClusterMode("disabled")
+	VchaClusterModeMaintenance = VchaClusterMode("maintenance")
+)
+
+func init() {
+	t["VchaClusterMode"] = reflect.TypeOf((*VchaClusterMode)(nil)).Elem()
+}
+
+type VchaClusterState string
+
+const (
+	VchaClusterStateHealthy  = VchaClusterState("healthy")
+	VchaClusterStateDegraded = VchaClusterState("degraded")
+	VchaClusterStateIsolated = VchaClusterState("isolated")
+)
+
+func init() {
+	t["VchaClusterState"] = reflect.TypeOf((*VchaClusterState)(nil)).Elem()
+}
+
+type VchaNodeRole string
+
+const (
+	VchaNodeRoleActive  = VchaNodeRole("active")
+	VchaNodeRolePassive = VchaNodeRole("passive")
+	VchaNodeRoleWitness = VchaNodeRole("witness")
+)
+
+func init() {
+	t["VchaNodeRole"] = reflect.TypeOf((*VchaNodeRole)(nil)).Elem()
+}
+
+type VchaNodeState string
+
+const (
+	VchaNodeStateUp   = VchaNodeState("up")
+	VchaNodeStateDown = VchaNodeState("down")
+)
+
+func init() {
+	t["VchaNodeState"] = reflect.TypeOf((*VchaNodeState)(nil)).Elem()
+}
+
+type VchaState string
+
+const (
+	VchaStateConfigured    = VchaState("configured")
+	VchaStateNotConfigured = VchaState("notConfigured")
+	VchaStateInvalid       = VchaState("invalid")
+	VchaStatePrepared      = VchaState("prepared")
+)
+
+func init() {
+	t["VchaState"] = reflect.TypeOf((*VchaState)(nil)).Elem()
 }
 
 type VirtualAppVAppState string
@@ -3178,6 +3491,18 @@ func init() {
 	t["VirtualMachineConfigInfoSwapPlacementType"] = reflect.TypeOf((*VirtualMachineConfigInfoSwapPlacementType)(nil)).Elem()
 }
 
+type VirtualMachineConfigSpecEncryptedVMotionModes string
+
+const (
+	VirtualMachineConfigSpecEncryptedVMotionModesDisabled      = VirtualMachineConfigSpecEncryptedVMotionModes("disabled")
+	VirtualMachineConfigSpecEncryptedVMotionModesOpportunistic = VirtualMachineConfigSpecEncryptedVMotionModes("opportunistic")
+	VirtualMachineConfigSpecEncryptedVMotionModesRequired      = VirtualMachineConfigSpecEncryptedVMotionModes("required")
+)
+
+func init() {
+	t["VirtualMachineConfigSpecEncryptedVMotionModes"] = reflect.TypeOf((*VirtualMachineConfigSpecEncryptedVMotionModes)(nil)).Elem()
+}
+
 type VirtualMachineConfigSpecNpivWwnOp string
 
 const (
@@ -3414,8 +3739,16 @@ const (
 	VirtualMachineGuestOsIdentifierRhel7_64Guest           = VirtualMachineGuestOsIdentifier("rhel7_64Guest")
 	VirtualMachineGuestOsIdentifierCentosGuest             = VirtualMachineGuestOsIdentifier("centosGuest")
 	VirtualMachineGuestOsIdentifierCentos64Guest           = VirtualMachineGuestOsIdentifier("centos64Guest")
+	VirtualMachineGuestOsIdentifierCentos6Guest            = VirtualMachineGuestOsIdentifier("centos6Guest")
+	VirtualMachineGuestOsIdentifierCentos6_64Guest         = VirtualMachineGuestOsIdentifier("centos6_64Guest")
+	VirtualMachineGuestOsIdentifierCentos7Guest            = VirtualMachineGuestOsIdentifier("centos7Guest")
+	VirtualMachineGuestOsIdentifierCentos7_64Guest         = VirtualMachineGuestOsIdentifier("centos7_64Guest")
 	VirtualMachineGuestOsIdentifierOracleLinuxGuest        = VirtualMachineGuestOsIdentifier("oracleLinuxGuest")
 	VirtualMachineGuestOsIdentifierOracleLinux64Guest      = VirtualMachineGuestOsIdentifier("oracleLinux64Guest")
+	VirtualMachineGuestOsIdentifierOracleLinux6Guest       = VirtualMachineGuestOsIdentifier("oracleLinux6Guest")
+	VirtualMachineGuestOsIdentifierOracleLinux6_64Guest    = VirtualMachineGuestOsIdentifier("oracleLinux6_64Guest")
+	VirtualMachineGuestOsIdentifierOracleLinux7Guest       = VirtualMachineGuestOsIdentifier("oracleLinux7Guest")
+	VirtualMachineGuestOsIdentifierOracleLinux7_64Guest    = VirtualMachineGuestOsIdentifier("oracleLinux7_64Guest")
 	VirtualMachineGuestOsIdentifierSuseGuest               = VirtualMachineGuestOsIdentifier("suseGuest")
 	VirtualMachineGuestOsIdentifierSuse64Guest             = VirtualMachineGuestOsIdentifier("suse64Guest")
 	VirtualMachineGuestOsIdentifierSlesGuest               = VirtualMachineGuestOsIdentifier("slesGuest")
@@ -3446,16 +3779,22 @@ const (
 	VirtualMachineGuestOsIdentifierDebian7_64Guest         = VirtualMachineGuestOsIdentifier("debian7_64Guest")
 	VirtualMachineGuestOsIdentifierDebian8Guest            = VirtualMachineGuestOsIdentifier("debian8Guest")
 	VirtualMachineGuestOsIdentifierDebian8_64Guest         = VirtualMachineGuestOsIdentifier("debian8_64Guest")
+	VirtualMachineGuestOsIdentifierDebian9Guest            = VirtualMachineGuestOsIdentifier("debian9Guest")
+	VirtualMachineGuestOsIdentifierDebian9_64Guest         = VirtualMachineGuestOsIdentifier("debian9_64Guest")
+	VirtualMachineGuestOsIdentifierDebian10Guest           = VirtualMachineGuestOsIdentifier("debian10Guest")
+	VirtualMachineGuestOsIdentifierDebian10_64Guest        = VirtualMachineGuestOsIdentifier("debian10_64Guest")
 	VirtualMachineGuestOsIdentifierAsianux3Guest           = VirtualMachineGuestOsIdentifier("asianux3Guest")
 	VirtualMachineGuestOsIdentifierAsianux3_64Guest        = VirtualMachineGuestOsIdentifier("asianux3_64Guest")
 	VirtualMachineGuestOsIdentifierAsianux4Guest           = VirtualMachineGuestOsIdentifier("asianux4Guest")
 	VirtualMachineGuestOsIdentifierAsianux4_64Guest        = VirtualMachineGuestOsIdentifier("asianux4_64Guest")
 	VirtualMachineGuestOsIdentifierAsianux5_64Guest        = VirtualMachineGuestOsIdentifier("asianux5_64Guest")
+	VirtualMachineGuestOsIdentifierAsianux7_64Guest        = VirtualMachineGuestOsIdentifier("asianux7_64Guest")
 	VirtualMachineGuestOsIdentifierOpensuseGuest           = VirtualMachineGuestOsIdentifier("opensuseGuest")
 	VirtualMachineGuestOsIdentifierOpensuse64Guest         = VirtualMachineGuestOsIdentifier("opensuse64Guest")
 	VirtualMachineGuestOsIdentifierFedoraGuest             = VirtualMachineGuestOsIdentifier("fedoraGuest")
 	VirtualMachineGuestOsIdentifierFedora64Guest           = VirtualMachineGuestOsIdentifier("fedora64Guest")
 	VirtualMachineGuestOsIdentifierCoreos64Guest           = VirtualMachineGuestOsIdentifier("coreos64Guest")
+	VirtualMachineGuestOsIdentifierVmwarePhoton64Guest     = VirtualMachineGuestOsIdentifier("vmwarePhoton64Guest")
 	VirtualMachineGuestOsIdentifierOther24xLinuxGuest      = VirtualMachineGuestOsIdentifier("other24xLinuxGuest")
 	VirtualMachineGuestOsIdentifierOther26xLinuxGuest      = VirtualMachineGuestOsIdentifier("other26xLinuxGuest")
 	VirtualMachineGuestOsIdentifierOtherLinuxGuest         = VirtualMachineGuestOsIdentifier("otherLinuxGuest")
@@ -3490,9 +3829,12 @@ const (
 	VirtualMachineGuestOsIdentifierDarwin12_64Guest        = VirtualMachineGuestOsIdentifier("darwin12_64Guest")
 	VirtualMachineGuestOsIdentifierDarwin13_64Guest        = VirtualMachineGuestOsIdentifier("darwin13_64Guest")
 	VirtualMachineGuestOsIdentifierDarwin14_64Guest        = VirtualMachineGuestOsIdentifier("darwin14_64Guest")
+	VirtualMachineGuestOsIdentifierDarwin15_64Guest        = VirtualMachineGuestOsIdentifier("darwin15_64Guest")
+	VirtualMachineGuestOsIdentifierDarwin16_64Guest        = VirtualMachineGuestOsIdentifier("darwin16_64Guest")
 	VirtualMachineGuestOsIdentifierVmkernelGuest           = VirtualMachineGuestOsIdentifier("vmkernelGuest")
 	VirtualMachineGuestOsIdentifierVmkernel5Guest          = VirtualMachineGuestOsIdentifier("vmkernel5Guest")
 	VirtualMachineGuestOsIdentifierVmkernel6Guest          = VirtualMachineGuestOsIdentifier("vmkernel6Guest")
+	VirtualMachineGuestOsIdentifierVmkernel65Guest         = VirtualMachineGuestOsIdentifier("vmkernel65Guest")
 	VirtualMachineGuestOsIdentifierOtherGuest              = VirtualMachineGuestOsIdentifier("otherGuest")
 	VirtualMachineGuestOsIdentifierOtherGuest64            = VirtualMachineGuestOsIdentifier("otherGuest64")
 )
@@ -3719,6 +4061,20 @@ func init() {
 	t["VirtualMachineTicketType"] = reflect.TypeOf((*VirtualMachineTicketType)(nil)).Elem()
 }
 
+type VirtualMachineToolsInstallType string
+
+const (
+	VirtualMachineToolsInstallTypeGuestToolsTypeUnknown     = VirtualMachineToolsInstallType("guestToolsTypeUnknown")
+	VirtualMachineToolsInstallTypeGuestToolsTypeMSI         = VirtualMachineToolsInstallType("guestToolsTypeMSI")
+	VirtualMachineToolsInstallTypeGuestToolsTypeTar         = VirtualMachineToolsInstallType("guestToolsTypeTar")
+	VirtualMachineToolsInstallTypeGuestToolsTypeOSP         = VirtualMachineToolsInstallType("guestToolsTypeOSP")
+	VirtualMachineToolsInstallTypeGuestToolsTypeOpenVMTools = VirtualMachineToolsInstallType("guestToolsTypeOpenVMTools")
+)
+
+func init() {
+	t["VirtualMachineToolsInstallType"] = reflect.TypeOf((*VirtualMachineToolsInstallType)(nil)).Elem()
+}
+
 type VirtualMachineToolsRunningStatus string
 
 const (
@@ -3852,6 +4208,18 @@ const (
 
 func init() {
 	t["VirtualMachineVideoCardUse3dRenderer"] = reflect.TypeOf((*VirtualMachineVideoCardUse3dRenderer)(nil)).Elem()
+}
+
+type VirtualMachineWindowsQuiesceSpecVssBackupContext string
+
+const (
+	VirtualMachineWindowsQuiesceSpecVssBackupContextCtx_auto              = VirtualMachineWindowsQuiesceSpecVssBackupContext("ctx_auto")
+	VirtualMachineWindowsQuiesceSpecVssBackupContextCtx_backup            = VirtualMachineWindowsQuiesceSpecVssBackupContext("ctx_backup")
+	VirtualMachineWindowsQuiesceSpecVssBackupContextCtx_file_share_backup = VirtualMachineWindowsQuiesceSpecVssBackupContext("ctx_file_share_backup")
+)
+
+func init() {
+	t["VirtualMachineWindowsQuiesceSpecVssBackupContext"] = reflect.TypeOf((*VirtualMachineWindowsQuiesceSpecVssBackupContext)(nil)).Elem()
 }
 
 type VirtualPointingDeviceHostChoice string

--- a/vendor/github.com/vmware/govmomi/vim25/types/if.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/if.go
@@ -118,6 +118,40 @@ func init() {
 	t["BaseAuthorizationEvent"] = reflect.TypeOf((*AuthorizationEvent)(nil)).Elem()
 }
 
+func (b *BaseConfigInfo) GetBaseConfigInfo() *BaseConfigInfo { return b }
+
+type BaseBaseConfigInfo interface {
+	GetBaseConfigInfo() *BaseConfigInfo
+}
+
+func init() {
+	t["BaseBaseConfigInfo"] = reflect.TypeOf((*BaseConfigInfo)(nil)).Elem()
+}
+
+func (b *BaseConfigInfoBackingInfo) GetBaseConfigInfoBackingInfo() *BaseConfigInfoBackingInfo {
+	return b
+}
+
+type BaseBaseConfigInfoBackingInfo interface {
+	GetBaseConfigInfoBackingInfo() *BaseConfigInfoBackingInfo
+}
+
+func init() {
+	t["BaseBaseConfigInfoBackingInfo"] = reflect.TypeOf((*BaseConfigInfoBackingInfo)(nil)).Elem()
+}
+
+func (b *BaseConfigInfoFileBackingInfo) GetBaseConfigInfoFileBackingInfo() *BaseConfigInfoFileBackingInfo {
+	return b
+}
+
+type BaseBaseConfigInfoFileBackingInfo interface {
+	GetBaseConfigInfoFileBackingInfo() *BaseConfigInfoFileBackingInfo
+}
+
+func init() {
+	t["BaseBaseConfigInfoFileBackingInfo"] = reflect.TypeOf((*BaseConfigInfoFileBackingInfo)(nil)).Elem()
+}
+
 func (b *CannotAccessNetwork) GetCannotAccessNetwork() *CannotAccessNetwork { return b }
 
 type BaseCannotAccessNetwork interface {
@@ -374,6 +408,26 @@ type BaseCpuIncompatible interface {
 
 func init() {
 	t["BaseCpuIncompatible"] = reflect.TypeOf((*CpuIncompatible)(nil)).Elem()
+}
+
+func (b *CryptoSpec) GetCryptoSpec() *CryptoSpec { return b }
+
+type BaseCryptoSpec interface {
+	GetCryptoSpec() *CryptoSpec
+}
+
+func init() {
+	t["BaseCryptoSpec"] = reflect.TypeOf((*CryptoSpec)(nil)).Elem()
+}
+
+func (b *CryptoSpecNoOp) GetCryptoSpecNoOp() *CryptoSpecNoOp { return b }
+
+type BaseCryptoSpecNoOp interface {
+	GetCryptoSpecNoOp() *CryptoSpecNoOp
+}
+
+func init() {
+	t["BaseCryptoSpecNoOp"] = reflect.TypeOf((*CryptoSpecNoOp)(nil)).Elem()
 }
 
 func (b *CustomFieldDefEvent) GetCustomFieldDefEvent() *CustomFieldDefEvent { return b }
@@ -1388,6 +1442,28 @@ func init() {
 	t["BaseHostProfileConfigSpec"] = reflect.TypeOf((*HostProfileConfigSpec)(nil)).Elem()
 }
 
+func (b *HostProfilesEntityCustomizations) GetHostProfilesEntityCustomizations() *HostProfilesEntityCustomizations {
+	return b
+}
+
+type BaseHostProfilesEntityCustomizations interface {
+	GetHostProfilesEntityCustomizations() *HostProfilesEntityCustomizations
+}
+
+func init() {
+	t["BaseHostProfilesEntityCustomizations"] = reflect.TypeOf((*HostProfilesEntityCustomizations)(nil)).Elem()
+}
+
+func (b *HostSriovDevicePoolInfo) GetHostSriovDevicePoolInfo() *HostSriovDevicePoolInfo { return b }
+
+type BaseHostSriovDevicePoolInfo interface {
+	GetHostSriovDevicePoolInfo() *HostSriovDevicePoolInfo
+}
+
+func init() {
+	t["BaseHostSriovDevicePoolInfo"] = reflect.TypeOf((*HostSriovDevicePoolInfo)(nil)).Elem()
+}
+
 func (b *HostSystemSwapConfigurationSystemSwapOption) GetHostSystemSwapConfigurationSystemSwapOption() *HostSystemSwapConfigurationSystemSwapOption {
 	return b
 }
@@ -1798,6 +1874,26 @@ func init() {
 	t["BaseNoPermission"] = reflect.TypeOf((*NoPermission)(nil)).Elem()
 }
 
+func (b *NodeDeploymentSpec) GetNodeDeploymentSpec() *NodeDeploymentSpec { return b }
+
+type BaseNodeDeploymentSpec interface {
+	GetNodeDeploymentSpec() *NodeDeploymentSpec
+}
+
+func init() {
+	t["BaseNodeDeploymentSpec"] = reflect.TypeOf((*NodeDeploymentSpec)(nil)).Elem()
+}
+
+func (b *NodeNetworkSpec) GetNodeNetworkSpec() *NodeNetworkSpec { return b }
+
+type BaseNodeNetworkSpec interface {
+	GetNodeNetworkSpec() *NodeNetworkSpec
+}
+
+func init() {
+	t["BaseNodeNetworkSpec"] = reflect.TypeOf((*NodeNetworkSpec)(nil)).Elem()
+}
+
 func (b *NotEnoughCpus) GetNotEnoughCpus() *NotEnoughCpus { return b }
 
 type BaseNotEnoughCpus interface {
@@ -2168,6 +2264,16 @@ type BaseProfileEvent interface {
 
 func init() {
 	t["BaseProfileEvent"] = reflect.TypeOf((*ProfileEvent)(nil)).Elem()
+}
+
+func (b *ProfileExecuteResult) GetProfileExecuteResult() *ProfileExecuteResult { return b }
+
+type BaseProfileExecuteResult interface {
+	GetProfileExecuteResult() *ProfileExecuteResult
+}
+
+func init() {
+	t["BaseProfileExecuteResult"] = reflect.TypeOf((*ProfileExecuteResult)(nil)).Elem()
 }
 
 func (b *ProfileExpression) GetProfileExpression() *ProfileExpression { return b }
@@ -2896,6 +3002,18 @@ func init() {
 	t["BaseVirtualMachineDiskDeviceInfo"] = reflect.TypeOf((*VirtualMachineDiskDeviceInfo)(nil)).Elem()
 }
 
+func (b *VirtualMachineGuestQuiesceSpec) GetVirtualMachineGuestQuiesceSpec() *VirtualMachineGuestQuiesceSpec {
+	return b
+}
+
+type BaseVirtualMachineGuestQuiesceSpec interface {
+	GetVirtualMachineGuestQuiesceSpec() *VirtualMachineGuestQuiesceSpec
+}
+
+func init() {
+	t["BaseVirtualMachineGuestQuiesceSpec"] = reflect.TypeOf((*VirtualMachineGuestQuiesceSpec)(nil)).Elem()
+}
+
 func (b *VirtualMachinePciPassthroughInfo) GetVirtualMachinePciPassthroughInfo() *VirtualMachinePciPassthroughInfo {
 	return b
 }
@@ -2918,6 +3036,18 @@ type BaseVirtualMachineProfileSpec interface {
 
 func init() {
 	t["BaseVirtualMachineProfileSpec"] = reflect.TypeOf((*VirtualMachineProfileSpec)(nil)).Elem()
+}
+
+func (b *VirtualMachineSriovDevicePoolInfo) GetVirtualMachineSriovDevicePoolInfo() *VirtualMachineSriovDevicePoolInfo {
+	return b
+}
+
+type BaseVirtualMachineSriovDevicePoolInfo interface {
+	GetVirtualMachineSriovDevicePoolInfo() *VirtualMachineSriovDevicePoolInfo
+}
+
+func init() {
+	t["BaseVirtualMachineSriovDevicePoolInfo"] = reflect.TypeOf((*VirtualMachineSriovDevicePoolInfo)(nil)).Elem()
 }
 
 func (b *VirtualMachineTargetInfo) GetVirtualMachineTargetInfo() *VirtualMachineTargetInfo { return b }
@@ -3026,6 +3156,26 @@ type BaseVirtualVmxnet interface {
 
 func init() {
 	t["BaseVirtualVmxnet"] = reflect.TypeOf((*VirtualVmxnet)(nil)).Elem()
+}
+
+func (b *VirtualVmxnet3) GetVirtualVmxnet3() *VirtualVmxnet3 { return b }
+
+type BaseVirtualVmxnet3 interface {
+	GetVirtualVmxnet3() *VirtualVmxnet3
+}
+
+func init() {
+	t["BaseVirtualVmxnet3"] = reflect.TypeOf((*VirtualVmxnet3)(nil)).Elem()
+}
+
+func (b *VirtualVmxnet3Option) GetVirtualVmxnet3Option() *VirtualVmxnet3Option { return b }
+
+type BaseVirtualVmxnet3Option interface {
+	GetVirtualVmxnet3Option() *VirtualVmxnet3Option
+}
+
+func init() {
+	t["BaseVirtualVmxnet3Option"] = reflect.TypeOf((*VirtualVmxnet3Option)(nil)).Elem()
 }
 
 func (b *VirtualVmxnetOption) GetVirtualVmxnetOption() *VirtualVmxnetOption { return b }
@@ -3284,4 +3434,26 @@ type BaseVsanUpgradeSystemUpgradeHistoryItem interface {
 
 func init() {
 	t["BaseVsanUpgradeSystemUpgradeHistoryItem"] = reflect.TypeOf((*VsanUpgradeSystemUpgradeHistoryItem)(nil)).Elem()
+}
+
+func (b *VslmCreateSpecBackingSpec) GetVslmCreateSpecBackingSpec() *VslmCreateSpecBackingSpec {
+	return b
+}
+
+type BaseVslmCreateSpecBackingSpec interface {
+	GetVslmCreateSpecBackingSpec() *VslmCreateSpecBackingSpec
+}
+
+func init() {
+	t["BaseVslmCreateSpecBackingSpec"] = reflect.TypeOf((*VslmCreateSpecBackingSpec)(nil)).Elem()
+}
+
+func (b *VslmMigrateSpec) GetVslmMigrateSpec() *VslmMigrateSpec { return b }
+
+type BaseVslmMigrateSpec interface {
+	GetVslmMigrateSpec() *VslmMigrateSpec
+}
+
+func init() {
+	t["BaseVslmMigrateSpec"] = reflect.TypeOf((*VslmMigrateSpec)(nil)).Elem()
 }

--- a/vendor/github.com/vmware/govmomi/vim25/types/internal.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/internal.go
@@ -237,6 +237,10 @@ type RetrieveManagedMethodExecuter struct {
 	This ManagedObjectReference `xml:"_this"`
 }
 
+func init() {
+	t["RetrieveManagedMethodExecuter"] = reflect.TypeOf((*RetrieveManagedMethodExecuter)(nil)).Elem()
+}
+
 type RetrieveManagedMethodExecuterResponse struct {
 	Returnval *ReflectManagedMethodExecuter `xml:"urn:vim25 returnval"`
 }

--- a/vendor/github.com/vmware/govmomi/vim25/types/types.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/types.go
@@ -89,8 +89,9 @@ func init() {
 type AccountUpdatedEvent struct {
 	HostEvent
 
-	Spec  BaseHostAccountSpec `xml:"spec,typeattr"`
-	Group bool                `xml:"group"`
+	Spec            BaseHostAccountSpec `xml:"spec,typeattr"`
+	Group           bool                `xml:"group"`
+	PrevDescription string              `xml:"prevDescription,omitempty"`
 }
 
 func init() {
@@ -378,6 +379,46 @@ type AddDisks_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type AddFilter AddFilterRequestType
+
+func init() {
+	t["AddFilter"] = reflect.TypeOf((*AddFilter)(nil)).Elem()
+}
+
+type AddFilterEntities AddFilterEntitiesRequestType
+
+func init() {
+	t["AddFilterEntities"] = reflect.TypeOf((*AddFilterEntities)(nil)).Elem()
+}
+
+type AddFilterEntitiesRequestType struct {
+	This     ManagedObjectReference   `xml:"_this"`
+	FilterId string                   `xml:"filterId"`
+	Entities []ManagedObjectReference `xml:"entities,omitempty"`
+}
+
+func init() {
+	t["AddFilterEntitiesRequestType"] = reflect.TypeOf((*AddFilterEntitiesRequestType)(nil)).Elem()
+}
+
+type AddFilterEntitiesResponse struct {
+}
+
+type AddFilterRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+	FilterName string                 `xml:"filterName"`
+	InfoIds    []string               `xml:"infoIds,omitempty"`
+}
+
+func init() {
+	t["AddFilterRequestType"] = reflect.TypeOf((*AddFilterRequestType)(nil)).Elem()
+}
+
+type AddFilterResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
 type AddGuestAlias AddGuestAliasRequestType
 
 func init() {
@@ -461,6 +502,43 @@ func init() {
 type AddInternetScsiStaticTargetsResponse struct {
 }
 
+type AddKey AddKeyRequestType
+
+func init() {
+	t["AddKey"] = reflect.TypeOf((*AddKey)(nil)).Elem()
+}
+
+type AddKeyRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Key  CryptoKeyPlain         `xml:"key"`
+}
+
+func init() {
+	t["AddKeyRequestType"] = reflect.TypeOf((*AddKeyRequestType)(nil)).Elem()
+}
+
+type AddKeyResponse struct {
+}
+
+type AddKeys AddKeysRequestType
+
+func init() {
+	t["AddKeys"] = reflect.TypeOf((*AddKeys)(nil)).Elem()
+}
+
+type AddKeysRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Keys []CryptoKeyPlain       `xml:"keys,omitempty"`
+}
+
+func init() {
+	t["AddKeysRequestType"] = reflect.TypeOf((*AddKeysRequestType)(nil)).Elem()
+}
+
+type AddKeysResponse struct {
+	Returnval []CryptoKeyResult `xml:"returnval,omitempty"`
+}
+
 type AddLicense AddLicenseRequestType
 
 func init() {
@@ -479,6 +557,25 @@ func init() {
 
 type AddLicenseResponse struct {
 	Returnval LicenseManagerLicenseInfo `xml:"returnval"`
+}
+
+type AddMonitoredEntities AddMonitoredEntitiesRequestType
+
+func init() {
+	t["AddMonitoredEntities"] = reflect.TypeOf((*AddMonitoredEntities)(nil)).Elem()
+}
+
+type AddMonitoredEntitiesRequestType struct {
+	This       ManagedObjectReference   `xml:"_this"`
+	ProviderId string                   `xml:"providerId"`
+	Entities   []ManagedObjectReference `xml:"entities,omitempty"`
+}
+
+func init() {
+	t["AddMonitoredEntitiesRequestType"] = reflect.TypeOf((*AddMonitoredEntitiesRequestType)(nil)).Elem()
+}
+
+type AddMonitoredEntitiesResponse struct {
 }
 
 type AddNetworkResourcePool AddNetworkResourcePoolRequestType
@@ -818,7 +915,8 @@ func init() {
 type AlarmReconfiguredEvent struct {
 	AlarmEvent
 
-	Entity ManagedEntityEventArgument `xml:"entity"`
+	Entity        ManagedEntityEventArgument `xml:"entity"`
+	ConfigChanges *ChangesInfoEventArgument  `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -1221,6 +1319,25 @@ func init() {
 	t["ApplicationQuiesceFaultFault"] = reflect.TypeOf((*ApplicationQuiesceFaultFault)(nil)).Elem()
 }
 
+type ApplyEntitiesConfigRequestType struct {
+	This             ManagedObjectReference              `xml:"_this"`
+	ApplyConfigSpecs []ApplyHostProfileConfigurationSpec `xml:"applyConfigSpecs,omitempty"`
+}
+
+func init() {
+	t["ApplyEntitiesConfigRequestType"] = reflect.TypeOf((*ApplyEntitiesConfigRequestType)(nil)).Elem()
+}
+
+type ApplyEntitiesConfig_Task ApplyEntitiesConfigRequestType
+
+func init() {
+	t["ApplyEntitiesConfig_Task"] = reflect.TypeOf((*ApplyEntitiesConfig_Task)(nil)).Elem()
+}
+
+type ApplyEntitiesConfig_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type ApplyHostConfigRequestType struct {
 	This       ManagedObjectReference                 `xml:"_this"`
 	Host       ManagedObjectReference                 `xml:"host"`
@@ -1242,14 +1359,34 @@ type ApplyHostConfig_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type ApplyHostProfileConfigurationSpec struct {
+	ProfileExecuteResult
+
+	Host                ManagedObjectReference `xml:"host"`
+	TaskListRequirement []string               `xml:"taskListRequirement,omitempty"`
+	TaskDescription     []LocalizableMessage   `xml:"taskDescription,omitempty"`
+	RebootStateless     *bool                  `xml:"rebootStateless"`
+	RebootHost          *bool                  `xml:"rebootHost"`
+	FaultData           *LocalizedMethodFault  `xml:"faultData,omitempty"`
+}
+
+func init() {
+	t["ApplyHostProfileConfigurationSpec"] = reflect.TypeOf((*ApplyHostProfileConfigurationSpec)(nil)).Elem()
+}
+
 type ApplyProfile struct {
 	DynamicData
 
-	Enabled         bool                          `xml:"enabled"`
-	Policy          []ProfilePolicy               `xml:"policy,omitempty"`
-	ProfileTypeName string                        `xml:"profileTypeName,omitempty"`
-	ProfileVersion  string                        `xml:"profileVersion,omitempty"`
-	Property        []ProfileApplyProfileProperty `xml:"property,omitempty"`
+	Enabled          bool                          `xml:"enabled"`
+	Policy           []ProfilePolicy               `xml:"policy,omitempty"`
+	ProfileTypeName  string                        `xml:"profileTypeName,omitempty"`
+	ProfileVersion   string                        `xml:"profileVersion,omitempty"`
+	Property         []ProfileApplyProfileProperty `xml:"property,omitempty"`
+	Favorite         *bool                         `xml:"favorite"`
+	ToBeMerged       *bool                         `xml:"toBeMerged"`
+	ToReplaceWith    *bool                         `xml:"toReplaceWith"`
+	ToBeDeleted      *bool                         `xml:"toBeDeleted"`
+	CopyEnableStatus *bool                         `xml:"copyEnableStatus"`
 }
 
 func init() {
@@ -1414,6 +1551,14 @@ func init() {
 	t["ArrayOfAnyURI"] = reflect.TypeOf((*ArrayOfAnyURI)(nil)).Elem()
 }
 
+type ArrayOfApplyHostProfileConfigurationSpec struct {
+	ApplyHostProfileConfigurationSpec []ApplyHostProfileConfigurationSpec `xml:"ApplyHostProfileConfigurationSpec,omitempty"`
+}
+
+func init() {
+	t["ArrayOfApplyHostProfileConfigurationSpec"] = reflect.TypeOf((*ArrayOfApplyHostProfileConfigurationSpec)(nil)).Elem()
+}
+
 type ArrayOfApplyProfile struct {
 	ApplyProfile []BaseApplyProfile `xml:"ApplyProfile,omitempty,typeattr"`
 }
@@ -1460,6 +1605,14 @@ type ArrayOfByte struct {
 
 func init() {
 	t["ArrayOfByte"] = reflect.TypeOf((*ArrayOfByte)(nil)).Elem()
+}
+
+type ArrayOfChangesInfoEventArgument struct {
+	ChangesInfoEventArgument []ChangesInfoEventArgument `xml:"ChangesInfoEventArgument,omitempty"`
+}
+
+func init() {
+	t["ArrayOfChangesInfoEventArgument"] = reflect.TypeOf((*ArrayOfChangesInfoEventArgument)(nil)).Elem()
 }
 
 type ArrayOfCheckResult struct {
@@ -1678,12 +1831,36 @@ func init() {
 	t["ArrayOfClusterRuleSpec"] = reflect.TypeOf((*ArrayOfClusterRuleSpec)(nil)).Elem()
 }
 
+type ArrayOfClusterVmOrchestrationInfo struct {
+	ClusterVmOrchestrationInfo []ClusterVmOrchestrationInfo `xml:"ClusterVmOrchestrationInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfClusterVmOrchestrationInfo"] = reflect.TypeOf((*ArrayOfClusterVmOrchestrationInfo)(nil)).Elem()
+}
+
+type ArrayOfClusterVmOrchestrationSpec struct {
+	ClusterVmOrchestrationSpec []ClusterVmOrchestrationSpec `xml:"ClusterVmOrchestrationSpec,omitempty"`
+}
+
+func init() {
+	t["ArrayOfClusterVmOrchestrationSpec"] = reflect.TypeOf((*ArrayOfClusterVmOrchestrationSpec)(nil)).Elem()
+}
+
 type ArrayOfComplianceFailure struct {
 	ComplianceFailure []ComplianceFailure `xml:"ComplianceFailure,omitempty"`
 }
 
 func init() {
 	t["ArrayOfComplianceFailure"] = reflect.TypeOf((*ArrayOfComplianceFailure)(nil)).Elem()
+}
+
+type ArrayOfComplianceFailureComplianceFailureValues struct {
+	ComplianceFailureComplianceFailureValues []ComplianceFailureComplianceFailureValues `xml:"ComplianceFailureComplianceFailureValues,omitempty"`
+}
+
+func init() {
+	t["ArrayOfComplianceFailureComplianceFailureValues"] = reflect.TypeOf((*ArrayOfComplianceFailureComplianceFailureValues)(nil)).Elem()
 }
 
 type ArrayOfComplianceLocator struct {
@@ -1716,6 +1893,46 @@ type ArrayOfConflictingConfigurationConfig struct {
 
 func init() {
 	t["ArrayOfConflictingConfigurationConfig"] = reflect.TypeOf((*ArrayOfConflictingConfigurationConfig)(nil)).Elem()
+}
+
+type ArrayOfCryptoKeyId struct {
+	CryptoKeyId []CryptoKeyId `xml:"CryptoKeyId,omitempty"`
+}
+
+func init() {
+	t["ArrayOfCryptoKeyId"] = reflect.TypeOf((*ArrayOfCryptoKeyId)(nil)).Elem()
+}
+
+type ArrayOfCryptoKeyPlain struct {
+	CryptoKeyPlain []CryptoKeyPlain `xml:"CryptoKeyPlain,omitempty"`
+}
+
+func init() {
+	t["ArrayOfCryptoKeyPlain"] = reflect.TypeOf((*ArrayOfCryptoKeyPlain)(nil)).Elem()
+}
+
+type ArrayOfCryptoKeyResult struct {
+	CryptoKeyResult []CryptoKeyResult `xml:"CryptoKeyResult,omitempty"`
+}
+
+func init() {
+	t["ArrayOfCryptoKeyResult"] = reflect.TypeOf((*ArrayOfCryptoKeyResult)(nil)).Elem()
+}
+
+type ArrayOfCryptoManagerKmipClusterStatus struct {
+	CryptoManagerKmipClusterStatus []CryptoManagerKmipClusterStatus `xml:"CryptoManagerKmipClusterStatus,omitempty"`
+}
+
+func init() {
+	t["ArrayOfCryptoManagerKmipClusterStatus"] = reflect.TypeOf((*ArrayOfCryptoManagerKmipClusterStatus)(nil)).Elem()
+}
+
+type ArrayOfCryptoManagerKmipServerStatus struct {
+	CryptoManagerKmipServerStatus []CryptoManagerKmipServerStatus `xml:"CryptoManagerKmipServerStatus,omitempty"`
+}
+
+func init() {
+	t["ArrayOfCryptoManagerKmipServerStatus"] = reflect.TypeOf((*ArrayOfCryptoManagerKmipServerStatus)(nil)).Elem()
 }
 
 type ArrayOfCustomFieldDef struct {
@@ -1836,6 +2053,14 @@ type ArrayOfDatastoreMountPathDatastorePair struct {
 
 func init() {
 	t["ArrayOfDatastoreMountPathDatastorePair"] = reflect.TypeOf((*ArrayOfDatastoreMountPathDatastorePair)(nil)).Elem()
+}
+
+type ArrayOfDatastoreVVolContainerFailoverPair struct {
+	DatastoreVVolContainerFailoverPair []DatastoreVVolContainerFailoverPair `xml:"DatastoreVVolContainerFailoverPair,omitempty"`
+}
+
+func init() {
+	t["ArrayOfDatastoreVVolContainerFailoverPair"] = reflect.TypeOf((*ArrayOfDatastoreVVolContainerFailoverPair)(nil)).Elem()
 }
 
 type ArrayOfDiagnosticManagerBundleInfo struct {
@@ -2390,6 +2615,22 @@ func init() {
 	t["ArrayOfHbrManagerVmReplicationCapability"] = reflect.TypeOf((*ArrayOfHbrManagerVmReplicationCapability)(nil)).Elem()
 }
 
+type ArrayOfHealthUpdate struct {
+	HealthUpdate []HealthUpdate `xml:"HealthUpdate,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHealthUpdate"] = reflect.TypeOf((*ArrayOfHealthUpdate)(nil)).Elem()
+}
+
+type ArrayOfHealthUpdateInfo struct {
+	HealthUpdateInfo []HealthUpdateInfo `xml:"HealthUpdateInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHealthUpdateInfo"] = reflect.TypeOf((*ArrayOfHealthUpdateInfo)(nil)).Elem()
+}
+
 type ArrayOfHostAccessControlEntry struct {
 	HostAccessControlEntry []HostAccessControlEntry `xml:"HostAccessControlEntry,omitempty"`
 }
@@ -2636,6 +2877,14 @@ type ArrayOfHostFirewallRulesetIpNetwork struct {
 
 func init() {
 	t["ArrayOfHostFirewallRulesetIpNetwork"] = reflect.TypeOf((*ArrayOfHostFirewallRulesetIpNetwork)(nil)).Elem()
+}
+
+type ArrayOfHostGraphicsConfigDeviceType struct {
+	HostGraphicsConfigDeviceType []HostGraphicsConfigDeviceType `xml:"HostGraphicsConfigDeviceType,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostGraphicsConfigDeviceType"] = reflect.TypeOf((*ArrayOfHostGraphicsConfigDeviceType)(nil)).Elem()
 }
 
 type ArrayOfHostGraphicsInfo struct {
@@ -3046,6 +3295,30 @@ func init() {
 	t["ArrayOfHostPowerPolicy"] = reflect.TypeOf((*ArrayOfHostPowerPolicy)(nil)).Elem()
 }
 
+type ArrayOfHostProfileManagerCompositionValidationResultResultElement struct {
+	HostProfileManagerCompositionValidationResultResultElement []HostProfileManagerCompositionValidationResultResultElement `xml:"HostProfileManagerCompositionValidationResultResultElement,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostProfileManagerCompositionValidationResultResultElement"] = reflect.TypeOf((*ArrayOfHostProfileManagerCompositionValidationResultResultElement)(nil)).Elem()
+}
+
+type ArrayOfHostProfileManagerHostToConfigSpecMap struct {
+	HostProfileManagerHostToConfigSpecMap []HostProfileManagerHostToConfigSpecMap `xml:"HostProfileManagerHostToConfigSpecMap,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostProfileManagerHostToConfigSpecMap"] = reflect.TypeOf((*ArrayOfHostProfileManagerHostToConfigSpecMap)(nil)).Elem()
+}
+
+type ArrayOfHostProfilesEntityCustomizations struct {
+	HostProfilesEntityCustomizations []BaseHostProfilesEntityCustomizations `xml:"HostProfilesEntityCustomizations,omitempty,typeattr"`
+}
+
+func init() {
+	t["ArrayOfHostProfilesEntityCustomizations"] = reflect.TypeOf((*ArrayOfHostProfilesEntityCustomizations)(nil)).Elem()
+}
+
 type ArrayOfHostProtocolEndpoint struct {
 	HostProtocolEndpoint []HostProtocolEndpoint `xml:"HostProtocolEndpoint,omitempty"`
 }
@@ -3150,6 +3423,14 @@ func init() {
 	t["ArrayOfHostSnmpDestination"] = reflect.TypeOf((*ArrayOfHostSnmpDestination)(nil)).Elem()
 }
 
+type ArrayOfHostSriovDevicePoolInfo struct {
+	HostSriovDevicePoolInfo []BaseHostSriovDevicePoolInfo `xml:"HostSriovDevicePoolInfo,omitempty,typeattr"`
+}
+
+func init() {
+	t["ArrayOfHostSriovDevicePoolInfo"] = reflect.TypeOf((*ArrayOfHostSriovDevicePoolInfo)(nil)).Elem()
+}
+
 type ArrayOfHostSslThumbprintInfo struct {
 	HostSslThumbprintInfo []HostSslThumbprintInfo `xml:"HostSslThumbprintInfo,omitempty"`
 }
@@ -3204,6 +3485,14 @@ type ArrayOfHostStorageSystemVmfsVolumeResult struct {
 
 func init() {
 	t["ArrayOfHostStorageSystemVmfsVolumeResult"] = reflect.TypeOf((*ArrayOfHostStorageSystemVmfsVolumeResult)(nil)).Elem()
+}
+
+type ArrayOfHostSubSpecification struct {
+	HostSubSpecification []HostSubSpecification `xml:"HostSubSpecification,omitempty"`
+}
+
+func init() {
+	t["ArrayOfHostSubSpecification"] = reflect.TypeOf((*ArrayOfHostSubSpecification)(nil)).Elem()
 }
 
 type ArrayOfHostSystemIdentificationInfo struct {
@@ -3414,6 +3703,14 @@ func init() {
 	t["ArrayOfHttpNfcLeaseManifestEntry"] = reflect.TypeOf((*ArrayOfHttpNfcLeaseManifestEntry)(nil)).Elem()
 }
 
+type ArrayOfID struct {
+	ID []ID `xml:"ID,omitempty"`
+}
+
+func init() {
+	t["ArrayOfID"] = reflect.TypeOf((*ArrayOfID)(nil)).Elem()
+}
+
 type ArrayOfImportOperationBulkFaultFaultOnImport struct {
 	ImportOperationBulkFaultFaultOnImport []ImportOperationBulkFaultFaultOnImport `xml:"ImportOperationBulkFaultFaultOnImport,omitempty"`
 }
@@ -3508,6 +3805,22 @@ type ArrayOfKeyValue struct {
 
 func init() {
 	t["ArrayOfKeyValue"] = reflect.TypeOf((*ArrayOfKeyValue)(nil)).Elem()
+}
+
+type ArrayOfKmipClusterInfo struct {
+	KmipClusterInfo []KmipClusterInfo `xml:"KmipClusterInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfKmipClusterInfo"] = reflect.TypeOf((*ArrayOfKmipClusterInfo)(nil)).Elem()
+}
+
+type ArrayOfKmipServerInfo struct {
+	KmipServerInfo []KmipServerInfo `xml:"KmipServerInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfKmipServerInfo"] = reflect.TypeOf((*ArrayOfKmipServerInfo)(nil)).Elem()
 }
 
 type ArrayOfLicenseAssignmentManagerLicenseAssignment struct {
@@ -4174,6 +4487,14 @@ func init() {
 	t["ArrayOfPropertySpec"] = reflect.TypeOf((*ArrayOfPropertySpec)(nil)).Elem()
 }
 
+type ArrayOfRelation struct {
+	Relation []Relation `xml:"Relation,omitempty"`
+}
+
+func init() {
+	t["ArrayOfRelation"] = reflect.TypeOf((*ArrayOfRelation)(nil)).Elem()
+}
+
 type ArrayOfReplicationInfoDiskSettings struct {
 	ReplicationInfoDiskSettings []ReplicationInfoDiskSettings `xml:"ReplicationInfoDiskSettings,omitempty"`
 }
@@ -4278,6 +4599,14 @@ func init() {
 	t["ArrayOfShort"] = reflect.TypeOf((*ArrayOfShort)(nil)).Elem()
 }
 
+type ArrayOfSoftwarePackage struct {
+	SoftwarePackage []SoftwarePackage `xml:"SoftwarePackage,omitempty"`
+}
+
+func init() {
+	t["ArrayOfSoftwarePackage"] = reflect.TypeOf((*ArrayOfSoftwarePackage)(nil)).Elem()
+}
+
 type ArrayOfStaticRouteProfile struct {
 	StaticRouteProfile []StaticRouteProfile `xml:"StaticRouteProfile,omitempty"`
 }
@@ -4342,6 +4671,22 @@ func init() {
 	t["ArrayOfString"] = reflect.TypeOf((*ArrayOfString)(nil)).Elem()
 }
 
+type ArrayOfStructuredCustomizations struct {
+	StructuredCustomizations []StructuredCustomizations `xml:"StructuredCustomizations,omitempty"`
+}
+
+func init() {
+	t["ArrayOfStructuredCustomizations"] = reflect.TypeOf((*ArrayOfStructuredCustomizations)(nil)).Elem()
+}
+
+type ArrayOfSystemEventInfo struct {
+	SystemEventInfo []SystemEventInfo `xml:"SystemEventInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfSystemEventInfo"] = reflect.TypeOf((*ArrayOfSystemEventInfo)(nil)).Elem()
+}
+
 type ArrayOfTag struct {
 	Tag []Tag `xml:"Tag,omitempty"`
 }
@@ -4382,12 +4727,28 @@ func init() {
 	t["ArrayOfUpdateVirtualMachineFilesResultFailedVmFileInfo"] = reflect.TypeOf((*ArrayOfUpdateVirtualMachineFilesResultFailedVmFileInfo)(nil)).Elem()
 }
 
+type ArrayOfUsbScanCodeSpecKeyEvent struct {
+	UsbScanCodeSpecKeyEvent []UsbScanCodeSpecKeyEvent `xml:"UsbScanCodeSpecKeyEvent,omitempty"`
+}
+
+func init() {
+	t["ArrayOfUsbScanCodeSpecKeyEvent"] = reflect.TypeOf((*ArrayOfUsbScanCodeSpecKeyEvent)(nil)).Elem()
+}
+
 type ArrayOfUserGroupProfile struct {
 	UserGroupProfile []UserGroupProfile `xml:"UserGroupProfile,omitempty"`
 }
 
 func init() {
 	t["ArrayOfUserGroupProfile"] = reflect.TypeOf((*ArrayOfUserGroupProfile)(nil)).Elem()
+}
+
+type ArrayOfUserPrivilegeResult struct {
+	UserPrivilegeResult []UserPrivilegeResult `xml:"UserPrivilegeResult,omitempty"`
+}
+
+func init() {
+	t["ArrayOfUserPrivilegeResult"] = reflect.TypeOf((*ArrayOfUserPrivilegeResult)(nil)).Elem()
 }
 
 type ArrayOfUserProfile struct {
@@ -4548,6 +4909,22 @@ type ArrayOfVVolHostPE struct {
 
 func init() {
 	t["ArrayOfVVolHostPE"] = reflect.TypeOf((*ArrayOfVVolHostPE)(nil)).Elem()
+}
+
+type ArrayOfVVolVmConfigFileUpdateResultFailedVmConfigFileInfo struct {
+	VVolVmConfigFileUpdateResultFailedVmConfigFileInfo []VVolVmConfigFileUpdateResultFailedVmConfigFileInfo `xml:"VVolVmConfigFileUpdateResultFailedVmConfigFileInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVVolVmConfigFileUpdateResultFailedVmConfigFileInfo"] = reflect.TypeOf((*ArrayOfVVolVmConfigFileUpdateResultFailedVmConfigFileInfo)(nil)).Elem()
+}
+
+type ArrayOfVchaNodeRuntimeInfo struct {
+	VchaNodeRuntimeInfo []VchaNodeRuntimeInfo `xml:"VchaNodeRuntimeInfo,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVchaNodeRuntimeInfo"] = reflect.TypeOf((*ArrayOfVchaNodeRuntimeInfo)(nil)).Elem()
 }
 
 type ArrayOfVimVasaProviderInfo struct {
@@ -4998,6 +5375,14 @@ func init() {
 	t["ArrayOfVmPortGroupProfile"] = reflect.TypeOf((*ArrayOfVmPortGroupProfile)(nil)).Elem()
 }
 
+type ArrayOfVmfsConfigOption struct {
+	VmfsConfigOption []VmfsConfigOption `xml:"VmfsConfigOption,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVmfsConfigOption"] = reflect.TypeOf((*ArrayOfVmfsConfigOption)(nil)).Elem()
+}
+
 type ArrayOfVmfsDatastoreOption struct {
 	VmfsDatastoreOption []VmfsDatastoreOption `xml:"VmfsDatastoreOption,omitempty"`
 }
@@ -5126,6 +5511,14 @@ func init() {
 	t["ArrayOfVsanUpgradeSystemUpgradeHistoryItem"] = reflect.TypeOf((*ArrayOfVsanUpgradeSystemUpgradeHistoryItem)(nil)).Elem()
 }
 
+type ArrayOfVslmTagEntry struct {
+	VslmTagEntry []VslmTagEntry `xml:"VslmTagEntry,omitempty"`
+}
+
+func init() {
+	t["ArrayOfVslmTagEntry"] = reflect.TypeOf((*ArrayOfVslmTagEntry)(nil)).Elem()
+}
+
 type ArrayUpdateSpec struct {
 	DynamicData
 
@@ -5174,6 +5567,28 @@ func init() {
 type AssociateProfileResponse struct {
 }
 
+type AttachDiskRequestType struct {
+	This          ManagedObjectReference `xml:"_this"`
+	DiskId        ID                     `xml:"diskId"`
+	Datastore     ManagedObjectReference `xml:"datastore"`
+	ControllerKey int32                  `xml:"controllerKey,omitempty"`
+	UnitNumber    *int32                 `xml:"unitNumber"`
+}
+
+func init() {
+	t["AttachDiskRequestType"] = reflect.TypeOf((*AttachDiskRequestType)(nil)).Elem()
+}
+
+type AttachDisk_Task AttachDiskRequestType
+
+func init() {
+	t["AttachDisk_Task"] = reflect.TypeOf((*AttachDisk_Task)(nil)).Elem()
+}
+
+type AttachDisk_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type AttachScsiLun AttachScsiLunRequestType
 
 func init() {
@@ -5209,6 +5624,26 @@ func init() {
 }
 
 type AttachScsiLunResponse struct {
+}
+
+type AttachTagToVStorageObject AttachTagToVStorageObjectRequestType
+
+func init() {
+	t["AttachTagToVStorageObject"] = reflect.TypeOf((*AttachTagToVStorageObject)(nil)).Elem()
+}
+
+type AttachTagToVStorageObjectRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	Id       ID                     `xml:"id"`
+	Category string                 `xml:"category"`
+	Tag      string                 `xml:"tag"`
+}
+
+func init() {
+	t["AttachTagToVStorageObjectRequestType"] = reflect.TypeOf((*AttachTagToVStorageObjectRequestType)(nil)).Elem()
+}
+
+type AttachTagToVStorageObjectResponse struct {
 }
 
 type AttachVmfsExtent AttachVmfsExtentRequestType
@@ -5426,6 +5861,63 @@ type BadUsernameSessionEvent struct {
 
 func init() {
 	t["BadUsernameSessionEvent"] = reflect.TypeOf((*BadUsernameSessionEvent)(nil)).Elem()
+}
+
+type BaseConfigInfo struct {
+	DynamicData
+
+	Id         ID                            `xml:"id"`
+	Name       string                        `xml:"name"`
+	CreateTime time.Time                     `xml:"createTime"`
+	Backing    BaseBaseConfigInfoBackingInfo `xml:"backing,typeattr"`
+}
+
+func init() {
+	t["BaseConfigInfo"] = reflect.TypeOf((*BaseConfigInfo)(nil)).Elem()
+}
+
+type BaseConfigInfoBackingInfo struct {
+	DynamicData
+
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["BaseConfigInfoBackingInfo"] = reflect.TypeOf((*BaseConfigInfoBackingInfo)(nil)).Elem()
+}
+
+type BaseConfigInfoDiskFileBackingInfo struct {
+	BaseConfigInfoFileBackingInfo
+
+	ProvisioningType string `xml:"provisioningType"`
+}
+
+func init() {
+	t["BaseConfigInfoDiskFileBackingInfo"] = reflect.TypeOf((*BaseConfigInfoDiskFileBackingInfo)(nil)).Elem()
+}
+
+type BaseConfigInfoFileBackingInfo struct {
+	BaseConfigInfoBackingInfo
+
+	FilePath        string                            `xml:"filePath"`
+	BackingObjectId string                            `xml:"backingObjectId,omitempty"`
+	Parent          BaseBaseConfigInfoFileBackingInfo `xml:"parent,omitempty,typeattr"`
+	DeltaSizeInMB   int64                             `xml:"deltaSizeInMB,omitempty"`
+}
+
+func init() {
+	t["BaseConfigInfoFileBackingInfo"] = reflect.TypeOf((*BaseConfigInfoFileBackingInfo)(nil)).Elem()
+}
+
+type BaseConfigInfoRawDiskMappingBackingInfo struct {
+	BaseConfigInfoFileBackingInfo
+
+	LunUuid           string `xml:"lunUuid"`
+	CompatibilityMode string `xml:"compatibilityMode"`
+}
+
+func init() {
+	t["BaseConfigInfoRawDiskMappingBackingInfo"] = reflect.TypeOf((*BaseConfigInfoRawDiskMappingBackingInfo)(nil)).Elem()
 }
 
 type BatchResult struct {
@@ -5918,20 +6410,6 @@ func init() {
 	t["CannotDeleteFileFault"] = reflect.TypeOf((*CannotDeleteFileFault)(nil)).Elem()
 }
 
-type CannotDisableDrsOnClusterManagedByVDC struct {
-	RuntimeFault
-}
-
-func init() {
-	t["CannotDisableDrsOnClusterManagedByVDC"] = reflect.TypeOf((*CannotDisableDrsOnClusterManagedByVDC)(nil)).Elem()
-}
-
-type CannotDisableDrsOnClusterManagedByVDCFault CannotDisableDrsOnClusterManagedByVDC
-
-func init() {
-	t["CannotDisableDrsOnClusterManagedByVDCFault"] = reflect.TypeOf((*CannotDisableDrsOnClusterManagedByVDCFault)(nil)).Elem()
-}
-
 type CannotDisableDrsOnClustersWithVApps struct {
 	RuntimeFault
 }
@@ -6317,6 +6795,18 @@ func init() {
 type ChangeOwnerResponse struct {
 }
 
+type ChangesInfoEventArgument struct {
+	DynamicData
+
+	Modified string `xml:"modified,omitempty"`
+	Added    string `xml:"added,omitempty"`
+	Deleted  string `xml:"deleted,omitempty"`
+}
+
+func init() {
+	t["ChangesInfoEventArgument"] = reflect.TypeOf((*ChangesInfoEventArgument)(nil)).Elem()
+}
+
 type CheckAddHostEvcRequestType struct {
 	This    ManagedObjectReference `xml:"_this"`
 	CnxSpec HostConnectSpec        `xml:"cnxSpec"`
@@ -6635,6 +7125,23 @@ func init() {
 type ClearNFSUserResponse struct {
 }
 
+type ClearSystemEventLog ClearSystemEventLogRequestType
+
+func init() {
+	t["ClearSystemEventLog"] = reflect.TypeOf((*ClearSystemEventLog)(nil)).Elem()
+}
+
+type ClearSystemEventLogRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["ClearSystemEventLogRequestType"] = reflect.TypeOf((*ClearSystemEventLogRequestType)(nil)).Elem()
+}
+
+type ClearSystemEventLogResponse struct {
+}
+
 type ClockSkew struct {
 	HostConfigFault
 }
@@ -6721,6 +7228,27 @@ func init() {
 }
 
 type CloneVM_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type CloneVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+	Spec      VslmCloneSpec          `xml:"spec"`
+}
+
+func init() {
+	t["CloneVStorageObjectRequestType"] = reflect.TypeOf((*CloneVStorageObjectRequestType)(nil)).Elem()
+}
+
+type CloneVStorageObject_Task CloneVStorageObjectRequestType
+
+func init() {
+	t["CloneVStorageObject_Task"] = reflect.TypeOf((*CloneVStorageObject_Task)(nil)).Elem()
+}
+
+type CloneVStorageObject_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
@@ -6840,16 +7368,20 @@ func init() {
 type ClusterConfigInfoEx struct {
 	ComputeResourceConfigInfo
 
-	DasConfig      ClusterDasConfigInfo       `xml:"dasConfig"`
-	DasVmConfig    []ClusterDasVmConfigInfo   `xml:"dasVmConfig,omitempty"`
-	DrsConfig      ClusterDrsConfigInfo       `xml:"drsConfig"`
-	DrsVmConfig    []ClusterDrsVmConfigInfo   `xml:"drsVmConfig,omitempty"`
-	Rule           []BaseClusterRuleInfo      `xml:"rule,omitempty,typeattr"`
-	DpmConfigInfo  *ClusterDpmConfigInfo      `xml:"dpmConfigInfo,omitempty"`
-	DpmHostConfig  []ClusterDpmHostConfigInfo `xml:"dpmHostConfig,omitempty"`
-	VsanConfigInfo *VsanClusterConfigInfo     `xml:"vsanConfigInfo,omitempty"`
-	VsanHostConfig []VsanHostConfigInfo       `xml:"vsanHostConfig,omitempty"`
-	Group          []BaseClusterGroupInfo     `xml:"group,omitempty,typeattr"`
+	DasConfig           ClusterDasConfigInfo            `xml:"dasConfig"`
+	DasVmConfig         []ClusterDasVmConfigInfo        `xml:"dasVmConfig,omitempty"`
+	DrsConfig           ClusterDrsConfigInfo            `xml:"drsConfig"`
+	DrsVmConfig         []ClusterDrsVmConfigInfo        `xml:"drsVmConfig,omitempty"`
+	Rule                []BaseClusterRuleInfo           `xml:"rule,omitempty,typeattr"`
+	Orchestration       *ClusterOrchestrationInfo       `xml:"orchestration,omitempty"`
+	VmOrchestration     []ClusterVmOrchestrationInfo    `xml:"vmOrchestration,omitempty"`
+	DpmConfigInfo       *ClusterDpmConfigInfo           `xml:"dpmConfigInfo,omitempty"`
+	DpmHostConfig       []ClusterDpmHostConfigInfo      `xml:"dpmHostConfig,omitempty"`
+	VsanConfigInfo      *VsanClusterConfigInfo          `xml:"vsanConfigInfo,omitempty"`
+	VsanHostConfig      []VsanHostConfigInfo            `xml:"vsanHostConfig,omitempty"`
+	Group               []BaseClusterGroupInfo          `xml:"group,omitempty,typeattr"`
+	InfraUpdateHaConfig *ClusterInfraUpdateHaConfigInfo `xml:"infraUpdateHaConfig,omitempty"`
+	ProactiveDrsConfig  *ClusterProactiveDrsConfigInfo  `xml:"proactiveDrsConfig,omitempty"`
 }
 
 func init() {
@@ -6873,16 +7405,20 @@ func init() {
 type ClusterConfigSpecEx struct {
 	ComputeResourceConfigSpec
 
-	DasConfig          *ClusterDasConfigInfo      `xml:"dasConfig,omitempty"`
-	DasVmConfigSpec    []ClusterDasVmConfigSpec   `xml:"dasVmConfigSpec,omitempty"`
-	DrsConfig          *ClusterDrsConfigInfo      `xml:"drsConfig,omitempty"`
-	DrsVmConfigSpec    []ClusterDrsVmConfigSpec   `xml:"drsVmConfigSpec,omitempty"`
-	RulesSpec          []ClusterRuleSpec          `xml:"rulesSpec,omitempty"`
-	DpmConfig          *ClusterDpmConfigInfo      `xml:"dpmConfig,omitempty"`
-	DpmHostConfigSpec  []ClusterDpmHostConfigSpec `xml:"dpmHostConfigSpec,omitempty"`
-	VsanConfig         *VsanClusterConfigInfo     `xml:"vsanConfig,omitempty"`
-	VsanHostConfigSpec []VsanHostConfigInfo       `xml:"vsanHostConfigSpec,omitempty"`
-	GroupSpec          []ClusterGroupSpec         `xml:"groupSpec,omitempty"`
+	DasConfig           *ClusterDasConfigInfo           `xml:"dasConfig,omitempty"`
+	DasVmConfigSpec     []ClusterDasVmConfigSpec        `xml:"dasVmConfigSpec,omitempty"`
+	DrsConfig           *ClusterDrsConfigInfo           `xml:"drsConfig,omitempty"`
+	DrsVmConfigSpec     []ClusterDrsVmConfigSpec        `xml:"drsVmConfigSpec,omitempty"`
+	RulesSpec           []ClusterRuleSpec               `xml:"rulesSpec,omitempty"`
+	Orchestration       *ClusterOrchestrationInfo       `xml:"orchestration,omitempty"`
+	VmOrchestrationSpec []ClusterVmOrchestrationSpec    `xml:"vmOrchestrationSpec,omitempty"`
+	DpmConfig           *ClusterDpmConfigInfo           `xml:"dpmConfig,omitempty"`
+	DpmHostConfigSpec   []ClusterDpmHostConfigSpec      `xml:"dpmHostConfigSpec,omitempty"`
+	VsanConfig          *VsanClusterConfigInfo          `xml:"vsanConfig,omitempty"`
+	VsanHostConfigSpec  []VsanHostConfigInfo            `xml:"vsanHostConfigSpec,omitempty"`
+	GroupSpec           []ClusterGroupSpec              `xml:"groupSpec,omitempty"`
+	InfraUpdateHaConfig *ClusterInfraUpdateHaConfigInfo `xml:"infraUpdateHaConfig,omitempty"`
+	ProactiveDrsConfig  *ClusterProactiveDrsConfigInfo  `xml:"proactiveDrsConfig,omitempty"`
 }
 
 func init() {
@@ -6933,6 +7469,8 @@ func init() {
 
 type ClusterDasAdmissionControlPolicy struct {
 	DynamicData
+
+	ResourceReductionToToleratePercent int32 `xml:"resourceReductionToToleratePercent,omitempty"`
 }
 
 func init() {
@@ -7111,6 +7649,7 @@ type ClusterDasVmSettings struct {
 	DynamicData
 
 	RestartPriority               string                                `xml:"restartPriority,omitempty"`
+	RestartPriorityTimeout        int32                                 `xml:"restartPriorityTimeout,omitempty"`
 	IsolationResponse             string                                `xml:"isolationResponse,omitempty"`
 	VmToolsMonitoringSettings     *ClusterVmToolsMonitoringSettings     `xml:"vmToolsMonitoringSettings,omitempty"`
 	VmComponentProtectionSettings *ClusterVmComponentProtectionSettings `xml:"vmComponentProtectionSettings,omitempty"`
@@ -7118,6 +7657,17 @@ type ClusterDasVmSettings struct {
 
 func init() {
 	t["ClusterDasVmSettings"] = reflect.TypeOf((*ClusterDasVmSettings)(nil)).Elem()
+}
+
+type ClusterDependencyRuleInfo struct {
+	ClusterRuleInfo
+
+	VmGroup          string `xml:"vmGroup"`
+	DependsOnVmGroup string `xml:"dependsOnVmGroup"`
+}
+
+func init() {
+	t["ClusterDependencyRuleInfo"] = reflect.TypeOf((*ClusterDependencyRuleInfo)(nil)).Elem()
 }
 
 type ClusterDestroyedEvent struct {
@@ -7356,6 +7906,7 @@ type ClusterFailoverHostAdmissionControlPolicy struct {
 	ClusterDasAdmissionControlPolicy
 
 	FailoverHosts []ManagedObjectReference `xml:"failoverHosts,omitempty"`
+	FailoverLevel int32                    `xml:"failoverLevel,omitempty"`
 }
 
 func init() {
@@ -7399,6 +7950,8 @@ type ClusterFailoverResourcesAdmissionControlPolicy struct {
 
 	CpuFailoverResourcesPercent    int32 `xml:"cpuFailoverResourcesPercent"`
 	MemoryFailoverResourcesPercent int32 `xml:"memoryFailoverResourcesPercent"`
+	FailoverLevel                  int32 `xml:"failoverLevel,omitempty"`
+	AutoComputePercentages         *bool `xml:"autoComputePercentages"`
 }
 
 func init() {
@@ -7448,6 +8001,16 @@ func init() {
 	t["ClusterHostGroup"] = reflect.TypeOf((*ClusterHostGroup)(nil)).Elem()
 }
 
+type ClusterHostInfraUpdateHaModeAction struct {
+	ClusterAction
+
+	OperationType string `xml:"operationType"`
+}
+
+func init() {
+	t["ClusterHostInfraUpdateHaModeAction"] = reflect.TypeOf((*ClusterHostInfraUpdateHaModeAction)(nil)).Elem()
+}
+
 type ClusterHostPowerAction struct {
 	ClusterAction
 
@@ -7472,6 +8035,20 @@ func init() {
 	t["ClusterHostRecommendation"] = reflect.TypeOf((*ClusterHostRecommendation)(nil)).Elem()
 }
 
+type ClusterInfraUpdateHaConfigInfo struct {
+	DynamicData
+
+	Enabled             *bool    `xml:"enabled"`
+	Behavior            string   `xml:"behavior,omitempty"`
+	ModerateRemediation string   `xml:"moderateRemediation,omitempty"`
+	SevereRemediation   string   `xml:"severeRemediation,omitempty"`
+	Providers           []string `xml:"providers,omitempty"`
+}
+
+func init() {
+	t["ClusterInfraUpdateHaConfigInfo"] = reflect.TypeOf((*ClusterInfraUpdateHaConfigInfo)(nil)).Elem()
+}
+
 type ClusterInitialPlacementAction struct {
 	ClusterAction
 
@@ -7487,6 +8064,7 @@ type ClusterIoFilterInfo struct {
 	IoFilterInfo
 
 	OpType string `xml:"opType"`
+	VibUrl string `xml:"vibUrl,omitempty"`
 }
 
 func init() {
@@ -7503,6 +8081,17 @@ func init() {
 	t["ClusterMigrationAction"] = reflect.TypeOf((*ClusterMigrationAction)(nil)).Elem()
 }
 
+type ClusterNetworkConfigSpec struct {
+	DynamicData
+
+	NetworkPortGroup ManagedObjectReference  `xml:"networkPortGroup"`
+	IpSettings       CustomizationIPSettings `xml:"ipSettings"`
+}
+
+func init() {
+	t["ClusterNetworkConfigSpec"] = reflect.TypeOf((*ClusterNetworkConfigSpec)(nil)).Elem()
+}
+
 type ClusterNotAttemptedVmInfo struct {
 	DynamicData
 
@@ -7512,6 +8101,16 @@ type ClusterNotAttemptedVmInfo struct {
 
 func init() {
 	t["ClusterNotAttemptedVmInfo"] = reflect.TypeOf((*ClusterNotAttemptedVmInfo)(nil)).Elem()
+}
+
+type ClusterOrchestrationInfo struct {
+	DynamicData
+
+	DefaultVmReadiness *ClusterVmReadiness `xml:"defaultVmReadiness,omitempty"`
+}
+
+func init() {
+	t["ClusterOrchestrationInfo"] = reflect.TypeOf((*ClusterOrchestrationInfo)(nil)).Elem()
 }
 
 type ClusterOvercommittedEvent struct {
@@ -7532,6 +8131,16 @@ type ClusterPowerOnVmResult struct {
 
 func init() {
 	t["ClusterPowerOnVmResult"] = reflect.TypeOf((*ClusterPowerOnVmResult)(nil)).Elem()
+}
+
+type ClusterProactiveDrsConfigInfo struct {
+	DynamicData
+
+	Enabled *bool `xml:"enabled"`
+}
+
+func init() {
+	t["ClusterProactiveDrsConfigInfo"] = reflect.TypeOf((*ClusterProactiveDrsConfigInfo)(nil)).Elem()
 }
 
 type ClusterProfileCompleteConfigSpec struct {
@@ -7602,6 +8211,8 @@ func init() {
 
 type ClusterReconfiguredEvent struct {
 	ClusterEvent
+
+	ConfigChanges *ChangesInfoEventArgument `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -7727,6 +8338,38 @@ func init() {
 	t["ClusterVmHostRuleInfo"] = reflect.TypeOf((*ClusterVmHostRuleInfo)(nil)).Elem()
 }
 
+type ClusterVmOrchestrationInfo struct {
+	DynamicData
+
+	Vm          ManagedObjectReference `xml:"vm"`
+	VmReadiness ClusterVmReadiness     `xml:"vmReadiness"`
+}
+
+func init() {
+	t["ClusterVmOrchestrationInfo"] = reflect.TypeOf((*ClusterVmOrchestrationInfo)(nil)).Elem()
+}
+
+type ClusterVmOrchestrationSpec struct {
+	ArrayUpdateSpec
+
+	Info *ClusterVmOrchestrationInfo `xml:"info,omitempty"`
+}
+
+func init() {
+	t["ClusterVmOrchestrationSpec"] = reflect.TypeOf((*ClusterVmOrchestrationSpec)(nil)).Elem()
+}
+
+type ClusterVmReadiness struct {
+	DynamicData
+
+	ReadyCondition string `xml:"readyCondition,omitempty"`
+	PostReadyDelay int32  `xml:"postReadyDelay,omitempty"`
+}
+
+func init() {
+	t["ClusterVmReadiness"] = reflect.TypeOf((*ClusterVmReadiness)(nil)).Elem()
+}
+
 type ClusterVmToolsMonitoringSettings struct {
 	DynamicData
 
@@ -7760,13 +8403,27 @@ func init() {
 type ComplianceFailure struct {
 	DynamicData
 
-	FailureType    string             `xml:"failureType"`
-	Message        LocalizableMessage `xml:"message"`
-	ExpressionName string             `xml:"expressionName,omitempty"`
+	FailureType    string                                     `xml:"failureType"`
+	Message        LocalizableMessage                         `xml:"message"`
+	ExpressionName string                                     `xml:"expressionName,omitempty"`
+	FailureValues  []ComplianceFailureComplianceFailureValues `xml:"failureValues,omitempty"`
 }
 
 func init() {
 	t["ComplianceFailure"] = reflect.TypeOf((*ComplianceFailure)(nil)).Elem()
+}
+
+type ComplianceFailureComplianceFailureValues struct {
+	DynamicData
+
+	ComparisonIdentifier string  `xml:"comparisonIdentifier"`
+	ProfileInstance      string  `xml:"profileInstance,omitempty"`
+	HostValue            AnyType `xml:"hostValue,omitempty,typeattr"`
+	ProfileValue         AnyType `xml:"profileValue,omitempty,typeattr"`
+}
+
+func init() {
+	t["ComplianceFailureComplianceFailureValues"] = reflect.TypeOf((*ComplianceFailureComplianceFailureValues)(nil)).Elem()
 }
 
 type ComplianceLocator struct {
@@ -7967,6 +8624,24 @@ type ConfigTarget struct {
 
 func init() {
 	t["ConfigTarget"] = reflect.TypeOf((*ConfigTarget)(nil)).Elem()
+}
+
+type ConfigureCryptoKey ConfigureCryptoKeyRequestType
+
+func init() {
+	t["ConfigureCryptoKey"] = reflect.TypeOf((*ConfigureCryptoKey)(nil)).Elem()
+}
+
+type ConfigureCryptoKeyRequestType struct {
+	This  ManagedObjectReference `xml:"_this"`
+	KeyId *CryptoKeyId           `xml:"keyId,omitempty"`
+}
+
+func init() {
+	t["ConfigureCryptoKeyRequestType"] = reflect.TypeOf((*ConfigureCryptoKeyRequestType)(nil)).Elem()
+}
+
+type ConfigureCryptoKeyResponse struct {
 }
 
 type ConfigureDatastoreIORMRequestType struct {
@@ -8219,6 +8894,26 @@ func init() {
 
 type ContinueRetrievePropertiesExResponse struct {
 	Returnval RetrieveResult `xml:"returnval"`
+}
+
+type ConvertNamespacePathToUuidPath ConvertNamespacePathToUuidPathRequestType
+
+func init() {
+	t["ConvertNamespacePathToUuidPath"] = reflect.TypeOf((*ConvertNamespacePathToUuidPath)(nil)).Elem()
+}
+
+type ConvertNamespacePathToUuidPathRequestType struct {
+	This         ManagedObjectReference  `xml:"_this"`
+	Datacenter   *ManagedObjectReference `xml:"datacenter,omitempty"`
+	NamespaceUrl string                  `xml:"namespaceUrl"`
+}
+
+func init() {
+	t["ConvertNamespacePathToUuidPathRequestType"] = reflect.TypeOf((*ConvertNamespacePathToUuidPathRequestType)(nil)).Elem()
+}
+
+type ConvertNamespacePathToUuidPathResponse struct {
+	Returnval string `xml:"returnval"`
 }
 
 type CopyDatastoreFileRequestType struct {
@@ -8654,6 +9349,25 @@ type CreateDirectoryResponse struct {
 	Returnval string `xml:"returnval"`
 }
 
+type CreateDiskRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Spec VslmCreateSpec         `xml:"spec"`
+}
+
+func init() {
+	t["CreateDiskRequestType"] = reflect.TypeOf((*CreateDiskRequestType)(nil)).Elem()
+}
+
+type CreateDisk_Task CreateDiskRequestType
+
+func init() {
+	t["CreateDisk_Task"] = reflect.TypeOf((*CreateDisk_Task)(nil)).Elem()
+}
+
+type CreateDisk_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type CreateFilter CreateFilterRequestType
 
 func init() {
@@ -9042,6 +9756,28 @@ type CreateSecondaryVM_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type CreateSnapshotExRequestType struct {
+	This        ManagedObjectReference             `xml:"_this"`
+	Name        string                             `xml:"name"`
+	Description string                             `xml:"description,omitempty"`
+	Memory      bool                               `xml:"memory"`
+	QuiesceSpec BaseVirtualMachineGuestQuiesceSpec `xml:"quiesceSpec,omitempty,typeattr"`
+}
+
+func init() {
+	t["CreateSnapshotExRequestType"] = reflect.TypeOf((*CreateSnapshotExRequestType)(nil)).Elem()
+}
+
+type CreateSnapshotEx_Task CreateSnapshotExRequestType
+
+func init() {
+	t["CreateSnapshotEx_Task"] = reflect.TypeOf((*CreateSnapshotEx_Task)(nil)).Elem()
+}
+
+type CreateSnapshotEx_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type CreateSnapshotRequestType struct {
 	This        ManagedObjectReference `xml:"_this"`
 	Name        string                 `xml:"name"`
@@ -9284,6 +10020,162 @@ type CreateVvolDatastoreResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type CryptoKeyId struct {
+	DynamicData
+
+	KeyId      string         `xml:"keyId"`
+	ProviderId *KeyProviderId `xml:"providerId,omitempty"`
+}
+
+func init() {
+	t["CryptoKeyId"] = reflect.TypeOf((*CryptoKeyId)(nil)).Elem()
+}
+
+type CryptoKeyPlain struct {
+	DynamicData
+
+	KeyId     CryptoKeyId `xml:"keyId"`
+	Algorithm string      `xml:"algorithm"`
+	KeyData   string      `xml:"keyData"`
+}
+
+func init() {
+	t["CryptoKeyPlain"] = reflect.TypeOf((*CryptoKeyPlain)(nil)).Elem()
+}
+
+type CryptoKeyResult struct {
+	DynamicData
+
+	KeyId   CryptoKeyId `xml:"keyId"`
+	Success bool        `xml:"success"`
+	Reason  string      `xml:"reason,omitempty"`
+}
+
+func init() {
+	t["CryptoKeyResult"] = reflect.TypeOf((*CryptoKeyResult)(nil)).Elem()
+}
+
+type CryptoManagerKmipCertificateInfo struct {
+	DynamicData
+
+	Subject             string    `xml:"subject"`
+	Issuer              string    `xml:"issuer"`
+	SerialNumber        string    `xml:"serialNumber"`
+	NotBefore           time.Time `xml:"notBefore"`
+	NotAfter            time.Time `xml:"notAfter"`
+	Fingerprint         string    `xml:"fingerprint"`
+	CheckTime           time.Time `xml:"checkTime"`
+	SecondsSinceValid   int32     `xml:"secondsSinceValid,omitempty"`
+	SecondsBeforeExpire int32     `xml:"secondsBeforeExpire,omitempty"`
+}
+
+func init() {
+	t["CryptoManagerKmipCertificateInfo"] = reflect.TypeOf((*CryptoManagerKmipCertificateInfo)(nil)).Elem()
+}
+
+type CryptoManagerKmipClusterStatus struct {
+	DynamicData
+
+	ClusterId      KeyProviderId                     `xml:"clusterId"`
+	Servers        []CryptoManagerKmipServerStatus   `xml:"servers"`
+	ClientCertInfo *CryptoManagerKmipCertificateInfo `xml:"clientCertInfo,omitempty"`
+}
+
+func init() {
+	t["CryptoManagerKmipClusterStatus"] = reflect.TypeOf((*CryptoManagerKmipClusterStatus)(nil)).Elem()
+}
+
+type CryptoManagerKmipServerCertInfo struct {
+	DynamicData
+
+	Certificate       string                            `xml:"certificate"`
+	CertInfo          *CryptoManagerKmipCertificateInfo `xml:"certInfo,omitempty"`
+	ClientTrustServer *bool                             `xml:"clientTrustServer"`
+}
+
+func init() {
+	t["CryptoManagerKmipServerCertInfo"] = reflect.TypeOf((*CryptoManagerKmipServerCertInfo)(nil)).Elem()
+}
+
+type CryptoManagerKmipServerStatus struct {
+	DynamicData
+
+	Name              string                            `xml:"name"`
+	Status            ManagedEntityStatus               `xml:"status"`
+	ConnectionStatus  string                            `xml:"connectionStatus"`
+	CertInfo          *CryptoManagerKmipCertificateInfo `xml:"certInfo,omitempty"`
+	ClientTrustServer *bool                             `xml:"clientTrustServer"`
+	ServerTrustClient *bool                             `xml:"serverTrustClient"`
+}
+
+func init() {
+	t["CryptoManagerKmipServerStatus"] = reflect.TypeOf((*CryptoManagerKmipServerStatus)(nil)).Elem()
+}
+
+type CryptoSpec struct {
+	DynamicData
+}
+
+func init() {
+	t["CryptoSpec"] = reflect.TypeOf((*CryptoSpec)(nil)).Elem()
+}
+
+type CryptoSpecDecrypt struct {
+	CryptoSpec
+}
+
+func init() {
+	t["CryptoSpecDecrypt"] = reflect.TypeOf((*CryptoSpecDecrypt)(nil)).Elem()
+}
+
+type CryptoSpecDeepRecrypt struct {
+	CryptoSpec
+
+	NewKeyId CryptoKeyId `xml:"newKeyId"`
+}
+
+func init() {
+	t["CryptoSpecDeepRecrypt"] = reflect.TypeOf((*CryptoSpecDeepRecrypt)(nil)).Elem()
+}
+
+type CryptoSpecEncrypt struct {
+	CryptoSpec
+
+	CryptoKeyId CryptoKeyId `xml:"cryptoKeyId"`
+}
+
+func init() {
+	t["CryptoSpecEncrypt"] = reflect.TypeOf((*CryptoSpecEncrypt)(nil)).Elem()
+}
+
+type CryptoSpecNoOp struct {
+	CryptoSpec
+}
+
+func init() {
+	t["CryptoSpecNoOp"] = reflect.TypeOf((*CryptoSpecNoOp)(nil)).Elem()
+}
+
+type CryptoSpecRegister struct {
+	CryptoSpecNoOp
+
+	CryptoKeyId CryptoKeyId `xml:"cryptoKeyId"`
+}
+
+func init() {
+	t["CryptoSpecRegister"] = reflect.TypeOf((*CryptoSpecRegister)(nil)).Elem()
+}
+
+type CryptoSpecShallowRecrypt struct {
+	CryptoSpec
+
+	NewKeyId CryptoKeyId `xml:"newKeyId"`
+}
+
+func init() {
+	t["CryptoSpecShallowRecrypt"] = reflect.TypeOf((*CryptoSpecShallowRecrypt)(nil)).Elem()
+}
+
 type CurrentTime CurrentTimeRequestType
 
 func init() {
@@ -9385,10 +10277,11 @@ func init() {
 type CustomFieldValueChangedEvent struct {
 	CustomFieldEvent
 
-	Entity   ManagedEntityEventArgument `xml:"entity"`
-	FieldKey int32                      `xml:"fieldKey"`
-	Name     string                     `xml:"name"`
-	Value    string                     `xml:"value"`
+	Entity    ManagedEntityEventArgument `xml:"entity"`
+	FieldKey  int32                      `xml:"fieldKey"`
+	Name      string                     `xml:"name"`
+	Value     string                     `xml:"value"`
+	PrevState string                     `xml:"prevState,omitempty"`
 }
 
 func init() {
@@ -10033,6 +10926,7 @@ type DVPortgroupConfigInfo struct {
 	ConfigVersion                string                                    `xml:"configVersion,omitempty"`
 	AutoExpand                   *bool                                     `xml:"autoExpand"`
 	VmVnicNetworkResourcePoolKey string                                    `xml:"vmVnicNetworkResourcePoolKey,omitempty"`
+	Uplink                       *bool                                     `xml:"uplink"`
 }
 
 func init() {
@@ -10103,7 +10997,8 @@ func init() {
 type DVPortgroupReconfiguredEvent struct {
 	DVPortgroupEvent
 
-	ConfigSpec DVPortgroupConfigSpec `xml:"configSpec"`
+	ConfigSpec    DVPortgroupConfigSpec     `xml:"configSpec"`
+	ConfigChanges *ChangesInfoEventArgument `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -10845,6 +11740,9 @@ type DatastoreCapability struct {
 	NativeSnapshotSupported          *bool `xml:"nativeSnapshotSupported"`
 	TopLevelDirectoryCreateSupported *bool `xml:"topLevelDirectoryCreateSupported"`
 	SeSparseSupported                *bool `xml:"seSparseSupported"`
+	VmfsSparseSupported              *bool `xml:"vmfsSparseSupported"`
+	VsanSparseSupported              *bool `xml:"vsanSparseSupported"`
+	UpitSupported                    *bool `xml:"upitSupported"`
 }
 
 func init() {
@@ -10966,7 +11864,9 @@ func init() {
 type DatastoreFileEvent struct {
 	DatastoreEvent
 
-	TargetFile string `xml:"targetFile"`
+	TargetFile        string `xml:"targetFile"`
+	SourceOfOperation string `xml:"sourceOfOperation,omitempty"`
+	Succeeded         *bool  `xml:"succeeded"`
 }
 
 func init() {
@@ -11116,6 +12016,18 @@ type DatastoreSummary struct {
 
 func init() {
 	t["DatastoreSummary"] = reflect.TypeOf((*DatastoreSummary)(nil)).Elem()
+}
+
+type DatastoreVVolContainerFailoverPair struct {
+	DynamicData
+
+	SrcContainer string     `xml:"srcContainer,omitempty"`
+	TgtContainer string     `xml:"tgtContainer"`
+	VvolMapping  []KeyValue `xml:"vvolMapping,omitempty"`
+}
+
+func init() {
+	t["DatastoreVVolContainerFailoverPair"] = reflect.TypeOf((*DatastoreVVolContainerFailoverPair)(nil)).Elem()
 }
 
 type DateTimeProfile struct {
@@ -11298,6 +12210,43 @@ func init() {
 type DeleteFileResponse struct {
 }
 
+type DeleteHostSpecification DeleteHostSpecificationRequestType
+
+func init() {
+	t["DeleteHostSpecification"] = reflect.TypeOf((*DeleteHostSpecification)(nil)).Elem()
+}
+
+type DeleteHostSpecificationRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Host ManagedObjectReference `xml:"host"`
+}
+
+func init() {
+	t["DeleteHostSpecificationRequestType"] = reflect.TypeOf((*DeleteHostSpecificationRequestType)(nil)).Elem()
+}
+
+type DeleteHostSpecificationResponse struct {
+}
+
+type DeleteHostSubSpecification DeleteHostSubSpecificationRequestType
+
+func init() {
+	t["DeleteHostSubSpecification"] = reflect.TypeOf((*DeleteHostSubSpecification)(nil)).Elem()
+}
+
+type DeleteHostSubSpecificationRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	Host        ManagedObjectReference `xml:"host"`
+	SubSpecName string                 `xml:"subSpecName"`
+}
+
+func init() {
+	t["DeleteHostSubSpecificationRequestType"] = reflect.TypeOf((*DeleteHostSubSpecificationRequestType)(nil)).Elem()
+}
+
+type DeleteHostSubSpecificationResponse struct {
+}
+
 type DeleteRegistryKeyInGuest DeleteRegistryKeyInGuestRequestType
 
 func init() {
@@ -11355,6 +12304,26 @@ func init() {
 }
 
 type DeleteScsiLunStateResponse struct {
+}
+
+type DeleteVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["DeleteVStorageObjectRequestType"] = reflect.TypeOf((*DeleteVStorageObjectRequestType)(nil)).Elem()
+}
+
+type DeleteVStorageObject_Task DeleteVStorageObjectRequestType
+
+func init() {
+	t["DeleteVStorageObject_Task"] = reflect.TypeOf((*DeleteVStorageObject_Task)(nil)).Elem()
+}
+
+type DeleteVStorageObject_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type DeleteVffsVolumeState DeleteVffsVolumeStateRequestType
@@ -11719,6 +12688,25 @@ type Destroy_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type DetachDiskRequestType struct {
+	This   ManagedObjectReference `xml:"_this"`
+	DiskId ID                     `xml:"diskId"`
+}
+
+func init() {
+	t["DetachDiskRequestType"] = reflect.TypeOf((*DetachDiskRequestType)(nil)).Elem()
+}
+
+type DetachDisk_Task DetachDiskRequestType
+
+func init() {
+	t["DetachDisk_Task"] = reflect.TypeOf((*DetachDisk_Task)(nil)).Elem()
+}
+
+type DetachDisk_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type DetachScsiLun DetachScsiLunRequestType
 
 func init() {
@@ -11754,6 +12742,26 @@ func init() {
 }
 
 type DetachScsiLunResponse struct {
+}
+
+type DetachTagFromVStorageObject DetachTagFromVStorageObjectRequestType
+
+func init() {
+	t["DetachTagFromVStorageObject"] = reflect.TypeOf((*DetachTagFromVStorageObject)(nil)).Elem()
+}
+
+type DetachTagFromVStorageObjectRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	Id       ID                     `xml:"id"`
+	Category string                 `xml:"category"`
+	Tag      string                 `xml:"tag"`
+}
+
+func init() {
+	t["DetachTagFromVStorageObjectRequestType"] = reflect.TypeOf((*DetachTagFromVStorageObjectRequestType)(nil)).Elem()
+}
+
+type DetachTagFromVStorageObjectResponse struct {
 }
 
 type DeviceBackedVirtualDiskSpec struct {
@@ -11796,6 +12804,16 @@ type DeviceControllerNotSupportedFault DeviceControllerNotSupported
 
 func init() {
 	t["DeviceControllerNotSupportedFault"] = reflect.TypeOf((*DeviceControllerNotSupportedFault)(nil)).Elem()
+}
+
+type DeviceGroupId struct {
+	DynamicData
+
+	Id string `xml:"id"`
+}
+
+func init() {
+	t["DeviceGroupId"] = reflect.TypeOf((*DeviceGroupId)(nil)).Elem()
 }
 
 type DeviceHotPlugNotSupported struct {
@@ -12606,13 +13624,14 @@ func init() {
 type DistributedVirtualSwitchPortCriteria struct {
 	DynamicData
 
-	Connected    *bool                   `xml:"connected"`
-	Active       *bool                   `xml:"active"`
-	UplinkPort   *bool                   `xml:"uplinkPort"`
-	Scope        *ManagedObjectReference `xml:"scope,omitempty"`
-	PortgroupKey []string                `xml:"portgroupKey,omitempty"`
-	Inside       *bool                   `xml:"inside"`
-	PortKey      []string                `xml:"portKey,omitempty"`
+	Connected    *bool                    `xml:"connected"`
+	Active       *bool                    `xml:"active"`
+	UplinkPort   *bool                    `xml:"uplinkPort"`
+	Scope        *ManagedObjectReference  `xml:"scope,omitempty"`
+	PortgroupKey []string                 `xml:"portgroupKey,omitempty"`
+	Inside       *bool                    `xml:"inside"`
+	PortKey      []string                 `xml:"portKey,omitempty"`
+	Host         []ManagedObjectReference `xml:"host,omitempty"`
 }
 
 func init() {
@@ -12638,6 +13657,8 @@ type DistributedVirtualSwitchPortStatistics struct {
 	PacketsOutDropped   int64 `xml:"packetsOutDropped"`
 	PacketsInException  int64 `xml:"packetsInException"`
 	PacketsOutException int64 `xml:"packetsOutException"`
+	BytesInFromPnic     int64 `xml:"bytesInFromPnic,omitempty"`
+	BytesOutToPnic      int64 `xml:"bytesOutToPnic,omitempty"`
 }
 
 func init() {
@@ -13367,9 +14388,10 @@ func init() {
 type DvsPortBlockedEvent struct {
 	DvsEvent
 
-	PortKey      string        `xml:"portKey"`
-	StatusDetail string        `xml:"statusDetail,omitempty"`
-	RuntimeInfo  *DVPortStatus `xml:"runtimeInfo,omitempty"`
+	PortKey        string        `xml:"portKey"`
+	StatusDetail   string        `xml:"statusDetail,omitempty"`
+	RuntimeInfo    *DVPortStatus `xml:"runtimeInfo,omitempty"`
+	PrevBlockState string        `xml:"prevBlockState,omitempty"`
 }
 
 func init() {
@@ -13489,7 +14511,8 @@ func init() {
 type DvsPortReconfiguredEvent struct {
 	DvsEvent
 
-	PortKey []string `xml:"portKey"`
+	PortKey       []string                   `xml:"portKey"`
+	ConfigChanges []ChangesInfoEventArgument `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -13510,8 +14533,9 @@ func init() {
 type DvsPortUnblockedEvent struct {
 	DvsEvent
 
-	PortKey     string        `xml:"portKey"`
-	RuntimeInfo *DVPortStatus `xml:"runtimeInfo,omitempty"`
+	PortKey        string        `xml:"portKey"`
+	RuntimeInfo    *DVPortStatus `xml:"runtimeInfo,omitempty"`
+	PrevBlockState string        `xml:"prevBlockState,omitempty"`
 }
 
 func init() {
@@ -13580,7 +14604,8 @@ type DvsReconfigureVmVnicNetworkResourcePool_TaskResponse struct {
 type DvsReconfiguredEvent struct {
 	DvsEvent
 
-	ConfigSpec BaseDVSConfigSpec `xml:"configSpec,typeattr"`
+	ConfigSpec    BaseDVSConfigSpec         `xml:"configSpec,typeattr"`
+	ConfigChanges *ChangesInfoEventArgument `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -14165,6 +15190,24 @@ func init() {
 type EnableAlarmActionsResponse struct {
 }
 
+type EnableCrypto EnableCryptoRequestType
+
+func init() {
+	t["EnableCrypto"] = reflect.TypeOf((*EnableCrypto)(nil)).Elem()
+}
+
+type EnableCryptoRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	KeyPlain CryptoKeyPlain         `xml:"keyPlain"`
+}
+
+func init() {
+	t["EnableCryptoRequestType"] = reflect.TypeOf((*EnableCryptoRequestType)(nil)).Elem()
+}
+
+type EnableCryptoResponse struct {
+}
+
 type EnableFeature EnableFeatureRequestType
 
 func init() {
@@ -14670,6 +15713,7 @@ type EventFilterSpec struct {
 	Type               []string                   `xml:"type,omitempty"`
 	Tag                []string                   `xml:"tag,omitempty"`
 	EventTypeId        []string                   `xml:"eventTypeId,omitempty"`
+	MaxCount           int32                      `xml:"maxCount,omitempty"`
 }
 
 func init() {
@@ -14726,7 +15770,7 @@ func init() {
 }
 
 type ExecuteHostProfileResponse struct {
-	Returnval ProfileExecuteResult `xml:"returnval"`
+	Returnval BaseProfileExecuteResult `xml:"returnval,typeattr"`
 }
 
 type ExecuteSimpleCommand ExecuteSimpleCommandRequestType
@@ -15038,6 +16082,27 @@ type ExtSolutionManagerInfoTabInfo struct {
 
 func init() {
 	t["ExtSolutionManagerInfoTabInfo"] = reflect.TypeOf((*ExtSolutionManagerInfoTabInfo)(nil)).Elem()
+}
+
+type ExtendDiskRequestType struct {
+	This            ManagedObjectReference `xml:"_this"`
+	Id              ID                     `xml:"id"`
+	Datastore       ManagedObjectReference `xml:"datastore"`
+	NewCapacityInMB int64                  `xml:"newCapacityInMB"`
+}
+
+func init() {
+	t["ExtendDiskRequestType"] = reflect.TypeOf((*ExtendDiskRequestType)(nil)).Elem()
+}
+
+type ExtendDisk_Task ExtendDiskRequestType
+
+func init() {
+	t["ExtendDisk_Task"] = reflect.TypeOf((*ExtendDisk_Task)(nil)).Elem()
+}
+
+type ExtendDisk_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type ExtendVffs ExtendVffsRequestType
@@ -15368,6 +16433,28 @@ type FailoverLevelRestored struct {
 
 func init() {
 	t["FailoverLevelRestored"] = reflect.TypeOf((*FailoverLevelRestored)(nil)).Elem()
+}
+
+type FailoverNodeInfo struct {
+	DynamicData
+
+	ClusterIpSettings CustomizationIPSettings  `xml:"clusterIpSettings"`
+	FailoverIp        *CustomizationIPSettings `xml:"failoverIp,omitempty"`
+	BiosUuid          string                   `xml:"biosUuid,omitempty"`
+}
+
+func init() {
+	t["FailoverNodeInfo"] = reflect.TypeOf((*FailoverNodeInfo)(nil)).Elem()
+}
+
+type FaultDomainId struct {
+	DynamicData
+
+	Id string `xml:"id"`
+}
+
+func init() {
+	t["FaultDomainId"] = reflect.TypeOf((*FaultDomainId)(nil)).Elem()
 }
 
 type FaultToleranceAntiAffinityViolated struct {
@@ -15728,6 +16815,44 @@ type FetchDVPortsResponse struct {
 	Returnval []DistributedVirtualPort `xml:"returnval,omitempty"`
 }
 
+type FetchSystemEventLog FetchSystemEventLogRequestType
+
+func init() {
+	t["FetchSystemEventLog"] = reflect.TypeOf((*FetchSystemEventLog)(nil)).Elem()
+}
+
+type FetchSystemEventLogRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["FetchSystemEventLogRequestType"] = reflect.TypeOf((*FetchSystemEventLogRequestType)(nil)).Elem()
+}
+
+type FetchSystemEventLogResponse struct {
+	Returnval []SystemEventInfo `xml:"returnval,omitempty"`
+}
+
+type FetchUserPrivilegeOnEntities FetchUserPrivilegeOnEntitiesRequestType
+
+func init() {
+	t["FetchUserPrivilegeOnEntities"] = reflect.TypeOf((*FetchUserPrivilegeOnEntities)(nil)).Elem()
+}
+
+type FetchUserPrivilegeOnEntitiesRequestType struct {
+	This     ManagedObjectReference   `xml:"_this"`
+	Entities []ManagedObjectReference `xml:"entities"`
+	UserName string                   `xml:"userName"`
+}
+
+func init() {
+	t["FetchUserPrivilegeOnEntitiesRequestType"] = reflect.TypeOf((*FetchUserPrivilegeOnEntitiesRequestType)(nil)).Elem()
+}
+
+type FetchUserPrivilegeOnEntitiesResponse struct {
+	Returnval []UserPrivilegeResult `xml:"returnval,omitempty"`
+}
+
 type FileAlreadyExists struct {
 	FileFault
 }
@@ -15761,6 +16886,7 @@ type FileBackedVirtualDiskSpec struct {
 
 	CapacityKb int64                           `xml:"capacityKb"`
 	Profile    []BaseVirtualMachineProfileSpec `xml:"profile,omitempty,typeattr"`
+	Crypto     BaseCryptoSpec                  `xml:"crypto,omitempty,typeattr"`
 }
 
 func init() {
@@ -15787,6 +16913,7 @@ type FileInfo struct {
 	DynamicData
 
 	Path         string     `xml:"path"`
+	FriendlyName string     `xml:"friendlyName,omitempty"`
 	FileSize     int64      `xml:"fileSize,omitempty"`
 	Modification *time.Time `xml:"modification"`
 	Owner        string     `xml:"owner,omitempty"`
@@ -16553,6 +17680,25 @@ type GenerateCertificateSigningRequestResponse struct {
 	Returnval string `xml:"returnval"`
 }
 
+type GenerateClientCsr GenerateClientCsrRequestType
+
+func init() {
+	t["GenerateClientCsr"] = reflect.TypeOf((*GenerateClientCsr)(nil)).Elem()
+}
+
+type GenerateClientCsrRequestType struct {
+	This    ManagedObjectReference `xml:"_this"`
+	Cluster KeyProviderId          `xml:"cluster"`
+}
+
+func init() {
+	t["GenerateClientCsrRequestType"] = reflect.TypeOf((*GenerateClientCsrRequestType)(nil)).Elem()
+}
+
+type GenerateClientCsrResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
 type GenerateConfigTaskList GenerateConfigTaskListRequestType
 
 func init() {
@@ -16571,6 +17717,25 @@ func init() {
 
 type GenerateConfigTaskListResponse struct {
 	Returnval HostProfileManagerConfigTaskList `xml:"returnval"`
+}
+
+type GenerateHostConfigTaskSpecRequestType struct {
+	This      ManagedObjectReference     `xml:"_this"`
+	HostsInfo []StructuredCustomizations `xml:"hostsInfo,omitempty"`
+}
+
+func init() {
+	t["GenerateHostConfigTaskSpecRequestType"] = reflect.TypeOf((*GenerateHostConfigTaskSpecRequestType)(nil)).Elem()
+}
+
+type GenerateHostConfigTaskSpec_Task GenerateHostConfigTaskSpecRequestType
+
+func init() {
+	t["GenerateHostConfigTaskSpec_Task"] = reflect.TypeOf((*GenerateHostConfigTaskSpec_Task)(nil)).Elem()
+}
+
+type GenerateHostConfigTaskSpec_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type GenerateHostProfileTaskListRequestType struct {
@@ -16593,6 +17758,25 @@ type GenerateHostProfileTaskList_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type GenerateKey GenerateKeyRequestType
+
+func init() {
+	t["GenerateKey"] = reflect.TypeOf((*GenerateKey)(nil)).Elem()
+}
+
+type GenerateKeyRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	KeyProvider *KeyProviderId         `xml:"keyProvider,omitempty"`
+}
+
+func init() {
+	t["GenerateKeyRequestType"] = reflect.TypeOf((*GenerateKeyRequestType)(nil)).Elem()
+}
+
+type GenerateKeyResponse struct {
+	Returnval CryptoKeyResult `xml:"returnval"`
+}
+
 type GenerateLogBundlesRequestType struct {
 	This           ManagedObjectReference   `xml:"_this"`
 	IncludeDefault bool                     `xml:"includeDefault"`
@@ -16611,6 +17795,25 @@ func init() {
 
 type GenerateLogBundles_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type GenerateSelfSignedClientCert GenerateSelfSignedClientCertRequestType
+
+func init() {
+	t["GenerateSelfSignedClientCert"] = reflect.TypeOf((*GenerateSelfSignedClientCert)(nil)).Elem()
+}
+
+type GenerateSelfSignedClientCertRequestType struct {
+	This    ManagedObjectReference `xml:"_this"`
+	Cluster KeyProviderId          `xml:"cluster"`
+}
+
+func init() {
+	t["GenerateSelfSignedClientCertRequestType"] = reflect.TypeOf((*GenerateSelfSignedClientCertRequestType)(nil)).Elem()
+}
+
+type GenerateSelfSignedClientCertResponse struct {
+	Returnval string `xml:"returnval"`
 }
 
 type GenericDrsFault struct {
@@ -16738,6 +17941,24 @@ type GetResourceUsageResponse struct {
 	Returnval ClusterResourceUsageSummary `xml:"returnval"`
 }
 
+type GetVchaClusterHealth GetVchaClusterHealthRequestType
+
+func init() {
+	t["GetVchaClusterHealth"] = reflect.TypeOf((*GetVchaClusterHealth)(nil)).Elem()
+}
+
+type GetVchaClusterHealthRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["GetVchaClusterHealthRequestType"] = reflect.TypeOf((*GetVchaClusterHealthRequestType)(nil)).Elem()
+}
+
+type GetVchaClusterHealthResponse struct {
+	Returnval VchaClusterHealth `xml:"returnval"`
+}
+
 type GetVsanObjExtAttrs GetVsanObjExtAttrsRequestType
 
 func init() {
@@ -16780,7 +18001,8 @@ func init() {
 type GlobalMessageChangedEvent struct {
 	SessionEvent
 
-	Message string `xml:"message"`
+	Message     string `xml:"message"`
+	PrevMessage string `xml:"prevMessage,omitempty"`
 }
 
 func init() {
@@ -16931,6 +18153,7 @@ type GuestInfo struct {
 	ToolsVersionStatus2             string                             `xml:"toolsVersionStatus2,omitempty"`
 	ToolsRunningStatus              string                             `xml:"toolsRunningStatus,omitempty"`
 	ToolsVersion                    string                             `xml:"toolsVersion,omitempty"`
+	ToolsInstallType                string                             `xml:"toolsInstallType,omitempty"`
 	GuestId                         string                             `xml:"guestId,omitempty"`
 	GuestFamily                     string                             `xml:"guestFamily,omitempty"`
 	GuestFullName                   string                             `xml:"guestFullName,omitempty"`
@@ -17093,6 +18316,8 @@ type GuestOsDescriptor struct {
 	SupportsPvscsiControllerForBoot *bool           `xml:"supportsPvscsiControllerForBoot"`
 	DiskUuidEnabled                 *bool           `xml:"diskUuidEnabled"`
 	SupportsHotPlugPCI              *bool           `xml:"supportsHotPlugPCI"`
+	SupportsSecureBoot              *bool           `xml:"supportsSecureBoot"`
+	DefaultSecureBoot               *bool           `xml:"defaultSecureBoot"`
 }
 
 func init() {
@@ -17473,6 +18698,26 @@ func init() {
 	t["HAErrorsAtDestFault"] = reflect.TypeOf((*HAErrorsAtDestFault)(nil)).Elem()
 }
 
+type HasMonitoredEntity HasMonitoredEntityRequestType
+
+func init() {
+	t["HasMonitoredEntity"] = reflect.TypeOf((*HasMonitoredEntity)(nil)).Elem()
+}
+
+type HasMonitoredEntityRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+	Entity     ManagedObjectReference `xml:"entity"`
+}
+
+func init() {
+	t["HasMonitoredEntityRequestType"] = reflect.TypeOf((*HasMonitoredEntityRequestType)(nil)).Elem()
+}
+
+type HasMonitoredEntityResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
 type HasPrivilegeOnEntities HasPrivilegeOnEntitiesRequestType
 
 func init() {
@@ -17513,6 +18758,46 @@ func init() {
 
 type HasPrivilegeOnEntityResponse struct {
 	Returnval []bool `xml:"returnval,omitempty"`
+}
+
+type HasProvider HasProviderRequestType
+
+func init() {
+	t["HasProvider"] = reflect.TypeOf((*HasProvider)(nil)).Elem()
+}
+
+type HasProviderRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Id   string                 `xml:"id"`
+}
+
+func init() {
+	t["HasProviderRequestType"] = reflect.TypeOf((*HasProviderRequestType)(nil)).Elem()
+}
+
+type HasProviderResponse struct {
+	Returnval bool `xml:"returnval"`
+}
+
+type HasUserPrivilegeOnEntities HasUserPrivilegeOnEntitiesRequestType
+
+func init() {
+	t["HasUserPrivilegeOnEntities"] = reflect.TypeOf((*HasUserPrivilegeOnEntities)(nil)).Elem()
+}
+
+type HasUserPrivilegeOnEntitiesRequestType struct {
+	This     ManagedObjectReference   `xml:"_this"`
+	Entities []ManagedObjectReference `xml:"entities"`
+	UserName string                   `xml:"userName"`
+	PrivId   []string                 `xml:"privId,omitempty"`
+}
+
+func init() {
+	t["HasUserPrivilegeOnEntitiesRequestType"] = reflect.TypeOf((*HasUserPrivilegeOnEntitiesRequestType)(nil)).Elem()
+}
+
+type HasUserPrivilegeOnEntitiesResponse struct {
+	Returnval []EntityPrivilege `xml:"returnval,omitempty"`
 }
 
 type HbrDiskMigrationAction struct {
@@ -17587,6 +18872,32 @@ type HealthSystemRuntime struct {
 
 func init() {
 	t["HealthSystemRuntime"] = reflect.TypeOf((*HealthSystemRuntime)(nil)).Elem()
+}
+
+type HealthUpdate struct {
+	DynamicData
+
+	Entity             ManagedObjectReference `xml:"entity"`
+	HealthUpdateInfoId string                 `xml:"healthUpdateInfoId"`
+	Id                 string                 `xml:"id"`
+	Status             ManagedEntityStatus    `xml:"status"`
+	Remediation        string                 `xml:"remediation"`
+}
+
+func init() {
+	t["HealthUpdate"] = reflect.TypeOf((*HealthUpdate)(nil)).Elem()
+}
+
+type HealthUpdateInfo struct {
+	DynamicData
+
+	Id            string `xml:"id"`
+	ComponentType string `xml:"componentType"`
+	Description   string `xml:"description"`
+}
+
+func init() {
+	t["HealthUpdateInfo"] = reflect.TypeOf((*HealthUpdateInfo)(nil)).Elem()
 }
 
 type HeterogenousHostsBlockingEVC struct {
@@ -17771,8 +19082,13 @@ func init() {
 type HostBIOSInfo struct {
 	DynamicData
 
-	BiosVersion string     `xml:"biosVersion,omitempty"`
-	ReleaseDate *time.Time `xml:"releaseDate"`
+	BiosVersion          string     `xml:"biosVersion,omitempty"`
+	ReleaseDate          *time.Time `xml:"releaseDate"`
+	Vendor               string     `xml:"vendor,omitempty"`
+	MajorRelease         int32      `xml:"majorRelease,omitempty"`
+	MinorRelease         int32      `xml:"minorRelease,omitempty"`
+	FirmwareMajorRelease int32      `xml:"firmwareMajorRelease,omitempty"`
+	FirmwareMinorRelease int32      `xml:"firmwareMinorRelease,omitempty"`
 }
 
 func init() {
@@ -17920,11 +19236,27 @@ type HostCapability struct {
 	HostAccessManagerSupported                *bool           `xml:"hostAccessManagerSupported"`
 	ProvisioningNicSelectionSupported         *bool           `xml:"provisioningNicSelectionSupported"`
 	Nfs41Supported                            *bool           `xml:"nfs41Supported"`
+	Nfs41Krb5iSupported                       *bool           `xml:"nfs41Krb5iSupported"`
 	TurnDiskLocatorLedSupported               *bool           `xml:"turnDiskLocatorLedSupported"`
 	VirtualVolumeDatastoreSupported           *bool           `xml:"virtualVolumeDatastoreSupported"`
 	MarkAsSsdSupported                        *bool           `xml:"markAsSsdSupported"`
 	MarkAsLocalSupported                      *bool           `xml:"markAsLocalSupported"`
 	SmartCardAuthenticationSupported          *bool           `xml:"smartCardAuthenticationSupported"`
+	CryptoSupported                           *bool           `xml:"cryptoSupported"`
+	OneKVolumeAPIsSupported                   *bool           `xml:"oneKVolumeAPIsSupported"`
+	GatewayOnNicSupported                     *bool           `xml:"gatewayOnNicSupported"`
+	UpitSupported                             *bool           `xml:"upitSupported"`
+	CpuHwMmuSupported                         *bool           `xml:"cpuHwMmuSupported"`
+	EncryptedVMotionSupported                 *bool           `xml:"encryptedVMotionSupported"`
+	EncryptionChangeOnAddRemoveSupported      *bool           `xml:"encryptionChangeOnAddRemoveSupported"`
+	EncryptionHotOperationSupported           *bool           `xml:"encryptionHotOperationSupported"`
+	EncryptionWithSnapshotsSupported          *bool           `xml:"encryptionWithSnapshotsSupported"`
+	EncryptionFaultToleranceSupported         *bool           `xml:"encryptionFaultToleranceSupported"`
+	EncryptionMemorySaveSupported             *bool           `xml:"encryptionMemorySaveSupported"`
+	EncryptionRDMSupported                    *bool           `xml:"encryptionRDMSupported"`
+	EncryptionVFlashSupported                 *bool           `xml:"encryptionVFlashSupported"`
+	EncryptionCBRCSupported                   *bool           `xml:"encryptionCBRCSupported"`
+	EncryptionHBRSupported                    *bool           `xml:"encryptionHBRSupported"`
 }
 
 func init() {
@@ -17943,6 +19275,27 @@ type HostCertificateManagerCertificateInfo struct {
 
 func init() {
 	t["HostCertificateManagerCertificateInfo"] = reflect.TypeOf((*HostCertificateManagerCertificateInfo)(nil)).Elem()
+}
+
+type HostCloneVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+	Spec      VslmCloneSpec          `xml:"spec"`
+}
+
+func init() {
+	t["HostCloneVStorageObjectRequestType"] = reflect.TypeOf((*HostCloneVStorageObjectRequestType)(nil)).Elem()
+}
+
+type HostCloneVStorageObject_Task HostCloneVStorageObjectRequestType
+
+func init() {
+	t["HostCloneVStorageObject_Task"] = reflect.TypeOf((*HostCloneVStorageObject_Task)(nil)).Elem()
+}
+
+type HostCloneVStorageObject_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type HostCnxFailedAccountFailedEvent struct {
@@ -18134,6 +19487,7 @@ type HostConfigInfo struct {
 
 	Host                      ManagedObjectReference               `xml:"host"`
 	Product                   AboutInfo                            `xml:"product"`
+	DeploymentInfo            *HostDeploymentInfo                  `xml:"deploymentInfo,omitempty"`
 	HyperThread               *HostHyperThreadScheduleInfo         `xml:"hyperThread,omitempty"`
 	ConsoleReservation        *ServiceConsoleReservationInfo       `xml:"consoleReservation,omitempty"`
 	VirtualMachineReservation *VirtualMachineMemoryReservationInfo `xml:"virtualMachineReservation,omitempty"`
@@ -18181,7 +19535,9 @@ type HostConfigInfo struct {
 	HostConfigCheckSum        []byte                               `xml:"hostConfigCheckSum,omitempty"`
 	GraphicsInfo              []HostGraphicsInfo                   `xml:"graphicsInfo,omitempty"`
 	SharedPassthruGpuTypes    []string                             `xml:"sharedPassthruGpuTypes,omitempty"`
+	GraphicsConfig            *HostGraphicsConfig                  `xml:"graphicsConfig,omitempty"`
 	IoFilterInfo              []HostIoFilterInfo                   `xml:"ioFilterInfo,omitempty"`
+	SriovDevicePool           []BaseHostSriovDevicePoolInfo        `xml:"sriovDevicePool,omitempty,typeattr"`
 }
 
 func init() {
@@ -18227,6 +19583,7 @@ type HostConfigManager struct {
 	GraphicsManager           *ManagedObjectReference `xml:"graphicsManager,omitempty"`
 	VsanInternalSystem        *ManagedObjectReference `xml:"vsanInternalSystem,omitempty"`
 	CertificateManager        *ManagedObjectReference `xml:"certificateManager,omitempty"`
+	CryptoManager             *ManagedObjectReference `xml:"cryptoManager,omitempty"`
 }
 
 func init() {
@@ -18253,6 +19610,7 @@ type HostConfigSpec struct {
 	Memory                   *HostMemorySpec                         `xml:"memory,omitempty"`
 	ActiveDirectory          []HostActiveDirectory                   `xml:"activeDirectory,omitempty"`
 	GenericConfig            []KeyAnyValue                           `xml:"genericConfig,omitempty"`
+	GraphicsConfig           *HostGraphicsConfig                     `xml:"graphicsConfig,omitempty"`
 }
 
 func init() {
@@ -18448,6 +19806,25 @@ func init() {
 	t["HostCpuPowerManagementInfo"] = reflect.TypeOf((*HostCpuPowerManagementInfo)(nil)).Elem()
 }
 
+type HostCreateDiskRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Spec VslmCreateSpec         `xml:"spec"`
+}
+
+func init() {
+	t["HostCreateDiskRequestType"] = reflect.TypeOf((*HostCreateDiskRequestType)(nil)).Elem()
+}
+
+type HostCreateDisk_Task HostCreateDiskRequestType
+
+func init() {
+	t["HostCreateDisk_Task"] = reflect.TypeOf((*HostCreateDisk_Task)(nil)).Elem()
+}
+
+type HostCreateDisk_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type HostDasDisabledEvent struct {
 	HostEvent
 }
@@ -18631,6 +20008,36 @@ type HostDateTimeSystemTimeZone struct {
 
 func init() {
 	t["HostDateTimeSystemTimeZone"] = reflect.TypeOf((*HostDateTimeSystemTimeZone)(nil)).Elem()
+}
+
+type HostDeleteVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["HostDeleteVStorageObjectRequestType"] = reflect.TypeOf((*HostDeleteVStorageObjectRequestType)(nil)).Elem()
+}
+
+type HostDeleteVStorageObject_Task HostDeleteVStorageObjectRequestType
+
+func init() {
+	t["HostDeleteVStorageObject_Task"] = reflect.TypeOf((*HostDeleteVStorageObject_Task)(nil)).Elem()
+}
+
+type HostDeleteVStorageObject_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type HostDeploymentInfo struct {
+	DynamicData
+
+	BootedFromStatelessCache *bool `xml:"bootedFromStatelessCache"`
+}
+
+func init() {
+	t["HostDeploymentInfo"] = reflect.TypeOf((*HostDeploymentInfo)(nil)).Elem()
 }
 
 type HostDevice struct {
@@ -18985,6 +20392,27 @@ func init() {
 	t["HostEventArgument"] = reflect.TypeOf((*HostEventArgument)(nil)).Elem()
 }
 
+type HostExtendDiskRequestType struct {
+	This            ManagedObjectReference `xml:"_this"`
+	Id              ID                     `xml:"id"`
+	Datastore       ManagedObjectReference `xml:"datastore"`
+	NewCapacityInMB int64                  `xml:"newCapacityInMB"`
+}
+
+func init() {
+	t["HostExtendDiskRequestType"] = reflect.TypeOf((*HostExtendDiskRequestType)(nil)).Elem()
+}
+
+type HostExtendDisk_Task HostExtendDiskRequestType
+
+func init() {
+	t["HostExtendDisk_Task"] = reflect.TypeOf((*HostExtendDisk_Task)(nil)).Elem()
+}
+
+type HostExtendDisk_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type HostExtraNetworksEvent struct {
 	HostDasEvent
 
@@ -19317,6 +20745,29 @@ type HostGetVFlashModuleDefaultConfigResponse struct {
 	Returnval VirtualDiskVFlashCacheConfigInfo `xml:"returnval"`
 }
 
+type HostGraphicsConfig struct {
+	DynamicData
+
+	HostDefaultGraphicsType        string                         `xml:"hostDefaultGraphicsType"`
+	SharedPassthruAssignmentPolicy string                         `xml:"sharedPassthruAssignmentPolicy"`
+	DeviceType                     []HostGraphicsConfigDeviceType `xml:"deviceType,omitempty"`
+}
+
+func init() {
+	t["HostGraphicsConfig"] = reflect.TypeOf((*HostGraphicsConfig)(nil)).Elem()
+}
+
+type HostGraphicsConfigDeviceType struct {
+	DynamicData
+
+	DeviceId     string `xml:"deviceId"`
+	GraphicsType string `xml:"graphicsType"`
+}
+
+func init() {
+	t["HostGraphicsConfigDeviceType"] = reflect.TypeOf((*HostGraphicsConfigDeviceType)(nil)).Elem()
+}
+
 type HostGraphicsInfo struct {
 	DynamicData
 
@@ -19543,6 +20994,26 @@ type HostIncompatibleForRecordReplayFault HostIncompatibleForRecordReplay
 
 func init() {
 	t["HostIncompatibleForRecordReplayFault"] = reflect.TypeOf((*HostIncompatibleForRecordReplayFault)(nil)).Elem()
+}
+
+type HostInflateDiskRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["HostInflateDiskRequestType"] = reflect.TypeOf((*HostInflateDiskRequestType)(nil)).Elem()
+}
+
+type HostInflateDisk_Task HostInflateDiskRequestType
+
+func init() {
+	t["HostInflateDisk_Task"] = reflect.TypeOf((*HostInflateDisk_Task)(nil)).Elem()
+}
+
+type HostInflateDisk_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type HostInternetScsiHba struct {
@@ -20107,6 +21578,25 @@ func init() {
 	t["HostListSummaryQuickStats"] = reflect.TypeOf((*HostListSummaryQuickStats)(nil)).Elem()
 }
 
+type HostListVStorageObject HostListVStorageObjectRequestType
+
+func init() {
+	t["HostListVStorageObject"] = reflect.TypeOf((*HostListVStorageObject)(nil)).Elem()
+}
+
+type HostListVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["HostListVStorageObjectRequestType"] = reflect.TypeOf((*HostListVStorageObjectRequestType)(nil)).Elem()
+}
+
+type HostListVStorageObjectResponse struct {
+	Returnval []ID `xml:"returnval,omitempty"`
+}
+
 type HostLocalAuthenticationInfo struct {
 	HostAuthenticationStoreInfo
 }
@@ -20320,7 +21810,8 @@ func init() {
 type HostMonitoringStateChangedEvent struct {
 	ClusterEvent
 
-	State string `xml:"state"`
+	State     string `xml:"state"`
+	PrevState string `xml:"prevState,omitempty"`
 }
 
 func init() {
@@ -20895,6 +22386,8 @@ type HostNumericSensorInfo struct {
 	BaseUnits      string                 `xml:"baseUnits"`
 	RateUnits      string                 `xml:"rateUnits,omitempty"`
 	SensorType     string                 `xml:"sensorType"`
+	Id             string                 `xml:"id,omitempty"`
+	TimeStamp      string                 `xml:"timeStamp,omitempty"`
 }
 
 func init() {
@@ -20904,10 +22397,12 @@ func init() {
 type HostOpaqueNetworkInfo struct {
 	DynamicData
 
-	OpaqueNetworkId   string   `xml:"opaqueNetworkId"`
-	OpaqueNetworkName string   `xml:"opaqueNetworkName"`
-	OpaqueNetworkType string   `xml:"opaqueNetworkType"`
-	PnicZone          []string `xml:"pnicZone,omitempty"`
+	OpaqueNetworkId   string                   `xml:"opaqueNetworkId"`
+	OpaqueNetworkName string                   `xml:"opaqueNetworkName"`
+	OpaqueNetworkType string                   `xml:"opaqueNetworkType"`
+	PnicZone          []string                 `xml:"pnicZone,omitempty"`
+	Capability        *OpaqueNetworkCapability `xml:"capability,omitempty"`
+	ExtraConfig       []BaseOptionValue        `xml:"extraConfig,omitempty,typeattr"`
 }
 
 func init() {
@@ -20917,12 +22412,13 @@ func init() {
 type HostOpaqueSwitch struct {
 	DynamicData
 
-	Key      string                            `xml:"key"`
-	Name     string                            `xml:"name,omitempty"`
-	Pnic     []string                          `xml:"pnic,omitempty"`
-	PnicZone []HostOpaqueSwitchPhysicalNicZone `xml:"pnicZone,omitempty"`
-	Status   string                            `xml:"status,omitempty"`
-	Vtep     []HostVirtualNic                  `xml:"vtep,omitempty"`
+	Key         string                            `xml:"key"`
+	Name        string                            `xml:"name,omitempty"`
+	Pnic        []string                          `xml:"pnic,omitempty"`
+	PnicZone    []HostOpaqueSwitchPhysicalNicZone `xml:"pnicZone,omitempty"`
+	Status      string                            `xml:"status,omitempty"`
+	Vtep        []HostVirtualNic                  `xml:"vtep,omitempty"`
+	ExtraConfig []BaseOptionValue                 `xml:"extraConfig,omitempty,typeattr"`
 }
 
 func init() {
@@ -21319,6 +22815,7 @@ type HostProfileCompleteConfigSpec struct {
 	DisabledExpressionList        []string                `xml:"disabledExpressionList,omitempty"`
 	ValidatorHost                 *ManagedObjectReference `xml:"validatorHost,omitempty"`
 	Validating                    *bool                   `xml:"validating"`
+	HostConfig                    *HostProfileConfigInfo  `xml:"hostConfig,omitempty"`
 }
 
 func init() {
@@ -21333,6 +22830,7 @@ type HostProfileConfigInfo struct {
 	DefaultComplyLocator   []ComplianceLocator `xml:"defaultComplyLocator,omitempty"`
 	CustomComplyProfile    *ComplianceProfile  `xml:"customComplyProfile,omitempty"`
 	DisabledExpressionList []string            `xml:"disabledExpressionList,omitempty"`
+	Description            *ProfileDescription `xml:"description,omitempty"`
 }
 
 func init() {
@@ -21358,6 +22856,25 @@ func init() {
 	t["HostProfileHostBasedConfigSpec"] = reflect.TypeOf((*HostProfileHostBasedConfigSpec)(nil)).Elem()
 }
 
+type HostProfileManagerCompositionValidationResultResultElement struct {
+	DynamicData
+
+	Target                  ManagedObjectReference `xml:"target"`
+	Status                  string                 `xml:"status"`
+	Errors                  []LocalizableMessage   `xml:"errors,omitempty"`
+	SourceDiffForToBeMerged *HostApplyProfile      `xml:"sourceDiffForToBeMerged,omitempty"`
+	TargetDiffForToBeMerged *HostApplyProfile      `xml:"targetDiffForToBeMerged,omitempty"`
+	ToBeAdded               *HostApplyProfile      `xml:"toBeAdded,omitempty"`
+	ToBeDeleted             *HostApplyProfile      `xml:"toBeDeleted,omitempty"`
+	ToBeDisabled            *HostApplyProfile      `xml:"toBeDisabled,omitempty"`
+	ToBeEnabled             *HostApplyProfile      `xml:"toBeEnabled,omitempty"`
+	ToBeReenableCC          *HostApplyProfile      `xml:"toBeReenableCC,omitempty"`
+}
+
+func init() {
+	t["HostProfileManagerCompositionValidationResultResultElement"] = reflect.TypeOf((*HostProfileManagerCompositionValidationResultResultElement)(nil)).Elem()
+}
+
 type HostProfileManagerConfigTaskList struct {
 	DynamicData
 
@@ -21368,6 +22885,17 @@ type HostProfileManagerConfigTaskList struct {
 
 func init() {
 	t["HostProfileManagerConfigTaskList"] = reflect.TypeOf((*HostProfileManagerConfigTaskList)(nil)).Elem()
+}
+
+type HostProfileManagerHostToConfigSpecMap struct {
+	DynamicData
+
+	Host       ManagedObjectReference   `xml:"host"`
+	ConfigSpec BaseAnswerFileCreateSpec `xml:"configSpec,typeattr"`
+}
+
+func init() {
+	t["HostProfileManagerHostToConfigSpecMap"] = reflect.TypeOf((*HostProfileManagerHostToConfigSpecMap)(nil)).Elem()
 }
 
 type HostProfileSerializedHostProfileSpec struct {
@@ -21381,16 +22909,29 @@ func init() {
 	t["HostProfileSerializedHostProfileSpec"] = reflect.TypeOf((*HostProfileSerializedHostProfileSpec)(nil)).Elem()
 }
 
+type HostProfilesEntityCustomizations struct {
+	DynamicData
+}
+
+func init() {
+	t["HostProfilesEntityCustomizations"] = reflect.TypeOf((*HostProfilesEntityCustomizations)(nil)).Elem()
+}
+
 type HostProtocolEndpoint struct {
 	DynamicData
 
-	PeType       string                   `xml:"peType"`
-	Uuid         string                   `xml:"uuid"`
-	HostKey      []ManagedObjectReference `xml:"hostKey,omitempty"`
-	StorageArray string                   `xml:"storageArray,omitempty"`
-	NfsServer    string                   `xml:"nfsServer,omitempty"`
-	NfsDir       string                   `xml:"nfsDir,omitempty"`
-	DeviceId     string                   `xml:"deviceId,omitempty"`
+	PeType            string                   `xml:"peType"`
+	Type              string                   `xml:"type,omitempty"`
+	Uuid              string                   `xml:"uuid"`
+	HostKey           []ManagedObjectReference `xml:"hostKey,omitempty"`
+	StorageArray      string                   `xml:"storageArray,omitempty"`
+	NfsServer         string                   `xml:"nfsServer,omitempty"`
+	NfsDir            string                   `xml:"nfsDir,omitempty"`
+	NfsServerScope    string                   `xml:"nfsServerScope,omitempty"`
+	NfsServerMajor    string                   `xml:"nfsServerMajor,omitempty"`
+	NfsServerAuthType string                   `xml:"nfsServerAuthType,omitempty"`
+	NfsServerUser     string                   `xml:"nfsServerUser,omitempty"`
+	DeviceId          string                   `xml:"deviceId,omitempty"`
 }
 
 func init() {
@@ -21452,12 +22993,51 @@ func init() {
 	t["HostProxySwitchSpec"] = reflect.TypeOf((*HostProxySwitchSpec)(nil)).Elem()
 }
 
+type HostReconcileDatastoreInventoryRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["HostReconcileDatastoreInventoryRequestType"] = reflect.TypeOf((*HostReconcileDatastoreInventoryRequestType)(nil)).Elem()
+}
+
+type HostReconcileDatastoreInventory_Task HostReconcileDatastoreInventoryRequestType
+
+func init() {
+	t["HostReconcileDatastoreInventory_Task"] = reflect.TypeOf((*HostReconcileDatastoreInventory_Task)(nil)).Elem()
+}
+
+type HostReconcileDatastoreInventory_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type HostReconnectionFailedEvent struct {
 	HostEvent
 }
 
 func init() {
 	t["HostReconnectionFailedEvent"] = reflect.TypeOf((*HostReconnectionFailedEvent)(nil)).Elem()
+}
+
+type HostRegisterDisk HostRegisterDiskRequestType
+
+func init() {
+	t["HostRegisterDisk"] = reflect.TypeOf((*HostRegisterDisk)(nil)).Elem()
+}
+
+type HostRegisterDiskRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Path string                 `xml:"path"`
+	Name string                 `xml:"name,omitempty"`
+}
+
+func init() {
+	t["HostRegisterDiskRequestType"] = reflect.TypeOf((*HostRegisterDiskRequestType)(nil)).Elem()
+}
+
+type HostRegisterDiskResponse struct {
+	Returnval VStorageObject `xml:"returnval"`
 }
 
 type HostReliableMemoryInfo struct {
@@ -21468,6 +23048,27 @@ type HostReliableMemoryInfo struct {
 
 func init() {
 	t["HostReliableMemoryInfo"] = reflect.TypeOf((*HostReliableMemoryInfo)(nil)).Elem()
+}
+
+type HostRelocateVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+	Spec      VslmRelocateSpec       `xml:"spec"`
+}
+
+func init() {
+	t["HostRelocateVStorageObjectRequestType"] = reflect.TypeOf((*HostRelocateVStorageObjectRequestType)(nil)).Elem()
+}
+
+type HostRelocateVStorageObject_Task HostRelocateVStorageObjectRequestType
+
+func init() {
+	t["HostRelocateVStorageObject_Task"] = reflect.TypeOf((*HostRelocateVStorageObject_Task)(nil)).Elem()
+}
+
+type HostRelocateVStorageObject_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type HostRemoveVFlashResource HostRemoveVFlashResourceRequestType
@@ -21495,6 +23096,26 @@ func init() {
 	t["HostRemovedEvent"] = reflect.TypeOf((*HostRemovedEvent)(nil)).Elem()
 }
 
+type HostRenameVStorageObject HostRenameVStorageObjectRequestType
+
+func init() {
+	t["HostRenameVStorageObject"] = reflect.TypeOf((*HostRenameVStorageObject)(nil)).Elem()
+}
+
+type HostRenameVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+	Name      string                 `xml:"name"`
+}
+
+func init() {
+	t["HostRenameVStorageObjectRequestType"] = reflect.TypeOf((*HostRenameVStorageObjectRequestType)(nil)).Elem()
+}
+
+type HostRenameVStorageObjectResponse struct {
+}
+
 type HostResignatureRescanResult struct {
 	DynamicData
 
@@ -21506,6 +23127,46 @@ func init() {
 	t["HostResignatureRescanResult"] = reflect.TypeOf((*HostResignatureRescanResult)(nil)).Elem()
 }
 
+type HostRetrieveVStorageObject HostRetrieveVStorageObjectRequestType
+
+func init() {
+	t["HostRetrieveVStorageObject"] = reflect.TypeOf((*HostRetrieveVStorageObject)(nil)).Elem()
+}
+
+type HostRetrieveVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["HostRetrieveVStorageObjectRequestType"] = reflect.TypeOf((*HostRetrieveVStorageObjectRequestType)(nil)).Elem()
+}
+
+type HostRetrieveVStorageObjectResponse struct {
+	Returnval VStorageObject `xml:"returnval"`
+}
+
+type HostRetrieveVStorageObjectState HostRetrieveVStorageObjectStateRequestType
+
+func init() {
+	t["HostRetrieveVStorageObjectState"] = reflect.TypeOf((*HostRetrieveVStorageObjectState)(nil)).Elem()
+}
+
+type HostRetrieveVStorageObjectStateRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["HostRetrieveVStorageObjectStateRequestType"] = reflect.TypeOf((*HostRetrieveVStorageObjectStateRequestType)(nil)).Elem()
+}
+
+type HostRetrieveVStorageObjectStateResponse struct {
+	Returnval VStorageObjectStateInfo `xml:"returnval"`
+}
+
 type HostRuntimeInfo struct {
 	DynamicData
 
@@ -21513,6 +23174,7 @@ type HostRuntimeInfo struct {
 	PowerState                 HostSystemPowerState                        `xml:"powerState"`
 	StandbyMode                string                                      `xml:"standbyMode,omitempty"`
 	InMaintenanceMode          bool                                        `xml:"inMaintenanceMode"`
+	InQuarantineMode           *bool                                       `xml:"inQuarantineMode"`
 	BootTime                   *time.Time                                  `xml:"bootTime"`
 	HealthSystemRuntime        *HealthSystemRuntime                        `xml:"healthSystemRuntime,omitempty"`
 	DasHostState               *ClusterDasFdmHostState                     `xml:"dasHostState,omitempty"`
@@ -21521,6 +23183,8 @@ type HostRuntimeInfo struct {
 	NetworkRuntimeInfo         *HostRuntimeInfoNetworkRuntimeInfo          `xml:"networkRuntimeInfo,omitempty"`
 	VFlashResourceRuntimeInfo  *HostVFlashManagerVFlashResourceRunTimeInfo `xml:"vFlashResourceRuntimeInfo,omitempty"`
 	HostMaxVirtualDiskCapacity int64                                       `xml:"hostMaxVirtualDiskCapacity,omitempty"`
+	CryptoState                string                                      `xml:"cryptoState,omitempty"`
+	CryptoKeyId                *CryptoKeyId                                `xml:"cryptoKeyId,omitempty"`
 }
 
 func init() {
@@ -21552,6 +23216,24 @@ func init() {
 	t["HostRuntimeInfoNetworkRuntimeInfo"] = reflect.TypeOf((*HostRuntimeInfoNetworkRuntimeInfo)(nil)).Elem()
 }
 
+type HostScheduleReconcileDatastoreInventory HostScheduleReconcileDatastoreInventoryRequestType
+
+func init() {
+	t["HostScheduleReconcileDatastoreInventory"] = reflect.TypeOf((*HostScheduleReconcileDatastoreInventory)(nil)).Elem()
+}
+
+type HostScheduleReconcileDatastoreInventoryRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["HostScheduleReconcileDatastoreInventoryRequestType"] = reflect.TypeOf((*HostScheduleReconcileDatastoreInventoryRequestType)(nil)).Elem()
+}
+
+type HostScheduleReconcileDatastoreInventoryResponse struct {
+}
+
 type HostScsiDisk struct {
 	ScsiLun
 
@@ -21562,6 +23244,7 @@ type HostScsiDisk struct {
 	PhysicalLocation      []string              `xml:"physicalLocation,omitempty"`
 	EmulatedDIXDIFEnabled *bool                 `xml:"emulatedDIXDIFEnabled"`
 	VsanDiskInfo          *VsanHostVsanDiskInfo `xml:"vsanDiskInfo,omitempty"`
+	ScsiDiskType          string                `xml:"scsiDiskType,omitempty"`
 }
 
 func init() {
@@ -21636,6 +23319,24 @@ type HostSecuritySpec struct {
 
 func init() {
 	t["HostSecuritySpec"] = reflect.TypeOf((*HostSecuritySpec)(nil)).Elem()
+}
+
+type HostSerialAttachedHba struct {
+	HostHostBusAdapter
+
+	NodeWorldWideName string `xml:"nodeWorldWideName"`
+}
+
+func init() {
+	t["HostSerialAttachedHba"] = reflect.TypeOf((*HostSerialAttachedHba)(nil)).Elem()
+}
+
+type HostSerialAttachedTargetTransport struct {
+	HostTargetTransport
+}
+
+func init() {
+	t["HostSerialAttachedTargetTransport"] = reflect.TypeOf((*HostSerialAttachedTargetTransport)(nil)).Elem()
 }
 
 type HostService struct {
@@ -21773,6 +23474,56 @@ func init() {
 	t["HostSnmpSystemAgentLimits"] = reflect.TypeOf((*HostSnmpSystemAgentLimits)(nil)).Elem()
 }
 
+type HostSpecGetUpdatedHosts HostSpecGetUpdatedHostsRequestType
+
+func init() {
+	t["HostSpecGetUpdatedHosts"] = reflect.TypeOf((*HostSpecGetUpdatedHosts)(nil)).Elem()
+}
+
+type HostSpecGetUpdatedHostsRequestType struct {
+	This          ManagedObjectReference `xml:"_this"`
+	StartChangeID string                 `xml:"startChangeID,omitempty"`
+	EndChangeID   string                 `xml:"endChangeID,omitempty"`
+}
+
+func init() {
+	t["HostSpecGetUpdatedHostsRequestType"] = reflect.TypeOf((*HostSpecGetUpdatedHostsRequestType)(nil)).Elem()
+}
+
+type HostSpecGetUpdatedHostsResponse struct {
+	Returnval []ManagedObjectReference `xml:"returnval,omitempty"`
+}
+
+type HostSpecification struct {
+	DynamicData
+
+	CreatedTime  time.Time              `xml:"createdTime"`
+	LastModified *time.Time             `xml:"lastModified"`
+	Host         ManagedObjectReference `xml:"host"`
+	SubSpecs     []HostSubSpecification `xml:"subSpecs,omitempty"`
+	ChangeID     string                 `xml:"changeID,omitempty"`
+}
+
+func init() {
+	t["HostSpecification"] = reflect.TypeOf((*HostSpecification)(nil)).Elem()
+}
+
+type HostSpecificationOperationFailed struct {
+	VimFault
+
+	Host ManagedObjectReference `xml:"host"`
+}
+
+func init() {
+	t["HostSpecificationOperationFailed"] = reflect.TypeOf((*HostSpecificationOperationFailed)(nil)).Elem()
+}
+
+type HostSpecificationOperationFailedFault HostSpecificationOperationFailed
+
+func init() {
+	t["HostSpecificationOperationFailedFault"] = reflect.TypeOf((*HostSpecificationOperationFailedFault)(nil)).Elem()
+}
+
 type HostSriovConfig struct {
 	HostPciPassthruConfig
 
@@ -21782,6 +23533,16 @@ type HostSriovConfig struct {
 
 func init() {
 	t["HostSriovConfig"] = reflect.TypeOf((*HostSriovConfig)(nil)).Elem()
+}
+
+type HostSriovDevicePoolInfo struct {
+	DynamicData
+
+	Key string `xml:"key"`
+}
+
+func init() {
+	t["HostSriovDevicePoolInfo"] = reflect.TypeOf((*HostSriovDevicePoolInfo)(nil)).Elem()
 }
 
 type HostSriovInfo struct {
@@ -21797,6 +23558,18 @@ type HostSriovInfo struct {
 
 func init() {
 	t["HostSriovInfo"] = reflect.TypeOf((*HostSriovInfo)(nil)).Elem()
+}
+
+type HostSriovNetworkDevicePoolInfo struct {
+	HostSriovDevicePoolInfo
+
+	SwitchKey  string        `xml:"switchKey,omitempty"`
+	SwitchUuid string        `xml:"switchUuid,omitempty"`
+	Pnic       []PhysicalNic `xml:"pnic,omitempty"`
+}
+
+func init() {
+	t["HostSriovNetworkDevicePoolInfo"] = reflect.TypeOf((*HostSriovNetworkDevicePoolInfo)(nil)).Elem()
 }
 
 type HostSslThumbprintInfo struct {
@@ -21896,6 +23669,18 @@ type HostStorageSystemVmfsVolumeResult struct {
 
 func init() {
 	t["HostStorageSystemVmfsVolumeResult"] = reflect.TypeOf((*HostStorageSystemVmfsVolumeResult)(nil)).Elem()
+}
+
+type HostSubSpecification struct {
+	DynamicData
+
+	Name        string    `xml:"name"`
+	CreatedTime time.Time `xml:"createdTime"`
+	Data        []byte    `xml:"data,omitempty"`
+}
+
+func init() {
+	t["HostSubSpecification"] = reflect.TypeOf((*HostSubSpecification)(nil)).Elem()
 }
 
 type HostSyncFailedEvent struct {
@@ -22419,6 +24204,16 @@ func init() {
 	t["HostVirtualNicConnection"] = reflect.TypeOf((*HostVirtualNicConnection)(nil)).Elem()
 }
 
+type HostVirtualNicIpRouteSpec struct {
+	DynamicData
+
+	IpRouteConfig BaseHostIpRouteConfig `xml:"ipRouteConfig,omitempty,typeattr"`
+}
+
+func init() {
+	t["HostVirtualNicIpRouteSpec"] = reflect.TypeOf((*HostVirtualNicIpRouteSpec)(nil)).Elem()
+}
+
 type HostVirtualNicManagerInfo struct {
 	DynamicData
 
@@ -22464,6 +24259,7 @@ type HostVirtualNicSpec struct {
 	OpaqueNetwork          *HostVirtualNicOpaqueNetworkSpec        `xml:"opaqueNetwork,omitempty"`
 	ExternalId             string                                  `xml:"externalId,omitempty"`
 	PinnedPnic             string                                  `xml:"pinnedPnic,omitempty"`
+	IpRouteSpec            *HostVirtualNicIpRouteSpec              `xml:"ipRouteSpec,omitempty"`
 }
 
 func init() {
@@ -22588,10 +24384,13 @@ func init() {
 type HostVmfsSpec struct {
 	DynamicData
 
-	Extent       HostScsiDiskPartition `xml:"extent"`
-	BlockSizeMb  int32                 `xml:"blockSizeMb,omitempty"`
-	MajorVersion int32                 `xml:"majorVersion"`
-	VolumeName   string                `xml:"volumeName"`
+	Extent           HostScsiDiskPartition `xml:"extent"`
+	BlockSizeMb      int32                 `xml:"blockSizeMb,omitempty"`
+	MajorVersion     int32                 `xml:"majorVersion"`
+	VolumeName       string                `xml:"volumeName"`
+	BlockSize        int32                 `xml:"blockSize,omitempty"`
+	UnmapGranularity int32                 `xml:"unmapGranularity,omitempty"`
+	UnmapPriority    string                `xml:"unmapPriority,omitempty"`
 }
 
 func init() {
@@ -22602,6 +24401,9 @@ type HostVmfsVolume struct {
 	HostFileSystemVolume
 
 	BlockSizeMb      int32                   `xml:"blockSizeMb"`
+	BlockSize        int32                   `xml:"blockSize,omitempty"`
+	UnmapGranularity int32                   `xml:"unmapGranularity,omitempty"`
+	UnmapPriority    string                  `xml:"unmapPriority,omitempty"`
 	MaxBlocks        int32                   `xml:"maxBlocks"`
 	MajorVersion     int32                   `xml:"majorVersion"`
 	Version          string                  `xml:"version"`
@@ -22611,6 +24413,7 @@ type HostVmfsVolume struct {
 	ForceMountedInfo *HostForceMountedInfo   `xml:"forceMountedInfo,omitempty"`
 	Ssd              *bool                   `xml:"ssd"`
 	Local            *bool                   `xml:"local"`
+	ScsiDiskType     string                  `xml:"scsiDiskType,omitempty"`
 }
 
 func init() {
@@ -22620,7 +24423,8 @@ func init() {
 type HostVnicConnectedToCustomizedDVPortEvent struct {
 	HostEvent
 
-	Vnic VnicPortArgument `xml:"vnic"`
+	Vnic        VnicPortArgument `xml:"vnic"`
+	PrevPortKey string           `xml:"prevPortKey,omitempty"`
 }
 
 func init() {
@@ -22888,6 +24692,16 @@ func init() {
 }
 
 type HttpNfcLeaseProgressResponse struct {
+}
+
+type ID struct {
+	DynamicData
+
+	Id string `xml:"id"`
+}
+
+func init() {
+	t["ID"] = reflect.TypeOf((*ID)(nil)).Elem()
 }
 
 type IDEDiskNotSupported struct {
@@ -23241,6 +25055,26 @@ type IndependentDiskVMotionNotSupportedFault IndependentDiskVMotionNotSupported
 
 func init() {
 	t["IndependentDiskVMotionNotSupportedFault"] = reflect.TypeOf((*IndependentDiskVMotionNotSupportedFault)(nil)).Elem()
+}
+
+type InflateDiskRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["InflateDiskRequestType"] = reflect.TypeOf((*InflateDiskRequestType)(nil)).Elem()
+}
+
+type InflateDisk_Task InflateDiskRequestType
+
+func init() {
+	t["InflateDisk_Task"] = reflect.TypeOf((*InflateDisk_Task)(nil)).Elem()
+}
+
+type InflateDisk_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
 type InflateVirtualDiskRequestType struct {
@@ -24434,9 +26268,10 @@ func init() {
 type InvalidProfileReferenceHost struct {
 	RuntimeFault
 
-	Reason  string                  `xml:"reason,omitempty"`
-	Host    *ManagedObjectReference `xml:"host,omitempty"`
-	Profile *ManagedObjectReference `xml:"profile,omitempty"`
+	Reason      string                  `xml:"reason,omitempty"`
+	Host        *ManagedObjectReference `xml:"host,omitempty"`
+	Profile     *ManagedObjectReference `xml:"profile,omitempty"`
+	ProfileName string                  `xml:"profileName,omitempty"`
 }
 
 func init() {
@@ -24581,6 +26416,22 @@ func init() {
 	t["InvalidVmConfigFault"] = reflect.TypeOf((*InvalidVmConfigFault)(nil)).Elem()
 }
 
+type InvalidVmState struct {
+	InvalidState
+
+	Vm ManagedObjectReference `xml:"vm"`
+}
+
+func init() {
+	t["InvalidVmState"] = reflect.TypeOf((*InvalidVmState)(nil)).Elem()
+}
+
+type InvalidVmStateFault InvalidVmState
+
+func init() {
+	t["InvalidVmStateFault"] = reflect.TypeOf((*InvalidVmStateFault)(nil)).Elem()
+}
+
 type InventoryDescription struct {
 	DynamicData
 
@@ -24634,6 +26485,7 @@ type IoFilterInfo struct {
 	Name        string `xml:"name"`
 	Vendor      string `xml:"vendor"`
 	Version     string `xml:"version"`
+	Type        string `xml:"type,omitempty"`
 	Summary     string `xml:"summary,omitempty"`
 	ReleaseDate string `xml:"releaseDate,omitempty"`
 }
@@ -24999,17 +26851,21 @@ func init() {
 type IscsiPortInfo struct {
 	DynamicData
 
-	VnicDevice       string          `xml:"vnicDevice,omitempty"`
-	Vnic             *HostVirtualNic `xml:"vnic,omitempty"`
-	PnicDevice       string          `xml:"pnicDevice,omitempty"`
-	Pnic             *PhysicalNic    `xml:"pnic,omitempty"`
-	SwitchName       string          `xml:"switchName,omitempty"`
-	SwitchUuid       string          `xml:"switchUuid,omitempty"`
-	PortgroupName    string          `xml:"portgroupName,omitempty"`
-	PortgroupKey     string          `xml:"portgroupKey,omitempty"`
-	PortKey          string          `xml:"portKey,omitempty"`
-	ComplianceStatus *IscsiStatus    `xml:"complianceStatus,omitempty"`
-	PathStatus       string          `xml:"pathStatus,omitempty"`
+	VnicDevice        string          `xml:"vnicDevice,omitempty"`
+	Vnic              *HostVirtualNic `xml:"vnic,omitempty"`
+	PnicDevice        string          `xml:"pnicDevice,omitempty"`
+	Pnic              *PhysicalNic    `xml:"pnic,omitempty"`
+	SwitchName        string          `xml:"switchName,omitempty"`
+	SwitchUuid        string          `xml:"switchUuid,omitempty"`
+	PortgroupName     string          `xml:"portgroupName,omitempty"`
+	PortgroupKey      string          `xml:"portgroupKey,omitempty"`
+	PortKey           string          `xml:"portKey,omitempty"`
+	OpaqueNetworkId   string          `xml:"opaqueNetworkId,omitempty"`
+	OpaqueNetworkType string          `xml:"opaqueNetworkType,omitempty"`
+	OpaqueNetworkName string          `xml:"opaqueNetworkName,omitempty"`
+	ExternalId        string          `xml:"externalId,omitempty"`
+	ComplianceStatus  *IscsiStatus    `xml:"complianceStatus,omitempty"`
+	PathStatus        string          `xml:"pathStatus,omitempty"`
 }
 
 func init() {
@@ -25127,6 +26983,16 @@ func init() {
 	t["KeyAnyValue"] = reflect.TypeOf((*KeyAnyValue)(nil)).Elem()
 }
 
+type KeyProviderId struct {
+	DynamicData
+
+	Id string `xml:"id"`
+}
+
+func init() {
+	t["KeyProviderId"] = reflect.TypeOf((*KeyProviderId)(nil)).Elem()
+}
+
 type KeyValue struct {
 	DynamicData
 
@@ -25136,6 +27002,62 @@ type KeyValue struct {
 
 func init() {
 	t["KeyValue"] = reflect.TypeOf((*KeyValue)(nil)).Elem()
+}
+
+type KmipClusterInfo struct {
+	DynamicData
+
+	ClusterId    KeyProviderId    `xml:"clusterId"`
+	Servers      []KmipServerInfo `xml:"servers,omitempty"`
+	UseAsDefault bool             `xml:"useAsDefault"`
+}
+
+func init() {
+	t["KmipClusterInfo"] = reflect.TypeOf((*KmipClusterInfo)(nil)).Elem()
+}
+
+type KmipServerInfo struct {
+	DynamicData
+
+	Name         string `xml:"name"`
+	Address      string `xml:"address"`
+	Port         int32  `xml:"port"`
+	ProxyAddress string `xml:"proxyAddress,omitempty"`
+	ProxyPort    int32  `xml:"proxyPort,omitempty"`
+	Reconnect    int32  `xml:"reconnect,omitempty"`
+	Protocol     string `xml:"protocol,omitempty"`
+	Nbio         int32  `xml:"nbio,omitempty"`
+	Timeout      int32  `xml:"timeout,omitempty"`
+	UserName     string `xml:"userName,omitempty"`
+}
+
+func init() {
+	t["KmipServerInfo"] = reflect.TypeOf((*KmipServerInfo)(nil)).Elem()
+}
+
+type KmipServerSpec struct {
+	DynamicData
+
+	ClusterId KeyProviderId  `xml:"clusterId"`
+	Info      KmipServerInfo `xml:"info"`
+	Password  string         `xml:"password,omitempty"`
+}
+
+func init() {
+	t["KmipServerSpec"] = reflect.TypeOf((*KmipServerSpec)(nil)).Elem()
+}
+
+type KmipServerStatus struct {
+	DynamicData
+
+	ClusterId   KeyProviderId       `xml:"clusterId"`
+	Name        string              `xml:"name"`
+	Status      ManagedEntityStatus `xml:"status"`
+	Description string              `xml:"description"`
+}
+
+func init() {
+	t["KmipServerStatus"] = reflect.TypeOf((*KmipServerStatus)(nil)).Elem()
 }
 
 type LargeRDMConversionNotSupported struct {
@@ -25694,6 +27616,44 @@ type ListGuestMappedAliasesResponse struct {
 	Returnval []GuestMappedAliases `xml:"returnval,omitempty"`
 }
 
+type ListKeys ListKeysRequestType
+
+func init() {
+	t["ListKeys"] = reflect.TypeOf((*ListKeys)(nil)).Elem()
+}
+
+type ListKeysRequestType struct {
+	This  ManagedObjectReference `xml:"_this"`
+	Limit int32                  `xml:"limit,omitempty"`
+}
+
+func init() {
+	t["ListKeysRequestType"] = reflect.TypeOf((*ListKeysRequestType)(nil)).Elem()
+}
+
+type ListKeysResponse struct {
+	Returnval []CryptoKeyId `xml:"returnval,omitempty"`
+}
+
+type ListKmipServers ListKmipServersRequestType
+
+func init() {
+	t["ListKmipServers"] = reflect.TypeOf((*ListKmipServers)(nil)).Elem()
+}
+
+type ListKmipServersRequestType struct {
+	This  ManagedObjectReference `xml:"_this"`
+	Limit int32                  `xml:"limit,omitempty"`
+}
+
+func init() {
+	t["ListKmipServersRequestType"] = reflect.TypeOf((*ListKmipServersRequestType)(nil)).Elem()
+}
+
+type ListKmipServersResponse struct {
+	Returnval []KmipClusterInfo `xml:"returnval,omitempty"`
+}
+
 type ListProcessesInGuest ListProcessesInGuestRequestType
 
 func init() {
@@ -25779,10 +27739,69 @@ type ListSmartCardTrustAnchorsResponse struct {
 	Returnval []string `xml:"returnval,omitempty"`
 }
 
+type ListTagsAttachedToVStorageObject ListTagsAttachedToVStorageObjectRequestType
+
+func init() {
+	t["ListTagsAttachedToVStorageObject"] = reflect.TypeOf((*ListTagsAttachedToVStorageObject)(nil)).Elem()
+}
+
+type ListTagsAttachedToVStorageObjectRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Id   ID                     `xml:"id"`
+}
+
+func init() {
+	t["ListTagsAttachedToVStorageObjectRequestType"] = reflect.TypeOf((*ListTagsAttachedToVStorageObjectRequestType)(nil)).Elem()
+}
+
+type ListTagsAttachedToVStorageObjectResponse struct {
+	Returnval []VslmTagEntry `xml:"returnval,omitempty"`
+}
+
+type ListVStorageObject ListVStorageObjectRequestType
+
+func init() {
+	t["ListVStorageObject"] = reflect.TypeOf((*ListVStorageObject)(nil)).Elem()
+}
+
+type ListVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["ListVStorageObjectRequestType"] = reflect.TypeOf((*ListVStorageObjectRequestType)(nil)).Elem()
+}
+
+type ListVStorageObjectResponse struct {
+	Returnval []ID `xml:"returnval,omitempty"`
+}
+
+type ListVStorageObjectsAttachedToTag ListVStorageObjectsAttachedToTagRequestType
+
+func init() {
+	t["ListVStorageObjectsAttachedToTag"] = reflect.TypeOf((*ListVStorageObjectsAttachedToTag)(nil)).Elem()
+}
+
+type ListVStorageObjectsAttachedToTagRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	Category string                 `xml:"category"`
+	Tag      string                 `xml:"tag"`
+}
+
+func init() {
+	t["ListVStorageObjectsAttachedToTagRequestType"] = reflect.TypeOf((*ListVStorageObjectsAttachedToTagRequestType)(nil)).Elem()
+}
+
+type ListVStorageObjectsAttachedToTagResponse struct {
+	Returnval []ID `xml:"returnval,omitempty"`
+}
+
 type LocalDatastoreCreatedEvent struct {
 	HostEvent
 
-	Datastore DatastoreEventArgument `xml:"datastore"`
+	Datastore    DatastoreEventArgument `xml:"datastore"`
+	DatastoreUrl string                 `xml:"datastoreUrl,omitempty"`
 }
 
 func init() {
@@ -26337,6 +28356,24 @@ func init() {
 }
 
 type MarkAsVirtualMachineResponse struct {
+}
+
+type MarkDefault MarkDefaultRequestType
+
+func init() {
+	t["MarkDefault"] = reflect.TypeOf((*MarkDefault)(nil)).Elem()
+}
+
+type MarkDefaultRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	ClusterId KeyProviderId          `xml:"clusterId"`
+}
+
+func init() {
+	t["MarkDefaultRequestType"] = reflect.TypeOf((*MarkDefaultRequestType)(nil)).Elem()
+}
+
+type MarkDefaultResponse struct {
 }
 
 type MarkForRemoval MarkForRemovalRequestType
@@ -27375,7 +29412,8 @@ func init() {
 type NASDatastoreCreatedEvent struct {
 	HostEvent
 
-	Datastore DatastoreEventArgument `xml:"datastore"`
+	Datastore    DatastoreEventArgument `xml:"datastore"`
+	DatastoreUrl string                 `xml:"datastoreUrl,omitempty"`
 }
 
 func init() {
@@ -28362,6 +30400,34 @@ func init() {
 	t["NoVmInVAppFault"] = reflect.TypeOf((*NoVmInVAppFault)(nil)).Elem()
 }
 
+type NodeDeploymentSpec struct {
+	DynamicData
+
+	EsxHost                 *ManagedObjectReference `xml:"esxHost,omitempty"`
+	Datastore               *ManagedObjectReference `xml:"datastore,omitempty"`
+	PublicNetworkPortGroup  *ManagedObjectReference `xml:"publicNetworkPortGroup,omitempty"`
+	ClusterNetworkPortGroup *ManagedObjectReference `xml:"clusterNetworkPortGroup,omitempty"`
+	Folder                  ManagedObjectReference  `xml:"folder"`
+	ResourcePool            *ManagedObjectReference `xml:"resourcePool,omitempty"`
+	ManagementVc            *ServiceLocator         `xml:"managementVc,omitempty"`
+	NodeName                string                  `xml:"nodeName"`
+	IpSettings              CustomizationIPSettings `xml:"ipSettings"`
+}
+
+func init() {
+	t["NodeDeploymentSpec"] = reflect.TypeOf((*NodeDeploymentSpec)(nil)).Elem()
+}
+
+type NodeNetworkSpec struct {
+	DynamicData
+
+	IpSettings CustomizationIPSettings `xml:"ipSettings"`
+}
+
+func init() {
+	t["NodeNetworkSpec"] = reflect.TypeOf((*NodeNetworkSpec)(nil)).Elem()
+}
+
 type NonADUserRequired struct {
 	ActiveDirectoryFault
 }
@@ -28879,6 +30945,16 @@ type OnceTaskScheduler struct {
 
 func init() {
 	t["OnceTaskScheduler"] = reflect.TypeOf((*OnceTaskScheduler)(nil)).Elem()
+}
+
+type OpaqueNetworkCapability struct {
+	DynamicData
+
+	NetworkReservationSupported bool `xml:"networkReservationSupported"`
+}
+
+func init() {
+	t["OpaqueNetworkCapability"] = reflect.TypeOf((*OpaqueNetworkCapability)(nil)).Elem()
 }
 
 type OpaqueNetworkSummary struct {
@@ -30600,6 +32676,26 @@ type ParseDescriptorResponse struct {
 	Returnval OvfParseDescriptorResult `xml:"returnval"`
 }
 
+type PassiveNodeDeploymentSpec struct {
+	NodeDeploymentSpec
+
+	FailoverIpSettings *CustomizationIPSettings `xml:"failoverIpSettings,omitempty"`
+}
+
+func init() {
+	t["PassiveNodeDeploymentSpec"] = reflect.TypeOf((*PassiveNodeDeploymentSpec)(nil)).Elem()
+}
+
+type PassiveNodeNetworkSpec struct {
+	NodeNetworkSpec
+
+	FailoverIpSettings *CustomizationIPSettings `xml:"failoverIpSettings,omitempty"`
+}
+
+func init() {
+	t["PassiveNodeNetworkSpec"] = reflect.TypeOf((*PassiveNodeNetworkSpec)(nil)).Elem()
+}
+
 type PasswordField struct {
 	DynamicData
 
@@ -31076,8 +33172,10 @@ func init() {
 type PermissionUpdatedEvent struct {
 	PermissionEvent
 
-	Role      RoleEventArgument `xml:"role"`
-	Propagate bool              `xml:"propagate"`
+	Role          RoleEventArgument  `xml:"role"`
+	Propagate     bool               `xml:"propagate"`
+	PrevRole      *RoleEventArgument `xml:"prevRole,omitempty"`
+	PrevPropagate *bool              `xml:"prevPropagate"`
 }
 
 func init() {
@@ -31466,6 +33564,25 @@ func init() {
 type PostEventResponse struct {
 }
 
+type PostHealthUpdates PostHealthUpdatesRequestType
+
+func init() {
+	t["PostHealthUpdates"] = reflect.TypeOf((*PostHealthUpdates)(nil)).Elem()
+}
+
+type PostHealthUpdatesRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+	Updates    []HealthUpdate         `xml:"updates,omitempty"`
+}
+
+func init() {
+	t["PostHealthUpdatesRequestType"] = reflect.TypeOf((*PostHealthUpdatesRequestType)(nil)).Elem()
+}
+
+type PostHealthUpdatesResponse struct {
+}
+
 type PowerDownHostToStandByRequestType struct {
 	This                  ManagedObjectReference `xml:"_this"`
 	TimeoutSec            int32                  `xml:"timeoutSec"`
@@ -31655,6 +33772,23 @@ func init() {
 
 type PowerUpHostFromStandBy_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type PrepareCrypto PrepareCryptoRequestType
+
+func init() {
+	t["PrepareCrypto"] = reflect.TypeOf((*PrepareCrypto)(nil)).Elem()
+}
+
+type PrepareCryptoRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["PrepareCryptoRequestType"] = reflect.TypeOf((*PrepareCryptoRequestType)(nil)).Elem()
+}
+
+type PrepareCryptoResponse struct {
 }
 
 type PrivilegeAvailability struct {
@@ -31923,10 +34057,13 @@ func init() {
 type ProfileParameterMetadata struct {
 	DynamicData
 
-	Id           ExtendedElementDescription `xml:"id"`
-	Type         string                     `xml:"type"`
-	Optional     bool                       `xml:"optional"`
-	DefaultValue AnyType                    `xml:"defaultValue,omitempty,typeattr"`
+	Id                ExtendedElementDescription `xml:"id"`
+	Type              string                     `xml:"type"`
+	Optional          bool                       `xml:"optional"`
+	DefaultValue      AnyType                    `xml:"defaultValue,omitempty,typeattr"`
+	Hidden            *bool                      `xml:"hidden"`
+	SecuritySensitive *bool                      `xml:"securitySensitive"`
+	ReadOnly          *bool                      `xml:"readOnly"`
 }
 
 func init() {
@@ -32004,7 +34141,9 @@ func init() {
 type ProfileReferenceHostChangedEvent struct {
 	ProfileEvent
 
-	ReferenceHost *ManagedObjectReference `xml:"referenceHost,omitempty"`
+	ReferenceHost         *ManagedObjectReference `xml:"referenceHost,omitempty"`
+	ReferenceHostName     string                  `xml:"referenceHostName,omitempty"`
+	PrevReferenceHostName string                  `xml:"prevReferenceHostName,omitempty"`
 }
 
 func init() {
@@ -32133,6 +34272,42 @@ type PropertySpec struct {
 
 func init() {
 	t["PropertySpec"] = reflect.TypeOf((*PropertySpec)(nil)).Elem()
+}
+
+type PutUsbScanCodes PutUsbScanCodesRequestType
+
+func init() {
+	t["PutUsbScanCodes"] = reflect.TypeOf((*PutUsbScanCodes)(nil)).Elem()
+}
+
+type PutUsbScanCodesRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Spec UsbScanCodeSpec        `xml:"spec"`
+}
+
+func init() {
+	t["PutUsbScanCodesRequestType"] = reflect.TypeOf((*PutUsbScanCodesRequestType)(nil)).Elem()
+}
+
+type PutUsbScanCodesResponse struct {
+	Returnval int32 `xml:"returnval"`
+}
+
+type QuarantineModeFault struct {
+	VmConfigFault
+
+	VmName    string `xml:"vmName"`
+	FaultType string `xml:"faultType"`
+}
+
+func init() {
+	t["QuarantineModeFault"] = reflect.TypeOf((*QuarantineModeFault)(nil)).Elem()
+}
+
+type QuarantineModeFaultFault QuarantineModeFault
+
+func init() {
+	t["QuarantineModeFaultFault"] = reflect.TypeOf((*QuarantineModeFaultFault)(nil)).Elem()
 }
 
 type QueryAnswerFileStatus QueryAnswerFileStatusRequestType
@@ -32872,6 +35047,82 @@ type QueryFaultToleranceCompatibilityResponse struct {
 	Returnval []LocalizedMethodFault `xml:"returnval,omitempty"`
 }
 
+type QueryFilterEntities QueryFilterEntitiesRequestType
+
+func init() {
+	t["QueryFilterEntities"] = reflect.TypeOf((*QueryFilterEntities)(nil)).Elem()
+}
+
+type QueryFilterEntitiesRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	FilterId string                 `xml:"filterId"`
+}
+
+func init() {
+	t["QueryFilterEntitiesRequestType"] = reflect.TypeOf((*QueryFilterEntitiesRequestType)(nil)).Elem()
+}
+
+type QueryFilterEntitiesResponse struct {
+	Returnval []ManagedObjectReference `xml:"returnval,omitempty"`
+}
+
+type QueryFilterInfoIds QueryFilterInfoIdsRequestType
+
+func init() {
+	t["QueryFilterInfoIds"] = reflect.TypeOf((*QueryFilterInfoIds)(nil)).Elem()
+}
+
+type QueryFilterInfoIdsRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	FilterId string                 `xml:"filterId"`
+}
+
+func init() {
+	t["QueryFilterInfoIdsRequestType"] = reflect.TypeOf((*QueryFilterInfoIdsRequestType)(nil)).Elem()
+}
+
+type QueryFilterInfoIdsResponse struct {
+	Returnval []string `xml:"returnval,omitempty"`
+}
+
+type QueryFilterList QueryFilterListRequestType
+
+func init() {
+	t["QueryFilterList"] = reflect.TypeOf((*QueryFilterList)(nil)).Elem()
+}
+
+type QueryFilterListRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+}
+
+func init() {
+	t["QueryFilterListRequestType"] = reflect.TypeOf((*QueryFilterListRequestType)(nil)).Elem()
+}
+
+type QueryFilterListResponse struct {
+	Returnval []string `xml:"returnval,omitempty"`
+}
+
+type QueryFilterName QueryFilterNameRequestType
+
+func init() {
+	t["QueryFilterName"] = reflect.TypeOf((*QueryFilterName)(nil)).Elem()
+}
+
+type QueryFilterNameRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	FilterId string                 `xml:"filterId"`
+}
+
+func init() {
+	t["QueryFilterNameRequestType"] = reflect.TypeOf((*QueryFilterNameRequestType)(nil)).Elem()
+}
+
+type QueryFilterNameResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
 type QueryFirmwareConfigUploadURL QueryFirmwareConfigUploadURLRequestType
 
 func init() {
@@ -32888,6 +35139,44 @@ func init() {
 
 type QueryFirmwareConfigUploadURLResponse struct {
 	Returnval string `xml:"returnval"`
+}
+
+type QueryHealthUpdateInfos QueryHealthUpdateInfosRequestType
+
+func init() {
+	t["QueryHealthUpdateInfos"] = reflect.TypeOf((*QueryHealthUpdateInfos)(nil)).Elem()
+}
+
+type QueryHealthUpdateInfosRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+}
+
+func init() {
+	t["QueryHealthUpdateInfosRequestType"] = reflect.TypeOf((*QueryHealthUpdateInfosRequestType)(nil)).Elem()
+}
+
+type QueryHealthUpdateInfosResponse struct {
+	Returnval []HealthUpdateInfo `xml:"returnval,omitempty"`
+}
+
+type QueryHealthUpdates QueryHealthUpdatesRequestType
+
+func init() {
+	t["QueryHealthUpdates"] = reflect.TypeOf((*QueryHealthUpdates)(nil)).Elem()
+}
+
+type QueryHealthUpdatesRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+}
+
+func init() {
+	t["QueryHealthUpdatesRequestType"] = reflect.TypeOf((*QueryHealthUpdatesRequestType)(nil)).Elem()
+}
+
+type QueryHealthUpdatesResponse struct {
+	Returnval []HealthUpdate `xml:"returnval,omitempty"`
 }
 
 type QueryHostConnectionInfo QueryHostConnectionInfoRequestType
@@ -33215,6 +35504,25 @@ type QueryModulesResponse struct {
 	Returnval []KernelModuleInfo `xml:"returnval,omitempty"`
 }
 
+type QueryMonitoredEntities QueryMonitoredEntitiesRequestType
+
+func init() {
+	t["QueryMonitoredEntities"] = reflect.TypeOf((*QueryMonitoredEntities)(nil)).Elem()
+}
+
+type QueryMonitoredEntitiesRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+}
+
+func init() {
+	t["QueryMonitoredEntitiesRequestType"] = reflect.TypeOf((*QueryMonitoredEntitiesRequestType)(nil)).Elem()
+}
+
+type QueryMonitoredEntitiesResponse struct {
+	Returnval []ManagedObjectReference `xml:"returnval,omitempty"`
+}
+
 type QueryNFSUser QueryNFSUserRequestType
 
 func init() {
@@ -33539,6 +35847,43 @@ type QueryProfileStructureResponse struct {
 	Returnval ProfileProfileStructure `xml:"returnval"`
 }
 
+type QueryProviderList QueryProviderListRequestType
+
+func init() {
+	t["QueryProviderList"] = reflect.TypeOf((*QueryProviderList)(nil)).Elem()
+}
+
+type QueryProviderListRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["QueryProviderListRequestType"] = reflect.TypeOf((*QueryProviderListRequestType)(nil)).Elem()
+}
+
+type QueryProviderListResponse struct {
+	Returnval []string `xml:"returnval,omitempty"`
+}
+
+type QueryProviderName QueryProviderNameRequestType
+
+func init() {
+	t["QueryProviderName"] = reflect.TypeOf((*QueryProviderName)(nil)).Elem()
+}
+
+type QueryProviderNameRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Id   string                 `xml:"id"`
+}
+
+func init() {
+	t["QueryProviderNameRequestType"] = reflect.TypeOf((*QueryProviderNameRequestType)(nil)).Elem()
+}
+
+type QueryProviderNameResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
 type QueryResourceConfigOption QueryResourceConfigOptionRequestType
 
 func init() {
@@ -33686,6 +36031,26 @@ func init() {
 
 type QueryTpmAttestationReportResponse struct {
 	Returnval *HostTpmAttestationReport `xml:"returnval,omitempty"`
+}
+
+type QueryUnmonitoredHosts QueryUnmonitoredHostsRequestType
+
+func init() {
+	t["QueryUnmonitoredHosts"] = reflect.TypeOf((*QueryUnmonitoredHosts)(nil)).Elem()
+}
+
+type QueryUnmonitoredHostsRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+	Cluster    ManagedObjectReference `xml:"cluster"`
+}
+
+func init() {
+	t["QueryUnmonitoredHostsRequestType"] = reflect.TypeOf((*QueryUnmonitoredHostsRequestType)(nil)).Elem()
+}
+
+type QueryUnmonitoredHostsResponse struct {
+	Returnval []ManagedObjectReference `xml:"returnval,omitempty"`
 }
 
 type QueryUnownedFiles QueryUnownedFilesRequestType
@@ -33859,6 +36224,24 @@ func init() {
 
 type QueryVirtualDiskUuidResponse struct {
 	Returnval string `xml:"returnval"`
+}
+
+type QueryVmfsConfigOption QueryVmfsConfigOptionRequestType
+
+func init() {
+	t["QueryVmfsConfigOption"] = reflect.TypeOf((*QueryVmfsConfigOption)(nil)).Elem()
+}
+
+type QueryVmfsConfigOptionRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+}
+
+func init() {
+	t["QueryVmfsConfigOptionRequestType"] = reflect.TypeOf((*QueryVmfsConfigOptionRequestType)(nil)).Elem()
+}
+
+type QueryVmfsConfigOptionResponse struct {
+	Returnval []VmfsConfigOption `xml:"returnval,omitempty"`
 }
 
 type QueryVmfsDatastoreCreateOptions QueryVmfsDatastoreCreateOptionsRequestType
@@ -34379,6 +36762,25 @@ func init() {
 }
 
 type RecommissionVsanNode_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type ReconcileDatastoreInventoryRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["ReconcileDatastoreInventoryRequestType"] = reflect.TypeOf((*ReconcileDatastoreInventoryRequestType)(nil)).Elem()
+}
+
+type ReconcileDatastoreInventory_Task ReconcileDatastoreInventoryRequestType
+
+func init() {
+	t["ReconcileDatastoreInventory_Task"] = reflect.TypeOf((*ReconcileDatastoreInventory_Task)(nil)).Elem()
+}
+
+type ReconcileDatastoreInventory_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
@@ -35056,6 +37458,26 @@ type RegisterChildVM_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type RegisterDisk RegisterDiskRequestType
+
+func init() {
+	t["RegisterDisk"] = reflect.TypeOf((*RegisterDisk)(nil)).Elem()
+}
+
+type RegisterDiskRequestType struct {
+	This ManagedObjectReference `xml:"_this"`
+	Path string                 `xml:"path"`
+	Name string                 `xml:"name,omitempty"`
+}
+
+func init() {
+	t["RegisterDiskRequestType"] = reflect.TypeOf((*RegisterDiskRequestType)(nil)).Elem()
+}
+
+type RegisterDiskResponse struct {
+	Returnval VStorageObject `xml:"returnval"`
+}
+
 type RegisterExtension RegisterExtensionRequestType
 
 func init() {
@@ -35072,6 +37494,44 @@ func init() {
 }
 
 type RegisterExtensionResponse struct {
+}
+
+type RegisterHealthUpdateProvider RegisterHealthUpdateProviderRequestType
+
+func init() {
+	t["RegisterHealthUpdateProvider"] = reflect.TypeOf((*RegisterHealthUpdateProvider)(nil)).Elem()
+}
+
+type RegisterHealthUpdateProviderRequestType struct {
+	This             ManagedObjectReference `xml:"_this"`
+	Name             string                 `xml:"name"`
+	HealthUpdateInfo []HealthUpdateInfo     `xml:"healthUpdateInfo,omitempty"`
+}
+
+func init() {
+	t["RegisterHealthUpdateProviderRequestType"] = reflect.TypeOf((*RegisterHealthUpdateProviderRequestType)(nil)).Elem()
+}
+
+type RegisterHealthUpdateProviderResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
+type RegisterKmipServer RegisterKmipServerRequestType
+
+func init() {
+	t["RegisterKmipServer"] = reflect.TypeOf((*RegisterKmipServer)(nil)).Elem()
+}
+
+type RegisterKmipServerRequestType struct {
+	This   ManagedObjectReference `xml:"_this"`
+	Server KmipServerSpec         `xml:"server"`
+}
+
+func init() {
+	t["RegisterKmipServerRequestType"] = reflect.TypeOf((*RegisterKmipServerRequestType)(nil)).Elem()
+}
+
+type RegisterKmipServerResponse struct {
 }
 
 type RegisterVMRequestType struct {
@@ -35095,6 +37555,18 @@ func init() {
 
 type RegisterVM_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type Relation struct {
+	DynamicData
+
+	Constraint string `xml:"constraint,omitempty"`
+	Name       string `xml:"name"`
+	Version    string `xml:"version,omitempty"`
+}
+
+func init() {
+	t["Relation"] = reflect.TypeOf((*Relation)(nil)).Elem()
 }
 
 type ReleaseCredentialsInGuest ReleaseCredentialsInGuestRequestType
@@ -35136,6 +37608,25 @@ func init() {
 type ReleaseIpAllocationResponse struct {
 }
 
+type ReleaseManagedSnapshot ReleaseManagedSnapshotRequestType
+
+func init() {
+	t["ReleaseManagedSnapshot"] = reflect.TypeOf((*ReleaseManagedSnapshot)(nil)).Elem()
+}
+
+type ReleaseManagedSnapshotRequestType struct {
+	This       ManagedObjectReference  `xml:"_this"`
+	Vdisk      string                  `xml:"vdisk"`
+	Datacenter *ManagedObjectReference `xml:"datacenter,omitempty"`
+}
+
+func init() {
+	t["ReleaseManagedSnapshotRequestType"] = reflect.TypeOf((*ReleaseManagedSnapshotRequestType)(nil)).Elem()
+}
+
+type ReleaseManagedSnapshotResponse struct {
+}
+
 type Reload ReloadRequestType
 
 func init() {
@@ -35170,6 +37661,27 @@ func init() {
 }
 
 type RelocateVM_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type RelocateVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+	Spec      VslmRelocateSpec       `xml:"spec"`
+}
+
+func init() {
+	t["RelocateVStorageObjectRequestType"] = reflect.TypeOf((*RelocateVStorageObjectRequestType)(nil)).Elem()
+}
+
+type RelocateVStorageObject_Task RelocateVStorageObjectRequestType
+
+func init() {
+	t["RelocateVStorageObject_Task"] = reflect.TypeOf((*RelocateVStorageObject_Task)(nil)).Elem()
+}
+
+type RelocateVStorageObject_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
@@ -35399,6 +37911,43 @@ func init() {
 	t["RemoveFailedFault"] = reflect.TypeOf((*RemoveFailedFault)(nil)).Elem()
 }
 
+type RemoveFilter RemoveFilterRequestType
+
+func init() {
+	t["RemoveFilter"] = reflect.TypeOf((*RemoveFilter)(nil)).Elem()
+}
+
+type RemoveFilterEntities RemoveFilterEntitiesRequestType
+
+func init() {
+	t["RemoveFilterEntities"] = reflect.TypeOf((*RemoveFilterEntities)(nil)).Elem()
+}
+
+type RemoveFilterEntitiesRequestType struct {
+	This     ManagedObjectReference   `xml:"_this"`
+	FilterId string                   `xml:"filterId"`
+	Entities []ManagedObjectReference `xml:"entities,omitempty"`
+}
+
+func init() {
+	t["RemoveFilterEntitiesRequestType"] = reflect.TypeOf((*RemoveFilterEntitiesRequestType)(nil)).Elem()
+}
+
+type RemoveFilterEntitiesResponse struct {
+}
+
+type RemoveFilterRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	FilterId string                 `xml:"filterId"`
+}
+
+func init() {
+	t["RemoveFilterRequestType"] = reflect.TypeOf((*RemoveFilterRequestType)(nil)).Elem()
+}
+
+type RemoveFilterResponse struct {
+}
+
 type RemoveGroup RemoveGroupRequestType
 
 func init() {
@@ -35498,6 +38047,64 @@ func init() {
 type RemoveInternetScsiStaticTargetsResponse struct {
 }
 
+type RemoveKey RemoveKeyRequestType
+
+func init() {
+	t["RemoveKey"] = reflect.TypeOf((*RemoveKey)(nil)).Elem()
+}
+
+type RemoveKeyRequestType struct {
+	This  ManagedObjectReference `xml:"_this"`
+	Key   CryptoKeyId            `xml:"key"`
+	Force bool                   `xml:"force"`
+}
+
+func init() {
+	t["RemoveKeyRequestType"] = reflect.TypeOf((*RemoveKeyRequestType)(nil)).Elem()
+}
+
+type RemoveKeyResponse struct {
+}
+
+type RemoveKeys RemoveKeysRequestType
+
+func init() {
+	t["RemoveKeys"] = reflect.TypeOf((*RemoveKeys)(nil)).Elem()
+}
+
+type RemoveKeysRequestType struct {
+	This  ManagedObjectReference `xml:"_this"`
+	Keys  []CryptoKeyId          `xml:"keys,omitempty"`
+	Force bool                   `xml:"force"`
+}
+
+func init() {
+	t["RemoveKeysRequestType"] = reflect.TypeOf((*RemoveKeysRequestType)(nil)).Elem()
+}
+
+type RemoveKeysResponse struct {
+	Returnval []CryptoKeyResult `xml:"returnval,omitempty"`
+}
+
+type RemoveKmipServer RemoveKmipServerRequestType
+
+func init() {
+	t["RemoveKmipServer"] = reflect.TypeOf((*RemoveKmipServer)(nil)).Elem()
+}
+
+type RemoveKmipServerRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ClusterId  KeyProviderId          `xml:"clusterId"`
+	ServerName string                 `xml:"serverName"`
+}
+
+func init() {
+	t["RemoveKmipServerRequestType"] = reflect.TypeOf((*RemoveKmipServerRequestType)(nil)).Elem()
+}
+
+type RemoveKmipServerResponse struct {
+}
+
 type RemoveLicense RemoveLicenseRequestType
 
 func init() {
@@ -35533,6 +38140,25 @@ func init() {
 }
 
 type RemoveLicenseResponse struct {
+}
+
+type RemoveMonitoredEntities RemoveMonitoredEntitiesRequestType
+
+func init() {
+	t["RemoveMonitoredEntities"] = reflect.TypeOf((*RemoveMonitoredEntities)(nil)).Elem()
+}
+
+type RemoveMonitoredEntitiesRequestType struct {
+	This       ManagedObjectReference   `xml:"_this"`
+	ProviderId string                   `xml:"providerId"`
+	Entities   []ManagedObjectReference `xml:"entities,omitempty"`
+}
+
+func init() {
+	t["RemoveMonitoredEntitiesRequestType"] = reflect.TypeOf((*RemoveMonitoredEntitiesRequestType)(nil)).Elem()
+}
+
+type RemoveMonitoredEntitiesResponse struct {
 }
 
 type RemoveNetworkResourcePool RemoveNetworkResourcePoolRequestType
@@ -35820,6 +38446,26 @@ func init() {
 type RenameSnapshotResponse struct {
 }
 
+type RenameVStorageObject RenameVStorageObjectRequestType
+
+func init() {
+	t["RenameVStorageObject"] = reflect.TypeOf((*RenameVStorageObject)(nil)).Elem()
+}
+
+type RenameVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+	Name      string                 `xml:"name"`
+}
+
+func init() {
+	t["RenameVStorageObjectRequestType"] = reflect.TypeOf((*RenameVStorageObjectRequestType)(nil)).Elem()
+}
+
+type RenameVStorageObjectResponse struct {
+}
+
 type Rename_Task RenameRequestType
 
 func init() {
@@ -35932,6 +38578,17 @@ func init() {
 	t["ReplicationFaultFault"] = reflect.TypeOf((*ReplicationFaultFault)(nil)).Elem()
 }
 
+type ReplicationGroupId struct {
+	DynamicData
+
+	FaultDomainId FaultDomainId `xml:"faultDomainId"`
+	DeviceGroupId DeviceGroupId `xml:"deviceGroupId"`
+}
+
+func init() {
+	t["ReplicationGroupId"] = reflect.TypeOf((*ReplicationGroupId)(nil)).Elem()
+}
+
 type ReplicationIncompatibleWithFT struct {
 	ReplicationFault
 }
@@ -35986,6 +38643,16 @@ type ReplicationNotSupportedOnHostFault ReplicationNotSupportedOnHost
 
 func init() {
 	t["ReplicationNotSupportedOnHostFault"] = reflect.TypeOf((*ReplicationNotSupportedOnHostFault)(nil)).Elem()
+}
+
+type ReplicationSpec struct {
+	DynamicData
+
+	ReplicationGroupId ReplicationGroupId `xml:"replicationGroupId"`
+}
+
+func init() {
+	t["ReplicationSpec"] = reflect.TypeOf((*ReplicationSpec)(nil)).Elem()
 }
 
 type ReplicationVmConfigFault struct {
@@ -36554,6 +39221,8 @@ func init() {
 
 type ResourcePoolReconfiguredEvent struct {
 	ResourcePoolEvent
+
+	ConfigChanges *ChangesInfoEventArgument `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -36769,6 +39438,44 @@ type RetrieveArgumentDescriptionResponse struct {
 	Returnval []EventArgDesc `xml:"returnval,omitempty"`
 }
 
+type RetrieveClientCert RetrieveClientCertRequestType
+
+func init() {
+	t["RetrieveClientCert"] = reflect.TypeOf((*RetrieveClientCert)(nil)).Elem()
+}
+
+type RetrieveClientCertRequestType struct {
+	This    ManagedObjectReference `xml:"_this"`
+	Cluster KeyProviderId          `xml:"cluster"`
+}
+
+func init() {
+	t["RetrieveClientCertRequestType"] = reflect.TypeOf((*RetrieveClientCertRequestType)(nil)).Elem()
+}
+
+type RetrieveClientCertResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
+type RetrieveClientCsr RetrieveClientCsrRequestType
+
+func init() {
+	t["RetrieveClientCsr"] = reflect.TypeOf((*RetrieveClientCsr)(nil)).Elem()
+}
+
+type RetrieveClientCsrRequestType struct {
+	This    ManagedObjectReference `xml:"_this"`
+	Cluster KeyProviderId          `xml:"cluster"`
+}
+
+func init() {
+	t["RetrieveClientCsrRequestType"] = reflect.TypeOf((*RetrieveClientCsrRequestType)(nil)).Elem()
+}
+
+type RetrieveClientCsrResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
 type RetrieveDasAdvancedRuntimeInfo RetrieveDasAdvancedRuntimeInfoRequestType
 
 func init() {
@@ -36899,6 +39606,104 @@ type RetrieveHostAccessControlEntriesResponse struct {
 	Returnval []HostAccessControlEntry `xml:"returnval,omitempty"`
 }
 
+type RetrieveHostCustomizations RetrieveHostCustomizationsRequestType
+
+func init() {
+	t["RetrieveHostCustomizations"] = reflect.TypeOf((*RetrieveHostCustomizations)(nil)).Elem()
+}
+
+type RetrieveHostCustomizationsForProfile RetrieveHostCustomizationsForProfileRequestType
+
+func init() {
+	t["RetrieveHostCustomizationsForProfile"] = reflect.TypeOf((*RetrieveHostCustomizationsForProfile)(nil)).Elem()
+}
+
+type RetrieveHostCustomizationsForProfileRequestType struct {
+	This         ManagedObjectReference   `xml:"_this"`
+	Hosts        []ManagedObjectReference `xml:"hosts,omitempty"`
+	ApplyProfile HostApplyProfile         `xml:"applyProfile"`
+}
+
+func init() {
+	t["RetrieveHostCustomizationsForProfileRequestType"] = reflect.TypeOf((*RetrieveHostCustomizationsForProfileRequestType)(nil)).Elem()
+}
+
+type RetrieveHostCustomizationsForProfileResponse struct {
+	Returnval []StructuredCustomizations `xml:"returnval,omitempty"`
+}
+
+type RetrieveHostCustomizationsRequestType struct {
+	This  ManagedObjectReference   `xml:"_this"`
+	Hosts []ManagedObjectReference `xml:"hosts,omitempty"`
+}
+
+func init() {
+	t["RetrieveHostCustomizationsRequestType"] = reflect.TypeOf((*RetrieveHostCustomizationsRequestType)(nil)).Elem()
+}
+
+type RetrieveHostCustomizationsResponse struct {
+	Returnval []StructuredCustomizations `xml:"returnval,omitempty"`
+}
+
+type RetrieveHostSpecification RetrieveHostSpecificationRequestType
+
+func init() {
+	t["RetrieveHostSpecification"] = reflect.TypeOf((*RetrieveHostSpecification)(nil)).Elem()
+}
+
+type RetrieveHostSpecificationRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	Host     ManagedObjectReference `xml:"host"`
+	FromHost bool                   `xml:"fromHost"`
+}
+
+func init() {
+	t["RetrieveHostSpecificationRequestType"] = reflect.TypeOf((*RetrieveHostSpecificationRequestType)(nil)).Elem()
+}
+
+type RetrieveHostSpecificationResponse struct {
+	Returnval HostSpecification `xml:"returnval"`
+}
+
+type RetrieveKmipServerCert RetrieveKmipServerCertRequestType
+
+func init() {
+	t["RetrieveKmipServerCert"] = reflect.TypeOf((*RetrieveKmipServerCert)(nil)).Elem()
+}
+
+type RetrieveKmipServerCertRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	KeyProvider KeyProviderId          `xml:"keyProvider"`
+	Server      KmipServerInfo         `xml:"server"`
+}
+
+func init() {
+	t["RetrieveKmipServerCertRequestType"] = reflect.TypeOf((*RetrieveKmipServerCertRequestType)(nil)).Elem()
+}
+
+type RetrieveKmipServerCertResponse struct {
+	Returnval CryptoManagerKmipServerCertInfo `xml:"returnval"`
+}
+
+type RetrieveKmipServersStatusRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	Clusters []KmipClusterInfo      `xml:"clusters,omitempty"`
+}
+
+func init() {
+	t["RetrieveKmipServersStatusRequestType"] = reflect.TypeOf((*RetrieveKmipServersStatusRequestType)(nil)).Elem()
+}
+
+type RetrieveKmipServersStatus_Task RetrieveKmipServersStatusRequestType
+
+func init() {
+	t["RetrieveKmipServersStatus_Task"] = reflect.TypeOf((*RetrieveKmipServersStatus_Task)(nil)).Elem()
+}
+
+type RetrieveKmipServersStatus_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type RetrieveObjectScheduledTask RetrieveObjectScheduledTaskRequestType
 
 func init() {
@@ -37015,6 +39820,25 @@ type RetrieveRolePermissionsResponse struct {
 	Returnval []Permission `xml:"returnval,omitempty"`
 }
 
+type RetrieveSelfSignedClientCert RetrieveSelfSignedClientCertRequestType
+
+func init() {
+	t["RetrieveSelfSignedClientCert"] = reflect.TypeOf((*RetrieveSelfSignedClientCert)(nil)).Elem()
+}
+
+type RetrieveSelfSignedClientCertRequestType struct {
+	This    ManagedObjectReference `xml:"_this"`
+	Cluster KeyProviderId          `xml:"cluster"`
+}
+
+func init() {
+	t["RetrieveSelfSignedClientCertRequestType"] = reflect.TypeOf((*RetrieveSelfSignedClientCertRequestType)(nil)).Elem()
+}
+
+type RetrieveSelfSignedClientCertResponse struct {
+	Returnval string `xml:"returnval"`
+}
+
 type RetrieveServiceContent RetrieveServiceContentRequestType
 
 func init() {
@@ -37056,6 +39880,46 @@ func init() {
 
 type RetrieveUserGroupsResponse struct {
 	Returnval []BaseUserSearchResult `xml:"returnval,omitempty,typeattr"`
+}
+
+type RetrieveVStorageObject RetrieveVStorageObjectRequestType
+
+func init() {
+	t["RetrieveVStorageObject"] = reflect.TypeOf((*RetrieveVStorageObject)(nil)).Elem()
+}
+
+type RetrieveVStorageObjectRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["RetrieveVStorageObjectRequestType"] = reflect.TypeOf((*RetrieveVStorageObjectRequestType)(nil)).Elem()
+}
+
+type RetrieveVStorageObjectResponse struct {
+	Returnval VStorageObject `xml:"returnval"`
+}
+
+type RetrieveVStorageObjectState RetrieveVStorageObjectStateRequestType
+
+func init() {
+	t["RetrieveVStorageObjectState"] = reflect.TypeOf((*RetrieveVStorageObjectState)(nil)).Elem()
+}
+
+type RetrieveVStorageObjectStateRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Id        ID                     `xml:"id"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["RetrieveVStorageObjectStateRequestType"] = reflect.TypeOf((*RetrieveVStorageObjectStateRequestType)(nil)).Elem()
+}
+
+type RetrieveVStorageObjectStateResponse struct {
+	Returnval VStorageObjectStateInfo `xml:"returnval"`
 }
 
 type RevertToCurrentSnapshotRequestType struct {
@@ -37157,7 +40021,10 @@ func init() {
 type RoleUpdatedEvent struct {
 	RoleEvent
 
-	PrivilegeList []string `xml:"privilegeList,omitempty"`
+	PrivilegeList     []string `xml:"privilegeList,omitempty"`
+	PrevRoleName      string   `xml:"prevRoleName,omitempty"`
+	PrivilegesAdded   []string `xml:"privilegesAdded,omitempty"`
+	PrivilegesRemoved []string `xml:"privilegesRemoved,omitempty"`
 }
 
 func init() {
@@ -37378,6 +40245,24 @@ type ScanHostPatch_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
 }
 
+type ScheduleReconcileDatastoreInventory ScheduleReconcileDatastoreInventoryRequestType
+
+func init() {
+	t["ScheduleReconcileDatastoreInventory"] = reflect.TypeOf((*ScheduleReconcileDatastoreInventory)(nil)).Elem()
+}
+
+type ScheduleReconcileDatastoreInventoryRequestType struct {
+	This      ManagedObjectReference `xml:"_this"`
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["ScheduleReconcileDatastoreInventoryRequestType"] = reflect.TypeOf((*ScheduleReconcileDatastoreInventoryRequestType)(nil)).Elem()
+}
+
+type ScheduleReconcileDatastoreInventoryResponse struct {
+}
+
 type ScheduledHardwareUpgradeInfo struct {
 	DynamicData
 
@@ -37506,6 +40391,8 @@ func init() {
 
 type ScheduledTaskReconfiguredEvent struct {
 	ScheduledTaskEvent
+
+	ConfigChanges *ChangesInfoEventArgument `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -37913,46 +40800,52 @@ func init() {
 type ServiceContent struct {
 	DynamicData
 
-	RootFolder                ManagedObjectReference  `xml:"rootFolder"`
-	PropertyCollector         ManagedObjectReference  `xml:"propertyCollector"`
-	ViewManager               *ManagedObjectReference `xml:"viewManager,omitempty"`
-	About                     AboutInfo               `xml:"about"`
-	Setting                   *ManagedObjectReference `xml:"setting,omitempty"`
-	UserDirectory             *ManagedObjectReference `xml:"userDirectory,omitempty"`
-	SessionManager            *ManagedObjectReference `xml:"sessionManager,omitempty"`
-	AuthorizationManager      *ManagedObjectReference `xml:"authorizationManager,omitempty"`
-	ServiceManager            *ManagedObjectReference `xml:"serviceManager,omitempty"`
-	PerfManager               *ManagedObjectReference `xml:"perfManager,omitempty"`
-	ScheduledTaskManager      *ManagedObjectReference `xml:"scheduledTaskManager,omitempty"`
-	AlarmManager              *ManagedObjectReference `xml:"alarmManager,omitempty"`
-	EventManager              *ManagedObjectReference `xml:"eventManager,omitempty"`
-	TaskManager               *ManagedObjectReference `xml:"taskManager,omitempty"`
-	ExtensionManager          *ManagedObjectReference `xml:"extensionManager,omitempty"`
-	CustomizationSpecManager  *ManagedObjectReference `xml:"customizationSpecManager,omitempty"`
-	CustomFieldsManager       *ManagedObjectReference `xml:"customFieldsManager,omitempty"`
-	AccountManager            *ManagedObjectReference `xml:"accountManager,omitempty"`
-	DiagnosticManager         *ManagedObjectReference `xml:"diagnosticManager,omitempty"`
-	LicenseManager            *ManagedObjectReference `xml:"licenseManager,omitempty"`
-	SearchIndex               *ManagedObjectReference `xml:"searchIndex,omitempty"`
-	FileManager               *ManagedObjectReference `xml:"fileManager,omitempty"`
-	DatastoreNamespaceManager *ManagedObjectReference `xml:"datastoreNamespaceManager,omitempty"`
-	VirtualDiskManager        *ManagedObjectReference `xml:"virtualDiskManager,omitempty"`
-	VirtualizationManager     *ManagedObjectReference `xml:"virtualizationManager,omitempty"`
-	SnmpSystem                *ManagedObjectReference `xml:"snmpSystem,omitempty"`
-	VmProvisioningChecker     *ManagedObjectReference `xml:"vmProvisioningChecker,omitempty"`
-	VmCompatibilityChecker    *ManagedObjectReference `xml:"vmCompatibilityChecker,omitempty"`
-	OvfManager                *ManagedObjectReference `xml:"ovfManager,omitempty"`
-	IpPoolManager             *ManagedObjectReference `xml:"ipPoolManager,omitempty"`
-	DvSwitchManager           *ManagedObjectReference `xml:"dvSwitchManager,omitempty"`
-	HostProfileManager        *ManagedObjectReference `xml:"hostProfileManager,omitempty"`
-	ClusterProfileManager     *ManagedObjectReference `xml:"clusterProfileManager,omitempty"`
-	ComplianceManager         *ManagedObjectReference `xml:"complianceManager,omitempty"`
-	LocalizationManager       *ManagedObjectReference `xml:"localizationManager,omitempty"`
-	StorageResourceManager    *ManagedObjectReference `xml:"storageResourceManager,omitempty"`
-	GuestOperationsManager    *ManagedObjectReference `xml:"guestOperationsManager,omitempty"`
-	OverheadMemoryManager     *ManagedObjectReference `xml:"overheadMemoryManager,omitempty"`
-	CertificateManager        *ManagedObjectReference `xml:"certificateManager,omitempty"`
-	IoFilterManager           *ManagedObjectReference `xml:"ioFilterManager,omitempty"`
+	RootFolder                  ManagedObjectReference  `xml:"rootFolder"`
+	PropertyCollector           ManagedObjectReference  `xml:"propertyCollector"`
+	ViewManager                 *ManagedObjectReference `xml:"viewManager,omitempty"`
+	About                       AboutInfo               `xml:"about"`
+	Setting                     *ManagedObjectReference `xml:"setting,omitempty"`
+	UserDirectory               *ManagedObjectReference `xml:"userDirectory,omitempty"`
+	SessionManager              *ManagedObjectReference `xml:"sessionManager,omitempty"`
+	AuthorizationManager        *ManagedObjectReference `xml:"authorizationManager,omitempty"`
+	ServiceManager              *ManagedObjectReference `xml:"serviceManager,omitempty"`
+	PerfManager                 *ManagedObjectReference `xml:"perfManager,omitempty"`
+	ScheduledTaskManager        *ManagedObjectReference `xml:"scheduledTaskManager,omitempty"`
+	AlarmManager                *ManagedObjectReference `xml:"alarmManager,omitempty"`
+	EventManager                *ManagedObjectReference `xml:"eventManager,omitempty"`
+	TaskManager                 *ManagedObjectReference `xml:"taskManager,omitempty"`
+	ExtensionManager            *ManagedObjectReference `xml:"extensionManager,omitempty"`
+	CustomizationSpecManager    *ManagedObjectReference `xml:"customizationSpecManager,omitempty"`
+	CustomFieldsManager         *ManagedObjectReference `xml:"customFieldsManager,omitempty"`
+	AccountManager              *ManagedObjectReference `xml:"accountManager,omitempty"`
+	DiagnosticManager           *ManagedObjectReference `xml:"diagnosticManager,omitempty"`
+	LicenseManager              *ManagedObjectReference `xml:"licenseManager,omitempty"`
+	SearchIndex                 *ManagedObjectReference `xml:"searchIndex,omitempty"`
+	FileManager                 *ManagedObjectReference `xml:"fileManager,omitempty"`
+	DatastoreNamespaceManager   *ManagedObjectReference `xml:"datastoreNamespaceManager,omitempty"`
+	VirtualDiskManager          *ManagedObjectReference `xml:"virtualDiskManager,omitempty"`
+	VirtualizationManager       *ManagedObjectReference `xml:"virtualizationManager,omitempty"`
+	SnmpSystem                  *ManagedObjectReference `xml:"snmpSystem,omitempty"`
+	VmProvisioningChecker       *ManagedObjectReference `xml:"vmProvisioningChecker,omitempty"`
+	VmCompatibilityChecker      *ManagedObjectReference `xml:"vmCompatibilityChecker,omitempty"`
+	OvfManager                  *ManagedObjectReference `xml:"ovfManager,omitempty"`
+	IpPoolManager               *ManagedObjectReference `xml:"ipPoolManager,omitempty"`
+	DvSwitchManager             *ManagedObjectReference `xml:"dvSwitchManager,omitempty"`
+	HostProfileManager          *ManagedObjectReference `xml:"hostProfileManager,omitempty"`
+	ClusterProfileManager       *ManagedObjectReference `xml:"clusterProfileManager,omitempty"`
+	ComplianceManager           *ManagedObjectReference `xml:"complianceManager,omitempty"`
+	LocalizationManager         *ManagedObjectReference `xml:"localizationManager,omitempty"`
+	StorageResourceManager      *ManagedObjectReference `xml:"storageResourceManager,omitempty"`
+	GuestOperationsManager      *ManagedObjectReference `xml:"guestOperationsManager,omitempty"`
+	OverheadMemoryManager       *ManagedObjectReference `xml:"overheadMemoryManager,omitempty"`
+	CertificateManager          *ManagedObjectReference `xml:"certificateManager,omitempty"`
+	IoFilterManager             *ManagedObjectReference `xml:"ioFilterManager,omitempty"`
+	VStorageObjectManager       *ManagedObjectReference `xml:"vStorageObjectManager,omitempty"`
+	HostSpecManager             *ManagedObjectReference `xml:"hostSpecManager,omitempty"`
+	CryptoManager               *ManagedObjectReference `xml:"cryptoManager,omitempty"`
+	HealthUpdateManager         *ManagedObjectReference `xml:"healthUpdateManager,omitempty"`
+	FailoverClusterConfigurator *ManagedObjectReference `xml:"failoverClusterConfigurator,omitempty"`
+	FailoverClusterManager      *ManagedObjectReference `xml:"failoverClusterManager,omitempty"`
 }
 
 func init() {
@@ -38719,6 +41612,57 @@ type SoftRuleVioCorrectionImpactFault SoftRuleVioCorrectionImpact
 
 func init() {
 	t["SoftRuleVioCorrectionImpactFault"] = reflect.TypeOf((*SoftRuleVioCorrectionImpactFault)(nil)).Elem()
+}
+
+type SoftwarePackage struct {
+	DynamicData
+
+	Name                      string                    `xml:"name"`
+	Version                   string                    `xml:"version"`
+	Type                      string                    `xml:"type"`
+	Vendor                    string                    `xml:"vendor"`
+	AcceptanceLevel           string                    `xml:"acceptanceLevel"`
+	Summary                   string                    `xml:"summary"`
+	Description               string                    `xml:"description"`
+	ReferenceURL              []string                  `xml:"referenceURL,omitempty"`
+	CreationDate              *time.Time                `xml:"creationDate"`
+	Depends                   []Relation                `xml:"depends,omitempty"`
+	Conflicts                 []Relation                `xml:"conflicts,omitempty"`
+	Replaces                  []Relation                `xml:"replaces,omitempty"`
+	Provides                  []string                  `xml:"provides,omitempty"`
+	MaintenanceModeRequired   *bool                     `xml:"maintenanceModeRequired"`
+	HardwarePlatformsRequired []string                  `xml:"hardwarePlatformsRequired,omitempty"`
+	Capability                SoftwarePackageCapability `xml:"capability"`
+	Tag                       []string                  `xml:"tag,omitempty"`
+	Payload                   []string                  `xml:"payload,omitempty"`
+}
+
+func init() {
+	t["SoftwarePackage"] = reflect.TypeOf((*SoftwarePackage)(nil)).Elem()
+}
+
+type SoftwarePackageCapability struct {
+	DynamicData
+
+	LiveInstallAllowed *bool `xml:"liveInstallAllowed"`
+	LiveRemoveAllowed  *bool `xml:"liveRemoveAllowed"`
+	StatelessReady     *bool `xml:"statelessReady"`
+	Overlay            *bool `xml:"overlay"`
+}
+
+func init() {
+	t["SoftwarePackageCapability"] = reflect.TypeOf((*SoftwarePackageCapability)(nil)).Elem()
+}
+
+type SourceNodeSpec struct {
+	DynamicData
+
+	ManagementVc ServiceLocator         `xml:"managementVc"`
+	ActiveVc     ManagedObjectReference `xml:"activeVc"`
+}
+
+func init() {
+	t["SourceNodeSpec"] = reflect.TypeOf((*SourceNodeSpec)(nil)).Elem()
 }
 
 type SsdDiskNotAvailable struct {
@@ -39639,6 +42583,17 @@ func init() {
 	t["StringPolicy"] = reflect.TypeOf((*StringPolicy)(nil)).Elem()
 }
 
+type StructuredCustomizations struct {
+	HostProfilesEntityCustomizations
+
+	Entity         ManagedObjectReference `xml:"entity"`
+	Customizations *AnswerFile            `xml:"customizations,omitempty"`
+}
+
+func init() {
+	t["StructuredCustomizations"] = reflect.TypeOf((*StructuredCustomizations)(nil)).Elem()
+}
+
 type SuspendVAppRequestType struct {
 	This ManagedObjectReference `xml:"_this"`
 }
@@ -39773,6 +42728,20 @@ type SystemErrorFault SystemError
 
 func init() {
 	t["SystemErrorFault"] = reflect.TypeOf((*SystemErrorFault)(nil)).Elem()
+}
+
+type SystemEventInfo struct {
+	DynamicData
+
+	RecordId     int64  `xml:"recordId"`
+	When         string `xml:"when"`
+	SelType      int64  `xml:"selType"`
+	Message      string `xml:"message"`
+	SensorNumber int64  `xml:"sensorNumber"`
+}
+
+func init() {
+	t["SystemEventInfo"] = reflect.TypeOf((*SystemEventInfo)(nil)).Elem()
 }
 
 type Tag struct {
@@ -40331,6 +43300,7 @@ type ToolsConfigInfo struct {
 	DynamicData
 
 	ToolsVersion         int32                                `xml:"toolsVersion,omitempty"`
+	ToolsInstallType     string                               `xml:"toolsInstallType,omitempty"`
 	AfterPowerOn         *bool                                `xml:"afterPowerOn"`
 	AfterResume          *bool                                `xml:"afterResume"`
 	BeforeGuestStandby   *bool                                `xml:"beforeGuestStandby"`
@@ -40338,6 +43308,7 @@ type ToolsConfigInfo struct {
 	BeforeGuestReboot    *bool                                `xml:"beforeGuestReboot"`
 	ToolsUpgradePolicy   string                               `xml:"toolsUpgradePolicy,omitempty"`
 	PendingCustomization string                               `xml:"pendingCustomization,omitempty"`
+	CustomizationKeyId   *CryptoKeyId                         `xml:"customizationKeyId,omitempty"`
 	SyncTimeWithHost     *bool                                `xml:"syncTimeWithHost"`
 	LastInstallInfo      *ToolsConfigInfoToolsLastInstallInfo `xml:"lastInstallInfo,omitempty"`
 }
@@ -40910,6 +43881,24 @@ func init() {
 type UnregisterExtensionResponse struct {
 }
 
+type UnregisterHealthUpdateProvider UnregisterHealthUpdateProviderRequestType
+
+func init() {
+	t["UnregisterHealthUpdateProvider"] = reflect.TypeOf((*UnregisterHealthUpdateProvider)(nil)).Elem()
+}
+
+type UnregisterHealthUpdateProviderRequestType struct {
+	This       ManagedObjectReference `xml:"_this"`
+	ProviderId string                 `xml:"providerId"`
+}
+
+func init() {
+	t["UnregisterHealthUpdateProviderRequestType"] = reflect.TypeOf((*UnregisterHealthUpdateProviderRequestType)(nil)).Elem()
+}
+
+type UnregisterHealthUpdateProviderResponse struct {
+}
+
 type UnregisterVM UnregisterVMRequestType
 
 func init() {
@@ -41370,6 +44359,43 @@ func init() {
 type UpdateFlagsResponse struct {
 }
 
+type UpdateGraphicsConfig UpdateGraphicsConfigRequestType
+
+func init() {
+	t["UpdateGraphicsConfig"] = reflect.TypeOf((*UpdateGraphicsConfig)(nil)).Elem()
+}
+
+type UpdateGraphicsConfigRequestType struct {
+	This   ManagedObjectReference `xml:"_this"`
+	Config HostGraphicsConfig     `xml:"config"`
+}
+
+func init() {
+	t["UpdateGraphicsConfigRequestType"] = reflect.TypeOf((*UpdateGraphicsConfigRequestType)(nil)).Elem()
+}
+
+type UpdateGraphicsConfigResponse struct {
+}
+
+type UpdateHostCustomizationsRequestType struct {
+	This                ManagedObjectReference                  `xml:"_this"`
+	HostToConfigSpecMap []HostProfileManagerHostToConfigSpecMap `xml:"hostToConfigSpecMap,omitempty"`
+}
+
+func init() {
+	t["UpdateHostCustomizationsRequestType"] = reflect.TypeOf((*UpdateHostCustomizationsRequestType)(nil)).Elem()
+}
+
+type UpdateHostCustomizations_Task UpdateHostCustomizationsRequestType
+
+func init() {
+	t["UpdateHostCustomizations_Task"] = reflect.TypeOf((*UpdateHostCustomizations_Task)(nil)).Elem()
+}
+
+type UpdateHostCustomizations_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type UpdateHostImageAcceptanceLevel UpdateHostImageAcceptanceLevelRequestType
 
 func init() {
@@ -41404,6 +44430,44 @@ func init() {
 }
 
 type UpdateHostProfileResponse struct {
+}
+
+type UpdateHostSpecification UpdateHostSpecificationRequestType
+
+func init() {
+	t["UpdateHostSpecification"] = reflect.TypeOf((*UpdateHostSpecification)(nil)).Elem()
+}
+
+type UpdateHostSpecificationRequestType struct {
+	This     ManagedObjectReference `xml:"_this"`
+	Host     ManagedObjectReference `xml:"host"`
+	HostSpec HostSpecification      `xml:"hostSpec"`
+}
+
+func init() {
+	t["UpdateHostSpecificationRequestType"] = reflect.TypeOf((*UpdateHostSpecificationRequestType)(nil)).Elem()
+}
+
+type UpdateHostSpecificationResponse struct {
+}
+
+type UpdateHostSubSpecification UpdateHostSubSpecificationRequestType
+
+func init() {
+	t["UpdateHostSubSpecification"] = reflect.TypeOf((*UpdateHostSubSpecification)(nil)).Elem()
+}
+
+type UpdateHostSubSpecificationRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	Host        ManagedObjectReference `xml:"host"`
+	HostSubSpec HostSubSpecification   `xml:"hostSubSpec"`
+}
+
+func init() {
+	t["UpdateHostSubSpecificationRequestType"] = reflect.TypeOf((*UpdateHostSubSpecificationRequestType)(nil)).Elem()
+}
+
+type UpdateHostSubSpecificationResponse struct {
 }
 
 type UpdateInternetScsiAdvancedOptions UpdateInternetScsiAdvancedOptionsRequestType
@@ -41631,6 +44695,43 @@ func init() {
 }
 
 type UpdateIpmiResponse struct {
+}
+
+type UpdateKmipServer UpdateKmipServerRequestType
+
+func init() {
+	t["UpdateKmipServer"] = reflect.TypeOf((*UpdateKmipServer)(nil)).Elem()
+}
+
+type UpdateKmipServerRequestType struct {
+	This   ManagedObjectReference `xml:"_this"`
+	Server KmipServerSpec         `xml:"server"`
+}
+
+func init() {
+	t["UpdateKmipServerRequestType"] = reflect.TypeOf((*UpdateKmipServerRequestType)(nil)).Elem()
+}
+
+type UpdateKmipServerResponse struct {
+}
+
+type UpdateKmsSignedCsrClientCert UpdateKmsSignedCsrClientCertRequestType
+
+func init() {
+	t["UpdateKmsSignedCsrClientCert"] = reflect.TypeOf((*UpdateKmsSignedCsrClientCert)(nil)).Elem()
+}
+
+type UpdateKmsSignedCsrClientCertRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	Cluster     KeyProviderId          `xml:"cluster"`
+	Certificate string                 `xml:"certificate"`
+}
+
+func init() {
+	t["UpdateKmsSignedCsrClientCertRequestType"] = reflect.TypeOf((*UpdateKmsSignedCsrClientCertRequestType)(nil)).Elem()
+}
+
+type UpdateKmsSignedCsrClientCertResponse struct {
 }
 
 type UpdateLicense UpdateLicenseRequestType
@@ -41951,6 +45052,25 @@ func init() {
 type UpdateScsiLunDisplayNameResponse struct {
 }
 
+type UpdateSelfSignedClientCert UpdateSelfSignedClientCertRequestType
+
+func init() {
+	t["UpdateSelfSignedClientCert"] = reflect.TypeOf((*UpdateSelfSignedClientCert)(nil)).Elem()
+}
+
+type UpdateSelfSignedClientCertRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	Cluster     KeyProviderId          `xml:"cluster"`
+	Certificate string                 `xml:"certificate"`
+}
+
+func init() {
+	t["UpdateSelfSignedClientCertRequestType"] = reflect.TypeOf((*UpdateSelfSignedClientCertRequestType)(nil)).Elem()
+}
+
+type UpdateSelfSignedClientCertResponse struct {
+}
+
 type UpdateServiceConsoleVirtualNic UpdateServiceConsoleVirtualNicRequestType
 
 func init() {
@@ -42127,6 +45247,25 @@ func init() {
 type UpdateVAppConfigResponse struct {
 }
 
+type UpdateVVolVirtualMachineFilesRequestType struct {
+	This         ManagedObjectReference               `xml:"_this"`
+	FailoverPair []DatastoreVVolContainerFailoverPair `xml:"failoverPair,omitempty"`
+}
+
+func init() {
+	t["UpdateVVolVirtualMachineFilesRequestType"] = reflect.TypeOf((*UpdateVVolVirtualMachineFilesRequestType)(nil)).Elem()
+}
+
+type UpdateVVolVirtualMachineFiles_Task UpdateVVolVirtualMachineFilesRequestType
+
+func init() {
+	t["UpdateVVolVirtualMachineFiles_Task"] = reflect.TypeOf((*UpdateVVolVirtualMachineFiles_Task)(nil)).Elem()
+}
+
+type UpdateVVolVirtualMachineFiles_TaskResponse struct {
+	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
 type UpdateVirtualMachineFilesRequestType struct {
 	This                      ManagedObjectReference            `xml:"_this"`
 	MountPathDatastoreMapping []DatastoreMountPathDatastorePair `xml:"mountPathDatastoreMapping"`
@@ -42203,6 +45342,25 @@ func init() {
 }
 
 type UpdateVirtualSwitchResponse struct {
+}
+
+type UpdateVmfsUnmapPriority UpdateVmfsUnmapPriorityRequestType
+
+func init() {
+	t["UpdateVmfsUnmapPriority"] = reflect.TypeOf((*UpdateVmfsUnmapPriority)(nil)).Elem()
+}
+
+type UpdateVmfsUnmapPriorityRequestType struct {
+	This          ManagedObjectReference `xml:"_this"`
+	VmfsUuid      string                 `xml:"vmfsUuid"`
+	UnmapPriority string                 `xml:"unmapPriority"`
+}
+
+func init() {
+	t["UpdateVmfsUnmapPriorityRequestType"] = reflect.TypeOf((*UpdateVmfsUnmapPriorityRequestType)(nil)).Elem()
+}
+
+type UpdateVmfsUnmapPriorityResponse struct {
 }
 
 type UpdateVsanRequestType struct {
@@ -42388,6 +45546,83 @@ func init() {
 	t["UplinkPortVlanUntrunkedEvent"] = reflect.TypeOf((*UplinkPortVlanUntrunkedEvent)(nil)).Elem()
 }
 
+type UploadClientCert UploadClientCertRequestType
+
+func init() {
+	t["UploadClientCert"] = reflect.TypeOf((*UploadClientCert)(nil)).Elem()
+}
+
+type UploadClientCertRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	Cluster     KeyProviderId          `xml:"cluster"`
+	Certificate string                 `xml:"certificate"`
+	PrivateKey  string                 `xml:"privateKey"`
+}
+
+func init() {
+	t["UploadClientCertRequestType"] = reflect.TypeOf((*UploadClientCertRequestType)(nil)).Elem()
+}
+
+type UploadClientCertResponse struct {
+}
+
+type UploadKmipServerCert UploadKmipServerCertRequestType
+
+func init() {
+	t["UploadKmipServerCert"] = reflect.TypeOf((*UploadKmipServerCert)(nil)).Elem()
+}
+
+type UploadKmipServerCertRequestType struct {
+	This        ManagedObjectReference `xml:"_this"`
+	Cluster     KeyProviderId          `xml:"cluster"`
+	Certificate string                 `xml:"certificate"`
+}
+
+func init() {
+	t["UploadKmipServerCertRequestType"] = reflect.TypeOf((*UploadKmipServerCertRequestType)(nil)).Elem()
+}
+
+type UploadKmipServerCertResponse struct {
+}
+
+type UsbScanCodeSpec struct {
+	DynamicData
+
+	KeyEvents []UsbScanCodeSpecKeyEvent `xml:"keyEvents"`
+}
+
+func init() {
+	t["UsbScanCodeSpec"] = reflect.TypeOf((*UsbScanCodeSpec)(nil)).Elem()
+}
+
+type UsbScanCodeSpecKeyEvent struct {
+	DynamicData
+
+	UsbHidCode int32                        `xml:"usbHidCode"`
+	Modifiers  *UsbScanCodeSpecModifierType `xml:"modifiers,omitempty"`
+}
+
+func init() {
+	t["UsbScanCodeSpecKeyEvent"] = reflect.TypeOf((*UsbScanCodeSpecKeyEvent)(nil)).Elem()
+}
+
+type UsbScanCodeSpecModifierType struct {
+	DynamicData
+
+	LeftControl  *bool `xml:"leftControl"`
+	LeftShift    *bool `xml:"leftShift"`
+	LeftAlt      *bool `xml:"leftAlt"`
+	LeftGui      *bool `xml:"leftGui"`
+	RightControl *bool `xml:"rightControl"`
+	RightShift   *bool `xml:"rightShift"`
+	RightAlt     *bool `xml:"rightAlt"`
+	RightGui     *bool `xml:"rightGui"`
+}
+
+func init() {
+	t["UsbScanCodeSpecModifierType"] = reflect.TypeOf((*UsbScanCodeSpecModifierType)(nil)).Elem()
+}
+
 type UserAssignedToGroup struct {
 	HostEvent
 
@@ -42471,6 +45706,17 @@ type UserPasswordChanged struct {
 
 func init() {
 	t["UserPasswordChanged"] = reflect.TypeOf((*UserPasswordChanged)(nil)).Elem()
+}
+
+type UserPrivilegeResult struct {
+	DynamicData
+
+	Entity     ManagedObjectReference `xml:"entity"`
+	Privileges []string               `xml:"privileges,omitempty"`
+}
+
+func init() {
+	t["UserPrivilegeResult"] = reflect.TypeOf((*UserPrivilegeResult)(nil)).Elem()
 }
 
 type UserProfile struct {
@@ -42860,7 +46106,8 @@ func init() {
 type VMFSDatastoreCreatedEvent struct {
 	HostEvent
 
-	Datastore DatastoreEventArgument `xml:"datastore"`
+	Datastore    DatastoreEventArgument `xml:"datastore"`
+	DatastoreUrl string                 `xml:"datastoreUrl,omitempty"`
 }
 
 func init() {
@@ -43229,11 +46476,12 @@ func init() {
 type VMwareDVSVspanCapability struct {
 	DynamicData
 
-	MixedDestSupported         bool `xml:"mixedDestSupported"`
-	DvportSupported            bool `xml:"dvportSupported"`
-	RemoteSourceSupported      bool `xml:"remoteSourceSupported"`
-	RemoteDestSupported        bool `xml:"remoteDestSupported"`
-	EncapRemoteSourceSupported bool `xml:"encapRemoteSourceSupported"`
+	MixedDestSupported         bool  `xml:"mixedDestSupported"`
+	DvportSupported            bool  `xml:"dvportSupported"`
+	RemoteSourceSupported      bool  `xml:"remoteSourceSupported"`
+	RemoteDestSupported        bool  `xml:"remoteDestSupported"`
+	EncapRemoteSourceSupported bool  `xml:"encapRemoteSourceSupported"`
+	ErspanProtocolSupported    *bool `xml:"erspanProtocolSupported"`
 }
 
 func init() {
@@ -43391,6 +46639,10 @@ type VMwareVspanSession struct {
 	NormalTrafficAllowed  bool             `xml:"normalTrafficAllowed"`
 	SessionType           string           `xml:"sessionType,omitempty"`
 	SamplingRate          int32            `xml:"samplingRate,omitempty"`
+	EncapType             string           `xml:"encapType,omitempty"`
+	ErspanId              int32            `xml:"erspanId,omitempty"`
+	ErspanCOS             int32            `xml:"erspanCOS,omitempty"`
+	ErspanGraNanosec      *bool            `xml:"erspanGraNanosec"`
 }
 
 func init() {
@@ -43413,6 +46665,38 @@ func init() {
 	t["VRPEditSpec"] = reflect.TypeOf((*VRPEditSpec)(nil)).Elem()
 }
 
+type VStorageObject struct {
+	DynamicData
+
+	Config VStorageObjectConfigInfo `xml:"config"`
+}
+
+func init() {
+	t["VStorageObject"] = reflect.TypeOf((*VStorageObject)(nil)).Elem()
+}
+
+type VStorageObjectConfigInfo struct {
+	BaseConfigInfo
+
+	CapacityInMB    int64    `xml:"capacityInMB"`
+	ConsumptionType []string `xml:"consumptionType,omitempty"`
+	ConsumerId      []ID     `xml:"consumerId,omitempty"`
+}
+
+func init() {
+	t["VStorageObjectConfigInfo"] = reflect.TypeOf((*VStorageObjectConfigInfo)(nil)).Elem()
+}
+
+type VStorageObjectStateInfo struct {
+	DynamicData
+
+	Tentative *bool `xml:"tentative"`
+}
+
+func init() {
+	t["VStorageObjectStateInfo"] = reflect.TypeOf((*VStorageObjectStateInfo)(nil)).Elem()
+}
+
 type VVolHostPE struct {
 	DynamicData
 
@@ -43422,6 +46706,28 @@ type VVolHostPE struct {
 
 func init() {
 	t["VVolHostPE"] = reflect.TypeOf((*VVolHostPE)(nil)).Elem()
+}
+
+type VVolVmConfigFileUpdateResult struct {
+	DynamicData
+
+	SucceededVmConfigFile []KeyValue                                           `xml:"succeededVmConfigFile,omitempty"`
+	FailedVmConfigFile    []VVolVmConfigFileUpdateResultFailedVmConfigFileInfo `xml:"failedVmConfigFile,omitempty"`
+}
+
+func init() {
+	t["VVolVmConfigFileUpdateResult"] = reflect.TypeOf((*VVolVmConfigFileUpdateResult)(nil)).Elem()
+}
+
+type VVolVmConfigFileUpdateResultFailedVmConfigFileInfo struct {
+	DynamicData
+
+	TargetConfigVVolId string               `xml:"targetConfigVVolId"`
+	Fault              LocalizedMethodFault `xml:"fault"`
+}
+
+func init() {
+	t["VVolVmConfigFileUpdateResultFailedVmConfigFileInfo"] = reflect.TypeOf((*VVolVmConfigFileUpdateResultFailedVmConfigFileInfo)(nil)).Elem()
 }
 
 type ValidateCredentialsInGuest ValidateCredentialsInGuestRequestType
@@ -43533,6 +46839,90 @@ type VcAgentUpgradedEvent struct {
 
 func init() {
 	t["VcAgentUpgradedEvent"] = reflect.TypeOf((*VcAgentUpgradedEvent)(nil)).Elem()
+}
+
+type VchaClusterConfigInfo struct {
+	DynamicData
+
+	FailoverNodeInfo1 *FailoverNodeInfo `xml:"failoverNodeInfo1,omitempty"`
+	FailoverNodeInfo2 *FailoverNodeInfo `xml:"failoverNodeInfo2,omitempty"`
+	WitnessNodeInfo   *WitnessNodeInfo  `xml:"witnessNodeInfo,omitempty"`
+	State             string            `xml:"state"`
+}
+
+func init() {
+	t["VchaClusterConfigInfo"] = reflect.TypeOf((*VchaClusterConfigInfo)(nil)).Elem()
+}
+
+type VchaClusterConfigSpec struct {
+	DynamicData
+
+	PassiveIp string `xml:"passiveIp"`
+	WitnessIp string `xml:"witnessIp"`
+}
+
+func init() {
+	t["VchaClusterConfigSpec"] = reflect.TypeOf((*VchaClusterConfigSpec)(nil)).Elem()
+}
+
+type VchaClusterDeploymentSpec struct {
+	DynamicData
+
+	PassiveDeploymentSpec PassiveNodeDeploymentSpec `xml:"passiveDeploymentSpec"`
+	WitnessDeploymentSpec BaseNodeDeploymentSpec    `xml:"witnessDeploymentSpec,typeattr"`
+	ActiveVcSpec          SourceNodeSpec            `xml:"activeVcSpec"`
+	ActiveVcNetworkConfig *ClusterNetworkConfigSpec `xml:"activeVcNetworkConfig,omitempty"`
+}
+
+func init() {
+	t["VchaClusterDeploymentSpec"] = reflect.TypeOf((*VchaClusterDeploymentSpec)(nil)).Elem()
+}
+
+type VchaClusterHealth struct {
+	DynamicData
+
+	RuntimeInfo           VchaClusterRuntimeInfo `xml:"runtimeInfo"`
+	HealthMessages        []LocalizableMessage   `xml:"healthMessages,omitempty"`
+	AdditionalInformation []LocalizableMessage   `xml:"additionalInformation,omitempty"`
+}
+
+func init() {
+	t["VchaClusterHealth"] = reflect.TypeOf((*VchaClusterHealth)(nil)).Elem()
+}
+
+type VchaClusterNetworkSpec struct {
+	DynamicData
+
+	WitnessNetworkSpec BaseNodeNetworkSpec    `xml:"witnessNetworkSpec,typeattr"`
+	PassiveNetworkSpec PassiveNodeNetworkSpec `xml:"passiveNetworkSpec"`
+}
+
+func init() {
+	t["VchaClusterNetworkSpec"] = reflect.TypeOf((*VchaClusterNetworkSpec)(nil)).Elem()
+}
+
+type VchaClusterRuntimeInfo struct {
+	DynamicData
+
+	ClusterState string                `xml:"clusterState"`
+	NodeInfo     []VchaNodeRuntimeInfo `xml:"nodeInfo,omitempty"`
+	ClusterMode  string                `xml:"clusterMode"`
+}
+
+func init() {
+	t["VchaClusterRuntimeInfo"] = reflect.TypeOf((*VchaClusterRuntimeInfo)(nil)).Elem()
+}
+
+type VchaNodeRuntimeInfo struct {
+	DynamicData
+
+	NodeState string `xml:"nodeState"`
+	NodeRole  string `xml:"nodeRole"`
+	NodeIp    string `xml:"nodeIp"`
+}
+
+func init() {
+	t["VchaNodeRuntimeInfo"] = reflect.TypeOf((*VchaNodeRuntimeInfo)(nil)).Elem()
 }
 
 type VimAccountPasswordChangedEvent struct {
@@ -43847,10 +47237,22 @@ type VirtualDeviceConfigSpec struct {
 	FileOperation VirtualDeviceConfigSpecFileOperation `xml:"fileOperation,omitempty"`
 	Device        BaseVirtualDevice                    `xml:"device,typeattr"`
 	Profile       []BaseVirtualMachineProfileSpec      `xml:"profile,omitempty,typeattr"`
+	Backing       *VirtualDeviceConfigSpecBackingSpec  `xml:"backing,omitempty"`
 }
 
 func init() {
 	t["VirtualDeviceConfigSpec"] = reflect.TypeOf((*VirtualDeviceConfigSpec)(nil)).Elem()
+}
+
+type VirtualDeviceConfigSpecBackingSpec struct {
+	DynamicData
+
+	Parent *VirtualDeviceConfigSpecBackingSpec `xml:"parent,omitempty"`
+	Crypto BaseCryptoSpec                      `xml:"crypto,omitempty,typeattr"`
+}
+
+func init() {
+	t["VirtualDeviceConfigSpecBackingSpec"] = reflect.TypeOf((*VirtualDeviceConfigSpecBackingSpec)(nil)).Elem()
 }
 
 type VirtualDeviceConnectInfo struct {
@@ -44021,6 +47423,7 @@ type VirtualDisk struct {
 	DiskObjectId          string                            `xml:"diskObjectId,omitempty"`
 	VFlashCacheConfigInfo *VirtualDiskVFlashCacheConfigInfo `xml:"vFlashCacheConfigInfo,omitempty"`
 	Iofilter              []string                          `xml:"iofilter,omitempty"`
+	VDiskId               *ID                               `xml:"vDiskId,omitempty"`
 }
 
 func init() {
@@ -44117,6 +47520,7 @@ type VirtualDiskFlatVer2BackingInfo struct {
 	DeltaGrainSize         int32                           `xml:"deltaGrainSize,omitempty"`
 	DeltaDiskFormatVariant string                          `xml:"deltaDiskFormatVariant,omitempty"`
 	Sharing                string                          `xml:"sharing,omitempty"`
+	KeyId                  *CryptoKeyId                    `xml:"keyId,omitempty"`
 }
 
 func init() {
@@ -44279,6 +47683,7 @@ type VirtualDiskSeSparseBackingInfo struct {
 	DeltaDiskFormat string                          `xml:"deltaDiskFormat,omitempty"`
 	DigestEnabled   *bool                           `xml:"digestEnabled"`
 	GrainSize       int32                           `xml:"grainSize,omitempty"`
+	KeyId           *CryptoKeyId                    `xml:"keyId,omitempty"`
 }
 
 func init() {
@@ -44339,6 +47744,7 @@ type VirtualDiskSparseVer2BackingInfo struct {
 	ContentId     string                            `xml:"contentId,omitempty"`
 	ChangeId      string                            `xml:"changeId,omitempty"`
 	Parent        *VirtualDiskSparseVer2BackingInfo `xml:"parent,omitempty"`
+	KeyId         *CryptoKeyId                      `xml:"keyId,omitempty"`
 }
 
 func init() {
@@ -44792,12 +48198,13 @@ func init() {
 type VirtualMachineBootOptions struct {
 	DynamicData
 
-	BootDelay           int64                                         `xml:"bootDelay,omitempty"`
-	EnterBIOSSetup      *bool                                         `xml:"enterBIOSSetup"`
-	BootRetryEnabled    *bool                                         `xml:"bootRetryEnabled"`
-	BootRetryDelay      int64                                         `xml:"bootRetryDelay,omitempty"`
-	BootOrder           []BaseVirtualMachineBootOptionsBootableDevice `xml:"bootOrder,omitempty,typeattr"`
-	NetworkBootProtocol string                                        `xml:"networkBootProtocol,omitempty"`
+	BootDelay            int64                                         `xml:"bootDelay,omitempty"`
+	EnterBIOSSetup       *bool                                         `xml:"enterBIOSSetup"`
+	EfiSecureBootEnabled *bool                                         `xml:"efiSecureBootEnabled"`
+	BootRetryEnabled     *bool                                         `xml:"bootRetryEnabled"`
+	BootRetryDelay       int64                                         `xml:"bootRetryDelay,omitempty"`
+	BootOrder            []BaseVirtualMachineBootOptionsBootableDevice `xml:"bootOrder,omitempty,typeattr"`
+	NetworkBootProtocol  string                                        `xml:"networkBootProtocol,omitempty"`
 }
 
 func init() {
@@ -44888,6 +48295,7 @@ type VirtualMachineCapability struct {
 	SeSparseDiskSupported               *bool `xml:"seSparseDiskSupported"`
 	NestedHVSupported                   *bool `xml:"nestedHVSupported"`
 	VPMCSupported                       *bool `xml:"vPMCSupported"`
+	SecureBootSupported                 *bool `xml:"secureBootSupported"`
 }
 
 func init() {
@@ -44896,6 +48304,8 @@ func init() {
 
 type VirtualMachineCdromInfo struct {
 	VirtualMachineTargetInfo
+
+	Description string `xml:"description,omitempty"`
 }
 
 func init() {
@@ -44982,6 +48392,9 @@ type VirtualMachineConfigInfo struct {
 	MessageBusTunnelEnabled      *bool                                      `xml:"messageBusTunnelEnabled"`
 	VmStorageObjectId            string                                     `xml:"vmStorageObjectId,omitempty"`
 	SwapStorageObjectId          string                                     `xml:"swapStorageObjectId,omitempty"`
+	KeyId                        *CryptoKeyId                               `xml:"keyId,omitempty"`
+	GuestIntegrityInfo           *VirtualMachineGuestIntegrityInfo          `xml:"guestIntegrityInfo,omitempty"`
+	MigrateEncryption            string                                     `xml:"migrateEncryption,omitempty"`
 }
 
 func init() {
@@ -45106,6 +48519,8 @@ type VirtualMachineConfigSpec struct {
 	ScheduledHardwareUpgradeInfo *ScheduledHardwareUpgradeInfo     `xml:"scheduledHardwareUpgradeInfo,omitempty"`
 	VmProfile                    []BaseVirtualMachineProfileSpec   `xml:"vmProfile,omitempty,typeattr"`
 	MessageBusTunnelEnabled      *bool                             `xml:"messageBusTunnelEnabled"`
+	Crypto                       BaseCryptoSpec                    `xml:"crypto,omitempty,typeattr"`
+	MigrateEncryption            string                            `xml:"migrateEncryption,omitempty"`
 }
 
 func init() {
@@ -45159,18 +48574,6 @@ type VirtualMachineCpuIdInfoSpec struct {
 
 func init() {
 	t["VirtualMachineCpuIdInfoSpec"] = reflect.TypeOf((*VirtualMachineCpuIdInfoSpec)(nil)).Elem()
-}
-
-type VirtualMachineCreateChildSpec struct {
-	DynamicData
-
-	Location     *VirtualMachineRelocateSpec `xml:"location,omitempty"`
-	Persistent   bool                        `xml:"persistent"`
-	ConfigParams []BaseOptionValue           `xml:"configParams,omitempty,typeattr"`
-}
-
-func init() {
-	t["VirtualMachineCreateChildSpec"] = reflect.TypeOf((*VirtualMachineCreateChildSpec)(nil)).Elem()
 }
 
 type VirtualMachineDatastoreInfo struct {
@@ -45228,8 +48631,9 @@ func init() {
 type VirtualMachineDefinedProfileSpec struct {
 	VirtualMachineProfileSpec
 
-	ProfileId   string                        `xml:"profileId"`
-	ProfileData *VirtualMachineProfileRawData `xml:"profileData,omitempty"`
+	ProfileId       string                        `xml:"profileId"`
+	ReplicationSpec *ReplicationSpec              `xml:"replicationSpec,omitempty"`
+	ProfileData     *VirtualMachineProfileRawData `xml:"profileData,omitempty"`
 }
 
 func init() {
@@ -45443,6 +48847,7 @@ type VirtualMachineFlagInfo struct {
 	SnapshotPowerOffBehavior string `xml:"snapshotPowerOffBehavior,omitempty"`
 	RecordReplayEnabled      *bool  `xml:"recordReplayEnabled"`
 	FaultToleranceType       string `xml:"faultToleranceType,omitempty"`
+	CbrcCacheEnabled         *bool  `xml:"cbrcCacheEnabled"`
 }
 
 func init() {
@@ -45460,13 +48865,34 @@ func init() {
 type VirtualMachineForkConfigInfo struct {
 	DynamicData
 
-	ParentEnabled    *bool  `xml:"parentEnabled"`
-	ChildForkGroupId string `xml:"childForkGroupId,omitempty"`
-	ChildType        string `xml:"childType,omitempty"`
+	ParentEnabled     *bool  `xml:"parentEnabled"`
+	ChildForkGroupId  string `xml:"childForkGroupId,omitempty"`
+	ParentForkGroupId string `xml:"parentForkGroupId,omitempty"`
+	ChildType         string `xml:"childType,omitempty"`
 }
 
 func init() {
 	t["VirtualMachineForkConfigInfo"] = reflect.TypeOf((*VirtualMachineForkConfigInfo)(nil)).Elem()
+}
+
+type VirtualMachineGuestIntegrityInfo struct {
+	DynamicData
+
+	Enabled *bool `xml:"enabled"`
+}
+
+func init() {
+	t["VirtualMachineGuestIntegrityInfo"] = reflect.TypeOf((*VirtualMachineGuestIntegrityInfo)(nil)).Elem()
+}
+
+type VirtualMachineGuestQuiesceSpec struct {
+	DynamicData
+
+	Timeout int32 `xml:"timeout,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineGuestQuiesceSpec"] = reflect.TypeOf((*VirtualMachineGuestQuiesceSpec)(nil)).Elem()
 }
 
 type VirtualMachineGuestSummary struct {
@@ -45625,6 +49051,7 @@ type VirtualMachineNetworkInfo struct {
 	VirtualMachineTargetInfo
 
 	Network BaseNetworkSummary `xml:"network,typeattr"`
+	Vswitch string             `xml:"vswitch,omitempty"`
 }
 
 func init() {
@@ -45885,15 +49312,37 @@ func init() {
 	t["VirtualMachineSoundInfo"] = reflect.TypeOf((*VirtualMachineSoundInfo)(nil)).Elem()
 }
 
+type VirtualMachineSriovDevicePoolInfo struct {
+	DynamicData
+
+	Key string `xml:"key"`
+}
+
+func init() {
+	t["VirtualMachineSriovDevicePoolInfo"] = reflect.TypeOf((*VirtualMachineSriovDevicePoolInfo)(nil)).Elem()
+}
+
 type VirtualMachineSriovInfo struct {
 	VirtualMachinePciPassthroughInfo
 
-	VirtualFunction bool   `xml:"virtualFunction"`
-	Pnic            string `xml:"pnic,omitempty"`
+	VirtualFunction bool                                  `xml:"virtualFunction"`
+	Pnic            string                                `xml:"pnic,omitempty"`
+	DevicePool      BaseVirtualMachineSriovDevicePoolInfo `xml:"devicePool,omitempty,typeattr"`
 }
 
 func init() {
 	t["VirtualMachineSriovInfo"] = reflect.TypeOf((*VirtualMachineSriovInfo)(nil)).Elem()
+}
+
+type VirtualMachineSriovNetworkDevicePoolInfo struct {
+	VirtualMachineSriovDevicePoolInfo
+
+	SwitchKey  string `xml:"switchKey,omitempty"`
+	SwitchUuid string `xml:"switchUuid,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineSriovNetworkDevicePoolInfo"] = reflect.TypeOf((*VirtualMachineSriovNetworkDevicePoolInfo)(nil)).Elem()
 }
 
 type VirtualMachineStorageInfo struct {
@@ -46088,6 +49537,19 @@ func init() {
 	t["VirtualMachineVideoCard"] = reflect.TypeOf((*VirtualMachineVideoCard)(nil)).Elem()
 }
 
+type VirtualMachineWindowsQuiesceSpec struct {
+	VirtualMachineGuestQuiesceSpec
+
+	VssBackupType          int32  `xml:"vssBackupType,omitempty"`
+	VssBootableSystemState *bool  `xml:"vssBootableSystemState"`
+	VssPartialFileSupport  *bool  `xml:"vssPartialFileSupport"`
+	VssBackupContext       string `xml:"vssBackupContext,omitempty"`
+}
+
+func init() {
+	t["VirtualMachineWindowsQuiesceSpec"] = reflect.TypeOf((*VirtualMachineWindowsQuiesceSpec)(nil)).Elem()
+}
+
 type VirtualMachineWipeResult struct {
 	DynamicData
 
@@ -46097,6 +49559,24 @@ type VirtualMachineWipeResult struct {
 
 func init() {
 	t["VirtualMachineWipeResult"] = reflect.TypeOf((*VirtualMachineWipeResult)(nil)).Elem()
+}
+
+type VirtualNVMEController struct {
+	VirtualController
+}
+
+func init() {
+	t["VirtualNVMEController"] = reflect.TypeOf((*VirtualNVMEController)(nil)).Elem()
+}
+
+type VirtualNVMEControllerOption struct {
+	VirtualControllerOption
+
+	NumNVMEDisks IntOption `xml:"numNVMEDisks"`
+}
+
+func init() {
+	t["VirtualNVMEControllerOption"] = reflect.TypeOf((*VirtualNVMEControllerOption)(nil)).Elem()
 }
 
 type VirtualNicManagerNetConfig struct {
@@ -46134,6 +49614,7 @@ type VirtualPCIControllerOption struct {
 	NumVmxnet3EthernetCards       *IntOption `xml:"numVmxnet3EthernetCards,omitempty"`
 	NumParaVirtualSCSIControllers *IntOption `xml:"numParaVirtualSCSIControllers,omitempty"`
 	NumSATAControllers            *IntOption `xml:"numSATAControllers,omitempty"`
+	NumNVMEControllers            *IntOption `xml:"numNVMEControllers,omitempty"`
 }
 
 func init() {
@@ -46874,6 +50355,22 @@ func init() {
 	t["VirtualVmxnet3Option"] = reflect.TypeOf((*VirtualVmxnet3Option)(nil)).Elem()
 }
 
+type VirtualVmxnet3Vrdma struct {
+	VirtualVmxnet3
+}
+
+func init() {
+	t["VirtualVmxnet3Vrdma"] = reflect.TypeOf((*VirtualVmxnet3Vrdma)(nil)).Elem()
+}
+
+type VirtualVmxnet3VrdmaOption struct {
+	VirtualVmxnet3Option
+}
+
+func init() {
+	t["VirtualVmxnet3VrdmaOption"] = reflect.TypeOf((*VirtualVmxnet3VrdmaOption)(nil)).Elem()
+}
+
 type VirtualVmxnetOption struct {
 	VirtualEthernetCardOption
 }
@@ -47061,10 +50558,21 @@ func init() {
 	t["VmConfigFaultFault"] = reflect.TypeOf((*VmConfigFaultFault)(nil)).Elem()
 }
 
+type VmConfigFileEncryptionInfo struct {
+	DynamicData
+
+	KeyId *CryptoKeyId `xml:"keyId,omitempty"`
+}
+
+func init() {
+	t["VmConfigFileEncryptionInfo"] = reflect.TypeOf((*VmConfigFileEncryptionInfo)(nil)).Elem()
+}
+
 type VmConfigFileInfo struct {
 	FileInfo
 
-	ConfigVersion int32 `xml:"configVersion,omitempty"`
+	ConfigVersion int32                       `xml:"configVersion,omitempty"`
+	Encryption    *VmConfigFileEncryptionInfo `xml:"encryption,omitempty"`
 }
 
 func init() {
@@ -47086,6 +50594,7 @@ type VmConfigFileQueryFilter struct {
 	DynamicData
 
 	MatchConfigVersion []int32 `xml:"matchConfigVersion,omitempty"`
+	Encrypted          *bool   `xml:"encrypted"`
 }
 
 func init() {
@@ -47095,7 +50604,8 @@ func init() {
 type VmConfigFileQueryFlags struct {
 	DynamicData
 
-	ConfigVersion bool `xml:"configVersion"`
+	ConfigVersion bool  `xml:"configVersion"`
+	Encryption    *bool `xml:"encryption"`
 }
 
 func init() {
@@ -47292,15 +50802,26 @@ func init() {
 	t["VmDiskFailedEvent"] = reflect.TypeOf((*VmDiskFailedEvent)(nil)).Elem()
 }
 
+type VmDiskFileEncryptionInfo struct {
+	DynamicData
+
+	KeyId *CryptoKeyId `xml:"keyId,omitempty"`
+}
+
+func init() {
+	t["VmDiskFileEncryptionInfo"] = reflect.TypeOf((*VmDiskFileEncryptionInfo)(nil)).Elem()
+}
+
 type VmDiskFileInfo struct {
 	FileInfo
 
-	DiskType        string   `xml:"diskType,omitempty"`
-	CapacityKb      int64    `xml:"capacityKb,omitempty"`
-	HardwareVersion int32    `xml:"hardwareVersion,omitempty"`
-	ControllerType  string   `xml:"controllerType,omitempty"`
-	DiskExtents     []string `xml:"diskExtents,omitempty"`
-	Thin            *bool    `xml:"thin"`
+	DiskType        string                    `xml:"diskType,omitempty"`
+	CapacityKb      int64                     `xml:"capacityKb,omitempty"`
+	HardwareVersion int32                     `xml:"hardwareVersion,omitempty"`
+	ControllerType  string                    `xml:"controllerType,omitempty"`
+	DiskExtents     []string                  `xml:"diskExtents,omitempty"`
+	Thin            *bool                     `xml:"thin"`
+	Encryption      *VmDiskFileEncryptionInfo `xml:"encryption,omitempty"`
 }
 
 func init() {
@@ -47325,6 +50846,7 @@ type VmDiskFileQueryFilter struct {
 	MatchHardwareVersion []int32  `xml:"matchHardwareVersion,omitempty"`
 	ControllerType       []string `xml:"controllerType,omitempty"`
 	Thin                 *bool    `xml:"thin"`
+	Encrypted            *bool    `xml:"encrypted"`
 }
 
 func init() {
@@ -47340,6 +50862,7 @@ type VmDiskFileQueryFlags struct {
 	ControllerType  *bool `xml:"controllerType"`
 	DiskExtents     *bool `xml:"diskExtents"`
 	Thin            *bool `xml:"thin"`
+	Encryption      *bool `xml:"encryption"`
 }
 
 func init() {
@@ -47701,7 +51224,8 @@ func init() {
 type VmHealthMonitoringStateChangedEvent struct {
 	ClusterEvent
 
-	State string `xml:"state"`
+	State     string `xml:"state"`
+	PrevState string `xml:"prevState,omitempty"`
 }
 
 func init() {
@@ -48038,7 +51562,8 @@ func init() {
 type VmReconfiguredEvent struct {
 	VmEvent
 
-	ConfigSpec VirtualMachineConfigSpec `xml:"configSpec"`
+	ConfigSpec    VirtualMachineConfigSpec  `xml:"configSpec"`
+	ConfigChanges *ChangesInfoEventArgument `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -48186,6 +51711,8 @@ func init() {
 
 type VmResourceReallocatedEvent struct {
 	VmEvent
+
+	ConfigChanges *ChangesInfoEventArgument `xml:"configChanges,omitempty"`
 }
 
 func init() {
@@ -48578,6 +52105,17 @@ type VmfsAmbiguousMountFault VmfsAmbiguousMount
 
 func init() {
 	t["VmfsAmbiguousMountFault"] = reflect.TypeOf((*VmfsAmbiguousMountFault)(nil)).Elem()
+}
+
+type VmfsConfigOption struct {
+	DynamicData
+
+	BlockSizeOption        int32   `xml:"blockSizeOption"`
+	UnmapGranularityOption []int32 `xml:"unmapGranularityOption,omitempty"`
+}
+
+func init() {
+	t["VmfsConfigOption"] = reflect.TypeOf((*VmfsConfigOption)(nil)).Elem()
 }
 
 type VmfsDatastoreAllExtentOption struct {
@@ -49345,6 +52883,89 @@ func init() {
 	t["VsanUpgradeSystemWrongEsxVersionIssue"] = reflect.TypeOf((*VsanUpgradeSystemWrongEsxVersionIssue)(nil)).Elem()
 }
 
+type VslmCloneSpec struct {
+	VslmMigrateSpec
+
+	Name string `xml:"name"`
+}
+
+func init() {
+	t["VslmCloneSpec"] = reflect.TypeOf((*VslmCloneSpec)(nil)).Elem()
+}
+
+type VslmCreateSpec struct {
+	DynamicData
+
+	Name         string                        `xml:"name"`
+	BackingSpec  BaseVslmCreateSpecBackingSpec `xml:"backingSpec,typeattr"`
+	CapacityInMB int64                         `xml:"capacityInMB"`
+}
+
+func init() {
+	t["VslmCreateSpec"] = reflect.TypeOf((*VslmCreateSpec)(nil)).Elem()
+}
+
+type VslmCreateSpecBackingSpec struct {
+	DynamicData
+
+	Datastore ManagedObjectReference `xml:"datastore"`
+}
+
+func init() {
+	t["VslmCreateSpecBackingSpec"] = reflect.TypeOf((*VslmCreateSpecBackingSpec)(nil)).Elem()
+}
+
+type VslmCreateSpecDiskFileBackingSpec struct {
+	VslmCreateSpecBackingSpec
+
+	ProvisioningType string `xml:"provisioningType,omitempty"`
+}
+
+func init() {
+	t["VslmCreateSpecDiskFileBackingSpec"] = reflect.TypeOf((*VslmCreateSpecDiskFileBackingSpec)(nil)).Elem()
+}
+
+type VslmCreateSpecRawDiskMappingBackingSpec struct {
+	VslmCreateSpecBackingSpec
+
+	LunUuid           string `xml:"lunUuid"`
+	CompatibilityMode string `xml:"compatibilityMode"`
+}
+
+func init() {
+	t["VslmCreateSpecRawDiskMappingBackingSpec"] = reflect.TypeOf((*VslmCreateSpecRawDiskMappingBackingSpec)(nil)).Elem()
+}
+
+type VslmMigrateSpec struct {
+	DynamicData
+
+	BackingSpec BaseVslmCreateSpecBackingSpec `xml:"backingSpec,typeattr"`
+	Consolidate *bool                         `xml:"consolidate"`
+}
+
+func init() {
+	t["VslmMigrateSpec"] = reflect.TypeOf((*VslmMigrateSpec)(nil)).Elem()
+}
+
+type VslmRelocateSpec struct {
+	VslmMigrateSpec
+}
+
+func init() {
+	t["VslmRelocateSpec"] = reflect.TypeOf((*VslmRelocateSpec)(nil)).Elem()
+}
+
+type VslmTagEntry struct {
+	DynamicData
+
+	TagName            string `xml:"tagName"`
+	ParentCategoryName string `xml:"parentCategoryName"`
+}
+
+func init() {
+	t["VslmTagEntry"] = reflect.TypeOf((*VslmTagEntry)(nil)).Elem()
+}
+
 type VspanDestPortConflict struct {
 	DvsFault
 
@@ -49660,6 +53281,17 @@ type WipeDiskFaultFault WipeDiskFault
 
 func init() {
 	t["WipeDiskFaultFault"] = reflect.TypeOf((*WipeDiskFaultFault)(nil)).Elem()
+}
+
+type WitnessNodeInfo struct {
+	DynamicData
+
+	IpSettings CustomizationIPSettings `xml:"ipSettings"`
+	BiosUuid   string                  `xml:"biosUuid,omitempty"`
+}
+
+func init() {
+	t["WitnessNodeInfo"] = reflect.TypeOf((*WitnessNodeInfo)(nil)).Elem()
 }
 
 type XmlToCustomizationSpecItem XmlToCustomizationSpecItemRequestType

--- a/vendor/github.com/vmware/govmomi/vim25/xml/extras.go
+++ b/vendor/github.com/vmware/govmomi/vim25/xml/extras.go
@@ -71,7 +71,11 @@ func typeToString(typ reflect.Type) string {
 	case reflect.Float64:
 		return "xsd:double"
 	case reflect.String:
-		return "xsd:string"
+		name := typ.Name()
+		if name == "string" {
+			return "xsd:string"
+		}
+		return name
 	case reflect.Struct:
 		if typ == stringToTypeMap["xsd:dateTime"] {
 			return "xsd:dateTime"


### PR DESCRIPTION
Fixes #40558

Current vSphere Cloud provider doesn't allow a user to select a datastore for dynamic provisioning. All the volumes are created in default datastore provided by the user in the global vsphere configuration file.

With this fix, the user will be able to provide the datastore in the storage class definition. This will allow the volumes to be created in the datastore specified by the user in the storage class definition. This field is optional. If no datastore is specified, the volume will be created in the default datastore specified in the global config file.

For example:

User creates a storage class with the datastore

kind: StorageClass
apiVersion: storage.k8s.io/v1beta1
metadata:
name: slow
provisioner: kubernetes.io/vsphere-volume
parameters:
diskformat: thin
datastore: VMFSDatastore
Now the volume will be created in the datastore - "VMFSDatastore" specified by the user.

If the user creates a storage class without any datastore

kind: StorageClass
apiVersion: storage.k8s.io/v1beta1
metadata:
name: slow
provisioner: kubernetes.io/vsphere-volume
parameters:
diskformat: thin
Now the volume will be created in the datastore which in the global configuration file (vsphere.conf)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```

@pdhamdhere @kerneltime