### PR TITLE
move kubeadm api group testing to kubeadm package

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -39,4 +40,19 @@ filegroup(
         "//cmd/kubeadm/app/apis/kubeadm/validation:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["serialization_test.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm/install:go_default_library",
+        "//pkg/api/testing:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/api/testing",
+        "//vendor:k8s.io/apimachinery/pkg/apimachinery/announced",
+        "//vendor:k8s.io/apimachinery/pkg/apimachinery/registered",
+        "//vendor:k8s.io/apimachinery/pkg/runtime",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/serializer",
+    ],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/serialization_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/serialization_test.go
@@ -34,7 +34,6 @@ const (
 )
 
 func TestRoundTripTypes(t *testing.T) {
-
 	groupFactoryRegistry := make(announced.APIGroupFactoryRegistry)
 	registry := registered.NewOrDie("")
 	scheme := runtime.NewScheme()

--- a/cmd/kubeadm/app/apis/kubeadm/serialization_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/serialization_test.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm_test
+
+import (
+	"math/rand"
+	"testing"
+
+	apitesting "k8s.io/apimachinery/pkg/api/testing"
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/install"
+	kapitesting "k8s.io/kubernetes/pkg/api/testing"
+)
+
+const (
+	seed = 1
+)
+
+func TestRoundTripTypes(t *testing.T) {
+
+	groupFactoryRegistry := make(announced.APIGroupFactoryRegistry)
+	registry := registered.NewOrDie("")
+	scheme := runtime.NewScheme()
+	codecs := serializer.NewCodecFactory(scheme)
+
+	install.Install(groupFactoryRegistry, registry, scheme)
+	// TODO: once we've pulled kubeadm types of the main scheme, we should
+	// move the fuzzers funcs here
+	fuzzer := apitesting.FuzzerFor(kapitesting.FuzzerFuncs(t, codecs), rand.NewSource(seed))
+	apitesting.RoundTripTypesWithoutProtobuf(t, scheme, codecs, fuzzer, nil)
+}

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
@@ -10,6 +10,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "conversion.go",
         "defaults.go",
         "doc.go",
         "register.go",
@@ -21,6 +22,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/client-go/pkg/api",
     ],
 )
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/conversion.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/api"
+)
+
+func addConversionFuncs(scheme *runtime.Scheme) error {
+	// Add non-generated conversion functions
+	return scheme.AddConversionFuncs(
+		api.Convert_v1_TypeMeta_To_v1_TypeMeta,
+	)
+}

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/register.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/register.go
@@ -29,7 +29,7 @@ const GroupName = "kubeadm.k8s.io"
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 
 var (
-	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, addDefaultingFuncs)
+	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, addDefaultingFuncs, addConversionFuncs)
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -26,6 +26,7 @@ cmd/kube-controller-manager/app/options
 cmd/kube-discovery
 cmd/kube-proxy
 cmd/kubeadm
+cmd/kubeadm/app/apis/kubeadm
 cmd/kubeadm/app/apis/kubeadm/install
 cmd/kubeadm/app/phases/apiconfig
 cmd/kubeadm/app/phases/certs

--- a/pkg/api/testapi/BUILD
+++ b/pkg/api/testapi/BUILD
@@ -13,8 +13,6 @@ go_library(
     srcs = ["testapi.go"],
     tags = ["automanaged"],
     deps = [
-        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//cmd/kubeadm/app/apis/kubeadm/install:go_default_library",
         "//federation/apis/federation:go_default_library",
         "//federation/apis/federation/install:go_default_library",
         "//pkg/api:go_default_library",

--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/recognizer"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/federation/apis/federation"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -48,7 +47,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/apis/storage"
 
-	_ "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/install"
 	_ "k8s.io/kubernetes/federation/apis/federation/install"
 	_ "k8s.io/kubernetes/pkg/api/install"
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
@@ -265,15 +263,6 @@ func init() {
 			externalGroupVersion: externalGroupVersion,
 			internalGroupVersion: authorization.SchemeGroupVersion,
 			internalTypes:        api.Scheme.KnownTypes(authorization.SchemeGroupVersion),
-			externalTypes:        api.Scheme.KnownTypes(externalGroupVersion),
-		}
-	}
-	if _, ok := Groups[kubeadm.GroupName]; !ok {
-		externalGroupVersion := schema.GroupVersion{Group: kubeadm.GroupName, Version: api.Registry.GroupOrDie(kubeadm.GroupName).GroupVersion.Version}
-		Groups[kubeadm.GroupName] = TestGroup{
-			externalGroupVersion: externalGroupVersion,
-			internalGroupVersion: kubeadm.SchemeGroupVersion,
-			internalTypes:        api.Scheme.KnownTypes(kubeadm.SchemeGroupVersion),
 			externalTypes:        api.Scheme.KnownTypes(externalGroupVersion),
 		}
 	}


### PR DESCRIPTION
I think this is sufficient to at least preserve round trip testing.