### PR TITLE
Ignore bazel-* directories when looking for tests to run

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -33,6 +33,7 @@ kube::test::find_dirs() {
     find -L . -not \( \
         \( \
           -path './_artifacts/*' \
+          -o -path './bazel-*/*' \
           -o -path './_output/*' \
           -o -path './_gopath/*' \
           -o -path './cmd/kubeadm/test/*' \


### PR DESCRIPTION
**What this PR does / why we need it**: if you do a Bazel build and then try to run `make test` without `bazel clean`, the test script blows up. cc @cheftako

**Special notes for your reviewer**: there are probably other scripts (e.g. some of `hack/verify-*`) that mishandle the bazel-* convenience symlinks, but I'm not sure if it's worth the effort to fix those unless people complain.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
