### PR TITLE
fix service spec for kube api server

### DIFF
--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -173,7 +173,7 @@ func (c *Controller) UpdateKubernetesService(reconcile bool) error {
 		return err
 	}
 
-	servicePorts, serviceType := createPortAndServiceSpec(c.ServicePort, c.KubernetesServiceNodePort, "https", c.ExtraServicePorts)
+	servicePorts, serviceType := createPortAndServiceSpec(c.ServicePort, c.PublicServicePort, c.KubernetesServiceNodePort, "https", c.ExtraServicePorts)
 	if err := c.CreateOrUpdateMasterServiceIfNeeded(kubernetesServiceName, c.ServiceIP, servicePorts, serviceType, reconcile); err != nil {
 		return err
 	}
@@ -205,13 +205,13 @@ func (c *Controller) CreateNamespaceIfNeeded(ns string) error {
 
 // createPortAndServiceSpec creates an array of service ports.
 // If the NodePort value is 0, just the servicePort is used, otherwise, a node port is exposed.
-func createPortAndServiceSpec(servicePort int, nodePort int, servicePortName string, extraServicePorts []api.ServicePort) ([]api.ServicePort, api.ServiceType) {
+func createPortAndServiceSpec(servicePort int, targetServicePort int, nodePort int, servicePortName string, extraServicePorts []api.ServicePort) ([]api.ServicePort, api.ServiceType) {
 	//Use the Cluster IP type for the service port if NodePort isn't provided.
 	//Otherwise, we will be binding the master service to a NodePort.
 	servicePorts := []api.ServicePort{{Protocol: api.ProtocolTCP,
 		Port:       int32(servicePort),
 		Name:       servicePortName,
-		TargetPort: intstr.FromInt(servicePort)}}
+		TargetPort: intstr.FromInt(targetServicePort)}}
 	serviceType := api.ServiceTypeClusterIP
 	if nodePort > 0 {
 		servicePorts[0].NodePort = int32(nodePort)


### PR DESCRIPTION
For the auto generated kube api-server service, the service spec re-uses the service port itself. The endpoint is created correctly using public port. Fix the service also because there are some plugin controllers that react to service spec itself.

Before fix:
```
sh-4.2# kubectl get endpoints
NAME         ENDPOINTS                                         AGE
kubernetes   172.17.0.2:8443,172.17.0.2:8053,172.17.0.2:8053   20h

sh-4.2# kubectl get services kubernetes -o json
...
...
        "spec": {
                "clusterIP": "172.30.0.1",
                "ports": [
                    {
                        "name": "https",
                        "port": 443,
                        "protocol": "TCP",
                        "targetPort": 443     ## <--- same as port, even if the endpoint really means 8443
                    },
                    {
                        "name": "dns",
                        "port": 53,
                        "protocol": "UDP",
                        "targetPort": 8053
                    },
                    {
                        "name": "dns-tcp",
                         ...
```

After fix:
```
"spec": {
                "clusterIP": "172.30.0.1",
                "ports": [
                    {
                        "name": "https",
                        "port": 443,
                        "protocol": "TCP",
                        "targetPort": 8443     # <-- fixed, now matches the endpoint object
                    },
                    {
                        "name": "dns",
                        "port": 53,
                        "protocol": "UDP",
                        "targetPort": 8053
                    },
                    {
                        "name": "dns-tcp",

``