### PR TITLE
Added Bind method to SchedulerExtender interface

### DIFF
--- a/examples/scheduler-policy-config-with-extender.json
+++ b/examples/scheduler-policy-config-with-extender.json
@@ -14,15 +14,15 @@
 	{"name" : "ServiceSpreadingPriority", "weight" : 1},
 	{"name" : "EqualPriority", "weight" : 1}
 	],
-"extenders":[ 
+"extender": 
 	{
         "urlPrefix": "http://127.0.0.1:12346/scheduler",
         "apiVersion": "v1beta1",
         "filterVerb": "filter",
         "prioritizeVerb": "prioritize",
+        "bindVerb": "bind",
         "weight": 5,
         "enableHttps": false,
         "nodeCacheCapable": false
 	}
-    ]
 }

--- a/plugin/pkg/scheduler/algorithm/scheduler_interface.go
+++ b/plugin/pkg/scheduler/algorithm/scheduler_interface.go
@@ -35,6 +35,9 @@ type SchedulerExtender interface {
 	// are used to compute the weighted score for an extender. The weighted scores are added to
 	// the scores computed  by Kubernetes scheduler. The total scores are used to do the host selection.
 	Prioritize(pod *v1.Pod, nodes []*v1.Node) (hostPriorities *schedulerapi.HostPriorityList, weight int, err error)
+
+	// Bind delegates the action of binding a pod to a node to the extender.
+	Bind(binding *v1.Binding) error
 }
 
 // ScheduleAlgorithm is an interface implemented by things that know how to schedule pods

--- a/plugin/pkg/scheduler/api/BUILD
+++ b/plugin/pkg/scheduler/api/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/client-go/rest",
     ],
 )

--- a/plugin/pkg/scheduler/api/v1/BUILD
+++ b/plugin/pkg/scheduler/api/v1/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/client-go/rest",
     ],
 )

--- a/plugin/pkg/scheduler/api/v1/types.go
+++ b/plugin/pkg/scheduler/api/v1/types.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
 )
