### PR TITLE
e2e for pod delete after its uid dir has been deleted

### DIFF
--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -130,10 +130,7 @@ func updateNodeLabels(c clientset.Interface, nodeNames sets.String, toAdd, toRem
 	}
 }
 
-// Calls startVolumeServer to create and run a nfs-server pod. Returns server pod and its
-// ip address.
-// Note: startVolumeServer() waits for the nfs-server pod to be Running and sleeps some
-//   so that the nfs server can start up.
+// Wraps startVolumeServer to create and run a nfs-server pod. Returns server pod and its ip address.
 func createNfsServerPod(c clientset.Interface, config VolumeTestConfig) (*v1.Pod, string) {
 
 	pod := startVolumeServer(c, config)
@@ -143,6 +140,26 @@ func createNfsServerPod(c clientset.Interface, config VolumeTestConfig) (*v1.Pod
 	framework.Logf("NFS server IP address: %v", ip)
 
 	return pod, ip
+}
+
+// Restart the passed-in nfs-server by issuing a `/usr/sbin/rpc.nfsd 1` command in the
+// pod's (only) container. This command changes the number of nfs server threads from
+// (presumably) zero back to 1, and therefore allows nfs to open connections again.
+func restartNfsServer(serverPod *v1.Pod) {
+
+	const startcmd = "/usr/sbin/rpc.nfsd 1"
+	ns := fmt.Sprintf("--namespace=%v", serverPod.Namespace)
+	framework.RunKubectlOrDie("exec", ns, serverPod.Name, "--", "/bin/sh", "-c", startcmd)
+}
+
+// Stop the passed-in nfs-server by issuing a `/usr/sbin/rpc.nfsd 0` command in the
+// pod's (only) container. This command changes the number of nfs server threads to 0,
+// thus closing all open nfs connections.
+func stopNfsServer(serverPod *v1.Pod) {
+
+	const stopcmd = "/usr/sbin/rpc.nfsd 0"
+	ns := fmt.Sprintf("--namespace=%v", serverPod.Namespace)
+	framework.RunKubectlOrDie("exec", ns, serverPod.Name, "--", "/bin/sh", "-c", stopcmd)
 }
 
 // Creates a pod that mounts an nfs volume that is served by the nfs-server pod. The container
@@ -208,6 +225,23 @@ func createPodUsingNfs(f *framework.Framework, c clientset.Interface, ns, nfsIP,
 	return rtnPod
 }
 
+// move the passed-in pod's UID directory to /tmp.
+func movePodUidDir(c clientset.Interface, pod *v1.Pod) {
+
+	dest := "/tmp"
+	podDir := filepath.Join("/var/lib/kubelet/pods", string(pod.UID))
+	cmd := fmt.Sprintf("mv %v %v", podDir, dest)
+	// use ip rather than hostname in GCE
+	nodeIP, err := framework.GetHostExternalAddress(c, pod)
+	Expect(err).NotTo(HaveOccurred())
+
+	// excute cmd over ssh
+	result, _ := nodeExec(nodeIP, cmd)
+	framework.LogSSHResult(result)
+	Expect(result.Code).To(BeZero())
+	Expect(len(result.Stderr)).To(BeZero())
+}
+
 // Checks for a lingering nfs mount and/or uid directory on the pod's host. The host IP is used
 // so that this test runs in GCE, where it appears that SSH cannot resolve the hostname.
 // If expectClean is true then we expect the node to be cleaned up and thus commands like
@@ -218,42 +252,48 @@ func checkPodCleanup(c clientset.Interface, pod *v1.Pod, expectClean bool) {
 
 	timeout := 5 * time.Minute
 	poll := 20 * time.Second
-	podUID := string(pod.UID)
-	podDir := filepath.Join("/var/lib/kubelet/pods", podUID)
+	podDir := filepath.Join("/var/lib/kubelet/pods", string(pod.UID))
 	mountDir := filepath.Join(podDir, "volumes", "kubernetes.io~nfs")
 	// use ip rather than hostname in GCE
 	nodeIP, err := framework.GetHostExternalAddress(c, pod)
 	Expect(err).NotTo(HaveOccurred())
 
-	condMsg := map[bool]string{
-		true:  "deleted",
-		false: "present",
+	condMsg := "deleted"
+	if !expectClean {
+		condMsg = "present"
 	}
 
-	// table of host tests to perform
-	tests := map[string]string{ //["what-to-test"] "remote-command"
-		"pod UID directory": fmt.Sprintf("sudo ls %v", podDir),
-		"pod nfs mount":     fmt.Sprintf("sudo mount | grep %v", mountDir),
+	// table of host tests to perform (order may matter so not using a map)
+	type testT struct {
+		feature string // feature to test
+		cmd     string // remote command to execute on node
+	}
+	tests := []testT{
+		{
+			feature: "pod UID directory",
+			cmd:     fmt.Sprintf("sudo ls %v", podDir),
+		},
+		{
+			feature: "pod nfs mount",
+			cmd:     fmt.Sprintf("sudo mount | grep %v", mountDir),
+		},
 	}
 
-	for test, cmd := range tests {
-		framework.Logf("Wait up to %v for host's (%v) %q to be %v", timeout, nodeIP, test, condMsg[expectClean])
+	for _, test := range tests {
+		framework.Logf("Wait up to %v for host's (%v) %q to be %v", timeout, nodeIP, test.feature, condMsg)
 		err = wait.Poll(poll, timeout, func() (bool, error) {
-			result, _ := nodeExec(nodeIP, cmd)
+			result, _ := nodeExec(nodeIP, test.cmd)
 			framework.LogSSHResult(result)
-			sawFiles := result.Code == 0
-			if expectClean && sawFiles { // keep trying
+			ok := (result.Code == 0 && len(result.Stdout) > 0 && len(result.Stderr) == 0)
+			if expectClean && ok { // keep trying
 				return false, nil
 			}
-			if !expectClean && !sawFiles { // stop wait loop
-				return true, fmt.Errorf("%v is gone but expected to exist", test)
+			if !expectClean && !ok { // stop wait loop
+				return true, fmt.Errorf("%v is gone but expected to exist", test.feature)
 			}
 			return true, nil // done, host is as expected
 		})
-		if err != nil {
-			framework.Logf("Host (%v) cleanup error: %v. Expected %q to be %v", nodeIP, err, test, condMsg[expectClean])
-			Expect(err).NotTo(HaveOccurred())
-		}
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Host (%v) cleanup error: %v. Expected %q to be %v", nodeIP, err, test.feature, condMsg))
 	}
 
 	if expectClean {
@@ -375,14 +415,20 @@ var _ = framework.KubeDescribe("kubelet", func() {
 		}
 	})
 
-	// Delete nfs server pod after another pods accesses the mounted nfs volume.
-	framework.KubeDescribe("host cleanup with volume mounts [HostCleanup][Flaky]", func() {
+	// Test host cleanup when disrupting the volume server.
+	framework.KubeDescribe("host cleanup with volume mounts [HostCleanup][Slow]", func() {
+
 		type hostCleanupTest struct {
 			itDescr string
 			podCmd  string
 		}
 
-		Context("Host cleanup after pod using NFS mount is deleted [Volume][NFS]", func() {
+		// Disrupt the nfs server pod after a client pod accesses the nfs volume.
+		// Note: the nfs-server is stopped NOT deleted. This is done to preserve its ip addr.
+		//       If the nfs-server pod is deleted the client pod's mount can not be unmounted.
+		//       If the nfs-server pod is deleted and re-created, due to having a different ip
+		//       addr, the client pod's mount still cannot be unmounted.
+		Context("Host cleanup after disrupting NFS volume [NFS]", func() {
 			// issue #31272
 			var (
 				nfsServerPod *v1.Pod
@@ -395,11 +441,11 @@ var _ = framework.KubeDescribe("kubelet", func() {
 			testTbl := []hostCleanupTest{
 				{
 					itDescr: "after deleting the nfs-server, the host should be cleaned-up when deleting sleeping pod which mounts an NFS vol",
-					podCmd:  "sleep 6000",
+					podCmd:  "sleep 6000", // keep pod running
 				},
 				{
 					itDescr: "after deleting the nfs-server, the host should be cleaned-up when deleting a pod accessing the NFS vol",
-					podCmd:  "while true; do echo FeFieFoFum >>/mnt/SUCCESS; cat /mnt/SUCCESS; done",
+					podCmd:  "while true; do echo FeFieFoFum >>/mnt/SUCCESS; sleep 1; cat /mnt/SUCCESS; done",
 				},
 			}
 
@@ -420,31 +466,45 @@ var _ = framework.KubeDescribe("kubelet", func() {
 			})
 
 			// execute It blocks from above table of tests
-			for _, test := range testTbl {
-				t := test // local copy for closure
-				It(fmt.Sprintf("%v [Serial]", t.itDescr), func() {
-					// create a pod which uses the nfs server's volume
+			for _, t := range testTbl {
+				It(t.itDescr, func() {
 					pod = createPodUsingNfs(f, c, ns, nfsIP, t.podCmd)
 
-					By("Delete the NFS server pod")
-					deletePodWithWait(f, c, nfsServerPod)
-					nfsServerPod = nil
+					By("Stop the NFS server")
+					stopNfsServer(nfsServerPod)
 
 					By("Delete the pod mounted to the NFS volume")
 					deletePodWithWait(f, c, pod)
 					// pod object is now stale, but is intentionally not nil
 
-					By("Check if host running deleted pod has been cleaned up -- expect not")
-					// expect the pod's host *not* to be cleaned up
+					By("Check if pod's host has been cleaned up -- expect not")
 					checkPodCleanup(c, pod, false)
 
-					By("Recreate the nfs server pod")
-					nfsServerPod, nfsIP = createNfsServerPod(c, NFSconfig)
+					By("Restart the nfs server")
+					restartNfsServer(nfsServerPod)
+
 					By("Verify host running the deleted pod is now cleaned up")
-					// expect the pod's host to be cleaned up
 					checkPodCleanup(c, pod, true)
 				})
 			}
+
+			// Move a pod's uid dir to /tmp, delete pod, should complete.
+			// Addresses issue #37657.
+			// Note: pod's vol mount is moved too and can be unmounted via `umount -f`.
+			It("move pod's uid dir and delete pod [Disruptive]", func() {
+				pod = createPodUsingNfs(f, c, ns, nfsIP, "sleep 6000")
+
+				By("Move pod's uid dir to /tmp")
+				movePodUidDir(c, pod)
+
+				By("Delete the pod mounted to the NFS volume")
+				deletePodWithWait(f, c, pod)
+				// pod object is now stale, but is intentionally not nil
+				// Note: the pod's nfs mount, now in /tmp,  will not be unmounted
+
+				By("Verify host running the deleted pod is cleaned up")
+				checkPodCleanup(c, pod, true)
+			})
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
e2e to test host/kubelet mount cleanup.

**Which issue this PR fixes**
provides an e2e test for closed issue [37657](https://github.com/kubernetes/kubernetes/issues/37657).

**Special notes for your reviewer**:
Note: this pr is built on pr [41178](https://github.com/kubernetes/kubernetes/pull/41178). The only new code here is the `movePodUidDir()` func and `It("move pod's uid dir and delete pod [Disruptive]", func() {...`

```release-note
NONE
```
