### PR TITLE
Improved code coverage for /pkg/kubelet/types

### DIFF
--- a/pkg/kubelet/types/BUILD
+++ b/pkg/kubelet/types/BUILD
@@ -35,6 +35,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )

--- a/pkg/kubelet/types/types_test.go
+++ b/pkg/kubelet/types/types_test.go
@@ -20,8 +20,82 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/api/v1"
 )
+
+func TestConvertToTimestamp(t *testing.T) {
+	timestamp := "2017-02-17T15:34:49.830882016+08:00"
+	convertedTimeStamp := ConvertToTimestamp(timestamp).GetString()
+	assert.Equal(t, timestamp, convertedTimeStamp)
+}
+
+func TestLen(t *testing.T) {
+	var cases = []struct {
+		statuses SortedContainerStatuses
+		expected int
+	}{
+		{
+			statuses: SortedContainerStatuses{{Name: "first"}},
+			expected: 1,
+		},
+		{
+			statuses: SortedContainerStatuses{{Name: "first"}, {Name: "second"}},
+			expected: 2,
+		},
+	}
+	for _, data := range cases {
+		assert.Equal(t, data.expected, data.statuses.Len())
+	}
+}
+
+func TestSwap(t *testing.T) {
+	var cases = []struct {
+		statuses SortedContainerStatuses
+		expected SortedContainerStatuses
+	}{
+		{
+			statuses: SortedContainerStatuses{{Name: "first"}, {Name: "second"}},
+			expected: SortedContainerStatuses{{Name: "second"}, {Name: "first"}},
+		},
+	}
+	for _, data := range cases {
+		data.statuses.Swap(0, 1)
+		if !reflect.DeepEqual(data.statuses, data.expected) {
+			t.Errorf(
+				"failed Swap:\n\texpected: %v\n\t  actual: %v",
+				data.expected,
+				data.statuses,
+			)
+		}
+	}
+}
+
+func TestLess(t *testing.T) {
+	var cases = []struct {
+		statuses SortedContainerStatuses
+		expected bool
+	}{
+		{
+			statuses: SortedContainerStatuses{{Name: "first"}, {Name: "second"}},
+			expected: true,
+		},
+		{
+			statuses: SortedContainerStatuses{{Name: "second"}, {Name: "first"}},
+			expected: false,
+		},
+	}
+	for _, data := range cases {
+		actual := data.statuses.Less(0, 1)
+		if actual != data.expected {
+			t.Errorf(
+				"failed Less:\n\texpected: %t\n\t  actual: %t",
+				data.expected,
+				actual,
+			)
+		}
+	}
+}
 
 func TestSortInitContainerStatuses(t *testing.T) {
 	pod := v1.Pod{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
The test coverage for /pkg/kubelet/types was increased from 50% to 87.5%

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
