### PR TITLE
[Federation][Kubefed] Flag cleanup

### DIFF
--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -84,7 +84,8 @@ function init() {
       --host-cluster-context="${HOST_CLUSTER_CONTEXT}" \
       --dns-zone-name="${DNS_ZONE_NAME}" \
       --dns-provider="${DNS_PROVIDER}" \
-      --image="${kube_registry}/hyperkube-amd64:${kube_version}"
+      --image="${kube_registry}/hyperkube-amd64:${kube_version}" \
+      --apiserver-arg-overrides="--storage-backend=etcd2"
 }
 
 # join_clusters joins the clusters in the local kubeconfig to federation. The clusters

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -141,7 +141,6 @@ type initFederationOptions struct {
 	etcdPVCapacity                   string
 	etcdPersistentStorage            bool
 	dryRun                           bool
-	storageBackend                   string
 	apiServerOverridesString         string
 	apiServerOverrides               map[string]string
 	controllerManagerOverridesString string
@@ -161,7 +160,6 @@ func (o *initFederationOptions) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.etcdPVCapacity, "etcd-pv-capacity", "10Gi", "Size of persistent volume claim to be used for etcd.")
 	flags.BoolVar(&o.etcdPersistentStorage, "etcd-persistent-storage", true, "Use persistent volume for etcd. Defaults to 'true'.")
 	flags.BoolVar(&o.dryRun, "dry-run", false, "dry run without sending commands to server.")
-	flags.StringVar(&o.storageBackend, "storage-backend", "etcd2", "The storage backend for persistence. Options: 'etcd2' (default), 'etcd3'.")
 	flags.StringVar(&o.apiServerOverridesString, "apiserver-arg-overrides", "", "comma separated list of federation-apiserver arguments to override: Example \"--arg1=value1,--arg2=value2...\"")
 	flags.StringVar(&o.controllerManagerOverridesString, "controllermanager-arg-overrides", "", "comma separated list of federation-controller-manager arguments to override: Example \"--arg1=value1,--arg2=value2...\"")
 	flags.StringVar(&o.apiServerServiceTypeString, apiserverServiceTypeFlag, string(v1.ServiceTypeLoadBalancer), "The type of service to create for federation API server. Options: 'LoadBalancer' (default), 'NodePort'.")
@@ -313,7 +311,7 @@ func (i *initFederation) Run(cmdOut io.Writer, config util.AdminConfig) error {
 	}
 
 	// 6. Create federation API server
-	_, err = createAPIServer(hostClientset, i.commonOptions.FederationSystemNamespace, serverName, i.options.image, serverCredName, advertiseAddress, i.options.storageBackend, i.options.apiServerOverrides, pvc, i.options.dryRun)
+	_, err = createAPIServer(hostClientset, i.commonOptions.FederationSystemNamespace, serverName, i.options.image, serverCredName, advertiseAddress, i.options.apiServerOverrides, pvc, i.options.dryRun)
 	if err != nil {
 		return err
 	}
@@ -593,7 +591,7 @@ func createPVC(clientset client.Interface, namespace, svcName, etcdPVCapacity st
 	return clientset.Core().PersistentVolumeClaims(namespace).Create(pvc)
 }
 
