### PR TITLE
Bump the minimum kubeadm control plane version to v1.6.0-alpha.2

### DIFF
--- a/cmd/kubeadm/app/cmd/defaults.go
+++ b/cmd/kubeadm/app/cmd/defaults.go
@@ -60,7 +60,7 @@ func setInitDynamicDefaults(cfg *kubeadmapi.MasterConfiguration) error {
 		return fmt.Errorf("couldn't parse kubernetes version %q: %v", cfg.KubernetesVersion, err)
 	}
 	if k8sVersion.LT(minK8sVersion) {
-		return fmt.Errorf("this version of kubeadm only supports deploying clusters with the control plane version >= v1.6.0-alpha.1. Current version: %s", cfg.KubernetesVersion)
+		return fmt.Errorf("this version of kubeadm only supports deploying clusters with the control plane version >= v%s. Current version: %s", kubeadmconstants.MinimumControlPlaneVersion, cfg.KubernetesVersion)
 	}
 
 	fmt.Printf("[init] Using Kubernetes version: %s\n", cfg.KubernetesVersion)

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -44,7 +44,7 @@ const (
 	AuthzModeWebhook     = "Webhook"
 
 	// Important: a "v"-prefix shouldn't exist here; semver doesn't allow that
-	MinimumControlPlaneVersion = "1.6.0-alpha.1"
+	MinimumControlPlaneVersion = "1.6.0-alpha.2"
 
 	// Constants for what we name our ServiceAccounts with limited access to the cluster in case of RBAC
 	KubeDNSServiceAccountName   = "kube-dns"


### PR DESCRIPTION
**What this PR does / why we need it**:

There went in quite a lot of useful features into v1.6.0-alpha.2 that kubeadm will use.
This bump the minimum limit so we can depend on those features.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
@mikedanese @errordeveloper @pires @dmmcquay @dgoodwin 