### PR TITLE
Snip the kube-aggregator cmdutil link

### DIFF
--- a/cmd/kube-aggregator/BUILD
+++ b/cmd/kube-aggregator/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//cmd/kube-aggregator/pkg/client/listers/apiregistration/internalversion:go_default_library",
         "//cmd/kube-aggregator/pkg/client/listers/apiregistration/v1alpha1:go_default_library",
         "//cmd/kube-aggregator/pkg/cmd/server:go_default_library",
-        "//pkg/kubectl/cmd/util:go_default_library",
         "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )

--- a/cmd/kube-aggregator/main.go
+++ b/cmd/kube-aggregator/main.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-aggregator/pkg/cmd/server"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	// force compilation of packages we'll later rely upon
 	_ "k8s.io/kubernetes/cmd/kube-aggregator/pkg/apis/apiregistration/install"
@@ -44,6 +43,6 @@ func main() {
 	cmd := server.NewCommandStartAggregator(os.Stdout, os.Stderr)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 	if err := cmd.Execute(); err != nil {
-		cmdutil.CheckErr(err)
+		panic(err)
 	}
 }

--- a/cmd/kube-aggregator/pkg/apis/apiregistration/validation/BUILD
+++ b/cmd/kube-aggregator/pkg/apis/apiregistration/validation/BUILD
@@ -13,7 +13,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//cmd/kube-aggregator/pkg/apis/apiregistration:go_default_library",
-        "//pkg/api/validation:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/api/validation",
         "//vendor:k8s.io/apimachinery/pkg/api/validation/path",
         "//vendor:k8s.io/apimachinery/pkg/util/validation",
         "//vendor:k8s.io/apimachinery/pkg/util/validation/field",

--- a/cmd/kube-aggregator/pkg/apis/apiregistration/validation/validation.go
+++ b/cmd/kube-aggregator/pkg/apis/apiregistration/validation/validation.go
@@ -19,10 +19,10 @@ package validation
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/api/validation/path"
 	utilvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/kubernetes/pkg/api/validation"
 
 	discoveryapi "k8s.io/kubernetes/cmd/kube-aggregator/pkg/apis/apiregistration"
 )

--- a/cmd/kube-aggregator/pkg/apiserver/BUILD
+++ b/cmd/kube-aggregator/pkg/apiserver/BUILD
@@ -51,7 +51,7 @@ go_library(
         "//cmd/kube-aggregator/pkg/client/listers/apiregistration/internalversion:go_default_library",
         "//cmd/kube-aggregator/pkg/registry/apiservice/etcd:go_default_library",
         "//pkg/api:go_default_library",
-        "//pkg/controller:go_default_library",
+        "//pkg/api/install:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",

--- a/cmd/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/cmd/kube-aggregator/pkg/apiserver/apiserver.go
@@ -39,6 +39,8 @@ import (
 	informers "k8s.io/kubernetes/cmd/kube-aggregator/pkg/client/informers/internalversion"
 	listers "k8s.io/kubernetes/cmd/kube-aggregator/pkg/client/listers/apiregistration/internalversion"
 	apiservicestorage "k8s.io/kubernetes/cmd/kube-aggregator/pkg/registry/apiservice/etcd"
+
+	_ "k8s.io/kubernetes/pkg/api/install"
 )
 
 // legacyAPIServiceName is the fixed name of the only non-groupified API version

--- a/cmd/kube-aggregator/pkg/apiserver/apiservice_controller.go
+++ b/cmd/kube-aggregator/pkg/apiserver/apiservice_controller.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/kubernetes/pkg/controller"
 
 	"k8s.io/kubernetes/cmd/kube-aggregator/pkg/apis/apiregistration"
 	informers "k8s.io/kubernetes/cmd/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion"
@@ -122,7 +121,7 @@ func (c *APIServiceRegistrationController) processNextWorkItem() bool {
 }
 
 func (c *APIServiceRegistrationController) enqueue(obj *apiregistration.APIService) {
-	key, err := controller.KeyFunc(obj)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
 		glog.Errorf("Couldn't get key for object %#v: %v", obj, err)
 		return

--- a/cmd/kube-aggregator/pkg/apiserver/handler_apis_test.go
+++ b/cmd/kube-aggregator/pkg/apiserver/handler_apis_test.go
@@ -81,7 +81,8 @@ func TestAPIsDelegation(t *testing.T) {
 			continue
 		}
 		if resp.StatusCode != http.StatusOK {
-			httputil.DumpResponse(resp, true)
+			bytes, _ := httputil.DumpResponse(resp, true)
+			t.Log(string(bytes))
 			t.Errorf("%s: %v", path, err)
 			continue
 		}

--- a/cmd/kube-aggregator/pkg/cmd/server/BUILD
+++ b/cmd/kube-aggregator/pkg/cmd/server/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//cmd/kube-aggregator/pkg/apis/apiregistration/v1alpha1:go_default_library",
         "//cmd/kube-aggregator/pkg/apiserver:go_default_library",
         "//pkg/api:go_default_library",
-        "//pkg/kubectl/cmd/util:go_default_library",
         "//vendor:github.com/spf13/cobra",
         "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",

--- a/cmd/kube-aggregator/pkg/cmd/server/start.go
+++ b/cmd/kube-aggregator/pkg/cmd/server/start.go
@@ -32,7 +32,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/cmd/kube-aggregator/pkg/apiserver"
 	"k8s.io/kubernetes/pkg/api"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"k8s.io/kubernetes/cmd/kube-aggregator/pkg/apis/apiregistration/v1alpha1"
 )
@@ -64,10 +63,17 @@ func NewCommandStartAggregator(out, err io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Short: "Launch a API aggregator and proxy server",
 		Long:  "Launch a API aggregator and proxy server",
-		Run: func(c *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete())
-			cmdutil.CheckErr(o.Validate(args))
-			cmdutil.CheckErr(o.RunAggregator())
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(); err != nil {
+				return err
+			}
+			if err := o.Validate(args); err != nil {
+				return err
+			}
+			if err := o.RunAggregator(); err != nil {
+				return err
+			}
+			return nil
 		},
 	}
 

--- a/cmd/kube-aggregator/pkg/registry/apiservice/etcd/BUILD
+++ b/cmd/kube-aggregator/pkg/registry/apiservice/etcd/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//cmd/kube-aggregator/pkg/apis/apiregistration:go_default_library",
         "//cmd/kube-aggregator/pkg/registry/apiservice:go_default_library",
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apiserver/pkg/registry/generic",
         "//vendor:k8s.io/apiserver/pkg/registry/generic/registry",

--- a/cmd/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/cmd/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/cmd/kube-aggregator/pkg/apis/apiregistration"
 	"k8s.io/kubernetes/cmd/kube-aggregator/pkg/registry/apiservice"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 // rest implements a RESTStorage for API services against etcd
@@ -42,7 +41,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		},
 		PredicateFunc:     apiservice.MatchAPIService,
 		QualifiedResource: apiregistration.Resource("apiservices"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("apiservices"),
+		WatchCacheSize:    100,
 
 		CreateStrategy: apiservice.Strategy,
 		UpdateStrategy: apiservice.Strategy,


### PR DESCRIPTION
`cmdutil` is largely focused on client commands. This snips the link by using built-in cobra capabilities and helps the import tree a lot.

