### PR TITLE
Test: Create multivolume StatefulSet test

### DIFF
--- a/test/e2e/statefulset.go
+++ b/test/e2e/statefulset.go
@@ -44,6 +44,8 @@ const (
 	// We don't restart MySQL cluster regardless of restartCluster, since MySQL doesn't handle restart well
 	restartCluster = true
 
+	multivolumeZookeeperManifestPath = "test/e2e/testing-manifests/statefulset/multivolumezk"
+
 	// Timeout for reads from databases running on stateful pods.
 	readTimeout = 60 * time.Second
 )
@@ -440,6 +442,11 @@ var _ = framework.KubeDescribe("StatefulSet", func() {
 			appTester.run()
 		})
 
+		It("should create a working multivolume zookeeper cluster", func() {
+			appTester.statefulPod = &multivolumeZookeeperTester{zookeeperTester{tester: sst}}
+			appTester.run()
+		})
+
 		It("should creating a working redis cluster", func() {
 			appTester.statefulPod = &redisTester{tester: sst}
 			appTester.run()
@@ -545,6 +552,19 @@ func (z *zookeeperTester) read(statefulPodIndex int, key string) string {
 	ns := fmt.Sprintf("--namespace=%v", z.ss.Namespace)
 	cmd := fmt.Sprintf("/opt/zookeeper/bin/zkCli.sh get /%v", key)
 	return lastLine(framework.RunKubectlOrDie("exec", ns, name, "--", "/bin/sh", "-c", cmd))
+}
+
+type multivolumeZookeeperTester struct {
+	zookeeperTester
+}
+
+func (z *multivolumeZookeeperTester) name() string {
+	return "multivolumezk"
+}
+
+func (z *multivolumeZookeeperTester) deploy(ns string) *apps.StatefulSet {
+	z.ss = z.tester.CreateStatefulSet(multivolumeZookeeperManifestPath, ns)
+	return z.ss
 }
 
 type mysqlGaleraTester struct {

--- a/test/e2e/testing-manifests/statefulset/multivolumezk/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/multivolumezk/service.yaml
@@ -1,0 +1,20 @@
+# A headless service to create DNS records
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+  name: multivolumezk
+  labels:
+    app: multivolumezk
+spec:
+  ports:
+  - port: 2888
+    name: peer
+  - port: 3888
+    name: leader-election
+  # *.zk.default.svc.cluster.local
+  clusterIP: None
+  selector:
+    app: multivolumezk
+

--- a/test/e2e/testing-manifests/statefulset/multivolumezk/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/multivolumezk/statefulset.yaml
@@ -1,0 +1,128 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: multivolumezk
+spec:
+  serviceName: "multivolumezk"
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: multivolumezk
+      annotations:
+        pod.alpha.kubernetes.io/init-containers: '[
+            {
+                "name": "install",
+                "image": "gcr.io/google_containers/zookeeper-install-3.5.0-alpha:e2e",
+                "imagePullPolicy": "Always",
+                "args": ["--install-into=/opt", "--work-dir=/work-dir"],
+                "volumeMounts": [
+                    {
+                        "name": "opt",
+                        "mountPath": "/opt/"
+                    },
+                    {
+                        "name": "workdir",
+                        "mountPath": "/work-dir"
+                    }
+                ]
+            },
+            {
+                "name": "bootstrap",
+                "image": "java:openjdk-8-jre",
+                "command": ["/work-dir/peer-finder"],
+                "args": ["-on-start=\"/work-dir/on-start.sh\"", "-service=multivolumezk"],
+                "env": [
+                  {
+                      "name": "POD_NAMESPACE",
+                      "valueFrom": {
+                          "fieldRef": {
+                              "apiVersion": "v1",
+                              "fieldPath": "metadata.namespace"
+                          }
+                      }
+                   }
+                ],
+                "volumeMounts": [
+                    {
+                        "name": "opt",
+                        "mountPath": "/opt"
+                    },
+                    {
+                        "name": "workdir",
+                        "mountPath": "/work-dir"
+                    },
+                    {
+                        "name": "datadir",
+                        "mountPath": "/tmp/zookeeper"
+                    }
+                ]
+            }
+        ]'
+    spec:
+      containers:
+      - name: multivolumezk
+        image: java:openjdk-8-jre
+        ports:
+        - containerPort: 2888
+          name: peer
+        - containerPort: 3888
+          name: leader-election
+        command:
+        - /opt/zookeeper/bin/zkServer.sh
+        args:
+        - start-foreground
+        readinessProbe:
+          exec:
+            command:
+            - sh
+            - -c
+            - "/opt/zookeeper/bin/zkCli.sh ls /"
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
+        volumeMounts:
+        - name: datadir
+          mountPath: /tmp/zookeeper
+        # We don't (currently) actually use the supplemental volumes
+        - name: logdir
+          mountPath: /zklogs
+        - name: otherdir1
+          mountPath: /other1
+        - name: opt
+          mountPath: /opt
+        # Mount the work-dir just for debugging
+        - name: workdir
+          mountPath: /work-dir
+      volumes:
+      - name: opt
+        emptyDir: {}
+      - name: workdir
+        emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: logdir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi
+  - metadata:
+      name: otherdir1
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
We create a StatefulSet with two volumes per pod.  We reuse the
zookeeper StatefulSet, but we don't currently use the second volume.
That will need to be fixed in the zookeeper image in the contrib repo.

However, this should be enough to detect issue #35695.

```release-note
NONE
```
