### PR TITLE
Bump fluentd-gcp google_cloud plugin version

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get -qq update && \
     sed -i -e "s/USER=td-agent/USER=root/" -e "s/GROUP=td-agent/GROUP=root/" /etc/init.d/td-agent && \
     td-agent-gem install --no-document fluent-plugin-record-reformer -v 0.8.2 && \
     td-agent-gem install --no-document fluent-plugin-systemd -v 0.0.5 && \
-    td-agent-gem install --no-document fluent-plugin-google-cloud -v 0.5.2 && \
+    td-agent-gem install --no-document fluent-plugin-google-cloud -v 0.5.6 && \
     td-agent-gem install --no-document fluent-plugin-detect-exceptions -v 0.0.4 && \
     # Remove build tools
     apt-get remove -y -qq gcc make && \


### PR DESCRIPTION
Bump the version of `fluent-plugin-google-cloud` in fluentd-gcp image, because it's broken for version `0.5.2`.

Recently, gem `google-api-client` was updated to version `0.10.0`. The new version broke `fluent-plugin-google-cloud` which doesn't specify the upper version of `google-api-client` gem. I'm bumping the version used in our image to allow future changes in this release to be run and tested.

This PR doesn't bump the version, since no effective changes has happened, leaving this for the next PR to do.

CC @igorpeshansky