### PR TITLE
Revert "fix flaky host cleanup test"

### DIFF
--- a/test/e2e/pvutil.go
+++ b/test/e2e/pvutil.go
@@ -408,10 +408,13 @@ func deletePodWithWait(f *framework.Framework, c clientset.Interface, pod *v1.Po
 		Expect(err).NotTo(HaveOccurred())
 	}
 
-	// wait for pod to terminate
+	// wait for pod to terminate. Expect apierr NotFound
 	err = f.WaitForPodTerminated(pod.Name, "")
-	Expect(apierrs.IsNotFound(err)).To(BeTrue(), fmt.Sprintf("Expected IsNotFound error deleting pod %q, instead got: %v", pod.Name, err))
-
+	Expect(err).To(HaveOccurred())
+	if !apierrs.IsNotFound(err) {
+		framework.Logf("Error! Expected IsNotFound error deleting pod %q, instead got: %v", pod.Name, err)
+		Expect(apierrs.IsNotFound(err)).To(BeTrue())
+	}
 	framework.Logf("Ignore \"not found\" error above. Pod %v successfully deleted", pod.Name)
 }
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#41178 

E2E tests [HostCleanup][Slow]  are failing for NFS in gci-gce-slow suit.