### PR TITLE
replace token to discovery in example

### DIFF
--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -33,30 +33,30 @@ func NewKubeadmCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		Long: dedent.Dedent(`
 			kubeadm: easily bootstrap a secure Kubernetes cluster.
 
-			    ┌──────────────────────────────────────────────────────────┐
-			    │ KUBEADM IS ALPHA, DO NOT USE IT FOR PRODUCTION CLUSTERS! │
-			    │                                                          │
-			    │ But, please try it out! Give us feedback at:             │
-			    │ https://github.com/kubernetes/kubeadm/issues             │
-			    │ and at-mention @kubernetes/sig-cluster-lifecycle         │
-			    └──────────────────────────────────────────────────────────┘
+			    ┌───────────────────────────────────────────────────────────────┐
+			    │ KUBEADM IS ALPHA, DO NOT USE IT FOR PRODUCTION CLUSTERS!      │
+			    │                                                               │
+			    │ But, please try it out! Give us feedback at:                  │
+			    │ https://github.com/kubernetes/kubeadm/issues                  │
+			    │ and at-mention @kubernetes/sig-cluster-lifecycle              │
+			    └───────────────────────────────────────────────────────────────┘
 
 			Example usage:
 
 			    Create a two-machine cluster with one master (which controls the cluster),
 			    and one node (where your workloads, like Pods and ReplicaSets run).
 
-			    ┌──────────────────────────────────────────────────────────┐
-			    │ On the first machine                                     │
-			    ├──────────────────────────────────────────────────────────┤
-			    │ master# kubeadm init                                     │
-			    └──────────────────────────────────────────────────────────┘
+			    ┌───────────────────────────────────────────────────────────────┐
+			    │ On the first machine                                          │
+			    ├───────────────────────────────────────────────────────────────┤
+			    │ master# kubeadm init                                          │
+			    └───────────────────────────────────────────────────────────────┘
 
-			    ┌──────────────────────────────────────────────────────────┐
-			    │ On the second machine                                    │
-			    ├──────────────────────────────────────────────────────────┤
-			    │ node# kubeadm join --token=<token> <ip-of-master>        │
-			    └──────────────────────────────────────────────────────────┘
+			    ┌───────────────────────────────────────────────────────────────┐
+			    │ On the second machine                                         │
+			    ├───────────────────────────────────────────────────────────────┤
+			    │ node# kubeadm join --discovery token://<token>@<ip-of-master> │
+			    └───────────────────────────────────────────────────────────────┘
 
 			    You can then repeat the second step on as many other machines as you like.
 


### PR DESCRIPTION
ref to https://github.com/kubernetes/kubeadm/issues/157

```
#kubeadm init
[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.
[init] Using Kubernetes version: v1.6.0-alpha.1
[init] Using Authorization mode: RBAC
[init] A token has not been provided, generating one
[preflight] Running pre-flight checks
[preflight] Starting the kubelet service
[certificates] Generated CA certificate and key.
[certificates] Generated API server certificate and key.
[certificates] Generated API server kubelet client certificate and key.
[certificates] Generated service account token signing key.
[certificates] Generated service account token signing public key.
[certificates] Valid certificates and keys now exist in "/etc/kubernetes/pki"
[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/admin.conf"
[kubeconfig] Wrote KubeConfig file to disk: "/etc/kubernetes/kubelet.conf"
[apiclient] Created API client, waiting for the control plane to become ready
[apiclient] Waiting for API server authorization
[apiclient] Waiting for API server authorization
[apiclient] Waiting for API server authorization
[apiclient] All control plane components are healthy after 18.260284 seconds
[apiclient] Waiting for at least one node to register and become ready
[apiclient] First node is ready after 3.509666 seconds
[apiclient] Test deployment succeeded
[apiconfig] Created RBAC rules
[token-discovery] Using token: e4b248:0563c2e3d0635b02
[token-discovery] Created the kube-discovery deployment, waiting for it to become ready
[token-discovery] kube-discovery is ready after 2.503299 seconds
[addons] Created essential addon: kube-proxy
[addons] Created essential addon: kube-dns

Your Kubernetes master has initialized successfully!

You should now deploy a pod network to the cluster.
Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
    http://kubernetes.io/docs/admin/addons/

You can now join any number of machines by running the following on each node:

kubeadm join --discovery token://e4b248:0563c2e3d0635b02@192.168.122.100:9898
```