### PR TITLE
Update the DNS spec from upstream

### DIFF
--- a/cmd/kubeadm/app/phases/addons/addons.go
+++ b/cmd/kubeadm/app/phases/addons/addons.go
@@ -51,16 +51,11 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 		return fmt.Errorf("error when parsing kube-proxy daemonset template: %v", err)
 	}
 
-	dnsDeploymentBytes, err := kubeadmutil.ParseTemplate(KubeDNSDeployment, struct {
-		ImageRepository, Arch, Version, DNSDomain string
-		Replicas                                  int
-	}{
+	dnsDeploymentBytes, err := kubeadmutil.ParseTemplate(KubeDNSDeployment, struct{ ImageRepository, Arch, Version, DNSDomain string }{
 		ImageRepository: kubeadmapi.GlobalEnvParams.RepositoryPrefix,
 		Arch:            runtime.GOARCH,
-		// TODO: Support larger amount of replicas?
-		Replicas:  1,
-		Version:   KubeDNSVersion,
-		DNSDomain: cfg.Networking.DNSDomain,
+		Version:         KubeDNSVersion,
+		DNSDomain:       cfg.Networking.DNSDomain,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing kube-dns deployment template: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates kubeadm to use the latest DNS spec.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

@bowei @MrHohn @thockin  In the future, kubedns changes should be applied to this kubeadm file as well

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

@pires @errordeveloper @dmmcquay @mikedanese 