-func createAPIServer(clientset client.Interface, namespace, name, image, credentialsName, advertiseAddress, storageBackend string, argOverrides map[string]string, pvc *api.PersistentVolumeClaim, dryRun bool) (*extensions.Deployment, error) {
+func createAPIServer(clientset client.Interface, namespace, name, image, credentialsName, advertiseAddress string, argOverrides map[string]string, pvc *api.PersistentVolumeClaim, dryRun bool) (*extensions.Deployment, error) {
 	command := []string{
 		"/hyperkube",
 		"federation-apiserver",
@@ -608,7 +606,6 @@ func createAPIServer(clientset client.Interface, namespace, name, image, credent
 		"--admission-control":    "NamespaceLifecycle",
 	}
 
-	argsMap["--storage-backend"] = storageBackend
 	if advertiseAddress != "" {
 		argsMap["--advertise-address"] = advertiseAddress
 	}

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -91,7 +91,6 @@ func TestInitFederation(t *testing.T) {
 		etcdPersistence       string
 		expectedErr           string
 		dnsProviderConfig     string
-		storageBackend        string
 		dryRun                string
 		apiserverArgOverrides string
 		cmArgOverrides        string
@@ -108,7 +107,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPersistence:       "true",
 			expectedErr:           "",
 			dnsProviderConfig:     "dns-provider.conf",
-			storageBackend:        "etcd2",
 			dryRun:                "",
 			apiserverArgOverrides: "--client-ca-file=override,--log-dir=override",
 			cmArgOverrides:        "--dns-provider=override,--log-dir=override",
@@ -124,7 +122,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "", //test for default value of pvc-size
 			etcdPersistence:      "true",
 			expectedErr:          "",
-			storageBackend:       "etcd2",
 			dryRun:               "",
 		},
 		{
@@ -138,7 +135,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "",
 			etcdPersistence:      "true",
 			expectedErr:          "",
-			storageBackend:       "etcd2",
 			dryRun:               "valid-run",
 		},
 		{
@@ -152,7 +148,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "false",
 			expectedErr:          "",
-			storageBackend:       "etcd3",
 			dryRun:               "",
 		},
 		{
@@ -165,7 +160,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "true",
 			expectedErr:          "",
-			storageBackend:       "etcd3",
 			dryRun:               "",
 		},
 		{
@@ -179,7 +173,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "true",
 			expectedErr:          "",
-			storageBackend:       "etcd3",
 			dryRun:               "",
 		},
 	}
@@ -198,7 +191,7 @@ func TestInitFederation(t *testing.T) {
 			tc.dnsProviderConfig = tmpfile.Name()
 			defer os.Remove(tmpfile.Name())
 		}
-		hostFactory, err := fakeInitHostFactory(tc.apiserverServiceType, tc.federation, util.DefaultFederationSystemNamespace, tc.advertiseAddress, tc.lbIP, tc.dnsZoneName, tc.image, dnsProvider, tc.dnsProviderConfig, tc.etcdPersistence, tc.etcdPVCapacity, tc.storageBackend, tc.apiserverArgOverrides, tc.cmArgOverrides)
+		hostFactory, err := fakeInitHostFactory(tc.apiserverServiceType, tc.federation, util.DefaultFederationSystemNamespace, tc.advertiseAddress, tc.lbIP, tc.dnsZoneName, tc.image, dnsProvider, tc.dnsProviderConfig, tc.etcdPersistence, tc.etcdPVCapacity, tc.apiserverArgOverrides, tc.cmArgOverrides)
 		if err != nil {
 			t.Fatalf("[%d] unexpected error: %v", i, err)
 		}
@@ -218,9 +211,6 @@ func TestInitFederation(t *testing.T) {
 		cmd.Flags().Set("apiserver-arg-overrides", tc.apiserverArgOverrides)
 		cmd.Flags().Set("controllermanager-arg-overrides", tc.cmArgOverrides)
 
-		if tc.storageBackend != "" {
-			cmd.Flags().Set("storage-backend", tc.storageBackend)
-		}
 		if tc.dnsProviderConfig != "" {
 			cmd.Flags().Set("dns-provider-config", tc.dnsProviderConfig)
 		}
@@ -564,7 +554,7 @@ func TestCertsHTTPS(t *testing.T) {
 	}
 }
 
-func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, namespaceName, advertiseAddress, lbIp, dnsZoneName, image, dnsProvider, dnsProviderConfig, etcdPersistence, etcdPVCapacity, storageProvider, apiserverOverrideArg, cmOverrideArg string) (cmdutil.Factory, error) {
+func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, namespaceName, advertiseAddress, lbIp, dnsZoneName, image, dnsProvider, dnsProviderConfig, etcdPersistence, etcdPVCapacity, apiserverOverrideArg, cmOverrideArg string) (cmdutil.Factory, error) {
 	svcName := federationName + "-apiserver"
 	svcUrlPrefix := "/api/v1/namespaces/federation-system/services"
 	credSecretName := svcName + "-credentials"
@@ -782,7 +772,6 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 		"--tls-cert-file=/etc/federation/apiserver/server.crt",
 		"--tls-private-key-file=/etc/federation/apiserver/server.key",
 		"--admission-control=NamespaceLifecycle",
-		fmt.Sprintf("--storage-backend=%s", storageProvider),
 		fmt.Sprintf("--advertise-address=%s", address),
 	}
 

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -629,7 +629,6 @@ start-services
 static-pods-config
 stats-port
 stop-services
-storage-backend
 storage-media-type
 storage-version
 storage-versions


### PR DESCRIPTION
This PR is for the issue https://github.com/kubernetes/kubernetes/issues/41333

**Special notes for your reviewer**:
@marun @madhusudancs 


**Release note**:

```
Kubefed init unlearned the following flags:
--storage-backend

Users should instead use the following flag to pass additional arguments:
--apiserver-arg-overrides to api server
```
