### PR TITLE
Fix cluster-cidr flag

### DIFF
--- a/cmd/kubeadm/app/phases/addons/BUILD
+++ b/cmd/kubeadm/app/phases/addons/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -37,5 +38,12 @@ filegroup(
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["addons_test.go"],
+    library = ":go_default_library",
     tags = ["automanaged"],
 )

--- a/cmd/kubeadm/app/phases/addons/addons.go
+++ b/cmd/kubeadm/app/phases/addons/addons.go
@@ -158,5 +158,5 @@ func getClusterCIDR(podsubnet string) string {
 	if len(podsubnet) == 0 {
 		return ""
 	}
-	return "--cluster-cidr" + podsubnet
+	return "- --cluster-cidr=" + podsubnet
 }

--- a/cmd/kubeadm/app/phases/addons/addons_test.go
+++ b/cmd/kubeadm/app/phases/addons/addons_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addons
+
+import "testing"
+
+func TestGetClusterCIDR(t *testing.T) {
+	emptyClusterCIDR := getClusterCIDR("")
+	if emptyClusterCIDR != "" {
+		t.Errorf("Invalid format: %s", emptyClusterCIDR)
+	}
+
+	clusterCIDR := getClusterCIDR("10.244.0.0/16")
+	if clusterCIDR != "- --cluster-cidr=10.244.0.0/16" {
+		t.Errorf("Invalid format: %s", clusterCIDR)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the kube-proxy daemonset config when using the `pod-network-cidr flag`. The return value of `getClusterCIDR` should be prefixed with a `-`.

**Special notes for your reviewer**:
None

@luxas 