### PR TITLE
Register deepcopy and defaulter funcs for metav1

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
@@ -55,6 +55,10 @@ func AddToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 		Convert_watch_Event_to_versioned_Event,
 		Convert_versioned_Event_to_versioned_InternalEvent,
 	)
+
+	// register manually. This usually goes through the SchemeBuilder, which we cannot use here.
+	scheme.AddGeneratedDeepCopyFuncs(GetGeneratedDeepCopyFuncs()...)
+	RegisterDefaults(scheme)
 }
 
 // scheme is the registry for the common types that adhere to the meta v1 API spec.
@@ -70,4 +74,8 @@ func init() {
 		&GetOptions{},
 		&DeleteOptions{},
 	)
+
+	// register manually. This usually goes through the SchemeBuilder, which we cannot use here.
+	scheme.AddGeneratedDeepCopyFuncs(GetGeneratedDeepCopyFuncs()...)
+	RegisterDefaults(scheme)
 }


### PR DESCRIPTION
Houston, we've had a problem here. ObjectMeta had used the reflection fallback path for deepcopy for probably some time.

Remark: my original plan for https://github.com/kubernetes/kubernetes/pull/36412 was/is to rebase that during the master branch freeze for 1.6 and get it merged just before master opens again. Otherwise, I fear it will be rebase hell. With https://github.com/kubernetes/kubernetes/pull/36412 these kind of errors are not possible anymore.