### PR TITLE
implement configmap upgrade test

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -33,6 +33,7 @@ var upgradeTests = []upgrades.Test{
 	&upgrades.ServiceUpgradeTest{},
 	&upgrades.SecretUpgradeTest{},
 	&upgrades.DeploymentUpgradeTest{},
+	&upgrades.ConfigMapUpgradeTest{},
 }
 
 var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {

--- a/test/e2e/upgrades/BUILD
+++ b/test/e2e/upgrades/BUILD
@@ -10,6 +10,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "configmaps.go",
         "deployments.go",
         "secrets.go",
         "services.go",

--- a/test/e2e/upgrades/configmaps.go
+++ b/test/e2e/upgrades/configmaps.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrades
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+// ConfigMapUpgradeTest tests that a ConfigMap is available before and after
+// a cluster upgrade.
+type ConfigMapUpgradeTest struct {
+	configMap *v1.ConfigMap
+}
+
+// Setup creates a ConfigMap and then verifies that a pod can consume it.
+func (t *ConfigMapUpgradeTest) Setup(f *framework.Framework) {
+	configMapName := "upgrade-configmap"
+
+	// Grab a unique namespace so we don't collide.
+	ns, err := f.CreateNamespace("configmap-upgrade", nil)
+	framework.ExpectNoError(err)
+
+	t.configMap = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      configMapName,
+		},
+		Data: map[string]string{
+			"data": "some configmap data",
+		},
+	}
+
+	By("Creating a ConfigMap")
+	if t.configMap, err = f.ClientSet.Core().ConfigMaps(ns.Name).Create(t.configMap); err != nil {
+		framework.Failf("unable to create test ConfigMap %s: %v", t.configMap.Name, err)
+	}
+
+	By("Making sure the ConfigMap is consumable")
+	t.testPod(f)
+}
+
+// Test waits for the upgrade to complete, and then verifies that a
+// pod can still consume the ConfigMap.
+func (t *ConfigMapUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
+	<-done
+	By("Consuming the ConfigMap after upgrade")
+	t.testPod(f)
+}
+
+// Teardown cleans up any remaining resources.
+func (t *ConfigMapUpgradeTest) Teardown(f *framework.Framework) {
+	// rely on the namespace deletion to clean up everything
+}
+
+// testPod creates a pod that consumes a ConfigMap and prints it out. The
+// output is then verified.
+func (t *ConfigMapUpgradeTest) testPod(f *framework.Framework) {
+	volumeName := "configmap-volume"
+	volumeMountPath := "/etc/configmap-volume"
+
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-configmap-" + string(uuid.NewUUID()),
+			Namespace: t.configMap.ObjectMeta.Namespace,
+		},
+		Spec: v1.PodSpec{
+			Volumes: []v1.Volume{
+				{
+					Name: volumeName,
+					VolumeSource: v1.VolumeSource{
+						ConfigMap: &v1.ConfigMapVolumeSource{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: t.configMap.ObjectMeta.Name,
+							},
+						},
+					},
+				},
+			},
+			Containers: []v1.Container{
+				{
+					Name:  "configmap-volume-test",
+					Image: "gcr.io/google_containers/mounttest:0.7",
+					Args: []string{
+						fmt.Sprintf("--file_content=%s/data", volumeMountPath),
+						fmt.Sprintf("--file_mode=%s/data", volumeMountPath),
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      volumeName,
+							MountPath: volumeMountPath,
+						},
+					},
+				},
+				{
+					Name:    "configmap-env-test",
+					Image:   "gcr.io/google_containers/busybox:1.24",
+					Command: []string{"sh", "-c", "env"},
+					Env: []v1.EnvVar{
+						{
+							Name: "CONFIGMAP_DATA",
+							ValueFrom: &v1.EnvVarSource{
+								ConfigMapKeyRef: &v1.ConfigMapKeySelector{
+									LocalObjectReference: v1.LocalObjectReference{
+										Name: t.configMap.ObjectMeta.Name,
+									},
+									Key: "data",
+								},
+							},
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+
+	expectedOutput := []string{
+		"content of file \"/etc/configmap-volume/data\": some configmap data",
+		"mode of file \"/etc/configmap-volume/data\": -rw-r--r--",
+	}
+	f.TestContainerOutput("volume consume configmap", pod, 0, expectedOutput)
+
+	expectedOutput = []string{"CONFIGMAP_DATA=some configmap data"}
+	f.TestContainerOutput("env consume configmap", pod, 1, expectedOutput)
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Add an automated ConfigMap upgrade test to the e2e upgrade test suite. The test creates a ConfigMap and verifies it can be consumed by pods before/after upgrade. See PR #39953 and #40747 for context.

**Special notes for your reviewer**:
@krousey please review for consistency with new upgrade test interface. I copied heavily from secrets test for this. I will implement similar tests for DaemonSets and Jobs next. Note that I have not run this test locally.

**Release note**:
`NONE`
