### PR TITLE
make iscsi portals optional

### DIFF
--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -1660,8 +1660,7 @@
     "required": [
      "targetPortal",
      "iqn",
-     "lun",
-     "portals"
+     "lun"
     ],
     "properties": {
      "targetPortal": {

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -1665,8 +1665,7 @@
     "required": [
      "targetPortal",
      "iqn",
-     "lun",
-     "portals"
+     "lun"
     ],
     "properties": {
      "targetPortal": {

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -7067,8 +7067,7 @@
     "required": [
      "targetPortal",
      "iqn",
-     "lun",
-     "portals"
+     "lun"
     ],
     "properties": {
      "targetPortal": {

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -18068,8 +18068,7 @@
     "required": [
      "targetPortal",
      "iqn",
-     "lun",
-     "portals"
+     "lun"
     ],
     "properties": {
      "targetPortal": {

--- a/docs/api-reference/apps/v1beta1/definitions.html
+++ b/docs/api-reference/apps/v1beta1/definitions.html
@@ -2626,7 +2626,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">portals</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">iSCSI target portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -5389,7 +5389,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-21 16:52:32 UTC
+Last updated 2017-02-23 20:32:09 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/batch/v1/definitions.html
+++ b/docs/api-reference/batch/v1/definitions.html
@@ -2537,7 +2537,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">portals</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">iSCSI target portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -5321,7 +5321,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-21 16:53:18 UTC
+Last updated 2017-02-23 20:32:42 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -2317,7 +2317,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">portals</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">iSCSI target portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -7612,7 +7612,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-21 16:53:39 UTC
+Last updated 2017-02-23 20:32:58 UTC
 </div>
 </div>
 </body>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -2553,7 +2553,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">portals</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">iSCSI target portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
@@ -9638,7 +9638,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-21 16:52:23 UTC
+Last updated 2017-02-23 20:32:02 UTC
 </div>
 </div>
 </body>

--- a/pkg/api/v1/types.generated.go
+++ b/pkg/api/v1/types.generated.go
@@ -15298,11 +15298,12 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			yyq2[3] = x.ISCSIInterface != ""
 			yyq2[4] = x.FSType != ""
 			yyq2[5] = x.ReadOnly != false
+			yyq2[6] = len(x.Portals) != 0
 			var yynn2 int
 			if yyr2 || yy2arr2 {
 				r.EncodeArrayStart(7)
 			} else {
-				yynn2 = 4
+				yynn2 = 3
 				for _, b := range yyq2 {
 					if b {
 						yynn2++
@@ -15445,28 +15446,34 @@ func (x *ISCSIVolumeSource) CodecEncodeSelf(e *codec1978.Encoder) {
 			}
 			if yyr2 || yy2arr2 {
 				z.EncSendContainerState(codecSelfer_containerArrayElem1234)
-				if x.Portals == nil {
-					r.EncodeNil()
-				} else {
-					yym22 := z.EncBinary()
-					_ = yym22
-					if false {
+				if yyq2[6] {
+					if x.Portals == nil {
+						r.EncodeNil()
 					} else {
-						z.F.EncSliceStringV(x.Portals, false, e)
+						yym22 := z.EncBinary()
+						_ = yym22
+						if false {
+						} else {
+							z.F.EncSliceStringV(x.Portals, false, e)
+						}
 					}
+				} else {
+					r.EncodeNil()
 				}
 			} else {
-				z.EncSendContainerState(codecSelfer_containerMapKey1234)
-				r.EncodeString(codecSelferC_UTF81234, string("portals"))
-				z.EncSendContainerState(codecSelfer_containerMapValue1234)
-				if x.Portals == nil {
-					r.EncodeNil()
-				} else {
-					yym23 := z.EncBinary()
-					_ = yym23
-					if false {
+				if yyq2[6] {
+					z.EncSendContainerState(codecSelfer_containerMapKey1234)
+					r.EncodeString(codecSelferC_UTF81234, string("portals"))
+					z.EncSendContainerState(codecSelfer_containerMapValue1234)
+					if x.Portals == nil {
+						r.EncodeNil()
 					} else {
-						z.F.EncSliceStringV(x.Portals, false, e)
+						yym23 := z.EncBinary()
+						_ = yym23
+						if false {
+						} else {
+							z.F.EncSliceStringV(x.Portals, false, e)
+						}
 					}
 				}
 			}

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -1015,7 +1015,7 @@ type ISCSIVolumeSource struct {
 	// iSCSI target portal List. The portal is either an IP or ip_addr:port if the port
 	// is other than default (typically TCP ports 860 and 3260).
 	// +optional
-	Portals []string `json:"portals" protobuf:"bytes,7,opt,name=portals"`
+	Portals []string `json:"portals,omitempty" protobuf:"bytes,7,opt,name=portals"`
 }
 
 // Represents a Fibre Channel volume.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Make iSCSI portals optional

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
