### PR TITLE
Add more logs during the progress check

### DIFF
--- a/pkg/controller/deployment/progress.go
+++ b/pkg/controller/deployment/progress.go
@@ -64,11 +64,15 @@ func (dc *DeploymentController) hasFailed(d *extensions.Deployment) (bool, error
 
 	// If the deployment is complete or it is progressing, there is no need to check if it
 	// has timed out.
+	// TODO: Switch to a much higher verbosity level
+	glog.V(2).Infof("Checking if deployment %q is complete or progressing", d.Name)
 	if util.DeploymentComplete(d, &newStatus) || util.DeploymentProgressing(d, &newStatus) {
 		return false, nil
 	}
 
 	// Check if the deployment has timed out.
+	// TODO: Switch to a much higher verbosity level
+	glog.V(2).Infof("Checking if deployment %q has timed out", d.Name)
 	return util.DeploymentTimedOut(d, &newStatus), nil
 }
 

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -867,8 +867,13 @@ func DeploymentTimedOut(deployment *extensions.Deployment, newStatus *extensions
 	// progress or tried to create a replica set, or resumed a paused deployment and
 	// compare against progressDeadlineSeconds.
 	from := condition.LastUpdateTime
+	now := nowFn()
 	delta := time.Duration(*deployment.Spec.ProgressDeadlineSeconds) * time.Second
-	return from.Add(delta).Before(nowFn())
+	timedOut := from.Add(delta).Before(now)
+
+	// TODO: Switch to a much higher verbosity level
+	glog.V(2).Infof("Deployment %q timed out (%t) [last progress check: %v - now: %v]", deployment.Name, timedOut, from, now)
+	return timedOut
 }
 
 // NewRSNewReplicas calculates the number of replicas a deployment's new RS should have.


### PR DESCRIPTION
@soltysh this is needed for debugging https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke/4460#k8sio-deployment-lack-of-progress-should-be-reported-in-the-deployment-status

Probably the last set of logs I will need for this one. I have opened https://github.com/kubernetes/kubernetes/issues/41187 to reduce the verbosity level before 1.6 ships.