### PR TITLE
kubelet: reduce extraneous logging for pods using host network

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -198,7 +198,9 @@ func (m *kubeGenericRuntimeManager) determinePodSandboxIP(podNamespace, podName 
 		return ""
 	}
 	ip := podSandbox.Network.Ip
-	if net.ParseIP(ip) == nil {
+	if len(ip) != 0 && net.ParseIP(ip) == nil {
+		// ip could be an empty string if runtime is not responsible for the
+		// IP (e.g., host networking).
 		glog.Warningf("Pod Sandbox reported an unparseable IP %v", ip)
 		return ""
 	}


### PR DESCRIPTION
For pods using the host network, kubelet/shim should not log
error/warning messages when determining the pod IP address.

