### PR TITLE
Revert GCI and CMV image updates in release-1.5 branch

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -43,8 +43,8 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-debian
 # containervm. If you are updating the containervm version, update this
 # variable. Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-CVM_VERSION=${CVM_VERSION:-container-vm-v20170201}
-GCI_VERSION=${KUBE_GCI_VERSION:-gci-beta-56-9000-80-0}
+CVM_VERSION=${CVM_VERSION:-container-vm-v20170117}
+GCI_VERSION=${KUBE_GCI_VERSION:-gci-dev-56-8977-0-0}
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -44,8 +44,8 @@ NODE_OS_DISTRIBUTION=${KUBE_NODE_OS_DISTRIBUTION:-${KUBE_OS_DISTRIBUTION:-debian
 # containervm. If you are updating the containervm version, update this
 # variable. Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-CVM_VERSION=${CVM_VERSION:-container-vm-v20170201}
-GCI_VERSION=${KUBE_GCI_VERSION:-gci-beta-56-9000-80-0}
+CVM_VERSION=${CVM_VERSION:-container-vm-v20170117}
+GCI_VERSION=${KUBE_GCI_VERSION:-gci-dev-56-8977-0-0}
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-google-containers}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}

--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -49,21 +49,21 @@ images:
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
   gci-resource1:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   gci-resource2:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   gci-resource3:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"

--- a/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/benchmark-config.yaml
@@ -1,56 +1,56 @@
 ---
 images:
   gci-density1:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   gci-density2:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   gci-density2-qps60:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   gci-density3:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-2
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   gci-density4:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
   gci-resource1:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   gci-resource2:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   gci-resource3:
-    image: gci-beta-56-9000-80-0
+    image: gci-dev-56-8977-0-0
     project: google-containers
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"

--- a/test/e2e_node/jenkins/cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/image-config.yaml
@@ -3,6 +3,6 @@ images:
     image: e2e-node-containervm-v20160604-image
     project: kubernetes-node-e2e-images
   gci-family:
-    image_regex: gci-beta-56-9000-80-0
+    image_regex: gci-dev-56-8977-0-0
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -13,6 +13,6 @@ images:
     image: e2e-node-containervm-v20160604-image
     project: kubernetes-node-e2e-images
   gci-family:
-    image_regex: gci-beta-56-9000-80-0 # docker 1.11.2
+    image_regex: gci-dev-56-8977-0-0
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"


### PR DESCRIPTION
Reverts PRs https://github.com/kubernetes/kubernetes/pull/41218 and https://github.com/kubernetes/kubernetes/pull/40831 in order to attempt to fix https://github.com/kubernetes/kubernetes/issues/41283.
