### PR TITLE
Ingress: ability for GCE/GKE to reference "pre-shared" TLS cert

### DIFF
--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -40,6 +40,14 @@ const (
 	// allowed safe and unsafe sysctls in a pod spec. It's a comma-separated list of plain sysctl
 	// names or sysctl patterns (which end in *). The string "*" matches all sysctls.
 	SysctlsPodSecurityPolicyAnnotationKey string = "security.alpha.kubernetes.io/sysctls"
+
+	// IngressPreSharedCertAnnotationKey represents the specific pre-shared SSL
+	// certicate for the Ingress controller to use. The controller *does not*
+	// manage this certificate, it is the users responsibility to create/delete it.
+	// In GCE, the Ingress controller assigns the SSL certificate with this name
+	// to the target proxies of the Ingress.
+	// TODO: In Nginx.
+	IngressPreSharedCertAnnotationKey = "kubernetes.io/ingress.pre-shared-cert"
 )
 
 // describes the attributes of a scale subresource

--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -1174,8 +1174,9 @@ func TestValidateIngress(t *testing.T) {
 	newValid := func() extensions.Ingress {
 		return extensions.Ingress{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "foo",
-				Namespace: metav1.NamespaceDefault,
+				Name:        "foo",
+				Namespace:   metav1.NamespaceDefault,
+				Annotations: map[string]string{},
 			},
 			Spec: extensions.IngressSpec{
 				Backend: &extensions.IngressBackend{
@@ -1324,6 +1325,18 @@ func TestValidateIngressTLS(t *testing.T) {
 	}
 	badWildcardTLSErr := fmt.Sprintf("spec.tls[0].hosts: Invalid value: '%v'", wildcardHost)
 	errorCases[badWildcardTLSErr] = badWildcardTLS
+
+	secret := "tls-secret"
+	doubleTLSSource := newValid()
+	fmt.Println(doubleTLSSource)
+	doubleTLSSource.Annotations[extensions.IngressPreSharedCertAnnotationKey] = "reference-to-cert"
+	doubleTLSSource.Spec.TLS = []extensions.IngressTLS{
+		{
+			SecretName: secret,
+		},
+	}
+	doubleTLSSourceErr := fmt.Sprintf("metadata.annotations: Forbidden: may only specify 1 source for TLS (annotation or API)")
+	errorCases[doubleTLSSourceErr] = doubleTLSSource
 
 	for k, v := range errorCases {
 		errs := ValidateIngress(&v)

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -794,7 +794,10 @@ func formatHosts(rules []extensions.IngressRule) string {
 	return ret
 }
 
-func formatPorts(tls []extensions.IngressTLS) string {
+func formatPorts(annotations map[string]string, tls []extensions.IngressTLS) string {
+	if annotations[extensions.IngressPreSharedCertAnnotationKey] != "" {
+		return "80, 443"
+	}
 	if len(tls) != 0 {
 		return "80, 443"
 	}
@@ -816,7 +819,7 @@ func printIngress(ingress *extensions.Ingress, w io.Writer, options printers.Pri
 		name,
 		formatHosts(ingress.Spec.Rules),
 		loadBalancerStatusStringer(ingress.Status.LoadBalancer, options.Wide),
-		formatPorts(ingress.Spec.TLS),
+		formatPorts(ingress.Annotations, ingress.Spec.TLS),
 		translateTimestamp(ingress.CreationTimestamp),
 	); err != nil {
 		return err

--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -297,8 +297,13 @@ func BuildInsecureClient(timeout time.Duration) *http.Client {
 // createCertificate creates TLS certificates for the given Ingress.
 func createCertificate(ing *extensions.Ingress) (host string, rootCA, privKey []byte, err error) {
 	var k, c bytes.Buffer
-	tls := ing.Spec.TLS[0]
-	host = strings.Join(tls.Hosts, ",")
+	host = "example.com"
+
+	if len(ing.Spec.TLS) > 0 {
+		tls := ing.Spec.TLS[0]
+		host = strings.Join(tls.Hosts, ",")
+	}
+
 	Logf("Generating RSA cert for host %v", host)
 
 	if err = generateRSACerts(host, true, &k, &c); err != nil {

--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -724,10 +724,10 @@ func (cont *GCEIngressController) Init() {
 	}
 }
 
-// createTLSCertificate generates a random TLS cert with the given name. Returns
+// CreateTLSCertificate generates a random TLS cert with the given name. Returns
 // a string representing the name of the certificate. Caller is expected to
 // manage cleanup of the cert by invoking deleteTLSCertificate.
-func (j *IngressTestJig) createTLSCertificate(cont *GCEIngressController, name string) string {
+func (j *IngressTestJig) CreateTLSCertificate(cont *GCEIngressController, name string) string {
 	_, cert, key, err := createCertificate(j.Ingress)
 	if err != nil {
 		Failf("Failed to generate TLS cert %v: %v", name, err)
@@ -748,7 +748,7 @@ func (j *IngressTestJig) createTLSCertificate(cont *GCEIngressController, name s
 }
 
 // deleteTLSCertificate deletes all TLS certs allocated through calls to
-// createTLSCertificate.
+// CreateTLSCertificate.
 func (cont *GCEIngressController) deleteTLSCertificate() error {
 	if cont.certName != "" {
 		if err := GcloudComputeResourceDelete("ssl-certificates", cont.certName, cont.Cloud.ProjectID); err == nil {

--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -938,6 +938,15 @@ func (j *IngressTestJig) GetRootCA(secretName string) (rootCA []byte) {
 	return
 }
 
+// TODO: hard-coded, should use key defined
+func (j *IngressTestJig) AddPreSharedCert(certName string) {
+	j.Ingress.Annotations["kubernetes.io/ingress.pre-shared-cert"] = certName
+	Logf("Updating ingress %v to use TLS cert %v for TLS termination", j.Ingress.Name, certName)
+	j.Update(func(ing *extensions.Ingress) {
+		ing.Annotations["kubernetes.io/ingress.pre-shared-cert"] = certName
+	})
+}
+
 // DeleteIngress deletes the ingress resource
 func (j *IngressTestJig) DeleteIngress() {
 	ExpectNoError(j.Client.Extensions().Ingresses(j.Ingress.Namespace).Delete(j.Ingress.Name, nil))

--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -728,16 +728,16 @@ func (cont *GCEIngressController) Init() {
 // a string representing the name of the certificate. Caller is expected to
 // manage cleanup of the cert by invoking deleteTLSCertificate.
 func (j *IngressTestJig) createTLSCertificate(cont *GCEIngressController, name string) string {
-	host, cert, key, err := createCertificate(j.Ingress)
+	_, cert, key, err := createCertificate(j.Ingress)
 	if err != nil {
 		Failf("Failed to generate TLS cert %v: %v", name, err)
 	}
 
 	gceCloud := cont.Cloud.Provider.(*gcecloud.GCECloud)
-	c, err = gceCloud.CreateSslCertificate(&compute.SslCertificate{
+	c, err := gceCloud.CreateSslCertificate(&compute.SslCertificate{
 		Name:        name,
-		Certificate: cert,
-		PrivateKey:  key,
+		Certificate: string(cert),
+		PrivateKey:  string(key),
 	})
 	if err != nil {
 		Failf("Failed to create TLS cert %v: %v", name, err)

--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -374,7 +374,6 @@ func CleanupGCEIngressController(gceController *GCEIngressController) {
 		By(fmt.Sprintf("WARNING: possibly leaked static IP: %v\n", ipErr))
 	}
 
-	// TODO:
 	// TLS cert allocated on behalf of the test, never deleted by the
 	// controller. Delete this cert only after the controller has had a chance
 	// to cleanup or it might interfere with the controller, causing it to
@@ -390,7 +389,6 @@ func CleanupGCEIngressController(gceController *GCEIngressController) {
 		// of quota anyway.
 		By(fmt.Sprintf("WARNING: possibly leaked TLS cert: %v\n", certErr))
 	}
-	// TODO:
 
 	// Always try to cleanup even if pollErr == nil, because the cleanup
 	// routine also purges old leaked resources based on creation timestamp.

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -139,7 +139,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7", func() {
 			// framework.ExpectNoError(jig.verifyURL(fmt.Sprintf("https://%v/", ip), "", 30, 1*time.Second, httpClient))
 		})
 
-		It("should create ingress with pre-shared TLS certification", func() {
+		It("should create ingress with pre-shared TLS certificate", func() {
 			jig.createIngress(filepath.Join(ingressManifestPath, "pre-shared-cert"), ns, map[string]string{
 				"kubernetes.io/ingress.allow-http": "false",
 			})

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
@@ -1,0 +1,12 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: pre-shared-cert
+  # This annotation is added by the test upon creating a TLS cert.
+  # annotations:
+  #  kubernetes.io/ingress.pre-shared-cert: "certname"
+spec:
+  backend:
+    serviceName: echoheaders-https
+    servicePort: 80
+

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: echoheaders-https
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: echoheaders-https
+    spec:
+      containers:
+      - name: echoheaders-https
+        image: gcr.io/google_containers/echoserver:1.4
+        ports:
+        - containerPort: 8080

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/rc.yaml
@@ -1,16 +1,1 @@
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: echoheaders-https
-spec:
-  replicas: 2
-  template:
-    metadata:
-      labels:
-        app: echoheaders-https
-    spec:
-      containers:
-      - name: echoheaders-https
-        image: gcr.io/google_containers/echoserver:1.4
-        ports:
-        - containerPort: 8080
+../static-ip/rc.yaml

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoheaders-https
+  labels:
+    app: echoheaders-https
+spec:
+  type: NodePort
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+    name: http
+  selector:
+    app: echoheaders-https

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/svc.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/svc.yaml
@@ -1,15 +1,1 @@
-apiVersion: v1
-kind: Service
-metadata:
-  name: echoheaders-https
-  labels:
-    app: echoheaders-https
-spec:
-  type: NodePort
-  ports:
-  - port: 80
-    targetPort: 8080
-    protocol: TCP
-    name: http
-  selector:
-    app: echoheaders-https
+../static-ip/svc.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
- Validation of Ingress extension annotation + spec
- Ingress annotation key
- unit test for validation code
- e2e test for creating an Ingress using a "pre-shared" cert in GCE

**Which issue this PR fixes**:
Related to https://github.com/kubernetes/ingress/pull/291.

**Special notes for your reviewer**:
- [ ] `TODO` item on naming of this annotation key (https://github.com/kubernetes/kubernetes/pull/41593/files#diff-e1c628c34c42840b0392c48481d41320R50)
- [ ] `TODO` on using hard code reference (https://github.com/kubernetes/kubernetes/pull/41593/files#diff-e16855fea21e8f1c5fc244fb70a02917R941)

Also, please correct mistakes, it is my first time making a code contribution to k8s and writing e2e tests.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
