### PR TITLE
[CRI] beef up network teardown in  StopPodSandbox

### DIFF
--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/dockershim/cm:go_default_library",
+        "//pkg/kubelet/dockershim/errors:go_default_library",
         "//pkg/kubelet/dockertools:go_default_library",
         "//pkg/kubelet/dockertools/securitycontext:go_default_library",
         "//pkg/kubelet/leaky:go_default_library",
@@ -83,6 +84,7 @@ go_test(
         "//pkg/kubelet/api/v1alpha1/runtime:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/container/testing:go_default_library",
+        "//pkg/kubelet/dockershim/errors:go_default_library",
         "//pkg/kubelet/dockershim/testing:go_default_library",
         "//pkg/kubelet/dockertools:go_default_library",
         "//pkg/kubelet/dockertools/securitycontext:go_default_library",
@@ -113,6 +115,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/kubelet/dockershim/cm:all-srcs",
+        "//pkg/kubelet/dockershim/errors:all-srcs",
         "//pkg/kubelet/dockershim/remote:all-srcs",
         "//pkg/kubelet/dockershim/testing:all-srcs",
     ],

--- a/pkg/kubelet/dockershim/checkpoint_store_test.go
+++ b/pkg/kubelet/dockershim/checkpoint_store_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/errors"
 )
 
 func TestFileStore(t *testing.T) {
@@ -102,7 +103,7 @@ func TestFileStore(t *testing.T) {
 		err = store.Delete(c.key)
 		assert.NoError(t, err)
 		_, err = store.Read(c.key)
-		assert.Error(t, err)
+		assert.EqualValues(t, errors.CheckpointNotFoundError, err)
 	}
 
 	// Test delete non existed checkpoint

--- a/pkg/kubelet/dockershim/docker_checkpoint.go
+++ b/pkg/kubelet/dockershim/docker_checkpoint.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 
 	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/errors"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 )
 
@@ -33,8 +34,6 @@ const (
 	protocolUDP          = Protocol("udp")
 	schemaVersion        = "v1"
 )
-
-var CorruptCheckpointError = fmt.Errorf("checkpoint is corrupted.")
 
 type Protocol string
 
@@ -108,11 +107,11 @@ func (handler *PersistentCheckpointHandler) GetCheckpoint(podSandboxID string) (
 	err = json.Unmarshal(blob, &checkpoint)
 	if err != nil {
 		glog.Errorf("Failed to unmarshal checkpoint %q. Checkpoint content: %q. ErrMsg: %v", podSandboxID, string(blob), err)
-		return &checkpoint, CorruptCheckpointError
+		return &checkpoint, errors.CorruptCheckpointError
 	}
 	if checkpoint.CheckSum != calculateChecksum(checkpoint) {
 		glog.Errorf("Checksum of checkpoint %q is not valid", podSandboxID)
-		return &checkpoint, CorruptCheckpointError
+		return &checkpoint, errors.CorruptCheckpointError
 	}
 	return &checkpoint, nil
 }

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -27,6 +27,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/errors"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/kubelet/types"
@@ -355,7 +356,7 @@ func (ds *dockerService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter) ([]
 			if err != nil {
 				glog.Errorf("Failed to retrieve checkpoint for sandbox %q: %v", id, err)
 
-				if err == CorruptCheckpointError {
+				if err == errors.CorruptCheckpointError {
 					glog.V(2).Info("Removing corrupted checkpoint %q: %+v", id, *checkpoint)
 					ds.checkpointHandler.RemoveCheckpoint(id)
 				}

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -32,6 +32,7 @@ import (
 	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/cm"
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/errors"
 	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/network/cni"
@@ -292,8 +293,14 @@ func (ds *dockerService) GetNetNS(podSandboxID string) (string, error) {
 func (ds *dockerService) GetPodPortMappings(podSandboxID string) ([]*hostport.PortMapping, error) {
 	// TODO: get portmappings from docker labels for backward compatibility
 	checkpoint, err := ds.checkpointHandler.GetCheckpoint(podSandboxID)
+	// Return empty portMappings if checkpoint is not found
 	if err != nil {
-		return nil, err
+		if err == errors.CheckpointNotFoundError {
+			glog.Warningf("Failed to retrieve checkpoint for sandbox %q: %v", err)
+			return nil, nil
+		} else {
+			return nil, err
+		}
 	}
 
 	portMappings := []*hostport.PortMapping{}

--- a/pkg/kubelet/dockershim/errors/BUILD
+++ b/pkg/kubelet/dockershim/errors/BUILD
@@ -9,9 +9,8 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["util.go"],
+    srcs = ["errors.go"],
     tags = ["automanaged"],
-    deps = ["//pkg/kubelet/dockershim/errors:go_default_library"],
 )
 
 filegroup(

--- a/pkg/kubelet/dockershim/errors/errors.go
+++ b/pkg/kubelet/dockershim/errors/errors.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import "fmt"
+
+var CorruptCheckpointError = fmt.Errorf("checkpoint is corrupted.")
+var CheckpointNotFoundError = fmt.Errorf("checkpoint is not found.")

--- a/pkg/kubelet/dockershim/testing/util.go
+++ b/pkg/kubelet/dockershim/testing/util.go
@@ -17,8 +17,9 @@ limitations under the License.
 package testing
 
 import (
-	"fmt"
 	"sync"
+
+	"k8s.io/kubernetes/pkg/kubelet/dockershim/errors"
 )
 
 // MemStore is an implementation of CheckpointStore interface which stores checkpoint in memory.
@@ -43,7 +44,7 @@ func (mstore *MemStore) Read(key string) ([]byte, error) {
 	defer mstore.Unlock()
 	data, ok := mstore.mem[key]
 	if !ok {
-		return nil, fmt.Errorf("checkpoint %q could not be found", key)
+		return nil, errors.CheckpointNotFoundError
 	}
 	return data, nil
 }


### PR DESCRIPTION
1. Added CheckpointNotFound error to allow dockershim to conduct error handling
2. Retry network teardown if failed

ref: https://github.com/kubernetes/kubernetes/issues/41225