@@ -30,8 +31,8 @@ type Policy struct {
 	Predicates []PredicatePolicy `json:"predicates"`
 	// Holds the information to configure the priority functions
 	Priorities []PriorityPolicy `json:"priorities"`
-	// Holds the information to communicate with the extender(s)
-	ExtenderConfigs []ExtenderConfig `json:"extenders"`
+	// Holds the information to communicate with the extender
+	ExtenderConfig *ExtenderConfig `json:"extender"`
 }
 
 type PredicatePolicy struct {
@@ -118,6 +119,9 @@ type ExtenderConfig struct {
 	FilterVerb string `json:"filterVerb,omitempty"`
 	// Verb for the prioritize call, empty if not supported. This verb is appended to the URLPrefix when issuing the prioritize call to extender.
 	PrioritizeVerb string `json:"prioritizeVerb,omitempty"`
+	// Verb for the bind call, empty if not supported. This verb is appended to the URLPrefix when issuing the bind call to extender.
+	// If this method is implemented by the extender, it is the extender's responsibility to bind the pod to apiserver.
+	BindVerb string `json:"bindVerb,omitempty"`
 	// The numeric multiplier for the node scores that the prioritize call generates.
 	// The weight should be a positive integer
 	Weight int `json:"weight,omitempty"`
@@ -160,6 +164,24 @@ type ExtenderFilterResult struct {
 	NodeNames *[]string `json:"nodenames,omitempty"`
 	// Filtered out nodes where the pod can't be scheduled and the failure messages
 	FailedNodes FailedNodesMap `json:"failedNodes,omitempty"`
+	// Error message indicating failure
+	Error string `json:"error,omitempty"`
+}
+
+// Binding represents the binding of a pod to a node.
+type Binding struct {
+	// PodName is the name of the pod being bound
+	PodName string `json:"podName"`
+	// PodNamespace is the namespace of the pod being bound
+	PodNamespace string `json:"podNamespace"`
+	// PodUID is the UID of the pod being bound
+	PodUID types.UID `json:"podUID"`
+	// Node selected by the scheduler
+	Node string `json:"node"`
+}
+
+// BindingResult represents the result of binding of a pod to a node.
+type BindingResult struct {
 	// Error message indicating failure
 	Error string `json:"error,omitempty"`
 }

--- a/plugin/pkg/scheduler/api/validation/validation.go
+++ b/plugin/pkg/scheduler/api/validation/validation.go
@@ -34,9 +34,9 @@ func ValidatePolicy(policy schedulerapi.Policy) error {
 		}
 	}
 
-	for _, extender := range policy.ExtenderConfigs {
-		if extender.Weight < 0 {
-			validationErrors = append(validationErrors, fmt.Errorf("Priority for extender %s should have a non negative weight applied to it", extender.URLPrefix))
+	if policy.ExtenderConfig != nil {
+		if policy.ExtenderConfig.Weight < 0 {
+			validationErrors = append(validationErrors, fmt.Errorf("Priority for extender %s should have a non negative weight applied to it", policy.ExtenderConfig.URLPrefix))
 		}
 	}
 	return utilerrors.NewAggregate(validationErrors)

--- a/plugin/pkg/scheduler/core/extender.go
+++ b/plugin/pkg/scheduler/core/extender.go
@@ -41,6 +41,7 @@ type HTTPExtender struct {
 	extenderURL      string
 	filterVerb       string
 	prioritizeVerb   string
+	bindVerb         string
 	weight           int
 	client           *http.Client
 	nodeCacheCapable bool
@@ -86,6 +87,7 @@ func NewHTTPExtender(config *schedulerapi.ExtenderConfig) (algorithm.SchedulerEx
 		extenderURL:      config.URLPrefix,
 		filterVerb:       config.FilterVerb,
 		prioritizeVerb:   config.PrioritizeVerb,
+		bindVerb:         config.BindVerb,
 		weight:           config.Weight,
 		client:           client,
 		nodeCacheCapable: config.NodeCacheCapable,
@@ -193,6 +195,27 @@ func (h *HTTPExtender) Prioritize(pod *v1.Pod, nodes []*v1.Node) (*schedulerapi.
 	return &result, h.weight, nil
 }
 
+// Bind delegates the action of binding a pod to a node to the extender.
+func (h *HTTPExtender) Bind(binding *v1.Binding) error {
+	var result schedulerapi.BindingResult
+	if h.bindVerb == "" {
+		return nil
+	}
+	req := &schedulerapi.Binding{
+		PodName:      binding.Name,
+		PodNamespace: binding.Namespace,
+		PodUID:       binding.UID,
+		Node:         binding.Target.Name,
+	}
+	if err := h.send(h.bindVerb, &req, &result); err != nil {
+		return err
+	}
+	if result.Error != "" {
+		return fmt.Errorf(result.Error)
+	}
+	return nil
+}
+
 // Helper function to send messages to the extender
 func (h *HTTPExtender) send(action string, args interface{}, result interface{}) error {
 	out, err := json.Marshal(args)
@@ -212,6 +235,10 @@ func (h *HTTPExtender) send(action string, args interface{}, result interface{})
 	resp, err := h.client.Do(req)
 	if err != nil {
 		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Failed %v with extender at URL %v, code %v", action, h.extenderURL, resp.StatusCode)
 	}
 
 	defer resp.Body.Close()

--- a/plugin/pkg/scheduler/core/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/core/generic_scheduler_test.go
@@ -307,8 +307,7 @@ func TestGenericScheduler(t *testing.T) {
 		}
 
 		scheduler := NewGenericScheduler(
-			cache, test.predicates, algorithm.EmptyMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer,
-			[]algorithm.SchedulerExtender{})
+			cache, test.predicates, algorithm.EmptyMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer, nil)
 		machine, err := scheduler.Schedule(test.pod, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 
 		if !reflect.DeepEqual(err, test.wErr) {
@@ -527,7 +526,7 @@ func TestZeroRequest(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		list, err := PrioritizeNodes(
 			test.pod, nodeNameToInfo, algorithm.EmptyMetadataProducer, priorityConfigs,
-			schedulertesting.FakeNodeLister(test.nodes), []algorithm.SchedulerExtender{})
+			schedulertesting.FakeNodeLister(test.nodes), nil)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -78,7 +78,7 @@ type Configurator interface {
 	Create() (*Config, error)
 	CreateFromProvider(providerName string) (*Config, error)
 	CreateFromConfig(policy schedulerapi.Policy) (*Config, error)
-	CreateFromKeys(predicateKeys, priorityKeys sets.String, extenders []algorithm.SchedulerExtender) (*Config, error)
+	CreateFromKeys(predicateKeys, priorityKeys sets.String, extender algorithm.SchedulerExtender, binder Binder) (*Config, error)
 }
 
 // TODO over time we should make this struct a hidden implementation detail of the scheduler.
@@ -191,7 +191,7 @@ func (s *Scheduler) scheduleOne() {
 		defer metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
 
 		b := &v1.Binding{
-			ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name},
+			ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name, UID: pod.UID},
 			Target: v1.ObjectReference{
 				Kind: "Node",
 				Name: dest,

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -484,7 +484,7 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.
 		algorithm.EmptyMetadataProducer,
 		[]algorithm.PriorityConfig{},
 		algorithm.EmptyMetadataProducer,
-		[]algorithm.SchedulerExtender{})
+		nil)
 	bindingChan := make(chan *v1.Binding, 1)
 	errChan := make(chan error, 1)
 	cfg := &Config{
@@ -514,7 +514,7 @@ func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, sc
 		algorithm.EmptyMetadataProducer,
 		[]algorithm.PriorityConfig{},
 		algorithm.EmptyMetadataProducer,
-		[]algorithm.SchedulerExtender{})
+		nil)
 	bindingChan := make(chan *v1.Binding, 2)
 	cfg := &Config{
 		SchedulerCache: scache,


### PR DESCRIPTION
- Bind is used to let the extender know of the scheduling decision
- Extender uses this to set aside resources against the pod

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
