### PR TITLE
Add LegacyHostIP as a fallback to federation api-server nodeport service

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -380,6 +380,7 @@ func createService(clientset *client.Clientset, namespace, svcName, apiserverAdv
 func getClusterNodeIPs(clientset *client.Clientset) ([]string, error) {
 	preferredAddressTypes := []api.NodeAddressType{
 		api.NodeExternalIP,
+		api.NodeLegacyHostIP,
 	}
 	nodeList, err := clientset.Nodes().List(metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
while deploying federation using kubefed and using NodePort type service for api-server, if the cluster does not have NodeExternalIP for nodes, then it leads to incorrect endpoint being written to kubeconfig.
So falling back to use LegacyHostIP in such cases.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Partly fixes an issue in this [thread](https://github.com/kubernetes/kubernetes/issues/41127#issuecomment-278888658)

**Special notes for your reviewer**:

**Release note**:
`NONE`
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
cc @kubernetes/sig-federation-bugs @madhusudancs 