### PR TITLE
kubeadm: adding tests for util/tokens.go

### DIFF
--- a/cmd/kubeadm/app/util/tokens.go
+++ b/cmd/kubeadm/app/util/tokens.go
@@ -120,7 +120,7 @@ func DiscoveryPort(d *kubeadmapi.TokenDiscovery) int32 {
 	if len(split) == 1 {
 		return kubeadmapiext.DefaultDiscoveryBindPort
 	}
-	if i, err := strconv.Atoi(split[1]); err != nil {
+	if i, err := strconv.Atoi(split[1]); err == nil {
 		return int32(i)
 	}
 	return kubeadmapiext.DefaultDiscoveryBindPort


### PR DESCRIPTION
**What this PR does / why we need it**: added tests to util pkg and raised coverage from ~48% to ~67%.  Will get better coverage once migration to client-go is complete.  Included a fix for a logic error in tokens.go found through writing tests

Adding unit tests is a WIP from #34136

**Special notes for your reviewer**: /cc @luxas @pires 

**Release note**:
```release-note
NONE
```
