### PR TITLE
kubeadm: test-cmd: token{delete}

### DIFF
--- a/cmd/kubeadm/test/cmd/token_test.go
+++ b/cmd/kubeadm/test/cmd/token_test.go
@@ -70,3 +70,31 @@ func TestCmdTokenGenerateTypoError(t *testing.T) {
 		t.Error("'kubeadm ex token genorate' (a deliberate typo) exited without an error when we expected non-zero exit status")
 	}
 }
+func TestCmdTokenDelete(t *testing.T) {
+	if *kubeadmCmdSkip {
+		t.Log("kubeadm cmd tests being skipped")
+		t.Skip()
+	}
+
+	var tests = []struct {
+		args     string
+		expected bool
+	}{
+		{"", false},       // no token provided
+		{"foobar", false}, // invalid token
+	}
+
+	for _, rt := range tests {
+		_, _, actual := RunCmd(*kubeadmPath, "ex", "token", "delete", rt.args)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed CmdTokenDelete running 'kubeadm ex token %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+				rt.args,
+				actual,
+				rt.expected,
+				(actual == nil),
+			)
+		}
+		kubeadmReset()
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Adding test-cmds for kubeadm ex token delete. Will followup with more test-cmds for other flags as soon as validation for the flags works. 

Adding tests is a WIP from #34136

**Special notes for your reviewer**: /cc @luxas @pires 

**Release note**:
```release-note
NONE
```