### PR TITLE
Expose the constants in pkg/controller/bootstrap and add a validate token function

### DIFF
--- a/pkg/bootstrap/api/types.go
+++ b/pkg/bootstrap/api/types.go
@@ -45,4 +45,13 @@ const (
 	// sign configs as part of the bootstrap process. Value must be "true". Any
 	// other value is assumed to be false. Optional.
 	BootstrapTokenUsageSigningKey = "usage-bootstrap-signing"
+
+	// ConfigMapClusterInfo defines the name for the ConfigMap where the information how to connect and trust the cluster exist
+	ConfigMapClusterInfo = "cluster-info"
+
+	// KubeConfigKey defines at which key in the Data object of the ConfigMap the KubeConfig object is stored
+	KubeConfigKey = "kubeconfig"
+
+	// JWSSignatureKeyPrefix defines what key prefix the JWS-signed tokens have
+	JWSSignatureKeyPrefix = "jws-kubeconfig-"
 )

--- a/pkg/controller/bootstrap/bootstrapsigner_test.go
+++ b/pkg/controller/bootstrap/bootstrapsigner_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	core "k8s.io/client-go/testing"
+	bootstrapapi "k8s.io/kubernetes/pkg/bootstrap/api"
 )
 
 func init() {
@@ -43,15 +44,15 @@ func newConfigMap(tokenID, signature string) *v1.ConfigMap {
 	ret := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       metav1.NamespacePublic,
-			Name:            configMapClusterInfo,
+			Name:            bootstrapapi.ConfigMapClusterInfo,
 			ResourceVersion: "1",
 		},
 		Data: map[string]string{
-			kubeConfigKey: "payload",
+			bootstrapapi.KubeConfigKey: "payload",
 		},
 	}
 	if len(tokenID) > 0 {
-		ret.Data[signaturePrefix+tokenID] = signature
+		ret.Data[bootstrapapi.JWSSignatureKeyPrefix+tokenID] = signature
 	}
 	return ret
 }

--- a/pkg/controller/bootstrap/jws_test.go
+++ b/pkg/controller/bootstrap/jws_test.go
@@ -51,3 +51,17 @@ func TestComputeDetachedSig(t *testing.T) {
 		t.Errorf("Wrong signature. Got: %v", sig)
 	}
 }
+
+func TestDetachedTokenIsValid(t *testing.T) {
+	// Valid detached JWS token and valid inputs should succeed
+	sig := "eyJhbGciOiJIUzI1NiIsImtpZCI6Impvc2h1YSJ9..VShe2taLd-YTrmWuRkcL_8QTNDHYxQIEBsAYYiIj1_8"
+	if !DetachedTokenIsValid(sig, content, id, secret) {
+		t.Errorf("Content %q and token \"%s:%s\" should equal signature: %q", content, id, secret, sig)
+	}
+
+	// Invalid detached JWS token and valid inputs should fail
+	sig2 := sig + "foo"
+	if DetachedTokenIsValid(sig2, content, id, secret) {
+		t.Errorf("Content %q and token \"%s:%s\" should not equal signature: %q", content, id, secret, sig)
+	}
+}


### PR DESCRIPTION

**What this PR does / why we need it**: In order to hook up #36101 against kubeadm, we have to expose the constants and add a function to validate the token

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
cc @jbeda @mikedanese @pires @dmmcquay 