### PR TITLE
Adjust nodiskconflict support based on iscsi multipath.

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -131,21 +130,12 @@ func isVolumeConflict(volume v1.Volume, pod *v1.Pod) bool {
 		}
 
 		if volume.ISCSI != nil && existingVolume.ISCSI != nil {
-			iqn, lun, target := volume.ISCSI.IQN, volume.ISCSI.Lun, volume.ISCSI.TargetPortal
-			eiqn, elun, etarget := existingVolume.ISCSI.IQN, existingVolume.ISCSI.Lun, existingVolume.ISCSI.TargetPortal
-			if !strings.Contains(target, ":") {
-				target = target + ":3260"
-			}
-			if !strings.Contains(etarget, ":") {
-				etarget = etarget + ":3260"
-			}
-			lun1 := strconv.Itoa(int(lun))
-			elun1 := strconv.Itoa(int(elun))
-
-			// two ISCSI volumes are same, if they share the same iqn, lun and target. As iscsi volumes are of type
+			iqn := volume.ISCSI.IQN
+			eiqn := existingVolume.ISCSI.IQN
+			// two ISCSI volumes are same, if they share the same iqn. As iscsi volumes are of type
 			// RWO or ROX, we could permit only one RW mount. Same iscsi volume mounted by multiple Pods
 			// conflict unless all other pods mount as read only.
-			if iqn == eiqn && lun1 == elun1 && target == etarget && !(volume.ISCSI.ReadOnly && existingVolume.ISCSI.ReadOnly) {
+			if iqn == eiqn && !(volume.ISCSI.ReadOnly && existingVolume.ISCSI.ReadOnly) {
 				return true
 			}
 		}

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -739,7 +739,7 @@ func TestISCSIDiskConflicts(t *testing.T) {
 				VolumeSource: v1.VolumeSource{
 					ISCSI: &v1.ISCSIVolumeSource{
 						TargetPortal: "127.0.0.1:3260",
-						IQN:          "iqn.2014-12.server:storage.target01",
+						IQN:          "iqn.2016-12.server:storage.target01",
 						FSType:       "ext4",
 						Lun:          0,
 					},
@@ -752,10 +752,10 @@ func TestISCSIDiskConflicts(t *testing.T) {
 			{
 				VolumeSource: v1.VolumeSource{
 					ISCSI: &v1.ISCSIVolumeSource{
-						TargetPortal: "127.0.0.2:3260",
-						IQN:          "iqn.2014-12.server:storage.target01",
+						TargetPortal: "127.0.0.1:3260",
+						IQN:          "iqn.2017-12.server:storage.target01",
 						FSType:       "ext4",
-						Lun:          1,
+						Lun:          0,
 					},
 				},
 			},


### PR DESCRIPTION
With the multipath support is in place, to declare whether both iscsi disks are same, we need to only depend on IQN.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

