### PR TITLE
Base etcd-empty-dir-cleanup on busybox, run as nobody, and update to etcdctl 3.0.14

### DIFF
--- a/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
@@ -10,4 +10,4 @@ spec:
   dnsPolicy: Default
   containers:
   - name: etcd-empty-dir-cleanup
-    image: gcr.io/google_containers/etcd-empty-dir-cleanup:0.0.1
+    image: gcr.io/google-containers/etcd-empty-dir-cleanup:3.0.14.0

--- a/cluster/images/etcd-empty-dir-cleanup/Dockerfile
+++ b/cluster/images/etcd-empty-dir-cleanup/Dockerfile
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gliderlabs/alpine
+FROM busybox
 
-RUN apk-install bash
-ADD etcd-empty-dir-cleanup.sh etcd-empty-dir-cleanup.sh
-ADD etcdctl etcdctl
+COPY etcdctl etcd-empty-dir-cleanup.sh /
+RUN chmod a+rx /etcdctl /etcd-empty-dir-cleanup.sh
+
 ENV ETCDCTL /etcdctl
 ENV SLEEP_SECOND 3600
-RUN chmod +x etcd-empty-dir-cleanup.sh
-CMD bash /etcd-empty-dir-cleanup.sh
+
+USER nobody:nogroup
+
+ENTRYPOINT ["/etcd-empty-dir-cleanup.sh"]

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -14,9 +14,9 @@
 
 .PHONY:	build push
 
-ETCD_VERSION = 2.2.1
-IMAGE = gcr.io/google_containers/etcd-empty-dir-cleanup
-TAG = 0.0.1
+ETCD_VERSION = 3.0.14
+IMAGE = gcr.io/google-containers/etcd-empty-dir-cleanup
+TAG = 3.0.14.0
 
 clean:
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz

--- a/cluster/images/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.sh
+++ b/cluster/images/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Copyright 2016 The Kubernetes Authors.
 #
@@ -17,7 +17,7 @@
 echo "Removing empty directories from etcd..."
 
 cleanup_empty_dirs () {
-  if [[ $(${ETCDCTL} ls $1) ]]; then
+  if [ "$(${ETCDCTL} ls $1)" ]; then
     for SUBDIR in $(${ETCDCTL} ls -p $1 | grep "/$")
     do
       cleanup_empty_dirs ${SUBDIR}


### PR DESCRIPTION
**What this PR does / why we need it**: since the `etcd-empty-dir-cleanup` image just uses a simple shell script and `etcdctl`, we can base it on busybox, which is a smaller target than alpine.

I've also updated this to use an `etcdctl` from etcd 3.0.14, which matches the version of etcd we're running in 1.6 clusters (I believe), and changed the tag to match the `etcdctl` version.

Tested in my own e2e cluster, where it seems to work.

I haven't pushed the image yet, so e2e tests *may* fail. Tagging `do-not-merge`; if you think this looks good, I'll push the image and retest.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

cc @timstclair @mml @wojtek-t