### PR TITLE
Allow `make test` to pass on OSX

### DIFF
--- a/hack/e2e_test.go
+++ b/hack/e2e_test.go
@@ -267,7 +267,7 @@ func TestGetKubetest(t *testing.T) {
 
 			stat:     pk,
 			path:     true,
-			age:      100,
+			age:      time.Second,
 			upgraded: true,
 			touched:  true,
 			goPath:   gp,
@@ -281,7 +281,7 @@ func TestGetKubetest(t *testing.T) {
 
 			stat:     pk,
 			path:     true,
-			age:      100,
+			age:      time.Second,
 			upgraded: false,
 			touched:  false,
 			goPath:   gpk,
@@ -295,7 +295,7 @@ func TestGetKubetest(t *testing.T) {
 
 			stat:     pk,
 			path:     true,
-			age:      100,
+			age:      time.Second,
 			upgraded: true,
 			touched:  false,
 			goPath:   gpk,
@@ -314,7 +314,7 @@ func TestGetKubetest(t *testing.T) {
 				if p != c.stat {
 					return nil, fmt.Errorf("Failed to find %s", p)
 				}
-				return FileInfo{time.Now().Add(c.age)}, nil
+				return FileInfo{time.Now().Add(c.age * -1)}, nil
 			},
 			func(name string) (string, error) {
 				if c.path {


### PR DESCRIPTION
**What this PR does / why we need it**: `make test` doesn't pass on my OSX setup (10.11.6, go1.7, docker 1.13.1) on `master`, `release-1.5`, nor `release-1.4`.  Our [docs on unit tests](https://github.com/kubernetes/community/blob/master/contributors/devel/testing.md#unit-tests) say they should always pass on OS X.  This PR allows them to pass.

**Release note**:
```release-note
NONE
```

ref: #24717 for the motivation behind dereferencing mount symlinks

/cc @kubernetes/sig-testing-pr-reviews
