### PR TITLE
give nodes update/delete permissions

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -192,6 +192,7 @@ func ClusterRoles() []rbac.ClusterRole {
 				rbac.NewRule("create", "get", "list", "watch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 				// TODO: restrict to the bound node once supported
 				rbac.NewRule("update", "patch").Groups(legacyGroup).Resources("nodes/status").RuleOrDie(),
+				rbac.NewRule("update", "patch", "delete").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 
 				// TODO: restrict to the bound node as creator once supported
 				rbac.NewRule("create", "update", "patch").Groups(legacyGroup).Resources("events").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -544,6 +544,14 @@ items:
   - apiGroups:
     - ""
     resources:
+    - nodes
+    verbs:
+    - delete
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
     - events
     verbs:
     - create


### PR DESCRIPTION
delete permission is logically paired with create permission (and is used during self-registration scenarios when a node has been restarted and an existing node object has a mismatched externalID)

we already need to scope update nodes/status permission to only let a node update itself, and we would scope these at the same time.

fixes https://github.com/kubernetes/kubernetes/issues/41224