### PR TITLE
Add verify-gofmt as a Bazel test.

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,8 +2,5 @@
 build --verbose_failures
 test --test_output=errors
 
-# Retry tests up to 3 times if they fail.
-test --flaky_test_attempts=3
-
 # Include git version info
 build --workspace_status_command hack/print-workspace-status.sh

--- a/Makefile
+++ b/Makefile
@@ -500,7 +500,7 @@ endef
 	@echo "$$BAZEL_TEST_HELP_INFO"
 else
 bazel-test:
-	bazel test  //cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all
+	bazel test --flaky_test_attempts=3 //cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all
 endif
 
 ifeq ($(PRINT_HELP),y)

--- a/hack/BUILD
+++ b/hack/BUILD
@@ -27,10 +27,21 @@ sh_test(
     tags = ["manual"],
 )
 
+sh_test(
+    name = "verify-gofmt",
+    srcs = ["verify-gofmt.sh"],
+    data = [
+        "//:all-srcs",
+        "@io_bazel_rules_go_toolchain//:toolchain",
+    ],
+    tags = ["manual"],
+)
+
 test_suite(
     name = "verify-all",
     tags = ["manual"],
     tests = [
         "verify-boilerplate",
+        "verify-gofmt",
     ],
 )

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -23,9 +23,14 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-kube::golang::verify_go_version
-
 cd "${KUBE_ROOT}"
+
+# Prefer bazel's gofmt.
+gofmt="external/io_bazel_rules_go_toolchain/bin/gofmt"
+if [[ ! -x "${gofmt}" ]]; then
+  gofmt=$(which gofmt)
+  kube::golang::verify_go_version
+fi
 
 find_files() {
   find . -not \( \
@@ -38,14 +43,13 @@ find_files() {
         -o -wholename '*/third_party/*' \
         -o -wholename '*/vendor/*' \
         -o -wholename './staging' \
+        -o -wholename '*/bindata.go' \
       \) -prune \
     \) -name '*.go'
 }
 
-GOFMT="gofmt -s -w"
-bad_files=$(find_files | xargs $GOFMT -l)
-if [[ -n "${bad_files}" ]]; then
-  echo "!!! '$GOFMT' needs to be run on the following files: "
-  echo "${bad_files}"
+diff=$(find_files | xargs ${gofmt} -d -s 2>&1)
+if [[ -n "${diff}" ]]; then
+  echo "${diff}"
   exit 1
 fi


### PR DESCRIPTION
Also, moved `--flaky_test_attempts=3` out of `.bazelrc` since it was annoying. I think this verify-all pattern is working well in test-infra, we should try and make it happen here.

**Release note**:
```release-note
NONE
```
