### PR TITLE
controller: handle nanoseconds properly for progress checks

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -841,10 +841,10 @@ func DeploymentTimedOut(deployment *extensions.Deployment, newStatus *extensions
 	// Look at the difference in seconds between now and the last time we reported any
 	// progress or tried to create a replica set, or resumed a paused deployment and
 	// compare against progressDeadlineSeconds.
-	from := condition.LastUpdateTime
-	now := nowFn()
+	from := condition.LastUpdateTime.Truncate(time.Second)
+	now := nowFn().Round(time.Second)
 	delta := time.Duration(*deployment.Spec.ProgressDeadlineSeconds) * time.Second
-	timedOut := from.Add(delta).Before(now)
+	timedOut := from.Add(delta).Before(now) || from.Add(delta).Equal(now)
 
 	// TODO: Switch to a much higher verbosity level
 	glog.V(2).Infof("Deployment %q timed out (%t) [last progress check: %v - now: %v]", deployment.Name, timedOut, from, now)

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -1052,8 +1052,8 @@ func TestDeploymentTimedOut(t *testing.T) {
 		ten  = int32(10)
 	)
 
-	timeFn := func(min, sec int) time.Time {
-		return time.Date(2016, 1, 1, 0, min, sec, 0, time.UTC)
+	timeFn := func(min, sec, ns int) time.Time {
+		return time.Date(2016, 1, 1, 0, min, sec, ns, time.UTC)
 	}
 	deployment := func(condType extensions.DeploymentConditionType, status v1.ConditionStatus, pds *int32, from time.Time) extensions.Deployment {
 		return extensions.Deployment{
@@ -1083,32 +1083,44 @@ func TestDeploymentTimedOut(t *testing.T) {
 		{
 			name: "no progressDeadlineSeconds specified - no timeout",
 
-			d:        deployment(extensions.DeploymentProgressing, v1.ConditionTrue, null, timeFn(1, 9)),
-			nowFn:    func() time.Time { return timeFn(1, 20) },
+			d:        deployment(extensions.DeploymentProgressing, v1.ConditionTrue, null, timeFn(1, 9, 0)),
+			nowFn:    func() time.Time { return timeFn(1, 20, 0) },
 			expected: false,
 		},
 		{
 			name: "progressDeadlineSeconds: 10s, now - started => 00:01:20 - 00:01:09 => 11s",
 
-			d:        deployment(extensions.DeploymentProgressing, v1.ConditionTrue, &ten, timeFn(1, 9)),
-			nowFn:    func() time.Time { return timeFn(1, 20) },
+			d:        deployment(extensions.DeploymentProgressing, v1.ConditionTrue, &ten, timeFn(1, 9, 0)),
+			nowFn:    func() time.Time { return timeFn(1, 20, 0) },
 			expected: true,
 		},
 		{
 			name: "progressDeadlineSeconds: 10s, now - started => 00:01:20 - 00:01:11 => 9s",
 
-			d:        deployment(extensions.DeploymentProgressing, v1.ConditionTrue, &ten, timeFn(1, 11)),
-			nowFn:    func() time.Time { return timeFn(1, 20) },
+			d:        deployment(extensions.DeploymentProgressing, v1.ConditionTrue, &ten, timeFn(1, 11, 0)),
+			nowFn:    func() time.Time { return timeFn(1, 20, 0) },
 			expected: false,
+		},
+		{
+			name: "handle nanoseconds properly #1",
+
+			d:        deployment(extensions.DeploymentProgressing, v1.ConditionTrue, &ten, timeFn(1, 0, 0)),
+			nowFn:    func() time.Time { return timeFn(1, 9, 500000000) },
+			expected: true,
+		},
+		{
+			name: "handle nanoseconds properly #2",
+			// https://github.com/kubernetes/kubernetes/issues/39785#issuecomment-279959133
+			d:        deployment(extensions.DeploymentProgressing, v1.ConditionTrue, &ten, timeFn(33, 20, 506962913)),
+			nowFn:    func() time.Time { return timeFn(33, 30, 497349178) },
+			expected: true,
 		},
 	}
 
 	for _, test := range tests {
-		t.Log(test.name)
-
 		nowFn = test.nowFn
 		if got, exp := DeploymentTimedOut(&test.d, &test.d.Status), test.expected; got != exp {
-			t.Errorf("expected timeout: %t, got: %t", exp, got)
+			t.Errorf("%s: expected timeout: %t, got: %t", test.name, exp, got)
 		}
 	}
 }


### PR DESCRIPTION
Truncate the starting time and round the ending time to allow some room
for skewed times (nanoseconds). Also refine the progress deadline check
to mark Deployments with ProgressDeadlineExceeded once the deadline is
reached.

Should fix https://github.com/kubernetes/kubernetes/issues/39785

@kubernetes/sig-apps-misc 