### PR TITLE
move pid of nsenter into container cgroup

### DIFF
--- a/pkg/kubelet/dockertools/exec.go
+++ b/pkg/kubelet/dockertools/exec.go
@@ -17,10 +17,14 @@ limitations under the License.
 package dockertools
 
 import (
+	"bufio"
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	dockertypes "github.com/docker/engine-api/types"
@@ -45,14 +49,21 @@ func (*NsenterExecHandler) ExecInContainer(client DockerInterface, container *do
 		return fmt.Errorf("exec unavailable - unable to locate nsenter")
 	}
 
+	cgexec, err := exec.LookPath("cgexec")
+	if err != nil {
+		return fmt.Errorf("exec unavailable - unable to locate cgexec")
+	}
+
 	containerPid := container.State.Pid
 
+	args, _ := cgexecArgs(containerPid)
 	// TODO what if the container doesn't have `env`???
-	args := []string{"-t", fmt.Sprintf("%d", containerPid), "-m", "-i", "-u", "-n", "-p", "--", "env", "-i"}
+	args = append(args, nsenter, "-t", fmt.Sprintf("%d", containerPid), "-m", "-i", "-u", "-n", "-p", "--", "env", "-i")
 	args = append(args, fmt.Sprintf("HOSTNAME=%s", container.Config.Hostname))
 	args = append(args, container.Config.Env...)
 	args = append(args, cmd...)
-	command := exec.Command(nsenter, args...)
+	//cgexec -g memory:/system.slice/docker-bbe0d2d2a404c8650472eb7a57975d25178fa4a49c4d6b176f9e25527805b17a.scope -g ... nsenter -t 17153 -m -i -u -n -p -- env -i HOSTNAME=test1-3020125803-sqqvl -i ... /bin/bash
+	command := exec.Command(cgexec, args...)
 	var cmdErr error
 	if tty {
 		p, err := kubecontainer.StartPty(command)
@@ -166,4 +177,38 @@ func (*NativeExecHandler) ExecInContainer(client DockerInterface, container *doc
 	}
 
 	return err
+}
+
+func cgexecArgs(pid int) ([]string, error) {
+	//$ cat /proc/17153/cgroup
+	//10:cpuset:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//9:perf_event:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//8:freezer:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//7:hugetlb:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//6:devices:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//5:memory:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//4:blkio:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//3:net_cls:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//2:cpuacct,cpu:/docker/2469451a734cd4699f15b090ce9d36554e89bcc913989907e8961d66a9aebc17
+	//1:name=systemd:/system.slice/docker.service
+	data, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	if err != nil {
+		return nil, err
+	}
+	var (
+		id         int
+		cgroupPath string
+		args       []string
+	)
+	sc := bufio.NewScanner(bytes.NewReader(data))
+	for sc.Scan() {
+		line := sc.Text()
+		if n, err := fmt.Sscanf(line, "%d:%s", &id, &cgroupPath); n == 2 && err == nil {
+			//skip name=systemd:/system.slice/docker.service
+			if !strings.HasPrefix(cgroupPath, "name") {
+				args = append(args, "-g", cgroupPath)
+			}
+		}
+	}
+	return args, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR moves the pid of nsenter and its child commands, such as bash into container's cgroup.
Previously, if we enter a pod via `kubectl exec` and executes a costly command such as open a big file via vim, the memory cost is counted on the buffer of the kubelet cause the pid of nsenter is in the kubelet cgroup. I think the container itself should bear the cost as along with docker exec which moves pid of bash into container's cgroup.

```
[root@kubernetes-master vagrant]# kubectl exec test1-3020125803-sqqvl -it sh
# 

[root@kubernetes-node-1 vagrant]# pstree -ups 2647
systemd(1)───kubelet(1222)───nsenter(2647)───sh(2648)
[root@kubernetes-node-1 vagrant]# cat /proc/2648/cgroup 
10:hugetlb:/
9:devices:/system.slice/kubelet.service
8:cpuset:/
7:net_cls,net_prio:/
6:blkio:/system.slice/kubelet.service
5:cpu,cpuacct:/system.slice/kubelet.service
4:freezer:/
3:perf_event:/
2:memory:/system.slice/kubelet.service
1:name=systemd:/system.slice/kubelet.service
```

**Special notes for your reviewer**:
The current PR makes use of cgexec which brings a dependency of cgexec, but it can be replaced by a shell script.

```
sh -c "echo \$$ > /sys/fs/cgroup/memory/system.slice/docker-bbe0d2d2a404c8650472eb7a57975d25178fa4a49c4d6b176f9e25527805b17a.scope/tasks && nsenter -t 9155 -m -i -u -n -p -- env -i HOSTNAME=test1-3020125803-sqqvl /bin/bash"
```

If the PR is reasonable, I can make the change.