### PR TITLE
Tolerate unknown fields in strategic merge patch

### DIFF
--- a/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/0.response
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/0.response
@@ -1,0 +1,25 @@
+{
+	"kind": "StorageClass",
+	"apiVersion": "storage.k8s.io/v1beta1",
+	"metadata": {
+		"name": "foo",
+		"selfLink": "/apis/storage.k8s.io/v1beta1/storageclassesfoo",
+		"uid": "b2287558-f190-11e6-b041-acbc32c1ca87",
+		"resourceVersion": "21388",
+		"creationTimestamp": "2017-02-13T02:04:04Z",
+		"labels": {
+			"label1": "value1"
+		}
+	},
+	"provisioner": "foo",
+	"parameters": {
+		"baz": "qux",
+		"foo": "bar"
+	},
+	"unknownServerField1": {
+		"data": true
+	},
+	"unknownServerField2": {
+		"data": true
+	}
+}

--- a/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/1.edited
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/1.edited
@@ -1,0 +1,23 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  creationTimestamp: 2017-02-13T02:04:04Z
+  labels:
+    label1: value1
+    label2: value2
+  name: foo
+  resourceVersion: "21388"
+  selfLink: /apis/storage.k8s.io/v1beta1/storageclassesfoo
+  uid: b2287558-f190-11e6-b041-acbc32c1ca87
+parameters:
+  baz: qux
+  foo: bar
+provisioner: foo
+unknownClientField:
+  clientdata: true
+unknownServerField1:
+  data: true

--- a/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/1.original
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/1.original
@@ -1,0 +1,22 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: storage.k8s.io/v1beta1
+kind: StorageClass
+metadata:
+  creationTimestamp: 2017-02-13T02:04:04Z
+  labels:
+    label1: value1
+  name: foo
+  resourceVersion: "21388"
+  selfLink: /apis/storage.k8s.io/v1beta1/storageclassesfoo
+  uid: b2287558-f190-11e6-b041-acbc32c1ca87
+parameters:
+  baz: qux
+  foo: bar
+provisioner: foo
+unknownServerField1:
+  data: true
+unknownServerField2:
+  data: true

--- a/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/2.request
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/2.request
@@ -1,0 +1,12 @@
+{
+	"metadata": {
+		"labels": {
+			"label2": "value2"
+		},
+		"namespace": ""
+	},
+	"unknownClientField": {
+		"clientdata": true
+	},
+	"unknownServerField2": null
+}

--- a/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/2.response
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/2.response
@@ -1,0 +1,26 @@
+{
+	"kind": "StorageClass",
+	"apiVersion": "storage.k8s.io/v1beta1",
+	"metadata": {
+		"name": "foo",
+		"selfLink": "/apis/storage.k8s.io/v1beta1/storageclassesfoo",
+		"uid": "b2287558-f190-11e6-b041-acbc32c1ca87",
+		"resourceVersion": "21431",
+		"creationTimestamp": "2017-02-13T02:04:04Z",
+		"labels": {
+			"label1": "value1",
+			"label2": "value2"
+		}
+	},
+	"provisioner": "foo",
+	"parameters": {
+		"baz": "qux",
+		"foo": "bar"
+	},
+	"unknownClientField": {
+		"clientdata": true
+	},
+	"unknownServerField1": {
+		"data": true
+	}
+}

--- a/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-unknown-field-known-group-kind/test.yaml
@@ -1,0 +1,25 @@
+description: edit an unknown version of a known group/kind
+mode: edit
+args:
+- storageclasses.v1beta1.storage.k8s.io/foo
+namespace: default
+expectedStdout:
+- "storageclass \"foo\" edited"
+expectedExitCode: 0
+steps:
+- type: request
+  expectedMethod: GET
+  expectedPath: /apis/storage.k8s.io/v1beta1/storageclasses/foo
+  expectedInput: 0.request
+  resultingStatusCode: 200
+  resultingOutput: 0.response
+- type: edit
+  expectedInput: 1.original
+  resultingOutput: 1.edited
+- type: request
+  expectedMethod: PATCH
+  expectedPath: /apis/storage.k8s.io/v1beta1/storageclasses/foo
+  expectedContentType: application/strategic-merge-patch+json
+  expectedInput: 2.request
+  resultingStatusCode: 200
+  resultingOutput: 2.response

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -160,6 +160,12 @@ func diffMaps(original, modified map[string]interface{}, t reflect.Type, ignoreC
 			modifiedValueTyped := modifiedValue.(map[string]interface{})
 			fieldType, fieldPatchStrategy, _, err := forkedjson.LookupPatchMetadata(t, key)
 			if err != nil {
+				// We couldn't look up metadata for the field
+				// If the values are identical, this doesn't matter, no patch is needed
+				if reflect.DeepEqual(originalValue, modifiedValue) {
+					continue
+				}
+				// Otherwise, return the error
 				return nil, err
 			}
 
@@ -184,6 +190,12 @@ func diffMaps(original, modified map[string]interface{}, t reflect.Type, ignoreC
 			modifiedValueTyped := modifiedValue.([]interface{})
 			fieldType, fieldPatchStrategy, fieldPatchMergeKey, err := forkedjson.LookupPatchMetadata(t, key)
 			if err != nil {
+				// We couldn't look up metadata for the field
+				// If the values are identical, this doesn't matter, no patch is needed
+				if reflect.DeepEqual(originalValue, modifiedValue) {
+					continue
+				}
+				// Otherwise, return the error
 				return nil, err
 			}
 

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -9143,6 +9143,7 @@ go_test(
         "//vendor:github.com/ghodss/yaml",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/util/mergepatch",
+        "//vendor:k8s.io/apimachinery/pkg/util/sets",
     ],
 )
 


### PR DESCRIPTION
When using `apply` or `edit` with an object that has a compiled-in struct, if an unknown server-side field is sent, or is present in a provided file, the strategic merge patch computation fails looking up type info from the go struct

If the field only exists in one side of the patch (is being added or removed), or is identical in both sides of the patch, we should tolerate missing type info, since it doesn't affect the patch.