### PR TITLE
Workaround for outbound Internet traffic in acs (windows Kubernetes in Azure)

### DIFF
--- a/pkg/kubelet/dockertools/docker.go
+++ b/pkg/kubelet/dockertools/docker.go
@@ -30,6 +30,7 @@ import (
 	"github.com/docker/docker/pkg/jsonmessage"
 	dockerapi "github.com/docker/engine-api/client"
 	dockertypes "github.com/docker/engine-api/types"
+	dockernetworktypes "github.com/docker/engine-api/types/network"
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -56,6 +57,7 @@ type DockerInterface interface {
 	StartContainer(id string) error
 	StopContainer(id string, timeout int) error
 	RemoveContainer(id string, opts dockertypes.ContainerRemoveOptions) error
+	ConnectNetwork(id string, containerID string, config *dockernetworktypes.EndpointSettings) error
 	InspectImageByRef(imageRef string) (*dockertypes.ImageInspect, error)
 	InspectImageByID(imageID string) (*dockertypes.ImageInspect, error)
 	ListImages(opts dockertypes.ImageListOptions) ([]dockertypes.Image, error)

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -845,6 +845,11 @@ func (dm *DockerManager) runContainer(
 	}
 	dm.recorder.Eventf(ref, v1.EventTypeNormal, events.CreatedContainer, createdEventMsg)
 
+	// Windows specific workaround to configure networking post container creation.
+	// Uncomment below once we have network namespace sharing is available
+	//if container.Name == PodInfraContainerName {
+	dm.configureInfraContainerNetworkConfig(createResp.ID)
+
 	if err = dm.client.StartContainer(createResp.ID); err != nil {
 		dm.recorder.Eventf(ref, v1.EventTypeWarning, events.FailedToStartContainer,
 			"Failed to start container with docker id %v with error: %v", utilstrings.ShortenString(createResp.ID, 12), err)
@@ -852,6 +857,15 @@ func (dm *DockerManager) runContainer(
 	}
 	dm.recorder.Eventf(ref, v1.EventTypeNormal, events.StartedContainer, "Started container with docker id %v", utilstrings.ShortenString(createResp.ID, 12))
 
+	// Windows specific workaround to configure networking post container creation.
+	dns := ""
+	if len(opts.DNS) > 0 {
+		dns = opts.DNS[0]
+	}
+
+	// Uncomment below once we have network namespace sharing is available
+	//if container.Name == PodInfraContainerName {
+	dm.FinalizeInfraContainerNetwork(kubecontainer.DockerID(createResp.ID).ContainerID(), dns)
 	return kubecontainer.DockerID(createResp.ID).ContainerID(), nil
 }
 

--- a/pkg/kubelet/dockertools/docker_manager_linux.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux.go
@@ -51,6 +51,16 @@ func getContainerIP(container *dockertypes.ContainerJSON) string {
 // We don't want to override the networking mode on Linux.
 func getNetworkingMode() string { return "" }
 
+// Configure Infra Networking post Container Creation, before the container starts
+func (dm *DockerManager) configureInfraContainerNetworkConfig(containerID string) {
+	// Do nothing
+}
+
+// Configure Infra Networking post Container Creation, after the container starts
+func (dm *DockerManager) FinalizeInfraContainerNetwork(containerID kubecontainer.ContainerID, DNS string) {
+	// Do nothing
+}
+
 // Returns true if the container name matches the infrastructure's container name
 func containerProvidesPodIP(containerName string) bool {
 	return containerName == PodInfraContainerName

--- a/pkg/kubelet/dockertools/docker_manager_unsupported.go
+++ b/pkg/kubelet/dockertools/docker_manager_unsupported.go
@@ -46,6 +46,16 @@ func containerProvidesPodIP(containerName string) bool {
 	return false
 }
 
+// Configure Infra Networking post Container Creation, before the container starts
+func (dm *DockerManager) configureInfraContainerNetworkConfig(containerID string) {
+	// Do nothing
+}
+
+// Configure Infra Networking post Container Creation, after the container starts
+func (dm *DockerManager) FinalizeInfraContainerNetwork(containerID kubecontainer.ContainerID, DNS string) {
+	// Do nothing
+}
+
 func containerIsNetworked(containerName string) bool {
 	return false
 }

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	dockertypes "github.com/docker/engine-api/types"
+	dockernetworktypes "github.com/docker/engine-api/types/network"
 	dockercontainer "github.com/docker/engine-api/types/container"
 	"k8s.io/client-go/util/clock"
 
@@ -538,6 +539,20 @@ func (f *FakeDockerClient) RemoveContainer(id string, opts dockertypes.Container
 	// To be a good fake, report error if container is not stopped.
 	return fmt.Errorf("container not stopped")
 }
+
+func (f *FakeDockerClient) ConnectNetwork(id string, containerID string, config *dockernetworktypes.EndpointSettings) error {
+	f.Lock()
+	defer f.Unlock()
+	f.appendCalled(calledDetail{name: "connect"})
+	err := f.popError("connect")
+	if err != nil {
+		return err
+	}
+	// TBD
+	// To be a good fake, report error if container is not stopped.
+	return nil
+}
+
 
 // Logs is a test-spy implementation of DockerInterface.Logs.
 // It adds an entry "logs" to the internal method call record.

--- a/pkg/kubelet/dockertools/instrumented_docker.go
+++ b/pkg/kubelet/dockertools/instrumented_docker.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	dockertypes "github.com/docker/engine-api/types"
+	dockernetworktypes "github.com/docker/engine-api/types/network"
 	"k8s.io/kubernetes/pkg/kubelet/metrics"
 )
 
@@ -103,6 +104,16 @@ func (in instrumentedDockerInterface) RemoveContainer(id string, opts dockertype
 	defer recordOperation(operation, time.Now())
 
 	err := in.client.RemoveContainer(id, opts)
+	recordError(operation, err)
+	return err
+}
+
+func (in instrumentedDockerInterface) ConnectNetwork(id string, containerID string, config *dockernetworktypes.EndpointSettings) error {
+
+	const operation = "connect_network"
+	defer recordOperation(operation, time.Now())
+
+	err := in.client.ConnectNetwork(id, containerID, config)
 	recordError(operation, err)
 	return err
 }

--- a/pkg/kubelet/dockertools/kube_docker_client.go
+++ b/pkg/kubelet/dockertools/kube_docker_client.go
@@ -33,6 +33,7 @@ import (
 	dockerstdcopy "github.com/docker/docker/pkg/stdcopy"
 	dockerapi "github.com/docker/engine-api/client"
 	dockertypes "github.com/docker/engine-api/types"
+	dockernetworktypes "github.com/docker/engine-api/types/network"
 	"golang.org/x/net/context"
 )
 
@@ -172,6 +173,17 @@ func (d *kubeDockerClient) RemoveContainer(id string, opts dockertypes.Container
 	ctx, cancel := d.getTimeoutContext()
 	defer cancel()
 	err := d.client.ContainerRemove(ctx, id, opts)
+	if ctxErr := contextError(ctx); ctxErr != nil {
+		return ctxErr
+	}
+	return err
+}
+
+func (d *kubeDockerClient) ConnectNetwork(id string, containerID string, config *dockernetworktypes.EndpointSettings) error {
+
+	ctx, cancel := d.getTimeoutContext()
+	defer cancel()
+	err := d.client.NetworkConnect(ctx, id, containerID, config)
 	if ctxErr := contextError(ctx); ctxErr != nil {
 		return ctxErr
 	}


### PR DESCRIPTION
Following are the workaround added to overcome the current limitation and provide network connectivity for the PODS in windows.

(*) Connect a Nat Network to the container (Second adapter)
(*) Modify the route so that internet traffic goes via Nat network, and POD traffic goes over the CONTAINER_NETWORK
(*) Modify getContainerIP to return the IP corresponding to POD network, and ignore Nat Network

**What this PR does / why we need it**:
This PR enables Kubernetes to work in Windows, deployed in Azure
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
