### PR TITLE
fix ENABLE_KUBELET_DEBUG_HANDLERS typo

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -798,7 +798,7 @@ if [[ "${START_MODE}" != "nokubelet" ]]; then
         ;;
       Linux)
         start_kubelet
-	if [[ "${ENABLE_KUBELET_DEBUG_HANDLER}" = true ]]; then
+	if [[ "${ENABLE_KUBELET_DEBUG_HANDLERS}" = true ]]; then
 	  warning "kubelet is debug mode."
 	fi
         ;;


### PR DESCRIPTION
There was a typo when the env var was added, so this is an unbound variable.
