### PR TITLE
only construct shortcutmapper when we have the discovery client

### DIFF
--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -72,11 +72,12 @@ func (f *ring1Factory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
 				api.Registry.RESTMapper(), // hardcoded fall back
 			},
 		}
-	}
 
-	// wrap with shortcuts
-	mapper, err = NewShortcutExpander(mapper, discoveryClient)
-	CheckErr(err)
+		// wrap with shortcuts, they require a discoveryClient
+		mapper, err = NewShortcutExpander(mapper, discoveryClient)
+		// you only have an error on missing discoveryClient, so this shouldn't fail.  Check anyway.
+		CheckErr(err)
+	}
 
 	// wrap with output preferences
 	cfg, err := f.clientAccessFactory.ClientConfigForVersion(nil)


### PR DESCRIPTION
Resource shortnames come from the discoveryclient, so we should only wrap with that mapper when we have the information we need.