### PR TITLE
extract createResource from if err != nil{}

### DIFF
--- a/pkg/kubectl/resource/helper.go
+++ b/pkg/kubectl/resource/helper.go
@@ -105,11 +105,7 @@ func (m *Helper) Delete(namespace, name string) error {
 func (m *Helper) Create(namespace string, modify bool, obj runtime.Object) (runtime.Object, error) {
 	if modify {
 		// Attempt to version the object based on client logic.
-		version, err := m.Versioner.ResourceVersion(obj)
-		if err != nil {
-			// We don't know how to clear the version on this object, so send it to the server as is
-			return m.createResource(m.RESTClient, m.Resource, namespace, obj)
-		}
+		version, _ := m.Versioner.ResourceVersion(obj)
 		if version != "" {
 			if err := m.Versioner.SetResourceVersion(obj, ""); err != nil {
 				return nil, err


### PR DESCRIPTION
 If m.Versioner.ResourceVersion(obj) return err, version must be “”,so since we do not print err info,we do not need to judge err,judging version is enough.