### PR TITLE
api/fieldpath: Expose single annotations via downward API

### DIFF
--- a/pkg/apis/core/v1/BUILD
+++ b/pkg/apis/core/v1/BUILD
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/extensions:go_default_library",
+        "//pkg/util/annotations:go_default_library",
         "//pkg/util/parsers:go_default_library",
         "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/util/annotations"
 )
 
 // This is a "fast-path" that avoids reflection for common types. It focuses on the objects that are
@@ -156,6 +157,10 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	// Add field conversion funcs.
 	err = scheme.AddFieldLabelConversionFunc("v1", "Pod",
 		func(label, value string) (string, string, error) {
+			if ok, _ := annotations.ValidateAndParse(label); ok {
+				return label, value, nil
+			}
+
 			switch label {
 			case "metadata.annotations",
 				"metadata.labels",

--- a/pkg/apis/core/validation/BUILD
+++ b/pkg/apis/core/validation/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//pkg/capabilities:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/security/apparmor:go_default_library",
+        "//pkg/util/annotations:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/security/apparmor"
+	"k8s.io/kubernetes/pkg/util/annotations"
 )
 
 // TODO: delete this global variable when we enable the validation of common
@@ -1788,10 +1789,17 @@ func validateObjectFieldSelector(fs *core.ObjectFieldSelector, expressions *sets
 		allErrs = append(allErrs, field.Required(fldPath.Child("fieldPath"), ""))
 	} else {
 		internalFieldPath, _, err := legacyscheme.Scheme.ConvertFieldLabel(fs.APIVersion, "Pod", fs.FieldPath, "")
+		isAnnotationFieldPathValid, key := annotations.ValidateAndParse(internalFieldPath)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("fieldPath"), fs.FieldPath, fmt.Sprintf("error converting fieldPath: %v", err)))
-		} else if !expressions.Has(internalFieldPath) {
+		} else if !expressions.Has(internalFieldPath) && !isAnnotationFieldPathValid {
 			allErrs = append(allErrs, field.NotSupported(fldPath.Child("fieldPath"), internalFieldPath, expressions.List()))
+		}
+
+		if isAnnotationFieldPathValid {
+			for _, msg := range validation.IsQualifiedName(key) {
+				allErrs = append(allErrs, field.Invalid(fldPath, key, msg))
+			}
 		}
 	}
 

--- a/pkg/fieldpath/BUILD
+++ b/pkg/fieldpath/BUILD
@@ -13,7 +13,10 @@ go_library(
         "fieldpath.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/fieldpath",
-    deps = ["//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library"],
+    deps = [
+        "//pkg/util/annotations:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/fieldpath/fieldpath.go
+++ b/pkg/fieldpath/fieldpath.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/kubernetes/pkg/util/annotations"
 )
 
 // FormatMap formats map[string]string to a string.
@@ -40,6 +41,11 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return "", nil
+	}
+
+	isAnnotationFieldPathValid, key := annotations.ValidateAndParse(fieldPath)
+	if isAnnotationFieldPathValid {
+		return accessor.GetAnnotations()[key], nil
 	}
 
 	switch fieldPath {

--- a/pkg/fieldpath/fieldpath_test.go
+++ b/pkg/fieldpath/fieldpath_test.go
@@ -88,6 +88,16 @@ func TestExtractFieldPathAsString(t *testing.T) {
 			},
 			expectedValue: "builder=\"john-doe\"",
 		},
+		{
+			name:      "ok - annotation",
+			fieldPath: "metadata.annotations['spec.pod.beta.kubernetes.io/statefulset-index']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"spec.pod.beta.kubernetes.io/statefulset-index": "1"},
+				},
+			},
+			expectedValue: "1",
+		},
 
 		{
 			name:      "invalid expression",
@@ -95,6 +105,16 @@ func TestExtractFieldPathAsString(t *testing.T) {
 			obj: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "object-namespace",
+				},
+			},
+			expectedMessageFragment: "unsupported fieldPath",
+		},
+		{
+			name:      "invalid annotation",
+			fieldPath: "metadata.annotations['unescaped]forbidden[characters'inside[]key']",
+			obj: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
 				},
 			},
 			expectedMessageFragment: "unsupported fieldPath",

--- a/pkg/util/BUILD
+++ b/pkg/util/BUILD
@@ -11,6 +11,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/util/annotations:all-srcs",
         "//pkg/util/async:all-srcs",
         "//pkg/util/bandwidth:all-srcs",
         "//pkg/util/config:all-srcs",

