### PR TITLE
Fix statefulset e2e test

### DIFF
--- a/examples/cockroachdb/cockroachdb-statefulset.yaml
+++ b/examples/cockroachdb/cockroachdb-statefulset.yaml
@@ -147,16 +147,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: /_admin/v1/health
-            port: http
-          initialDelaySeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /_admin/v1/health
-            port: http
-          initialDelaySeconds: 10
         volumeMounts:
         - name: datadir
           mountPath: /cockroach/cockroach-data

--- a/test/e2e/testing-manifests/statefulset/cockroachdb/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/cockroachdb/statefulset.yaml
@@ -62,16 +62,6 @@ spec:
           name: grpc
         - containerPort: 8080
           name: http
-        livenessProbe:
-          httpGet:
-            path: /_admin/v1/health
-            port: http
-          initialDelaySeconds: 30
-        readinessProbe:
-          httpGet:
-            path: /_admin/v1/health
-            port: http
-          initialDelaySeconds: 10
         volumeMounts:
         - name: datadir
           mountPath: /cockroach/cockroach-data


### PR DESCRIPTION
...by removing the liveness/readiness probes from the cockroachdb
manifests, as explained in
https://github.com/kubernetes/test-infra/issues/1740#issuecomment-279555187

@kow3ns @spxtr 