### PR TITLE
Improved code coverage for pkg/kubelet/types/labels

### DIFF
--- a/pkg/kubelet/types/BUILD
+++ b/pkg/kubelet/types/BUILD
@@ -28,6 +28,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "labels_test.go",
         "pod_update_test.go",
         "types_test.go",
     ],

--- a/pkg/kubelet/types/labels_test.go
+++ b/pkg/kubelet/types/labels_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetContainerName(t *testing.T) {
+	var cases = []struct {
+		labels        map[string]string
+		containerName string
+	}{
+		{
+			labels: map[string]string{
+				"io.kubernetes.container.name": "c1",
+			},
+			containerName: "c1",
+		},
+		{
+			labels: map[string]string{
+				"io.kubernetes.container.name": "c2",
+			},
+			containerName: "c2",
+		},
+	}
+	for _, data := range cases {
+		containerName := GetContainerName(data.labels)
+		assert.Equal(t, data.containerName, containerName)
+	}
+}
+
+func TestGetPodName(t *testing.T) {
+	var cases = []struct {
+		labels  map[string]string
+		podName string
+	}{
+		{
+			labels: map[string]string{
+				"io.kubernetes.pod.name": "p1",
+			},
+			podName: "p1",
+		},
+		{
+			labels: map[string]string{
+				"io.kubernetes.pod.name": "p2",
+			},
+			podName: "p2",
+		},
+	}
+	for _, data := range cases {
+		podName := GetPodName(data.labels)
+		assert.Equal(t, data.podName, podName)
+	}
+}
+
+func TestGetPodUID(t *testing.T) {
+	var cases = []struct {
+		labels map[string]string
+		podUID string
+	}{
+		{
+			labels: map[string]string{
+				"io.kubernetes.pod.uid": "uid1",
+			},
+			podUID: "uid1",
+		},
+		{
+			labels: map[string]string{
+				"io.kubernetes.pod.uid": "uid2",
+			},
+			podUID: "uid2",
+		},
+	}
+	for _, data := range cases {
+		podUID := GetPodUID(data.labels)
+		assert.Equal(t, data.podUID, podUID)
+	}
+}
+
+func TestGetPodNamespace(t *testing.T) {
+	var cases = []struct {
+		labels       map[string]string
+		podNamespace string
+	}{
+		{
+			labels: map[string]string{
+				"io.kubernetes.pod.namespace": "ns1",
+			},
+			podNamespace: "ns1",
+		},
+		{
+			labels: map[string]string{
+				"io.kubernetes.pod.namespace": "ns2",
+			},
+			podNamespace: "ns2",
+		},
+	}
+	for _, data := range cases {
+		podNamespace := GetPodNamespace(data.labels)
+		assert.Equal(t, data.podNamespace, podNamespace)
+	}
+}


### PR DESCRIPTION
The test coverage improved from 0% to 100%.
This fixed part of #40780

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Increase test coverage.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
release-note-none

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
