### PR TITLE
Spew replica sets in any deployment upgrade test failure

### DIFF
--- a/test/e2e/upgrades/deployments.go
+++ b/test/e2e/upgrades/deployments.go
@@ -113,12 +113,15 @@ func (t *DeploymentUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 	_, allOldRSs, newRS, err := deploymentutil.GetAllReplicaSets(t.d, f.ClientSet)
 	framework.ExpectNoError(err)
 	if newRS == nil {
+		By(t.spewReplicaSets(newRS, allOldRSs))
 		framework.ExpectNoError(fmt.Errorf("expected a new replica set for deployment %q", t.d.Name))
 	}
 	if newRS.UID != t.newRS.UID {
+		By(t.spewReplicaSets(newRS, allOldRSs))
 		framework.ExpectNoError(fmt.Errorf("expected new replica set:\n%#v\ngot new replica set:\n%#v\n", t.newRS, newRS))
 	}
 	if len(allOldRSs) != 1 {
+		By(t.spewReplicaSets(newRS, allOldRSs))
 		errString := fmt.Sprintf("expected one old replica set, got %d\n", len(allOldRSs))
 		for i := range allOldRSs {
 			rs := allOldRSs[i]
@@ -127,6 +130,7 @@ func (t *DeploymentUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 		framework.ExpectNoError(fmt.Errorf(errString))
 	}
 	if allOldRSs[0].UID != t.oldRS.UID {
+		By(t.spewReplicaSets(newRS, allOldRSs))
 		framework.ExpectNoError(fmt.Errorf("expected old replica set:\n%#v\ngot old replica set:\n%#v\n", t.oldRS, allOldRSs[0]))
 	}
 }
@@ -134,4 +138,15 @@ func (t *DeploymentUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 // Teardown cleans up any remaining resources.
 func (t *DeploymentUpgradeTest) Teardown(f *framework.Framework) {
 	// rely on the namespace deletion to clean up everything
+}
+
+func (t *DeploymentUpgradeTest) spewReplicaSets(newRS *extensions.ReplicaSet, allOldRSs []*extensions.ReplicaSet) string {
+	msg := fmt.Sprintf("old replica sets prior to the upgrade:\n%#v\n", t.oldRS)
+	msg += fmt.Sprintf("new replica sets prior to the upgrade:\n%#v\n", t.newRS)
+	msg += fmt.Sprintf("new replica set after the upgrade:\n%#v\n", newRS)
+	msg += fmt.Sprintf("old replica sets after the upgrade:\n")
+	for i := range allOldRSs {
+		msg += fmt.Sprintf("%#v\n", allOldRSs[i])
+	}
+	return msg
 }


### PR DESCRIPTION
Should help identifying whether the new replica set is considered as old after the upgrade (or maybe it's something else too).

For debugging https://github.com/kubernetes/kubernetes/issues/41518
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-latest-upgrade-master/5/

The failure seems suspiciously related to https://github.com/kubernetes/kubernetes/issues/40415 but it may not be related at all too...

@kubernetes/sig-apps-bugs 