### PR TITLE
[Federation]: Stop removing finalizers on deletion

### DIFF
--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
@@ -208,7 +208,6 @@ func NewReplicaSetController(federationClient fedclientset.Interface) *ReplicaSe
 
 	frsc.deletionHelper = deletionhelper.NewDeletionHelper(
 		frsc.hasFinalizerFunc,
-		frsc.removeFinalizerFunc,
 		frsc.addFinalizerFunc,
 		// objNameFunc
 		func(obj runtime.Object) string {
@@ -233,31 +232,6 @@ func (frsc *ReplicaSetController) hasFinalizerFunc(obj runtime.Object, finalizer
 		}
 	}
 	return false
-}
-
-// Removes the finalizer from the given objects ObjectMeta.
-// Assumes that the given object is a replicaset.
-func (frsc *ReplicaSetController) removeFinalizerFunc(obj runtime.Object, finalizer string) (runtime.Object, error) {
-	replicaset := obj.(*extensionsv1.ReplicaSet)
-	newFinalizers := []string{}
-	hasFinalizer := false
-	for i := range replicaset.ObjectMeta.Finalizers {
-		if string(replicaset.ObjectMeta.Finalizers[i]) != finalizer {
-			newFinalizers = append(newFinalizers, replicaset.ObjectMeta.Finalizers[i])
-		} else {
-			hasFinalizer = true
-		}
-	}
-	if !hasFinalizer {
-		// Nothing to do.
-		return obj, nil
-	}
-	replicaset.ObjectMeta.Finalizers = newFinalizers
-	replicaset, err := frsc.fedClient.Extensions().ReplicaSets(replicaset.Namespace).Update(replicaset)
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove finalizer %s from replicaset %s: %v", finalizer, replicaset.Name, err)
-	}
-	return replicaset, nil
 }
 
 // Adds the given finalizers to the given objects ObjectMeta.
@@ -636,7 +610,7 @@ func (frsc *ReplicaSetController) reconcileReplicaSetsOnClusterChange() {
 // delete deletes the given replicaset or returns error if the deletion was not complete.
 func (frsc *ReplicaSetController) delete(replicaset *extensionsv1.ReplicaSet) error {
 	glog.V(3).Infof("Handling deletion of replicaset: %v", *replicaset)
-	_, err := frsc.deletionHelper.HandleObjectInUnderlyingClusters(replicaset)
+	err := frsc.deletionHelper.HandleObjectInUnderlyingClusters(replicaset)
 	if err != nil {
 		return err
 	}

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -289,7 +289,6 @@ func New(federationClient fedclientset.Interface, dns dnsprovider.Interface,
 
 	s.deletionHelper = deletionhelper.NewDeletionHelper(
 		s.hasFinalizerFunc,
-		s.removeFinalizerFunc,
 		s.addFinalizerFunc,
 		// objNameFunc
 		func(obj pkgruntime.Object) string {
@@ -318,31 +317,6 @@ func (s *ServiceController) hasFinalizerFunc(obj pkgruntime.Object, finalizer st
 		}
 	}
 	return false
-}
-
-// Removes the finalizer from the given objects ObjectMeta.
-// Assumes that the given object is a service.
-func (s *ServiceController) removeFinalizerFunc(obj pkgruntime.Object, finalizer string) (pkgruntime.Object, error) {
-	service := obj.(*v1.Service)
-	newFinalizers := []string{}
-	hasFinalizer := false
-	for i := range service.ObjectMeta.Finalizers {
-		if string(service.ObjectMeta.Finalizers[i]) != finalizer {
-			newFinalizers = append(newFinalizers, service.ObjectMeta.Finalizers[i])
-		} else {
-			hasFinalizer = true
-		}
-	}
-	if !hasFinalizer {
-		// Nothing to do.
-		return obj, nil
-	}
-	service.ObjectMeta.Finalizers = newFinalizers
-	service, err := s.federationClient.Core().Services(service.Namespace).Update(service)
-	if err != nil {
-		return nil, fmt.Errorf("failed to remove finalizer %s from service %s: %v", finalizer, service.Name, err)
-	}
-	return service, nil
 }
 
 // Adds the given finalizers to the given objects ObjectMeta.
@@ -1045,7 +1019,7 @@ func (s *ServiceController) processServiceUpdate(cachedService *cachedService, s
 // delete deletes the given service or returns error if the deletion was not complete.
 func (s *ServiceController) delete(service *v1.Service) error {
 	glog.V(3).Infof("Handling deletion of service: %v", *service)
-	_, err := s.deletionHelper.HandleObjectInUnderlyingClusters(service)
+	err := s.deletionHelper.HandleObjectInUnderlyingClusters(service)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Finalizers were only being removed on deletion, which seemed redundant.

Also, no caller was using the object returned by ``HandleObjectInUnderlyingClusters``, so now only the error is returned.

cc: @kubernetes/sig-federation-pr-reviews  