### PR TITLE
deprecate and disconnect --output-version

### DIFF
--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -79,9 +79,7 @@ func NewCmdConfigView(out io.Writer, ConfigAccess clientcmd.ConfigAccess) *cobra
 
 			printer, _, err := cmdutil.PrinterForCommand(cmd)
 			cmdutil.CheckErr(err)
-			version, err := cmdutil.OutputVersion(cmd, &latest.ExternalVersion)
-			cmdutil.CheckErr(err)
-			printer = kubectl.NewVersionedPrinter(printer, latest.Scheme, version)
+			printer = kubectl.NewVersionedPrinter(printer, latest.Scheme, latest.ExternalVersion)
 
 			cmdutil.CheckErr(options.Run(out, printer))
 		},

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -80,8 +80,9 @@ func NewCmdConvert(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddPrinterFlags(cmd)
+	cmdutil.AddNonDeprecatedPrinterFlags(cmd)
 	cmd.Flags().BoolVar(&options.local, "local", true, "If true, convert will NOT try to contact api-server but run locally.")
+	cmd.Flags().String("output-version", "", "Output the formatted object with the given group version (for ex: 'extensions/v1beta1').")
 	cmdutil.AddInclude3rdPartyFlags(cmd)
 	return cmd
 }
@@ -100,9 +101,24 @@ type ConvertOptions struct {
 	outputVersion schema.GroupVersion
 }
 
