### PR TITLE
rename variables to make sure that they conform to golang variable name conventions

### DIFF
--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -65,7 +65,7 @@ type AnnotateOptions struct {
 }
 
 var (
-	annotate_long = templates.LongDesc(`
+	annotateLong = templates.LongDesc(`
 		Update the annotations on one or more resources.
 
 		* An annotation is a key/value pair that can hold larger (compared to a label), and possibly not human-readable, data.
@@ -73,9 +73,9 @@ var (
 		* If --overwrite is true, then existing annotations can be overwritten, otherwise attempting to overwrite an annotation will result in an error.
 		* If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
 
-		` + valid_resources)
+		` + validResources)
 
-	annotate_example = templates.Examples(i18n.T(`
+	annotateExample = templates.Examples(i18n.T(`
     # Update pod 'foo' with the annotation 'description' and the value 'my frontend'.
     # If the same annotation is set multiple times, only the last value will be applied
     kubectl annotate pods foo description='my frontend'
@@ -114,8 +114,8 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]",
 		Short:   i18n.T("Update the annotations on a resource"),
-		Long:    annotate_long,
-		Example: annotate_example,
+		Long:    annotateLong,
+		Example: annotateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(out, cmd, args); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))

--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	apiversions_example = templates.Examples(i18n.T(`
+	apiversionsExample = templates.Examples(i18n.T(`
 		# Print the supported API versions
 		kubectl api-versions`))
 )
@@ -43,7 +43,7 @@ func NewCmdApiVersions(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Aliases: []string{"apiversions"},
 		Short:   "Print the supported API versions on the server, in the form of \"group/version\"",
 		Long:    "Print the supported API versions on the server, in the form of \"group/version\"",
-		Example: apiversions_example,
+		Example: apiversionsExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunApiVersions(f, out)
 			cmdutil.CheckErr(err)

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -72,7 +72,7 @@ const (
 )
 
 var (
-	apply_long = templates.LongDesc(i18n.T(`
+	applyLong = templates.LongDesc(i18n.T(`
 		Apply a configuration to a resource by filename or stdin.
 		This resource will be created if it doesn't exist yet.
 		To use 'apply', always create the resource initially with either 'apply' or 'create --save-config'.
@@ -81,7 +81,7 @@ var (
 
 		Alpha Disclaimer: the --prune functionality is not yet complete. Do not use unless you are aware of what the current state is. See https://issues.k8s.io/34274.`))
 
-	apply_example = templates.Examples(i18n.T(`
+	applyExample = templates.Examples(i18n.T(`
 		# Apply the configuration in pod.json to a pod.
 		kubectl apply -f ./pod.json
 
@@ -102,8 +102,8 @@ func NewCmdApply(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "apply -f FILENAME",
 		Short:   i18n.T("Apply a configuration to a resource by filename or stdin"),
-		Long:    apply_long,
-		Example: apply_example,
+		Long:    applyLong,
+		Example: applyExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(validateArgs(cmd, args))
 			cmdutil.CheckErr(validatePruneAll(options.Prune, cmdutil.GetFlagBool(cmd, "all"), options.Selector))

--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	attach_example = templates.Examples(i18n.T(`
+	attachExample = templates.Examples(i18n.T(`
 		# Get output from running pod 123456-7890, using the first container by default
 		kubectl attach 123456-7890
 
@@ -74,7 +74,7 @@ func NewCmdAttach(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) 
 		Use:     "attach (POD | TYPE/NAME) -c CONTAINER",
 		Short:   i18n.T("Attach to a running container"),
 		Long:    "Attach to a process that is already running inside an existing container.",
-		Example: attach_example,
+		Example: attachExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))
 			cmdutil.CheckErr(options.Validate())

--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -38,7 +38,7 @@ var (
   Display addresses of the master and services with label kubernetes.io/cluster-service=true
   To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.`))
 
-	clusterinfo_example = templates.Examples(i18n.T(`
+	clusterinfoExample = templates.Examples(i18n.T(`
 		# Print the address of the master and cluster services
 		kubectl cluster-info`))
 )
@@ -50,7 +50,7 @@ func NewCmdClusterInfo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Aliases: []string{"clusterinfo"},
 		Short:   i18n.T("Display cluster info"),
 		Long:    longDescr,
-		Example: clusterinfo_example,
+		Example: clusterinfoExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunClusterInfo(f, out, cmd)
 			cmdutil.CheckErr(err)

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	bash_completion_func = `# call kubectl get $1,
+	bashCompletionFunc = `# call kubectl get $1,
 __kubectl_override_flag_list=(kubeconfig cluster user context namespace server)
 __kubectl_override_flags()
 {
@@ -199,7 +199,7 @@ __custom_func() {
 	// If you add a resource to this list, please also take a look at pkg/kubectl/kubectl.go
 	// and add a short forms entry in expandResourceShortcut() when appropriate.
 	// TODO: This should be populated using the discovery information from apiserver.
-	valid_resources = `Valid resource types include:
+	validResources = `Valid resource types include:
 
     * all
     * certificatesigningrequests (aka 'csr')
@@ -260,7 +260,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 
       Find more information at https://github.com/kubernetes/kubernetes.`),
 		Run: runHelp,
-		BashCompletionFunction: bash_completion_func,
+		BashCompletionFunction: bashCompletionFunc,
 	}
 
 	f.BindFlags(cmds.PersistentFlags())

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -47,7 +47,7 @@ var (
 		will first check for an exact match on TYPE and NAME_PREFIX. If no such resource
 		exists, it will output details for every resource that has a name prefixed with NAME_PREFIX.
 
-		` + valid_resources)
+		` + validResources)
 
 	describe_example = templates.Examples(i18n.T(`
 		# Describe a node
@@ -111,7 +111,7 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 		enforceNamespace = false
 	}
 	if len(args) == 0 && cmdutil.IsFilenameEmpty(options.Filenames) {
-		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", valid_resources)
+		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", validResources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -34,7 +34,7 @@ var (
 	explainLong = templates.LongDesc(`
 		Documentation of resources.
 
-		` + valid_resources)
+		` + validResources)
 
 	explainExamples = templates.Examples(i18n.T(`
 		# Get the documentation of the resource and its fields
@@ -64,7 +64,7 @@ func NewCmdExplain(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 // RunExplain executes the appropriate steps to print a model's documentation
 func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		fmt.Fprint(cmdErr, "You must specify the type of resource to explain. ", valid_resources)
+		fmt.Fprint(cmdErr, "You must specify the type of resource to explain. ", validResources)
 		return cmdutil.UsageError(cmd, "Required resource not specified.")
 	}
 	if len(args) > 1 {

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -52,7 +52,7 @@ var (
 	get_long = templates.LongDesc(`
 		Display one or many resources.
 
-		` + valid_resources + `
+		` + validResources + `
 
 		This command will hide resources that have completed, such as pods that are
 		in the Succeeded or Failed phases. You can see the full results for any
@@ -174,7 +174,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 	}
 
 	if len(args) == 0 && cmdutil.IsFilenameEmpty(options.Filenames) {
-		fmt.Fprint(errOut, "You must specify the type of resource to get. ", valid_resources)
+		fmt.Fprint(errOut, "You must specify the type of resource to get. ", validResources)
 
 		fullCmdName := cmd.Parent().CommandPath()
 		usageString := "Required resource not specified."

--- a/pkg/kubectl/cmd/help.go
+++ b/pkg/kubectl/cmd/help.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/i18n"
 )
 
-var help_long = templates.LongDesc(i18n.T(`
+var helpLong = templates.LongDesc(i18n.T(`
 	Help provides help for any command in the application.
 	Simply type kubectl help [path to command] for full details.`))
 
@@ -33,7 +33,7 @@ func NewCmdHelp() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "help [command] | STRING_TO_SEARCH",
 		Short: i18n.T("Help about any command"),
-		Long:  help_long,
+		Long:  helpLong,
 
 		Run: RunHelp,
 	}

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -67,14 +67,14 @@ type LabelOptions struct {
 }
 
 var (
-	label_long = templates.LongDesc(i18n.T(`
+	labelLong = templates.LongDesc(i18n.T(`
 		Update the labels on a resource.
 
 		* A label must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to %[1]d characters.
 		* If --overwrite is true, then existing labels can be overwritten, otherwise attempting to overwrite a label will result in an error.
 		* If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.`))
 
-	label_example = templates.Examples(i18n.T(`
+	labelExample = templates.Examples(i18n.T(`
 		# Update pod 'foo' with the label 'unhealthy' and the value 'true'.
 		kubectl label pods foo unhealthy=true
 
@@ -112,8 +112,8 @@ func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]",
 		Short:   i18n.T("Update the labels on a resource"),
-		Long:    fmt.Sprintf(label_long, validation.LabelValueMaxLength),
-		Example: label_example,
+		Long:    fmt.Sprintf(labelLong, validation.LabelValueMaxLength),
+		Example: labelExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(out, cmd, args); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))

--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	logs_example = templates.Examples(i18n.T(`
+	logsExample = templates.Examples(i18n.T(`
 		# Return snapshot logs from pod nginx with only one container
 		kubectl logs nginx
 
@@ -94,7 +94,7 @@ func NewCmdLogs(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Use:     "logs [-f] [-p] (POD | TYPE/NAME) [-c CONTAINER]",
 		Short:   i18n.T("Print the logs for a container in a pod"),
 		Long:    "Print the logs for a container in a pod or specified resource. If the pod has only one container, the container name is optional.",
-		Example: logs_example,
+		Example: logsExample,
 		PreRun: func(cmd *cobra.Command, args []string) {
 			if len(os.Args) > 1 && os.Args[1] == "log" {
 				printDeprecationWarning("logs", "log")

--- a/pkg/kubectl/cmd/options.go
+++ b/pkg/kubectl/cmd/options.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	options_example = templates.Examples(i18n.T(`
+	optionsExample = templates.Examples(i18n.T(`
 		# Print flags inherited by all commands
 		kubectl options`))
 )
@@ -35,7 +35,7 @@ func NewCmdOptions() *cobra.Command {
 		Use:     "options",
 		Short:   i18n.T("Print the list of flags inherited by all commands"),
 		Long:    "Print the list of flags inherited by all commands",
-		Example: options_example,
+		Example: optionsExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Usage()
 		},

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -56,14 +56,14 @@ type PatchOptions struct {
 }
 
 var (
-	patch_long = templates.LongDesc(i18n.T(`
+	patchLong = templates.LongDesc(i18n.T(`
 		Update field(s) of a resource using strategic merge patch
 
 		JSON and YAML formats are accepted.
 
 		Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.`))
 
-	patch_example = templates.Examples(i18n.T(`
+	patchExample = templates.Examples(i18n.T(`
 		# Partially update a node using strategic merge patch
 		kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'
 
@@ -94,8 +94,8 @@ func NewCmdPatch(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "patch (-f FILENAME | TYPE NAME) -p PATCH",
 		Short:   i18n.T("Update field(s) of a resource using strategic merge patch"),
-		Long:    patch_long,
-		Example: patch_example,
+		Long:    patchLong,
+		Example: patchExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.OutputFormat = cmdutil.GetFlagString(cmd, "output")
 			err := RunPatch(f, out, cmd, args, options)

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -50,7 +50,7 @@ type PortForwardOptions struct {
 }
 
 var (
-	portforward_example = templates.Examples(i18n.T(`
+	portforwardExample = templates.Examples(i18n.T(`
 		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
 		kubectl port-forward mypod 5000 6000
 
@@ -75,7 +75,7 @@ func NewCmdPortForward(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.Comma
 		Use:     "port-forward POD [LOCAL_PORT:]REMOTE_PORT [...[LOCAL_PORT_N:]REMOTE_PORT_N]",
 		Short:   i18n.T("Forward one or more local ports to a pod"),
 		Long:    "Forward one or more local ports to a pod.",
-		Example: portforward_example,
+		Example: portforwardExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := opts.Complete(f, cmd, args); err != nil {
 				cmdutil.CheckErr(err)

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -32,8 +32,8 @@ import (
 )
 
 var (
-	default_port = 8001
-	proxy_long   = templates.LongDesc(i18n.T(`
+	defaultPort = 8001
+	proxyLong   = templates.LongDesc(i18n.T(`
 		To proxy all of the kubernetes api and nothing else, use:
 
 		    $ kubectl proxy --api-prefix=/
@@ -50,7 +50,7 @@ var (
 
 		The above lets you 'curl localhost:8001/custom/api/v1/pods'`))
 
-	proxy_example = templates.Examples(i18n.T(`
+	proxyExample = templates.Examples(i18n.T(`
 		# Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
 		kubectl proxy --port=8011 --www=./local/www/
 
@@ -67,8 +67,8 @@ func NewCmdProxy(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "proxy [--port=PORT] [--www=static-dir] [--www-prefix=prefix] [--api-prefix=prefix]",
 		Short:   i18n.T("Run a proxy to the Kubernetes API server"),
-		Long:    proxy_long,
-		Example: proxy_example,
+		Long:    proxyLong,
+		Example: proxyExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunProxy(f, out, cmd)
 			cmdutil.CheckErr(err)
@@ -81,7 +81,7 @@ func NewCmdProxy(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("reject-paths", kubectl.DefaultPathRejectRE, "Regular expression for paths that the proxy should reject.")
 	cmd.Flags().String("accept-hosts", kubectl.DefaultHostAcceptRE, "Regular expression for hosts that the proxy should accept.")
 	cmd.Flags().String("reject-methods", kubectl.DefaultMethodRejectRE, "Regular expression for HTTP methods that the proxy should reject.")
-	cmd.Flags().IntP("port", "p", default_port, "The port on which to run the proxy. Set to 0 to pick a random port.")
+	cmd.Flags().IntP("port", "p", defaultPort, "The port on which to run the proxy. Set to 0 to pick a random port.")
 	cmd.Flags().StringP("address", "", "127.0.0.1", "The IP address on which to serve on.")
 	cmd.Flags().Bool("disable-filter", false, "If true, disable request filtering in the proxy. This is dangerous, and can leave you vulnerable to XSRF attacks, when used with an accessible port.")
 	cmd.Flags().StringP("unix-socket", "u", "", "Unix socket on which to run the proxy.")
@@ -93,7 +93,7 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	port := cmdutil.GetFlagInt(cmd, "port")
 	address := cmdutil.GetFlagString(cmd, "address")
 
-	if port != default_port && path != "" {
+	if port != defaultPort && path != "" {
 		return errors.New("Don't specify both --unix-socket and --port")
 	}
 

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	replace_long = templates.LongDesc(i18n.T(`
+	replaceLong = templates.LongDesc(i18n.T(`
 		Replace a resource by filename or stdin.
 
 		JSON and YAML formats are accepted. If replacing an existing resource, the
@@ -47,7 +47,7 @@ var (
 
 		Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.`))
 
-	replace_example = templates.Examples(i18n.T(`
+	replaceExample = templates.Examples(i18n.T(`
 		# Replace a pod using the data in pod.json.
 		kubectl replace -f ./pod.json
 
@@ -69,8 +69,8 @@ func NewCmdReplace(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		// update is deprecated.
 		Aliases: []string{"update"},
 		Short:   i18n.T("Replace a resource by filename or stdin"),
-		Long:    replace_long,
-		Example: replace_example,
+		Long:    replaceLong,
+		Example: replaceExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
 			err := RunReplace(f, out, cmd, args, options)

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -43,7 +43,7 @@ import (
 )
 
 var (
-	rollingUpdate_long = templates.LongDesc(i18n.T(`
+	rollingUpdateLong = templates.LongDesc(i18n.T(`
 		Perform a rolling update of the given ReplicationController.
 
 		Replaces the specified replication controller with a new replication controller by updating one pod at a time to use the
@@ -52,7 +52,7 @@ var (
 
 		![Workflow](http://kubernetes.io/images/docs/kubectl_rollingupdate.svg)`))
 
-	rollingUpdate_example = templates.Examples(i18n.T(`
+	rollingUpdateExample = templates.Examples(i18n.T(`
 		# Update pods of frontend-v1 using new replication controller data in frontend-v2.json.
 		kubectl rolling-update frontend-v1 -f frontend-v2.json
 
@@ -84,8 +84,8 @@ func NewCmdRollingUpdate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		// rollingupdate is deprecated.
 		Aliases: []string{"rollingupdate"},
 		Short:   i18n.T("Perform a rolling update of the given ReplicationController"),
-		Long:    rollingUpdate_long,
-		Example: rollingUpdate_example,
+		Long:    rollingUpdateLong,
+		Example: rollingUpdateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunRollingUpdate(f, out, cmd, args, options)
 			cmdutil.CheckErr(err)

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -48,12 +48,12 @@ import (
 )
 
 var (
-	run_long = templates.LongDesc(i18n.T(`
+	runLong = templates.LongDesc(i18n.T(`
 		Create and run a particular image, possibly replicated.
 
 		Creates a deployment or job to manage the created container(s).`))
 
-	run_example = templates.Examples(i18n.T(`
+	runExample = templates.Examples(i18n.T(`
 		# Start a single instance of nginx.
 		kubectl run nginx --image=nginx
 
@@ -94,8 +94,8 @@ func NewCmdRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *co
 		// run-container is deprecated
 		Aliases: []string{"run-container"},
 		Short:   i18n.T("Run a particular image on the cluster"),
-		Long:    run_long,
-		Example: run_example,
+		Long:    runLong,
+		Example: runExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			argsLenAtDash := cmd.ArgsLenAtDash()
 			err := Run(f, cmdIn, cmdOut, cmdErr, cmd, args, argsLenAtDash)

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -31,7 +31,7 @@ import (
 )
 
 var (
-	scale_long = templates.LongDesc(i18n.T(`
+	scaleLong = templates.LongDesc(i18n.T(`
 		Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job.
 
 		Scale also allows users to specify one or more preconditions for the scale action.
@@ -40,7 +40,7 @@ var (
 		scale is attempted, and it is guaranteed that the precondition holds true when the
 		scale is sent to the server.`))
 
-	scale_example = templates.Examples(i18n.T(`
+	scaleExample = templates.Examples(i18n.T(`
 		# Scale a replicaset named 'foo' to 3.
 		kubectl scale --replicas=3 rs/foo
 
@@ -69,8 +69,8 @@ func NewCmdScale(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		// resize is deprecated
 		Aliases: []string{"resize"},
 		Short:   i18n.T("Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job"),
-		Long:    scale_long,
-		Example: scale_example,
+		Long:    scaleLong,
+		Example: scaleExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
 			shortOutput := cmdutil.GetFlagString(cmd, "output") == "name"

--- a/pkg/kubectl/cmd/stop.go
+++ b/pkg/kubectl/cmd/stop.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	stop_long = templates.LongDesc(i18n.T(`
+	stopLong = templates.LongDesc(i18n.T(`
 		Deprecated: Gracefully shut down a resource by name or filename.
 
 		The stop command is deprecated, all its functionalities are covered by delete command.
@@ -37,7 +37,7 @@ var (
 		Attempts to shut down and delete a resource that supports graceful termination.
 		If the resource is scalable it will be scaled to 0 before deletion.`))
 
-	stop_example = templates.Examples(i18n.T(`
+	stopExample = templates.Examples(i18n.T(`
 		# Shut down foo.
 		kubectl stop replicationcontroller foo
 
@@ -57,8 +57,8 @@ func NewCmdStop(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:        "stop (-f FILENAME | TYPE (NAME | -l label | --all))",
 		Short:      i18n.T("Deprecated: Gracefully shut down a resource by name or filename"),
-		Long:       stop_long,
-		Example:    stop_example,
+		Long:       stopLong,
+		Example:    stopExample,
 		Deprecated: fmt.Sprintf("use %q instead.", "delete"),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -62,7 +62,7 @@ type TaintOptions struct {
 }
 
 var (
-	taint_long = templates.LongDesc(i18n.T(`
+	taintLong = templates.LongDesc(i18n.T(`
 		Update the taints on one or more nodes.
 
 		* A taint consists of a key, value, and effect. As an argument here, it is expressed as key=value:effect.
@@ -71,7 +71,7 @@ var (
 		* The effect must be NoSchedule, PreferNoSchedule or NoExecute.
 		* Currently taint can only apply to node.`))
 
-	taint_example = templates.Examples(i18n.T(`
+	taintExample = templates.Examples(i18n.T(`
 		# Update node 'foo' with a taint with key 'dedicated' and value 'special-user' and effect 'NoSchedule'.
 		# If a taint with that key and effect already exists, its value is replaced as specified.
 		kubectl taint nodes foo dedicated=special-user:NoSchedule
@@ -92,8 +92,8 @@ func NewCmdTaint(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N",
 		Short:   i18n.T("Update the taints on one or more nodes"),
-		Long:    fmt.Sprintf(taint_long, validation.DNS1123SubdomainMaxLength, validation.LabelValueMaxLength),
-		Example: taint_example,
+		Long:    fmt.Sprintf(taintLong, validation.DNS1123SubdomainMaxLength, validation.LabelValueMaxLength),
+		Example: taintExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(f, out, cmd, args); err != nil {
 				cmdutil.CheckErr(err)

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -38,7 +38,7 @@ type Version struct {
 }
 
 var (
-	version_example = templates.Examples(i18n.T(`
+	versionExample = templates.Examples(i18n.T(`
 		# Print the client and server versions for the current context
 		kubectl version`))
 )
@@ -48,7 +48,7 @@ func NewCmdVersion(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Use:     "version",
 		Short:   i18n.T("Print the client and server version information"),
 		Long:    "Print the client and server version information for the current context",
-		Example: version_example,
+		Example: versionExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunVersion(f, out, cmd)
 			cmdutil.CheckErr(err)


### PR DESCRIPTION
rename variables to make sure that they conform to golang variable name conventions

**What this PR does / why we need it**:

there are lots of package level unexported variables in package `cmd` not conforming golang variable name conventions, such as `version_example`, in this PR i rename all of them to make sure that they conform to golang variable name conventions
