### PR TITLE
fix scheduler performance test script 

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -43,7 +43,6 @@ kube::test::find_dirs() {
           -o -path './test/e2e/*' \
           -o -path './test/e2e_node/*' \
           -o -path './test/integration/*' \
-          -o -path './test/component/scheduler/perf/*' \
           -o -path './third_party/*' \
           -o -path './staging/*' \
           -o -path './vendor/*' \

--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -32,7 +32,7 @@ Currently the test suite has the following:
 How To Run
 ------
 ```
-cd kubernetes/test/component/scheduler/perf
+cd kubernetes/test/integration/scheduler_perf
 ./test-performance.sh
 ```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

 

 `test-performance.sh` is  in  dir `kubernetes/test/integration/scheduler_perf`

the  dir `kubernetes/test/component/scheduler/perf`  does not exist

Thanks.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