--- a/pkg/util/annotations/BUILD
+++ b/pkg/util/annotations/BUILD
@@ -1,0 +1,33 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["annotations.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/annotations",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["annotations_test.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/annotations",
+    library = ":go_default_library",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/util/annotations/annotations.go
+++ b/pkg/util/annotations/annotations.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import (
+	"fmt"
+	"regexp"
+)
+
+const (
+	metadataAnnotationPattern string = "^metadata\\.annotations\\['(.+)'\\]$"
+)
+
+var (
+	annotationRegexp = regexp.MustCompile(metadataAnnotationPattern)
+)
+
+func parseKey(s string) (string, error) {
+	submatch := annotationRegexp.FindStringSubmatch(s)
+
+	if len(submatch) < 2 {
+		return "", fmt.Errorf("Invalid fieldPath - couldn't extract annotation label")
+	}
+
+	return submatch[1], nil
+}
+
+// Validate checks whether the given field path is an annotation field path and if yes,
+// then it also returns a key pointed by the field path.
+func ValidateAndParse(s string) (bool, string) {
+	/* if !p.annotationRegexp.MatchString(s) {
+		return false, ""
+	} */
+
+	key, err := parseKey(s)
+	if err != nil {
+		return false, ""
+	}
+
+	var previous rune
+	for _, c := range key {
+		if (c == '\'' || c == '[' || c == ']') && previous != '\\' {
+			return false, ""
+		}
+		previous = c
+	}
+
+	return true, key
+}

--- a/pkg/util/annotations/annotations_test.go
+++ b/pkg/util/annotations/annotations_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package annotations
+
+import "testing"
+
+func TestValidateAndParse(t *testing.T) {
+	cases := []struct {
+		s             string
+		expectCorrect bool
+		expectedKey   string
+	}{
+		{
+			s:             "metadata.annotations['foo']",
+			expectCorrect: true,
+			expectedKey:   "foo",
+		},
+		{
+			s:             "metadata.annotations['\\[let\\'s\"escape\\[some\\]characters']",
+			expectCorrect: true,
+			expectedKey:   "\\[let\\'s\"escape\\[some\\]characters",
+		},
+		{
+			s:             "metadata.annotations['and]here[we[]failed[with]escaping']",
+			expectCorrect: false,
+			expectedKey:   "",
+		},
+		{
+			s:             "metadata.annotations['and'here[]even'worse']",
+			expectCorrect: false,
+			expectedKey:   "",
+		},
+		{
+			s:             "metadata.annotations[\"foo\"]",
+			expectCorrect: false,
+			expectedKey:   "",
+		},
+		{
+			s:             "metadata.annotations['']",
+			expectCorrect: false,
+			expectedKey:   "",
+		},
+		{
+			s:             "metadata.annotations[]",
+			expectCorrect: false,
+			expectedKey:   "",
+		},
+		{
+			s:             "metadata.annotations['foo']someunwantedtext",
+			expectCorrect: false,
+			expectedKey:   "",
+		},
+		{
+			s:             "metadata.foo",
+			expectCorrect: false,
+			expectedKey:   "",
+		},
+	}
+
+	for _, c := range cases {
+		isCorrect, key := ValidateAndParse(c.s)
+
+		if c.expectCorrect && !isCorrect {
+			t.Errorf("Expected %s to match, but it doesn't", c.s)
+		}
+
+		if !c.expectCorrect && isCorrect {
+			t.Errorf("Expected %s to not match, but it does", c.s)
+		}
+
+		if c.expectedKey != key {
+			t.Errorf("Expected %s key, instead got %s", c.expectedKey, key)
+		}
+	}
+}

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -545,6 +545,48 @@ func TestCollectDataWithDownwardAPI(t *testing.T) {
 		success    bool
 	}{
 		{
+			name: "annotation",
+			volumeFile: []v1.DownwardAPIVolumeFile{
+				{Path: "annotation", FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.annotations['a1']"}}},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						"a1": "value1",
+						"a2": "value2",
+					},
+					UID: testPodUID},
+			},
+			mode: 0644,
+			payload: map[string]util.FileProjection{
+				"annotation": {Data: []byte("value1"), Mode: 0644},
+			},
+			success: true,
+		},
+		{
+			name: "annotation-error",
+			volumeFile: []v1.DownwardAPIVolumeFile{
+				{Path: "annotation", FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.annotations['unescaped]forbidden[characters'inside[]key']"}}},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						"a1": "value1",
+						"a2": "value2",
+					},
+					UID: testPodUID},
+			},
+			mode: 0644,
+			payload: map[string]util.FileProjection{
+				"annotation": {Data: []byte("does-not-matter-because-this-test-case-will-fail-anyway"), Mode: 0644},
+			},
+			success: false,
+		},
+		{
 			name: "labels",
 			volumeFile: []v1.DownwardAPIVolumeFile{
 				{Path: "labels", FieldRef: &v1.ObjectFieldSelector{


### PR DESCRIPTION
Introduce the fieldPath for exposing single annotations in environment downward API. This fieldPath has the following syntax:

```
metadata.annotations['annotationKey']
```

Fixes #31218
Ref kubernetes/community#147
Ref #40651