### PR TITLE
Ensure only 1 Swift URL is used in cluster operations

### DIFF
--- a/cluster/openstack-heat/util.sh
+++ b/cluster/openstack-heat/util.sh
@@ -194,7 +194,7 @@ function run-heat-script() {
     else
       rgx="publicURL: (.+)$"
     fi
-    SWIFT_SERVER_URL=$(openstack catalog show object-store --format value | egrep -o "$rgx" | cut -d" " -f2)
+    SWIFT_SERVER_URL=$(openstack catalog show object-store --format value | egrep -o "$rgx" | cut -d" " -f2 | head -n 1)
   fi
   local swift_repo_url="${SWIFT_SERVER_URL}/kubernetes"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Extracts only 1 Swift URL if multiple are returned from Keystone.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

https://github.com/kubernetes/kubernetes/issues/34930

**Special notes for your reviewer**:

**Release note**:
```release-note
Heat cluster operations now support environments that have multiple Swift URLs
```
