### PR TITLE
add deads2k to approvers for controllers

### DIFF
--- a/pkg/controller/OWNERS
+++ b/pkg/controller/OWNERS
@@ -1,5 +1,6 @@
 approvers:
 - bprashanth
+- deads2k
 - derekwaynecarr
 - mikedanese
 reviewers:


### PR DESCRIPTION
I've done significant maintenance on these for a while and introduced new patterns like shared informers and rate limited work queues.