### PR TITLE
Change node e2e cri-validation configs

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -193,7 +193,6 @@ ENABLE_CONTROLLER_ATTACH_DETACH=${ENABLE_CONTROLLER_ATTACH_DETACH:-"true"} # cur
 # which should be able to be used as the CA to verify itself
 CERT_DIR=${CERT_DIR:-"/var/run/kubernetes"}
 ROOT_CA_FILE=${CERT_DIR}/server-ca.crt
-EXPERIMENTAL_CRI=${EXPERIMENTAL_CRI:-"false"}
 
 # name of the cgroup driver, i.e. cgroupfs or systemd
 if [[ ${CONTAINER_RUNTIME} == "docker" ]]; then
@@ -570,7 +569,6 @@ function start_kubelet {
         --v=${LOG_LEVEL} \
         --chaos-chance="${CHAOS_CHANCE}" \
         --container-runtime="${CONTAINER_RUNTIME}" \
-        --experimental-cri=${EXPERIMENTAL_CRI} \
         --rkt-path="${RKT_PATH}" \
         --rkt-stage1-image="${RKT_STAGE1_IMAGE}" \
         --hostname-override="${HOSTNAME_OVERRIDE}" \

--- a/test/e2e_node/jenkins/non-cri_validation/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/non-cri_validation/benchmark-config.yaml
@@ -1,0 +1,58 @@
+---
+images:
+  gci-density1:
+    image: gci-beta-56-9000-80-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'create 35 pods with 0s? interval \[Benchmark\]'
+  gci-density2:
+    image: gci-beta-56-9000-80-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'create 105 pods with 0s? interval \[Benchmark\]'
+  gci-density2-qps60:
+    image: gci-beta-56-9000-80-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
+  gci-density3:
+    image: gci-beta-56-9000-80-0
+    project: google-containers
+    machine: n1-standard-2
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'create 105 pods with 0s? interval \[Benchmark\]'
+  gci-density4:
+    image: gci-beta-56-9000-80-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'create 105 pods with 100ms interval \[Benchmark\]'
+  gci-resource1:
+    image: gci-beta-56-9000-80-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 0 pods per node \[Benchmark\]'
+  gci-resource2:
+    image: gci-beta-56-9000-80-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 35 pods per node \[Benchmark\]'
+  gci-resource3:
+    image: gci-beta-56-9000-80-0
+    project: google-containers
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 105 pods per node \[Benchmark\]'

--- a/test/e2e_node/jenkins/non-cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/non-cri_validation/image-config.yaml
@@ -1,0 +1,14 @@
+images:
+  containervm:
+    image: e2e-node-containervm-v20161208-image # docker 1.11.2
+    project: kubernetes-node-e2e-images
+  gci-family:
+    image_regex: gci-beta-56-9000-80-0 # docker 1.11.2
+    project: google-containers
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+  ubuntu-docker12:
+    image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
+    project: kubernetes-node-e2e-images
+  ubuntu-docker10:
+    image: e2e-node-ubuntu-trusty-docker10-v2-image # docker 1.10.3
+    project: kubernetes-node-e2e-images

--- a/test/e2e_node/jenkins/non-cri_validation/jenkins-benchmark.properties
+++ b/test/e2e_node/jenkins/non-cri_validation/jenkins-benchmark.properties
@@ -1,0 +1,9 @@
+GCE_HOSTS=
+GCE_IMAGE_CONFIG_PATH=test/e2e_node/jenkins/non-cri_validation/benchmark-config.yaml
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ci-node-e2e
+CLEANUP=true
+GINKGO_FLAGS='--skip="\[Flaky\]"'
+TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
+KUBELET_ARGS='--enable-cri=false'
+PARALLELISM=1

--- a/test/e2e_node/jenkins/non-cri_validation/jenkins-pull.properties
+++ b/test/e2e_node/jenkins/non-cri_validation/jenkins-pull.properties
@@ -1,0 +1,8 @@
+GCE_HOSTS=
+GCE_IMAGE_CONFIG_PATH=test/e2e_node/jenkins/non-cri_validation/image-config.yaml
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-pr-node-e2e
+CLEANUP=true
+GINKGO_FLAGS='--skip="\[Flaky\]|\[Slow\]|\[Serial\]" --flakeAttempts=2'
+TEST_ARGS='--feature-gates=StreamingProxyRedirects=true'
+KUBELET_ARGS='--enable-cri=false'

--- a/test/e2e_node/jenkins/non-cri_validation/jenkins-serial.properties
+++ b/test/e2e_node/jenkins/non-cri_validation/jenkins-serial.properties
@@ -1,0 +1,10 @@
+GCE_HOSTS=
+GCE_IMAGE_CONFIG_PATH=test/e2e_node/jenkins/non-cri_validation/image-config.yaml
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ci-node-e2e
+CLEANUP=true
+GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]"'
+TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
+KUBELET_ARGS='--enable-cri=false'
+PARALLELISM=1
+TIMEOUT=3h

--- a/test/e2e_node/jenkins/non-cri_validation/jenkins-validation.properties
+++ b/test/e2e_node/jenkins/non-cri_validation/jenkins-validation.properties
@@ -1,0 +1,8 @@
+GCE_HOSTS=
+GCE_IMAGE_CONFIG_PATH=test/e2e_node/jenkins/non-cri_validation/image-config.yaml
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ci-node-e2e
+CLEANUP=true
+GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
+KUBELET_ARGS='--enable-cri=false'
+TIMEOUT=1h


### PR DESCRIPTION
Copy the configs to a new directory to test non-cri implementation. We can
remove the original directory after the dependent PRs are merged.