### PR TITLE
Allow the CertificateController to use any Signer implementation.

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -32,11 +32,17 @@ func startCSRController(ctx ControllerContext) (bool, error) {
 		return false, nil
 	}
 	c := ctx.ClientBuilder.ClientOrDie("certificate-controller")
+
+	signer, err := certcontroller.NewCFSSLSigner(ctx.Options.ClusterSigningCertFile, ctx.Options.ClusterSigningKeyFile)
+	if err != nil {
+		glog.Errorf("Failed to start certificate controller: %v", err)
+		return false, nil
+	}
+
 	certController, err := certcontroller.NewCertificateController(
 		c,
 		ctx.NewInformerFactory.Certificates().V1beta1().CertificateSigningRequests(),
-		ctx.Options.ClusterSigningCertFile,
-		ctx.Options.ClusterSigningKeyFile,
+		signer,
 		certcontroller.NewGroupApprover(ctx.Options.ApproveAllKubeletCSRsForGroup),
 	)
 	if err != nil {

--- a/pkg/controller/certificates/certificate_controller_test.go
+++ b/pkg/controller/certificates/certificate_controller_test.go
@@ -58,12 +58,16 @@ func newController(csrs ...runtime.Object) (*testController, error) {
 		return nil, err
 	}
 
+	signer, err := NewCFSSLSigner(certFile, keyFile)
+	if err != nil {
+		return nil, err
+	}
+
 	approver := &fakeAutoApprover{make(chan *certificates.CertificateSigningRequest, 1)}
 	controller, err := NewCertificateController(
 		client,
 		informerFactory.Certificates().V1beta1().CertificateSigningRequests(),
-		certFile,
-		keyFile,
+		signer,
 		approver,
 	)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This will allow developers to create `CertificateController`s with arbitrary `Signer`s, instead of forcing the use of `CFSSLSigner`. It matches the behavior of allowing an arbitrary `AutoApprover` to be passed in the constructor.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

CC @mikedanese 