### PR TITLE
Bump addon-manager version to v6.4-alpha.1 in kubemark

### DIFF
--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -13,7 +13,7 @@ spec:
     # - cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
     # - cluster/images/hyperkube/static-pods/addon-manager-multinode.json
     # - cluster/gce/coreos/kube-manifests/kube-addon-manager.yaml
-    image: {{kube_docker_registry}}/kube-addon-manager:v6.1
+    image: {{kube_docker_registry}}/kube-addon-manager:v6.4-alpha.1
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/41493

cc @wojtek-t @liggitt 