### PR TITLE
Allow `make test-integration` to pass on OSX

### DIFF
--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -57,6 +57,10 @@ func TestRunServer(t *testing.T) {
 	defer os.Remove(kubeconfigFile.Name())
 	clientcmd.WriteToFile(*adminKubeConfig, kubeconfigFile.Name())
 
+	// Avoid default cert-dir of /var/run/kubernetes to allow this to run on darwin
+	certDir, _ := ioutil.TempDir("", "test-integration-apiserver")
+	defer os.Remove(certDir)
+
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	cmd := server.NewCommandStartWardleServer(os.Stdout, os.Stderr, stopCh)
@@ -66,6 +70,7 @@ func TestRunServer(t *testing.T) {
 		"--authentication-kubeconfig", kubeconfigFile.Name(),
 		"--authorization-kubeconfig", kubeconfigFile.Name(),
 		"--etcd-servers", framework.GetEtcdURLFromEnv(),
+		"--cert-dir", certDir,
 	})
 	go cmd.Execute()
 

--- a/test/integration/kubeaggregator/aggregator_test.go
+++ b/test/integration/kubeaggregator/aggregator_test.go
@@ -18,7 +18,9 @@ package kubeaggregator
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -50,6 +52,12 @@ func runAPIServer(t *testing.T, stopCh <-chan struct{}) string {
 	// Change the ports, because otherwise it will fail if examples/apiserver/apiserver_test and this are run in parallel.
 	serverRunOptions.SecureServing.ServingOptions.BindPort = 6443 + 3
 	serverRunOptions.InsecureServing.BindPort = 8080 + 3
+
+	// Avoid default cert-dir of /var/run/kubernetes to allow this to run on darwin
+	certDir, _ := ioutil.TempDir("", "test-integration-kubeaggregator")
+	defer os.Remove(certDir)
+	serverRunOptions.SecureServing.ServerCert.CertDirectory = certDir
+
 	go func() {
 		if err := serverRunOptions.Run(stopCh); err != nil {
 			t.Fatalf("Error in bringing up the example apiserver: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**: `make test-integration` isn't passing on my OSX setup (10.11.6, go1.7, docker 1.13.1).  Tests that startup an api server fail because the default `cert-dir` of `/var/run/kubernetes` isn't world-writable.  Use a tempdir instead.

**Release note**:
```release-note
NONE
```

/cc @kubernetes/sig-testing-pr-reviews 
