### PR TITLE
fix kubectl create configmap help messages

### DIFF
--- a/pkg/kubectl/cmd/create_configmap.go
+++ b/pkg/kubectl/cmd/create_configmap.go
@@ -42,10 +42,10 @@ var (
 		symlinks, devices, pipes, etc).`)
 
 	configMapExample = templates.Examples(`
-		  # Create a new configmap named my-config with keys for each file in folder bar
+		  # Create a new configmap named my-config based on folder bar
 		  kubectl create configmap my-config --from-file=path/to/bar
 
-		  # Create a new configmap named my-config with specified keys instead of names on disk
+		  # Create a new configmap named my-config with specified keys instead of file basenames on disk
 		  kubectl create configmap my-config --from-file=key1=/path/to/bar/file1.txt --from-file=key2=/path/to/bar/file2.txt
 
 		  # Create a new configmap named my-config with key1=config1 and key2=config2
@@ -69,7 +69,7 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.ConfigMapV1GeneratorName)
-	cmd.Flags().StringSlice("from-file", []string{}, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid configmap key.")
+	cmd.Flags().StringSlice("from-file", []string{}, "Key file can be specified using its file path, in which case file basename will be used as configmap key, or optionally with a key and file path, in which case the given key will be used.  Specifying a directory will iterate each named file in the directory whose basename is a valid configmap key.")
 	cmd.Flags().StringArray("from-literal", []string{}, "Specify a key and literal value to insert in configmap (i.e. mykey=somevalue)")
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: bruceauyeung <ouyang.qinhua@zte.com.cn>

**What this PR does / why we need it**:

1. the first example command actually doesn't specify any keys. i think `with keys for each file` is incorrect.
2. `names on disk` is confusing.  in usage the word `NAME` means configmap, so i think it's better saying `file basenames on disk`
3. in this context, `--from-file` can be specified multiple times, but in each occurance only one key file can be specified, besides we should keep consistent with the later case (key is specified). so i changed words in this sentence to singular. and to avoid confusing, i use `key` instead of `name`

