### PR TITLE
Modify kubemark run-e2e-tests.sh to run right command based on environment

### DIFF
--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -38,6 +38,10 @@ else
 	ARGS=$@
 fi
 
-go run ./hack/e2e.go -v --check_version_skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
-# Just make local test easier...
-# ${KUBE_ROOT}/hack/ginkgo-e2e.sh "--e2e-verify-service-account=false" "--dump-logs-on-failure=false" $ARGS
+if [[ -f /.dockerenv ]]; then
+	# Running inside a dockerized runner.
+	go run ./hack/e2e.go -v --check_version_skew=false --test --test_args="--e2e-verify-service-account=false --dump-logs-on-failure=false ${ARGS}"
+else
+	# Running locally.
+	${KUBE_ROOT}/hack/ginkgo-e2e.sh "--e2e-verify-service-account=false" "--dump-logs-on-failure=false" $ARGS
+fi


### PR DESCRIPTION
In order to run-e2e-tests.sh in kubemark, we currently need to toggle comment b/w the last 2 lines of the script. This is inconvenient to change each time and sometimes this change gets accidentally included as part of a PR. It's even difficult for someone newly trying kubemark to figure this out in order to run tests. Changed the logic to use the right command based on whether the script is running from within a docker container or just locally.

cc @kubernetes/sig-scalability-misc @wojtek-t @gmarek 