### PR TITLE
Make scheduler_perf warn rather then fail if scheduling rate is betwe…

### DIFF
--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	threshold3K  = 100
+	warning3K    = 100
+	threshold3K  = 30
 	threshold30K = 30
 	threshold60K = 30
 )
@@ -44,8 +45,11 @@ func TestSchedule100Node3KPods(t *testing.T) {
 	}
 
 	config := defaultSchedulerBenchmarkConfig(100, 3000)
-	if min := schedulePods(config); min < threshold3K {
-		t.Errorf("Too small pod scheduling throughput for 3k pods. Expected %v got %v", threshold3K, min)
+	min := schedulePods(config)
+	if min < threshold3K {
+		t.Errorf("Failing: Scheduling rate was too low for an interval, we saw rate of %v, which is the allowed minimum of %v ! ", min, threshold3K)
+	} else if min < warning3K {
+		fmt.Printf("Warning: pod scheduling throughput for 3k pods was slow for an interval... Saw a interval with very low (%v) scheduling rate!", min)
 	} else {
 		fmt.Printf("Minimal observed throughput for 3k pod test: %v\n", min)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**

Fix scheduler per bench tests so they pass even if there is a cold interval .

**Special notes for your reviewer**:

This wont effect CI, as this bench test is run manually by devs.