### PR TITLE
Prompt user to use secure config in kubeadm

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -48,6 +48,9 @@ var (
 	initDoneMsgf = dedent.Dedent(`
 		Your Kubernetes master has initialized successfully!
 
+		To start using your cluster, you need to run:
+		export KUBECONFIG=%s
+
 		You should now deploy a pod network to the cluster.
 		Run "kubectl apply -f [podnetwork].yaml" with one of the options listed at:
 		    http://kubernetes.io/docs/admin/addons/
@@ -267,7 +270,7 @@ func (i *Init) Run(out io.Writer) error {
 		return err
 	}
 
-	fmt.Fprintf(out, initDoneMsgf, generateJoinArgs(i.cfg))
+	fmt.Fprintf(out, initDoneMsgf, path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.AdminKubeConfigFileName), generateJoinArgs(i.cfg))
 	return nil
 }
 


### PR DESCRIPTION
If don't set the kubeconfig, the default action is to use insecure port to connect to apiserver.  It's necessary to tell people to use the admin.kubeconfig 

```
#kubectl cluster-info
Kubernetes master is running at http://localhost:8080
KubeDNS is running at http://localhost:8080/api/v1/proxy/namespaces/kube-system/services/kube-dns

To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
```