### PR TITLE
Fix kubemark hollow-npd.

### DIFF
--- a/test/kubemark/resources/hollow-node_template.json
+++ b/test/kubemark/resources/hollow-node_template.json
@@ -39,12 +39,6 @@
 						}
 					},
 					{
-						"name": "kernellog-volume",
-						"hostPath": {
-							"path": "/var/log"
-						}
-					},
-					{
 						"name": "no-serviceaccount-access-to-real-master",
 						"emptyDir": {}
 					}
@@ -178,11 +172,6 @@
 						{
 							"name": "kernelmonitorconfig-volume",
 							"mountPath": "/config",
-							"readOnly": true
-						},
-						{
-							"name": "kernellog-volume",
-							"mountPath": "/log",
 							"readOnly": true
 						},
 						{

--- a/test/kubemark/resources/kernel-monitor.json
+++ b/test/kubemark/resources/kernel-monitor.json
@@ -5,7 +5,7 @@
 		"message": "dummy",
 		"timestampFormat": "dummy"
 	},
-	"logPath": "/log/faillog",
+	"logPath": "/dev/null",
 	"lookback": "10m",
 	"bufferSize": 10,
 	"source": "kernel-monitor",


### PR DESCRIPTION
In NPD v0.3.0-alpha.1, node problem detector will error out if the specified log file doesn't exist.

Previously, kubemark uses a non-exist log file `/log/faillog` to make npd idle, as hollow-npd. However, it won't work with new npd.

This PR changed the log path to `/dev/null`, so that npd won't be able to read anything, and `/dev/null` will definitely exist in the container.

I started kubemark cluster with this change myself, and it works properly now.

@foxish @shyamjvs @wojtek-t 