### PR TITLE
Revert "Generate valid container id in fake docker client."

### DIFF
--- a/pkg/kubelet/dockershim/convert.go
+++ b/pkg/kubelet/dockershim/convert.go
@@ -51,7 +51,7 @@ func imageToRuntimeAPIImage(image *dockertypes.Image) (*runtimeapi.Image, error)
 }
 
 func imageInspectToRuntimeAPIImage(image *dockertypes.ImageInspect) (*runtimeapi.Image, error) {
-	if image == nil || image.Config == nil {
+	if image == nil {
 		return nil, fmt.Errorf("unable to convert a nil pointer to a runtime API image")
 	}
 

--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -217,7 +217,7 @@ func (ds *dockerService) createContainerLogSymlink(containerID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get container %q log path: %v", containerID, err)
 	}
-	if path != "" && realPath != "" {
+	if path != "" {
 		// Only create the symlink when container log path is specified.
 		if err = ds.os.Symlink(realPath, path); err != nil {
 			return fmt.Errorf("failed to create symbolic link %q to the container log file %q for container %q: %v",

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -26,7 +26,6 @@ import (
 
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/runtime"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
-	"k8s.io/kubernetes/pkg/kubelet/dockertools"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 )
@@ -158,7 +157,7 @@ func TestNetworkPluginInvocation(t *testing.T) {
 		map[string]string{"label": name},
 		map[string]string{"annotation": ns},
 	)
-	cID := kubecontainer.ContainerID{Type: runtimeName, ID: dockertools.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
+	cID := kubecontainer.ContainerID{Type: runtimeName, ID: fmt.Sprintf("/%v", makeSandboxName(c))}
 
 	mockPlugin.EXPECT().Name().Return("mockNetworkPlugin").AnyTimes()
 	setup := mockPlugin.EXPECT().SetUpPod(ns, name, cID)
@@ -196,7 +195,7 @@ func TestHostNetworkPluginInvocation(t *testing.T) {
 			},
 		},
 	}
-	cID := kubecontainer.ContainerID{Type: runtimeName, ID: dockertools.GetFakeContainerID(fmt.Sprintf("/%v", makeSandboxName(c)))}
+	cID := kubecontainer.ContainerID{Type: runtimeName, ID: fmt.Sprintf("/%v", makeSandboxName(c))}
 
 	// No calls to network plugin are expected
 	_, err := ds.RunPodSandbox(c)

--- a/pkg/kubelet/dockertools/docker_manager_linux_test.go
+++ b/pkg/kubelet/dockertools/docker_manager_linux_test.go
@@ -118,7 +118,13 @@ func TestSeccompIsUnconfinedByDefaultWithDockerV110(t *testing.T) {
 		"create", "start", "inspect_container",
 	})
 
-	assert.NoError(t, fakeDocker.AssertCreatedByNameWithOrder([]string{"POD", "bar"}))
+	fakeDocker.Lock()
+	if len(fakeDocker.Created) != 2 ||
+		!matchString(t, "/k8s_POD\\.[a-f0-9]+_foo_new_", fakeDocker.Created[0]) ||
+		!matchString(t, "/k8s_bar\\.[a-f0-9]+_foo_new_", fakeDocker.Created[1]) {
+		t.Errorf("unexpected containers created %v", fakeDocker.Created)
+	}
+	fakeDocker.Unlock()
 
 	newContainer, err := fakeDocker.InspectContainer(fakeDocker.Created[1])
 	if err != nil {
@@ -151,7 +157,13 @@ func TestUnconfinedSeccompProfileWithDockerV110(t *testing.T) {
 		"create", "start", "inspect_container",
 	})
 
-	assert.NoError(t, fakeDocker.AssertCreatedByNameWithOrder([]string{"POD", "bar4"}))
+	fakeDocker.Lock()
+	if len(fakeDocker.Created) != 2 ||
+		!matchString(t, "/k8s_POD\\.[a-f0-9]+_foo4_new_", fakeDocker.Created[0]) ||
+		!matchString(t, "/k8s_bar4\\.[a-f0-9]+_foo4_new_", fakeDocker.Created[1]) {
+		t.Errorf("unexpected containers created %v", fakeDocker.Created)
+	}
+	fakeDocker.Unlock()
 
 	newContainer, err := fakeDocker.InspectContainer(fakeDocker.Created[1])
 	if err != nil {
@@ -180,7 +192,13 @@ func TestDefaultSeccompProfileWithDockerV110(t *testing.T) {
 		"create", "start", "inspect_container",
 	})
 
-	assert.NoError(t, fakeDocker.AssertCreatedByNameWithOrder([]string{"POD", "bar1"}))
+	fakeDocker.Lock()
+	if len(fakeDocker.Created) != 2 ||
+		!matchString(t, "/k8s_POD\\.[a-f0-9]+_foo1_new_", fakeDocker.Created[0]) ||
+		!matchString(t, "/k8s_bar1\\.[a-f0-9]+_foo1_new_", fakeDocker.Created[1]) {
+		t.Errorf("unexpected containers created %v", fakeDocker.Created)
+	}
+	fakeDocker.Unlock()
 
 	newContainer, err := fakeDocker.InspectContainer(fakeDocker.Created[1])
 	if err != nil {
@@ -210,7 +228,13 @@ func TestSeccompContainerAnnotationTrumpsPod(t *testing.T) {
 		"create", "start", "inspect_container",
 	})
 
-	assert.NoError(t, fakeDocker.AssertCreatedByNameWithOrder([]string{"POD", "bar2"}))
+	fakeDocker.Lock()
+	if len(fakeDocker.Created) != 2 ||
+		!matchString(t, "/k8s_POD\\.[a-f0-9]+_foo2_new_", fakeDocker.Created[0]) ||
+		!matchString(t, "/k8s_bar2\\.[a-f0-9]+_foo2_new_", fakeDocker.Created[1]) {
+		t.Errorf("unexpected containers created %v", fakeDocker.Created)
+	}
+	fakeDocker.Unlock()
 
 	newContainer, err := fakeDocker.InspectContainer(fakeDocker.Created[1])
 	if err != nil {
@@ -236,7 +260,13 @@ func TestSecurityOptsAreNilWithDockerV19(t *testing.T) {
 		"create", "start", "inspect_container",
 	})
 
-	assert.NoError(t, fakeDocker.AssertCreatedByNameWithOrder([]string{"POD", "bar"}))
+	fakeDocker.Lock()
+	if len(fakeDocker.Created) != 2 ||
+		!matchString(t, "/k8s_POD\\.[a-f0-9]+_foo_new_", fakeDocker.Created[0]) ||
+		!matchString(t, "/k8s_bar\\.[a-f0-9]+_foo_new_", fakeDocker.Created[1]) {
+		t.Errorf("unexpected containers created %v", fakeDocker.Created)
+	}
+	fakeDocker.Unlock()
 
 	newContainer, err := fakeDocker.InspectContainer(fakeDocker.Created[1])
 	if err != nil {
@@ -276,7 +306,13 @@ func TestCreateAppArmorContanier(t *testing.T) {
 		"create", "start", "inspect_container",
 	})
 
-	assert.NoError(t, fakeDocker.AssertCreatedByNameWithOrder([]string{"POD", "test"}))
+	fakeDocker.Lock()
+	if len(fakeDocker.Created) != 2 ||
+		!matchString(t, "/k8s_POD\\.[a-f0-9]+_foo_new_", fakeDocker.Created[0]) ||
+		!matchString(t, "/k8s_test\\.[a-f0-9]+_foo_new_", fakeDocker.Created[1]) {
+		t.Errorf("unexpected containers created %v", fakeDocker.Created)
+	}
+	fakeDocker.Unlock()
 
 	// Verify security opts.
 	newContainer, err := fakeDocker.InspectContainer(fakeDocker.Created[1])
@@ -348,7 +384,13 @@ func TestSeccompLocalhostProfileIsLoaded(t *testing.T) {
 			"create", "start", "inspect_container",
 		})
 
-		assert.NoError(t, fakeDocker.AssertCreatedByNameWithOrder([]string{"POD", "bar2"}))
+		fakeDocker.Lock()
+		if len(fakeDocker.Created) != 2 ||
+			!matchString(t, "/k8s_POD\\.[a-f0-9]+_foo2_new_", fakeDocker.Created[0]) ||
+			!matchString(t, "/k8s_bar2\\.[a-f0-9]+_foo2_new_", fakeDocker.Created[1]) {
+			t.Errorf("unexpected containers created %v", fakeDocker.Created)
+		}
+		fakeDocker.Unlock()
 
 		newContainer, err := fakeDocker.InspectContainer(fakeDocker.Created[1])
 		if err != nil {

--- a/pkg/kubelet/dockertools/fake_docker_client.go
+++ b/pkg/kubelet/dockertools/fake_docker_client.go
@@ -19,20 +19,18 @@ package dockertools
 import (
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"math/rand"
 	"os"
 	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	dockertypes "github.com/docker/engine-api/types"
 	dockercontainer "github.com/docker/engine-api/types/container"
-
 	"k8s.io/client-go/util/clock"
+
 	"k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -73,13 +71,9 @@ type FakeDockerClient struct {
 	ImageHistoryMap map[string][]dockertypes.ImageHistory
 }
 
-const (
-	// We don't check docker version now, just set the docker version of fake docker client to 1.8.1.
-	// Notice that if someday we also have minimum docker version requirement, this should also be updated.
-	fakeDockerVersion = "1.8.1"
-
-	fakeImageSize = 1024
-)
+// We don't check docker version now, just set the docker version of fake docker client to 1.8.1.
+// Notice that if someday we also have minimum docker version requirement, this should also be updated.
+const fakeDockerVersion = "1.8.1"
 
 func NewFakeDockerClient() *FakeDockerClient {
 	return &FakeDockerClient{
@@ -279,39 +273,17 @@ func (f *FakeDockerClient) AssertCallDetails(calls ...calledDetail) (err error) 
 	return
 }
 
-// idsToNames converts container ids into names. The caller must hold the lock.
-func (f *FakeDockerClient) idsToNames(ids []string) ([]string, error) {
-	names := []string{}
-	for _, id := range ids {
-		dockerName, _, err := ParseDockerName(f.ContainerMap[id].Name)
+func (f *FakeDockerClient) AssertCreated(created []string) error {
+	f.Lock()
+	defer f.Unlock()
+
+	actualCreated := []string{}
+	for _, c := range f.Created {
+		dockerName, _, err := ParseDockerName(c)
 		if err != nil {
-			return nil, fmt.Errorf("unexpected error: %v", err)
+			return fmt.Errorf("unexpected error: %v", err)
 		}
-		names = append(names, dockerName.ContainerName)
-	}
-	return names, nil
-}
-
-func (f *FakeDockerClient) AssertCreatedByNameWithOrder(created []string) error {
-	f.Lock()
-	defer f.Unlock()
-	actualCreated, err := f.idsToNames(f.Created)
-	if err != nil {
-		return err
-	}
-	if !reflect.DeepEqual(created, actualCreated) {
-		return fmt.Errorf("expected %#v, got %#v", created, actualCreated)
-	}
-	return nil
-}
-
-func (f *FakeDockerClient) AssertCreatedByName(created []string) error {
-	f.Lock()
-	defer f.Unlock()
-
-	actualCreated, err := f.idsToNames(f.Created)
-	if err != nil {
-		return err
+		actualCreated = append(actualCreated, dockerName.ContainerName)
 	}
 	sort.StringSlice(created).Sort()
 	sort.StringSlice(actualCreated).Sort()
@@ -321,18 +293,13 @@ func (f *FakeDockerClient) AssertCreatedByName(created []string) error {
 	return nil
 }
 
-func (f *FakeDockerClient) AssertStoppedByName(stopped []string) error {
+func (f *FakeDockerClient) AssertStarted(started []string) error {
 	f.Lock()
 	defer f.Unlock()
-
-	actualStopped, err := f.idsToNames(f.Stopped)
-	if err != nil {
-		return err
-	}
-	sort.StringSlice(stopped).Sort()
-	sort.StringSlice(actualStopped).Sort()
-	if !reflect.DeepEqual(stopped, actualStopped) {
-		return fmt.Errorf("expected %#v, got %#v", stopped, actualStopped)
+	sort.StringSlice(started).Sort()
+	sort.StringSlice(f.Started).Sort()
+	if !reflect.DeepEqual(started, f.Started) {
+		return fmt.Errorf("expected %#v, got %#v", started, f.Started)
 	}
 	return nil
 }
@@ -340,12 +307,21 @@ func (f *FakeDockerClient) AssertStoppedByName(stopped []string) error {
 func (f *FakeDockerClient) AssertStopped(stopped []string) error {
 	f.Lock()
 	defer f.Unlock()
-	// Copy stopped to avoid modifying it.
-	actualStopped := append([]string{}, f.Stopped...)
 	sort.StringSlice(stopped).Sort()
-	sort.StringSlice(actualStopped).Sort()
-	if !reflect.DeepEqual(stopped, actualStopped) {
-		return fmt.Errorf("expected %#v, got %#v", stopped, actualStopped)
+	sort.StringSlice(f.Stopped).Sort()
+	if !reflect.DeepEqual(stopped, f.Stopped) {
+		return fmt.Errorf("expected %#v, got %#v", stopped, f.Stopped)
+	}
+	return nil
+}
+
+func (f *FakeDockerClient) AssertRemoved(removed []string) error {
+	f.Lock()
+	defer f.Unlock()
+	sort.StringSlice(removed).Sort()
+	sort.StringSlice(f.Removed).Sort()
+	if !reflect.DeepEqual(removed, f.Removed) {
+		return fmt.Errorf("expected %#v, got %#v", removed, f.Removed)
 	}
 	return nil
 }
@@ -377,57 +353,30 @@ func (f *FakeDockerClient) ListContainers(options dockertypes.ContainerListOptio
 		// TODO(random-liu): Is a fully sorted array needed?
 		containerList = append(containerList, f.ExitedContainerList...)
 	}
-	// Filter containers with id, only support 1 id.
-	idFilters := options.Filter.Get("id")
-	if len(idFilters) != 0 {
-		var filtered []dockertypes.Container
-		for _, container := range containerList {
-			for _, idFilter := range idFilters {
-				if container.ID == idFilter {
-					filtered = append(filtered, container)
-					break
-				}
-			}
-		}
-		containerList = filtered
-	}
-	// Filter containers with status, only support 1 status.
-	statusFilters := options.Filter.Get("status")
-	if len(statusFilters) == 1 {
-		var filtered []dockertypes.Container
-		for _, container := range containerList {
-			for _, statusFilter := range statusFilters {
-				if container.Status == statusFilter {
-					filtered = append(filtered, container)
-					break
-				}
-			}
-		}
-		containerList = filtered
-	}
+	// TODO: Support other filters.
 	// Filter containers with label filter.
 	labelFilters := options.Filter.Get("label")
-	if len(labelFilters) != 0 {
-		var filtered []dockertypes.Container
-		for _, container := range containerList {
-			match := true
-			for _, labelFilter := range labelFilters {
-				kv := strings.Split(labelFilter, "=")
-				if len(kv) != 2 {
-					return nil, fmt.Errorf("invalid label filter %q", labelFilter)
-				}
-				if container.Labels[kv[0]] != kv[1] {
-					match = false
-					break
-				}
+	if len(labelFilters) == 0 {
+		return containerList, err
+	}
+	var filtered []dockertypes.Container
+	for _, container := range containerList {
+		match := true
+		for _, labelFilter := range labelFilters {
+			kv := strings.Split(labelFilter, "=")
+			if len(kv) != 2 {
+				return nil, fmt.Errorf("invalid label filter %q", labelFilter)
 			}
-			if match {
-				filtered = append(filtered, container)
+			if container.Labels[kv[0]] != kv[1] {
+				match = false
+				break
 			}
 		}
-		containerList = filtered
+		if match {
+			filtered = append(filtered, container)
+		}
 	}
-	return containerList, err
+	return filtered, err
 }
 
 // InspectContainer is a test-spy implementation of DockerInterface.InspectContainer.
@@ -481,13 +430,6 @@ func (f *FakeDockerClient) normalSleep(mean, stdDev, cutOffMillis int) {
 	time.Sleep(delay)
 }
 
-// GetFakeContainerID generates a fake container id from container name with a hash.
-func GetFakeContainerID(name string) string {
-	hash := fnv.New64a()
-	hash.Write([]byte(name))
-	return strconv.FormatUint(hash.Sum64(), 16)
-}
-
 // CreateContainer is a test-spy implementation of DockerInterface.CreateContainer.
 // It adds an entry "create" to the internal method call record.
 func (f *FakeDockerClient) CreateContainer(c dockertypes.ContainerCreateConfig) (*dockertypes.ContainerCreateResponse, error) {
@@ -500,13 +442,13 @@ func (f *FakeDockerClient) CreateContainer(c dockertypes.ContainerCreateConfig) 
 	// This is not a very good fake. We'll just add this container's name to the list.
 	// Docker likes to add a '/', so copy that behavior.
 	name := "/" + c.Name
-	id := GetFakeContainerID(name)
-	f.appendContainerTrace("Created", id)
+	id := name
+	f.appendContainerTrace("Created", name)
 	// The newest container should be in front, because we assume so in GetPodStatus()
 	f.RunningContainerList = append([]dockertypes.Container{
-		{ID: id, Names: []string{name}, Image: c.Config.Image, Labels: c.Config.Labels},
+		{ID: name, Names: []string{name}, Image: c.Config.Image, Labels: c.Config.Labels},
 	}, f.RunningContainerList...)
-	f.ContainerMap[id] = convertFakeContainer(&FakeContainer{
+	f.ContainerMap[name] = convertFakeContainer(&FakeContainer{
 		ID: id, Name: name, Config: c.Config, HostConfig: c.HostConfig, CreatedAt: f.Clock.Now()})
 	f.normalSleep(100, 25, 25)
 	return &dockertypes.ContainerCreateResponse{ID: id}, nil
@@ -618,10 +560,6 @@ func (f *FakeDockerClient) PullImage(image string, auth dockertypes.AuthConfig, 
 		f.Image = &dockertypes.ImageInspect{
 			ID:       image,
 			RepoTags: []string{image},
-			// Image size is required to be non-zero for CRI integration.
-			VirtualSize: fakeImageSize,
-			Size:        fakeImageSize,
-			Config:      &dockercontainer.Config{},
 		}
 		f.appendPulled(fmt.Sprintf("%s using %s", image, string(authJson)))
 	}

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -160,6 +160,8 @@ func GetHollowKubeletConfig(
 	c.SerializeImagePulls = true
 	c.SystemCgroups = ""
 	c.ProtectKernelDefaults = false
+	// TODO: This is a temporary workaround until we fix CRI+kubemark properly.
+	c.EnableCRI = false
 
 	// TODO(mtaufen): Note that PodInfraContainerImage was being set to the empty value before,
 	//                but this may not have been intentional. (previous code (SimpleKubelet)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#41524

ci-kubernetes-kubemark-500-gce was green on master 77a63381, and red on 34bf25fe (https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/logs/ci-kubernetes-kubemark-500-gce/)

/cc @wojtek-t @Random-Liu @yujuhong 

/cc @k8s-oncall for queue blocker
