### PR TITLE
Change timeout for ExecSync, RunPodSandbox and PullImage.

### DIFF
--- a/pkg/kubelet/remote/remote_image.go
+++ b/pkg/kubelet/remote/remote_image.go
@@ -91,7 +91,7 @@ func (r *RemoteImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimea
 
 // PullImage pulls an image with authentication config.
 func (r *RemoteImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimeapi.AuthConfig) (string, error) {
-	ctx, cancel := getContextWithTimeout(r.timeout)
+	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
 	resp, err := r.imageClient.PullImage(ctx, &runtimeapi.PullImageRequest{

--- a/pkg/kubelet/remote/remote_runtime.go
+++ b/pkg/kubelet/remote/remote_runtime.go
@@ -74,7 +74,9 @@ func (r *RemoteRuntimeService) Version(apiVersion string) (*runtimeapi.VersionRe
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 // the sandbox is in ready state.
 func (r *RemoteRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig) (string, error) {
-	ctx, cancel := getContextWithTimeout(r.timeout)
+	// Use 2 times longer timeout for sandbox operation (4 mins by defualt)
+	// TODO: Make the pod sandbox timeout configurable.
+	ctx, cancel := getContextWithTimeout(r.timeout * 2)
 	defer cancel()
 
 	resp, err := r.runtimeClient.RunPodSandbox(ctx, &runtimeapi.RunPodSandboxRequest{
@@ -281,7 +283,11 @@ func (r *RemoteRuntimeService) ContainerStatus(containerID string) (*runtimeapi.
 // ExecSync executes a command in the container, and returns the stdout output.
 // If command exits with a non-zero exit code, an error is returned.
 func (r *RemoteRuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
-	ctx, cancel := getContextWithTimeout(r.timeout)
+	ctx, cancel := getContextWithTimeout(timeout)
+	if timeout == 0 {
+		// Do not set timeout when timeout is 0.
+		ctx, cancel = getContextWithCancel()
+	}
 	defer cancel()
 
 	timeoutSeconds := int64(timeout.Seconds())

--- a/pkg/kubelet/remote/utils.go
+++ b/pkg/kubelet/remote/utils.go
@@ -36,6 +36,11 @@ func getContextWithTimeout(timeout time.Duration) (context.Context, context.Canc
 	return context.WithTimeout(context.Background(), timeout)
 }
 
+// getContextWithCancel returns a context with cancel.
+func getContextWithCancel() (context.Context, context.CancelFunc) {
+	return context.WithCancel(context.Background())
+}
+
 // verifySandboxStatus verified whether all required fields are set in PodSandboxStatus.
 func verifySandboxStatus(status *runtimeapi.PodSandboxStatus) error {
 	if status.Id == "" {


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/41225.

This PR:
* Change `ExecSync` to respect passed-in timeout.
* Double `RunPodSandbox` timeout.
* Remove `PullImage` timeout.

/cc @yujuhong @timstclair @feiskyer @freehan @kubernetes/sig-node-bugs 