### PR TITLE
Fix kubeadm version check

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -22,11 +22,9 @@ const (
 	DefaultServiceDNSDomain  = "cluster.local"
 	DefaultServicesSubnet    = "10.96.0.0/12"
 	DefaultKubernetesVersion = "latest"
-	// This is only for clusters without internet, were the latest stable version can't be determined
-	DefaultKubernetesFallbackVersion = "v1.6.0-alpha.1"
-	DefaultAPIBindPort               = 6443
-	DefaultDiscoveryBindPort         = 9898
-	DefaultAuthorizationMode         = "RBAC"
+	DefaultAPIBindPort       = 6443
+	DefaultDiscoveryBindPort = 9898
+	DefaultAuthorizationMode = "RBAC"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {

--- a/cmd/kubeadm/app/cmd/defaults.go
+++ b/cmd/kubeadm/app/cmd/defaults.go
@@ -50,7 +50,9 @@ func setInitDynamicDefaults(cfg *kubeadmapi.MasterConfiguration) error {
 		if cfg.KubernetesVersion != kubeadmapiext.DefaultKubernetesVersion {
 			return err
 		} else {
-			ver = kubeadmapiext.DefaultKubernetesFallbackVersion
+			// Cann't get the real control plane version
+			ver = "v" + kubeadmconstants.MinimumControlPlaneVersion
+			fmt.Printf("[init] WARNING: cann't parse the control plane version '%s', using MinimumControlPlaneVersion\n", cfg.KubernetesVersion)
 		}
 	}
 	cfg.KubernetesVersion = ver


### PR DESCRIPTION
```
#kubeadm init 
[kubeadm] WARNING: kubeadm is in alpha, please do not use it for production clusters.
this version of kubeadm only supports deploying clusters with the control plane version >= v1.6.0-alpha.2. Current version: v1.6.0-alpha.1
```
The current version in the result is not current. Change the error to warning when clusters without internet. 
