### PR TITLE
Improved code coverage for pkg/kubelet/types/pod_update

### DIFF
--- a/pkg/kubelet/types/BUILD
+++ b/pkg/kubelet/types/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/types/pod_update_test.go
+++ b/pkg/kubelet/types/pod_update_test.go
@@ -19,7 +19,10 @@ package types
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetValidatedSources(t *testing.T) {
@@ -41,4 +44,135 @@ func TestGetValidatedSources(t *testing.T) {
 	// Unknown source.
 	sources, err = GetValidatedSources([]string{"taco"})
 	require.Error(t, err)
+}
+
+func TestGetPodSource(t *testing.T) {
+	cases := []struct {
+		pod         v1.Pod
+		expected    string
+		errExpected bool
+	}{
+		{
+			pod:         v1.Pod{},
+			expected:    "",
+			errExpected: true,
+		},
+		{
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"kubernetes.io/config.source": "host-ipc-sources",
+					},
+				},
+			},
+			expected:    "host-ipc-sources",
+			errExpected: false,
+		},
+	}
+	for i, data := range cases {
+		source, err := GetPodSource(&data.pod)
+		if data.errExpected {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, data.expected, source, "test[%d]", i)
+		t.Logf("Test case [%d]", i)
+	}
+}
+
+func TestString(t *testing.T) {
+	cases := []struct {
+		sp       SyncPodType
+		expected string
+	}{
+		{
+			sp:       SyncPodCreate,
+			expected: "create",
+		},
+		{
+			sp:       SyncPodUpdate,
+			expected: "update",
+		},
+		{
+			sp:       SyncPodSync,
+			expected: "sync",
+		},
+		{
+			sp:       SyncPodKill,
+			expected: "kill",
+		},
+		{
+			sp:       50,
+			expected: "unknown",
+		},
+	}
+	for i, data := range cases {
+		syncPodString := data.sp.String()
+		assert.Equal(t, data.expected, syncPodString, "test[%d]", i)
+		t.Logf("Test case [%d]", i)
+	}
+}
+
+func TestIsCriticalPod(t *testing.T) {
+	cases := []struct {
+		pod      v1.Pod
+		expected bool
+	}{
+		{
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod1",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						"scheduler.alpha.kubernetes.io/critical-pod": "",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod2",
+					Namespace: "ns",
+					Annotations: map[string]string{
+						"scheduler.alpha.kubernetes.io/critical-pod": "abc",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						"scheduler.alpha.kubernetes.io/critical-pod": "abc",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			pod: v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod3",
+					Namespace: "kube-system",
+					Annotations: map[string]string{
+						"scheduler.alpha.kubernetes.io/critical-pod": "",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+	for i, data := range cases {
+		actual := IsCriticalPod(&data.pod)
+		if actual != data.expected {
+			t.Errorf("IsCriticalPod result wrong:\nexpected: %v\nactual: %v for test[%d] with Annotations: %v",
+				data.expected, actual, i, data.pod.Annotations)
+		}
+	}
 }


### PR DESCRIPTION
The test coverage for pod_update.go was imprved from 36% to 100%.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This fixed part of #40780
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
