### PR TITLE
Automated cherry pick of #41027 upstream release 1.5

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -44,7 +44,7 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-debian
 # variable. Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
 CVM_VERSION=${CVM_VERSION:-container-vm-v20170201}
-GCI_VERSION=${KUBE_GCI_VERSION:-gci-dev-56-8977-0-0}
+GCI_VERSION=${KUBE_GCI_VERSION:-gci-beta-56-9000-80-0}
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -45,7 +45,7 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-debian
 # variable. Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
 CVM_VERSION=${CVM_VERSION:-container-vm-v20170201}
-GCI_VERSION=${KUBE_GCI_VERSION:-gci-dev-56-8977-0-0}
+GCI_VERSION=${KUBE_GCI_VERSION:-gci-beta-56-9000-80-0}
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -49,21 +49,21 @@ images:
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
   gci-resource1:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   gci-resource2:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   gci-resource3:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"

--- a/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
@@ -1,56 +1,56 @@
 ---
 images:
   gci-density1:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   gci-density2:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   gci-density2-qps60:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   gci-density3:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-2
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   gci-density4:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
   gci-resource1:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   gci-resource2:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   gci-resource3:
-    image: gci-dev-56-8977-0-0
+    image: gci-beta-56-9000-80-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"

--- a/test/e2e_node/jenkins/cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/image-config.yaml
@@ -3,6 +3,6 @@ images:
     image: e2e-node-containervm-v20160604-image
     project: kubernetes-node-e2e-images
   gci-family:
-    image_regex: gci-dev-56-8977-0-0
+    image_regex: gci-beta-56-9000-80-0
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -13,6 +13,6 @@ images:
     image: e2e-node-containervm-v20160604-image
     project: kubernetes-node-e2e-images
   gci-family:
-    image_regex: gci-dev-56-8977-0-0
+    image_regex: gci-beta-56-9000-80-0 # docker 1.11.2
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"


### PR DESCRIPTION
cc/ @saad-ali 

Changelogs since gci-dev-56-8977-0-0 (currently used in Kubernetes):
 - "net.ipv4.conf.eth0.forwarding" and "net.ipv4.ip_forward" may get reset to 0
 - Track CVE-2016-9962 in Docker in GCI
 - Linux kernel CVE-2016-7097
 - Linux kernel CVE-2015-8964
 - Linux kernel CVE-2016-6828
 - Linux kernel CVE-2016-7917
 - Linux kernel CVE-2016-7042
 - Linux kernel CVE-2016-9793
 - Linux kernel CVE-2016-7039 and CVE-2016-8666
 - Linux kernel CVE-2016-8655
 - Toolbox: allow docker image to be loaded from local tarball
 - Update compute-image-package in GCI 
 - Change the product name on /etc/os-release (to COS)
 - Remove 'dogfood' from HWID_OVERRIDE in /etc/lsb-release
 - Include Google NVME extensions to optimize LocalSSD performance.
 - /proc/<pid>/io missing on GCI (enables process stats accounting)
 - Enable BLK_DEV_THROTTLING
