### PR TITLE
copy pkg/util/logs to apiserver

### DIFF
--- a/cmd/cloud-controller-manager/BUILD
+++ b/cmd/cloud-controller-manager/BUILD
@@ -24,13 +24,13 @@ go_library(
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/cloudprovider:go_default_library",
         "//pkg/cloudprovider/providers:go_default_library",
-        "//pkg/util/logs:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/server/healthz",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/cmd/cloud-controller-manager/controller-manager.go
+++ b/cmd/cloud-controller-manager/controller-manager.go
@@ -25,12 +25,12 @@ import (
 
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/cloud-controller-manager/app"
 	"k8s.io/kubernetes/cmd/cloud-controller-manager/app/options"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	_ "k8s.io/kubernetes/pkg/cloudprovider/providers"
-	"k8s.io/kubernetes/pkg/util/logs"
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 

--- a/cmd/hyperkube/BUILD
+++ b/cmd/hyperkube/BUILD
@@ -59,7 +59,6 @@ go_library(
         "//pkg/kubectl/cmd:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/util:go_default_library",
-        "//pkg/util/logs:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//plugin/cmd/kube-scheduler/app:go_default_library",
@@ -67,6 +66,7 @@ go_library(
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/server/healthz",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/cmd/hyperkube/hyperkube.go
+++ b/cmd/hyperkube/hyperkube.go
@@ -26,8 +26,8 @@ import (
 	"path"
 
 	utilflag "k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/util"
-	"k8s.io/kubernetes/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/cmd/kube-aggregator/BUILD
+++ b/cmd/kube-aggregator/BUILD
@@ -20,7 +20,7 @@ go_library(
         "//cmd/kube-aggregator/pkg/client/listers/apiregistration/v1alpha1:go_default_library",
         "//cmd/kube-aggregator/pkg/cmd/server:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
-        "//pkg/util/logs:go_default_library",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/cmd/kube-aggregator/main.go
+++ b/cmd/kube-aggregator/main.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"runtime"
 
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-aggregator/pkg/cmd/server"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/util/logs"
 
 	// force compilation of packages we'll later rely upon
 	_ "k8s.io/kubernetes/cmd/kube-aggregator/pkg/apis/apiregistration/install"

--- a/cmd/kube-apiserver/BUILD
+++ b/cmd/kube-apiserver/BUILD
@@ -22,11 +22,11 @@ go_library(
         "//cmd/kube-apiserver/app:go_default_library",
         "//cmd/kube-apiserver/app/options:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
-        "//pkg/util/logs:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -25,11 +25,11 @@ import (
 	"time"
 
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
-	"k8s.io/kubernetes/pkg/util/logs"
-	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
+	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/cmd/kube-controller-manager/BUILD
+++ b/cmd/kube-controller-manager/BUILD
@@ -22,13 +22,13 @@ go_library(
         "//cmd/kube-controller-manager/app:go_default_library",
         "//cmd/kube-controller-manager/app/options:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
-        "//pkg/util/logs:go_default_library",
         "//pkg/util/workqueue/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/server/healthz",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -26,10 +26,10 @@ import (
 
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app/options"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
-	"k8s.io/kubernetes/pkg/util/logs"
 	_ "k8s.io/kubernetes/pkg/util/workqueue/prometheus" // for workqueue metric registration
 	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"

--- a/cmd/kube-proxy/BUILD
+++ b/cmd/kube-proxy/BUILD
@@ -22,12 +22,12 @@ go_library(
         "//cmd/kube-proxy/app:go_default_library",
         "//cmd/kube-proxy/app/options:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
-        "//pkg/util/logs:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/server/healthz",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -22,11 +22,11 @@ import (
 
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-proxy/app"
 	"k8s.io/kubernetes/cmd/kube-proxy/app/options"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
-	"k8s.io/kubernetes/pkg/util/logs"
-	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
+	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/cmd/kubelet/BUILD
+++ b/cmd/kubelet/BUILD
@@ -22,11 +22,11 @@ go_library(
         "//cmd/kubelet/app:go_default_library",
         "//cmd/kubelet/app/options:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
-        "//pkg/util/logs:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -25,11 +25,11 @@ import (
 	"os"
 
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
-	"k8s.io/kubernetes/pkg/util/logs"
-	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
+	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/federation/cmd/federation-apiserver/BUILD
+++ b/federation/cmd/federation-apiserver/BUILD
@@ -21,10 +21,10 @@ go_library(
     deps = [
         "//federation/cmd/federation-apiserver/app:go_default_library",
         "//federation/cmd/federation-apiserver/app/options:go_default_library",
-        "//pkg/util/logs:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/federation/cmd/federation-apiserver/apiserver.go
+++ b/federation/cmd/federation-apiserver/apiserver.go
@@ -25,9 +25,9 @@ import (
 	"time"
 
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
-	"k8s.io/kubernetes/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"

--- a/federation/cmd/federation-controller-manager/BUILD
+++ b/federation/cmd/federation-controller-manager/BUILD
@@ -21,12 +21,12 @@ go_library(
     deps = [
         "//federation/cmd/federation-controller-manager/app:go_default_library",
         "//federation/cmd/federation-controller-manager/app/options:go_default_library",
-        "//pkg/util/logs:go_default_library",
         "//pkg/util/workqueue/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/server/healthz",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/federation/cmd/federation-controller-manager/controller-manager.go
+++ b/federation/cmd/federation-controller-manager/controller-manager.go
@@ -23,9 +23,9 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app"
 	"k8s.io/kubernetes/federation/cmd/federation-controller-manager/app/options"
-	"k8s.io/kubernetes/pkg/util/logs"
 	_ "k8s.io/kubernetes/pkg/util/workqueue/prometheus" // for workqueue metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 )

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -307,6 +307,7 @@ staging/src/k8s.io/apiserver/pkg/storage/names
 staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory
 staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory
 staging/src/k8s.io/apiserver/pkg/util/flushwriter
+staging/src/k8s.io/apiserver/pkg/util/logs
 staging/src/k8s.io/apiserver/plugin/pkg/authenticator
 staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password
 staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/allow

--- a/plugin/cmd/kube-scheduler/BUILD
+++ b/plugin/cmd/kube-scheduler/BUILD
@@ -19,13 +19,13 @@ go_library(
     srcs = ["scheduler.go"],
     tags = ["automanaged"],
     deps = [
-        "//pkg/util/logs:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//plugin/cmd/kube-scheduler/app:go_default_library",
         "//plugin/cmd/kube-scheduler/app/options:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/spf13/pflag",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 

--- a/plugin/cmd/kube-scheduler/scheduler.go
+++ b/plugin/cmd/kube-scheduler/scheduler.go
@@ -18,7 +18,7 @@ package main
 
 import (
 	"k8s.io/apiserver/pkg/util/flag"
-	"k8s.io/kubernetes/pkg/util/logs"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/version/verflag"
 	"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app"
 	"k8s.io/kubernetes/plugin/cmd/kube-scheduler/app/options"

--- a/staging/src/k8s.io/apiserver/pkg/util/logs/logs.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/logs/logs.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
+
+// TODO(thockin): This is temporary until we agree on log dirs and put those into each cmd.
+func init() {
+	flag.Set("logtostderr", "true")
+}
+
+// GlogWriter serves as a bridge between the standard log package and the glog package.
+type GlogWriter struct{}
+
+// Write implements the io.Writer interface.
+func (writer GlogWriter) Write(data []byte) (n int, err error) {
+	glog.Info(string(data))
+	return len(data), nil
+}
+
+// InitLogs initializes logs the way we want for kubernetes.
+func InitLogs() {
+	log.SetOutput(GlogWriter{})
+	log.SetFlags(0)
+	// The default glog flush interval is 30 seconds, which is frighteningly long.
+	go wait.Until(glog.Flush, *logFlushFreq, wait.NeverStop)
+}
+
+// FlushLogs flushes logs immediately.
+func FlushLogs() {
+	glog.Flush()
+}
+
+// NewLogger creates a new log.Logger which sends logs to glog.Info.
+func NewLogger(prefix string) *log.Logger {
+	return log.New(GlogWriter{}, prefix, 0)
+}

--- a/staging/src/k8s.io/sample-apiserver/main.go
+++ b/staging/src/k8s.io/sample-apiserver/main.go
@@ -22,14 +22,13 @@ import (
 	"runtime"
 
 	"k8s.io/apimachinery/pkg/util/wait"
-	// "k8s.io/kubernetes/pkg/util/logs"
+	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/sample-apiserver/pkg/cmd/server"
 )
 
 func main() {
-	// TODO move package and restore
-	// logs.InitLogs()
-	// defer logs.FlushLogs()
+	logs.InitLogs()
+	defer logs.FlushLogs()
 
 	if len(os.Getenv("GOMAXPROCS")) == 0 {
 		runtime.GOMAXPROCS(runtime.NumCPU())

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -15319,6 +15319,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//vendor:k8s.io/apimachinery/pkg/util/wait",
+        "//vendor:k8s.io/apiserver/pkg/util/logs",
         "//vendor:k8s.io/sample-apiserver/pkg/cmd/server",
     ],
 )
@@ -15671,5 +15672,16 @@ go_library(
         "//vendor:k8s.io/client-go/pkg/api",
         "//vendor:k8s.io/client-go/pkg/api/v1",
         "//vendor:k8s.io/client-go/pkg/apis/autoscaling",
+    ],
+)
+
+go_library(
+    name = "k8s.io/apiserver/pkg/util/logs",
+    srcs = ["k8s.io/apiserver/pkg/util/logs/logs.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:github.com/golang/glog",
+        "//vendor:github.com/spf13/pflag",
+        "//vendor:k8s.io/apimachinery/pkg/util/wait",
     ],
 )


### PR DESCRIPTION
This is a copy, not a move.  API servers need to be able to init the logs, but so do clients.  It would be weird to have the client-side commands depending on the server side logs utilities.

I updated all the server side references, but left the client-side ones.

@sttts @kubernetes/sig-api-machinery-pr-reviews acceptable?