### PR TITLE
Automated cherry pick of #41360

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -29,7 +29,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google_containers
-TAG = 1.28.2
+TAG = 1.28.3
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd-journal.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd-journal.conf
@@ -157,6 +157,28 @@
 </source>
 
 # Example:
+# 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
+# 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
+<source>
+  type tail
+  format multiline
+  multiline_flush_interval 5s
+  format_firstline /^\S+\s+AUDIT:/
+  # Fields must be explicitly captured by name to be parsed into the record.
+  # Fields may not always be present, and order may change, so this just looks
+  # for a list of key="\"quoted\" value" pairs separated by spaces.
+  # Unknown fields are ignored.
+  # Note: We can't separate query/response lines as format1/format2 because
+  #       they don't always come one after the other for a given query.
+  # TODO: Maybe add a JSON output mode to audit log so we can get rid of this?
+  format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
+  time_format %FT%T.%L%Z
+  path /var/log/kube-apiserver-audit.log
+  pos_file /var/log/gcp-kube-apiserver-audit.log.pos
+  tag kube-apiserver-audit
+</source>
+
+# Example:
 # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
 <source>
   type tail

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/google-fluentd.conf
@@ -158,6 +158,28 @@
 </source>
 
 # Example:
+# 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
+# 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
+<source>
+  type tail
+  format multiline
+  multiline_flush_interval 5s
+  format_firstline /^\S+\s+AUDIT:/
+  # Fields must be explicitly captured by name to be parsed into the record.
+  # Fields may not always be present, and order may change, so this just looks
+  # for a list of key="\"quoted\" value" pairs separated by spaces.
+  # Unknown fields are ignored.
+  # Note: We can't separate query/response lines as format1/format2 because
+  #       they don't always come one after the other for a given query.
+  # TODO: Maybe add a JSON output mode to audit log so we can get rid of this?
+  format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
+  time_format %FT%T.%L%Z
+  path /var/log/kube-apiserver-audit.log
+  pos_file /var/log/gcp-kube-apiserver-audit.log.pos
+  tag kube-apiserver-audit
+</source>
+
+# Example:
 # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
 <source>
   type tail

--- a/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.28.2
+    image: gcr.io/google_containers/fluentd-gcp:1.28.3
     command:
       - '/bin/sh'
       - '-c'

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.28.2
+    image: gcr.io/google_containers/fluentd-gcp:1.28.3
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
Cherry pick of #41360 on release-1.5.

#41360: fluentd-gcp: Add kube-apiserver-audit.log.