### PR TITLE
Log that debug handlers have been turned on.

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -285,7 +285,7 @@ const pprofBasePath = "/debug/pprof/"
 
 // InstallDeguggingHandlers registers the HTTP request patterns that serve logs or run commands/containers
 func (s *Server) InstallDebuggingHandlers(criHandler http.Handler) {
-	glog.Infof("Adding Debug Handlers")
+	glog.Infof("Adding debug handlers to kubelet server.")
 	var ws *restful.WebService
 
 	ws = new(restful.WebService)

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -285,6 +285,7 @@ const pprofBasePath = "/debug/pprof/"
 
 // InstallDeguggingHandlers registers the HTTP request patterns that serve logs or run commands/containers
 func (s *Server) InstallDebuggingHandlers(criHandler http.Handler) {
+	glog.Infof("Adding Debug Handlers")
 	var ws *restful.WebService
 
 	ws = new(restful.WebService)


### PR DESCRIPTION
**What this PR does / why we need it**: PR allows user to have a message in logs that debug handlers are on. It should allow the operator to know and automate a check for the case where debug has been left on. 

**Release note**:
```
NONE
```
