### PR TITLE
Allow `build/run.sh make help` to run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -490,13 +490,13 @@ endif
 
 
 ifeq ($(PRINT_HELP),y)
-bazel-test:
 define BAZEL_TEST_HELP_INFO
 # Test with bazel
 #
 # Example:
 # make bazel-test
 endef
+bazel-test:
 	@echo "$$BAZEL_TEST_HELP_INFO"
 else
 bazel-test:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: typo fix; `build/run.sh make help` doesn't work for me on OS X w/ docker 1.13.x, this PR fixes that

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
 /cc @spxtr