### PR TITLE
Allow GCE PD's to be dynamically generated based on image id

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -140,7 +140,7 @@ type Disks interface {
 
 	// CreateDisk creates a new PD with given properties. Tags are serialized
 	// as JSON into Description field.
-	CreateDisk(name string, diskType string, zone string, sizeGb int64, tags map[string]string) error
+	CreateDisk(name string, diskType string, zone string, sizeGb int64, imageID string, tags map[string]string) error
 
 	// DeleteDisk deletes PD.
 	DeleteDisk(diskToDelete string) error
@@ -2443,7 +2443,7 @@ func (gce *GCECloud) encodeDiskTags(tags map[string]string) (string, error) {
 // CreateDisk creates a new Persistent Disk, with the specified name & size, in
 // the specified zone. It stores specified tags encoded in JSON in Description
 // field.
-func (gce *GCECloud) CreateDisk(name string, diskType string, zone string, sizeGb int64, tags map[string]string) error {
+func (gce *GCECloud) CreateDisk(name string, diskType string, zone string, sizeGb int64, imageID string, tags map[string]string) error {
 	// Do not allow creation of PDs in zones that are not managed. Such PDs
 	// then cannot be deleted by DeleteDisk.
 	isManaged := false
@@ -2473,10 +2473,11 @@ func (gce *GCECloud) CreateDisk(name string, diskType string, zone string, sizeG
 	diskTypeUri := fmt.Sprintf(diskTypeUriTemplate, gce.projectID, zone, diskType)
 
 	diskToCreate := &compute.Disk{
-		Name:        name,
-		SizeGb:      sizeGb,
-		Description: tagsStr,
-		Type:        diskTypeUri,
+		Name:          name,
+		SizeGb:        sizeGb,
+		Description:   tagsStr,
+		Type:          diskTypeUri,
+		SourceImageId: imageID,
 	}
 
 	createOp, err := gce.service.Disks.Insert(gce.projectID, zone, diskToCreate).Do()

--- a/pkg/volume/gce_pd/attacher_test.go
+++ b/pkg/volume/gce_pd/attacher_test.go
@@ -356,7 +356,7 @@ func (testcase *testcase) DisksAreAttached(diskNames []string, nodeName types.No
 	return nil, errors.New("Not implemented")
 }
 
-func (testcase *testcase) CreateDisk(name string, diskType string, zone string, sizeGb int64, tags map[string]string) error {
+func (testcase *testcase) CreateDisk(name string, diskType string, zone string, sizeGb int64, imageID string, tags map[string]string) error {
 	return errors.New("Not implemented")
 }
 

--- a/pkg/volume/gce_pd/gce_util.go
+++ b/pkg/volume/gce_pd/gce_util.go
@@ -87,12 +87,15 @@ func (gceutil *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner) (strin
 	// the values to the cloud provider.
 	diskType := ""
 	zone := ""
+	imageID := ""
 	for k, v := range c.options.Parameters {
 		switch strings.ToLower(k) {
 		case "type":
 			diskType = v
 		case "zone":
 			zone = v
+		case "imageid":
+			imageID = v
 		default:
 			return "", 0, nil, fmt.Errorf("invalid option %q for volume plugin %s", k, c.plugin.GetPluginName())
 		}
@@ -114,7 +117,7 @@ func (gceutil *GCEDiskUtil) CreateVolume(c *gcePersistentDiskProvisioner) (strin
 		zone = volume.ChooseZoneForVolume(zones, c.options.PVC.Name)
 	}
 
-	err = cloud.CreateDisk(name, diskType, zone, int64(requestGB), *c.options.CloudTags)
+	err = cloud.CreateDisk(name, diskType, zone, int64(requestGB), imageID, *c.options.CloudTags)
 	if err != nil {
 		glog.V(2).Infof("Error creating GCE PD volume: %v", err)
 		return "", 0, nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This allows you to (optionally) specify `imageID` in the Storage Class volume parameters for the GCE provider. When volumes are dynamically provisioned by a PVC that references said storage class, it will get created based on the supplied imageID.

This is useful if you want to attach volumes to pods that have predictable content every time and need stronger immutability guarantees than hoping developers always remember to use read only volume mounts.

I've got a case where we want to load a whole bunch (~15 GB worth) of data into a pod. One approach is to bundle that data into the docker image, but that has some obvious drawbacks. Our workaround was to attach the data as a volume, but if someone accidentally overwrites some of the data, that could have some pretty serious impacts for any future pod accessing the drive.


**Which issue this PR fixes**:
fixes #41142 

**Special notes for your reviewer**:
Let me know if I can make any touch-ups

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Allow GCE PD's to be dynamically generated based on image id
```
