### PR TITLE
fix spelling error of type store struct, in store.go

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -94,7 +94,7 @@ type Store struct {
 	KeyRootFunc func(ctx genericapirequest.Context) string
 
 	// KeyFunc returns the key for a specific object in the collection.
-	// KeyFund is dalled for Create/Update/Get/Delete. Note that 'namespace'
+	// KeyFunc is called for Create/Update/Get/Delete. Note that 'namespace'
 	// can be gotten from ctx.
 	//
 	// KeyFunc and KeyRootFunc must be supplied together or not at all.


### PR DESCRIPTION
**What this PR does / why we need it**:
in the definition of type Store struct,the description of  KeyFunc has spelling errors 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
NONE

**Special notes for your reviewer**:
NONE
**Release note**:
NONE
