### PR TITLE
chore (samples): Don't cache apks at all in Dockerfiles

### DIFF
--- a/examples/storage/redis/image/Dockerfile
+++ b/examples/storage/redis/image/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine:3.4
 
-RUN apk add -U redis sed bash && rm -rf /var/cache/apk/*
+RUN apk add --no-cache redis sed bash
 
 COPY redis-master.conf /redis-master/redis.conf
 COPY redis-slave.conf /redis-slave/redis.conf

--- a/test/images/dnsutils/Dockerfile
+++ b/test/images/dnsutils/Dockerfile
@@ -14,5 +14,4 @@
 
 FROM alpine
 
-RUN apk update --no-cache
-RUN apk add bind-tools
+RUN apk add --no-cache bind-tools


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
It simplifies the sample Dockerfiles somewhat.

https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md#disabling-cache

**Special notes for your reviewer**:
While I'm here, any reason the Redis sample doesn't use the official Redis image from Dockerhub?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
