### PR TITLE
Cleanup make test-integration

### DIFF
--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -93,6 +93,7 @@ trap cleanup EXIT
 # If a test case is specified, just run once with v1 API version and exit
 if [[ -n "${KUBE_TEST_ARGS}" ]]; then
   runTests v1
+  exit 0
 fi
 
 # Pass arguments that begin with "-" and move them to goflags.

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -41,7 +41,7 @@ KUBE_TEST_ARGS=${KUBE_TEST_ARGS:-}
 kube::test::find_integration_test_dirs() {
   (
     cd ${KUBE_ROOT}
-    find test/integration/${1-} -name '*_test.go' -print0 \
+    find test/integration/ -name '*_test.go' -print0 \
       | xargs -0n1 dirname | sed "s|^|${KUBE_GO_PACKAGE}/|" \
       | LC_ALL=C sort -u
   )
@@ -67,7 +67,7 @@ runTests() {
   # TODO: Re-enable race detection when we switch to a thread-safe etcd client
   # KUBE_RACE="-race"
   make -C "${KUBE_ROOT}" test \
-      WHAT="$(kube::test::find_integration_test_dirs ${2-} | paste -sd' ' -) $(echo ${@:3})" \
+      WHAT="${WHAT:-$(kube::test::find_integration_test_dirs | paste -sd' ' -)}" \
       KUBE_GOFLAGS="${KUBE_GOFLAGS:-} -tags 'integration no-docker'" \
       KUBE_TEST_ARGS="${KUBE_TEST_ARGS:-} ${SHORT:--short=true} --vmodule=garbage*collector*=6 --alsologtostderr=true" \
       KUBE_RACE="" \
@@ -96,20 +96,8 @@ if [[ -n "${KUBE_TEST_ARGS}" ]]; then
   exit 0
 fi
 
-# Pass arguments that begin with "-" and move them to goflags.
-what_flags=()
-for arg in "$@"; do
-  if [[ "${arg}" == -* ]]; then
-    what_flags+=("${arg}")
-  fi
-done
-if [[ "${#what_flags[@]}" -eq 0 ]]; then
-  what_flags=''
-fi
-
-
 # Convert the CSV to an array of API versions to test
 IFS=';' read -a apiVersions <<< "${KUBE_TEST_API_VERSIONS}"
 for apiVersion in "${apiVersions[@]}"; do
-  runTests "${apiVersion}" "${1-}" "${what_flags[@]}"
+  runTests "${apiVersion}"
 done

--- a/hack/make-rules/test-integration.sh
+++ b/hack/make-rules/test-integration.sh
@@ -47,14 +47,20 @@ kube::test::find_integration_test_dirs() {
   )
 }
 
+CLEANUP_REQUIRED=
 cleanup() {
+  if [[ -z "${CLEANUP_REQUIRED}" ]]; then
+    return
+  fi
   kube::log::status "Cleaning up etcd"
   kube::etcd::cleanup
+  CLEANUP_REQUIRED=
   kube::log::status "Integration test cleanup complete"
 }
 
 runTests() {
   kube::log::status "Starting etcd instance"
+  CLEANUP_REQUIRED=1
   kube::etcd::start
   kube::log::status "Running integration test cases"
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -22,17 +22,12 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
-# For help output
-ARGHELP=""
-if [[ "$#" -gt 0 ]]; then
-    ARGHELP="WHAT='$@'"
-fi
-
-echo "NOTE: $0 has been replaced by 'make test-integration'"
+echo "$0 has been replaced by 'make test-integration'"
 echo
-echo "The equivalent of this invocation is: "
-echo "    make test-integration ${ARGHELP}"
+echo "The following invocation will run all integration tests: "
+echo '    make test-integration'
 echo
+echo "The following invocation will run a specific test with the verbose flag set: "
+echo '    make test-integration WHAT=./test/integration/pods KUBE_GOFLAGS="-v" KUBE_TEST_ARGS="-run ^TestPodUpdateActiveDeadlineSeconds$"'
 echo
-make --no-print-directory -C "${KUBE_ROOT}" test-integration WHAT="$*"
-
+exit 1


### PR DESCRIPTION
``make test-integration`` was using the first positional arg passed to ``WHAT`` to filter the list of integration test packages.  This PR switches to passing ``WHAT`` verbatim to be consistent with how ``make test`` works.  That means the new way to scope execution to a single integration package will be:

```bash
make test-integration WHAT="./test/integration/auth" KUBE_TEST_ARGS="-run=^TestKindAuthorization$"
```

Instead of:

```bash
make test-integration WHAT="auth -test.run=^TestKindAuthorization$"
```

This PR also ensures that the script exits after running a single test case and that etcd cleanup is not done twice at the end of a successful test run.  Both were issues encountered while diagnosing the scoping issue.

cc: @thockin @deads2k @stevekuznetsov @ncdc @derekwaynecarr  