### PR TITLE
kubeadm: changed manifest files to yaml

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -124,7 +124,7 @@ func (r *Reset) Run(out io.Writer) error {
 
 	// Only clear etcd data when the etcd manifest is found. In case it is not found, we must assume that the user
 	// provided external etcd endpoints. In that case, it is his own responsibility to reset etcd
-	etcdManifestPath := filepath.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, "manifests/etcd.json")
+	etcdManifestPath := filepath.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, "manifests/etcd.yaml")
 	if _, err := os.Stat(etcdManifestPath); err == nil {
 		dirsToClean = append(dirsToClean, "/var/lib/etcd")
 	} else {

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -61,8 +61,8 @@ func TestConfigDirCleaner(t *testing.T) {
 				"pki",
 			},
 			setupFiles: []string{
-				"manifests/etcd.json",
-				"manifests/kube-apiserver.json",
+				"manifests/etcd.yaml",
+				"manifests/kube-apiserver.yaml",
 				"pki/ca.pem",
 				kubeconfig.AdminKubeConfigFileName,
 				kubeconfig.KubeletKubeConfigFileName,
@@ -93,8 +93,8 @@ func TestConfigDirCleaner(t *testing.T) {
 				"pki",
 			},
 			setupFiles: []string{
-				"manifests/etcd.json",
-				"manifests/kube-apiserver.json",
+				"manifests/etcd.yaml",
+				"manifests/kube-apiserver.yaml",
 				"pki/ca.pem",
 				kubeconfig.AdminKubeConfigFileName,
 				kubeconfig.KubeletKubeConfigFileName,
@@ -113,8 +113,8 @@ func TestConfigDirCleaner(t *testing.T) {
 				".mydir",
 			},
 			setupFiles: []string{
-				"manifests/etcd.json",
-				"manifests/kube-apiserver.json",
+				"manifests/etcd.yaml",
+				"manifests/kube-apiserver.yaml",
 				"pki/ca.pem",
 				kubeconfig.AdminKubeConfigFileName,
 				kubeconfig.KubeletKubeConfigFileName,

--- a/cmd/kubeadm/app/master/BUILD
+++ b/cmd/kubeadm/app/master/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//pkg/apis/extensions/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
+        "//vendor:github.com/ghodss/yaml",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/api/resource",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -18,11 +18,12 @@ package master
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path"
 	"strings"
+
+	"github.com/ghodss/yaml"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,10 +130,10 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 		return fmt.Errorf("failed to create directory %q [%v]", manifestsPath, err)
 	}
 	for name, spec := range staticPodSpecs {
-		filename := path.Join(manifestsPath, name+".json")
-		serialized, err := json.MarshalIndent(spec, "", "  ")
+		filename := path.Join(manifestsPath, name+".yaml")
+		serialized, err := yaml.Marshal(spec)
 		if err != nil {
-			return fmt.Errorf("failed to marshal manifest for %q to JSON [%v]", name, err)
+			return fmt.Errorf("failed to marshal manifest for %q to YAML [%v]", name, err)
 		}
 		if err := cmdutil.DumpReaderToFile(bytes.NewReader(serialized), filename); err != nil {
 			return fmt.Errorf("failed to create static pod manifest file for %q (%q) [%v]", name, filename, err)

--- a/cmd/kubeadm/app/master/selfhosted.go
+++ b/cmd/kubeadm/app/master/selfhosted.go
@@ -335,7 +335,7 @@ func getSchedulerDeployment(cfg *kubeadmapi.MasterConfiguration) ext.Deployment 
 }
 
 func buildStaticManifestFilepath(name string) string {
-	return path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, "manifests", name+".json")
+	return path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, "manifests", name+".yaml")
 }
 
 func getMasterToleration() string {


### PR DESCRIPTION
**What this PR does / why we need it**: Static Pods are currently stored as .json files in /etc/kubernetes/manifests. This PR instead writes them as YAML, as requested by the SIG.

**Which issue this PR fixes**: fixes #https://github.com/kubernetes/kubeadm/issues/153

**Special notes for your reviewer**: /cc @luxas 

**Release note**:
```release-note
NONE
```
