### PR TITLE
[Federation][e2e] Remove ns creation in federated clusters

### DIFF
--- a/test/e2e_federation/federation-util.go
+++ b/test/e2e_federation/federation-util.go
@@ -207,7 +207,6 @@ func getRegisteredClusters(userAgentName string, f *fedframework.Framework) (map
 		Expect(framework.TestContext.KubeConfig).ToNot(Equal(""), "KubeConfig must be specified to load clusters' client config")
 		clusters[c.Name] = &cluster{c.Name, createClientsetForCluster(c, i, userAgentName), false, nil}
 	}
-	createNamespaceInClusters(clusters, f)
 	return clusters, primaryClusterName
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In federation e2e, framework creates a namespace for each test case. the same ns is supposed to be created in federated clusters. Due to issues in namespace controller, this was not working earlier. but now it is working.
so currently the namespace is created twice, once by namespace controller and another when we call `getRegisteredClusters`. depending on the timing of these 2 calls, some [test cases fails ](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-federation/1199#k8sio-federation-secrets-featurefederation-secret-objects-should-not-be-deleted-from-underlying-clusters-when-orphandependents-is-true). So removing the creation of namespace when `getRegisteredClusters` which is unnecessary.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes flakes in federation e2e.

cc @madhusudancs @nikhiljindal @kubernetes/sig-federation-bugs 