### PR TITLE
config set cluster api value

### DIFF
--- a/pkg/kubectl/cmd/config/create_cluster.go
+++ b/pkg/kubectl/cmd/config/create_cluster.go
@@ -121,6 +121,9 @@ func (o createClusterOptions) run() error {
 func (o *createClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluster) clientcmdapi.Cluster {
 	modifiedCluster := existingCluster
 
+	if o.apiVersion.Provided() {
+		modifiedCluster.APIVersion = o.apiVersion.Value()
+	}
 	if o.server.Provided() {
 		modifiedCluster.Server = o.server.Value()
 	}


### PR DESCRIPTION
Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1420280

**Release note**:
```release-note
NONE
```

This patch sets a specified api version if one is given while setting cluster values in kubeconfig

cc @AdoHe  @pweil- 