### PR TITLE
Split federation-{up,down} from e2e-{up,down}.

### DIFF
--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -49,7 +49,6 @@ function kubeconfig-federation-context() {
   CLUSTER_CONTEXT="federation-e2e-${KUBERNETES_PROVIDER}-${1}"
 }
 
-
 # Should NOT be called within the global scope, unless setting the desired global zone vars
 # This function is currently NOT USED in the global scope
 function set-federation-zone-vars {

--- a/federation/cluster/federation-down.sh
+++ b/federation/cluster/federation-down.sh
@@ -49,17 +49,17 @@ function unjoin_clusters() {
 
 unjoin_clusters
 
-cleanup-federation-api-objects || echo "Couldn't cleanup federation api objects"
-
-"${KUBE_ROOT}/cluster/kubectl.sh" delete namespace \
-    --context="${HOST_CLUSTER_CONTEXT}" \
-    "${FEDERATION_NAMESPACE}"
-
-# TODO(madhusudancs): This is an arbitrary amount of sleep to give Kubernetes
-# clusters enough time to delete the underlying cloud provider resources
-# corresponding to the Kubernetes resources we deleted as part of the test
-# teardowns. It is shameful that we are doing this, but this is just a bandage
-# to stop the bleeding. Please don't use this pattern anywhere. Remove this
-# when proper cloud provider cleanups are implemented in the individual test
-# `AfterEach` blocks.
-sleep 2m
+if cleanup-federation-api-objects; then
+  # TODO(madhusudancs): This is an arbitrary amount of sleep to give
+  # Kubernetes clusters enough time to delete the underlying cloud
+  # provider resources corresponding to the Kubernetes resources we
+  # deleted as part of the test tear downs. It is shameful that we
+  # are doing this, but this is just a bandage to stop the bleeding.
+  # Please don't use this pattern anywhere. Remove this when proper
+  # cloud provider cleanups are implemented in the individual test
+  # `AfterEach` blocks.
+  # Also, we wait only if the cleanup succeeds.
+  sleep 2m
+else
+  echo "Couldn't cleanup federation api objects"
+fi

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -97,7 +97,6 @@ function join_clusters() {
         --context="${FEDERATION_NAME}" \
         --secret-name="${context//_/-}"    # Replace "_" by "-"
 
-
     # Create kube-dns configmap in each cluster for kube-dns to accept
     # federation queries.
     # TODO: This shouldn't be required after

--- a/hack/e2e-internal/e2e-down.sh
+++ b/hack/e2e-internal/e2e-down.sh
@@ -29,25 +29,10 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 prepare-e2e
 
-if [[ "${FEDERATION:-}" == "true" ]];then
+if [[ "${FEDERATION:-}" == "true" ]]; then
   source "${KUBE_ROOT}/federation/cluster/common.sh"
 
-  if cleanup-federation-api-objects; then
-    # TODO(madhusudancs): This is an arbitrary amount of sleep to give
-    # Kubernetes clusters enough time to delete the underlying cloud
-    # provider resources corresponding to the Kubernetes resources we
-    # deleted as part of the test tear downs. It is shameful that we
-    # are doing this, but this is just a bandage to stop the bleeding.
-    # Please don't use this pattern anywhere. Remove this when proper
-    # cloud provider cleanups are implemented in the individual test
-    # `AfterEach` blocks.
-    # Also, we wait only if the cleanup succeeds.
-    sleep 2m
-  else
-    echo "Couldn't cleanup federation api objects"
-  fi
-
-  for zone in ${E2E_ZONES}; do
+  for zone in ${E2E_ZONES};do
     # bring down an e2e cluster
     (
       set-federation-zone-vars "$zone"

--- a/hack/e2e-internal/e2e-up.sh
+++ b/hack/e2e-internal/e2e-up.sh
@@ -30,24 +30,15 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 prepare-e2e
 
 if [[ "${FEDERATION:-}" == "true" ]]; then
-    cur_ip_octet2=180
-    # TODO(colhom): the last cluster that was created in the loop above is the current context.
-    # Hence, it will be the cluster that hosts the federated components.
-    # In the future, we will want to loop through the all the federated contexts,
-    # select each one and call federated-up
-    for zone in ${E2E_ZONES};do
-        (
-        export CLUSTER_IP_RANGE="10.${cur_ip_octet2}.0.0/16"
-        set-federation-zone-vars "$zone"
-        test-setup
-        )
-        cur_ip_octet2="$((cur_ip_octet2 + 1))"
-    done
-
-    # Sets ${CLUSTER_CONTEXT}
-    kubeconfig-federation-context "${zone}"
-
-    "${KUBE_ROOT}/federation/cluster/federation-up.sh" "${CLUSTER_CONTEXT}"
+  cur_ip_octet2=180
+  for zone in ${E2E_ZONES};do
+    (
+      export CLUSTER_IP_RANGE="10.${cur_ip_octet2}.0.0/16"
+      set-federation-zone-vars "$zone"
+      test-setup
+    )
+    cur_ip_octet2="$((cur_ip_octet2 + 1))"
+  done
 else
-    test-setup
+  test-setup
 fi


### PR DESCRIPTION
The idea is to introduce these as flags to kubetest so we can run these steps independently. I have a separate PR targeting `kubernetes/test-infra/kubetest` to add `--federation_up` and `--federation_down`. So one can run `hack/e2e.go --up --federation_up` to bring up both the clusters and federation control plane. Just `hack/e2e.go --up` to bring up clusters and just `hack/e2e.go --federation_up` to bring up federation control plane.

This PR depends on PR #41601. Please review only the last commit here. Other commits will be reviewed independently in their original PR.

```release-note
NONE
```
