### PR TITLE
Fix kubemark default e2e test suite's name

### DIFF
--- a/test/kubemark/run-e2e-tests.sh
+++ b/test/kubemark/run-e2e-tests.sh
@@ -33,7 +33,7 @@ export KUBECONFIG="${ABSOLUTE_ROOT}/test/kubemark/resources/kubeconfig.kubemark"
 export E2E_MIN_STARTUP_PODS=0
 
 if [[ -z "$@" ]]; then
-	ARGS='--ginkgo.focus=\[Feature:performance\]'
+	ARGS='--ginkgo.focus=\[Feature:Performance\]'
 else
 	ARGS=$@
 fi


### PR DESCRIPTION
Seems like the suite "[Feature:performance]" doesn't trigger tests anymore. Changed it to "[Feature:Performance]" in kubemark run-e2e-tests.sh.

cc @wojtek-t @gmarek 