### PR TITLE
Cleanup client example

### DIFF
--- a/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
@@ -26,11 +26,8 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-var (
-	kubeconfig = flag.String("kubeconfig", "./config", "absolute path to the kubeconfig file")
-)
-
 func main() {
+	kubeconfig := flag.String("kubeconfig", "./config", "absolute path to the kubeconfig file")
 	flag.Parse()
 	// uses the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/main.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/main.go
@@ -35,10 +35,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-var (
-	config *rest.Config
-)
-
 func main() {
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kube config. Only required if out-of-cluster.")
 	flag.Parse()

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/types_test.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/types_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ runtime.Object = &Example{}
+var _ metav1.ObjectMetaAccessor = &Example{}
+
+var _ runtime.Object = &ExampleList{}
+var _ metav1.ListMetaAccessor = &ExampleList{}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -16905,3 +16905,14 @@ go_test(
     library = ":k8s.io/apimachinery/pkg/api/testing",
     tags = ["automanaged"],
 )
+
+go_test(
+    name = "k8s.io/client-go/examples/third-party-resources_test",
+    srcs = ["k8s.io/client-go/examples/third-party-resources/types_test.go"],
+    library = ":k8s.io/client-go/examples/third-party-resources",
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/apimachinery/pkg/runtime",
+    ],
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Package level `config` variable in `third-party-resources/main.go` is not used, it is shadowed by the one defined in `main()`. Should probably be deleted.
- Package level `kubeconfig ` variable in `out-of-cluster/main.go` is global - make it private to `main()`.

**Which issue this PR fixes**
This fixes https://github.com/kubernetes/client-go/issues/59, except the part about global `api.Scheme`, also adds test with interface check. Supersedes https://github.com/kubernetes/client-go/pull/61.

**Special notes for your reviewer**:
This is my first PR to Kubernetes :)