+// outputVersion returns the preferred output version for generic content (JSON, YAML, or templates)
+// defaultVersion is never mutated.  Nil simply allows clean passing in common usage from client.Config
+func outputVersion(cmd *cobra.Command, defaultVersion *schema.GroupVersion) (schema.GroupVersion, error) {
+	outputVersionString := cmdutil.GetFlagString(cmd, "output-version")
+	if len(outputVersionString) == 0 {
+		if defaultVersion == nil {
+			return schema.GroupVersion{}, nil
+		}
+
+		return *defaultVersion, nil
+	}
+
+	return schema.ParseGroupVersion(outputVersionString)
+}
+
 // Complete collects information required to run Convert command from command line.
 func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) (err error) {
-	o.outputVersion, err = cmdutil.OutputVersion(cmd, &api.Registry.EnabledVersionsForGroup(api.GroupName)[0])
+	o.outputVersion, err = outputVersion(cmd, &api.Registry.EnabledVersionsForGroup(api.GroupName)[0])
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -117,9 +117,6 @@ func NewCmdEdit(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	cmdutil.AddFilenameOptionFlags(cmd, options, usage)
 	cmdutil.AddValidateFlags(cmd)
 	cmd.Flags().StringP("output", "o", "yaml", "Output format. One of: yaml|json.")
-	cmd.Flags().String("output-version", "", "DEPRECATED: To edit using a specific API version, fully-qualify the resource, version, and group (for example: 'jobs.v1.batch/myjob').")
-	cmd.Flags().MarkDeprecated("output-version", "editing is now done using the resource exactly as fetched from the API. To edit using a specific API version, fully-qualify the resource, version, and group (for example: 'jobs.v1.batch/myjob').")
-	cmd.Flags().MarkHidden("output-version")
 
 	cmd.Flags().Bool("windows-line-endings", gruntime.GOOS == "windows", "Use Windows line-endings (default Unix line-endings)")
 	cmdutil.AddApplyAnnotationFlags(cmd)

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -78,14 +78,6 @@ func (f *ring1Factory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
 	mapper, err = NewShortcutExpander(mapper, discoveryClient)
 	CheckErr(err)
 
-	// wrap with output preferences
-	cfg, err := f.clientAccessFactory.ClientConfigForVersion(nil)
-	checkErrWithPrefix("failed to get client config: ", err)
-	cmdApiVersion := schema.GroupVersion{}
-	if cfg.GroupVersion != nil {
-		cmdApiVersion = *cfg.GroupVersion
-	}
-	mapper = kubectl.OutputVersionMapper{RESTMapper: mapper, OutputVersions: []schema.GroupVersion{cmdApiVersion}}
 	return mapper, api.Scheme
 }
 
@@ -376,25 +368,15 @@ func (f *ring1Factory) PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTM
 
 	// Make sure we output versioned data for generic printers
 	if generic {
-		clientConfig, err := f.clientAccessFactory.ClientConfig()
-		if err != nil {
-			return nil, err
+		if mapping == nil {
+			return nil, fmt.Errorf("no serialization format found")
 		}
-
-		version, err := OutputVersion(cmd, clientConfig.GroupVersion)
-		if err != nil {
-			return nil, err
-		}
-		if version.Empty() && mapping != nil {
-			version = mapping.GroupVersionKind.GroupVersion()
-		}
+		version := mapping.GroupVersionKind.GroupVersion()
 		if version.Empty() {
-			return nil, fmt.Errorf("you must specify an output-version when using this output format")
+			return nil, fmt.Errorf("no serialization format found")
 		}
 
-		if mapping != nil {
-			printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version, mapping.GroupVersionKind.GroupVersion())
-		}
+		printer = kubectl.NewVersionedPrinter(printer, mapping.ObjectConvertor, version, mapping.GroupVersionKind.GroupVersion())
 
 	} else {
 		// Some callers do not have "label-columns" so we can't use the GetFlagStringSlice() helper

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 
@@ -31,8 +30,17 @@ import (
 
 // AddPrinterFlags adds printing related flags to a command (e.g. output format, no headers, template path)
 func AddPrinterFlags(cmd *cobra.Command) {
+	AddNonDeprecatedPrinterFlags(cmd)
+
+	cmd.Flags().String("output-version", "", "DEPRECATED: To use a specific API version, fully-qualify the resource, version, and group (for example: 'jobs.v1.batch/myjob').")
+	cmd.Flags().MarkDeprecated("output-version", "the resource is used exactly as fetched from the API. To get a specific API version, fully-qualify the resource, version, and group (for example: 'jobs.v1.batch/myjob').")
+	cmd.Flags().MarkHidden("output-version")
+}
+
+// AddNonDeprecatedPrinterFlags supports the conversion case which must logically have output-version.  Once output-version
+// is completely removed, this function can go away.
+func AddNonDeprecatedPrinterFlags(cmd *cobra.Command) {
 	AddOutputFlags(cmd)
-	cmd.Flags().String("output-version", "", "Output the formatted object with the given group version (for ex: 'extensions/v1beta1').")
 	AddNoHeadersFlags(cmd)
 	cmd.Flags().Bool("show-labels", false, "When printing, show all labels as the last column (default hide labels column)")
 	cmd.Flags().String("template", "", "Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].")
@@ -93,21 +101,6 @@ func ValidateOutputArgs(cmd *cobra.Command) error {
 		return UsageError(cmd, "Unexpected -o output mode: %v. We only support '-o name'.", outputMode)
 	}
 	return nil
-}
-
-// OutputVersion returns the preferred output version for generic content (JSON, YAML, or templates)
-// defaultVersion is never mutated.  Nil simply allows clean passing in common usage from client.Config
-func OutputVersion(cmd *cobra.Command, defaultVersion *schema.GroupVersion) (schema.GroupVersion, error) {
-	outputVersionString := GetFlagString(cmd, "output-version")
-	if len(outputVersionString) == 0 {
-		if defaultVersion == nil {
-			return schema.GroupVersion{}, nil
-		}
-
-		return *defaultVersion, nil
-	}
-
-	return schema.ParseGroupVersion(outputVersionString)
 }
 
 // PrinterForCommand returns the default printer for this command.

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"strings"
 
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/api"
 )
@@ -46,33 +45,6 @@ func listOfImages(spec *api.PodSpec) []string {
 
 func makeImageList(spec *api.PodSpec) string {
 	return strings.Join(listOfImages(spec), ",")
-}
-
-// OutputVersionMapper is a RESTMapper that will prefer mappings that
-// correspond to a preferred output version (if feasible)
-type OutputVersionMapper struct {
-	meta.RESTMapper
-
-	// output versions takes a list of preferred GroupVersions. Only the first
-	// hit for a given group will have effect.  This allows different output versions
-	// depending upon the group of the kind being requested
-	OutputVersions []schema.GroupVersion
-}
-
-// RESTMapping implements meta.RESTMapper by prepending the output version to the preferred version list.
-func (m OutputVersionMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
-	for _, preferredVersion := range m.OutputVersions {
-		if gk.Group == preferredVersion.Group {
-			mapping, err := m.RESTMapper.RESTMapping(gk, preferredVersion.Version)
-			if err == nil {
-				return mapping, nil
-			}
-
-			break
-		}
-	}
-
-	return m.RESTMapper.RESTMapping(gk, versions...)
 }
 
 // ResourceShortcuts represents a structure that holds the information how to


### PR DESCRIPTION
For at least two releases, there haven't been multiple versions of API groups and we don't plan to support conversions in commands other than `kubectl convert`.  This disconnects the `--output-version` option to be consistent with conversion agnostic command before it becomes an issue.

@kubernetes/sig-cli-pr-reviews @fabianofranz @smarterclayton

```release-note
`--output-version` is ignored for all commands except `kubectl convert`.  This is consistent with the generic nature of `kubectl` CRUD commands and the previous removal of `--api-version`.  Specific versions can be specified in the resource field: `resource.version.group`, `jobs.v1.batch`.
```
