### PR TITLE
kubeadm: unit tests for apis/kubeadm/validation

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
@@ -38,5 +38,8 @@ go_test(
     srcs = ["validation_test.go"],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//vendor:k8s.io/apimachinery/pkg/util/validation/field"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/util/validation/field",
+    ],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 func TestValidateServiceSubnet(t *testing.T) {
@@ -40,6 +41,104 @@ func TestValidateServiceSubnet(t *testing.T) {
 		if (len(actual) == 0) != rt.expected {
 			t.Errorf(
 				"failed ValidateServiceSubnet:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(len(actual) == 0),
+			)
+		}
+	}
+}
+
+func TestValidateMasterConfiguration(t *testing.T) {
+	var tests = []struct {
+		s        *kubeadm.MasterConfiguration
+		expected bool
+	}{
+		{&kubeadm.MasterConfiguration{}, false},
+		{&kubeadm.MasterConfiguration{
+			Discovery: kubeadm.Discovery{
+				HTTPS: &kubeadm.HTTPSDiscovery{URL: "foo"},
+				File:  &kubeadm.FileDiscovery{Path: "foo"},
+				Token: &kubeadm.TokenDiscovery{
+					ID:        "abcdef",
+					Secret:    "1234567890123456",
+					Addresses: []string{"foobar"},
+				},
+			},
+		}, false},
+		{&kubeadm.MasterConfiguration{
+			Discovery: kubeadm.Discovery{
+				HTTPS: &kubeadm.HTTPSDiscovery{URL: "foo"},
+			},
+		}, true},
+		{&kubeadm.MasterConfiguration{
+			Discovery: kubeadm.Discovery{
+				File: &kubeadm.FileDiscovery{Path: "foo"},
+			},
+		}, true},
+		{&kubeadm.MasterConfiguration{
+			Discovery: kubeadm.Discovery{
+				Token: &kubeadm.TokenDiscovery{
+					ID:        "abcdef",
+					Secret:    "1234567890123456",
+					Addresses: []string{"foobar"},
+				},
+			},
+		}, true},
+	}
+	for _, rt := range tests {
+		actual := ValidateMasterConfiguration(rt.s)
+		if (len(actual) == 0) != rt.expected {
+			t.Errorf(
+				"failed ValidateMasterConfiguration:\n\texpected: %t\n\t  actual: %t",
+				rt.expected,
+				(len(actual) == 0),
+			)
+		}
+	}
+}
+
+func TestValidateNodeConfiguration(t *testing.T) {
+	var tests = []struct {
+		s        *kubeadm.NodeConfiguration
+		expected bool
+	}{
+		{&kubeadm.NodeConfiguration{}, false},
+		{&kubeadm.NodeConfiguration{
+			Discovery: kubeadm.Discovery{
+				HTTPS: &kubeadm.HTTPSDiscovery{URL: "foo"},
+				File:  &kubeadm.FileDiscovery{Path: "foo"},
+				Token: &kubeadm.TokenDiscovery{
+					ID:        "abcdef",
+					Secret:    "1234567890123456",
+					Addresses: []string{"foobar"},
+				},
+			},
+		}, false},
+		{&kubeadm.NodeConfiguration{
+			Discovery: kubeadm.Discovery{
+				HTTPS: &kubeadm.HTTPSDiscovery{URL: "foo"},
+			},
+		}, true},
+		{&kubeadm.NodeConfiguration{
+			Discovery: kubeadm.Discovery{
+				File: &kubeadm.FileDiscovery{Path: "foo"},
+			},
+		}, true},
+		{&kubeadm.NodeConfiguration{
+			Discovery: kubeadm.Discovery{
+				Token: &kubeadm.TokenDiscovery{
+					ID:        "abcdef",
+					Secret:    "1234567890123456",
+					Addresses: []string{"foobar"},
+				},
+			},
+		}, true},
+	}
+	for _, rt := range tests {
+		actual := ValidateNodeConfiguration(rt.s)
+		if (len(actual) == 0) != rt.expected {
+			t.Errorf(
+				"failed ValidateNodeConfiguration:\n\texpected: %t\n\t  actual: %t",
 				rt.expected,
 				(len(actual) == 0),
 			)


### PR DESCRIPTION
**What this PR does / why we need it**: added tests to apis/kubeadm/validation pkg and raised coverage from ~21% to 100%.  

Adding unit tests is a WIP from #34136

**Special notes for your reviewer**: /cc @luxas @pires 

**Release note**:
```release-note
NONE
```