### PR TITLE
Kubectl can do smart things with partial name -- `kubectl logs`

### DIFF
--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -18,15 +18,20 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/validation"
@@ -72,6 +77,7 @@ const (
 type LogsOptions struct {
 	Namespace   string
 	ResourceArg string
+	Selector    string
 	Options     runtime.Object
 
 	Mapper       meta.RESTMapper
@@ -79,8 +85,9 @@ type LogsOptions struct {
 	ClientMapper resource.ClientMapper
 	Decoder      runtime.Decoder
 
-	Object        runtime.Object
-	LogsForObject func(object, options runtime.Object) (*restclient.Request, error)
+	Object          runtime.Object
+	PrefixMatchList []string
+	LogsForObject   func(object, options runtime.Object) (*restclient.Request, error)
 
 	Out io.Writer
 }
@@ -101,7 +108,7 @@ func NewCmdLogs(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, out, cmd, args))
 			cmdutil.CheckErr(o.Validate())
-			cmdutil.CheckErr(o.RunLogs())
+			cmdutil.CheckErr(o.RunLogs(out, args))
 		},
 		Aliases: []string{"log"},
 	}
@@ -123,15 +130,15 @@ func NewCmdLogs(f cmdutil.Factory, out io.Writer) *cobra.Command {
 
 func (o *LogsOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) error {
 	containerName := cmdutil.GetFlagString(cmd, "container")
-	selector := cmdutil.GetFlagString(cmd, "selector")
+	o.Selector = cmdutil.GetFlagString(cmd, "selector")
 	switch len(args) {
 	case 0:
-		if len(selector) == 0 {
+		if len(o.Selector) == 0 {
 			return cmdutil.UsageError(cmd, logsUsageStr)
 		}
 	case 1:
 		o.ResourceArg = args[0]
-		if len(selector) != 0 {
+		if len(o.Selector) != 0 {
 			return cmdutil.UsageError(cmd, "only a selector (-l) or a POD name is allowed")
 		}
 	case 2:
@@ -178,7 +185,7 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Comm
 	o.ClientMapper = resource.ClientMapperFunc(f.ClientForMapping)
 	o.Out = out
 
-	if len(selector) != 0 {
+	if len(o.Selector) != 0 {
 		if logOptions.Follow {
 			return cmdutil.UsageError(cmd, "only one of follow (-f) or selector (-l) is allowed")
 		}
@@ -190,26 +197,71 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Comm
 		}
 	}
 
-	mapper, typer := f.Object()
-	decoder := f.Decoder(true)
+	o.Mapper, o.Typer = f.Object()
+	o.Decoder = f.Decoder(true)
 	if o.Object == nil {
-		builder := resource.NewBuilder(mapper, typer, o.ClientMapper, decoder).
+		builder := resource.NewBuilder(o.Mapper, o.Typer, o.ClientMapper, o.Decoder).
 			NamespaceParam(o.Namespace).DefaultNamespace().
 			SingleResourceType()
 		if o.ResourceArg != "" {
 			builder.ResourceNames("pods", o.ResourceArg)
 		}
-		if selector != "" {
-			builder.ResourceTypes("pods").SelectorParam(selector)
+		if o.Selector != "" {
+			builder.ResourceTypes("pods").SelectorParam(o.Selector)
 		}
 		infos, err := builder.Do().Infos()
+		// if name not found use prefix match
+		aggErrs := []error{}
 		if err != nil {
-			return err
+			aggErrs = append(aggErrs, err)
+			if apierrors.IsNotFound(err) && o.ResourceArg != "" {
+				err = o.prefixMatchResourceList(simpleTrimResourceTypeName(o.ResourceArg), err)
+				if err != nil {
+					aggErrs = append(aggErrs, err)
+					return utilerrors.NewAggregate(aggErrs)
+				}
+			}
 		}
-		if selector == "" && len(infos) != 1 {
+
+		if o.Selector == "" && len(infos) != 1 {
 			return errors.New("expected a resource")
 		}
-		o.Object = infos[0].Object
+
+		if o.Object == nil {
+			o.Object = infos[0].Object
+		}
+	}
+	return nil
+}
+
+func simpleTrimResourceTypeName(s string) string {
+	if strings.Contains(s, "/") {
+		seg := strings.Split(s, "/")
+		return seg[0]
+	}
+	return s
+}
+
+func (o LogsOptions) prefixMatchResourceList(resourceType string, originalError error) error {
+	infos, err := resource.NewBuilder(o.Mapper, o.Typer, o.ClientMapper, o.Decoder).
+		NamespaceParam(o.Namespace).DefaultNamespace().
+		SingleResourceType().ResourceTypeOrNameArgs(true, resourceType).
+		Flatten().Do().Infos()
+	if err != nil {
+		return err
+	}
+	//match pods using prefix
+	prefixTimes := 0
+	for i, info := range infos {
+		if strings.HasPrefix(info.Name, o.ResourceArg) {
+			o.PrefixMatchList = append(o.PrefixMatchList, info.Name)
+			o.Object = infos[i].Object
+			prefixTimes++
+		}
+	}
+
+	if prefixTimes == 0 {
+		return originalError
 	}
 
 	return nil
@@ -228,18 +280,37 @@ func (o LogsOptions) Validate() error {
 }
 
 // RunLogs retrieves a pod log
-func (o LogsOptions) RunLogs() error {
-	switch t := o.Object.(type) {
-	case *api.PodList:
-		for _, p := range t.Items {
-			if err := o.getLogs(&p); err != nil {
-				return err
+func (o LogsOptions) RunLogs(out io.Writer, args []string) error {
+	if matchLen := len(o.PrefixMatchList); matchLen > 1 {
+		if matchLen > 5 {
+			o.PrefixMatchList = o.PrefixMatchList[:5]
+		}
+		first := true
+		fmt.Fprintf(out, "No pod named %s, did you mean? ", args[0])
+		for i := range o.PrefixMatchList {
+			if first {
+				fmt.Fprintf(out, "%s", o.PrefixMatchList[i])
+				first = false
+			} else {
+				fmt.Fprintf(out, ", %s", o.PrefixMatchList[i])
 			}
 		}
-		return nil
-	default:
-		return o.getLogs(o.Object)
+		fmt.Fprintf(out, "\n")
+	} else {
+		switch t := o.Object.(type) {
+		case *api.PodList:
+			for _, p := range t.Items {
+				if err := o.getLogs(&p); err != nil {
+					return err
+				}
+			}
+			return nil
+		default:
+			return o.getLogs(o.Object)
+		}
 	}
+
+	return nil
 }
 
 func (o LogsOptions) getLogs(obj runtime.Object) error {
@@ -247,7 +318,6 @@ func (o LogsOptions) getLogs(obj runtime.Object) error {
 	if err != nil {
 		return err
 	}
-
 	readCloser, err := req.Stream()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes parts of https://github.com/kubernetes/kubernetes/issues/17144.  follow up https://github.com/kubernetes/kubernetes/pull/39869
testing failed panic already been fixed by this pr.
since @jbeda think glob is a bad idea: [check sig-cli meeting](https://www.youtube.com/watch?v=SXd3-Tu5hBA&t=1233s), I just using prefix matching like `describe` did. if prefix is ok, I'll complete other command to support prefix matching.
cc @kubernetes/sig-cli-misc @pwittrock @AdoHe @jessfraz @ymqytw 