### PR TITLE
Add pod_infra_container_image support to local-up-cluster.sh script

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -190,6 +190,7 @@ LOG_LEVEL=${LOG_LEVEL:-3}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"docker"}
 CONTAINER_RUNTIME_ENDPOINT=${CONTAINER_RUNTIME_ENDPOINT:-""}
 IMAGE_SERVICE_ENDPOINT=${IMAGE_SERVICE_ENDPOINT:-""}
+POD_INFRA_CONTAINER_IMAGE=${POD_INFRA_CONTAINER_IMAGE:-""}
 ENABLE_CRI=${ENABLE_CRI:-"true"}
 RKT_PATH=${RKT_PATH:-""}
 RKT_STAGE1_IMAGE=${RKT_STAGE1_IMAGE:-""}
@@ -579,6 +580,10 @@ function start_kubelet {
       if [[ -n "${IMAGE_SERVICE_ENDPOINT}" ]]; then
         image_service_endpoint_args="--image-service-endpoint=${IMAGE_SERVICE_ENDPOINT}"
       fi
+      pod_infra_container_image_args=""
+      if [[ -n "${POD_INFRA_CONTAINER_IMAGE}" ]]; then
+        pod_infra_container_image_args="--pod-infra-container-image=${POD_INFRA_CONTAINER_IMAGE}"
+      fi
 
       sudo -E "${GO_OUT}/hyperkube" kubelet ${priv_arg}\
         --enable-cri="${ENABLE_CRI}" \
@@ -609,8 +614,9 @@ function start_kubelet {
         ${net_plugin_args} \
         ${container_runtime_endpoint_args} \
         ${image_service_endpoint_args} \
+        ${pod_infra_container_image_args} \
         --port="$KUBELET_PORT" \
-	${KUBELET_FLAGS} >"${KUBELET_LOG}" 2>&1 &
+        ${KUBELET_FLAGS} >"${KUBELET_LOG}" 2>&1 &
       KUBELET_PID=$!
       # Quick check that kubelet is running.
       if ps -p $KUBELET_PID > /dev/null ; then 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR will add the support to customize pod_infra_container_image parameter of kubelet using environment variable, so we can easily use the infra image of ourself, it'll help in two cases:
1) The user customize the infra image and need to let kubelet pull from the private docker registry

2) Due to GFW in China, we're not able to pull images from gcr.io, so we need this parameter to use local docker registry service to pull the image

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
NONE
```
