### PR TITLE
Add toleration to fluentd daemonset to make it run on master

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -14,11 +14,12 @@ spec:
         k8s-app: fluentd-es
         kubernetes.io/cluster-service: "true"
         version: v1.22
-  # This annotation ensures that fluentd does not get evicted if the node
-  # supports critical pod annotation based priority scheme.
-  # Note that this does not guarantee admission on the nodes (#40573).
+      # This annotation ensures that fluentd does not get evicted if the node
+      # supports critical pod annotation based priority scheme.
+      # Note that this does not guarantee admission on the nodes (#40573).
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key": "node.alpha.kubernetes.io/ismaster", "effect": "NoSchedule"}]'
     spec:
       containers:
       - name: fluentd-es

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -20,6 +20,7 @@ spec:
       # Note that this does not guarantee admission on the nodes (#40573).
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key": "node.alpha.kubernetes.io/ismaster", "effect": "NoSchedule"}]'
     spec:
       containers:
       - name: fluentd-gcp


### PR DESCRIPTION
Because of https://github.com/kubernetes/kubernetes/pull/41172 fluentd pods stopped being allocated on master node.

This PR introduces toleration for master taint for fluentd.

CC @davidopp @janetkuo @kubernetes/sig-scheduling-bugs

Unfortunately, we don't have e2e tests to ensure that master logs are being ingested. This problem is a great signal to work on https://github.com/kubernetes/kubernetes/issues/41411