### PR TITLE
Job: Failure Threshold

### DIFF
--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -521,8 +521,10 @@ func batchFuncs(t apitesting.TestingCommon) []interface{} {
 		func(j *batch.JobSpec, c fuzz.Continue) {
 			c.FuzzNoCustom(j) // fuzz self without calling this function again
 			completions := int32(c.Rand.Int31())
+			failureThresholds := int32(c.Rand.Int31())
 			parallelism := int32(c.Rand.Int31())
 			j.Completions = &completions
+			j.FailureThreshold = &failureThresholds
 			j.Parallelism = &parallelism
 			if c.Rand.Int31()%2 == 0 {
 				j.ManualSelector = newBool(true)

--- a/pkg/apis/batch/v1/types.go
+++ b/pkg/apis/batch/v1/types.go
@@ -74,6 +74,13 @@ type JobSpec struct {
 	// +optional
 	Completions *int32 `json:"completions,omitempty" protobuf:"varint,2,opt,name=completions"`
 
+	// FailureThreshold specifies the desire to have a job finish after a set number of failures occur.
+	// Setting this value means that the failure of any pod will contribute to the threshold and and signal all pods
+	// to finish once the threshold is met.
+	// More info: http://kubernetes.io/docs/user-guide/jobs
+	// +optional
+	FailureThreshold *int32 `json:"failureThreshold,omitempty" protobuf:"varint,2,opt,name=failureThreshold"`
+
 	// Optional duration in seconds relative to the startTime that the job may be active
 	// before the system tries to terminate it; value must be positive integer
 	// +optional

--- a/pkg/apis/batch/v1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v1/zz_generated.conversion.go
@@ -152,6 +152,7 @@ func Convert_batch_JobList_To_v1_JobList(in *batch.JobList, out *JobList, s conv
 func autoConvert_v1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s conversion.Scope) error {
 	out.Parallelism = (*int32)(unsafe.Pointer(in.Parallelism))
 	out.Completions = (*int32)(unsafe.Pointer(in.Completions))
+	// WARNING: in.FailureThreshold requires manual conversion: does not exist in peer-type
 	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
 	out.Selector = (*meta_v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))

--- a/pkg/apis/batch/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/batch/v1/zz_generated.deepcopy.go
@@ -108,6 +108,11 @@ func DeepCopy_v1_JobSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 			*out = new(int32)
 			**out = **in
 		}
+		if in.FailureThreshold != nil {
+			in, out := &in.FailureThreshold, &out.FailureThreshold
+			*out = new(int32)
+			**out = **in
+		}
 		if in.ActiveDeadlineSeconds != nil {
 			in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
 			*out = new(int64)

--- a/pkg/apis/batch/v2alpha1/conversion.go
+++ b/pkg/apis/batch/v2alpha1/conversion.go
@@ -57,6 +57,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 func Convert_batch_JobSpec_To_v2alpha1_JobSpec(in *batch.JobSpec, out *JobSpec, s conversion.Scope) error {
 	out.Parallelism = in.Parallelism
 	out.Completions = in.Completions
+	out.FailureThreshold = in.FailureThreshold
 	out.ActiveDeadlineSeconds = in.ActiveDeadlineSeconds
 	out.Selector = in.Selector
 	if in.ManualSelector != nil {

--- a/pkg/apis/batch/v2alpha1/types.go
+++ b/pkg/apis/batch/v2alpha1/types.go
@@ -101,6 +101,13 @@ type JobSpec struct {
 	// +optional
 	Completions *int32 `json:"completions,omitempty" protobuf:"varint,2,opt,name=completions"`
 
+	// FailureThreshold specifies the desire to have a job finish after a set number of failures occur.
+	// Setting this value means that the failure of any pod will contribute to the threshold and and signal all pods
+	// to finish once the threshold is met.
+	// More info: http://kubernetes.io/docs/user-guide/jobs
+	// +optional
+	FailureThreshold *int32 `json:"failureThreshold,omitempty" protobuf:"varint,2,opt,name=failureThreshold"`
+
 	// Optional duration in seconds relative to the startTime that the job may be active
 	// before the system tries to terminate it; value must be positive integer
 	// +optional

--- a/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
@@ -284,6 +284,7 @@ func Convert_batch_JobList_To_v2alpha1_JobList(in *batch.JobList, out *JobList, 
 func autoConvert_v2alpha1_JobSpec_To_batch_JobSpec(in *JobSpec, out *batch.JobSpec, s conversion.Scope) error {
 	out.Parallelism = (*int32)(unsafe.Pointer(in.Parallelism))
 	out.Completions = (*int32)(unsafe.Pointer(in.Completions))
+	// WARNING: in.FailureThreshold requires manual conversion: does not exist in peer-type
 	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
 	out.Selector = (*v1.LabelSelector)(unsafe.Pointer(in.Selector))
 	out.ManualSelector = (*bool)(unsafe.Pointer(in.ManualSelector))

--- a/pkg/apis/batch/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/batch/v2alpha1/zz_generated.deepcopy.go
@@ -193,6 +193,11 @@ func DeepCopy_v2alpha1_JobSpec(in interface{}, out interface{}, c *conversion.Cl
 			*out = new(int32)
 			**out = **in
 		}
+		if in.FailureThreshold != nil {
+			in, out := &in.FailureThreshold, &out.FailureThreshold
+			*out = new(int32)
+			**out = **in
+		}
 		if in.ActiveDeadlineSeconds != nil {
 			in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
 			*out = new(int64)

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -3203,6 +3203,13 @@ var OpenAPIDefinitions *openapi.OpenAPIDefinitions = &openapi.OpenAPIDefinitions
 							Format:      "int32",
 						},
 					},
+					"failureThreshold": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FailureThreshold specifies the desire to have a job finish after a set number of failures occur. Setting this value means that the failure of any pod will contribute to the threshold and and signal all pods to finish once the threshold is met. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
 					"activeDeadlineSeconds": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Optional duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer",
@@ -15681,6 +15688,13 @@ var OpenAPIDefinitions *openapi.OpenAPIDefinitions = &openapi.OpenAPIDefinitions
 					"completions": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Completions specifies the desired number of successfully finished pods the job should be run with.  Setting to nil means that the success of any pod signals the success of all pods, and allows parallelism to have any positive value.  Setting to 1 means that parallelism is limited to 1 and the success of that pod signals the success of the job. More info: http://kubernetes.io/docs/user-guide/jobs",
+							Type:        []string{"integer"},
+							Format:      "int32",
+						},
+					},
+					"failureThreshold": {
+						SchemaProps: spec.SchemaProps{
+							Description: "FailureThreshold specifies the desire to have a job finish after a set number of failures occur. Setting this value means that the failure of any pod will contribute to the threshold and and signal all pods to finish once the threshold is met. More info: http://kubernetes.io/docs/user-guide/jobs",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Jobs current implementation will keep recreating a pod as it fails to ensure that the job runs to completion.

This isn't always the ideal, sometimes we want our build to fail and be recreated at a much later date (or not at all) by a higher level API eg. CronJobs.

My solution, implement a "Failure Threshold".

This means that jobs will be allowed to have X number of failures before the Job is stopped entirely. This becomes really handy when using the CronJobs API and you know if the job fails you will get a new job at a later date.

**Which issue this PR fixes**:

* #39578
* #24533

**Special notes for your reviewer**:

A Job with a Failure Threshold can be created with the following:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: threshold-test
spec:
  failureThreshold: 2
  template:
    metadata:
      name: threshold-test
    spec:
      containers:
      - name: failure
        image: alpine
        command: ["exit",  "1"]
```

**Release note**:

```release-note
Adds failureThreshold field to Jobs. Stops Job from running after X failed executions.
```
