### PR TITLE
update the signing key for percona debian and ubuntu packages

### DIFF
--- a/examples/storage/mysql-galera/image/Dockerfile
+++ b/examples/storage/mysql-galera/image/Dockerfile
@@ -25,7 +25,7 @@ ENV TERM linux
 RUN apt-get update 
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y perl --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
-RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 1C4CBDCDCD2EFD2A
+RUN apt-key adv --keyserver keys.gnupg.net --recv-keys 8507EFA5
 
 RUN echo "deb http://repo.percona.com/apt trusty main" > /etc/apt/sources.list.d/percona.list
 RUN echo "deb-src http://repo.percona.com/apt trusty main" >> /etc/apt/sources.list.d/percona.list


### PR DESCRIPTION
**What this PR does / why we need it**:

> W: GPG error: http://repo.percona.com trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 9334A25F8507EFA5

The signing key has already been updated. Please refer to [Update the Signing Key for Percona Debian and Ubuntu Packages](https://www.percona.com/blog/2016/10/13/new-signing-key-for-percona-debian-and-ubuntu-packages/) for detailed explanations.
