### PR TITLE
Updating apiserver to return 202 when resource is being deleted asynchronously via cascading deletion

### DIFF
--- a/federation/registry/cluster/registry.go
+++ b/federation/registry/cluster/registry.go
@@ -78,6 +78,6 @@ func (s *storage) UpdateCluster(ctx genericapirequest.Context, cluster *federati
 }
 
 func (s *storage) DeleteCluster(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }

--- a/pkg/master/thirdparty/thirdparty.go
+++ b/pkg/master/thirdparty/thirdparty.go
@@ -175,7 +175,7 @@ func (m *ThirdPartyResourceServer) removeAllThirdPartyResources(registry *thirdp
 	}
 	for ix := range list.Items {
 		item := &list.Items[ix]
-		if _, err := registry.Delete(ctx, item.Name, nil); err != nil {
+		if _, _, err := registry.Delete(ctx, item.Name, nil); err != nil {
 			return err
 		}
 	}

--- a/pkg/registry/certificates/certificates/registry.go
+++ b/pkg/registry/certificates/certificates/registry.go
@@ -79,6 +79,6 @@ func (s *storage) GetCSR(ctx genericapirequest.Context, name string, options *me
 }
 
 func (s *storage) DeleteCSR(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }

--- a/pkg/registry/core/configmap/registry.go
+++ b/pkg/registry/core/configmap/registry.go
@@ -87,7 +87,6 @@ func (s *storage) UpdateConfigMap(ctx genericapirequest.Context, cfg *api.Config
 }
 
 func (s *storage) DeleteConfigMap(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
-
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }

--- a/pkg/registry/core/endpoint/registry.go
+++ b/pkg/registry/core/endpoint/registry.go
@@ -71,6 +71,6 @@ func (s *storage) UpdateEndpoints(ctx genericapirequest.Context, endpoints *api.
 }
 
 func (s *storage) DeleteEndpoints(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }

--- a/pkg/registry/core/namespace/registry.go
+++ b/pkg/registry/core/namespace/registry.go
@@ -77,6 +77,6 @@ func (s *storage) UpdateNamespace(ctx genericapirequest.Context, namespace *api.
 }
 
 func (s *storage) DeleteNamespace(ctx genericapirequest.Context, namespaceID string) error {
-	_, err := s.Delete(ctx, namespaceID, nil)
+	_, _, err := s.Delete(ctx, namespaceID, nil)
 	return err
 }

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -82,10 +82,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
 }
 
 // Delete enforces life-cycle rules for namespace termination
