### PR TITLE
Defaulting client certs owner to current user if not speicified

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -42,6 +42,8 @@ CGROUPS_PER_QOS=${CGROUPS_PER_QOS:-false}
 CGROUP_ROOT=${CGROUP_ROOT:-""}
 # name of the cgroup driver, i.e. cgroupfs or systemd
 CGROUP_DRIVER=${CGROUP_DRIVER:-""}
+# owner of client certs, default to current user if not specified
+USER=${USER:-$(whoami)}
 
 # enables testing eviction scenarios locally.
 EVICTION_HARD=${EVICTION_HARD:-"memory.available<100Mi"}


### PR DESCRIPTION
**What this PR does / why we need it**:

Defaulting client certs owner to current user if not speicified.

**Which issue this PR fixes** 

Fixes #41560.

**Release note**:

```release-note
NONE
```

cc/ @sttts @liggitt