### PR TITLE
kubeadm: Hide the unnecessary --fuzz-iters flag

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/BUILD
@@ -12,14 +12,11 @@ go_library(
     srcs = [
         "doc.go",
         "env.go",
-        "fuzzer.go",
         "register.go",
         "types.go",
     ],
     tags = ["automanaged"],
     deps = [
-        "//vendor:github.com/google/gofuzz",
-        "//vendor:k8s.io/apimachinery/pkg/api/testing",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
@@ -37,6 +34,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//cmd/kubeadm/app/apis/kubeadm/fuzzer:all-srcs",
         "//cmd/kubeadm/app/apis/kubeadm/install:all-srcs",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:all-srcs",
         "//cmd/kubeadm/app/apis/kubeadm/validation:all-srcs",

--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["fuzzer.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//vendor:github.com/google/gofuzz",
+        "//vendor:k8s.io/apimachinery/pkg/api/testing",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -14,24 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubeadm
+package fuzzer
 
 import (
 	"github.com/google/gofuzz"
 
 	apitesting "k8s.io/apimachinery/pkg/api/testing"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
 func KubeadmFuzzerFuncs(t apitesting.TestingCommon) []interface{} {
 	return []interface{}{
-		func(obj *MasterConfiguration, c fuzz.Continue) {
+		func(obj *kubeadm.MasterConfiguration, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
 			obj.KubernetesVersion = "v10"
 			obj.API.Port = 20
 			obj.Networking.ServiceSubnet = "foo"
 			obj.Networking.DNSDomain = "foo"
 			obj.AuthorizationMode = "foo"
-			obj.Discovery.Token = &TokenDiscovery{}
+			obj.Discovery.Token = &kubeadm.TokenDiscovery{}
 		},
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/install/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/install/BUILD
@@ -44,7 +44,7 @@ go_test(
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
-        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/fuzzer:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/testing",
     ],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/install/install_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/install/install_test.go
@@ -20,9 +20,9 @@ import (
 	"testing"
 
 	apitesting "k8s.io/apimachinery/pkg/api/testing"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/fuzzer"
 )
 
 func TestRoundTripTypes(t *testing.T) {
-	apitesting.RoundTripTestForAPIGroup(t, Install, kubeadm.KubeadmFuzzerFuncs(t))
+	apitesting.RoundTripTestForAPIGroup(t, Install, fuzzer.KubeadmFuzzerFuncs(t))
 }

--- a/pkg/api/testing/BUILD
+++ b/pkg/api/testing/BUILD
@@ -16,7 +16,7 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/fuzzer:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//pkg/api/v1:go_default_library",

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmfuzzer "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/fuzzer"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -637,7 +637,7 @@ func FuzzerFuncs(t apitesting.TestingCommon, codecs runtimeserializer.CodecFacto
 		batchFuncs(t),
 		autoscalingFuncs(t),
 		rbacFuncs(t),
-		kubeadm.KubeadmFuzzerFuncs(t),
+		kubeadmfuzzer.KubeadmFuzzerFuncs(t),
 		policyFuncs(t),
 		certificateFuncs(t),
 	)


### PR DESCRIPTION
super straightforward. We don't want this flag to leak into our UX.

cc @jbeda @dmmcquay @deads2k