### PR TITLE
Automated cherry pick of #40884

### DIFF
--- a/test/e2e_node/jenkins/cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/image-config.yaml
@@ -6,3 +6,6 @@ images:
     image_regex: gci-dev-56-8977-0-0
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml"
+  ubuntu-docker12:
+    image: e2e-node-ubuntu-trusty-docker12-v2-image
+    project: kubernetes-node-e2e-images

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -3,7 +3,10 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu-docker10:
-    image: e2e-node-ubuntu-trusty-docker10-v2-image
+    image: e2e-node-ubuntu-trusty-docker10-v2-image # docker 1.10.3
+    project: kubernetes-node-e2e-images
+  ubuntu-docker12:
+    image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
     project: kubernetes-node-e2e-images
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727


### PR DESCRIPTION
Cherry pick of #40884 on release-1.5.

#40884: Node E2E: Create new ubuntu image with docker 1.12.6.