### PR TITLE
Set OrphanDependents=&falseVar so the GC will (or should) remove the dummy Pod

### DIFF
--- a/cmd/kubeadm/app/master/apiclient.go
+++ b/cmd/kubeadm/app/master/apiclient.go
@@ -156,8 +156,10 @@ func createAndWaitForADummyDeployment(client *clientset.Clientset) error {
 
 	fmt.Println("[apiclient] Test deployment succeeded")
 
-	// TODO: In the future, make sure the ReplicaSet and Pod are garbage collected
-	if err := client.ExtensionsV1beta1().Deployments(metav1.NamespaceSystem).Delete("dummy", &metav1.DeleteOptions{}); err != nil {
+	falseVar := false
+	if err := client.ExtensionsV1beta1().Deployments(metav1.NamespaceSystem).Delete("dummy", &metav1.DeleteOptions{
+		OrphanDependents: &falseVar,
+	}); err != nil {
 		fmt.Printf("[apiclient] Failed to delete test deployment [%v] (will ignore)\n", err)
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

ref: https://github.com/kubernetes/kubeadm/issues/149

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This doesn't remove the Pod yet, only the ReplicaSet, but once the GC is working as expected, it'll remove the Pod with this configuration

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
@errordeveloper @mikedanese @pires @caesarxuchao @krmayankk @kargakis 