### PR TITLE
Add OWNERS file for CockroachDB example

### DIFF
--- a/examples/cockroachdb/OWNERS
+++ b/examples/cockroachdb/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - a-robinson
+approvers:
+  - a-robinson


### PR DESCRIPTION
As suggested in https://github.com/kubernetes/kubernetes/pull/41412#issuecomment-279803983

Two quick questions:

1. I assume that the OWNERS files inherit all owners from higher-level directories, right? https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md#adding-owners-files isn't 100% clear

1. Should I also make an OWNERS file for https://github.com/kubernetes/kubernetes/tree/master/test/e2e/testing-manifests/statefulset/cockroachdb?