### PR TITLE
[Kubemark] Add option to log hollow-node logs

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -38,6 +38,7 @@ readonly node_ssh_supported_providers="gce gke aws"
 
 readonly master_logfiles="kube-apiserver kube-scheduler rescheduler kube-controller-manager etcd etcd-events glbc cluster-autoscaler kube-addon-manager fluentd"
 readonly node_logfiles="kube-proxy fluentd"
+readonly hollow_node_logfiles="kubelet-hollow-node-* kubeproxy-hollow-node-* npd-*"
 readonly aws_logfiles="cloud-init-output"
 readonly gce_logfiles="startupscript"
 readonly kern_logfile="kern"
@@ -128,6 +129,9 @@ function save-logs() {
       case "${KUBERNETES_PROVIDER}" in
         gce|gke|kubemark)
           files="${files} ${gce_logfiles}"
+          if [[ "${KUBERNETES_PROVIDER}" -eq "kubemark" && "${ENABLE_HOLLOW_NODE_LOGS:-}" -eq "true" ]]; then
+            files="${files} ${hollow_node_logfiles}"
+          fi
           ;;
         aws)
           files="${files} ${aws_logfiles}"

--- a/test/kubemark/resources/hollow-node_template.json
+++ b/test/kubemark/resources/hollow-node_template.json
@@ -35,12 +35,6 @@
 					{
 						"name": "logs-volume",
 						"hostPath": {
-							"path": "/var/logs"
-						}
-					},
-					{
-						"name": "kernellog-volume",
-						"hostPath": {
 							"path": "/var/log"
 						}
 					},
@@ -80,7 +74,7 @@
 					"command": [
 						"/bin/sh",
 						"-c",
-						"./kubemark.sh --morph=kubelet --name=$(NODE_NAME) --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --v=2 1>>/var/logs/kubelet_$(NODE_NAME).log 2>&1"
+						"./kubemark.sh --morph=kubelet --name=$(NODE_NAME) --kubeconfig=/kubeconfig/kubelet.kubeconfig $(CONTENT_TYPE) --v=2 1>>/var/log/kubelet-$(NODE_NAME).log 2>&1"
 					],
 					"volumeMounts": [
 						{
@@ -90,7 +84,7 @@
 						},
 						{
 							"name": "logs-volume",
-							"mountPath": "/var/logs"
+							"mountPath": "/var/log"
 						}
 					],
 					"resources": {
@@ -129,7 +123,7 @@
 					"command": [
 						"/bin/sh",
 						"-c",
-						"./kubemark.sh --morph=proxy --name=$(NODE_NAME) --kubeconfig=/kubeconfig/kubeproxy.kubeconfig $(CONTENT_TYPE) --v=2 1>>/var/logs/kubeproxy_$(NODE_NAME).log 2>&1"
+						"./kubemark.sh --morph=proxy --name=$(NODE_NAME) --kubeconfig=/kubeconfig/kubeproxy.kubeconfig $(CONTENT_TYPE) --v=2 1>>/var/log/kubeproxy-$(NODE_NAME).log 2>&1"
 					],
 					"volumeMounts": [
 						{
@@ -139,7 +133,7 @@
 						},
 						{
 							"name": "logs-volume",
-							"mountPath": "/var/logs"
+							"mountPath": "/var/log"
 						}
 					],
 					"resources": {
@@ -167,7 +161,7 @@
 						"--kernel-monitor=/config/kernel.monitor",
 						"--apiserver-override=https://{{master_ip}}:443?inClusterConfig=false&auth=/kubeconfig/npd.kubeconfig",
 						"--alsologtostderr",
-						"1>>/var/logs/npd_$(NODE_NAME).log 2>&1"
+						"1>>/var/log/npd-$(NODE_NAME).log 2>&1"
 					],
 					"volumeMounts": [
 						{
@@ -181,18 +175,13 @@
 							"readOnly": true
 						},
 						{
-							"name": "kernellog-volume",
-							"mountPath": "/log",
-							"readOnly": true
-						},
-						{
 							"name": "no-serviceaccount-access-to-real-master",
 							"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
 							"readOnly": true
 						},
 						{
 							"name": "logs-volume",
-							"mountPath": "/var/logs"
+							"mountPath": "/var/log"
 						}
 					],
 					"resources": {

--- a/test/kubemark/resources/kernel-monitor.json
+++ b/test/kubemark/resources/kernel-monitor.json
@@ -1,5 +1,5 @@
 {
-	"logPath": "/log/faillog",
+	"logPath": "/var/log/faillog",
 	"lookback": "10m",
 	"startPattern": "Initializing cgroup subsys cpuset",
 	"bufferSize": 10,


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/41613

Added an option to log kubemark hollow-node logs which includes kubelet, kubeproxy and npd logs for each hollow-node.
Setting the env var `ENABLE_HOLLOW_NODE_LOGS=true` should now enable logging for tests.

cc @kubernetes/sig-scalability-misc @wojtek-t @gmarek @yujuhong @Random-Liu 