### PR TITLE
client-go: don't import client auth provider packages

### DIFF
--- a/cmd/kubectl/app/BUILD
+++ b/cmd/kubectl/app/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/util/logs:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
     ],
 )
 

--- a/cmd/kubectl/app/kubectl.go
+++ b/cmd/kubectl/app/kubectl.go
@@ -19,6 +19,7 @@ package app
 import (
 	"os"
 
+	_ "k8s.io/client-go/plugin/pkg/client/auth"         // kubectl auth providers.
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_clientset.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_clientset.go
@@ -63,8 +63,6 @@ func (g *genClientset) Imports(c *generator.Context) (imports []string) {
 	}
 	imports = append(imports, "github.com/golang/glog")
 	imports = append(imports, "k8s.io/client-go/util/flowcontrol")
-	// import solely to initialize client auth plugins.
-	imports = append(imports, "_ \"k8s.io/client-go/plugin/pkg/client/auth\"")
 	return
 }
 

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/BUILD
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/client-go/discovery",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/flowcontrol",
     ],

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/clientset.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/clientset.go
@@ -19,7 +19,6 @@ package test_internalclientset
 import (
 	"github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	internalversiontestgroup "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion"

--- a/federation/client/clientset_generated/federation_clientset/BUILD
+++ b/federation/client/clientset_generated/federation_clientset/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/client-go/discovery",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/flowcontrol",
     ],

--- a/federation/client/clientset_generated/federation_clientset/clientset.go
+++ b/federation/client/clientset_generated/federation_clientset/clientset.go
@@ -19,7 +19,6 @@ package federation_clientset
 import (
 	"github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	v1autoscaling "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1"

--- a/federation/client/clientset_generated/federation_internalclientset/BUILD
+++ b/federation/client/clientset_generated/federation_internalclientset/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/client-go/discovery",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/flowcontrol",
     ],

--- a/federation/client/clientset_generated/federation_internalclientset/clientset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/clientset.go
@@ -19,7 +19,6 @@ package federation_internalclientset
 import (
 	"github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	internalversionautoscaling "k8s.io/kubernetes/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion"

--- a/pkg/client/clientset_generated/clientset/BUILD
+++ b/pkg/client/clientset_generated/clientset/BUILD
@@ -46,7 +46,6 @@ go_library(
         "//pkg/client/clientset_generated/clientset/typed/storage/v1beta1:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/client-go/discovery",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/flowcontrol",
     ],

--- a/pkg/client/clientset_generated/clientset/clientset.go
+++ b/pkg/client/clientset_generated/clientset/clientset.go
@@ -19,7 +19,6 @@ package clientset
 import (
 	"github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	v1beta1apps "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/apps/v1beta1"

--- a/pkg/client/clientset_generated/internalclientset/BUILD
+++ b/pkg/client/clientset_generated/internalclientset/BUILD
@@ -42,7 +42,6 @@ go_library(
         "//pkg/client/clientset_generated/internalclientset/typed/storage/internalversion:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/client-go/discovery",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/flowcontrol",
     ],

--- a/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -19,7 +19,6 @@ package internalclientset
 import (
 	"github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	internalversionapps "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion"

--- a/staging/src/k8s.io/client-go/discovery/helper.go
+++ b/staging/src/k8s.io/client-go/discovery/helper.go
@@ -23,8 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
-	// Import solely to initialize client auth plugins.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
 // MatchesServerVersion queries the server to compares the build version

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -35,7 +35,6 @@ import (
 	v1alpha1rbac "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1"
 	v1beta1rbac "k8s.io/client-go/kubernetes/typed/rbac/v1beta1"
 	v1beta1storage "k8s.io/client-go/kubernetes/typed/storage/v1beta1"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 )

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -19,7 +19,6 @@ package clientset
 import (
 	"github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	v1alpha1apiregistration "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1alpha1"

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -19,7 +19,6 @@ package internalclientset
 import (
 	"github.com/golang/glog"
 	discovery "k8s.io/client-go/discovery"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/util/flowcontrol"
 	internalversionapiregistration "k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion"

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -12985,7 +12985,6 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/version",
         "//vendor:k8s.io/client-go/pkg/api",
         "//vendor:k8s.io/client-go/pkg/api/v1",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
     ],
 )
@@ -13575,7 +13574,6 @@ go_library(
         "//vendor:k8s.io/client-go/pkg/apis/policy/install",
         "//vendor:k8s.io/client-go/pkg/apis/rbac/install",
         "//vendor:k8s.io/client-go/pkg/apis/storage/install",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/flowcontrol",
     ],
@@ -16585,7 +16583,6 @@ go_library(
     deps = [
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/client-go/discovery",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/flowcontrol",
         "//vendor:k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1alpha1",
@@ -16664,7 +16661,6 @@ go_library(
     deps = [
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/client-go/discovery",
-        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/util/flowcontrol",
         "//vendor:k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion",


### PR DESCRIPTION
Both of these auth providers are useful for kubectl but not so much for everyone importing client-go. Let users optionally import them (example [0]) and reduce the overall number of imports that client-go requires.

Quick grep seems to imply it wont import it after.

```
$ grep -r 'client-go/plugin/pkg/client/auth' staging/
staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins.go:	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
staging/src/k8s.io/client-go/plugin/pkg/client/auth/plugins.go:	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
staging/src/k8s.io/client-go/examples/third-party-resources/main.go:	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go:	_ "k8s.io/client-go/plugin/pkg/client/auth"
staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go:	_ "k8s.io/client-go/plugin/pkg/client/auth"
```

closes https://github.com/kubernetes/client-go/issues/49
updates https://github.com/kubernetes/client-go/issues/79 (removes cloud.google.com/go import)

cc @kubernetes/sig-api-machinery-pr-reviews @kubernetes/sig-auth-pr-reviews 

```release-notes
client-go no longer imports GCP OAuth2 and OpenID Connect packages by default.
```

[0] https://github.com/kubernetes/client-go/blob/8b466d64c5da37e0d3985b907d812e1f58cb41cb/examples/third-party-resources/main.go#L34-L35