### PR TITLE
Make fluentd use default dns instead of cluster dns to make it work o…

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      dnsPolicy: Default
       containers:
       - name: fluentd-gcp
         image: gcr.io/google_containers/fluentd-gcp:1.38


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/41415

Fluentd for Stackdriver requires external urls (e.g. `logging.googleapis.com`) to be available in order to work. If fluentd runs on master, it cannot access the service endpoint of cluster DNS. This change makes fluentd use default dns to fix this problem.

CC @thockin @bowei 