### PR TITLE
Send only cluster domain queries to kube-dns

### DIFF
--- a/cluster/addons/dns/kubedns-controller.yaml.base
+++ b/cluster/addons/dns/kubedns-controller.yaml.base
@@ -49,7 +49,7 @@ spec:
       - name: kube-dns-config
         configMap:
           name: kube-dns
-          optional: true    
+          optional: true
       containers:
       - name: kubedns
         image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.12.1
@@ -116,8 +116,9 @@ spec:
           failureThreshold: 5
         args:
         - --cache-size=1000
-        - --no-resolv
-        - --server=127.0.0.1#10053
+        - --server=/__PILLAR__DNS__DOMAIN__/127.0.0.1#10053
+        - --server=/in-addr.arpa/127.0.0.1#10053
+        - --server=/ip6.arpa/127.0.0.1#10053
         - --log-facility=-
         ports:
         - containerPort: 53

--- a/cluster/addons/dns/kubedns-controller.yaml.in
+++ b/cluster/addons/dns/kubedns-controller.yaml.in
@@ -49,7 +49,7 @@ spec:
       - name: kube-dns-config
         configMap:
           name: kube-dns
-          optional: true    
+          optional: true
       containers:
       - name: kubedns
         image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.12.1
@@ -116,8 +116,9 @@ spec:
           failureThreshold: 5
         args:
         - --cache-size=1000
-        - --no-resolv
-        - --server=127.0.0.1#10053
+        - --server=/{{ pillar['dns_domain'] }}/127.0.0.1#10053
+        - --server=/in-addr.arpa/127.0.0.1#10053
+        - --server=/ip6.arpa/127.0.0.1#10053
         - --log-facility=-
         ports:
         - containerPort: 53

--- a/cluster/addons/dns/kubedns-controller.yaml.sed
+++ b/cluster/addons/dns/kubedns-controller.yaml.sed
@@ -49,7 +49,7 @@ spec:
       - name: kube-dns-config
         configMap:
           name: kube-dns
-          optional: true    
+          optional: true
       containers:
       - name: kubedns
         image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.12.1
@@ -115,8 +115,9 @@ spec:
           failureThreshold: 5
         args:
         - --cache-size=1000
-        - --no-resolv
-        - --server=127.0.0.1#10053
+        - --server=/$DNS_DOMAIN/127.0.0.1#10053
+        - --server=/in-addr.arpa/127.0.0.1#10053
+        - --server=/ip6.arpa/127.0.0.1#10053
         - --log-facility=-
         ports:
         - containerPort: 53


### PR DESCRIPTION
Queries not involving the cluster domain should be forwarded out (not to kube-dns)

```release-note
none
```
