### PR TITLE
kubeadm: added unit tests for discovery pkg

### DIFF
--- a/cmd/kubeadm/app/discovery/BUILD
+++ b/cmd/kubeadm/app/discovery/BUILD
@@ -30,7 +30,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["flags_test.go"],
+    srcs = [
+        "discovery_test.go",
+        "flags_test.go",
+    ],
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [

--- a/cmd/kubeadm/app/discovery/discovery_test.go
+++ b/cmd/kubeadm/app/discovery/discovery_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package discovery
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+)
+
+func TestFor(t *testing.T) {
+	tests := []struct {
+		d      kubeadm.Discovery
+		expect bool
+	}{
+		{d: kubeadm.Discovery{}, expect: false},
+		{
+			d: kubeadm.Discovery{
+				HTTPS: &kubeadm.HTTPSDiscovery{URL: "notnil"},
+			},
+			expect: false,
+		},
+		{
+			d: kubeadm.Discovery{
+				HTTPS: &kubeadm.HTTPSDiscovery{URL: "http://localhost"},
+			},
+			expect: false,
+		},
+		{
+			d: kubeadm.Discovery{
+				File: &kubeadm.FileDiscovery{Path: "notnil"},
+			},
+			expect: false,
+		},
+		{
+			d: kubeadm.Discovery{
+				Token: &kubeadm.TokenDiscovery{
+					ID:        "foo",
+					Secret:    "bar",
+					Addresses: []string{"foobar"},
+				},
+			}, expect: false,
+		},
+	}
+	for _, rt := range tests {
+		_, actual := For(rt.d)
+		if (actual == nil) != rt.expect {
+			t.Errorf(
+				"failed For:\n\texpected: %t\n\t  actual: %t",
+				rt.expect,
+				(actual == nil),
+			)
+		}
+	}
+}

--- a/cmd/kubeadm/app/discovery/flags_test.go
+++ b/cmd/kubeadm/app/discovery/flags_test.go
@@ -25,6 +25,96 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
+func TestNewDiscoveryValue(t *testing.T) {
+	tests := []struct {
+		d      *discoveryValue
+		expect string
+	}{
+		{
+			d: &discoveryValue{
+				v: &kubeadm.Discovery{}},
+			expect: "unknown",
+		},
+		{
+			d: &discoveryValue{
+				v: &kubeadm.Discovery{
+					HTTPS: &kubeadm.HTTPSDiscovery{URL: "notnil"},
+				},
+			},
+			expect: "notnil",
+		},
+		{
+			d: &discoveryValue{
+				v: &kubeadm.Discovery{
+					File: &kubeadm.FileDiscovery{Path: "notnil"},
+				},
+			},
+			expect: "file://notnil",
+		},
+		{
+			d: &discoveryValue{
+				v: &kubeadm.Discovery{
+					Token: &kubeadm.TokenDiscovery{
+						ID:        "foo",
+						Secret:    "bar",
+						Addresses: []string{"foobar"},
+					},
+				},
+			}, expect: "token://foo:bar@foobar",
+		},
+	}
+	for _, rt := range tests {
+		actual := rt.d.String()
+		if actual != rt.expect {
+			t.Errorf(
+				"failed discoveryValue string:\n\texpected: %s\n\t  actual: %s",
+				rt.expect,
+				actual,
+			)
+		}
+	}
+}
+
+func TestType(t *testing.T) {
+	tests := []struct {
+		d      *discoveryValue
+		expect string
+	}{
+		{d: &discoveryValue{}, expect: "discovery"},
+	}
+	for _, rt := range tests {
+		actual := rt.d.Type()
+		if actual != rt.expect {
+			t.Errorf(
+				"failed discoveryValue type:\n\texpected: %s\n\t  actual: %s",
+				rt.expect,
+				actual,
+			)
+		}
+	}
+}
+
+func TestSet(t *testing.T) {
+	tests := []struct {
+		d      *discoveryValue
+		s      string
+		expect bool
+	}{
+		{d: &discoveryValue{v: &kubeadm.Discovery{}}, s: "", expect: false},
+		{d: &discoveryValue{v: &kubeadm.Discovery{}}, s: "https://example.com", expect: true},
+	}
+	for _, rt := range tests {
+		actual := rt.d.Set(rt.s)
+		if (actual == nil) != rt.expect {
+			t.Errorf(
+				"failed discoveryValue set:\n\texpected: %t\n\t  actual: %t",
+				rt.expect,
+				(actual == nil),
+			)
+		}
+	}
+}
+
 func TestParseURL(t *testing.T) {
 	cases := []struct {
 		url       string


### PR DESCRIPTION
**What this PR does / why we need it**: added tests to discovery pkg and raised coverage from ~25% to ~71%.  

Adding unit tests is a WIP from #34136

**Special notes for your reviewer**: /cc @luxas @pires 

**Release note**:
```release-note
NONE
```