### PR TITLE
Add approvers to the aws OWNERS file

### DIFF
--- a/pkg/cloudprovider/providers/aws/OWNERS
+++ b/pkg/cloudprovider/providers/aws/OWNERS
@@ -1,3 +1,8 @@
 approvers:
 - justinsb
 - zmerlynn
+reviewers:
+- gnufied
+- jsafrane
+- justinsb
+- zmerlynn


### PR DESCRIPTION
Without this it was picking up reviewers from a much higher directory.

```release-note
NONE
```