-func (r *REST) Delete(ctx genericapirequest.Context, name string, options *metav1.DeleteOptions) (runtime.Object, error) {
+func (r *REST) Delete(ctx genericapirequest.Context, name string, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	nsObj, err := r.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	namespace := nsObj.(*api.Namespace)
@@ -105,7 +105,7 @@ func (r *REST) Delete(ctx genericapirequest.Context, name string, options *metav
 			name,
 			fmt.Errorf("Precondition failed: UID in precondition: %v, UID in object meta: %v", *options.Preconditions.UID, namespace.UID),
 		)
-		return nil, err
+		return nil, false, err
 	}
 
 	// upon first request to delete, we switch the phase to start namespace termination
@@ -113,7 +113,7 @@ func (r *REST) Delete(ctx genericapirequest.Context, name string, options *metav
 	if namespace.DeletionTimestamp.IsZero() {
 		key, err := r.Store.KeyFunc(ctx, name)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		preconditions := storage.Preconditions{UID: options.Preconditions.UID}
@@ -159,16 +159,16 @@ func (r *REST) Delete(ctx genericapirequest.Context, name string, options *metav
 			if _, ok := err.(*apierrors.StatusError); !ok {
 				err = apierrors.NewInternalError(err)
 			}
-			return nil, err
+			return nil, false, err
 		}
 
-		return out, nil
+		return out, false, nil
 	}
 
 	// prior to final deletion, we must ensure that finalizers is empty
 	if len(namespace.Spec.Finalizers) != 0 {
 		err = apierrors.NewConflict(api.Resource("namespaces"), namespace.Name, fmt.Errorf("The system is ensuring all content is removed from this namespace.  Upon completion, this namespace will automatically be purged by the system."))
-		return nil, err
+		return nil, false, err
 	}
 	return r.Store.Delete(ctx, name, options)
 }

--- a/pkg/registry/core/namespace/storage/storage_test.go
+++ b/pkg/registry/core/namespace/storage/storage_test.go
@@ -157,7 +157,7 @@ func TestDeleteNamespaceWithIncompleteFinalizers(t *testing.T) {
 	if err := storage.Storage.Create(ctx, key, namespace, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := storage.Delete(ctx, "foo", nil); err == nil {
+	if _, _, err := storage.Delete(ctx, "foo", nil); err == nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -182,7 +182,7 @@ func TestDeleteNamespaceWithCompleteFinalizers(t *testing.T) {
 	if err := storage.Storage.Create(ctx, key, namespace, nil, 0); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := storage.Delete(ctx, "foo", nil); err != nil {
+	if _, _, err := storage.Delete(ctx, "foo", nil); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }

--- a/pkg/registry/core/node/registry.go
+++ b/pkg/registry/core/node/registry.go
@@ -78,6 +78,6 @@ func (s *storage) GetNode(ctx genericapirequest.Context, name string, options *m
 }
 
 func (s *storage) DeleteNode(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }

--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -136,7 +136,7 @@ func (r *EvictionREST) Create(ctx genericapirequest.Context, obj runtime.Object)
 	// At this point there was either no PDB or we succeded in decrementing
 
 	// Try the delete
-	_, err = r.store.Delete(ctx, eviction.Name, eviction.DeleteOptions)
+	_, _, err = r.store.Delete(ctx, eviction.Name, eviction.DeleteOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -176,7 +176,7 @@ func TestIgnoreDeleteNotFound(t *testing.T) {
 	defer registry.Store.DestroyFunc()
 
 	// should fail if pod A is not created yet.
-	_, err := registry.Delete(testContext, pod.Name, nil)
+	_, _, err := registry.Delete(testContext, pod.Name, nil)
 	if !errors.IsNotFound(err) {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestIgnoreDeleteNotFound(t *testing.T) {
 	// registry shouldn't get any error since we ignore the NotFound error.
 	zero := int64(0)
 	opt := &metav1.DeleteOptions{GracePeriodSeconds: &zero}
-	obj, err := registry.Delete(testContext, pod.Name, opt)
+	obj, _, err := registry.Delete(testContext, pod.Name, opt)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/pkg/registry/core/replicationcontroller/registry.go
+++ b/pkg/registry/core/replicationcontroller/registry.go
@@ -90,6 +90,6 @@ func (s *storage) UpdateController(ctx genericapirequest.Context, controller *ap
 }
 
 func (s *storage) DeleteController(ctx genericapirequest.Context, controllerID string) error {
-	_, err := s.Delete(ctx, controllerID, nil)
+	_, _, err := s.Delete(ctx, controllerID, nil)
 	return err
 }

--- a/pkg/registry/core/secret/registry.go
+++ b/pkg/registry/core/secret/registry.go
@@ -77,6 +77,6 @@ func (s *storage) UpdateSecret(ctx genericapirequest.Context, secret *api.Secret
 }
 
 func (s *storage) DeleteSecret(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }

--- a/pkg/registry/core/service/registry.go
+++ b/pkg/registry/core/service/registry.go
@@ -74,7 +74,7 @@ func (s *storage) GetService(ctx genericapirequest.Context, name string, options
 }
 
 func (s *storage) DeleteService(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }
 

--- a/pkg/registry/core/serviceaccount/registry.go
+++ b/pkg/registry/core/serviceaccount/registry.go
@@ -77,6 +77,6 @@ func (s *storage) UpdateServiceAccount(ctx genericapirequest.Context, serviceAcc
 }
 
 func (s *storage) DeleteServiceAccount(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }

--- a/pkg/registry/extensions/deployment/registry.go
+++ b/pkg/registry/extensions/deployment/registry.go
@@ -82,6 +82,6 @@ func (s *storage) UpdateDeployment(ctx genericapirequest.Context, deployment *ex
 }
 
 func (s *storage) DeleteDeployment(ctx genericapirequest.Context, deploymentID string) error {
-	_, err := s.Delete(ctx, deploymentID, nil)
+	_, _, err := s.Delete(ctx, deploymentID, nil)
 	return err
 }

--- a/pkg/registry/extensions/replicaset/registry.go
+++ b/pkg/registry/extensions/replicaset/registry.go
@@ -91,6 +91,6 @@ func (s *storage) UpdateReplicaSet(ctx genericapirequest.Context, replicaSet *ex
 }
 
 func (s *storage) DeleteReplicaSet(ctx genericapirequest.Context, replicaSetID string) error {
-	_, err := s.Delete(ctx, replicaSetID, nil)
+	_, _, err := s.Delete(ctx, replicaSetID, nil)
 	return err
 }

--- a/pkg/registry/extensions/thirdpartyresourcedata/registry.go
+++ b/pkg/registry/extensions/thirdpartyresourcedata/registry.go
@@ -78,6 +78,6 @@ func (s *storage) UpdateThirdPartyResourceData(ctx genericapirequest.Context, Th
 }
 
 func (s *storage) DeleteThirdPartyResourceData(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }

--- a/pkg/registry/rbac/clusterrole/registry.go
+++ b/pkg/registry/rbac/clusterrole/registry.go
@@ -79,7 +79,7 @@ func (s *storage) GetClusterRole(ctx genericapirequest.Context, name string, opt
 }
 
 func (s *storage) DeleteClusterRole(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }
 

--- a/pkg/registry/rbac/clusterrolebinding/registry.go
+++ b/pkg/registry/rbac/clusterrolebinding/registry.go
@@ -79,7 +79,7 @@ func (s *storage) GetClusterRoleBinding(ctx genericapirequest.Context, name stri
 }
 
 func (s *storage) DeleteClusterRoleBinding(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }
 

--- a/pkg/registry/rbac/role/registry.go
+++ b/pkg/registry/rbac/role/registry.go
@@ -79,7 +79,7 @@ func (s *storage) GetRole(ctx genericapirequest.Context, name string, options *m
 }
 
 func (s *storage) DeleteRole(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }
 

--- a/pkg/registry/rbac/rolebinding/registry.go
+++ b/pkg/registry/rbac/rolebinding/registry.go
@@ -80,7 +80,7 @@ func (s *storage) GetRoleBinding(ctx genericapirequest.Context, name string, opt
 }
 
 func (s *storage) DeleteRoleBinding(ctx genericapirequest.Context, name string) error {
-	_, err := s.Delete(ctx, name, nil)
+	_, _, err := s.Delete(ctx, name, nil)
 	return err
 }
 

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -221,7 +221,7 @@ func (t *Tester) emitObject(obj runtime.Object, action string) error {
 		if err != nil {
 			return err
 		}
-		_, err = t.storage.Delete(ctx, accessor.GetName(), nil)
+		_, _, err = t.storage.Delete(ctx, accessor.GetName(), nil)
 	default:
 		err = fmt.Errorf("unexpected action: %v", action)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -457,19 +457,19 @@ func (storage *SimpleRESTStorage) checkContext(ctx request.Context) {
 	storage.actualNamespace, storage.namespacePresent = request.NamespaceFrom(ctx)
 }
 
-func (storage *SimpleRESTStorage) Delete(ctx request.Context, id string, options *metav1.DeleteOptions) (runtime.Object, error) {
+func (storage *SimpleRESTStorage) Delete(ctx request.Context, id string, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	storage.checkContext(ctx)
 	storage.deleted = id
 	storage.deleteOptions = options
 	if err := storage.errors["delete"]; err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	var obj runtime.Object = &metav1.Status{Status: metav1.StatusSuccess}
 	var err error
 	if storage.injectedFunction != nil {
 		obj, err = storage.injectedFunction(&genericapitesting.Simple{ObjectMeta: metav1.ObjectMeta{Name: id}})
 	}
-	return obj, err
+	return obj, true, err
 }
 
 func (storage *SimpleRESTStorage) New() runtime.Object {
@@ -605,7 +605,8 @@ type LegacyRESTStorage struct {
 }
 
 func (storage LegacyRESTStorage) Delete(ctx request.Context, id string) (runtime.Object, error) {
-	return storage.SimpleRESTStorage.Delete(ctx, id, nil)
+	obj, _, err := storage.SimpleRESTStorage.Delete(ctx, id, nil)
+	return obj, err
 }
 
 type MetadataRESTStorage struct {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -858,7 +858,8 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope RequestSco
 
 		trace.Step("About do delete object from database")
 		result, err := finishRequest(timeout, func() (runtime.Object, error) {
-			return r.Delete(ctx, name, options)
+			obj, _, err := r.Delete(ctx, name, options)
+			return obj, err
 		})
 		if err != nil {
 			scope.err(err, res.ResponseWriter, req.Request)

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -136,7 +136,9 @@ type GracefulDeleter interface {
 	// returned error value err when the specified resource is not found.
 	// Delete *may* return the object that was deleted, or a status object indicating additional
 	// information about deletion.
-	Delete(ctx genericapirequest.Context, name string, options *metav1.DeleteOptions) (runtime.Object, error)
+	// It also returns a boolean which is set to true if the resource was instantly
+	// deleted or false if it will be deleted asynchronously.
+	Delete(ctx genericapirequest.Context, name string, options *metav1.DeleteOptions) (runtime.Object, bool, error)
 }
 
 // GracefulDeleteAdapter adapts the Deleter interface to GracefulDeleter
@@ -145,8 +147,9 @@ type GracefulDeleteAdapter struct {
 }
 
 // Delete implements RESTGracefulDeleter in terms of Deleter
-func (w GracefulDeleteAdapter) Delete(ctx genericapirequest.Context, name string, options *metav1.DeleteOptions) (runtime.Object, error) {
-	return w.Deleter.Delete(ctx, name)
+func (w GracefulDeleteAdapter) Delete(ctx genericapirequest.Context, name string, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	obj, err := w.Deleter.Delete(ctx, name)
+	return obj, true, err
 }
 
 // CollectionDeleter is an object that can delete a collection

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -1,0 +1,158 @@
+// +build integration,!no-etcd
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func setup(t *testing.T) (*httptest.Server, clientset.Interface) {
+	masterConfig := framework.NewIntegrationTestMasterConfig()
+	masterConfig.EnableCoreControllers = false
+	_, s := framework.RunAMaster(masterConfig)
+
+	clientSet, err := clientset.NewForConfig(&restclient.Config{Host: s.URL})
+	if err != nil {
+		t.Fatalf("Error in create clientset: %v", err)
+	}
+	return s, clientSet
+}
+
+func verifyStatusCode(t *testing.T, verb, URL, body string, expectedStatusCode int) {
+	// We dont use the typed Go client to send this request to be able to verify the response status code.
+	bodyBytes := bytes.NewReader([]byte(body))
+	req, err := http.NewRequest(verb, URL, bodyBytes)
+	if err != nil {
+		t.Fatalf("unexpected error: %v in sending req with verb: %s, URL: %s and body: %s", err, verb, URL, body)
+	}
+	transport := http.DefaultTransport
+	glog.Infof("Sending request: %v", req)
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v in req: %v", err, req)
+	}
+	defer resp.Body.Close()
+	b, _ := ioutil.ReadAll(resp.Body)
+	if resp.StatusCode != expectedStatusCode {
+		t.Errorf("Expected status %v, but got %v", expectedStatusCode, resp.StatusCode)
+		t.Errorf("Body: %v", string(b))
+	}
+}
+
+func path(resource, namespace, name string) string {
+	return testapi.Extensions.ResourcePath(resource, namespace, name)
+}
+
+func newRS(namespace string) *v1beta1.ReplicaSet {
+	return &v1beta1.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ReplicaSet",
+			APIVersion: "extensions/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    namespace,
+			GenerateName: "apiserver-test",
+		},
+		Spec: v1beta1.ReplicaSetSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"name": "test"},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "fake-name",
+							Image: "fakeimage",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+var cascDel string = `
+{
+  "kind": "DeleteOptions",
+  "apiVersion": "` + api.Registry.GroupOrDie(api.GroupName).GroupVersion.String() + `",
+  "orphanDependents": false
+}
+`
+
+// Tests that the apiserver returns 202 status code as expected.
+func Test202StatusCode(t *testing.T) {
+	s, clientSet := setup(t)
+	defer s.Close()
+
+	ns := framework.CreateTestingNamespace("status-code", s, t)
+	defer framework.DeleteTestingNamespace(ns, s, t)
+
+	rsClient := clientSet.Extensions().ReplicaSets(ns.Name)
+
+	// 1. Create the resource without any finalizer and then delete it without setting DeleteOptions.
+	// Verify that server returns 200 in this case.
+	rs, err := rsClient.Create(newRS(ns.Name))
+	if err != nil {
+		t.Fatalf("Failed to create rs: %v", err)
+	}
+	verifyStatusCode(t, "DELETE", s.URL+path("replicasets", ns.Name, rs.Name), "", 200)
+
+	// 2. Create the resource with a finalizer so that the resource is not immediately deleted and then delete it without setting DeleteOptions.
+	// Verify that the apiserver still returns 200 since DeleteOptions.OrphanDependents is not set.
+	rs = newRS(ns.Name)
+	rs.ObjectMeta.Finalizers = []string{"kube.io/dummy-finalizer"}
+	rs, err = rsClient.Create(rs)
+	if err != nil {
+		t.Fatalf("Failed to create rs: %v", err)
+	}
+	verifyStatusCode(t, "DELETE", s.URL+path("replicasets", ns.Name, rs.Name), "", 200)
+
+	// 3. Create the resource and then delete it with DeleteOptions.OrphanDependents=false.
+	// Verify that the server still returns 200 since the resource is immediately deleted.
+	rs = newRS(ns.Name)
+	rs, err = rsClient.Create(rs)
+	if err != nil {
+		t.Fatalf("Failed to create rs: %v", err)
+	}
+	verifyStatusCode(t, "DELETE", s.URL+path("replicasets", ns.Name, rs.Name), cascDel, 200)
+
+	// 4. Create the resource with a finalizer so that the resource is not immediately deleted and then delete it with DeleteOptions.OrphanDependents=false.
+	// Verify that the server returns 202 in this case.
+	rs = newRS(ns.Name)
+	rs.ObjectMeta.Finalizers = []string{"kube.io/dummy-finalizer"}
+	rs, err = rsClient.Create(rs)
+	if err != nil {
+		t.Fatalf("Failed to create rs: %v", err)
+	}
+	verifyStatusCode(t, "DELETE", s.URL+path("replicasets", ns.Name, rs.Name), cascDel, 202)
+}


### PR DESCRIPTION
As per https://github.com/kubernetes/kubernetes/issues/33196#issuecomment-278440622.

cc @kubernetes/sig-api-machinery-pr-reviews @smarterclayton @caesarxuchao @bgrant0607 @kubernetes/api-reviewers 

```release-note
Updating apiserver to return http status code 202 for a delete request when the resource is not immediately deleted because of user requesting cascading deletion using DeleteOptions.OrphanDependents=false.
```