### PR TITLE
kubelet/envvars: Adding brackets to IPv6 addresses

### DIFF
--- a/pkg/kubelet/envvars/envvars.go
+++ b/pkg/kubelet/envvars/envvars.go
@@ -18,6 +18,7 @@ package envvars
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -78,18 +79,21 @@ func makeLinkVariables(service *v1.Service) []v1.EnvVar {
 		if sp.Protocol != "" {
 			protocol = string(sp.Protocol)
 		}
+
+		hostPort := net.JoinHostPort(service.Spec.ClusterIP, strconv.Itoa(int(sp.Port)))
+
 		if i == 0 {
 			// Docker special-cases the first port.
 			all = append(all, v1.EnvVar{
 				Name:  prefix + "_PORT",
-				Value: fmt.Sprintf("%s://%s:%d", strings.ToLower(protocol), service.Spec.ClusterIP, sp.Port),
+				Value: fmt.Sprintf("%s://%s", strings.ToLower(protocol), hostPort),
 			})
 		}
 		portPrefix := fmt.Sprintf("%s_PORT_%d_%s", prefix, sp.Port, strings.ToUpper(protocol))
 		all = append(all, []v1.EnvVar{
 			{
 				Name:  portPrefix,
-				Value: fmt.Sprintf("%s://%s:%d", strings.ToLower(protocol), service.Spec.ClusterIP, sp.Port),
+				Value: fmt.Sprintf("%s://%s", strings.ToLower(protocol), hostPort),
 			},
 			{
 				Name:  portPrefix + "_PROTO",

--- a/pkg/kubelet/envvars/envvars_test.go
+++ b/pkg/kubelet/envvars/envvars_test.go
@@ -79,6 +79,17 @@ func TestFromServices(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "super-ipv6"},
+			Spec: v1.ServiceSpec{
+				Selector:  map[string]string{"bar": "baz"},
+				ClusterIP: "2001:DB8::",
+				Ports: []v1.ServicePort{
+					{Name: "u-d-p", Port: 8084, Protocol: "UDP"},
+					{Name: "t-c-p", Port: 8084, Protocol: "TCP"},
+				},
+			},
+		},
 	}
 	vars := envvars.FromServices(sl)
 	expected := []v1.EnvVar{
@@ -114,6 +125,19 @@ func TestFromServices(t *testing.T) {
 		{Name: "Q_U_U_X_PORT_8083_TCP_PROTO", Value: "tcp"},
 		{Name: "Q_U_U_X_PORT_8083_TCP_PORT", Value: "8083"},
 		{Name: "Q_U_U_X_PORT_8083_TCP_ADDR", Value: "9.8.7.6"},
+		{Name: "SUPER_IPV6_SERVICE_HOST", Value: "2001:DB8::"},
+		{Name: "SUPER_IPV6_SERVICE_PORT", Value: "8084"},
+		{Name: "SUPER_IPV6_SERVICE_PORT_U_D_P", Value: "8084"},
+		{Name: "SUPER_IPV6_SERVICE_PORT_T_C_P", Value: "8084"},
+		{Name: "SUPER_IPV6_PORT", Value: "udp://[2001:DB8::]:8084"},
+		{Name: "SUPER_IPV6_PORT_8084_UDP", Value: "udp://[2001:DB8::]:8084"},
+		{Name: "SUPER_IPV6_PORT_8084_UDP_PROTO", Value: "udp"},
+		{Name: "SUPER_IPV6_PORT_8084_UDP_PORT", Value: "8084"},
+		{Name: "SUPER_IPV6_PORT_8084_UDP_ADDR", Value: "2001:DB8::"},
+		{Name: "SUPER_IPV6_PORT_8084_TCP", Value: "tcp://[2001:DB8::]:8084"},
+		{Name: "SUPER_IPV6_PORT_8084_TCP_PROTO", Value: "tcp"},
+		{Name: "SUPER_IPV6_PORT_8084_TCP_PORT", Value: "8084"},
+		{Name: "SUPER_IPV6_PORT_8084_TCP_ADDR", Value: "2001:DB8::"},
 	}
 	if len(vars) != len(expected) {
 		t.Errorf("Expected %d env vars, got: %+v", len(expected), vars)


### PR DESCRIPTION
Signed-off-by: André Martins <aanm90@gmail.com>

**What this PR does / why we need it**: This adds IPv6 brackets on environments variables pods

**Special notes for your reviewer**:

Since the IP is a string I think the fastest way to detect if it's an IPv6 was to check for the presence of `:` in it. Let me know what you think.
