### PR TITLE
Support service-node-port-range when initializing kubeadm

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -46,6 +46,7 @@ type API struct {
 	AdvertiseAddresses []string
 	ExternalDNSNames   []string
 	Port               int32
+	PortRange          string
 }
 
 type Discovery struct {

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -36,6 +36,7 @@ type API struct {
 	AdvertiseAddresses []string `json:"advertiseAddresses"`
 	ExternalDNSNames   []string `json:"externalDNSNames"`
 	Port               int32    `json:"port"`
+	PortRange          string   `json:"portRange"`
 }
 
 type Discovery struct {

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -101,6 +101,10 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 		&cfg.Networking.DNSDomain, "service-dns-domain", cfg.Networking.DNSDomain,
 		`Use alternative domain for services, e.g. "myorg.internal"`,
 	)
+	cmd.PersistentFlags().StringVar(
+		&cfg.API.PortRange, "service-node-port-range", cfg.API.PortRange,
+		`A port range to reserve for services with NodePort visibility. Example: '30000-32767'. Inclusive at both ends of the range. (default 30000-32767)"`,
+	)
 	cmd.PersistentFlags().Var(
 		flags.NewCloudProviderFlag(&cfg.CloudProvider), "cloud-provider",
 		`Enable cloud provider features (external load-balancers, storage, etc). Note that you have to configure all kubelets manually`,

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -367,6 +367,10 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, selfHosted bool) [
 		}
 	}
 
+	if cfg.API.PortRange != "" {
+		command = append(command, "--service-node-port-range="+cfg.API.PortRange)
+	}
+
 	return command
 }
 


### PR DESCRIPTION
fix #122