### PR TITLE
Fix lint failure in deepcopy generated files

### DIFF
--- a/cmd/kube-aggregator/pkg/apis/apiregistration/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/kube-aggregator/pkg/apis/apiregistration/v1alpha1/zz_generated.deepcopy.go
@@ -35,32 +35,34 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_APIService, InType: reflect.TypeOf(&APIService{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_APIServiceList, InType: reflect.TypeOf(&APIServiceList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_APIServiceSpec, InType: reflect.TypeOf(&APIServiceSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_APIServiceStatus, InType: reflect.TypeOf(&APIServiceStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ServiceReference, InType: reflect.TypeOf(&ServiceReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1APIService, InType: reflect.TypeOf(&APIService{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1APIServiceList, InType: reflect.TypeOf(&APIServiceList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1APIServiceSpec, InType: reflect.TypeOf(&APIServiceSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1APIServiceStatus, InType: reflect.TypeOf(&APIServiceStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ServiceReference, InType: reflect.TypeOf(&ServiceReference{})},
 	)
 }
 
-func DeepCopy_v1alpha1_APIService(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1APIService ...
+func DeepCopyv1alpha1APIService(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIService)
 		out := out.(*APIService)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1alpha1_APIServiceSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1alpha1APIServiceSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1alpha1_APIServiceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1APIServiceList ...
+func DeepCopyv1alpha1APIServiceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIServiceList)
 		out := out.(*APIServiceList)
@@ -69,7 +71,7 @@ func DeepCopy_v1alpha1_APIServiceList(in interface{}, out interface{}, c *conver
 			in, out := &in.Items, &out.Items
 			*out = make([]APIService, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_APIService(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1alpha1APIService(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -78,7 +80,8 @@ func DeepCopy_v1alpha1_APIServiceList(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1alpha1_APIServiceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1APIServiceSpec ...
+func DeepCopyv1alpha1APIServiceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIServiceSpec)
 		out := out.(*APIServiceSpec)
@@ -92,7 +95,8 @@ func DeepCopy_v1alpha1_APIServiceSpec(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1alpha1_APIServiceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1APIServiceStatus ...
+func DeepCopyv1alpha1APIServiceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIServiceStatus)
 		out := out.(*APIServiceStatus)
@@ -101,7 +105,8 @@ func DeepCopy_v1alpha1_APIServiceStatus(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_v1alpha1_ServiceReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ServiceReference ...
+func DeepCopyv1alpha1ServiceReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceReference)
 		out := out.(*ServiceReference)

--- a/cmd/kube-aggregator/pkg/apis/apiregistration/zz_generated.deepcopy.go
+++ b/cmd/kube-aggregator/pkg/apis/apiregistration/zz_generated.deepcopy.go
@@ -35,32 +35,34 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apiregistration_APIService, InType: reflect.TypeOf(&APIService{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apiregistration_APIServiceList, InType: reflect.TypeOf(&APIServiceList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apiregistration_APIServiceSpec, InType: reflect.TypeOf(&APIServiceSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apiregistration_APIServiceStatus, InType: reflect.TypeOf(&APIServiceStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apiregistration_ServiceReference, InType: reflect.TypeOf(&ServiceReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiregistrationAPIService, InType: reflect.TypeOf(&APIService{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiregistrationAPIServiceList, InType: reflect.TypeOf(&APIServiceList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiregistrationAPIServiceSpec, InType: reflect.TypeOf(&APIServiceSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiregistrationAPIServiceStatus, InType: reflect.TypeOf(&APIServiceStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiregistrationServiceReference, InType: reflect.TypeOf(&ServiceReference{})},
 	)
 }
 
-func DeepCopy_apiregistration_APIService(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiregistrationAPIService ...
+func DeepCopyapiregistrationAPIService(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIService)
 		out := out.(*APIService)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_apiregistration_APIServiceSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyapiregistrationAPIServiceSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_apiregistration_APIServiceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiregistrationAPIServiceList ...
+func DeepCopyapiregistrationAPIServiceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIServiceList)
 		out := out.(*APIServiceList)
@@ -69,7 +71,7 @@ func DeepCopy_apiregistration_APIServiceList(in interface{}, out interface{}, c 
 			in, out := &in.Items, &out.Items
 			*out = make([]APIService, len(*in))
 			for i := range *in {
-				if err := DeepCopy_apiregistration_APIService(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiregistrationAPIService(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -78,7 +80,8 @@ func DeepCopy_apiregistration_APIServiceList(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_apiregistration_APIServiceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiregistrationAPIServiceSpec ...
+func DeepCopyapiregistrationAPIServiceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIServiceSpec)
 		out := out.(*APIServiceSpec)
@@ -92,7 +95,8 @@ func DeepCopy_apiregistration_APIServiceSpec(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_apiregistration_APIServiceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiregistrationAPIServiceStatus ...
+func DeepCopyapiregistrationAPIServiceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIServiceStatus)
 		out := out.(*APIServiceStatus)
@@ -101,7 +105,8 @@ func DeepCopy_apiregistration_APIServiceStatus(in interface{}, out interface{}, 
 	}
 }
 
-func DeepCopy_apiregistration_ServiceReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiregistrationServiceReference ...
+func DeepCopyapiregistrationServiceReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceReference)
 		out := out.(*ServiceReference)

--- a/federation/apis/federation/v1beta1/zz_generated.deepcopy.go
+++ b/federation/apis/federation/v1beta1/zz_generated.deepcopy.go
@@ -36,36 +36,38 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_Cluster, InType: reflect.TypeOf(&Cluster{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ClusterCondition, InType: reflect.TypeOf(&ClusterCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ClusterList, InType: reflect.TypeOf(&ClusterList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ClusterSpec, InType: reflect.TypeOf(&ClusterSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ClusterStatus, InType: reflect.TypeOf(&ClusterStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ServerAddressByClientCIDR, InType: reflect.TypeOf(&ServerAddressByClientCIDR{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1Cluster, InType: reflect.TypeOf(&Cluster{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ClusterCondition, InType: reflect.TypeOf(&ClusterCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ClusterList, InType: reflect.TypeOf(&ClusterList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ClusterSpec, InType: reflect.TypeOf(&ClusterSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ClusterStatus, InType: reflect.TypeOf(&ClusterStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ServerAddressByClientCIDR, InType: reflect.TypeOf(&ServerAddressByClientCIDR{})},
 	)
 }
 
-func DeepCopy_v1beta1_Cluster(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1Cluster ...
+func DeepCopyv1beta1Cluster(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Cluster)
 		out := out.(*Cluster)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1beta1_ClusterSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1beta1_ClusterStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1ClusterSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1beta1ClusterStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_ClusterCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ClusterCondition ...
+func DeepCopyv1beta1ClusterCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterCondition)
 		out := out.(*ClusterCondition)
@@ -76,7 +78,8 @@ func DeepCopy_v1beta1_ClusterCondition(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1beta1_ClusterList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ClusterList ...
+func DeepCopyv1beta1ClusterList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterList)
 		out := out.(*ClusterList)
@@ -85,7 +88,7 @@ func DeepCopy_v1beta1_ClusterList(in interface{}, out interface{}, c *conversion
 			in, out := &in.Items, &out.Items
 			*out = make([]Cluster, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_Cluster(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1Cluster(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -94,7 +97,8 @@ func DeepCopy_v1beta1_ClusterList(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1beta1_ClusterSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ClusterSpec ...
+func DeepCopyv1beta1ClusterSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterSpec)
 		out := out.(*ClusterSpec)
@@ -113,7 +117,8 @@ func DeepCopy_v1beta1_ClusterSpec(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1beta1_ClusterStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ClusterStatus ...
+func DeepCopyv1beta1ClusterStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterStatus)
 		out := out.(*ClusterStatus)
@@ -122,7 +127,7 @@ func DeepCopy_v1beta1_ClusterStatus(in interface{}, out interface{}, c *conversi
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]ClusterCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_ClusterCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1ClusterCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -136,7 +141,8 @@ func DeepCopy_v1beta1_ClusterStatus(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1beta1_ServerAddressByClientCIDR(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ServerAddressByClientCIDR ...
+func DeepCopyv1beta1ServerAddressByClientCIDR(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServerAddressByClientCIDR)
 		out := out.(*ServerAddressByClientCIDR)

--- a/federation/apis/federation/zz_generated.deepcopy.go
+++ b/federation/apis/federation/zz_generated.deepcopy.go
@@ -36,38 +36,40 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_federation_Cluster, InType: reflect.TypeOf(&Cluster{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_federation_ClusterCondition, InType: reflect.TypeOf(&ClusterCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_federation_ClusterList, InType: reflect.TypeOf(&ClusterList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_federation_ClusterReplicaSetPreferences, InType: reflect.TypeOf(&ClusterReplicaSetPreferences{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_federation_ClusterSpec, InType: reflect.TypeOf(&ClusterSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_federation_ClusterStatus, InType: reflect.TypeOf(&ClusterStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_federation_FederatedReplicaSetPreferences, InType: reflect.TypeOf(&FederatedReplicaSetPreferences{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_federation_ServerAddressByClientCIDR, InType: reflect.TypeOf(&ServerAddressByClientCIDR{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyfederationCluster, InType: reflect.TypeOf(&Cluster{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyfederationClusterCondition, InType: reflect.TypeOf(&ClusterCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyfederationClusterList, InType: reflect.TypeOf(&ClusterList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyfederationClusterReplicaSetPreferences, InType: reflect.TypeOf(&ClusterReplicaSetPreferences{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyfederationClusterSpec, InType: reflect.TypeOf(&ClusterSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyfederationClusterStatus, InType: reflect.TypeOf(&ClusterStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyfederationFederatedReplicaSetPreferences, InType: reflect.TypeOf(&FederatedReplicaSetPreferences{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyfederationServerAddressByClientCIDR, InType: reflect.TypeOf(&ServerAddressByClientCIDR{})},
 	)
 }
 
-func DeepCopy_federation_Cluster(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyfederationCluster ...
+func DeepCopyfederationCluster(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Cluster)
 		out := out.(*Cluster)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_federation_ClusterSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_federation_ClusterStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyfederationClusterSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyfederationClusterStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_federation_ClusterCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyfederationClusterCondition ...
+func DeepCopyfederationClusterCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterCondition)
 		out := out.(*ClusterCondition)
@@ -78,7 +80,8 @@ func DeepCopy_federation_ClusterCondition(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_federation_ClusterList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyfederationClusterList ...
+func DeepCopyfederationClusterList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterList)
 		out := out.(*ClusterList)
@@ -87,7 +90,7 @@ func DeepCopy_federation_ClusterList(in interface{}, out interface{}, c *convers
 			in, out := &in.Items, &out.Items
 			*out = make([]Cluster, len(*in))
 			for i := range *in {
-				if err := DeepCopy_federation_Cluster(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyfederationCluster(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -96,7 +99,8 @@ func DeepCopy_federation_ClusterList(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_federation_ClusterReplicaSetPreferences(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyfederationClusterReplicaSetPreferences ...
+func DeepCopyfederationClusterReplicaSetPreferences(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterReplicaSetPreferences)
 		out := out.(*ClusterReplicaSetPreferences)
@@ -110,7 +114,8 @@ func DeepCopy_federation_ClusterReplicaSetPreferences(in interface{}, out interf
 	}
 }
 
-func DeepCopy_federation_ClusterSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyfederationClusterSpec ...
+func DeepCopyfederationClusterSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterSpec)
 		out := out.(*ClusterSpec)
@@ -129,7 +134,8 @@ func DeepCopy_federation_ClusterSpec(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_federation_ClusterStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyfederationClusterStatus ...
+func DeepCopyfederationClusterStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterStatus)
 		out := out.(*ClusterStatus)
@@ -138,7 +144,7 @@ func DeepCopy_federation_ClusterStatus(in interface{}, out interface{}, c *conve
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]ClusterCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_federation_ClusterCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyfederationClusterCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -152,7 +158,8 @@ func DeepCopy_federation_ClusterStatus(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_federation_FederatedReplicaSetPreferences(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyfederationFederatedReplicaSetPreferences ...
+func DeepCopyfederationFederatedReplicaSetPreferences(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FederatedReplicaSetPreferences)
 		out := out.(*FederatedReplicaSetPreferences)
@@ -162,7 +169,7 @@ func DeepCopy_federation_FederatedReplicaSetPreferences(in interface{}, out inte
 			*out = make(map[string]ClusterReplicaSetPreferences)
 			for key, val := range *in {
 				newVal := new(ClusterReplicaSetPreferences)
-				if err := DeepCopy_federation_ClusterReplicaSetPreferences(&val, newVal, c); err != nil {
+				if err := DeepCopyfederationClusterReplicaSetPreferences(&val, newVal, c); err != nil {
 					return err
 				}
 				(*out)[key] = *newVal
@@ -172,7 +179,8 @@ func DeepCopy_federation_FederatedReplicaSetPreferences(in interface{}, out inte
 	}
 }
 
-func DeepCopy_federation_ServerAddressByClientCIDR(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyfederationServerAddressByClientCIDR ...
+func DeepCopyfederationServerAddressByClientCIDR(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServerAddressByClientCIDR)
 		out := out.(*ServerAddressByClientCIDR)

--- a/federation/pkg/federation-controller/util/eventsink/eventsink.go
+++ b/federation/pkg/federation-controller/util/eventsink/eventsink.go
@@ -60,7 +60,7 @@ func init() {
 	}
 	if err := scheme.AddGeneratedDeepCopyFuncs(
 		conversion.GeneratedDeepCopyFunc{
-			Fn:     metav1.DeepCopy_v1_Time,
+			Fn:     metav1.DeepCopyv1Time,
 			InType: reflect.TypeOf(&metav1.Time{}),
 		},
 	); err != nil {

--- a/pkg/api/v1/zz_generated.deepcopy.go
+++ b/pkg/api/v1/zz_generated.deepcopy.go
@@ -36,170 +36,171 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_AWSElasticBlockStoreVolumeSource, InType: reflect.TypeOf(&AWSElasticBlockStoreVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Affinity, InType: reflect.TypeOf(&Affinity{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_AttachedVolume, InType: reflect.TypeOf(&AttachedVolume{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_AvoidPods, InType: reflect.TypeOf(&AvoidPods{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_AzureDiskVolumeSource, InType: reflect.TypeOf(&AzureDiskVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_AzureFileVolumeSource, InType: reflect.TypeOf(&AzureFileVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Binding, InType: reflect.TypeOf(&Binding{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Capabilities, InType: reflect.TypeOf(&Capabilities{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_CephFSVolumeSource, InType: reflect.TypeOf(&CephFSVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_CinderVolumeSource, InType: reflect.TypeOf(&CinderVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ComponentCondition, InType: reflect.TypeOf(&ComponentCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ComponentStatus, InType: reflect.TypeOf(&ComponentStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ComponentStatusList, InType: reflect.TypeOf(&ComponentStatusList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ConfigMap, InType: reflect.TypeOf(&ConfigMap{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ConfigMapEnvSource, InType: reflect.TypeOf(&ConfigMapEnvSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ConfigMapKeySelector, InType: reflect.TypeOf(&ConfigMapKeySelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ConfigMapList, InType: reflect.TypeOf(&ConfigMapList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ConfigMapVolumeSource, InType: reflect.TypeOf(&ConfigMapVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Container, InType: reflect.TypeOf(&Container{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ContainerImage, InType: reflect.TypeOf(&ContainerImage{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ContainerPort, InType: reflect.TypeOf(&ContainerPort{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ContainerState, InType: reflect.TypeOf(&ContainerState{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ContainerStateRunning, InType: reflect.TypeOf(&ContainerStateRunning{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ContainerStateTerminated, InType: reflect.TypeOf(&ContainerStateTerminated{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ContainerStateWaiting, InType: reflect.TypeOf(&ContainerStateWaiting{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ContainerStatus, InType: reflect.TypeOf(&ContainerStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_DaemonEndpoint, InType: reflect.TypeOf(&DaemonEndpoint{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_DeleteOptions, InType: reflect.TypeOf(&DeleteOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_DownwardAPIVolumeFile, InType: reflect.TypeOf(&DownwardAPIVolumeFile{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_DownwardAPIVolumeSource, InType: reflect.TypeOf(&DownwardAPIVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EmptyDirVolumeSource, InType: reflect.TypeOf(&EmptyDirVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EndpointAddress, InType: reflect.TypeOf(&EndpointAddress{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EndpointPort, InType: reflect.TypeOf(&EndpointPort{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EndpointSubset, InType: reflect.TypeOf(&EndpointSubset{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Endpoints, InType: reflect.TypeOf(&Endpoints{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EndpointsList, InType: reflect.TypeOf(&EndpointsList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EnvFromSource, InType: reflect.TypeOf(&EnvFromSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EnvVar, InType: reflect.TypeOf(&EnvVar{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EnvVarSource, InType: reflect.TypeOf(&EnvVarSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Event, InType: reflect.TypeOf(&Event{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EventList, InType: reflect.TypeOf(&EventList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_EventSource, InType: reflect.TypeOf(&EventSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ExecAction, InType: reflect.TypeOf(&ExecAction{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_FCVolumeSource, InType: reflect.TypeOf(&FCVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_FlexVolumeSource, InType: reflect.TypeOf(&FlexVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_FlockerVolumeSource, InType: reflect.TypeOf(&FlockerVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_GCEPersistentDiskVolumeSource, InType: reflect.TypeOf(&GCEPersistentDiskVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_GitRepoVolumeSource, InType: reflect.TypeOf(&GitRepoVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_GlusterfsVolumeSource, InType: reflect.TypeOf(&GlusterfsVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_HTTPGetAction, InType: reflect.TypeOf(&HTTPGetAction{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_HTTPHeader, InType: reflect.TypeOf(&HTTPHeader{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Handler, InType: reflect.TypeOf(&Handler{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_HostPathVolumeSource, InType: reflect.TypeOf(&HostPathVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ISCSIVolumeSource, InType: reflect.TypeOf(&ISCSIVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_KeyToPath, InType: reflect.TypeOf(&KeyToPath{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Lifecycle, InType: reflect.TypeOf(&Lifecycle{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_LimitRange, InType: reflect.TypeOf(&LimitRange{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_LimitRangeItem, InType: reflect.TypeOf(&LimitRangeItem{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_LimitRangeList, InType: reflect.TypeOf(&LimitRangeList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_LimitRangeSpec, InType: reflect.TypeOf(&LimitRangeSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_List, InType: reflect.TypeOf(&List{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ListOptions, InType: reflect.TypeOf(&ListOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_LoadBalancerIngress, InType: reflect.TypeOf(&LoadBalancerIngress{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_LoadBalancerStatus, InType: reflect.TypeOf(&LoadBalancerStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_LocalObjectReference, InType: reflect.TypeOf(&LocalObjectReference{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NFSVolumeSource, InType: reflect.TypeOf(&NFSVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Namespace, InType: reflect.TypeOf(&Namespace{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NamespaceList, InType: reflect.TypeOf(&NamespaceList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NamespaceSpec, InType: reflect.TypeOf(&NamespaceSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NamespaceStatus, InType: reflect.TypeOf(&NamespaceStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Node, InType: reflect.TypeOf(&Node{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeAddress, InType: reflect.TypeOf(&NodeAddress{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeAffinity, InType: reflect.TypeOf(&NodeAffinity{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeCondition, InType: reflect.TypeOf(&NodeCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeDaemonEndpoints, InType: reflect.TypeOf(&NodeDaemonEndpoints{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeList, InType: reflect.TypeOf(&NodeList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeProxyOptions, InType: reflect.TypeOf(&NodeProxyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeResources, InType: reflect.TypeOf(&NodeResources{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeSelector, InType: reflect.TypeOf(&NodeSelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeSelectorRequirement, InType: reflect.TypeOf(&NodeSelectorRequirement{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeSelectorTerm, InType: reflect.TypeOf(&NodeSelectorTerm{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeSpec, InType: reflect.TypeOf(&NodeSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeStatus, InType: reflect.TypeOf(&NodeStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_NodeSystemInfo, InType: reflect.TypeOf(&NodeSystemInfo{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ObjectFieldSelector, InType: reflect.TypeOf(&ObjectFieldSelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ObjectMeta, InType: reflect.TypeOf(&ObjectMeta{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ObjectReference, InType: reflect.TypeOf(&ObjectReference{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolume, InType: reflect.TypeOf(&PersistentVolume{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeClaim, InType: reflect.TypeOf(&PersistentVolumeClaim{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeClaimList, InType: reflect.TypeOf(&PersistentVolumeClaimList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeClaimSpec, InType: reflect.TypeOf(&PersistentVolumeClaimSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeClaimStatus, InType: reflect.TypeOf(&PersistentVolumeClaimStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeClaimVolumeSource, InType: reflect.TypeOf(&PersistentVolumeClaimVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeList, InType: reflect.TypeOf(&PersistentVolumeList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeSource, InType: reflect.TypeOf(&PersistentVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeSpec, InType: reflect.TypeOf(&PersistentVolumeSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PersistentVolumeStatus, InType: reflect.TypeOf(&PersistentVolumeStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PhotonPersistentDiskVolumeSource, InType: reflect.TypeOf(&PhotonPersistentDiskVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Pod, InType: reflect.TypeOf(&Pod{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodAffinity, InType: reflect.TypeOf(&PodAffinity{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodAffinityTerm, InType: reflect.TypeOf(&PodAffinityTerm{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodAntiAffinity, InType: reflect.TypeOf(&PodAntiAffinity{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodAttachOptions, InType: reflect.TypeOf(&PodAttachOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodCondition, InType: reflect.TypeOf(&PodCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodExecOptions, InType: reflect.TypeOf(&PodExecOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodList, InType: reflect.TypeOf(&PodList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodLogOptions, InType: reflect.TypeOf(&PodLogOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodPortForwardOptions, InType: reflect.TypeOf(&PodPortForwardOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodProxyOptions, InType: reflect.TypeOf(&PodProxyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodSecurityContext, InType: reflect.TypeOf(&PodSecurityContext{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodSignature, InType: reflect.TypeOf(&PodSignature{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodSpec, InType: reflect.TypeOf(&PodSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodStatus, InType: reflect.TypeOf(&PodStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodStatusResult, InType: reflect.TypeOf(&PodStatusResult{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodTemplate, InType: reflect.TypeOf(&PodTemplate{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodTemplateList, InType: reflect.TypeOf(&PodTemplateList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodTemplateSpec, InType: reflect.TypeOf(&PodTemplateSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Preconditions, InType: reflect.TypeOf(&Preconditions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PreferAvoidPodsEntry, InType: reflect.TypeOf(&PreferAvoidPodsEntry{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PreferredSchedulingTerm, InType: reflect.TypeOf(&PreferredSchedulingTerm{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Probe, InType: reflect.TypeOf(&Probe{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_QuobyteVolumeSource, InType: reflect.TypeOf(&QuobyteVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_RBDVolumeSource, InType: reflect.TypeOf(&RBDVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_RangeAllocation, InType: reflect.TypeOf(&RangeAllocation{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ReplicationController, InType: reflect.TypeOf(&ReplicationController{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ReplicationControllerCondition, InType: reflect.TypeOf(&ReplicationControllerCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ReplicationControllerList, InType: reflect.TypeOf(&ReplicationControllerList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ReplicationControllerSpec, InType: reflect.TypeOf(&ReplicationControllerSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ReplicationControllerStatus, InType: reflect.TypeOf(&ReplicationControllerStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ResourceFieldSelector, InType: reflect.TypeOf(&ResourceFieldSelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ResourceQuota, InType: reflect.TypeOf(&ResourceQuota{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ResourceQuotaList, InType: reflect.TypeOf(&ResourceQuotaList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ResourceQuotaSpec, InType: reflect.TypeOf(&ResourceQuotaSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ResourceQuotaStatus, InType: reflect.TypeOf(&ResourceQuotaStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ResourceRequirements, InType: reflect.TypeOf(&ResourceRequirements{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_SELinuxOptions, InType: reflect.TypeOf(&SELinuxOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Secret, InType: reflect.TypeOf(&Secret{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_SecretEnvSource, InType: reflect.TypeOf(&SecretEnvSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_SecretKeySelector, InType: reflect.TypeOf(&SecretKeySelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_SecretList, InType: reflect.TypeOf(&SecretList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_SecretVolumeSource, InType: reflect.TypeOf(&SecretVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_SecurityContext, InType: reflect.TypeOf(&SecurityContext{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_SerializedReference, InType: reflect.TypeOf(&SerializedReference{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Service, InType: reflect.TypeOf(&Service{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ServiceAccount, InType: reflect.TypeOf(&ServiceAccount{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ServiceAccountList, InType: reflect.TypeOf(&ServiceAccountList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ServiceList, InType: reflect.TypeOf(&ServiceList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ServicePort, InType: reflect.TypeOf(&ServicePort{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ServiceProxyOptions, InType: reflect.TypeOf(&ServiceProxyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ServiceSpec, InType: reflect.TypeOf(&ServiceSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ServiceStatus, InType: reflect.TypeOf(&ServiceStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Sysctl, InType: reflect.TypeOf(&Sysctl{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_TCPSocketAction, InType: reflect.TypeOf(&TCPSocketAction{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Taint, InType: reflect.TypeOf(&Taint{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Toleration, InType: reflect.TypeOf(&Toleration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Volume, InType: reflect.TypeOf(&Volume{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_VolumeMount, InType: reflect.TypeOf(&VolumeMount{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_VolumeSource, InType: reflect.TypeOf(&VolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_VsphereVirtualDiskVolumeSource, InType: reflect.TypeOf(&VsphereVirtualDiskVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_WeightedPodAffinityTerm, InType: reflect.TypeOf(&WeightedPodAffinityTerm{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1AWSElasticBlockStoreVolumeSource, InType: reflect.TypeOf(&AWSElasticBlockStoreVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Affinity, InType: reflect.TypeOf(&Affinity{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1AttachedVolume, InType: reflect.TypeOf(&AttachedVolume{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1AvoidPods, InType: reflect.TypeOf(&AvoidPods{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1AzureDiskVolumeSource, InType: reflect.TypeOf(&AzureDiskVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1AzureFileVolumeSource, InType: reflect.TypeOf(&AzureFileVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Binding, InType: reflect.TypeOf(&Binding{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Capabilities, InType: reflect.TypeOf(&Capabilities{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1CephFSVolumeSource, InType: reflect.TypeOf(&CephFSVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1CinderVolumeSource, InType: reflect.TypeOf(&CinderVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ComponentCondition, InType: reflect.TypeOf(&ComponentCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ComponentStatus, InType: reflect.TypeOf(&ComponentStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ComponentStatusList, InType: reflect.TypeOf(&ComponentStatusList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ConfigMap, InType: reflect.TypeOf(&ConfigMap{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ConfigMapEnvSource, InType: reflect.TypeOf(&ConfigMapEnvSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ConfigMapKeySelector, InType: reflect.TypeOf(&ConfigMapKeySelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ConfigMapList, InType: reflect.TypeOf(&ConfigMapList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ConfigMapVolumeSource, InType: reflect.TypeOf(&ConfigMapVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Container, InType: reflect.TypeOf(&Container{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ContainerImage, InType: reflect.TypeOf(&ContainerImage{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ContainerPort, InType: reflect.TypeOf(&ContainerPort{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ContainerState, InType: reflect.TypeOf(&ContainerState{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ContainerStateRunning, InType: reflect.TypeOf(&ContainerStateRunning{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ContainerStateTerminated, InType: reflect.TypeOf(&ContainerStateTerminated{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ContainerStateWaiting, InType: reflect.TypeOf(&ContainerStateWaiting{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ContainerStatus, InType: reflect.TypeOf(&ContainerStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1DaemonEndpoint, InType: reflect.TypeOf(&DaemonEndpoint{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1DeleteOptions, InType: reflect.TypeOf(&DeleteOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1DownwardAPIVolumeFile, InType: reflect.TypeOf(&DownwardAPIVolumeFile{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1DownwardAPIVolumeSource, InType: reflect.TypeOf(&DownwardAPIVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EmptyDirVolumeSource, InType: reflect.TypeOf(&EmptyDirVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EndpointAddress, InType: reflect.TypeOf(&EndpointAddress{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EndpointPort, InType: reflect.TypeOf(&EndpointPort{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EndpointSubset, InType: reflect.TypeOf(&EndpointSubset{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Endpoints, InType: reflect.TypeOf(&Endpoints{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EndpointsList, InType: reflect.TypeOf(&EndpointsList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EnvFromSource, InType: reflect.TypeOf(&EnvFromSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EnvVar, InType: reflect.TypeOf(&EnvVar{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EnvVarSource, InType: reflect.TypeOf(&EnvVarSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Event, InType: reflect.TypeOf(&Event{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EventList, InType: reflect.TypeOf(&EventList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1EventSource, InType: reflect.TypeOf(&EventSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ExecAction, InType: reflect.TypeOf(&ExecAction{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1FCVolumeSource, InType: reflect.TypeOf(&FCVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1FlexVolumeSource, InType: reflect.TypeOf(&FlexVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1FlockerVolumeSource, InType: reflect.TypeOf(&FlockerVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1GCEPersistentDiskVolumeSource, InType: reflect.TypeOf(&GCEPersistentDiskVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1GitRepoVolumeSource, InType: reflect.TypeOf(&GitRepoVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1GlusterfsVolumeSource, InType: reflect.TypeOf(&GlusterfsVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1HTTPGetAction, InType: reflect.TypeOf(&HTTPGetAction{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1HTTPHeader, InType: reflect.TypeOf(&HTTPHeader{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Handler, InType: reflect.TypeOf(&Handler{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1HostPathVolumeSource, InType: reflect.TypeOf(&HostPathVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ISCSIVolumeSource, InType: reflect.TypeOf(&ISCSIVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1KeyToPath, InType: reflect.TypeOf(&KeyToPath{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Lifecycle, InType: reflect.TypeOf(&Lifecycle{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1LimitRange, InType: reflect.TypeOf(&LimitRange{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1LimitRangeItem, InType: reflect.TypeOf(&LimitRangeItem{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1LimitRangeList, InType: reflect.TypeOf(&LimitRangeList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1LimitRangeSpec, InType: reflect.TypeOf(&LimitRangeSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1List, InType: reflect.TypeOf(&List{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ListOptions, InType: reflect.TypeOf(&ListOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1LoadBalancerIngress, InType: reflect.TypeOf(&LoadBalancerIngress{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1LoadBalancerStatus, InType: reflect.TypeOf(&LoadBalancerStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1LocalObjectReference, InType: reflect.TypeOf(&LocalObjectReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NFSVolumeSource, InType: reflect.TypeOf(&NFSVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Namespace, InType: reflect.TypeOf(&Namespace{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NamespaceList, InType: reflect.TypeOf(&NamespaceList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NamespaceSpec, InType: reflect.TypeOf(&NamespaceSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NamespaceStatus, InType: reflect.TypeOf(&NamespaceStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Node, InType: reflect.TypeOf(&Node{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeAddress, InType: reflect.TypeOf(&NodeAddress{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeAffinity, InType: reflect.TypeOf(&NodeAffinity{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeCondition, InType: reflect.TypeOf(&NodeCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeDaemonEndpoints, InType: reflect.TypeOf(&NodeDaemonEndpoints{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeList, InType: reflect.TypeOf(&NodeList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeProxyOptions, InType: reflect.TypeOf(&NodeProxyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeResources, InType: reflect.TypeOf(&NodeResources{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeSelector, InType: reflect.TypeOf(&NodeSelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeSelectorRequirement, InType: reflect.TypeOf(&NodeSelectorRequirement{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeSelectorTerm, InType: reflect.TypeOf(&NodeSelectorTerm{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeSpec, InType: reflect.TypeOf(&NodeSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeStatus, InType: reflect.TypeOf(&NodeStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1NodeSystemInfo, InType: reflect.TypeOf(&NodeSystemInfo{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ObjectFieldSelector, InType: reflect.TypeOf(&ObjectFieldSelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ObjectMeta, InType: reflect.TypeOf(&ObjectMeta{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ObjectReference, InType: reflect.TypeOf(&ObjectReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolume, InType: reflect.TypeOf(&PersistentVolume{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeClaim, InType: reflect.TypeOf(&PersistentVolumeClaim{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeClaimList, InType: reflect.TypeOf(&PersistentVolumeClaimList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeClaimSpec, InType: reflect.TypeOf(&PersistentVolumeClaimSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeClaimStatus, InType: reflect.TypeOf(&PersistentVolumeClaimStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeClaimVolumeSource, InType: reflect.TypeOf(&PersistentVolumeClaimVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeList, InType: reflect.TypeOf(&PersistentVolumeList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeSource, InType: reflect.TypeOf(&PersistentVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeSpec, InType: reflect.TypeOf(&PersistentVolumeSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PersistentVolumeStatus, InType: reflect.TypeOf(&PersistentVolumeStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PhotonPersistentDiskVolumeSource, InType: reflect.TypeOf(&PhotonPersistentDiskVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Pod, InType: reflect.TypeOf(&Pod{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodAffinity, InType: reflect.TypeOf(&PodAffinity{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodAffinityTerm, InType: reflect.TypeOf(&PodAffinityTerm{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodAntiAffinity, InType: reflect.TypeOf(&PodAntiAffinity{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodAttachOptions, InType: reflect.TypeOf(&PodAttachOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodCondition, InType: reflect.TypeOf(&PodCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodExecOptions, InType: reflect.TypeOf(&PodExecOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodList, InType: reflect.TypeOf(&PodList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodLogOptions, InType: reflect.TypeOf(&PodLogOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodPortForwardOptions, InType: reflect.TypeOf(&PodPortForwardOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodProxyOptions, InType: reflect.TypeOf(&PodProxyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodSecurityContext, InType: reflect.TypeOf(&PodSecurityContext{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodSignature, InType: reflect.TypeOf(&PodSignature{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodSpec, InType: reflect.TypeOf(&PodSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodStatus, InType: reflect.TypeOf(&PodStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodStatusResult, InType: reflect.TypeOf(&PodStatusResult{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodTemplate, InType: reflect.TypeOf(&PodTemplate{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodTemplateList, InType: reflect.TypeOf(&PodTemplateList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodTemplateSpec, InType: reflect.TypeOf(&PodTemplateSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Preconditions, InType: reflect.TypeOf(&Preconditions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PreferAvoidPodsEntry, InType: reflect.TypeOf(&PreferAvoidPodsEntry{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PreferredSchedulingTerm, InType: reflect.TypeOf(&PreferredSchedulingTerm{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Probe, InType: reflect.TypeOf(&Probe{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1QuobyteVolumeSource, InType: reflect.TypeOf(&QuobyteVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1RBDVolumeSource, InType: reflect.TypeOf(&RBDVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1RangeAllocation, InType: reflect.TypeOf(&RangeAllocation{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ReplicationController, InType: reflect.TypeOf(&ReplicationController{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ReplicationControllerCondition, InType: reflect.TypeOf(&ReplicationControllerCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ReplicationControllerList, InType: reflect.TypeOf(&ReplicationControllerList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ReplicationControllerSpec, InType: reflect.TypeOf(&ReplicationControllerSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ReplicationControllerStatus, InType: reflect.TypeOf(&ReplicationControllerStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ResourceFieldSelector, InType: reflect.TypeOf(&ResourceFieldSelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ResourceQuota, InType: reflect.TypeOf(&ResourceQuota{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ResourceQuotaList, InType: reflect.TypeOf(&ResourceQuotaList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ResourceQuotaSpec, InType: reflect.TypeOf(&ResourceQuotaSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ResourceQuotaStatus, InType: reflect.TypeOf(&ResourceQuotaStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ResourceRequirements, InType: reflect.TypeOf(&ResourceRequirements{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1SELinuxOptions, InType: reflect.TypeOf(&SELinuxOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Secret, InType: reflect.TypeOf(&Secret{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1SecretEnvSource, InType: reflect.TypeOf(&SecretEnvSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1SecretKeySelector, InType: reflect.TypeOf(&SecretKeySelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1SecretList, InType: reflect.TypeOf(&SecretList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1SecretVolumeSource, InType: reflect.TypeOf(&SecretVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1SecurityContext, InType: reflect.TypeOf(&SecurityContext{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1SerializedReference, InType: reflect.TypeOf(&SerializedReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Service, InType: reflect.TypeOf(&Service{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ServiceAccount, InType: reflect.TypeOf(&ServiceAccount{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ServiceAccountList, InType: reflect.TypeOf(&ServiceAccountList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ServiceList, InType: reflect.TypeOf(&ServiceList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ServicePort, InType: reflect.TypeOf(&ServicePort{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ServiceProxyOptions, InType: reflect.TypeOf(&ServiceProxyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ServiceSpec, InType: reflect.TypeOf(&ServiceSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ServiceStatus, InType: reflect.TypeOf(&ServiceStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Sysctl, InType: reflect.TypeOf(&Sysctl{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1TCPSocketAction, InType: reflect.TypeOf(&TCPSocketAction{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Taint, InType: reflect.TypeOf(&Taint{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Toleration, InType: reflect.TypeOf(&Toleration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Volume, InType: reflect.TypeOf(&Volume{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1VolumeMount, InType: reflect.TypeOf(&VolumeMount{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1VolumeSource, InType: reflect.TypeOf(&VolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1VsphereVirtualDiskVolumeSource, InType: reflect.TypeOf(&VsphereVirtualDiskVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1WeightedPodAffinityTerm, InType: reflect.TypeOf(&WeightedPodAffinityTerm{})},
 	)
 }
 
-func DeepCopy_v1_AWSElasticBlockStoreVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1AWSElasticBlockStoreVolumeSource ...
+func DeepCopyv1AWSElasticBlockStoreVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AWSElasticBlockStoreVolumeSource)
 		out := out.(*AWSElasticBlockStoreVolumeSource)
@@ -208,7 +209,8 @@ func DeepCopy_v1_AWSElasticBlockStoreVolumeSource(in interface{}, out interface{
 	}
 }
 
-func DeepCopy_v1_Affinity(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Affinity ...
+func DeepCopyv1Affinity(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Affinity)
 		out := out.(*Affinity)
@@ -216,21 +218,21 @@ func DeepCopy_v1_Affinity(in interface{}, out interface{}, c *conversion.Cloner)
 		if in.NodeAffinity != nil {
 			in, out := &in.NodeAffinity, &out.NodeAffinity
 			*out = new(NodeAffinity)
-			if err := DeepCopy_v1_NodeAffinity(*in, *out, c); err != nil {
+			if err := DeepCopyv1NodeAffinity(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.PodAffinity != nil {
 			in, out := &in.PodAffinity, &out.PodAffinity
 			*out = new(PodAffinity)
-			if err := DeepCopy_v1_PodAffinity(*in, *out, c); err != nil {
+			if err := DeepCopyv1PodAffinity(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.PodAntiAffinity != nil {
 			in, out := &in.PodAntiAffinity, &out.PodAntiAffinity
 			*out = new(PodAntiAffinity)
-			if err := DeepCopy_v1_PodAntiAffinity(*in, *out, c); err != nil {
+			if err := DeepCopyv1PodAntiAffinity(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -238,7 +240,8 @@ func DeepCopy_v1_Affinity(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_v1_AttachedVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1AttachedVolume ...
+func DeepCopyv1AttachedVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AttachedVolume)
 		out := out.(*AttachedVolume)
@@ -247,7 +250,8 @@ func DeepCopy_v1_AttachedVolume(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_AvoidPods(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1AvoidPods ...
+func DeepCopyv1AvoidPods(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AvoidPods)
 		out := out.(*AvoidPods)
@@ -256,7 +260,7 @@ func DeepCopy_v1_AvoidPods(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.PreferAvoidPods, &out.PreferAvoidPods
 			*out = make([]PreferAvoidPodsEntry, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_PreferAvoidPodsEntry(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1PreferAvoidPodsEntry(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -265,7 +269,8 @@ func DeepCopy_v1_AvoidPods(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_AzureDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1AzureDiskVolumeSource ...
+func DeepCopyv1AzureDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AzureDiskVolumeSource)
 		out := out.(*AzureDiskVolumeSource)
@@ -289,7 +294,8 @@ func DeepCopy_v1_AzureDiskVolumeSource(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_AzureFileVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1AzureFileVolumeSource ...
+func DeepCopyv1AzureFileVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AzureFileVolumeSource)
 		out := out.(*AzureFileVolumeSource)
@@ -298,21 +304,23 @@ func DeepCopy_v1_AzureFileVolumeSource(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_Binding(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Binding ...
+func DeepCopyv1Binding(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Binding)
 		out := out.(*Binding)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_Capabilities(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Capabilities ...
+func DeepCopyv1Capabilities(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Capabilities)
 		out := out.(*Capabilities)
@@ -331,7 +339,8 @@ func DeepCopy_v1_Capabilities(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_CephFSVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1CephFSVolumeSource ...
+func DeepCopyv1CephFSVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CephFSVolumeSource)
 		out := out.(*CephFSVolumeSource)
@@ -350,7 +359,8 @@ func DeepCopy_v1_CephFSVolumeSource(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1_CinderVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1CinderVolumeSource ...
+func DeepCopyv1CinderVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CinderVolumeSource)
 		out := out.(*CinderVolumeSource)
@@ -359,7 +369,8 @@ func DeepCopy_v1_CinderVolumeSource(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1_ComponentCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ComponentCondition ...
+func DeepCopyv1ComponentCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ComponentCondition)
 		out := out.(*ComponentCondition)
@@ -368,15 +379,16 @@ func DeepCopy_v1_ComponentCondition(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1_ComponentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ComponentStatus ...
+func DeepCopyv1ComponentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ComponentStatus)
 		out := out.(*ComponentStatus)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Conditions != nil {
 			in, out := &in.Conditions, &out.Conditions
@@ -387,7 +399,8 @@ func DeepCopy_v1_ComponentStatus(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_ComponentStatusList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ComponentStatusList ...
+func DeepCopyv1ComponentStatusList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ComponentStatusList)
 		out := out.(*ComponentStatusList)
@@ -396,7 +409,7 @@ func DeepCopy_v1_ComponentStatusList(in interface{}, out interface{}, c *convers
 			in, out := &in.Items, &out.Items
 			*out = make([]ComponentStatus, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ComponentStatus(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ComponentStatus(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -405,15 +418,16 @@ func DeepCopy_v1_ComponentStatusList(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_ConfigMap(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ConfigMap ...
+func DeepCopyv1ConfigMap(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMap)
 		out := out.(*ConfigMap)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
@@ -426,7 +440,8 @@ func DeepCopy_v1_ConfigMap(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_ConfigMapEnvSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ConfigMapEnvSource ...
+func DeepCopyv1ConfigMapEnvSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMapEnvSource)
 		out := out.(*ConfigMapEnvSource)
@@ -440,7 +455,8 @@ func DeepCopy_v1_ConfigMapEnvSource(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1_ConfigMapKeySelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ConfigMapKeySelector ...
+func DeepCopyv1ConfigMapKeySelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMapKeySelector)
 		out := out.(*ConfigMapKeySelector)
@@ -454,7 +470,8 @@ func DeepCopy_v1_ConfigMapKeySelector(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_ConfigMapList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ConfigMapList ...
+func DeepCopyv1ConfigMapList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMapList)
 		out := out.(*ConfigMapList)
@@ -463,7 +480,7 @@ func DeepCopy_v1_ConfigMapList(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.Items, &out.Items
 			*out = make([]ConfigMap, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ConfigMap(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ConfigMap(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -472,7 +489,8 @@ func DeepCopy_v1_ConfigMapList(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_ConfigMapVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ConfigMapVolumeSource ...
+func DeepCopyv1ConfigMapVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMapVolumeSource)
 		out := out.(*ConfigMapVolumeSource)
@@ -481,7 +499,7 @@ func DeepCopy_v1_ConfigMapVolumeSource(in interface{}, out interface{}, c *conve
 			in, out := &in.Items, &out.Items
 			*out = make([]KeyToPath, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_KeyToPath(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1KeyToPath(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -500,7 +518,8 @@ func DeepCopy_v1_ConfigMapVolumeSource(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_Container(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Container ...
+func DeepCopyv1Container(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Container)
 		out := out.(*Container)
@@ -524,7 +543,7 @@ func DeepCopy_v1_Container(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.EnvFrom, &out.EnvFrom
 			*out = make([]EnvFromSource, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_EnvFromSource(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1EnvFromSource(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -533,12 +552,12 @@ func DeepCopy_v1_Container(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.Env, &out.Env
 			*out = make([]EnvVar, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_EnvVar(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1EnvVar(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
 		}
-		if err := DeepCopy_v1_ResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
+		if err := DeepCopyv1ResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
 			return err
 		}
 		if in.VolumeMounts != nil {
@@ -549,28 +568,28 @@ func DeepCopy_v1_Container(in interface{}, out interface{}, c *conversion.Cloner
 		if in.LivenessProbe != nil {
 			in, out := &in.LivenessProbe, &out.LivenessProbe
 			*out = new(Probe)
-			if err := DeepCopy_v1_Probe(*in, *out, c); err != nil {
+			if err := DeepCopyv1Probe(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.ReadinessProbe != nil {
 			in, out := &in.ReadinessProbe, &out.ReadinessProbe
 			*out = new(Probe)
-			if err := DeepCopy_v1_Probe(*in, *out, c); err != nil {
+			if err := DeepCopyv1Probe(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.Lifecycle != nil {
 			in, out := &in.Lifecycle, &out.Lifecycle
 			*out = new(Lifecycle)
-			if err := DeepCopy_v1_Lifecycle(*in, *out, c); err != nil {
+			if err := DeepCopyv1Lifecycle(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.SecurityContext != nil {
 			in, out := &in.SecurityContext, &out.SecurityContext
 			*out = new(SecurityContext)
-			if err := DeepCopy_v1_SecurityContext(*in, *out, c); err != nil {
+			if err := DeepCopyv1SecurityContext(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -578,7 +597,8 @@ func DeepCopy_v1_Container(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_ContainerImage(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ContainerImage ...
+func DeepCopyv1ContainerImage(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerImage)
 		out := out.(*ContainerImage)
@@ -592,7 +612,8 @@ func DeepCopy_v1_ContainerImage(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_ContainerPort(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ContainerPort ...
+func DeepCopyv1ContainerPort(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerPort)
 		out := out.(*ContainerPort)
@@ -601,7 +622,8 @@ func DeepCopy_v1_ContainerPort(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_ContainerState(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ContainerState ...
+func DeepCopyv1ContainerState(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerState)
 		out := out.(*ContainerState)
@@ -614,14 +636,14 @@ func DeepCopy_v1_ContainerState(in interface{}, out interface{}, c *conversion.C
 		if in.Running != nil {
 			in, out := &in.Running, &out.Running
 			*out = new(ContainerStateRunning)
-			if err := DeepCopy_v1_ContainerStateRunning(*in, *out, c); err != nil {
+			if err := DeepCopyv1ContainerStateRunning(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.Terminated != nil {
 			in, out := &in.Terminated, &out.Terminated
 			*out = new(ContainerStateTerminated)
-			if err := DeepCopy_v1_ContainerStateTerminated(*in, *out, c); err != nil {
+			if err := DeepCopyv1ContainerStateTerminated(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -629,7 +651,8 @@ func DeepCopy_v1_ContainerState(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_ContainerStateRunning(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ContainerStateRunning ...
+func DeepCopyv1ContainerStateRunning(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerStateRunning)
 		out := out.(*ContainerStateRunning)
@@ -639,7 +662,8 @@ func DeepCopy_v1_ContainerStateRunning(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_ContainerStateTerminated(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ContainerStateTerminated ...
+func DeepCopyv1ContainerStateTerminated(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerStateTerminated)
 		out := out.(*ContainerStateTerminated)
@@ -650,7 +674,8 @@ func DeepCopy_v1_ContainerStateTerminated(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_v1_ContainerStateWaiting(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ContainerStateWaiting ...
+func DeepCopyv1ContainerStateWaiting(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerStateWaiting)
 		out := out.(*ContainerStateWaiting)
@@ -659,22 +684,24 @@ func DeepCopy_v1_ContainerStateWaiting(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_ContainerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ContainerStatus ...
+func DeepCopyv1ContainerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerStatus)
 		out := out.(*ContainerStatus)
 		*out = *in
-		if err := DeepCopy_v1_ContainerState(&in.State, &out.State, c); err != nil {
+		if err := DeepCopyv1ContainerState(&in.State, &out.State, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_v1_ContainerState(&in.LastTerminationState, &out.LastTerminationState, c); err != nil {
+		if err := DeepCopyv1ContainerState(&in.LastTerminationState, &out.LastTerminationState, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_DaemonEndpoint(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1DaemonEndpoint ...
+func DeepCopyv1DaemonEndpoint(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonEndpoint)
 		out := out.(*DaemonEndpoint)
@@ -683,7 +710,8 @@ func DeepCopy_v1_DaemonEndpoint(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_DeleteOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1DeleteOptions ...
+func DeepCopyv1DeleteOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeleteOptions)
 		out := out.(*DeleteOptions)
@@ -696,7 +724,7 @@ func DeepCopy_v1_DeleteOptions(in interface{}, out interface{}, c *conversion.Cl
 		if in.Preconditions != nil {
 			in, out := &in.Preconditions, &out.Preconditions
 			*out = new(Preconditions)
-			if err := DeepCopy_v1_Preconditions(*in, *out, c); err != nil {
+			if err := DeepCopyv1Preconditions(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -709,7 +737,8 @@ func DeepCopy_v1_DeleteOptions(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_DownwardAPIVolumeFile(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1DownwardAPIVolumeFile ...
+func DeepCopyv1DownwardAPIVolumeFile(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DownwardAPIVolumeFile)
 		out := out.(*DownwardAPIVolumeFile)
@@ -722,7 +751,7 @@ func DeepCopy_v1_DownwardAPIVolumeFile(in interface{}, out interface{}, c *conve
 		if in.ResourceFieldRef != nil {
 			in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
 			*out = new(ResourceFieldSelector)
-			if err := DeepCopy_v1_ResourceFieldSelector(*in, *out, c); err != nil {
+			if err := DeepCopyv1ResourceFieldSelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -735,7 +764,8 @@ func DeepCopy_v1_DownwardAPIVolumeFile(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_DownwardAPIVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1DownwardAPIVolumeSource ...
+func DeepCopyv1DownwardAPIVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DownwardAPIVolumeSource)
 		out := out.(*DownwardAPIVolumeSource)
@@ -744,7 +774,7 @@ func DeepCopy_v1_DownwardAPIVolumeSource(in interface{}, out interface{}, c *con
 			in, out := &in.Items, &out.Items
 			*out = make([]DownwardAPIVolumeFile, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_DownwardAPIVolumeFile(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1DownwardAPIVolumeFile(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -758,7 +788,8 @@ func DeepCopy_v1_DownwardAPIVolumeSource(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_v1_EmptyDirVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EmptyDirVolumeSource ...
+func DeepCopyv1EmptyDirVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EmptyDirVolumeSource)
 		out := out.(*EmptyDirVolumeSource)
@@ -767,7 +798,8 @@ func DeepCopy_v1_EmptyDirVolumeSource(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_EndpointAddress(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EndpointAddress ...
+func DeepCopyv1EndpointAddress(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EndpointAddress)
 		out := out.(*EndpointAddress)
@@ -786,7 +818,8 @@ func DeepCopy_v1_EndpointAddress(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_EndpointPort(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EndpointPort ...
+func DeepCopyv1EndpointPort(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EndpointPort)
 		out := out.(*EndpointPort)
@@ -795,7 +828,8 @@ func DeepCopy_v1_EndpointPort(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_EndpointSubset(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EndpointSubset ...
+func DeepCopyv1EndpointSubset(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EndpointSubset)
 		out := out.(*EndpointSubset)
@@ -804,7 +838,7 @@ func DeepCopy_v1_EndpointSubset(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Addresses, &out.Addresses
 			*out = make([]EndpointAddress, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_EndpointAddress(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1EndpointAddress(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -813,7 +847,7 @@ func DeepCopy_v1_EndpointSubset(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.NotReadyAddresses, &out.NotReadyAddresses
 			*out = make([]EndpointAddress, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_EndpointAddress(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1EndpointAddress(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -827,21 +861,22 @@ func DeepCopy_v1_EndpointSubset(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_Endpoints(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Endpoints ...
+func DeepCopyv1Endpoints(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Endpoints)
 		out := out.(*Endpoints)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Subsets != nil {
 			in, out := &in.Subsets, &out.Subsets
 			*out = make([]EndpointSubset, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_EndpointSubset(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1EndpointSubset(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -850,7 +885,8 @@ func DeepCopy_v1_Endpoints(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_EndpointsList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EndpointsList ...
+func DeepCopyv1EndpointsList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EndpointsList)
 		out := out.(*EndpointsList)
@@ -859,7 +895,7 @@ func DeepCopy_v1_EndpointsList(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.Items, &out.Items
 			*out = make([]Endpoints, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Endpoints(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Endpoints(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -868,7 +904,8 @@ func DeepCopy_v1_EndpointsList(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_EnvFromSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EnvFromSource ...
+func DeepCopyv1EnvFromSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EnvFromSource)
 		out := out.(*EnvFromSource)
@@ -876,14 +913,14 @@ func DeepCopy_v1_EnvFromSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.ConfigMapRef != nil {
 			in, out := &in.ConfigMapRef, &out.ConfigMapRef
 			*out = new(ConfigMapEnvSource)
-			if err := DeepCopy_v1_ConfigMapEnvSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1ConfigMapEnvSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.SecretRef != nil {
 			in, out := &in.SecretRef, &out.SecretRef
 			*out = new(SecretEnvSource)
-			if err := DeepCopy_v1_SecretEnvSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1SecretEnvSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -891,7 +928,8 @@ func DeepCopy_v1_EnvFromSource(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_EnvVar(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EnvVar ...
+func DeepCopyv1EnvVar(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EnvVar)
 		out := out.(*EnvVar)
@@ -899,7 +937,7 @@ func DeepCopy_v1_EnvVar(in interface{}, out interface{}, c *conversion.Cloner) e
 		if in.ValueFrom != nil {
 			in, out := &in.ValueFrom, &out.ValueFrom
 			*out = new(EnvVarSource)
-			if err := DeepCopy_v1_EnvVarSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1EnvVarSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -907,7 +945,8 @@ func DeepCopy_v1_EnvVar(in interface{}, out interface{}, c *conversion.Cloner) e
 	}
 }
 
-func DeepCopy_v1_EnvVarSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EnvVarSource ...
+func DeepCopyv1EnvVarSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EnvVarSource)
 		out := out.(*EnvVarSource)
@@ -920,21 +959,21 @@ func DeepCopy_v1_EnvVarSource(in interface{}, out interface{}, c *conversion.Clo
 		if in.ResourceFieldRef != nil {
 			in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
 			*out = new(ResourceFieldSelector)
-			if err := DeepCopy_v1_ResourceFieldSelector(*in, *out, c); err != nil {
+			if err := DeepCopyv1ResourceFieldSelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.ConfigMapKeyRef != nil {
 			in, out := &in.ConfigMapKeyRef, &out.ConfigMapKeyRef
 			*out = new(ConfigMapKeySelector)
-			if err := DeepCopy_v1_ConfigMapKeySelector(*in, *out, c); err != nil {
+			if err := DeepCopyv1ConfigMapKeySelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.SecretKeyRef != nil {
 			in, out := &in.SecretKeyRef, &out.SecretKeyRef
 			*out = new(SecretKeySelector)
-			if err := DeepCopy_v1_SecretKeySelector(*in, *out, c); err != nil {
+			if err := DeepCopyv1SecretKeySelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -942,15 +981,16 @@ func DeepCopy_v1_EnvVarSource(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_Event(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Event ...
+func DeepCopyv1Event(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Event)
 		out := out.(*Event)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		out.FirstTimestamp = in.FirstTimestamp.DeepCopy()
 		out.LastTimestamp = in.LastTimestamp.DeepCopy()
@@ -958,7 +998,8 @@ func DeepCopy_v1_Event(in interface{}, out interface{}, c *conversion.Cloner) er
 	}
 }
 
-func DeepCopy_v1_EventList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EventList ...
+func DeepCopyv1EventList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EventList)
 		out := out.(*EventList)
@@ -967,7 +1008,7 @@ func DeepCopy_v1_EventList(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.Items, &out.Items
 			*out = make([]Event, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Event(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Event(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -976,7 +1017,8 @@ func DeepCopy_v1_EventList(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_EventSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1EventSource ...
+func DeepCopyv1EventSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EventSource)
 		out := out.(*EventSource)
@@ -985,7 +1027,8 @@ func DeepCopy_v1_EventSource(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_ExecAction(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ExecAction ...
+func DeepCopyv1ExecAction(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ExecAction)
 		out := out.(*ExecAction)
@@ -999,7 +1042,8 @@ func DeepCopy_v1_ExecAction(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1_FCVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1FCVolumeSource ...
+func DeepCopyv1FCVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FCVolumeSource)
 		out := out.(*FCVolumeSource)
@@ -1018,7 +1062,8 @@ func DeepCopy_v1_FCVolumeSource(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_FlexVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1FlexVolumeSource ...
+func DeepCopyv1FlexVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FlexVolumeSource)
 		out := out.(*FlexVolumeSource)
@@ -1039,7 +1084,8 @@ func DeepCopy_v1_FlexVolumeSource(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1_FlockerVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1FlockerVolumeSource ...
+func DeepCopyv1FlockerVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FlockerVolumeSource)
 		out := out.(*FlockerVolumeSource)
@@ -1048,7 +1094,8 @@ func DeepCopy_v1_FlockerVolumeSource(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_GCEPersistentDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GCEPersistentDiskVolumeSource ...
+func DeepCopyv1GCEPersistentDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GCEPersistentDiskVolumeSource)
 		out := out.(*GCEPersistentDiskVolumeSource)
@@ -1057,7 +1104,8 @@ func DeepCopy_v1_GCEPersistentDiskVolumeSource(in interface{}, out interface{}, 
 	}
 }
 
-func DeepCopy_v1_GitRepoVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GitRepoVolumeSource ...
+func DeepCopyv1GitRepoVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GitRepoVolumeSource)
 		out := out.(*GitRepoVolumeSource)
@@ -1066,7 +1114,8 @@ func DeepCopy_v1_GitRepoVolumeSource(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_GlusterfsVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GlusterfsVolumeSource ...
+func DeepCopyv1GlusterfsVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GlusterfsVolumeSource)
 		out := out.(*GlusterfsVolumeSource)
@@ -1075,7 +1124,8 @@ func DeepCopy_v1_GlusterfsVolumeSource(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_HTTPGetAction(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1HTTPGetAction ...
+func DeepCopyv1HTTPGetAction(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HTTPGetAction)
 		out := out.(*HTTPGetAction)
@@ -1089,7 +1139,8 @@ func DeepCopy_v1_HTTPGetAction(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_HTTPHeader(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1HTTPHeader ...
+func DeepCopyv1HTTPHeader(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HTTPHeader)
 		out := out.(*HTTPHeader)
@@ -1098,7 +1149,8 @@ func DeepCopy_v1_HTTPHeader(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1_Handler(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Handler ...
+func DeepCopyv1Handler(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Handler)
 		out := out.(*Handler)
@@ -1106,14 +1158,14 @@ func DeepCopy_v1_Handler(in interface{}, out interface{}, c *conversion.Cloner) 
 		if in.Exec != nil {
 			in, out := &in.Exec, &out.Exec
 			*out = new(ExecAction)
-			if err := DeepCopy_v1_ExecAction(*in, *out, c); err != nil {
+			if err := DeepCopyv1ExecAction(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.HTTPGet != nil {
 			in, out := &in.HTTPGet, &out.HTTPGet
 			*out = new(HTTPGetAction)
-			if err := DeepCopy_v1_HTTPGetAction(*in, *out, c); err != nil {
+			if err := DeepCopyv1HTTPGetAction(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1126,7 +1178,8 @@ func DeepCopy_v1_Handler(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_v1_HostPathVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1HostPathVolumeSource ...
+func DeepCopyv1HostPathVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HostPathVolumeSource)
 		out := out.(*HostPathVolumeSource)
@@ -1135,7 +1188,8 @@ func DeepCopy_v1_HostPathVolumeSource(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_ISCSIVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ISCSIVolumeSource ...
+func DeepCopyv1ISCSIVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ISCSIVolumeSource)
 		out := out.(*ISCSIVolumeSource)
@@ -1144,7 +1198,8 @@ func DeepCopy_v1_ISCSIVolumeSource(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_v1_KeyToPath(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1KeyToPath ...
+func DeepCopyv1KeyToPath(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KeyToPath)
 		out := out.(*KeyToPath)
@@ -1158,7 +1213,8 @@ func DeepCopy_v1_KeyToPath(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_Lifecycle(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Lifecycle ...
+func DeepCopyv1Lifecycle(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Lifecycle)
 		out := out.(*Lifecycle)
@@ -1166,14 +1222,14 @@ func DeepCopy_v1_Lifecycle(in interface{}, out interface{}, c *conversion.Cloner
 		if in.PostStart != nil {
 			in, out := &in.PostStart, &out.PostStart
 			*out = new(Handler)
-			if err := DeepCopy_v1_Handler(*in, *out, c); err != nil {
+			if err := DeepCopyv1Handler(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.PreStop != nil {
 			in, out := &in.PreStop, &out.PreStop
 			*out = new(Handler)
-			if err := DeepCopy_v1_Handler(*in, *out, c); err != nil {
+			if err := DeepCopyv1Handler(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1181,24 +1237,26 @@ func DeepCopy_v1_Lifecycle(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_LimitRange(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LimitRange ...
+func DeepCopyv1LimitRange(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LimitRange)
 		out := out.(*LimitRange)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1_LimitRangeSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1LimitRangeSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_LimitRangeItem(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LimitRangeItem ...
+func DeepCopyv1LimitRangeItem(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LimitRangeItem)
 		out := out.(*LimitRangeItem)
@@ -1242,7 +1300,8 @@ func DeepCopy_v1_LimitRangeItem(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_LimitRangeList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LimitRangeList ...
+func DeepCopyv1LimitRangeList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LimitRangeList)
 		out := out.(*LimitRangeList)
@@ -1251,7 +1310,7 @@ func DeepCopy_v1_LimitRangeList(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Items, &out.Items
 			*out = make([]LimitRange, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_LimitRange(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1LimitRange(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1260,7 +1319,8 @@ func DeepCopy_v1_LimitRangeList(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_LimitRangeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LimitRangeSpec ...
+func DeepCopyv1LimitRangeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LimitRangeSpec)
 		out := out.(*LimitRangeSpec)
@@ -1269,7 +1329,7 @@ func DeepCopy_v1_LimitRangeSpec(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Limits, &out.Limits
 			*out = make([]LimitRangeItem, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_LimitRangeItem(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1LimitRangeItem(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1278,7 +1338,8 @@ func DeepCopy_v1_LimitRangeSpec(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_List(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1List ...
+func DeepCopyv1List(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*List)
 		out := out.(*List)
@@ -1287,10 +1348,10 @@ func DeepCopy_v1_List(in interface{}, out interface{}, c *conversion.Cloner) err
 			in, out := &in.Items, &out.Items
 			*out = make([]runtime.RawExtension, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*runtime.RawExtension)
+				} else {
+					return err
 				}
 			}
 		}
@@ -1298,7 +1359,8 @@ func DeepCopy_v1_List(in interface{}, out interface{}, c *conversion.Cloner) err
 	}
 }
 
-func DeepCopy_v1_ListOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ListOptions ...
+func DeepCopyv1ListOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ListOptions)
 		out := out.(*ListOptions)
@@ -1312,7 +1374,8 @@ func DeepCopy_v1_ListOptions(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_LoadBalancerIngress(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LoadBalancerIngress ...
+func DeepCopyv1LoadBalancerIngress(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LoadBalancerIngress)
 		out := out.(*LoadBalancerIngress)
@@ -1321,7 +1384,8 @@ func DeepCopy_v1_LoadBalancerIngress(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_LoadBalancerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LoadBalancerStatus ...
+func DeepCopyv1LoadBalancerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LoadBalancerStatus)
 		out := out.(*LoadBalancerStatus)
@@ -1335,7 +1399,8 @@ func DeepCopy_v1_LoadBalancerStatus(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1_LocalObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LocalObjectReference ...
+func DeepCopyv1LocalObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LocalObjectReference)
 		out := out.(*LocalObjectReference)
@@ -1344,7 +1409,8 @@ func DeepCopy_v1_LocalObjectReference(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_NFSVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NFSVolumeSource ...
+func DeepCopyv1NFSVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NFSVolumeSource)
 		out := out.(*NFSVolumeSource)
@@ -1353,24 +1419,26 @@ func DeepCopy_v1_NFSVolumeSource(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_Namespace(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Namespace ...
+func DeepCopyv1Namespace(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Namespace)
 		out := out.(*Namespace)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1_NamespaceSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1NamespaceSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_NamespaceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NamespaceList ...
+func DeepCopyv1NamespaceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NamespaceList)
 		out := out.(*NamespaceList)
@@ -1379,7 +1447,7 @@ func DeepCopy_v1_NamespaceList(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.Items, &out.Items
 			*out = make([]Namespace, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Namespace(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Namespace(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1388,7 +1456,8 @@ func DeepCopy_v1_NamespaceList(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_NamespaceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NamespaceSpec ...
+func DeepCopyv1NamespaceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NamespaceSpec)
 		out := out.(*NamespaceSpec)
@@ -1402,7 +1471,8 @@ func DeepCopy_v1_NamespaceSpec(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_NamespaceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NamespaceStatus ...
+func DeepCopyv1NamespaceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NamespaceStatus)
 		out := out.(*NamespaceStatus)
@@ -1411,24 +1481,26 @@ func DeepCopy_v1_NamespaceStatus(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_Node(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Node ...
+func DeepCopyv1Node(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Node)
 		out := out.(*Node)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1_NodeStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1NodeStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_NodeAddress(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeAddress ...
+func DeepCopyv1NodeAddress(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeAddress)
 		out := out.(*NodeAddress)
@@ -1437,7 +1509,8 @@ func DeepCopy_v1_NodeAddress(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_NodeAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeAffinity ...
+func DeepCopyv1NodeAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeAffinity)
 		out := out.(*NodeAffinity)
@@ -1445,7 +1518,7 @@ func DeepCopy_v1_NodeAffinity(in interface{}, out interface{}, c *conversion.Clo
 		if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 			in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
 			*out = new(NodeSelector)
-			if err := DeepCopy_v1_NodeSelector(*in, *out, c); err != nil {
+			if err := DeepCopyv1NodeSelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1453,7 +1526,7 @@ func DeepCopy_v1_NodeAffinity(in interface{}, out interface{}, c *conversion.Clo
 			in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
 			*out = make([]PreferredSchedulingTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_PreferredSchedulingTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1PreferredSchedulingTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1462,7 +1535,8 @@ func DeepCopy_v1_NodeAffinity(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_NodeCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeCondition ...
+func DeepCopyv1NodeCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeCondition)
 		out := out.(*NodeCondition)
@@ -1473,7 +1547,8 @@ func DeepCopy_v1_NodeCondition(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_NodeDaemonEndpoints(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeDaemonEndpoints ...
+func DeepCopyv1NodeDaemonEndpoints(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeDaemonEndpoints)
 		out := out.(*NodeDaemonEndpoints)
@@ -1482,7 +1557,8 @@ func DeepCopy_v1_NodeDaemonEndpoints(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_NodeList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeList ...
+func DeepCopyv1NodeList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeList)
 		out := out.(*NodeList)
@@ -1491,7 +1567,7 @@ func DeepCopy_v1_NodeList(in interface{}, out interface{}, c *conversion.Cloner)
 			in, out := &in.Items, &out.Items
 			*out = make([]Node, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Node(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Node(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1500,7 +1576,8 @@ func DeepCopy_v1_NodeList(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_v1_NodeProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeProxyOptions ...
+func DeepCopyv1NodeProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeProxyOptions)
 		out := out.(*NodeProxyOptions)
@@ -1509,7 +1586,8 @@ func DeepCopy_v1_NodeProxyOptions(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1_NodeResources(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeResources ...
+func DeepCopyv1NodeResources(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeResources)
 		out := out.(*NodeResources)
@@ -1525,7 +1603,8 @@ func DeepCopy_v1_NodeResources(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_NodeSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeSelector ...
+func DeepCopyv1NodeSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSelector)
 		out := out.(*NodeSelector)
@@ -1534,7 +1613,7 @@ func DeepCopy_v1_NodeSelector(in interface{}, out interface{}, c *conversion.Clo
 			in, out := &in.NodeSelectorTerms, &out.NodeSelectorTerms
 			*out = make([]NodeSelectorTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_NodeSelectorTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1NodeSelectorTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1543,7 +1622,8 @@ func DeepCopy_v1_NodeSelector(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_NodeSelectorRequirement(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeSelectorRequirement ...
+func DeepCopyv1NodeSelectorRequirement(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSelectorRequirement)
 		out := out.(*NodeSelectorRequirement)
@@ -1557,7 +1637,8 @@ func DeepCopy_v1_NodeSelectorRequirement(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_v1_NodeSelectorTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeSelectorTerm ...
+func DeepCopyv1NodeSelectorTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSelectorTerm)
 		out := out.(*NodeSelectorTerm)
@@ -1566,7 +1647,7 @@ func DeepCopy_v1_NodeSelectorTerm(in interface{}, out interface{}, c *conversion
 			in, out := &in.MatchExpressions, &out.MatchExpressions
 			*out = make([]NodeSelectorRequirement, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_NodeSelectorRequirement(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1NodeSelectorRequirement(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1575,7 +1656,8 @@ func DeepCopy_v1_NodeSelectorTerm(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1_NodeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeSpec ...
+func DeepCopyv1NodeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSpec)
 		out := out.(*NodeSpec)
@@ -1584,7 +1666,8 @@ func DeepCopy_v1_NodeSpec(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_v1_NodeStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeStatus ...
+func DeepCopyv1NodeStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeStatus)
 		out := out.(*NodeStatus)
@@ -1607,7 +1690,7 @@ func DeepCopy_v1_NodeStatus(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]NodeCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_NodeCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1NodeCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1621,7 +1704,7 @@ func DeepCopy_v1_NodeStatus(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.Images, &out.Images
 			*out = make([]ContainerImage, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ContainerImage(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ContainerImage(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1640,7 +1723,8 @@ func DeepCopy_v1_NodeStatus(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1_NodeSystemInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1NodeSystemInfo ...
+func DeepCopyv1NodeSystemInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSystemInfo)
 		out := out.(*NodeSystemInfo)
@@ -1649,7 +1733,8 @@ func DeepCopy_v1_NodeSystemInfo(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_ObjectFieldSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ObjectFieldSelector ...
+func DeepCopyv1ObjectFieldSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ObjectFieldSelector)
 		out := out.(*ObjectFieldSelector)
@@ -1658,7 +1743,8 @@ func DeepCopy_v1_ObjectFieldSelector(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_ObjectMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ObjectMeta ...
+func DeepCopyv1ObjectMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ObjectMeta)
 		out := out.(*ObjectMeta)
@@ -1692,10 +1778,10 @@ func DeepCopy_v1_ObjectMeta(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.OwnerReferences, &out.OwnerReferences
 			*out = make([]meta_v1.OwnerReference, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*meta_v1.OwnerReference)
+				} else {
+					return err
 				}
 			}
 		}
@@ -1708,7 +1794,8 @@ func DeepCopy_v1_ObjectMeta(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1_ObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ObjectReference ...
+func DeepCopyv1ObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ObjectReference)
 		out := out.(*ObjectReference)
@@ -1717,44 +1804,47 @@ func DeepCopy_v1_ObjectReference(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_PersistentVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolume ...
+func DeepCopyv1PersistentVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolume)
 		out := out.(*PersistentVolume)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1_PersistentVolumeSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1PersistentVolumeSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeClaim(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeClaim ...
+func DeepCopyv1PersistentVolumeClaim(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaim)
 		out := out.(*PersistentVolumeClaim)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1_PersistentVolumeClaimSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1_PersistentVolumeClaimStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1PersistentVolumeClaimSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1PersistentVolumeClaimStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeClaimList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeClaimList ...
+func DeepCopyv1PersistentVolumeClaimList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaimList)
 		out := out.(*PersistentVolumeClaimList)
@@ -1763,7 +1853,7 @@ func DeepCopy_v1_PersistentVolumeClaimList(in interface{}, out interface{}, c *c
 			in, out := &in.Items, &out.Items
 			*out = make([]PersistentVolumeClaim, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_PersistentVolumeClaim(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1PersistentVolumeClaim(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1772,7 +1862,8 @@ func DeepCopy_v1_PersistentVolumeClaimList(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeClaimSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeClaimSpec ...
+func DeepCopyv1PersistentVolumeClaimSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaimSpec)
 		out := out.(*PersistentVolumeClaimSpec)
@@ -1784,20 +1875,21 @@ func DeepCopy_v1_PersistentVolumeClaimSpec(in interface{}, out interface{}, c *c
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*meta_v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := DeepCopy_v1_ResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
+		if err := DeepCopyv1ResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeClaimStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeClaimStatus ...
+func DeepCopyv1PersistentVolumeClaimStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaimStatus)
 		out := out.(*PersistentVolumeClaimStatus)
@@ -1818,7 +1910,8 @@ func DeepCopy_v1_PersistentVolumeClaimStatus(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeClaimVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeClaimVolumeSource ...
+func DeepCopyv1PersistentVolumeClaimVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaimVolumeSource)
 		out := out.(*PersistentVolumeClaimVolumeSource)
@@ -1827,7 +1920,8 @@ func DeepCopy_v1_PersistentVolumeClaimVolumeSource(in interface{}, out interface
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeList ...
+func DeepCopyv1PersistentVolumeList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeList)
 		out := out.(*PersistentVolumeList)
@@ -1836,7 +1930,7 @@ func DeepCopy_v1_PersistentVolumeList(in interface{}, out interface{}, c *conver
 			in, out := &in.Items, &out.Items
 			*out = make([]PersistentVolume, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_PersistentVolume(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1PersistentVolume(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1845,7 +1939,8 @@ func DeepCopy_v1_PersistentVolumeList(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeSource ...
+func DeepCopyv1PersistentVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeSource)
 		out := out.(*PersistentVolumeSource)
@@ -1878,7 +1973,7 @@ func DeepCopy_v1_PersistentVolumeSource(in interface{}, out interface{}, c *conv
 		if in.RBD != nil {
 			in, out := &in.RBD, &out.RBD
 			*out = new(RBDVolumeSource)
-			if err := DeepCopy_v1_RBDVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1RBDVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1895,14 +1990,14 @@ func DeepCopy_v1_PersistentVolumeSource(in interface{}, out interface{}, c *conv
 		if in.CephFS != nil {
 			in, out := &in.CephFS, &out.CephFS
 			*out = new(CephFSVolumeSource)
-			if err := DeepCopy_v1_CephFSVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1CephFSVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.FC != nil {
 			in, out := &in.FC, &out.FC
 			*out = new(FCVolumeSource)
-			if err := DeepCopy_v1_FCVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1FCVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1914,7 +2009,7 @@ func DeepCopy_v1_PersistentVolumeSource(in interface{}, out interface{}, c *conv
 		if in.FlexVolume != nil {
 			in, out := &in.FlexVolume, &out.FlexVolume
 			*out = new(FlexVolumeSource)
-			if err := DeepCopy_v1_FlexVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1FlexVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1936,7 +2031,7 @@ func DeepCopy_v1_PersistentVolumeSource(in interface{}, out interface{}, c *conv
 		if in.AzureDisk != nil {
 			in, out := &in.AzureDisk, &out.AzureDisk
 			*out = new(AzureDiskVolumeSource)
-			if err := DeepCopy_v1_AzureDiskVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1AzureDiskVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1949,7 +2044,8 @@ func DeepCopy_v1_PersistentVolumeSource(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeSpec ...
+func DeepCopyv1PersistentVolumeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeSpec)
 		out := out.(*PersistentVolumeSpec)
@@ -1961,7 +2057,7 @@ func DeepCopy_v1_PersistentVolumeSpec(in interface{}, out interface{}, c *conver
 				(*out)[key] = val.DeepCopy()
 			}
 		}
-		if err := DeepCopy_v1_PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, c); err != nil {
+		if err := DeepCopyv1PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, c); err != nil {
 			return err
 		}
 		if in.AccessModes != nil {
@@ -1978,7 +2074,8 @@ func DeepCopy_v1_PersistentVolumeSpec(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_PersistentVolumeStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PersistentVolumeStatus ...
+func DeepCopyv1PersistentVolumeStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeStatus)
 		out := out.(*PersistentVolumeStatus)
@@ -1987,7 +2084,8 @@ func DeepCopy_v1_PersistentVolumeStatus(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_v1_PhotonPersistentDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PhotonPersistentDiskVolumeSource ...
+func DeepCopyv1PhotonPersistentDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PhotonPersistentDiskVolumeSource)
 		out := out.(*PhotonPersistentDiskVolumeSource)
@@ -1996,27 +2094,29 @@ func DeepCopy_v1_PhotonPersistentDiskVolumeSource(in interface{}, out interface{
 	}
 }
 
-func DeepCopy_v1_Pod(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Pod ...
+func DeepCopyv1Pod(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Pod)
 		out := out.(*Pod)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1_PodSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1_PodStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1PodSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1PodStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_PodAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodAffinity ...
+func DeepCopyv1PodAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodAffinity)
 		out := out.(*PodAffinity)
@@ -2025,7 +2125,7 @@ func DeepCopy_v1_PodAffinity(in interface{}, out interface{}, c *conversion.Clon
 			in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
 			*out = make([]PodAffinityTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_PodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1PodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2034,7 +2134,7 @@ func DeepCopy_v1_PodAffinity(in interface{}, out interface{}, c *conversion.Clon
 			in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
 			*out = make([]WeightedPodAffinityTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_WeightedPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1WeightedPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2043,17 +2143,18 @@ func DeepCopy_v1_PodAffinity(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_PodAffinityTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodAffinityTerm ...
+func DeepCopyv1PodAffinityTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodAffinityTerm)
 		out := out.(*PodAffinityTerm)
 		*out = *in
 		if in.LabelSelector != nil {
 			in, out := &in.LabelSelector, &out.LabelSelector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*meta_v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		if in.Namespaces != nil {
@@ -2065,7 +2166,8 @@ func DeepCopy_v1_PodAffinityTerm(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_PodAntiAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodAntiAffinity ...
+func DeepCopyv1PodAntiAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodAntiAffinity)
 		out := out.(*PodAntiAffinity)
@@ -2074,7 +2176,7 @@ func DeepCopy_v1_PodAntiAffinity(in interface{}, out interface{}, c *conversion.
 			in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
 			*out = make([]PodAffinityTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_PodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1PodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2083,7 +2185,7 @@ func DeepCopy_v1_PodAntiAffinity(in interface{}, out interface{}, c *conversion.
 			in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
 			*out = make([]WeightedPodAffinityTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_WeightedPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1WeightedPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2092,7 +2194,8 @@ func DeepCopy_v1_PodAntiAffinity(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_PodAttachOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodAttachOptions ...
+func DeepCopyv1PodAttachOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodAttachOptions)
 		out := out.(*PodAttachOptions)
@@ -2101,7 +2204,8 @@ func DeepCopy_v1_PodAttachOptions(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1_PodCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodCondition ...
+func DeepCopyv1PodCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodCondition)
 		out := out.(*PodCondition)
@@ -2112,7 +2216,8 @@ func DeepCopy_v1_PodCondition(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_PodExecOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodExecOptions ...
+func DeepCopyv1PodExecOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodExecOptions)
 		out := out.(*PodExecOptions)
@@ -2126,7 +2231,8 @@ func DeepCopy_v1_PodExecOptions(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_PodList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodList ...
+func DeepCopyv1PodList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodList)
 		out := out.(*PodList)
@@ -2135,7 +2241,7 @@ func DeepCopy_v1_PodList(in interface{}, out interface{}, c *conversion.Cloner) 
 			in, out := &in.Items, &out.Items
 			*out = make([]Pod, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Pod(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Pod(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2144,7 +2250,8 @@ func DeepCopy_v1_PodList(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_v1_PodLogOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodLogOptions ...
+func DeepCopyv1PodLogOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodLogOptions)
 		out := out.(*PodLogOptions)
@@ -2173,7 +2280,8 @@ func DeepCopy_v1_PodLogOptions(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_PodPortForwardOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodPortForwardOptions ...
+func DeepCopyv1PodPortForwardOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodPortForwardOptions)
 		out := out.(*PodPortForwardOptions)
@@ -2187,7 +2295,8 @@ func DeepCopy_v1_PodPortForwardOptions(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_PodProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodProxyOptions ...
+func DeepCopyv1PodProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodProxyOptions)
 		out := out.(*PodProxyOptions)
@@ -2196,7 +2305,8 @@ func DeepCopy_v1_PodProxyOptions(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_PodSecurityContext(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodSecurityContext ...
+func DeepCopyv1PodSecurityContext(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSecurityContext)
 		out := out.(*PodSecurityContext)
@@ -2230,24 +2340,26 @@ func DeepCopy_v1_PodSecurityContext(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1_PodSignature(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodSignature ...
+func DeepCopyv1PodSignature(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSignature)
 		out := out.(*PodSignature)
 		*out = *in
 		if in.PodController != nil {
 			in, out := &in.PodController, &out.PodController
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*meta_v1.OwnerReference)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodSpec ...
+func DeepCopyv1PodSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSpec)
 		out := out.(*PodSpec)
@@ -2256,7 +2368,7 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 			in, out := &in.Volumes, &out.Volumes
 			*out = make([]Volume, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Volume(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Volume(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2265,7 +2377,7 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 			in, out := &in.InitContainers, &out.InitContainers
 			*out = make([]Container, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Container(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Container(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2274,7 +2386,7 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 			in, out := &in.Containers, &out.Containers
 			*out = make([]Container, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Container(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Container(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2299,7 +2411,7 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 		if in.SecurityContext != nil {
 			in, out := &in.SecurityContext, &out.SecurityContext
 			*out = new(PodSecurityContext)
-			if err := DeepCopy_v1_PodSecurityContext(*in, *out, c); err != nil {
+			if err := DeepCopyv1PodSecurityContext(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -2311,7 +2423,7 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 		if in.Affinity != nil {
 			in, out := &in.Affinity, &out.Affinity
 			*out = new(Affinity)
-			if err := DeepCopy_v1_Affinity(*in, *out, c); err != nil {
+			if err := DeepCopyv1Affinity(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -2319,7 +2431,8 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_v1_PodStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodStatus ...
+func DeepCopyv1PodStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodStatus)
 		out := out.(*PodStatus)
@@ -2328,7 +2441,7 @@ func DeepCopy_v1_PodStatus(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]PodCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_PodCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1PodCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2342,7 +2455,7 @@ func DeepCopy_v1_PodStatus(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
 			*out = make([]ContainerStatus, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ContainerStatus(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ContainerStatus(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2351,7 +2464,7 @@ func DeepCopy_v1_PodStatus(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.ContainerStatuses, &out.ContainerStatuses
 			*out = make([]ContainerStatus, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ContainerStatus(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ContainerStatus(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2360,41 +2473,44 @@ func DeepCopy_v1_PodStatus(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_PodStatusResult(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodStatusResult ...
+func DeepCopyv1PodStatusResult(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodStatusResult)
 		out := out.(*PodStatusResult)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1_PodStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1PodStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_PodTemplate(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodTemplate ...
+func DeepCopyv1PodTemplate(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodTemplate)
 		out := out.(*PodTemplate)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := DeepCopyv1PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_PodTemplateList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodTemplateList ...
+func DeepCopyv1PodTemplateList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodTemplateList)
 		out := out.(*PodTemplateList)
@@ -2403,7 +2519,7 @@ func DeepCopy_v1_PodTemplateList(in interface{}, out interface{}, c *conversion.
 			in, out := &in.Items, &out.Items
 			*out = make([]PodTemplate, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_PodTemplate(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1PodTemplate(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2412,24 +2528,26 @@ func DeepCopy_v1_PodTemplateList(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_PodTemplateSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodTemplateSpec ...
+func DeepCopyv1PodTemplateSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodTemplateSpec)
 		out := out.(*PodTemplateSpec)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1_PodSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1PodSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_Preconditions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Preconditions ...
+func DeepCopyv1Preconditions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Preconditions)
 		out := out.(*Preconditions)
@@ -2443,12 +2561,13 @@ func DeepCopy_v1_Preconditions(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_PreferAvoidPodsEntry(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PreferAvoidPodsEntry ...
+func DeepCopyv1PreferAvoidPodsEntry(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PreferAvoidPodsEntry)
 		out := out.(*PreferAvoidPodsEntry)
 		*out = *in
-		if err := DeepCopy_v1_PodSignature(&in.PodSignature, &out.PodSignature, c); err != nil {
+		if err := DeepCopyv1PodSignature(&in.PodSignature, &out.PodSignature, c); err != nil {
 			return err
 		}
 		out.EvictionTime = in.EvictionTime.DeepCopy()
@@ -2456,31 +2575,34 @@ func DeepCopy_v1_PreferAvoidPodsEntry(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_PreferredSchedulingTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PreferredSchedulingTerm ...
+func DeepCopyv1PreferredSchedulingTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PreferredSchedulingTerm)
 		out := out.(*PreferredSchedulingTerm)
 		*out = *in
-		if err := DeepCopy_v1_NodeSelectorTerm(&in.Preference, &out.Preference, c); err != nil {
+		if err := DeepCopyv1NodeSelectorTerm(&in.Preference, &out.Preference, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_Probe(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Probe ...
+func DeepCopyv1Probe(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Probe)
 		out := out.(*Probe)
 		*out = *in
-		if err := DeepCopy_v1_Handler(&in.Handler, &out.Handler, c); err != nil {
+		if err := DeepCopyv1Handler(&in.Handler, &out.Handler, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_QuobyteVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1QuobyteVolumeSource ...
+func DeepCopyv1QuobyteVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*QuobyteVolumeSource)
 		out := out.(*QuobyteVolumeSource)
@@ -2489,7 +2611,8 @@ func DeepCopy_v1_QuobyteVolumeSource(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_RBDVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1RBDVolumeSource ...
+func DeepCopyv1RBDVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RBDVolumeSource)
 		out := out.(*RBDVolumeSource)
@@ -2508,15 +2631,16 @@ func DeepCopy_v1_RBDVolumeSource(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_RangeAllocation(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1RangeAllocation ...
+func DeepCopyv1RangeAllocation(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RangeAllocation)
 		out := out.(*RangeAllocation)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
@@ -2527,27 +2651,29 @@ func DeepCopy_v1_RangeAllocation(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_ReplicationController(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ReplicationController ...
+func DeepCopyv1ReplicationController(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationController)
 		out := out.(*ReplicationController)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1_ReplicationControllerSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1_ReplicationControllerStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1ReplicationControllerSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1ReplicationControllerStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_ReplicationControllerCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ReplicationControllerCondition ...
+func DeepCopyv1ReplicationControllerCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerCondition)
 		out := out.(*ReplicationControllerCondition)
@@ -2557,7 +2683,8 @@ func DeepCopy_v1_ReplicationControllerCondition(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_v1_ReplicationControllerList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ReplicationControllerList ...
+func DeepCopyv1ReplicationControllerList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerList)
 		out := out.(*ReplicationControllerList)
@@ -2566,7 +2693,7 @@ func DeepCopy_v1_ReplicationControllerList(in interface{}, out interface{}, c *c
 			in, out := &in.Items, &out.Items
 			*out = make([]ReplicationController, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ReplicationController(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ReplicationController(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2575,7 +2702,8 @@ func DeepCopy_v1_ReplicationControllerList(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_v1_ReplicationControllerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ReplicationControllerSpec ...
+func DeepCopyv1ReplicationControllerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerSpec)
 		out := out.(*ReplicationControllerSpec)
@@ -2595,7 +2723,7 @@ func DeepCopy_v1_ReplicationControllerSpec(in interface{}, out interface{}, c *c
 		if in.Template != nil {
 			in, out := &in.Template, &out.Template
 			*out = new(PodTemplateSpec)
-			if err := DeepCopy_v1_PodTemplateSpec(*in, *out, c); err != nil {
+			if err := DeepCopyv1PodTemplateSpec(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -2603,7 +2731,8 @@ func DeepCopy_v1_ReplicationControllerSpec(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_v1_ReplicationControllerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ReplicationControllerStatus ...
+func DeepCopyv1ReplicationControllerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerStatus)
 		out := out.(*ReplicationControllerStatus)
@@ -2612,7 +2741,7 @@ func DeepCopy_v1_ReplicationControllerStatus(in interface{}, out interface{}, c 
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]ReplicationControllerCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ReplicationControllerCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ReplicationControllerCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2621,7 +2750,8 @@ func DeepCopy_v1_ReplicationControllerStatus(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1_ResourceFieldSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ResourceFieldSelector ...
+func DeepCopyv1ResourceFieldSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceFieldSelector)
 		out := out.(*ResourceFieldSelector)
@@ -2631,27 +2761,29 @@ func DeepCopy_v1_ResourceFieldSelector(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1_ResourceQuota(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ResourceQuota ...
+func DeepCopyv1ResourceQuota(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceQuota)
 		out := out.(*ResourceQuota)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1_ResourceQuotaSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1_ResourceQuotaStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1ResourceQuotaSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1ResourceQuotaStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_ResourceQuotaList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ResourceQuotaList ...
+func DeepCopyv1ResourceQuotaList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceQuotaList)
 		out := out.(*ResourceQuotaList)
@@ -2660,7 +2792,7 @@ func DeepCopy_v1_ResourceQuotaList(in interface{}, out interface{}, c *conversio
 			in, out := &in.Items, &out.Items
 			*out = make([]ResourceQuota, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ResourceQuota(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ResourceQuota(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2669,7 +2801,8 @@ func DeepCopy_v1_ResourceQuotaList(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_v1_ResourceQuotaSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ResourceQuotaSpec ...
+func DeepCopyv1ResourceQuotaSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceQuotaSpec)
 		out := out.(*ResourceQuotaSpec)
@@ -2690,7 +2823,8 @@ func DeepCopy_v1_ResourceQuotaSpec(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_v1_ResourceQuotaStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ResourceQuotaStatus ...
+func DeepCopyv1ResourceQuotaStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceQuotaStatus)
 		out := out.(*ResourceQuotaStatus)
@@ -2713,7 +2847,8 @@ func DeepCopy_v1_ResourceQuotaStatus(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_ResourceRequirements(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ResourceRequirements ...
+func DeepCopyv1ResourceRequirements(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceRequirements)
 		out := out.(*ResourceRequirements)
@@ -2736,7 +2871,8 @@ func DeepCopy_v1_ResourceRequirements(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_SELinuxOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1SELinuxOptions ...
+func DeepCopyv1SELinuxOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SELinuxOptions)
 		out := out.(*SELinuxOptions)
@@ -2745,24 +2881,25 @@ func DeepCopy_v1_SELinuxOptions(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_Secret(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Secret ...
+func DeepCopyv1Secret(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Secret)
 		out := out.(*Secret)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
 			*out = make(map[string][]byte)
 			for key, val := range *in {
-				if newVal, err := c.DeepCopy(&val); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&val); err == nil {
 					(*out)[key] = *newVal.(*[]byte)
+				} else {
+					return err
 				}
 			}
 		}
@@ -2777,7 +2914,8 @@ func DeepCopy_v1_Secret(in interface{}, out interface{}, c *conversion.Cloner) e
 	}
 }
 
-func DeepCopy_v1_SecretEnvSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1SecretEnvSource ...
+func DeepCopyv1SecretEnvSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecretEnvSource)
 		out := out.(*SecretEnvSource)
@@ -2791,7 +2929,8 @@ func DeepCopy_v1_SecretEnvSource(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_SecretKeySelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1SecretKeySelector ...
+func DeepCopyv1SecretKeySelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecretKeySelector)
 		out := out.(*SecretKeySelector)
@@ -2805,7 +2944,8 @@ func DeepCopy_v1_SecretKeySelector(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_v1_SecretList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1SecretList ...
+func DeepCopyv1SecretList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecretList)
 		out := out.(*SecretList)
@@ -2814,7 +2954,7 @@ func DeepCopy_v1_SecretList(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.Items, &out.Items
 			*out = make([]Secret, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Secret(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Secret(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2823,7 +2963,8 @@ func DeepCopy_v1_SecretList(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1_SecretVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1SecretVolumeSource ...
+func DeepCopyv1SecretVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecretVolumeSource)
 		out := out.(*SecretVolumeSource)
@@ -2832,7 +2973,7 @@ func DeepCopy_v1_SecretVolumeSource(in interface{}, out interface{}, c *conversi
 			in, out := &in.Items, &out.Items
 			*out = make([]KeyToPath, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_KeyToPath(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1KeyToPath(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2851,7 +2992,8 @@ func DeepCopy_v1_SecretVolumeSource(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1_SecurityContext(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1SecurityContext ...
+func DeepCopyv1SecurityContext(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecurityContext)
 		out := out.(*SecurityContext)
@@ -2859,7 +3001,7 @@ func DeepCopy_v1_SecurityContext(in interface{}, out interface{}, c *conversion.
 		if in.Capabilities != nil {
 			in, out := &in.Capabilities, &out.Capabilities
 			*out = new(Capabilities)
-			if err := DeepCopy_v1_Capabilities(*in, *out, c); err != nil {
+			if err := DeepCopyv1Capabilities(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -2892,7 +3034,8 @@ func DeepCopy_v1_SecurityContext(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_SerializedReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1SerializedReference ...
+func DeepCopyv1SerializedReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SerializedReference)
 		out := out.(*SerializedReference)
@@ -2901,35 +3044,37 @@ func DeepCopy_v1_SerializedReference(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_Service(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Service ...
+func DeepCopyv1Service(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Service)
 		out := out.(*Service)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1_ServiceSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1_ServiceStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1ServiceSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1ServiceStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_ServiceAccount(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ServiceAccount ...
+func DeepCopyv1ServiceAccount(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceAccount)
 		out := out.(*ServiceAccount)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Secrets != nil {
 			in, out := &in.Secrets, &out.Secrets
@@ -2945,7 +3090,8 @@ func DeepCopy_v1_ServiceAccount(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_ServiceAccountList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ServiceAccountList ...
+func DeepCopyv1ServiceAccountList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceAccountList)
 		out := out.(*ServiceAccountList)
@@ -2954,7 +3100,7 @@ func DeepCopy_v1_ServiceAccountList(in interface{}, out interface{}, c *conversi
 			in, out := &in.Items, &out.Items
 			*out = make([]ServiceAccount, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_ServiceAccount(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1ServiceAccount(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2963,7 +3109,8 @@ func DeepCopy_v1_ServiceAccountList(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1_ServiceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ServiceList ...
+func DeepCopyv1ServiceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceList)
 		out := out.(*ServiceList)
@@ -2972,7 +3119,7 @@ func DeepCopy_v1_ServiceList(in interface{}, out interface{}, c *conversion.Clon
 			in, out := &in.Items, &out.Items
 			*out = make([]Service, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Service(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Service(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2981,7 +3128,8 @@ func DeepCopy_v1_ServiceList(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_ServicePort(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ServicePort ...
+func DeepCopyv1ServicePort(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServicePort)
 		out := out.(*ServicePort)
@@ -2990,7 +3138,8 @@ func DeepCopy_v1_ServicePort(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_ServiceProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ServiceProxyOptions ...
+func DeepCopyv1ServiceProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceProxyOptions)
 		out := out.(*ServiceProxyOptions)
@@ -2999,7 +3148,8 @@ func DeepCopy_v1_ServiceProxyOptions(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1_ServiceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ServiceSpec ...
+func DeepCopyv1ServiceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceSpec)
 		out := out.(*ServiceSpec)
@@ -3035,19 +3185,21 @@ func DeepCopy_v1_ServiceSpec(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_ServiceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ServiceStatus ...
+func DeepCopyv1ServiceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceStatus)
 		out := out.(*ServiceStatus)
 		*out = *in
-		if err := DeepCopy_v1_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, c); err != nil {
+		if err := DeepCopyv1LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_Sysctl(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Sysctl ...
+func DeepCopyv1Sysctl(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Sysctl)
 		out := out.(*Sysctl)
@@ -3056,7 +3208,8 @@ func DeepCopy_v1_Sysctl(in interface{}, out interface{}, c *conversion.Cloner) e
 	}
 }
 
-func DeepCopy_v1_TCPSocketAction(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1TCPSocketAction ...
+func DeepCopyv1TCPSocketAction(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TCPSocketAction)
 		out := out.(*TCPSocketAction)
@@ -3065,7 +3218,8 @@ func DeepCopy_v1_TCPSocketAction(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_Taint(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Taint ...
+func DeepCopyv1Taint(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Taint)
 		out := out.(*Taint)
@@ -3075,7 +3229,8 @@ func DeepCopy_v1_Taint(in interface{}, out interface{}, c *conversion.Cloner) er
 	}
 }
 
-func DeepCopy_v1_Toleration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Toleration ...
+func DeepCopyv1Toleration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Toleration)
 		out := out.(*Toleration)
@@ -3089,19 +3244,21 @@ func DeepCopy_v1_Toleration(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1_Volume(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Volume ...
+func DeepCopyv1Volume(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Volume)
 		out := out.(*Volume)
 		*out = *in
-		if err := DeepCopy_v1_VolumeSource(&in.VolumeSource, &out.VolumeSource, c); err != nil {
+		if err := DeepCopyv1VolumeSource(&in.VolumeSource, &out.VolumeSource, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_VolumeMount(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1VolumeMount ...
+func DeepCopyv1VolumeMount(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*VolumeMount)
 		out := out.(*VolumeMount)
@@ -3110,7 +3267,8 @@ func DeepCopy_v1_VolumeMount(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_VolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1VolumeSource ...
+func DeepCopyv1VolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*VolumeSource)
 		out := out.(*VolumeSource)
@@ -3143,7 +3301,7 @@ func DeepCopy_v1_VolumeSource(in interface{}, out interface{}, c *conversion.Clo
 		if in.Secret != nil {
 			in, out := &in.Secret, &out.Secret
 			*out = new(SecretVolumeSource)
-			if err := DeepCopy_v1_SecretVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1SecretVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3170,14 +3328,14 @@ func DeepCopy_v1_VolumeSource(in interface{}, out interface{}, c *conversion.Clo
 		if in.RBD != nil {
 			in, out := &in.RBD, &out.RBD
 			*out = new(RBDVolumeSource)
-			if err := DeepCopy_v1_RBDVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1RBDVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.FlexVolume != nil {
 			in, out := &in.FlexVolume, &out.FlexVolume
 			*out = new(FlexVolumeSource)
-			if err := DeepCopy_v1_FlexVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1FlexVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3189,7 +3347,7 @@ func DeepCopy_v1_VolumeSource(in interface{}, out interface{}, c *conversion.Clo
 		if in.CephFS != nil {
 			in, out := &in.CephFS, &out.CephFS
 			*out = new(CephFSVolumeSource)
-			if err := DeepCopy_v1_CephFSVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1CephFSVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3201,14 +3359,14 @@ func DeepCopy_v1_VolumeSource(in interface{}, out interface{}, c *conversion.Clo
 		if in.DownwardAPI != nil {
 			in, out := &in.DownwardAPI, &out.DownwardAPI
 			*out = new(DownwardAPIVolumeSource)
-			if err := DeepCopy_v1_DownwardAPIVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1DownwardAPIVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.FC != nil {
 			in, out := &in.FC, &out.FC
 			*out = new(FCVolumeSource)
-			if err := DeepCopy_v1_FCVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1FCVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3220,7 +3378,7 @@ func DeepCopy_v1_VolumeSource(in interface{}, out interface{}, c *conversion.Clo
 		if in.ConfigMap != nil {
 			in, out := &in.ConfigMap, &out.ConfigMap
 			*out = new(ConfigMapVolumeSource)
-			if err := DeepCopy_v1_ConfigMapVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1ConfigMapVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3237,7 +3395,7 @@ func DeepCopy_v1_VolumeSource(in interface{}, out interface{}, c *conversion.Clo
 		if in.AzureDisk != nil {
 			in, out := &in.AzureDisk, &out.AzureDisk
 			*out = new(AzureDiskVolumeSource)
-			if err := DeepCopy_v1_AzureDiskVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyv1AzureDiskVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3250,7 +3408,8 @@ func DeepCopy_v1_VolumeSource(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_VsphereVirtualDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1VsphereVirtualDiskVolumeSource ...
+func DeepCopyv1VsphereVirtualDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*VsphereVirtualDiskVolumeSource)
 		out := out.(*VsphereVirtualDiskVolumeSource)
@@ -3259,12 +3418,13 @@ func DeepCopy_v1_VsphereVirtualDiskVolumeSource(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_v1_WeightedPodAffinityTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1WeightedPodAffinityTerm ...
+func DeepCopyv1WeightedPodAffinityTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*WeightedPodAffinityTerm)
 		out := out.(*WeightedPodAffinityTerm)
 		*out = *in
-		if err := DeepCopy_v1_PodAffinityTerm(&in.PodAffinityTerm, &out.PodAffinityTerm, c); err != nil {
+		if err := DeepCopyv1PodAffinityTerm(&in.PodAffinityTerm, &out.PodAffinityTerm, c); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -38,171 +38,172 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_AWSElasticBlockStoreVolumeSource, InType: reflect.TypeOf(&AWSElasticBlockStoreVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Affinity, InType: reflect.TypeOf(&Affinity{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_AttachedVolume, InType: reflect.TypeOf(&AttachedVolume{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_AvoidPods, InType: reflect.TypeOf(&AvoidPods{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_AzureDiskVolumeSource, InType: reflect.TypeOf(&AzureDiskVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_AzureFileVolumeSource, InType: reflect.TypeOf(&AzureFileVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Binding, InType: reflect.TypeOf(&Binding{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Capabilities, InType: reflect.TypeOf(&Capabilities{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_CephFSVolumeSource, InType: reflect.TypeOf(&CephFSVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_CinderVolumeSource, InType: reflect.TypeOf(&CinderVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ComponentCondition, InType: reflect.TypeOf(&ComponentCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ComponentStatus, InType: reflect.TypeOf(&ComponentStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ComponentStatusList, InType: reflect.TypeOf(&ComponentStatusList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ConfigMap, InType: reflect.TypeOf(&ConfigMap{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ConfigMapEnvSource, InType: reflect.TypeOf(&ConfigMapEnvSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ConfigMapKeySelector, InType: reflect.TypeOf(&ConfigMapKeySelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ConfigMapList, InType: reflect.TypeOf(&ConfigMapList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ConfigMapVolumeSource, InType: reflect.TypeOf(&ConfigMapVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Container, InType: reflect.TypeOf(&Container{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ContainerImage, InType: reflect.TypeOf(&ContainerImage{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ContainerPort, InType: reflect.TypeOf(&ContainerPort{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ContainerState, InType: reflect.TypeOf(&ContainerState{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ContainerStateRunning, InType: reflect.TypeOf(&ContainerStateRunning{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ContainerStateTerminated, InType: reflect.TypeOf(&ContainerStateTerminated{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ContainerStateWaiting, InType: reflect.TypeOf(&ContainerStateWaiting{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ContainerStatus, InType: reflect.TypeOf(&ContainerStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ConversionError, InType: reflect.TypeOf(&ConversionError{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_DaemonEndpoint, InType: reflect.TypeOf(&DaemonEndpoint{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_DeleteOptions, InType: reflect.TypeOf(&DeleteOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_DownwardAPIVolumeFile, InType: reflect.TypeOf(&DownwardAPIVolumeFile{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_DownwardAPIVolumeSource, InType: reflect.TypeOf(&DownwardAPIVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EmptyDirVolumeSource, InType: reflect.TypeOf(&EmptyDirVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EndpointAddress, InType: reflect.TypeOf(&EndpointAddress{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EndpointPort, InType: reflect.TypeOf(&EndpointPort{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EndpointSubset, InType: reflect.TypeOf(&EndpointSubset{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Endpoints, InType: reflect.TypeOf(&Endpoints{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EndpointsList, InType: reflect.TypeOf(&EndpointsList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EnvFromSource, InType: reflect.TypeOf(&EnvFromSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EnvVar, InType: reflect.TypeOf(&EnvVar{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EnvVarSource, InType: reflect.TypeOf(&EnvVarSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Event, InType: reflect.TypeOf(&Event{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EventList, InType: reflect.TypeOf(&EventList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_EventSource, InType: reflect.TypeOf(&EventSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ExecAction, InType: reflect.TypeOf(&ExecAction{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_FCVolumeSource, InType: reflect.TypeOf(&FCVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_FlexVolumeSource, InType: reflect.TypeOf(&FlexVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_FlockerVolumeSource, InType: reflect.TypeOf(&FlockerVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_GCEPersistentDiskVolumeSource, InType: reflect.TypeOf(&GCEPersistentDiskVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_GitRepoVolumeSource, InType: reflect.TypeOf(&GitRepoVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_GlusterfsVolumeSource, InType: reflect.TypeOf(&GlusterfsVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_HTTPGetAction, InType: reflect.TypeOf(&HTTPGetAction{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_HTTPHeader, InType: reflect.TypeOf(&HTTPHeader{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Handler, InType: reflect.TypeOf(&Handler{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_HostPathVolumeSource, InType: reflect.TypeOf(&HostPathVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ISCSIVolumeSource, InType: reflect.TypeOf(&ISCSIVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_KeyToPath, InType: reflect.TypeOf(&KeyToPath{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Lifecycle, InType: reflect.TypeOf(&Lifecycle{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_LimitRange, InType: reflect.TypeOf(&LimitRange{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_LimitRangeItem, InType: reflect.TypeOf(&LimitRangeItem{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_LimitRangeList, InType: reflect.TypeOf(&LimitRangeList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_LimitRangeSpec, InType: reflect.TypeOf(&LimitRangeSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_List, InType: reflect.TypeOf(&List{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ListOptions, InType: reflect.TypeOf(&ListOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_LoadBalancerIngress, InType: reflect.TypeOf(&LoadBalancerIngress{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_LoadBalancerStatus, InType: reflect.TypeOf(&LoadBalancerStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_LocalObjectReference, InType: reflect.TypeOf(&LocalObjectReference{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NFSVolumeSource, InType: reflect.TypeOf(&NFSVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Namespace, InType: reflect.TypeOf(&Namespace{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NamespaceList, InType: reflect.TypeOf(&NamespaceList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NamespaceSpec, InType: reflect.TypeOf(&NamespaceSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NamespaceStatus, InType: reflect.TypeOf(&NamespaceStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Node, InType: reflect.TypeOf(&Node{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeAddress, InType: reflect.TypeOf(&NodeAddress{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeAffinity, InType: reflect.TypeOf(&NodeAffinity{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeCondition, InType: reflect.TypeOf(&NodeCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeDaemonEndpoints, InType: reflect.TypeOf(&NodeDaemonEndpoints{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeList, InType: reflect.TypeOf(&NodeList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeProxyOptions, InType: reflect.TypeOf(&NodeProxyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeResources, InType: reflect.TypeOf(&NodeResources{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeSelector, InType: reflect.TypeOf(&NodeSelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeSelectorRequirement, InType: reflect.TypeOf(&NodeSelectorRequirement{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeSelectorTerm, InType: reflect.TypeOf(&NodeSelectorTerm{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeSpec, InType: reflect.TypeOf(&NodeSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeStatus, InType: reflect.TypeOf(&NodeStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_NodeSystemInfo, InType: reflect.TypeOf(&NodeSystemInfo{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ObjectFieldSelector, InType: reflect.TypeOf(&ObjectFieldSelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ObjectMeta, InType: reflect.TypeOf(&ObjectMeta{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ObjectReference, InType: reflect.TypeOf(&ObjectReference{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolume, InType: reflect.TypeOf(&PersistentVolume{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeClaim, InType: reflect.TypeOf(&PersistentVolumeClaim{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeClaimList, InType: reflect.TypeOf(&PersistentVolumeClaimList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeClaimSpec, InType: reflect.TypeOf(&PersistentVolumeClaimSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeClaimStatus, InType: reflect.TypeOf(&PersistentVolumeClaimStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeClaimVolumeSource, InType: reflect.TypeOf(&PersistentVolumeClaimVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeList, InType: reflect.TypeOf(&PersistentVolumeList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeSource, InType: reflect.TypeOf(&PersistentVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeSpec, InType: reflect.TypeOf(&PersistentVolumeSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PersistentVolumeStatus, InType: reflect.TypeOf(&PersistentVolumeStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PhotonPersistentDiskVolumeSource, InType: reflect.TypeOf(&PhotonPersistentDiskVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Pod, InType: reflect.TypeOf(&Pod{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodAffinity, InType: reflect.TypeOf(&PodAffinity{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodAffinityTerm, InType: reflect.TypeOf(&PodAffinityTerm{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodAntiAffinity, InType: reflect.TypeOf(&PodAntiAffinity{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodAttachOptions, InType: reflect.TypeOf(&PodAttachOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodCondition, InType: reflect.TypeOf(&PodCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodExecOptions, InType: reflect.TypeOf(&PodExecOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodList, InType: reflect.TypeOf(&PodList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodLogOptions, InType: reflect.TypeOf(&PodLogOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodPortForwardOptions, InType: reflect.TypeOf(&PodPortForwardOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodProxyOptions, InType: reflect.TypeOf(&PodProxyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodSecurityContext, InType: reflect.TypeOf(&PodSecurityContext{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodSignature, InType: reflect.TypeOf(&PodSignature{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodSpec, InType: reflect.TypeOf(&PodSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodStatus, InType: reflect.TypeOf(&PodStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodStatusResult, InType: reflect.TypeOf(&PodStatusResult{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodTemplate, InType: reflect.TypeOf(&PodTemplate{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodTemplateList, InType: reflect.TypeOf(&PodTemplateList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PodTemplateSpec, InType: reflect.TypeOf(&PodTemplateSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Preconditions, InType: reflect.TypeOf(&Preconditions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PreferAvoidPodsEntry, InType: reflect.TypeOf(&PreferAvoidPodsEntry{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_PreferredSchedulingTerm, InType: reflect.TypeOf(&PreferredSchedulingTerm{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Probe, InType: reflect.TypeOf(&Probe{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_QuobyteVolumeSource, InType: reflect.TypeOf(&QuobyteVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_RBDVolumeSource, InType: reflect.TypeOf(&RBDVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_RangeAllocation, InType: reflect.TypeOf(&RangeAllocation{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ReplicationController, InType: reflect.TypeOf(&ReplicationController{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ReplicationControllerCondition, InType: reflect.TypeOf(&ReplicationControllerCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ReplicationControllerList, InType: reflect.TypeOf(&ReplicationControllerList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ReplicationControllerSpec, InType: reflect.TypeOf(&ReplicationControllerSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ReplicationControllerStatus, InType: reflect.TypeOf(&ReplicationControllerStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ResourceFieldSelector, InType: reflect.TypeOf(&ResourceFieldSelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ResourceQuota, InType: reflect.TypeOf(&ResourceQuota{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ResourceQuotaList, InType: reflect.TypeOf(&ResourceQuotaList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ResourceQuotaSpec, InType: reflect.TypeOf(&ResourceQuotaSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ResourceQuotaStatus, InType: reflect.TypeOf(&ResourceQuotaStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ResourceRequirements, InType: reflect.TypeOf(&ResourceRequirements{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_SELinuxOptions, InType: reflect.TypeOf(&SELinuxOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Secret, InType: reflect.TypeOf(&Secret{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_SecretEnvSource, InType: reflect.TypeOf(&SecretEnvSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_SecretKeySelector, InType: reflect.TypeOf(&SecretKeySelector{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_SecretList, InType: reflect.TypeOf(&SecretList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_SecretVolumeSource, InType: reflect.TypeOf(&SecretVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_SecurityContext, InType: reflect.TypeOf(&SecurityContext{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_SerializedReference, InType: reflect.TypeOf(&SerializedReference{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Service, InType: reflect.TypeOf(&Service{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ServiceAccount, InType: reflect.TypeOf(&ServiceAccount{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ServiceAccountList, InType: reflect.TypeOf(&ServiceAccountList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ServiceList, InType: reflect.TypeOf(&ServiceList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ServicePort, InType: reflect.TypeOf(&ServicePort{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ServiceProxyOptions, InType: reflect.TypeOf(&ServiceProxyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ServiceSpec, InType: reflect.TypeOf(&ServiceSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_ServiceStatus, InType: reflect.TypeOf(&ServiceStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Sysctl, InType: reflect.TypeOf(&Sysctl{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_TCPSocketAction, InType: reflect.TypeOf(&TCPSocketAction{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Taint, InType: reflect.TypeOf(&Taint{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Toleration, InType: reflect.TypeOf(&Toleration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_Volume, InType: reflect.TypeOf(&Volume{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_VolumeMount, InType: reflect.TypeOf(&VolumeMount{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_VolumeSource, InType: reflect.TypeOf(&VolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_VsphereVirtualDiskVolumeSource, InType: reflect.TypeOf(&VsphereVirtualDiskVolumeSource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_api_WeightedPodAffinityTerm, InType: reflect.TypeOf(&WeightedPodAffinityTerm{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiAWSElasticBlockStoreVolumeSource, InType: reflect.TypeOf(&AWSElasticBlockStoreVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiAffinity, InType: reflect.TypeOf(&Affinity{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiAttachedVolume, InType: reflect.TypeOf(&AttachedVolume{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiAvoidPods, InType: reflect.TypeOf(&AvoidPods{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiAzureDiskVolumeSource, InType: reflect.TypeOf(&AzureDiskVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiAzureFileVolumeSource, InType: reflect.TypeOf(&AzureFileVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiBinding, InType: reflect.TypeOf(&Binding{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiCapabilities, InType: reflect.TypeOf(&Capabilities{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiCephFSVolumeSource, InType: reflect.TypeOf(&CephFSVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiCinderVolumeSource, InType: reflect.TypeOf(&CinderVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiComponentCondition, InType: reflect.TypeOf(&ComponentCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiComponentStatus, InType: reflect.TypeOf(&ComponentStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiComponentStatusList, InType: reflect.TypeOf(&ComponentStatusList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiConfigMap, InType: reflect.TypeOf(&ConfigMap{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiConfigMapEnvSource, InType: reflect.TypeOf(&ConfigMapEnvSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiConfigMapKeySelector, InType: reflect.TypeOf(&ConfigMapKeySelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiConfigMapList, InType: reflect.TypeOf(&ConfigMapList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiConfigMapVolumeSource, InType: reflect.TypeOf(&ConfigMapVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiContainer, InType: reflect.TypeOf(&Container{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiContainerImage, InType: reflect.TypeOf(&ContainerImage{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiContainerPort, InType: reflect.TypeOf(&ContainerPort{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiContainerState, InType: reflect.TypeOf(&ContainerState{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiContainerStateRunning, InType: reflect.TypeOf(&ContainerStateRunning{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiContainerStateTerminated, InType: reflect.TypeOf(&ContainerStateTerminated{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiContainerStateWaiting, InType: reflect.TypeOf(&ContainerStateWaiting{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiContainerStatus, InType: reflect.TypeOf(&ContainerStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiConversionError, InType: reflect.TypeOf(&ConversionError{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiDaemonEndpoint, InType: reflect.TypeOf(&DaemonEndpoint{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiDeleteOptions, InType: reflect.TypeOf(&DeleteOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiDownwardAPIVolumeFile, InType: reflect.TypeOf(&DownwardAPIVolumeFile{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiDownwardAPIVolumeSource, InType: reflect.TypeOf(&DownwardAPIVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEmptyDirVolumeSource, InType: reflect.TypeOf(&EmptyDirVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEndpointAddress, InType: reflect.TypeOf(&EndpointAddress{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEndpointPort, InType: reflect.TypeOf(&EndpointPort{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEndpointSubset, InType: reflect.TypeOf(&EndpointSubset{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEndpoints, InType: reflect.TypeOf(&Endpoints{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEndpointsList, InType: reflect.TypeOf(&EndpointsList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEnvFromSource, InType: reflect.TypeOf(&EnvFromSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEnvVar, InType: reflect.TypeOf(&EnvVar{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEnvVarSource, InType: reflect.TypeOf(&EnvVarSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEvent, InType: reflect.TypeOf(&Event{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEventList, InType: reflect.TypeOf(&EventList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiEventSource, InType: reflect.TypeOf(&EventSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiExecAction, InType: reflect.TypeOf(&ExecAction{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiFCVolumeSource, InType: reflect.TypeOf(&FCVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiFlexVolumeSource, InType: reflect.TypeOf(&FlexVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiFlockerVolumeSource, InType: reflect.TypeOf(&FlockerVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiGCEPersistentDiskVolumeSource, InType: reflect.TypeOf(&GCEPersistentDiskVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiGitRepoVolumeSource, InType: reflect.TypeOf(&GitRepoVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiGlusterfsVolumeSource, InType: reflect.TypeOf(&GlusterfsVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiHTTPGetAction, InType: reflect.TypeOf(&HTTPGetAction{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiHTTPHeader, InType: reflect.TypeOf(&HTTPHeader{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiHandler, InType: reflect.TypeOf(&Handler{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiHostPathVolumeSource, InType: reflect.TypeOf(&HostPathVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiISCSIVolumeSource, InType: reflect.TypeOf(&ISCSIVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiKeyToPath, InType: reflect.TypeOf(&KeyToPath{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiLifecycle, InType: reflect.TypeOf(&Lifecycle{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiLimitRange, InType: reflect.TypeOf(&LimitRange{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiLimitRangeItem, InType: reflect.TypeOf(&LimitRangeItem{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiLimitRangeList, InType: reflect.TypeOf(&LimitRangeList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiLimitRangeSpec, InType: reflect.TypeOf(&LimitRangeSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiList, InType: reflect.TypeOf(&List{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiListOptions, InType: reflect.TypeOf(&ListOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiLoadBalancerIngress, InType: reflect.TypeOf(&LoadBalancerIngress{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiLoadBalancerStatus, InType: reflect.TypeOf(&LoadBalancerStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiLocalObjectReference, InType: reflect.TypeOf(&LocalObjectReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNFSVolumeSource, InType: reflect.TypeOf(&NFSVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNamespace, InType: reflect.TypeOf(&Namespace{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNamespaceList, InType: reflect.TypeOf(&NamespaceList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNamespaceSpec, InType: reflect.TypeOf(&NamespaceSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNamespaceStatus, InType: reflect.TypeOf(&NamespaceStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNode, InType: reflect.TypeOf(&Node{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeAddress, InType: reflect.TypeOf(&NodeAddress{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeAffinity, InType: reflect.TypeOf(&NodeAffinity{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeCondition, InType: reflect.TypeOf(&NodeCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeDaemonEndpoints, InType: reflect.TypeOf(&NodeDaemonEndpoints{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeList, InType: reflect.TypeOf(&NodeList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeProxyOptions, InType: reflect.TypeOf(&NodeProxyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeResources, InType: reflect.TypeOf(&NodeResources{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeSelector, InType: reflect.TypeOf(&NodeSelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeSelectorRequirement, InType: reflect.TypeOf(&NodeSelectorRequirement{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeSelectorTerm, InType: reflect.TypeOf(&NodeSelectorTerm{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeSpec, InType: reflect.TypeOf(&NodeSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeStatus, InType: reflect.TypeOf(&NodeStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiNodeSystemInfo, InType: reflect.TypeOf(&NodeSystemInfo{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiObjectFieldSelector, InType: reflect.TypeOf(&ObjectFieldSelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiObjectMeta, InType: reflect.TypeOf(&ObjectMeta{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiObjectReference, InType: reflect.TypeOf(&ObjectReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolume, InType: reflect.TypeOf(&PersistentVolume{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeClaim, InType: reflect.TypeOf(&PersistentVolumeClaim{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeClaimList, InType: reflect.TypeOf(&PersistentVolumeClaimList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeClaimSpec, InType: reflect.TypeOf(&PersistentVolumeClaimSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeClaimStatus, InType: reflect.TypeOf(&PersistentVolumeClaimStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeClaimVolumeSource, InType: reflect.TypeOf(&PersistentVolumeClaimVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeList, InType: reflect.TypeOf(&PersistentVolumeList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeSource, InType: reflect.TypeOf(&PersistentVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeSpec, InType: reflect.TypeOf(&PersistentVolumeSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPersistentVolumeStatus, InType: reflect.TypeOf(&PersistentVolumeStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPhotonPersistentDiskVolumeSource, InType: reflect.TypeOf(&PhotonPersistentDiskVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPod, InType: reflect.TypeOf(&Pod{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodAffinity, InType: reflect.TypeOf(&PodAffinity{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodAffinityTerm, InType: reflect.TypeOf(&PodAffinityTerm{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodAntiAffinity, InType: reflect.TypeOf(&PodAntiAffinity{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodAttachOptions, InType: reflect.TypeOf(&PodAttachOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodCondition, InType: reflect.TypeOf(&PodCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodExecOptions, InType: reflect.TypeOf(&PodExecOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodList, InType: reflect.TypeOf(&PodList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodLogOptions, InType: reflect.TypeOf(&PodLogOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodPortForwardOptions, InType: reflect.TypeOf(&PodPortForwardOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodProxyOptions, InType: reflect.TypeOf(&PodProxyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodSecurityContext, InType: reflect.TypeOf(&PodSecurityContext{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodSignature, InType: reflect.TypeOf(&PodSignature{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodSpec, InType: reflect.TypeOf(&PodSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodStatus, InType: reflect.TypeOf(&PodStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodStatusResult, InType: reflect.TypeOf(&PodStatusResult{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodTemplate, InType: reflect.TypeOf(&PodTemplate{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodTemplateList, InType: reflect.TypeOf(&PodTemplateList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPodTemplateSpec, InType: reflect.TypeOf(&PodTemplateSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPreconditions, InType: reflect.TypeOf(&Preconditions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPreferAvoidPodsEntry, InType: reflect.TypeOf(&PreferAvoidPodsEntry{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiPreferredSchedulingTerm, InType: reflect.TypeOf(&PreferredSchedulingTerm{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiProbe, InType: reflect.TypeOf(&Probe{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiQuobyteVolumeSource, InType: reflect.TypeOf(&QuobyteVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiRBDVolumeSource, InType: reflect.TypeOf(&RBDVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiRangeAllocation, InType: reflect.TypeOf(&RangeAllocation{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiReplicationController, InType: reflect.TypeOf(&ReplicationController{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiReplicationControllerCondition, InType: reflect.TypeOf(&ReplicationControllerCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiReplicationControllerList, InType: reflect.TypeOf(&ReplicationControllerList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiReplicationControllerSpec, InType: reflect.TypeOf(&ReplicationControllerSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiReplicationControllerStatus, InType: reflect.TypeOf(&ReplicationControllerStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiResourceFieldSelector, InType: reflect.TypeOf(&ResourceFieldSelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiResourceQuota, InType: reflect.TypeOf(&ResourceQuota{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiResourceQuotaList, InType: reflect.TypeOf(&ResourceQuotaList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiResourceQuotaSpec, InType: reflect.TypeOf(&ResourceQuotaSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiResourceQuotaStatus, InType: reflect.TypeOf(&ResourceQuotaStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiResourceRequirements, InType: reflect.TypeOf(&ResourceRequirements{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSELinuxOptions, InType: reflect.TypeOf(&SELinuxOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSecret, InType: reflect.TypeOf(&Secret{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSecretEnvSource, InType: reflect.TypeOf(&SecretEnvSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSecretKeySelector, InType: reflect.TypeOf(&SecretKeySelector{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSecretList, InType: reflect.TypeOf(&SecretList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSecretVolumeSource, InType: reflect.TypeOf(&SecretVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSecurityContext, InType: reflect.TypeOf(&SecurityContext{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSerializedReference, InType: reflect.TypeOf(&SerializedReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiService, InType: reflect.TypeOf(&Service{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiServiceAccount, InType: reflect.TypeOf(&ServiceAccount{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiServiceAccountList, InType: reflect.TypeOf(&ServiceAccountList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiServiceList, InType: reflect.TypeOf(&ServiceList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiServicePort, InType: reflect.TypeOf(&ServicePort{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiServiceProxyOptions, InType: reflect.TypeOf(&ServiceProxyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiServiceSpec, InType: reflect.TypeOf(&ServiceSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiServiceStatus, InType: reflect.TypeOf(&ServiceStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiSysctl, InType: reflect.TypeOf(&Sysctl{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiTCPSocketAction, InType: reflect.TypeOf(&TCPSocketAction{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiTaint, InType: reflect.TypeOf(&Taint{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiToleration, InType: reflect.TypeOf(&Toleration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiVolume, InType: reflect.TypeOf(&Volume{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiVolumeMount, InType: reflect.TypeOf(&VolumeMount{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiVolumeSource, InType: reflect.TypeOf(&VolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiVsphereVirtualDiskVolumeSource, InType: reflect.TypeOf(&VsphereVirtualDiskVolumeSource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyapiWeightedPodAffinityTerm, InType: reflect.TypeOf(&WeightedPodAffinityTerm{})},
 	)
 }
 
-func DeepCopy_api_AWSElasticBlockStoreVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiAWSElasticBlockStoreVolumeSource ...
+func DeepCopyapiAWSElasticBlockStoreVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AWSElasticBlockStoreVolumeSource)
 		out := out.(*AWSElasticBlockStoreVolumeSource)
@@ -211,7 +212,8 @@ func DeepCopy_api_AWSElasticBlockStoreVolumeSource(in interface{}, out interface
 	}
 }
 
-func DeepCopy_api_Affinity(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiAffinity ...
+func DeepCopyapiAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Affinity)
 		out := out.(*Affinity)
@@ -219,21 +221,21 @@ func DeepCopy_api_Affinity(in interface{}, out interface{}, c *conversion.Cloner
 		if in.NodeAffinity != nil {
 			in, out := &in.NodeAffinity, &out.NodeAffinity
 			*out = new(NodeAffinity)
-			if err := DeepCopy_api_NodeAffinity(*in, *out, c); err != nil {
+			if err := DeepCopyapiNodeAffinity(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.PodAffinity != nil {
 			in, out := &in.PodAffinity, &out.PodAffinity
 			*out = new(PodAffinity)
-			if err := DeepCopy_api_PodAffinity(*in, *out, c); err != nil {
+			if err := DeepCopyapiPodAffinity(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.PodAntiAffinity != nil {
 			in, out := &in.PodAntiAffinity, &out.PodAntiAffinity
 			*out = new(PodAntiAffinity)
-			if err := DeepCopy_api_PodAntiAffinity(*in, *out, c); err != nil {
+			if err := DeepCopyapiPodAntiAffinity(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -241,7 +243,8 @@ func DeepCopy_api_Affinity(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_api_AttachedVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiAttachedVolume ...
+func DeepCopyapiAttachedVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AttachedVolume)
 		out := out.(*AttachedVolume)
@@ -250,7 +253,8 @@ func DeepCopy_api_AttachedVolume(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_AvoidPods(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiAvoidPods ...
+func DeepCopyapiAvoidPods(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AvoidPods)
 		out := out.(*AvoidPods)
@@ -259,7 +263,7 @@ func DeepCopy_api_AvoidPods(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.PreferAvoidPods, &out.PreferAvoidPods
 			*out = make([]PreferAvoidPodsEntry, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_PreferAvoidPodsEntry(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPreferAvoidPodsEntry(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -268,7 +272,8 @@ func DeepCopy_api_AvoidPods(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_api_AzureDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiAzureDiskVolumeSource ...
+func DeepCopyapiAzureDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AzureDiskVolumeSource)
 		out := out.(*AzureDiskVolumeSource)
@@ -292,7 +297,8 @@ func DeepCopy_api_AzureDiskVolumeSource(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_AzureFileVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiAzureFileVolumeSource ...
+func DeepCopyapiAzureFileVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AzureFileVolumeSource)
 		out := out.(*AzureFileVolumeSource)
@@ -301,21 +307,23 @@ func DeepCopy_api_AzureFileVolumeSource(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_Binding(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiBinding ...
+func DeepCopyapiBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Binding)
 		out := out.(*Binding)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_Capabilities(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiCapabilities ...
+func DeepCopyapiCapabilities(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Capabilities)
 		out := out.(*Capabilities)
@@ -334,7 +342,8 @@ func DeepCopy_api_Capabilities(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_api_CephFSVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiCephFSVolumeSource ...
+func DeepCopyapiCephFSVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CephFSVolumeSource)
 		out := out.(*CephFSVolumeSource)
@@ -353,7 +362,8 @@ func DeepCopy_api_CephFSVolumeSource(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_api_CinderVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiCinderVolumeSource ...
+func DeepCopyapiCinderVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CinderVolumeSource)
 		out := out.(*CinderVolumeSource)
@@ -362,7 +372,8 @@ func DeepCopy_api_CinderVolumeSource(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_api_ComponentCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiComponentCondition ...
+func DeepCopyapiComponentCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ComponentCondition)
 		out := out.(*ComponentCondition)
@@ -371,15 +382,16 @@ func DeepCopy_api_ComponentCondition(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_api_ComponentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiComponentStatus ...
+func DeepCopyapiComponentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ComponentStatus)
 		out := out.(*ComponentStatus)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Conditions != nil {
 			in, out := &in.Conditions, &out.Conditions
@@ -390,7 +402,8 @@ func DeepCopy_api_ComponentStatus(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_ComponentStatusList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiComponentStatusList ...
+func DeepCopyapiComponentStatusList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ComponentStatusList)
 		out := out.(*ComponentStatusList)
@@ -399,7 +412,7 @@ func DeepCopy_api_ComponentStatusList(in interface{}, out interface{}, c *conver
 			in, out := &in.Items, &out.Items
 			*out = make([]ComponentStatus, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ComponentStatus(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiComponentStatus(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -408,15 +421,16 @@ func DeepCopy_api_ComponentStatusList(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_ConfigMap(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiConfigMap ...
+func DeepCopyapiConfigMap(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMap)
 		out := out.(*ConfigMap)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
@@ -429,7 +443,8 @@ func DeepCopy_api_ConfigMap(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_api_ConfigMapEnvSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiConfigMapEnvSource ...
+func DeepCopyapiConfigMapEnvSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMapEnvSource)
 		out := out.(*ConfigMapEnvSource)
@@ -443,7 +458,8 @@ func DeepCopy_api_ConfigMapEnvSource(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_api_ConfigMapKeySelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiConfigMapKeySelector ...
+func DeepCopyapiConfigMapKeySelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMapKeySelector)
 		out := out.(*ConfigMapKeySelector)
@@ -457,7 +473,8 @@ func DeepCopy_api_ConfigMapKeySelector(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_api_ConfigMapList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiConfigMapList ...
+func DeepCopyapiConfigMapList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMapList)
 		out := out.(*ConfigMapList)
@@ -466,7 +483,7 @@ func DeepCopy_api_ConfigMapList(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Items, &out.Items
 			*out = make([]ConfigMap, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ConfigMap(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiConfigMap(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -475,7 +492,8 @@ func DeepCopy_api_ConfigMapList(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_ConfigMapVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiConfigMapVolumeSource ...
+func DeepCopyapiConfigMapVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConfigMapVolumeSource)
 		out := out.(*ConfigMapVolumeSource)
@@ -484,7 +502,7 @@ func DeepCopy_api_ConfigMapVolumeSource(in interface{}, out interface{}, c *conv
 			in, out := &in.Items, &out.Items
 			*out = make([]KeyToPath, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_KeyToPath(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiKeyToPath(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -503,7 +521,8 @@ func DeepCopy_api_ConfigMapVolumeSource(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_Container(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiContainer ...
+func DeepCopyapiContainer(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Container)
 		out := out.(*Container)
@@ -527,7 +546,7 @@ func DeepCopy_api_Container(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.EnvFrom, &out.EnvFrom
 			*out = make([]EnvFromSource, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_EnvFromSource(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiEnvFromSource(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -536,12 +555,12 @@ func DeepCopy_api_Container(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.Env, &out.Env
 			*out = make([]EnvVar, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_EnvVar(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiEnvVar(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
 		}
-		if err := DeepCopy_api_ResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
+		if err := DeepCopyapiResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
 			return err
 		}
 		if in.VolumeMounts != nil {
@@ -552,28 +571,28 @@ func DeepCopy_api_Container(in interface{}, out interface{}, c *conversion.Clone
 		if in.LivenessProbe != nil {
 			in, out := &in.LivenessProbe, &out.LivenessProbe
 			*out = new(Probe)
-			if err := DeepCopy_api_Probe(*in, *out, c); err != nil {
+			if err := DeepCopyapiProbe(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.ReadinessProbe != nil {
 			in, out := &in.ReadinessProbe, &out.ReadinessProbe
 			*out = new(Probe)
-			if err := DeepCopy_api_Probe(*in, *out, c); err != nil {
+			if err := DeepCopyapiProbe(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.Lifecycle != nil {
 			in, out := &in.Lifecycle, &out.Lifecycle
 			*out = new(Lifecycle)
-			if err := DeepCopy_api_Lifecycle(*in, *out, c); err != nil {
+			if err := DeepCopyapiLifecycle(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.SecurityContext != nil {
 			in, out := &in.SecurityContext, &out.SecurityContext
 			*out = new(SecurityContext)
-			if err := DeepCopy_api_SecurityContext(*in, *out, c); err != nil {
+			if err := DeepCopyapiSecurityContext(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -581,7 +600,8 @@ func DeepCopy_api_Container(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_api_ContainerImage(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiContainerImage ...
+func DeepCopyapiContainerImage(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerImage)
 		out := out.(*ContainerImage)
@@ -595,7 +615,8 @@ func DeepCopy_api_ContainerImage(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_ContainerPort(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiContainerPort ...
+func DeepCopyapiContainerPort(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerPort)
 		out := out.(*ContainerPort)
@@ -604,7 +625,8 @@ func DeepCopy_api_ContainerPort(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_ContainerState(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiContainerState ...
+func DeepCopyapiContainerState(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerState)
 		out := out.(*ContainerState)
@@ -617,14 +639,14 @@ func DeepCopy_api_ContainerState(in interface{}, out interface{}, c *conversion.
 		if in.Running != nil {
 			in, out := &in.Running, &out.Running
 			*out = new(ContainerStateRunning)
-			if err := DeepCopy_api_ContainerStateRunning(*in, *out, c); err != nil {
+			if err := DeepCopyapiContainerStateRunning(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.Terminated != nil {
 			in, out := &in.Terminated, &out.Terminated
 			*out = new(ContainerStateTerminated)
-			if err := DeepCopy_api_ContainerStateTerminated(*in, *out, c); err != nil {
+			if err := DeepCopyapiContainerStateTerminated(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -632,7 +654,8 @@ func DeepCopy_api_ContainerState(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_ContainerStateRunning(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiContainerStateRunning ...
+func DeepCopyapiContainerStateRunning(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerStateRunning)
 		out := out.(*ContainerStateRunning)
@@ -642,7 +665,8 @@ func DeepCopy_api_ContainerStateRunning(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_ContainerStateTerminated(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiContainerStateTerminated ...
+func DeepCopyapiContainerStateTerminated(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerStateTerminated)
 		out := out.(*ContainerStateTerminated)
@@ -653,7 +677,8 @@ func DeepCopy_api_ContainerStateTerminated(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_api_ContainerStateWaiting(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiContainerStateWaiting ...
+func DeepCopyapiContainerStateWaiting(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerStateWaiting)
 		out := out.(*ContainerStateWaiting)
@@ -662,47 +687,50 @@ func DeepCopy_api_ContainerStateWaiting(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_ContainerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiContainerStatus ...
+func DeepCopyapiContainerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ContainerStatus)
 		out := out.(*ContainerStatus)
 		*out = *in
-		if err := DeepCopy_api_ContainerState(&in.State, &out.State, c); err != nil {
+		if err := DeepCopyapiContainerState(&in.State, &out.State, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_api_ContainerState(&in.LastTerminationState, &out.LastTerminationState, c); err != nil {
+		if err := DeepCopyapiContainerState(&in.LastTerminationState, &out.LastTerminationState, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_ConversionError(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiConversionError ...
+func DeepCopyapiConversionError(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ConversionError)
 		out := out.(*ConversionError)
 		*out = *in
 		// in.In is kind 'Interface'
 		if in.In != nil {
-			if newVal, err := c.DeepCopy(&in.In); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(&in.In); err == nil {
 				out.In = *newVal.(*interface{})
+			} else {
+				return err
 			}
 		}
 		// in.Out is kind 'Interface'
 		if in.Out != nil {
-			if newVal, err := c.DeepCopy(&in.Out); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(&in.Out); err == nil {
 				out.Out = *newVal.(*interface{})
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_DaemonEndpoint(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiDaemonEndpoint ...
+func DeepCopyapiDaemonEndpoint(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonEndpoint)
 		out := out.(*DaemonEndpoint)
@@ -711,7 +739,8 @@ func DeepCopy_api_DaemonEndpoint(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_DeleteOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiDeleteOptions ...
+func DeepCopyapiDeleteOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeleteOptions)
 		out := out.(*DeleteOptions)
@@ -724,7 +753,7 @@ func DeepCopy_api_DeleteOptions(in interface{}, out interface{}, c *conversion.C
 		if in.Preconditions != nil {
 			in, out := &in.Preconditions, &out.Preconditions
 			*out = new(Preconditions)
-			if err := DeepCopy_api_Preconditions(*in, *out, c); err != nil {
+			if err := DeepCopyapiPreconditions(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -737,7 +766,8 @@ func DeepCopy_api_DeleteOptions(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_DownwardAPIVolumeFile(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiDownwardAPIVolumeFile ...
+func DeepCopyapiDownwardAPIVolumeFile(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DownwardAPIVolumeFile)
 		out := out.(*DownwardAPIVolumeFile)
@@ -750,7 +780,7 @@ func DeepCopy_api_DownwardAPIVolumeFile(in interface{}, out interface{}, c *conv
 		if in.ResourceFieldRef != nil {
 			in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
 			*out = new(ResourceFieldSelector)
-			if err := DeepCopy_api_ResourceFieldSelector(*in, *out, c); err != nil {
+			if err := DeepCopyapiResourceFieldSelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -763,7 +793,8 @@ func DeepCopy_api_DownwardAPIVolumeFile(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_DownwardAPIVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiDownwardAPIVolumeSource ...
+func DeepCopyapiDownwardAPIVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DownwardAPIVolumeSource)
 		out := out.(*DownwardAPIVolumeSource)
@@ -772,7 +803,7 @@ func DeepCopy_api_DownwardAPIVolumeSource(in interface{}, out interface{}, c *co
 			in, out := &in.Items, &out.Items
 			*out = make([]DownwardAPIVolumeFile, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_DownwardAPIVolumeFile(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiDownwardAPIVolumeFile(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -786,7 +817,8 @@ func DeepCopy_api_DownwardAPIVolumeSource(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_api_EmptyDirVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEmptyDirVolumeSource ...
+func DeepCopyapiEmptyDirVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EmptyDirVolumeSource)
 		out := out.(*EmptyDirVolumeSource)
@@ -795,7 +827,8 @@ func DeepCopy_api_EmptyDirVolumeSource(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_api_EndpointAddress(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEndpointAddress ...
+func DeepCopyapiEndpointAddress(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EndpointAddress)
 		out := out.(*EndpointAddress)
@@ -814,7 +847,8 @@ func DeepCopy_api_EndpointAddress(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_EndpointPort(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEndpointPort ...
+func DeepCopyapiEndpointPort(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EndpointPort)
 		out := out.(*EndpointPort)
@@ -823,7 +857,8 @@ func DeepCopy_api_EndpointPort(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_api_EndpointSubset(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEndpointSubset ...
+func DeepCopyapiEndpointSubset(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EndpointSubset)
 		out := out.(*EndpointSubset)
@@ -832,7 +867,7 @@ func DeepCopy_api_EndpointSubset(in interface{}, out interface{}, c *conversion.
 			in, out := &in.Addresses, &out.Addresses
 			*out = make([]EndpointAddress, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_EndpointAddress(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiEndpointAddress(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -841,7 +876,7 @@ func DeepCopy_api_EndpointSubset(in interface{}, out interface{}, c *conversion.
 			in, out := &in.NotReadyAddresses, &out.NotReadyAddresses
 			*out = make([]EndpointAddress, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_EndpointAddress(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiEndpointAddress(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -855,21 +890,22 @@ func DeepCopy_api_EndpointSubset(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_Endpoints(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEndpoints ...
+func DeepCopyapiEndpoints(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Endpoints)
 		out := out.(*Endpoints)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Subsets != nil {
 			in, out := &in.Subsets, &out.Subsets
 			*out = make([]EndpointSubset, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_EndpointSubset(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiEndpointSubset(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -878,7 +914,8 @@ func DeepCopy_api_Endpoints(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_api_EndpointsList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEndpointsList ...
+func DeepCopyapiEndpointsList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EndpointsList)
 		out := out.(*EndpointsList)
@@ -887,7 +924,7 @@ func DeepCopy_api_EndpointsList(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Items, &out.Items
 			*out = make([]Endpoints, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Endpoints(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiEndpoints(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -896,7 +933,8 @@ func DeepCopy_api_EndpointsList(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_EnvFromSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEnvFromSource ...
+func DeepCopyapiEnvFromSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EnvFromSource)
 		out := out.(*EnvFromSource)
@@ -904,14 +942,14 @@ func DeepCopy_api_EnvFromSource(in interface{}, out interface{}, c *conversion.C
 		if in.ConfigMapRef != nil {
 			in, out := &in.ConfigMapRef, &out.ConfigMapRef
 			*out = new(ConfigMapEnvSource)
-			if err := DeepCopy_api_ConfigMapEnvSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiConfigMapEnvSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.SecretRef != nil {
 			in, out := &in.SecretRef, &out.SecretRef
 			*out = new(SecretEnvSource)
-			if err := DeepCopy_api_SecretEnvSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiSecretEnvSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -919,7 +957,8 @@ func DeepCopy_api_EnvFromSource(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_EnvVar(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEnvVar ...
+func DeepCopyapiEnvVar(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EnvVar)
 		out := out.(*EnvVar)
@@ -927,7 +966,7 @@ func DeepCopy_api_EnvVar(in interface{}, out interface{}, c *conversion.Cloner) 
 		if in.ValueFrom != nil {
 			in, out := &in.ValueFrom, &out.ValueFrom
 			*out = new(EnvVarSource)
-			if err := DeepCopy_api_EnvVarSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiEnvVarSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -935,7 +974,8 @@ func DeepCopy_api_EnvVar(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_api_EnvVarSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEnvVarSource ...
+func DeepCopyapiEnvVarSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EnvVarSource)
 		out := out.(*EnvVarSource)
@@ -948,21 +988,21 @@ func DeepCopy_api_EnvVarSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.ResourceFieldRef != nil {
 			in, out := &in.ResourceFieldRef, &out.ResourceFieldRef
 			*out = new(ResourceFieldSelector)
-			if err := DeepCopy_api_ResourceFieldSelector(*in, *out, c); err != nil {
+			if err := DeepCopyapiResourceFieldSelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.ConfigMapKeyRef != nil {
 			in, out := &in.ConfigMapKeyRef, &out.ConfigMapKeyRef
 			*out = new(ConfigMapKeySelector)
-			if err := DeepCopy_api_ConfigMapKeySelector(*in, *out, c); err != nil {
+			if err := DeepCopyapiConfigMapKeySelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.SecretKeyRef != nil {
 			in, out := &in.SecretKeyRef, &out.SecretKeyRef
 			*out = new(SecretKeySelector)
-			if err := DeepCopy_api_SecretKeySelector(*in, *out, c); err != nil {
+			if err := DeepCopyapiSecretKeySelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -970,15 +1010,16 @@ func DeepCopy_api_EnvVarSource(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_api_Event(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEvent ...
+func DeepCopyapiEvent(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Event)
 		out := out.(*Event)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		out.FirstTimestamp = in.FirstTimestamp.DeepCopy()
 		out.LastTimestamp = in.LastTimestamp.DeepCopy()
@@ -986,7 +1027,8 @@ func DeepCopy_api_Event(in interface{}, out interface{}, c *conversion.Cloner) e
 	}
 }
 
-func DeepCopy_api_EventList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEventList ...
+func DeepCopyapiEventList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EventList)
 		out := out.(*EventList)
@@ -995,7 +1037,7 @@ func DeepCopy_api_EventList(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.Items, &out.Items
 			*out = make([]Event, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Event(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiEvent(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1004,7 +1046,8 @@ func DeepCopy_api_EventList(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_api_EventSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiEventSource ...
+func DeepCopyapiEventSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*EventSource)
 		out := out.(*EventSource)
@@ -1013,7 +1056,8 @@ func DeepCopy_api_EventSource(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_api_ExecAction(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiExecAction ...
+func DeepCopyapiExecAction(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ExecAction)
 		out := out.(*ExecAction)
@@ -1027,7 +1071,8 @@ func DeepCopy_api_ExecAction(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_api_FCVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiFCVolumeSource ...
+func DeepCopyapiFCVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FCVolumeSource)
 		out := out.(*FCVolumeSource)
@@ -1046,7 +1091,8 @@ func DeepCopy_api_FCVolumeSource(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_FlexVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiFlexVolumeSource ...
+func DeepCopyapiFlexVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FlexVolumeSource)
 		out := out.(*FlexVolumeSource)
@@ -1067,7 +1113,8 @@ func DeepCopy_api_FlexVolumeSource(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_api_FlockerVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiFlockerVolumeSource ...
+func DeepCopyapiFlockerVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FlockerVolumeSource)
 		out := out.(*FlockerVolumeSource)
@@ -1076,7 +1123,8 @@ func DeepCopy_api_FlockerVolumeSource(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_GCEPersistentDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiGCEPersistentDiskVolumeSource ...
+func DeepCopyapiGCEPersistentDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GCEPersistentDiskVolumeSource)
 		out := out.(*GCEPersistentDiskVolumeSource)
@@ -1085,7 +1133,8 @@ func DeepCopy_api_GCEPersistentDiskVolumeSource(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_api_GitRepoVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiGitRepoVolumeSource ...
+func DeepCopyapiGitRepoVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GitRepoVolumeSource)
 		out := out.(*GitRepoVolumeSource)
@@ -1094,7 +1143,8 @@ func DeepCopy_api_GitRepoVolumeSource(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_GlusterfsVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiGlusterfsVolumeSource ...
+func DeepCopyapiGlusterfsVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GlusterfsVolumeSource)
 		out := out.(*GlusterfsVolumeSource)
@@ -1103,7 +1153,8 @@ func DeepCopy_api_GlusterfsVolumeSource(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_HTTPGetAction(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiHTTPGetAction ...
+func DeepCopyapiHTTPGetAction(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HTTPGetAction)
 		out := out.(*HTTPGetAction)
@@ -1117,7 +1168,8 @@ func DeepCopy_api_HTTPGetAction(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_HTTPHeader(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiHTTPHeader ...
+func DeepCopyapiHTTPHeader(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HTTPHeader)
 		out := out.(*HTTPHeader)
@@ -1126,7 +1178,8 @@ func DeepCopy_api_HTTPHeader(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_api_Handler(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiHandler ...
+func DeepCopyapiHandler(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Handler)
 		out := out.(*Handler)
@@ -1134,14 +1187,14 @@ func DeepCopy_api_Handler(in interface{}, out interface{}, c *conversion.Cloner)
 		if in.Exec != nil {
 			in, out := &in.Exec, &out.Exec
 			*out = new(ExecAction)
-			if err := DeepCopy_api_ExecAction(*in, *out, c); err != nil {
+			if err := DeepCopyapiExecAction(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.HTTPGet != nil {
 			in, out := &in.HTTPGet, &out.HTTPGet
 			*out = new(HTTPGetAction)
-			if err := DeepCopy_api_HTTPGetAction(*in, *out, c); err != nil {
+			if err := DeepCopyapiHTTPGetAction(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1154,7 +1207,8 @@ func DeepCopy_api_Handler(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_api_HostPathVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiHostPathVolumeSource ...
+func DeepCopyapiHostPathVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HostPathVolumeSource)
 		out := out.(*HostPathVolumeSource)
@@ -1163,7 +1217,8 @@ func DeepCopy_api_HostPathVolumeSource(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_api_ISCSIVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiISCSIVolumeSource ...
+func DeepCopyapiISCSIVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ISCSIVolumeSource)
 		out := out.(*ISCSIVolumeSource)
@@ -1172,7 +1227,8 @@ func DeepCopy_api_ISCSIVolumeSource(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_api_KeyToPath(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiKeyToPath ...
+func DeepCopyapiKeyToPath(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KeyToPath)
 		out := out.(*KeyToPath)
@@ -1186,7 +1242,8 @@ func DeepCopy_api_KeyToPath(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_api_Lifecycle(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiLifecycle ...
+func DeepCopyapiLifecycle(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Lifecycle)
 		out := out.(*Lifecycle)
@@ -1194,14 +1251,14 @@ func DeepCopy_api_Lifecycle(in interface{}, out interface{}, c *conversion.Clone
 		if in.PostStart != nil {
 			in, out := &in.PostStart, &out.PostStart
 			*out = new(Handler)
-			if err := DeepCopy_api_Handler(*in, *out, c); err != nil {
+			if err := DeepCopyapiHandler(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.PreStop != nil {
 			in, out := &in.PreStop, &out.PreStop
 			*out = new(Handler)
-			if err := DeepCopy_api_Handler(*in, *out, c); err != nil {
+			if err := DeepCopyapiHandler(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1209,24 +1266,26 @@ func DeepCopy_api_Lifecycle(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_api_LimitRange(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiLimitRange ...
+func DeepCopyapiLimitRange(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LimitRange)
 		out := out.(*LimitRange)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_api_LimitRangeSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyapiLimitRangeSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_LimitRangeItem(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiLimitRangeItem ...
+func DeepCopyapiLimitRangeItem(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LimitRangeItem)
 		out := out.(*LimitRangeItem)
@@ -1270,7 +1329,8 @@ func DeepCopy_api_LimitRangeItem(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_LimitRangeList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiLimitRangeList ...
+func DeepCopyapiLimitRangeList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LimitRangeList)
 		out := out.(*LimitRangeList)
@@ -1279,7 +1339,7 @@ func DeepCopy_api_LimitRangeList(in interface{}, out interface{}, c *conversion.
 			in, out := &in.Items, &out.Items
 			*out = make([]LimitRange, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_LimitRange(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiLimitRange(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1288,7 +1348,8 @@ func DeepCopy_api_LimitRangeList(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_LimitRangeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiLimitRangeSpec ...
+func DeepCopyapiLimitRangeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LimitRangeSpec)
 		out := out.(*LimitRangeSpec)
@@ -1297,7 +1358,7 @@ func DeepCopy_api_LimitRangeSpec(in interface{}, out interface{}, c *conversion.
 			in, out := &in.Limits, &out.Limits
 			*out = make([]LimitRangeItem, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_LimitRangeItem(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiLimitRangeItem(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1306,7 +1367,8 @@ func DeepCopy_api_LimitRangeSpec(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_List(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiList ...
+func DeepCopyapiList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*List)
 		out := out.(*List)
@@ -1315,10 +1377,10 @@ func DeepCopy_api_List(in interface{}, out interface{}, c *conversion.Cloner) er
 			in, out := &in.Items, &out.Items
 			*out = make([]runtime.Object, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*runtime.Object)
+				} else {
+					return err
 				}
 			}
 		}
@@ -1326,25 +1388,26 @@ func DeepCopy_api_List(in interface{}, out interface{}, c *conversion.Cloner) er
 	}
 }
 
-func DeepCopy_api_ListOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiListOptions ...
+func DeepCopyapiListOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ListOptions)
 		out := out.(*ListOptions)
 		*out = *in
 		// in.LabelSelector is kind 'Interface'
 		if in.LabelSelector != nil {
-			if newVal, err := c.DeepCopy(&in.LabelSelector); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(&in.LabelSelector); err == nil {
 				out.LabelSelector = *newVal.(*labels.Selector)
+			} else {
+				return err
 			}
 		}
 		// in.FieldSelector is kind 'Interface'
 		if in.FieldSelector != nil {
-			if newVal, err := c.DeepCopy(&in.FieldSelector); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(&in.FieldSelector); err == nil {
 				out.FieldSelector = *newVal.(*fields.Selector)
+			} else {
+				return err
 			}
 		}
 		if in.TimeoutSeconds != nil {
@@ -1356,7 +1419,8 @@ func DeepCopy_api_ListOptions(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_api_LoadBalancerIngress(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiLoadBalancerIngress ...
+func DeepCopyapiLoadBalancerIngress(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LoadBalancerIngress)
 		out := out.(*LoadBalancerIngress)
@@ -1365,7 +1429,8 @@ func DeepCopy_api_LoadBalancerIngress(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_LoadBalancerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiLoadBalancerStatus ...
+func DeepCopyapiLoadBalancerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LoadBalancerStatus)
 		out := out.(*LoadBalancerStatus)
@@ -1379,7 +1444,8 @@ func DeepCopy_api_LoadBalancerStatus(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_api_LocalObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiLocalObjectReference ...
+func DeepCopyapiLocalObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LocalObjectReference)
 		out := out.(*LocalObjectReference)
@@ -1388,7 +1454,8 @@ func DeepCopy_api_LocalObjectReference(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_api_NFSVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNFSVolumeSource ...
+func DeepCopyapiNFSVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NFSVolumeSource)
 		out := out.(*NFSVolumeSource)
@@ -1397,24 +1464,26 @@ func DeepCopy_api_NFSVolumeSource(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_Namespace(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNamespace ...
+func DeepCopyapiNamespace(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Namespace)
 		out := out.(*Namespace)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_api_NamespaceSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyapiNamespaceSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_NamespaceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNamespaceList ...
+func DeepCopyapiNamespaceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NamespaceList)
 		out := out.(*NamespaceList)
@@ -1423,7 +1492,7 @@ func DeepCopy_api_NamespaceList(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Items, &out.Items
 			*out = make([]Namespace, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Namespace(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiNamespace(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1432,7 +1501,8 @@ func DeepCopy_api_NamespaceList(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_NamespaceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNamespaceSpec ...
+func DeepCopyapiNamespaceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NamespaceSpec)
 		out := out.(*NamespaceSpec)
@@ -1446,7 +1516,8 @@ func DeepCopy_api_NamespaceSpec(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_NamespaceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNamespaceStatus ...
+func DeepCopyapiNamespaceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NamespaceStatus)
 		out := out.(*NamespaceStatus)
@@ -1455,24 +1526,26 @@ func DeepCopy_api_NamespaceStatus(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_Node(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNode ...
+func DeepCopyapiNode(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Node)
 		out := out.(*Node)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_api_NodeStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyapiNodeStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_NodeAddress(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeAddress ...
+func DeepCopyapiNodeAddress(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeAddress)
 		out := out.(*NodeAddress)
@@ -1481,7 +1554,8 @@ func DeepCopy_api_NodeAddress(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_api_NodeAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeAffinity ...
+func DeepCopyapiNodeAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeAffinity)
 		out := out.(*NodeAffinity)
@@ -1489,7 +1563,7 @@ func DeepCopy_api_NodeAffinity(in interface{}, out interface{}, c *conversion.Cl
 		if in.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 			in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
 			*out = new(NodeSelector)
-			if err := DeepCopy_api_NodeSelector(*in, *out, c); err != nil {
+			if err := DeepCopyapiNodeSelector(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1497,7 +1571,7 @@ func DeepCopy_api_NodeAffinity(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
 			*out = make([]PreferredSchedulingTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_PreferredSchedulingTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPreferredSchedulingTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1506,7 +1580,8 @@ func DeepCopy_api_NodeAffinity(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_api_NodeCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeCondition ...
+func DeepCopyapiNodeCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeCondition)
 		out := out.(*NodeCondition)
@@ -1517,7 +1592,8 @@ func DeepCopy_api_NodeCondition(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_NodeDaemonEndpoints(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeDaemonEndpoints ...
+func DeepCopyapiNodeDaemonEndpoints(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeDaemonEndpoints)
 		out := out.(*NodeDaemonEndpoints)
@@ -1526,7 +1602,8 @@ func DeepCopy_api_NodeDaemonEndpoints(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_NodeList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeList ...
+func DeepCopyapiNodeList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeList)
 		out := out.(*NodeList)
@@ -1535,7 +1612,7 @@ func DeepCopy_api_NodeList(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.Items, &out.Items
 			*out = make([]Node, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Node(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiNode(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1544,7 +1621,8 @@ func DeepCopy_api_NodeList(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_api_NodeProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeProxyOptions ...
+func DeepCopyapiNodeProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeProxyOptions)
 		out := out.(*NodeProxyOptions)
@@ -1553,7 +1631,8 @@ func DeepCopy_api_NodeProxyOptions(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_api_NodeResources(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeResources ...
+func DeepCopyapiNodeResources(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeResources)
 		out := out.(*NodeResources)
@@ -1569,7 +1648,8 @@ func DeepCopy_api_NodeResources(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_NodeSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeSelector ...
+func DeepCopyapiNodeSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSelector)
 		out := out.(*NodeSelector)
@@ -1578,7 +1658,7 @@ func DeepCopy_api_NodeSelector(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.NodeSelectorTerms, &out.NodeSelectorTerms
 			*out = make([]NodeSelectorTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_NodeSelectorTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiNodeSelectorTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1587,7 +1667,8 @@ func DeepCopy_api_NodeSelector(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_api_NodeSelectorRequirement(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeSelectorRequirement ...
+func DeepCopyapiNodeSelectorRequirement(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSelectorRequirement)
 		out := out.(*NodeSelectorRequirement)
@@ -1601,7 +1682,8 @@ func DeepCopy_api_NodeSelectorRequirement(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_api_NodeSelectorTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeSelectorTerm ...
+func DeepCopyapiNodeSelectorTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSelectorTerm)
 		out := out.(*NodeSelectorTerm)
@@ -1610,7 +1692,7 @@ func DeepCopy_api_NodeSelectorTerm(in interface{}, out interface{}, c *conversio
 			in, out := &in.MatchExpressions, &out.MatchExpressions
 			*out = make([]NodeSelectorRequirement, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_NodeSelectorRequirement(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiNodeSelectorRequirement(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1619,7 +1701,8 @@ func DeepCopy_api_NodeSelectorTerm(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_api_NodeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeSpec ...
+func DeepCopyapiNodeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSpec)
 		out := out.(*NodeSpec)
@@ -1628,7 +1711,8 @@ func DeepCopy_api_NodeSpec(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_api_NodeStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeStatus ...
+func DeepCopyapiNodeStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeStatus)
 		out := out.(*NodeStatus)
@@ -1651,7 +1735,7 @@ func DeepCopy_api_NodeStatus(in interface{}, out interface{}, c *conversion.Clon
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]NodeCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_NodeCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiNodeCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1665,7 +1749,7 @@ func DeepCopy_api_NodeStatus(in interface{}, out interface{}, c *conversion.Clon
 			in, out := &in.Images, &out.Images
 			*out = make([]ContainerImage, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ContainerImage(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiContainerImage(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1684,7 +1768,8 @@ func DeepCopy_api_NodeStatus(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_api_NodeSystemInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiNodeSystemInfo ...
+func DeepCopyapiNodeSystemInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NodeSystemInfo)
 		out := out.(*NodeSystemInfo)
@@ -1693,7 +1778,8 @@ func DeepCopy_api_NodeSystemInfo(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_ObjectFieldSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiObjectFieldSelector ...
+func DeepCopyapiObjectFieldSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ObjectFieldSelector)
 		out := out.(*ObjectFieldSelector)
@@ -1702,7 +1788,8 @@ func DeepCopy_api_ObjectFieldSelector(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_ObjectMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiObjectMeta ...
+func DeepCopyapiObjectMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ObjectMeta)
 		out := out.(*ObjectMeta)
@@ -1736,10 +1823,10 @@ func DeepCopy_api_ObjectMeta(in interface{}, out interface{}, c *conversion.Clon
 			in, out := &in.OwnerReferences, &out.OwnerReferences
 			*out = make([]v1.OwnerReference, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*v1.OwnerReference)
+				} else {
+					return err
 				}
 			}
 		}
@@ -1752,7 +1839,8 @@ func DeepCopy_api_ObjectMeta(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_api_ObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiObjectReference ...
+func DeepCopyapiObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ObjectReference)
 		out := out.(*ObjectReference)
@@ -1761,44 +1849,47 @@ func DeepCopy_api_ObjectReference(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_PersistentVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolume ...
+func DeepCopyapiPersistentVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolume)
 		out := out.(*PersistentVolume)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_api_PersistentVolumeSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyapiPersistentVolumeSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_PersistentVolumeClaim(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeClaim ...
+func DeepCopyapiPersistentVolumeClaim(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaim)
 		out := out.(*PersistentVolumeClaim)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_api_PersistentVolumeClaimSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_api_PersistentVolumeClaimStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyapiPersistentVolumeClaimSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyapiPersistentVolumeClaimStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_PersistentVolumeClaimList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeClaimList ...
+func DeepCopyapiPersistentVolumeClaimList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaimList)
 		out := out.(*PersistentVolumeClaimList)
@@ -1807,7 +1898,7 @@ func DeepCopy_api_PersistentVolumeClaimList(in interface{}, out interface{}, c *
 			in, out := &in.Items, &out.Items
 			*out = make([]PersistentVolumeClaim, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_PersistentVolumeClaim(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPersistentVolumeClaim(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1816,7 +1907,8 @@ func DeepCopy_api_PersistentVolumeClaimList(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_api_PersistentVolumeClaimSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeClaimSpec ...
+func DeepCopyapiPersistentVolumeClaimSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaimSpec)
 		out := out.(*PersistentVolumeClaimSpec)
@@ -1828,20 +1920,21 @@ func DeepCopy_api_PersistentVolumeClaimSpec(in interface{}, out interface{}, c *
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := DeepCopy_api_ResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
+		if err := DeepCopyapiResourceRequirements(&in.Resources, &out.Resources, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_PersistentVolumeClaimStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeClaimStatus ...
+func DeepCopyapiPersistentVolumeClaimStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaimStatus)
 		out := out.(*PersistentVolumeClaimStatus)
@@ -1862,7 +1955,8 @@ func DeepCopy_api_PersistentVolumeClaimStatus(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_api_PersistentVolumeClaimVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeClaimVolumeSource ...
+func DeepCopyapiPersistentVolumeClaimVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeClaimVolumeSource)
 		out := out.(*PersistentVolumeClaimVolumeSource)
@@ -1871,7 +1965,8 @@ func DeepCopy_api_PersistentVolumeClaimVolumeSource(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_api_PersistentVolumeList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeList ...
+func DeepCopyapiPersistentVolumeList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeList)
 		out := out.(*PersistentVolumeList)
@@ -1880,7 +1975,7 @@ func DeepCopy_api_PersistentVolumeList(in interface{}, out interface{}, c *conve
 			in, out := &in.Items, &out.Items
 			*out = make([]PersistentVolume, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_PersistentVolume(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPersistentVolume(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1889,7 +1984,8 @@ func DeepCopy_api_PersistentVolumeList(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_api_PersistentVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeSource ...
+func DeepCopyapiPersistentVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeSource)
 		out := out.(*PersistentVolumeSource)
@@ -1922,7 +2018,7 @@ func DeepCopy_api_PersistentVolumeSource(in interface{}, out interface{}, c *con
 		if in.RBD != nil {
 			in, out := &in.RBD, &out.RBD
 			*out = new(RBDVolumeSource)
-			if err := DeepCopy_api_RBDVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiRBDVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1939,7 +2035,7 @@ func DeepCopy_api_PersistentVolumeSource(in interface{}, out interface{}, c *con
 		if in.FlexVolume != nil {
 			in, out := &in.FlexVolume, &out.FlexVolume
 			*out = new(FlexVolumeSource)
-			if err := DeepCopy_api_FlexVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiFlexVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1951,14 +2047,14 @@ func DeepCopy_api_PersistentVolumeSource(in interface{}, out interface{}, c *con
 		if in.CephFS != nil {
 			in, out := &in.CephFS, &out.CephFS
 			*out = new(CephFSVolumeSource)
-			if err := DeepCopy_api_CephFSVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiCephFSVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.FC != nil {
 			in, out := &in.FC, &out.FC
 			*out = new(FCVolumeSource)
-			if err := DeepCopy_api_FCVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiFCVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1980,7 +2076,7 @@ func DeepCopy_api_PersistentVolumeSource(in interface{}, out interface{}, c *con
 		if in.AzureDisk != nil {
 			in, out := &in.AzureDisk, &out.AzureDisk
 			*out = new(AzureDiskVolumeSource)
-			if err := DeepCopy_api_AzureDiskVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiAzureDiskVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -1993,7 +2089,8 @@ func DeepCopy_api_PersistentVolumeSource(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_api_PersistentVolumeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeSpec ...
+func DeepCopyapiPersistentVolumeSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeSpec)
 		out := out.(*PersistentVolumeSpec)
@@ -2005,7 +2102,7 @@ func DeepCopy_api_PersistentVolumeSpec(in interface{}, out interface{}, c *conve
 				(*out)[key] = val.DeepCopy()
 			}
 		}
-		if err := DeepCopy_api_PersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, c); err != nil {
+		if err := DeepCopyapiPersistentVolumeSource(&in.PersistentVolumeSource, &out.PersistentVolumeSource, c); err != nil {
 			return err
 		}
 		if in.AccessModes != nil {
@@ -2022,7 +2119,8 @@ func DeepCopy_api_PersistentVolumeSpec(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_api_PersistentVolumeStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPersistentVolumeStatus ...
+func DeepCopyapiPersistentVolumeStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeStatus)
 		out := out.(*PersistentVolumeStatus)
@@ -2031,7 +2129,8 @@ func DeepCopy_api_PersistentVolumeStatus(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_api_PhotonPersistentDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPhotonPersistentDiskVolumeSource ...
+func DeepCopyapiPhotonPersistentDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PhotonPersistentDiskVolumeSource)
 		out := out.(*PhotonPersistentDiskVolumeSource)
@@ -2040,27 +2139,29 @@ func DeepCopy_api_PhotonPersistentDiskVolumeSource(in interface{}, out interface
 	}
 }
 
-func DeepCopy_api_Pod(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPod ...
+func DeepCopyapiPod(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Pod)
 		out := out.(*Pod)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_api_PodSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_api_PodStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyapiPodSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyapiPodStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_PodAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodAffinity ...
+func DeepCopyapiPodAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodAffinity)
 		out := out.(*PodAffinity)
@@ -2069,7 +2170,7 @@ func DeepCopy_api_PodAffinity(in interface{}, out interface{}, c *conversion.Clo
 			in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
 			*out = make([]PodAffinityTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_PodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2078,7 +2179,7 @@ func DeepCopy_api_PodAffinity(in interface{}, out interface{}, c *conversion.Clo
 			in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
 			*out = make([]WeightedPodAffinityTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_WeightedPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiWeightedPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2087,17 +2188,18 @@ func DeepCopy_api_PodAffinity(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_api_PodAffinityTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodAffinityTerm ...
+func DeepCopyapiPodAffinityTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodAffinityTerm)
 		out := out.(*PodAffinityTerm)
 		*out = *in
 		if in.LabelSelector != nil {
 			in, out := &in.LabelSelector, &out.LabelSelector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		if in.Namespaces != nil {
@@ -2109,7 +2211,8 @@ func DeepCopy_api_PodAffinityTerm(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_PodAntiAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodAntiAffinity ...
+func DeepCopyapiPodAntiAffinity(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodAntiAffinity)
 		out := out.(*PodAntiAffinity)
@@ -2118,7 +2221,7 @@ func DeepCopy_api_PodAntiAffinity(in interface{}, out interface{}, c *conversion
 			in, out := &in.RequiredDuringSchedulingIgnoredDuringExecution, &out.RequiredDuringSchedulingIgnoredDuringExecution
 			*out = make([]PodAffinityTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_PodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2127,7 +2230,7 @@ func DeepCopy_api_PodAntiAffinity(in interface{}, out interface{}, c *conversion
 			in, out := &in.PreferredDuringSchedulingIgnoredDuringExecution, &out.PreferredDuringSchedulingIgnoredDuringExecution
 			*out = make([]WeightedPodAffinityTerm, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_WeightedPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiWeightedPodAffinityTerm(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2136,7 +2239,8 @@ func DeepCopy_api_PodAntiAffinity(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_PodAttachOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodAttachOptions ...
+func DeepCopyapiPodAttachOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodAttachOptions)
 		out := out.(*PodAttachOptions)
@@ -2145,7 +2249,8 @@ func DeepCopy_api_PodAttachOptions(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_api_PodCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodCondition ...
+func DeepCopyapiPodCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodCondition)
 		out := out.(*PodCondition)
@@ -2156,7 +2261,8 @@ func DeepCopy_api_PodCondition(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_api_PodExecOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodExecOptions ...
+func DeepCopyapiPodExecOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodExecOptions)
 		out := out.(*PodExecOptions)
@@ -2170,7 +2276,8 @@ func DeepCopy_api_PodExecOptions(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_PodList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodList ...
+func DeepCopyapiPodList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodList)
 		out := out.(*PodList)
@@ -2179,7 +2286,7 @@ func DeepCopy_api_PodList(in interface{}, out interface{}, c *conversion.Cloner)
 			in, out := &in.Items, &out.Items
 			*out = make([]Pod, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Pod(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPod(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2188,7 +2295,8 @@ func DeepCopy_api_PodList(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_api_PodLogOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodLogOptions ...
+func DeepCopyapiPodLogOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodLogOptions)
 		out := out.(*PodLogOptions)
@@ -2217,7 +2325,8 @@ func DeepCopy_api_PodLogOptions(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_PodPortForwardOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodPortForwardOptions ...
+func DeepCopyapiPodPortForwardOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodPortForwardOptions)
 		out := out.(*PodPortForwardOptions)
@@ -2231,7 +2340,8 @@ func DeepCopy_api_PodPortForwardOptions(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_PodProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodProxyOptions ...
+func DeepCopyapiPodProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodProxyOptions)
 		out := out.(*PodProxyOptions)
@@ -2240,7 +2350,8 @@ func DeepCopy_api_PodProxyOptions(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_PodSecurityContext(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodSecurityContext ...
+func DeepCopyapiPodSecurityContext(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSecurityContext)
 		out := out.(*PodSecurityContext)
@@ -2274,24 +2385,26 @@ func DeepCopy_api_PodSecurityContext(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_api_PodSignature(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodSignature ...
+func DeepCopyapiPodSignature(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSignature)
 		out := out.(*PodSignature)
 		*out = *in
 		if in.PodController != nil {
 			in, out := &in.PodController, &out.PodController
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.OwnerReference)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodSpec ...
+func DeepCopyapiPodSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSpec)
 		out := out.(*PodSpec)
@@ -2300,7 +2413,7 @@ func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner)
 			in, out := &in.Volumes, &out.Volumes
 			*out = make([]Volume, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Volume(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiVolume(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2309,7 +2422,7 @@ func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner)
 			in, out := &in.InitContainers, &out.InitContainers
 			*out = make([]Container, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Container(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiContainer(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2318,7 +2431,7 @@ func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner)
 			in, out := &in.Containers, &out.Containers
 			*out = make([]Container, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Container(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiContainer(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2343,7 +2456,7 @@ func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner)
 		if in.SecurityContext != nil {
 			in, out := &in.SecurityContext, &out.SecurityContext
 			*out = new(PodSecurityContext)
-			if err := DeepCopy_api_PodSecurityContext(*in, *out, c); err != nil {
+			if err := DeepCopyapiPodSecurityContext(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -2355,7 +2468,7 @@ func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner)
 		if in.Affinity != nil {
 			in, out := &in.Affinity, &out.Affinity
 			*out = new(Affinity)
-			if err := DeepCopy_api_Affinity(*in, *out, c); err != nil {
+			if err := DeepCopyapiAffinity(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -2363,7 +2476,8 @@ func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_api_PodStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodStatus ...
+func DeepCopyapiPodStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodStatus)
 		out := out.(*PodStatus)
@@ -2372,7 +2486,7 @@ func DeepCopy_api_PodStatus(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]PodCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_PodCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPodCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2386,7 +2500,7 @@ func DeepCopy_api_PodStatus(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.InitContainerStatuses, &out.InitContainerStatuses
 			*out = make([]ContainerStatus, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ContainerStatus(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiContainerStatus(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2395,7 +2509,7 @@ func DeepCopy_api_PodStatus(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.ContainerStatuses, &out.ContainerStatuses
 			*out = make([]ContainerStatus, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ContainerStatus(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiContainerStatus(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2404,41 +2518,44 @@ func DeepCopy_api_PodStatus(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_api_PodStatusResult(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodStatusResult ...
+func DeepCopyapiPodStatusResult(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodStatusResult)
 		out := out.(*PodStatusResult)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_api_PodStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyapiPodStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_PodTemplate(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodTemplate ...
+func DeepCopyapiPodTemplate(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodTemplate)
 		out := out.(*PodTemplate)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_api_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := DeepCopyapiPodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_PodTemplateList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodTemplateList ...
+func DeepCopyapiPodTemplateList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodTemplateList)
 		out := out.(*PodTemplateList)
@@ -2447,7 +2564,7 @@ func DeepCopy_api_PodTemplateList(in interface{}, out interface{}, c *conversion
 			in, out := &in.Items, &out.Items
 			*out = make([]PodTemplate, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_PodTemplate(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiPodTemplate(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2456,24 +2573,26 @@ func DeepCopy_api_PodTemplateList(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_PodTemplateSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPodTemplateSpec ...
+func DeepCopyapiPodTemplateSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodTemplateSpec)
 		out := out.(*PodTemplateSpec)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_api_PodSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyapiPodSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_Preconditions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPreconditions ...
+func DeepCopyapiPreconditions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Preconditions)
 		out := out.(*Preconditions)
@@ -2487,12 +2606,13 @@ func DeepCopy_api_Preconditions(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_api_PreferAvoidPodsEntry(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPreferAvoidPodsEntry ...
+func DeepCopyapiPreferAvoidPodsEntry(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PreferAvoidPodsEntry)
 		out := out.(*PreferAvoidPodsEntry)
 		*out = *in
-		if err := DeepCopy_api_PodSignature(&in.PodSignature, &out.PodSignature, c); err != nil {
+		if err := DeepCopyapiPodSignature(&in.PodSignature, &out.PodSignature, c); err != nil {
 			return err
 		}
 		out.EvictionTime = in.EvictionTime.DeepCopy()
@@ -2500,31 +2620,34 @@ func DeepCopy_api_PreferAvoidPodsEntry(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_api_PreferredSchedulingTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiPreferredSchedulingTerm ...
+func DeepCopyapiPreferredSchedulingTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PreferredSchedulingTerm)
 		out := out.(*PreferredSchedulingTerm)
 		*out = *in
-		if err := DeepCopy_api_NodeSelectorTerm(&in.Preference, &out.Preference, c); err != nil {
+		if err := DeepCopyapiNodeSelectorTerm(&in.Preference, &out.Preference, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_Probe(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiProbe ...
+func DeepCopyapiProbe(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Probe)
 		out := out.(*Probe)
 		*out = *in
-		if err := DeepCopy_api_Handler(&in.Handler, &out.Handler, c); err != nil {
+		if err := DeepCopyapiHandler(&in.Handler, &out.Handler, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_QuobyteVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiQuobyteVolumeSource ...
+func DeepCopyapiQuobyteVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*QuobyteVolumeSource)
 		out := out.(*QuobyteVolumeSource)
@@ -2533,7 +2656,8 @@ func DeepCopy_api_QuobyteVolumeSource(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_RBDVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiRBDVolumeSource ...
+func DeepCopyapiRBDVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RBDVolumeSource)
 		out := out.(*RBDVolumeSource)
@@ -2552,15 +2676,16 @@ func DeepCopy_api_RBDVolumeSource(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_RangeAllocation(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiRangeAllocation ...
+func DeepCopyapiRangeAllocation(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RangeAllocation)
 		out := out.(*RangeAllocation)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
@@ -2571,27 +2696,29 @@ func DeepCopy_api_RangeAllocation(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_ReplicationController(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiReplicationController ...
+func DeepCopyapiReplicationController(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationController)
 		out := out.(*ReplicationController)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_api_ReplicationControllerSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_api_ReplicationControllerStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyapiReplicationControllerSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyapiReplicationControllerStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_ReplicationControllerCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiReplicationControllerCondition ...
+func DeepCopyapiReplicationControllerCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerCondition)
 		out := out.(*ReplicationControllerCondition)
@@ -2601,7 +2728,8 @@ func DeepCopy_api_ReplicationControllerCondition(in interface{}, out interface{}
 	}
 }
 
-func DeepCopy_api_ReplicationControllerList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiReplicationControllerList ...
+func DeepCopyapiReplicationControllerList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerList)
 		out := out.(*ReplicationControllerList)
@@ -2610,7 +2738,7 @@ func DeepCopy_api_ReplicationControllerList(in interface{}, out interface{}, c *
 			in, out := &in.Items, &out.Items
 			*out = make([]ReplicationController, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ReplicationController(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiReplicationController(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2619,7 +2747,8 @@ func DeepCopy_api_ReplicationControllerList(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_api_ReplicationControllerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiReplicationControllerSpec ...
+func DeepCopyapiReplicationControllerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerSpec)
 		out := out.(*ReplicationControllerSpec)
@@ -2634,7 +2763,7 @@ func DeepCopy_api_ReplicationControllerSpec(in interface{}, out interface{}, c *
 		if in.Template != nil {
 			in, out := &in.Template, &out.Template
 			*out = new(PodTemplateSpec)
-			if err := DeepCopy_api_PodTemplateSpec(*in, *out, c); err != nil {
+			if err := DeepCopyapiPodTemplateSpec(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -2642,7 +2771,8 @@ func DeepCopy_api_ReplicationControllerSpec(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_api_ReplicationControllerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiReplicationControllerStatus ...
+func DeepCopyapiReplicationControllerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerStatus)
 		out := out.(*ReplicationControllerStatus)
@@ -2651,7 +2781,7 @@ func DeepCopy_api_ReplicationControllerStatus(in interface{}, out interface{}, c
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]ReplicationControllerCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ReplicationControllerCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiReplicationControllerCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2660,7 +2790,8 @@ func DeepCopy_api_ReplicationControllerStatus(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_api_ResourceFieldSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiResourceFieldSelector ...
+func DeepCopyapiResourceFieldSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceFieldSelector)
 		out := out.(*ResourceFieldSelector)
@@ -2670,27 +2801,29 @@ func DeepCopy_api_ResourceFieldSelector(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_api_ResourceQuota(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiResourceQuota ...
+func DeepCopyapiResourceQuota(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceQuota)
 		out := out.(*ResourceQuota)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_api_ResourceQuotaSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_api_ResourceQuotaStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyapiResourceQuotaSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyapiResourceQuotaStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_ResourceQuotaList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiResourceQuotaList ...
+func DeepCopyapiResourceQuotaList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceQuotaList)
 		out := out.(*ResourceQuotaList)
@@ -2699,7 +2832,7 @@ func DeepCopy_api_ResourceQuotaList(in interface{}, out interface{}, c *conversi
 			in, out := &in.Items, &out.Items
 			*out = make([]ResourceQuota, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ResourceQuota(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiResourceQuota(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2708,7 +2841,8 @@ func DeepCopy_api_ResourceQuotaList(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_api_ResourceQuotaSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiResourceQuotaSpec ...
+func DeepCopyapiResourceQuotaSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceQuotaSpec)
 		out := out.(*ResourceQuotaSpec)
@@ -2729,7 +2863,8 @@ func DeepCopy_api_ResourceQuotaSpec(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_api_ResourceQuotaStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiResourceQuotaStatus ...
+func DeepCopyapiResourceQuotaStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceQuotaStatus)
 		out := out.(*ResourceQuotaStatus)
@@ -2752,7 +2887,8 @@ func DeepCopy_api_ResourceQuotaStatus(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_ResourceRequirements(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiResourceRequirements ...
+func DeepCopyapiResourceRequirements(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceRequirements)
 		out := out.(*ResourceRequirements)
@@ -2775,7 +2911,8 @@ func DeepCopy_api_ResourceRequirements(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_api_SELinuxOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSELinuxOptions ...
+func DeepCopyapiSELinuxOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SELinuxOptions)
 		out := out.(*SELinuxOptions)
@@ -2784,24 +2921,25 @@ func DeepCopy_api_SELinuxOptions(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_Secret(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSecret ...
+func DeepCopyapiSecret(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Secret)
 		out := out.(*Secret)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
 			*out = make(map[string][]byte)
 			for key, val := range *in {
-				if newVal, err := c.DeepCopy(&val); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&val); err == nil {
 					(*out)[key] = *newVal.(*[]byte)
+				} else {
+					return err
 				}
 			}
 		}
@@ -2809,7 +2947,8 @@ func DeepCopy_api_Secret(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_api_SecretEnvSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSecretEnvSource ...
+func DeepCopyapiSecretEnvSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecretEnvSource)
 		out := out.(*SecretEnvSource)
@@ -2823,7 +2962,8 @@ func DeepCopy_api_SecretEnvSource(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_SecretKeySelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSecretKeySelector ...
+func DeepCopyapiSecretKeySelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecretKeySelector)
 		out := out.(*SecretKeySelector)
@@ -2837,7 +2977,8 @@ func DeepCopy_api_SecretKeySelector(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_api_SecretList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSecretList ...
+func DeepCopyapiSecretList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecretList)
 		out := out.(*SecretList)
@@ -2846,7 +2987,7 @@ func DeepCopy_api_SecretList(in interface{}, out interface{}, c *conversion.Clon
 			in, out := &in.Items, &out.Items
 			*out = make([]Secret, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Secret(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiSecret(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2855,7 +2996,8 @@ func DeepCopy_api_SecretList(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_api_SecretVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSecretVolumeSource ...
+func DeepCopyapiSecretVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecretVolumeSource)
 		out := out.(*SecretVolumeSource)
@@ -2864,7 +3006,7 @@ func DeepCopy_api_SecretVolumeSource(in interface{}, out interface{}, c *convers
 			in, out := &in.Items, &out.Items
 			*out = make([]KeyToPath, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_KeyToPath(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiKeyToPath(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2883,7 +3025,8 @@ func DeepCopy_api_SecretVolumeSource(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_api_SecurityContext(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSecurityContext ...
+func DeepCopyapiSecurityContext(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SecurityContext)
 		out := out.(*SecurityContext)
@@ -2891,7 +3034,7 @@ func DeepCopy_api_SecurityContext(in interface{}, out interface{}, c *conversion
 		if in.Capabilities != nil {
 			in, out := &in.Capabilities, &out.Capabilities
 			*out = new(Capabilities)
-			if err := DeepCopy_api_Capabilities(*in, *out, c); err != nil {
+			if err := DeepCopyapiCapabilities(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -2924,7 +3067,8 @@ func DeepCopy_api_SecurityContext(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_SerializedReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSerializedReference ...
+func DeepCopyapiSerializedReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SerializedReference)
 		out := out.(*SerializedReference)
@@ -2933,35 +3077,37 @@ func DeepCopy_api_SerializedReference(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_Service(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiService ...
+func DeepCopyapiService(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Service)
 		out := out.(*Service)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_api_ServiceSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_api_ServiceStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyapiServiceSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyapiServiceStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_ServiceAccount(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiServiceAccount ...
+func DeepCopyapiServiceAccount(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceAccount)
 		out := out.(*ServiceAccount)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Secrets != nil {
 			in, out := &in.Secrets, &out.Secrets
@@ -2977,7 +3123,8 @@ func DeepCopy_api_ServiceAccount(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_api_ServiceAccountList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiServiceAccountList ...
+func DeepCopyapiServiceAccountList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceAccountList)
 		out := out.(*ServiceAccountList)
@@ -2986,7 +3133,7 @@ func DeepCopy_api_ServiceAccountList(in interface{}, out interface{}, c *convers
 			in, out := &in.Items, &out.Items
 			*out = make([]ServiceAccount, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_ServiceAccount(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiServiceAccount(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -2995,7 +3142,8 @@ func DeepCopy_api_ServiceAccountList(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_api_ServiceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiServiceList ...
+func DeepCopyapiServiceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceList)
 		out := out.(*ServiceList)
@@ -3004,7 +3152,7 @@ func DeepCopy_api_ServiceList(in interface{}, out interface{}, c *conversion.Clo
 			in, out := &in.Items, &out.Items
 			*out = make([]Service, len(*in))
 			for i := range *in {
-				if err := DeepCopy_api_Service(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyapiService(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -3013,7 +3161,8 @@ func DeepCopy_api_ServiceList(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_api_ServicePort(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiServicePort ...
+func DeepCopyapiServicePort(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServicePort)
 		out := out.(*ServicePort)
@@ -3022,7 +3171,8 @@ func DeepCopy_api_ServicePort(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_api_ServiceProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiServiceProxyOptions ...
+func DeepCopyapiServiceProxyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceProxyOptions)
 		out := out.(*ServiceProxyOptions)
@@ -3031,7 +3181,8 @@ func DeepCopy_api_ServiceProxyOptions(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_api_ServiceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiServiceSpec ...
+func DeepCopyapiServiceSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceSpec)
 		out := out.(*ServiceSpec)
@@ -3062,19 +3213,21 @@ func DeepCopy_api_ServiceSpec(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_api_ServiceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiServiceStatus ...
+func DeepCopyapiServiceStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServiceStatus)
 		out := out.(*ServiceStatus)
 		*out = *in
-		if err := DeepCopy_api_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, c); err != nil {
+		if err := DeepCopyapiLoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_Sysctl(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiSysctl ...
+func DeepCopyapiSysctl(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Sysctl)
 		out := out.(*Sysctl)
@@ -3083,7 +3236,8 @@ func DeepCopy_api_Sysctl(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_api_TCPSocketAction(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiTCPSocketAction ...
+func DeepCopyapiTCPSocketAction(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TCPSocketAction)
 		out := out.(*TCPSocketAction)
@@ -3092,7 +3246,8 @@ func DeepCopy_api_TCPSocketAction(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_api_Taint(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiTaint ...
+func DeepCopyapiTaint(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Taint)
 		out := out.(*Taint)
@@ -3102,7 +3257,8 @@ func DeepCopy_api_Taint(in interface{}, out interface{}, c *conversion.Cloner) e
 	}
 }
 
-func DeepCopy_api_Toleration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiToleration ...
+func DeepCopyapiToleration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Toleration)
 		out := out.(*Toleration)
@@ -3116,19 +3272,21 @@ func DeepCopy_api_Toleration(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_api_Volume(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiVolume ...
+func DeepCopyapiVolume(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Volume)
 		out := out.(*Volume)
 		*out = *in
-		if err := DeepCopy_api_VolumeSource(&in.VolumeSource, &out.VolumeSource, c); err != nil {
+		if err := DeepCopyapiVolumeSource(&in.VolumeSource, &out.VolumeSource, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_api_VolumeMount(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiVolumeMount ...
+func DeepCopyapiVolumeMount(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*VolumeMount)
 		out := out.(*VolumeMount)
@@ -3137,7 +3295,8 @@ func DeepCopy_api_VolumeMount(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiVolumeSource ...
+func DeepCopyapiVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*VolumeSource)
 		out := out.(*VolumeSource)
@@ -3170,7 +3329,7 @@ func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.Secret != nil {
 			in, out := &in.Secret, &out.Secret
 			*out = new(SecretVolumeSource)
-			if err := DeepCopy_api_SecretVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiSecretVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3197,7 +3356,7 @@ func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.RBD != nil {
 			in, out := &in.RBD, &out.RBD
 			*out = new(RBDVolumeSource)
-			if err := DeepCopy_api_RBDVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiRBDVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3209,7 +3368,7 @@ func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.FlexVolume != nil {
 			in, out := &in.FlexVolume, &out.FlexVolume
 			*out = new(FlexVolumeSource)
-			if err := DeepCopy_api_FlexVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiFlexVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3221,7 +3380,7 @@ func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.CephFS != nil {
 			in, out := &in.CephFS, &out.CephFS
 			*out = new(CephFSVolumeSource)
-			if err := DeepCopy_api_CephFSVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiCephFSVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3233,14 +3392,14 @@ func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.DownwardAPI != nil {
 			in, out := &in.DownwardAPI, &out.DownwardAPI
 			*out = new(DownwardAPIVolumeSource)
-			if err := DeepCopy_api_DownwardAPIVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiDownwardAPIVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
 		if in.FC != nil {
 			in, out := &in.FC, &out.FC
 			*out = new(FCVolumeSource)
-			if err := DeepCopy_api_FCVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiFCVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3252,7 +3411,7 @@ func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.ConfigMap != nil {
 			in, out := &in.ConfigMap, &out.ConfigMap
 			*out = new(ConfigMapVolumeSource)
-			if err := DeepCopy_api_ConfigMapVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiConfigMapVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3264,7 +3423,7 @@ func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cl
 		if in.AzureDisk != nil {
 			in, out := &in.AzureDisk, &out.AzureDisk
 			*out = new(AzureDiskVolumeSource)
-			if err := DeepCopy_api_AzureDiskVolumeSource(*in, *out, c); err != nil {
+			if err := DeepCopyapiAzureDiskVolumeSource(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -3277,7 +3436,8 @@ func DeepCopy_api_VolumeSource(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_api_VsphereVirtualDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiVsphereVirtualDiskVolumeSource ...
+func DeepCopyapiVsphereVirtualDiskVolumeSource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*VsphereVirtualDiskVolumeSource)
 		out := out.(*VsphereVirtualDiskVolumeSource)
@@ -3286,12 +3446,13 @@ func DeepCopy_api_VsphereVirtualDiskVolumeSource(in interface{}, out interface{}
 	}
 }
 
-func DeepCopy_api_WeightedPodAffinityTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyapiWeightedPodAffinityTerm ...
+func DeepCopyapiWeightedPodAffinityTerm(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*WeightedPodAffinityTerm)
 		out := out.(*WeightedPodAffinityTerm)
 		*out = *in
-		if err := DeepCopy_api_PodAffinityTerm(&in.PodAffinityTerm, &out.PodAffinityTerm, c); err != nil {
+		if err := DeepCopyapiPodAffinityTerm(&in.PodAffinityTerm, &out.PodAffinityTerm, c); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/apis/abac/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/abac/v1beta1/zz_generated.deepcopy.go
@@ -34,12 +34,13 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_Policy, InType: reflect.TypeOf(&Policy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PolicySpec, InType: reflect.TypeOf(&PolicySpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1Policy, InType: reflect.TypeOf(&Policy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PolicySpec, InType: reflect.TypeOf(&PolicySpec{})},
 	)
 }
 
-func DeepCopy_v1beta1_Policy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1Policy ...
+func DeepCopyv1beta1Policy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Policy)
 		out := out.(*Policy)
@@ -48,7 +49,8 @@ func DeepCopy_v1beta1_Policy(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1beta1_PolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PolicySpec ...
+func DeepCopyv1beta1PolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PolicySpec)
 		out := out.(*PolicySpec)

--- a/pkg/apis/apps/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.deepcopy.go
@@ -36,34 +36,36 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_StatefulSet, InType: reflect.TypeOf(&StatefulSet{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_StatefulSetList, InType: reflect.TypeOf(&StatefulSetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_StatefulSetSpec, InType: reflect.TypeOf(&StatefulSetSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_StatefulSetStatus, InType: reflect.TypeOf(&StatefulSetStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1StatefulSet, InType: reflect.TypeOf(&StatefulSet{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1StatefulSetList, InType: reflect.TypeOf(&StatefulSetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1StatefulSetSpec, InType: reflect.TypeOf(&StatefulSetSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1StatefulSetStatus, InType: reflect.TypeOf(&StatefulSetStatus{})},
 	)
 }
 
-func DeepCopy_v1beta1_StatefulSet(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1StatefulSet ...
+func DeepCopyv1beta1StatefulSet(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatefulSet)
 		out := out.(*StatefulSet)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1beta1_StatefulSetSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1beta1_StatefulSetStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1StatefulSetSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1beta1StatefulSetStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_StatefulSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1StatefulSetList ...
+func DeepCopyv1beta1StatefulSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatefulSetList)
 		out := out.(*StatefulSetList)
@@ -72,7 +74,7 @@ func DeepCopy_v1beta1_StatefulSetList(in interface{}, out interface{}, c *conver
 			in, out := &in.Items, &out.Items
 			*out = make([]StatefulSet, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_StatefulSet(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1StatefulSet(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -81,7 +83,8 @@ func DeepCopy_v1beta1_StatefulSetList(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1beta1_StatefulSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1StatefulSetSpec ...
+func DeepCopyv1beta1StatefulSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatefulSetSpec)
 		out := out.(*StatefulSetSpec)
@@ -93,20 +96,20 @@ func DeepCopy_v1beta1_StatefulSetSpec(in interface{}, out interface{}, c *conver
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := api_v1.DeepCopy_v1_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api_v1.DeepCopyv1PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		if in.VolumeClaimTemplates != nil {
 			in, out := &in.VolumeClaimTemplates, &out.VolumeClaimTemplates
 			*out = make([]api_v1.PersistentVolumeClaim, len(*in))
 			for i := range *in {
-				if err := api_v1.DeepCopy_v1_PersistentVolumeClaim(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := api_v1.DeepCopyv1PersistentVolumeClaim(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -115,7 +118,8 @@ func DeepCopy_v1beta1_StatefulSetSpec(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1beta1_StatefulSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1StatefulSetStatus ...
+func DeepCopyv1beta1StatefulSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatefulSetStatus)
 		out := out.(*StatefulSetStatus)

--- a/pkg/apis/apps/zz_generated.deepcopy.go
+++ b/pkg/apis/apps/zz_generated.deepcopy.go
@@ -36,34 +36,36 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apps_StatefulSet, InType: reflect.TypeOf(&StatefulSet{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apps_StatefulSetList, InType: reflect.TypeOf(&StatefulSetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apps_StatefulSetSpec, InType: reflect.TypeOf(&StatefulSetSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_apps_StatefulSetStatus, InType: reflect.TypeOf(&StatefulSetStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyappsStatefulSet, InType: reflect.TypeOf(&StatefulSet{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyappsStatefulSetList, InType: reflect.TypeOf(&StatefulSetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyappsStatefulSetSpec, InType: reflect.TypeOf(&StatefulSetSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyappsStatefulSetStatus, InType: reflect.TypeOf(&StatefulSetStatus{})},
 	)
 }
 
-func DeepCopy_apps_StatefulSet(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyappsStatefulSet ...
+func DeepCopyappsStatefulSet(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatefulSet)
 		out := out.(*StatefulSet)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_apps_StatefulSetSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_apps_StatefulSetStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyappsStatefulSetSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyappsStatefulSetStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_apps_StatefulSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyappsStatefulSetList ...
+func DeepCopyappsStatefulSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatefulSetList)
 		out := out.(*StatefulSetList)
@@ -72,7 +74,7 @@ func DeepCopy_apps_StatefulSetList(in interface{}, out interface{}, c *conversio
 			in, out := &in.Items, &out.Items
 			*out = make([]StatefulSet, len(*in))
 			for i := range *in {
-				if err := DeepCopy_apps_StatefulSet(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyappsStatefulSet(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -81,27 +83,28 @@ func DeepCopy_apps_StatefulSetList(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_apps_StatefulSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyappsStatefulSetSpec ...
+func DeepCopyappsStatefulSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatefulSetSpec)
 		out := out.(*StatefulSetSpec)
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := api.DeepCopy_api_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api.DeepCopyapiPodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		if in.VolumeClaimTemplates != nil {
 			in, out := &in.VolumeClaimTemplates, &out.VolumeClaimTemplates
 			*out = make([]api.PersistentVolumeClaim, len(*in))
 			for i := range *in {
-				if err := api.DeepCopy_api_PersistentVolumeClaim(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := api.DeepCopyapiPersistentVolumeClaim(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -110,7 +113,8 @@ func DeepCopy_apps_StatefulSetSpec(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_apps_StatefulSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyappsStatefulSetStatus ...
+func DeepCopyappsStatefulSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatefulSetStatus)
 		out := out.(*StatefulSetStatus)

--- a/pkg/apis/authentication/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/authentication/v1beta1/zz_generated.deepcopy.go
@@ -35,31 +35,33 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_TokenReview, InType: reflect.TypeOf(&TokenReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_TokenReviewSpec, InType: reflect.TypeOf(&TokenReviewSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_TokenReviewStatus, InType: reflect.TypeOf(&TokenReviewStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_UserInfo, InType: reflect.TypeOf(&UserInfo{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1TokenReview, InType: reflect.TypeOf(&TokenReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1TokenReviewSpec, InType: reflect.TypeOf(&TokenReviewSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1TokenReviewStatus, InType: reflect.TypeOf(&TokenReviewStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1UserInfo, InType: reflect.TypeOf(&UserInfo{})},
 	)
 }
 
-func DeepCopy_v1beta1_TokenReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1TokenReview ...
+func DeepCopyv1beta1TokenReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TokenReview)
 		out := out.(*TokenReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1beta1_TokenReviewStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1TokenReviewStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_TokenReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1TokenReviewSpec ...
+func DeepCopyv1beta1TokenReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TokenReviewSpec)
 		out := out.(*TokenReviewSpec)
@@ -68,19 +70,21 @@ func DeepCopy_v1beta1_TokenReviewSpec(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1beta1_TokenReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1TokenReviewStatus ...
+func DeepCopyv1beta1TokenReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TokenReviewStatus)
 		out := out.(*TokenReviewStatus)
 		*out = *in
-		if err := DeepCopy_v1beta1_UserInfo(&in.User, &out.User, c); err != nil {
+		if err := DeepCopyv1beta1UserInfo(&in.User, &out.User, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_UserInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1UserInfo ...
+func DeepCopyv1beta1UserInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*UserInfo)
 		out := out.(*UserInfo)
@@ -94,10 +98,10 @@ func DeepCopy_v1beta1_UserInfo(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.Extra, &out.Extra
 			*out = make(map[string]ExtraValue)
 			for key, val := range *in {
-				if newVal, err := c.DeepCopy(&val); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&val); err == nil {
 					(*out)[key] = *newVal.(*ExtraValue)
+				} else {
+					return err
 				}
 			}
 		}

--- a/pkg/apis/authentication/zz_generated.deepcopy.go
+++ b/pkg/apis/authentication/zz_generated.deepcopy.go
@@ -35,31 +35,33 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authentication_TokenReview, InType: reflect.TypeOf(&TokenReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authentication_TokenReviewSpec, InType: reflect.TypeOf(&TokenReviewSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authentication_TokenReviewStatus, InType: reflect.TypeOf(&TokenReviewStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authentication_UserInfo, InType: reflect.TypeOf(&UserInfo{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthenticationTokenReview, InType: reflect.TypeOf(&TokenReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthenticationTokenReviewSpec, InType: reflect.TypeOf(&TokenReviewSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthenticationTokenReviewStatus, InType: reflect.TypeOf(&TokenReviewStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthenticationUserInfo, InType: reflect.TypeOf(&UserInfo{})},
 	)
 }
 
-func DeepCopy_authentication_TokenReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthenticationTokenReview ...
+func DeepCopyauthenticationTokenReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TokenReview)
 		out := out.(*TokenReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_authentication_TokenReviewStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyauthenticationTokenReviewStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_authentication_TokenReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthenticationTokenReviewSpec ...
+func DeepCopyauthenticationTokenReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TokenReviewSpec)
 		out := out.(*TokenReviewSpec)
@@ -68,19 +70,21 @@ func DeepCopy_authentication_TokenReviewSpec(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_authentication_TokenReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthenticationTokenReviewStatus ...
+func DeepCopyauthenticationTokenReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TokenReviewStatus)
 		out := out.(*TokenReviewStatus)
 		*out = *in
-		if err := DeepCopy_authentication_UserInfo(&in.User, &out.User, c); err != nil {
+		if err := DeepCopyauthenticationUserInfo(&in.User, &out.User, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_authentication_UserInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthenticationUserInfo ...
+func DeepCopyauthenticationUserInfo(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*UserInfo)
 		out := out.(*UserInfo)
@@ -94,10 +98,10 @@ func DeepCopy_authentication_UserInfo(in interface{}, out interface{}, c *conver
 			in, out := &in.Extra, &out.Extra
 			*out = make(map[string]ExtraValue)
 			for key, val := range *in {
-				if newVal, err := c.DeepCopy(&val); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&val); err == nil {
 					(*out)[key] = *newVal.(*ExtraValue)
+				} else {
+					return err
 				}
 			}
 		}

--- a/pkg/apis/authorization/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/authorization/v1beta1/zz_generated.deepcopy.go
@@ -35,35 +35,37 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_LocalSubjectAccessReview, InType: reflect.TypeOf(&LocalSubjectAccessReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_NonResourceAttributes, InType: reflect.TypeOf(&NonResourceAttributes{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ResourceAttributes, InType: reflect.TypeOf(&ResourceAttributes{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_SelfSubjectAccessReview, InType: reflect.TypeOf(&SelfSubjectAccessReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_SelfSubjectAccessReviewSpec, InType: reflect.TypeOf(&SelfSubjectAccessReviewSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_SubjectAccessReview, InType: reflect.TypeOf(&SubjectAccessReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_SubjectAccessReviewSpec, InType: reflect.TypeOf(&SubjectAccessReviewSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_SubjectAccessReviewStatus, InType: reflect.TypeOf(&SubjectAccessReviewStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1LocalSubjectAccessReview, InType: reflect.TypeOf(&LocalSubjectAccessReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1NonResourceAttributes, InType: reflect.TypeOf(&NonResourceAttributes{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ResourceAttributes, InType: reflect.TypeOf(&ResourceAttributes{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1SelfSubjectAccessReview, InType: reflect.TypeOf(&SelfSubjectAccessReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1SelfSubjectAccessReviewSpec, InType: reflect.TypeOf(&SelfSubjectAccessReviewSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1SubjectAccessReview, InType: reflect.TypeOf(&SubjectAccessReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1SubjectAccessReviewSpec, InType: reflect.TypeOf(&SubjectAccessReviewSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1SubjectAccessReviewStatus, InType: reflect.TypeOf(&SubjectAccessReviewStatus{})},
 	)
 }
 
-func DeepCopy_v1beta1_LocalSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1LocalSubjectAccessReview ...
+func DeepCopyv1beta1LocalSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LocalSubjectAccessReview)
 		out := out.(*LocalSubjectAccessReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1beta1_SubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1beta1SubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_NonResourceAttributes(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1NonResourceAttributes ...
+func DeepCopyv1beta1NonResourceAttributes(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NonResourceAttributes)
 		out := out.(*NonResourceAttributes)
@@ -72,7 +74,8 @@ func DeepCopy_v1beta1_NonResourceAttributes(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_v1beta1_ResourceAttributes(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ResourceAttributes ...
+func DeepCopyv1beta1ResourceAttributes(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceAttributes)
 		out := out.(*ResourceAttributes)
@@ -81,24 +84,26 @@ func DeepCopy_v1beta1_ResourceAttributes(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_v1beta1_SelfSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1SelfSubjectAccessReview ...
+func DeepCopyv1beta1SelfSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SelfSubjectAccessReview)
 		out := out.(*SelfSubjectAccessReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1beta1_SelfSubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1beta1SelfSubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_SelfSubjectAccessReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1SelfSubjectAccessReviewSpec ...
+func DeepCopyv1beta1SelfSubjectAccessReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SelfSubjectAccessReviewSpec)
 		out := out.(*SelfSubjectAccessReviewSpec)
@@ -117,24 +122,26 @@ func DeepCopy_v1beta1_SelfSubjectAccessReviewSpec(in interface{}, out interface{
 	}
 }
 
-func DeepCopy_v1beta1_SubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1SubjectAccessReview ...
+func DeepCopyv1beta1SubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SubjectAccessReview)
 		out := out.(*SubjectAccessReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1beta1_SubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1beta1SubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_SubjectAccessReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1SubjectAccessReviewSpec ...
+func DeepCopyv1beta1SubjectAccessReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SubjectAccessReviewSpec)
 		out := out.(*SubjectAccessReviewSpec)
@@ -158,10 +165,10 @@ func DeepCopy_v1beta1_SubjectAccessReviewSpec(in interface{}, out interface{}, c
 			in, out := &in.Extra, &out.Extra
 			*out = make(map[string]ExtraValue)
 			for key, val := range *in {
-				if newVal, err := c.DeepCopy(&val); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&val); err == nil {
 					(*out)[key] = *newVal.(*ExtraValue)
+				} else {
+					return err
 				}
 			}
 		}
@@ -169,7 +176,8 @@ func DeepCopy_v1beta1_SubjectAccessReviewSpec(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_v1beta1_SubjectAccessReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1SubjectAccessReviewStatus ...
+func DeepCopyv1beta1SubjectAccessReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SubjectAccessReviewStatus)
 		out := out.(*SubjectAccessReviewStatus)

--- a/pkg/apis/authorization/zz_generated.deepcopy.go
+++ b/pkg/apis/authorization/zz_generated.deepcopy.go
@@ -35,35 +35,37 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authorization_LocalSubjectAccessReview, InType: reflect.TypeOf(&LocalSubjectAccessReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authorization_NonResourceAttributes, InType: reflect.TypeOf(&NonResourceAttributes{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authorization_ResourceAttributes, InType: reflect.TypeOf(&ResourceAttributes{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authorization_SelfSubjectAccessReview, InType: reflect.TypeOf(&SelfSubjectAccessReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authorization_SelfSubjectAccessReviewSpec, InType: reflect.TypeOf(&SelfSubjectAccessReviewSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authorization_SubjectAccessReview, InType: reflect.TypeOf(&SubjectAccessReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authorization_SubjectAccessReviewSpec, InType: reflect.TypeOf(&SubjectAccessReviewSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_authorization_SubjectAccessReviewStatus, InType: reflect.TypeOf(&SubjectAccessReviewStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthorizationLocalSubjectAccessReview, InType: reflect.TypeOf(&LocalSubjectAccessReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthorizationNonResourceAttributes, InType: reflect.TypeOf(&NonResourceAttributes{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthorizationResourceAttributes, InType: reflect.TypeOf(&ResourceAttributes{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthorizationSelfSubjectAccessReview, InType: reflect.TypeOf(&SelfSubjectAccessReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthorizationSelfSubjectAccessReviewSpec, InType: reflect.TypeOf(&SelfSubjectAccessReviewSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthorizationSubjectAccessReview, InType: reflect.TypeOf(&SubjectAccessReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthorizationSubjectAccessReviewSpec, InType: reflect.TypeOf(&SubjectAccessReviewSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyauthorizationSubjectAccessReviewStatus, InType: reflect.TypeOf(&SubjectAccessReviewStatus{})},
 	)
 }
 
-func DeepCopy_authorization_LocalSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthorizationLocalSubjectAccessReview ...
+func DeepCopyauthorizationLocalSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LocalSubjectAccessReview)
 		out := out.(*LocalSubjectAccessReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_authorization_SubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyauthorizationSubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_authorization_NonResourceAttributes(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthorizationNonResourceAttributes ...
+func DeepCopyauthorizationNonResourceAttributes(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NonResourceAttributes)
 		out := out.(*NonResourceAttributes)
@@ -72,7 +74,8 @@ func DeepCopy_authorization_NonResourceAttributes(in interface{}, out interface{
 	}
 }
 
-func DeepCopy_authorization_ResourceAttributes(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthorizationResourceAttributes ...
+func DeepCopyauthorizationResourceAttributes(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ResourceAttributes)
 		out := out.(*ResourceAttributes)
@@ -81,24 +84,26 @@ func DeepCopy_authorization_ResourceAttributes(in interface{}, out interface{}, 
 	}
 }
 
-func DeepCopy_authorization_SelfSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthorizationSelfSubjectAccessReview ...
+func DeepCopyauthorizationSelfSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SelfSubjectAccessReview)
 		out := out.(*SelfSubjectAccessReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_authorization_SelfSubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyauthorizationSelfSubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_authorization_SelfSubjectAccessReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthorizationSelfSubjectAccessReviewSpec ...
+func DeepCopyauthorizationSelfSubjectAccessReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SelfSubjectAccessReviewSpec)
 		out := out.(*SelfSubjectAccessReviewSpec)
@@ -117,24 +122,26 @@ func DeepCopy_authorization_SelfSubjectAccessReviewSpec(in interface{}, out inte
 	}
 }
 
-func DeepCopy_authorization_SubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthorizationSubjectAccessReview ...
+func DeepCopyauthorizationSubjectAccessReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SubjectAccessReview)
 		out := out.(*SubjectAccessReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_authorization_SubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyauthorizationSubjectAccessReviewSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_authorization_SubjectAccessReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthorizationSubjectAccessReviewSpec ...
+func DeepCopyauthorizationSubjectAccessReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SubjectAccessReviewSpec)
 		out := out.(*SubjectAccessReviewSpec)
@@ -158,10 +165,10 @@ func DeepCopy_authorization_SubjectAccessReviewSpec(in interface{}, out interfac
 			in, out := &in.Extra, &out.Extra
 			*out = make(map[string]ExtraValue)
 			for key, val := range *in {
-				if newVal, err := c.DeepCopy(&val); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&val); err == nil {
 					(*out)[key] = *newVal.(*ExtraValue)
+				} else {
+					return err
 				}
 			}
 		}
@@ -169,7 +176,8 @@ func DeepCopy_authorization_SubjectAccessReviewSpec(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_authorization_SubjectAccessReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyauthorizationSubjectAccessReviewStatus ...
+func DeepCopyauthorizationSubjectAccessReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SubjectAccessReviewStatus)
 		out := out.(*SubjectAccessReviewStatus)

--- a/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.deepcopy.go
@@ -35,18 +35,19 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_CrossVersionObjectReference, InType: reflect.TypeOf(&CrossVersionObjectReference{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_HorizontalPodAutoscaler, InType: reflect.TypeOf(&HorizontalPodAutoscaler{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_HorizontalPodAutoscalerList, InType: reflect.TypeOf(&HorizontalPodAutoscalerList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_HorizontalPodAutoscalerSpec, InType: reflect.TypeOf(&HorizontalPodAutoscalerSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_HorizontalPodAutoscalerStatus, InType: reflect.TypeOf(&HorizontalPodAutoscalerStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Scale, InType: reflect.TypeOf(&Scale{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ScaleSpec, InType: reflect.TypeOf(&ScaleSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_ScaleStatus, InType: reflect.TypeOf(&ScaleStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1CrossVersionObjectReference, InType: reflect.TypeOf(&CrossVersionObjectReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1HorizontalPodAutoscaler, InType: reflect.TypeOf(&HorizontalPodAutoscaler{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1HorizontalPodAutoscalerList, InType: reflect.TypeOf(&HorizontalPodAutoscalerList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1HorizontalPodAutoscalerSpec, InType: reflect.TypeOf(&HorizontalPodAutoscalerSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1HorizontalPodAutoscalerStatus, InType: reflect.TypeOf(&HorizontalPodAutoscalerStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Scale, InType: reflect.TypeOf(&Scale{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ScaleSpec, InType: reflect.TypeOf(&ScaleSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1ScaleStatus, InType: reflect.TypeOf(&ScaleStatus{})},
 	)
 }
 
-func DeepCopy_v1_CrossVersionObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1CrossVersionObjectReference ...
+func DeepCopyv1CrossVersionObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CrossVersionObjectReference)
 		out := out.(*CrossVersionObjectReference)
@@ -55,27 +56,29 @@ func DeepCopy_v1_CrossVersionObjectReference(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1_HorizontalPodAutoscaler(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1HorizontalPodAutoscaler ...
+func DeepCopyv1HorizontalPodAutoscaler(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HorizontalPodAutoscaler)
 		out := out.(*HorizontalPodAutoscaler)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1HorizontalPodAutoscalerStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_HorizontalPodAutoscalerList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1HorizontalPodAutoscalerList ...
+func DeepCopyv1HorizontalPodAutoscalerList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HorizontalPodAutoscalerList)
 		out := out.(*HorizontalPodAutoscalerList)
@@ -84,7 +87,7 @@ func DeepCopy_v1_HorizontalPodAutoscalerList(in interface{}, out interface{}, c 
 			in, out := &in.Items, &out.Items
 			*out = make([]HorizontalPodAutoscaler, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_HorizontalPodAutoscaler(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1HorizontalPodAutoscaler(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -93,7 +96,8 @@ func DeepCopy_v1_HorizontalPodAutoscalerList(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1_HorizontalPodAutoscalerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1HorizontalPodAutoscalerSpec ...
+func DeepCopyv1HorizontalPodAutoscalerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HorizontalPodAutoscalerSpec)
 		out := out.(*HorizontalPodAutoscalerSpec)
@@ -112,7 +116,8 @@ func DeepCopy_v1_HorizontalPodAutoscalerSpec(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1_HorizontalPodAutoscalerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1HorizontalPodAutoscalerStatus ...
+func DeepCopyv1HorizontalPodAutoscalerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HorizontalPodAutoscalerStatus)
 		out := out.(*HorizontalPodAutoscalerStatus)
@@ -136,21 +141,23 @@ func DeepCopy_v1_HorizontalPodAutoscalerStatus(in interface{}, out interface{}, 
 	}
 }
 
-func DeepCopy_v1_Scale(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Scale ...
+func DeepCopyv1Scale(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Scale)
 		out := out.(*Scale)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
+		} else {
+			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_ScaleSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ScaleSpec ...
+func DeepCopyv1ScaleSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ScaleSpec)
 		out := out.(*ScaleSpec)
@@ -159,7 +166,8 @@ func DeepCopy_v1_ScaleSpec(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_ScaleStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ScaleStatus ...
+func DeepCopyv1ScaleStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ScaleStatus)
 		out := out.(*ScaleStatus)

--- a/pkg/apis/autoscaling/zz_generated.deepcopy.go
+++ b/pkg/apis/autoscaling/zz_generated.deepcopy.go
@@ -35,18 +35,19 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_autoscaling_CrossVersionObjectReference, InType: reflect.TypeOf(&CrossVersionObjectReference{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_autoscaling_HorizontalPodAutoscaler, InType: reflect.TypeOf(&HorizontalPodAutoscaler{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_autoscaling_HorizontalPodAutoscalerList, InType: reflect.TypeOf(&HorizontalPodAutoscalerList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_autoscaling_HorizontalPodAutoscalerSpec, InType: reflect.TypeOf(&HorizontalPodAutoscalerSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_autoscaling_HorizontalPodAutoscalerStatus, InType: reflect.TypeOf(&HorizontalPodAutoscalerStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_autoscaling_Scale, InType: reflect.TypeOf(&Scale{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_autoscaling_ScaleSpec, InType: reflect.TypeOf(&ScaleSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_autoscaling_ScaleStatus, InType: reflect.TypeOf(&ScaleStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyautoscalingCrossVersionObjectReference, InType: reflect.TypeOf(&CrossVersionObjectReference{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyautoscalingHorizontalPodAutoscaler, InType: reflect.TypeOf(&HorizontalPodAutoscaler{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyautoscalingHorizontalPodAutoscalerList, InType: reflect.TypeOf(&HorizontalPodAutoscalerList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyautoscalingHorizontalPodAutoscalerSpec, InType: reflect.TypeOf(&HorizontalPodAutoscalerSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyautoscalingHorizontalPodAutoscalerStatus, InType: reflect.TypeOf(&HorizontalPodAutoscalerStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyautoscalingScale, InType: reflect.TypeOf(&Scale{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyautoscalingScaleSpec, InType: reflect.TypeOf(&ScaleSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyautoscalingScaleStatus, InType: reflect.TypeOf(&ScaleStatus{})},
 	)
 }
 
-func DeepCopy_autoscaling_CrossVersionObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyautoscalingCrossVersionObjectReference ...
+func DeepCopyautoscalingCrossVersionObjectReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CrossVersionObjectReference)
 		out := out.(*CrossVersionObjectReference)
@@ -55,27 +56,29 @@ func DeepCopy_autoscaling_CrossVersionObjectReference(in interface{}, out interf
 	}
 }
 
-func DeepCopy_autoscaling_HorizontalPodAutoscaler(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyautoscalingHorizontalPodAutoscaler ...
+func DeepCopyautoscalingHorizontalPodAutoscaler(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HorizontalPodAutoscaler)
 		out := out.(*HorizontalPodAutoscaler)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_autoscaling_HorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_autoscaling_HorizontalPodAutoscalerStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyautoscalingHorizontalPodAutoscalerSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyautoscalingHorizontalPodAutoscalerStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_autoscaling_HorizontalPodAutoscalerList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyautoscalingHorizontalPodAutoscalerList ...
+func DeepCopyautoscalingHorizontalPodAutoscalerList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HorizontalPodAutoscalerList)
 		out := out.(*HorizontalPodAutoscalerList)
@@ -84,7 +87,7 @@ func DeepCopy_autoscaling_HorizontalPodAutoscalerList(in interface{}, out interf
 			in, out := &in.Items, &out.Items
 			*out = make([]HorizontalPodAutoscaler, len(*in))
 			for i := range *in {
-				if err := DeepCopy_autoscaling_HorizontalPodAutoscaler(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyautoscalingHorizontalPodAutoscaler(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -93,7 +96,8 @@ func DeepCopy_autoscaling_HorizontalPodAutoscalerList(in interface{}, out interf
 	}
 }
 
-func DeepCopy_autoscaling_HorizontalPodAutoscalerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyautoscalingHorizontalPodAutoscalerSpec ...
+func DeepCopyautoscalingHorizontalPodAutoscalerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HorizontalPodAutoscalerSpec)
 		out := out.(*HorizontalPodAutoscalerSpec)
@@ -112,7 +116,8 @@ func DeepCopy_autoscaling_HorizontalPodAutoscalerSpec(in interface{}, out interf
 	}
 }
 
-func DeepCopy_autoscaling_HorizontalPodAutoscalerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyautoscalingHorizontalPodAutoscalerStatus ...
+func DeepCopyautoscalingHorizontalPodAutoscalerStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HorizontalPodAutoscalerStatus)
 		out := out.(*HorizontalPodAutoscalerStatus)
@@ -136,21 +141,23 @@ func DeepCopy_autoscaling_HorizontalPodAutoscalerStatus(in interface{}, out inte
 	}
 }
 
-func DeepCopy_autoscaling_Scale(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyautoscalingScale ...
+func DeepCopyautoscalingScale(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Scale)
 		out := out.(*Scale)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_autoscaling_ScaleSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyautoscalingScaleSpec ...
+func DeepCopyautoscalingScaleSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ScaleSpec)
 		out := out.(*ScaleSpec)
@@ -159,7 +166,8 @@ func DeepCopy_autoscaling_ScaleSpec(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_autoscaling_ScaleStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyautoscalingScaleStatus ...
+func DeepCopyautoscalingScaleStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ScaleStatus)
 		out := out.(*ScaleStatus)

--- a/pkg/apis/batch/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/batch/v1/zz_generated.deepcopy.go
@@ -36,35 +36,37 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Job, InType: reflect.TypeOf(&Job{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_JobCondition, InType: reflect.TypeOf(&JobCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_JobList, InType: reflect.TypeOf(&JobList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_JobSpec, InType: reflect.TypeOf(&JobSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_JobStatus, InType: reflect.TypeOf(&JobStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Job, InType: reflect.TypeOf(&Job{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1JobCondition, InType: reflect.TypeOf(&JobCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1JobList, InType: reflect.TypeOf(&JobList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1JobSpec, InType: reflect.TypeOf(&JobSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1JobStatus, InType: reflect.TypeOf(&JobStatus{})},
 	)
 }
 
-func DeepCopy_v1_Job(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Job ...
+func DeepCopyv1Job(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Job)
 		out := out.(*Job)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1_JobSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1_JobStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1JobSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1JobStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_JobCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1JobCondition ...
+func DeepCopyv1JobCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobCondition)
 		out := out.(*JobCondition)
@@ -75,7 +77,8 @@ func DeepCopy_v1_JobCondition(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_JobList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1JobList ...
+func DeepCopyv1JobList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobList)
 		out := out.(*JobList)
@@ -84,7 +87,7 @@ func DeepCopy_v1_JobList(in interface{}, out interface{}, c *conversion.Cloner) 
 			in, out := &in.Items, &out.Items
 			*out = make([]Job, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_Job(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1Job(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -93,7 +96,8 @@ func DeepCopy_v1_JobList(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_v1_JobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1JobSpec ...
+func DeepCopyv1JobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobSpec)
 		out := out.(*JobSpec)
@@ -115,10 +119,10 @@ func DeepCopy_v1_JobSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*meta_v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		if in.ManualSelector != nil {
@@ -126,14 +130,15 @@ func DeepCopy_v1_JobSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 			*out = new(bool)
 			**out = **in
 		}
-		if err := api_v1.DeepCopy_v1_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api_v1.DeepCopyv1PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_JobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1JobStatus ...
+func DeepCopyv1JobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobStatus)
 		out := out.(*JobStatus)
@@ -142,7 +147,7 @@ func DeepCopy_v1_JobStatus(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]JobCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1_JobCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1JobCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}

--- a/pkg/apis/batch/v2alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/batch/v2alpha1/zz_generated.deepcopy.go
@@ -36,41 +36,43 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_CronJob, InType: reflect.TypeOf(&CronJob{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_CronJobList, InType: reflect.TypeOf(&CronJobList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_CronJobSpec, InType: reflect.TypeOf(&CronJobSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_CronJobStatus, InType: reflect.TypeOf(&CronJobStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_Job, InType: reflect.TypeOf(&Job{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_JobCondition, InType: reflect.TypeOf(&JobCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_JobList, InType: reflect.TypeOf(&JobList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_JobSpec, InType: reflect.TypeOf(&JobSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_JobStatus, InType: reflect.TypeOf(&JobStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_JobTemplate, InType: reflect.TypeOf(&JobTemplate{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v2alpha1_JobTemplateSpec, InType: reflect.TypeOf(&JobTemplateSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1CronJob, InType: reflect.TypeOf(&CronJob{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1CronJobList, InType: reflect.TypeOf(&CronJobList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1CronJobSpec, InType: reflect.TypeOf(&CronJobSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1CronJobStatus, InType: reflect.TypeOf(&CronJobStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1Job, InType: reflect.TypeOf(&Job{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1JobCondition, InType: reflect.TypeOf(&JobCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1JobList, InType: reflect.TypeOf(&JobList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1JobSpec, InType: reflect.TypeOf(&JobSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1JobStatus, InType: reflect.TypeOf(&JobStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1JobTemplate, InType: reflect.TypeOf(&JobTemplate{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv2alpha1JobTemplateSpec, InType: reflect.TypeOf(&JobTemplateSpec{})},
 	)
 }
 
-func DeepCopy_v2alpha1_CronJob(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1CronJob ...
+func DeepCopyv2alpha1CronJob(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CronJob)
 		out := out.(*CronJob)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v2alpha1_CronJobSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v2alpha1_CronJobStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv2alpha1CronJobSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv2alpha1CronJobStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v2alpha1_CronJobList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1CronJobList ...
+func DeepCopyv2alpha1CronJobList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CronJobList)
 		out := out.(*CronJobList)
@@ -79,7 +81,7 @@ func DeepCopy_v2alpha1_CronJobList(in interface{}, out interface{}, c *conversio
 			in, out := &in.Items, &out.Items
 			*out = make([]CronJob, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v2alpha1_CronJob(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv2alpha1CronJob(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -88,7 +90,8 @@ func DeepCopy_v2alpha1_CronJobList(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_v2alpha1_CronJobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1CronJobSpec ...
+func DeepCopyv2alpha1CronJobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CronJobSpec)
 		out := out.(*CronJobSpec)
@@ -103,14 +106,15 @@ func DeepCopy_v2alpha1_CronJobSpec(in interface{}, out interface{}, c *conversio
 			*out = new(bool)
 			**out = **in
 		}
-		if err := DeepCopy_v2alpha1_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, c); err != nil {
+		if err := DeepCopyv2alpha1JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v2alpha1_CronJobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1CronJobStatus ...
+func DeepCopyv2alpha1CronJobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CronJobStatus)
 		out := out.(*CronJobStatus)
@@ -129,27 +133,29 @@ func DeepCopy_v2alpha1_CronJobStatus(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v2alpha1_Job(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1Job ...
+func DeepCopyv2alpha1Job(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Job)
 		out := out.(*Job)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v2alpha1_JobSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v2alpha1_JobStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv2alpha1JobSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv2alpha1JobStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v2alpha1_JobCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1JobCondition ...
+func DeepCopyv2alpha1JobCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobCondition)
 		out := out.(*JobCondition)
@@ -160,7 +166,8 @@ func DeepCopy_v2alpha1_JobCondition(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v2alpha1_JobList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1JobList ...
+func DeepCopyv2alpha1JobList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobList)
 		out := out.(*JobList)
@@ -169,7 +176,7 @@ func DeepCopy_v2alpha1_JobList(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.Items, &out.Items
 			*out = make([]Job, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v2alpha1_Job(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv2alpha1Job(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -178,7 +185,8 @@ func DeepCopy_v2alpha1_JobList(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v2alpha1_JobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1JobSpec ...
+func DeepCopyv2alpha1JobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobSpec)
 		out := out.(*JobSpec)
@@ -200,10 +208,10 @@ func DeepCopy_v2alpha1_JobSpec(in interface{}, out interface{}, c *conversion.Cl
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		if in.ManualSelector != nil {
@@ -211,14 +219,15 @@ func DeepCopy_v2alpha1_JobSpec(in interface{}, out interface{}, c *conversion.Cl
 			*out = new(bool)
 			**out = **in
 		}
-		if err := api_v1.DeepCopy_v1_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api_v1.DeepCopyv1PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v2alpha1_JobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1JobStatus ...
+func DeepCopyv2alpha1JobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobStatus)
 		out := out.(*JobStatus)
@@ -227,7 +236,7 @@ func DeepCopy_v2alpha1_JobStatus(in interface{}, out interface{}, c *conversion.
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]JobCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v2alpha1_JobCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv2alpha1JobCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -246,34 +255,36 @@ func DeepCopy_v2alpha1_JobStatus(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v2alpha1_JobTemplate(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1JobTemplate ...
+func DeepCopyv2alpha1JobTemplate(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobTemplate)
 		out := out.(*JobTemplate)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v2alpha1_JobTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := DeepCopyv2alpha1JobTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v2alpha1_JobTemplateSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv2alpha1JobTemplateSpec ...
+func DeepCopyv2alpha1JobTemplateSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobTemplateSpec)
 		out := out.(*JobTemplateSpec)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v2alpha1_JobSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv2alpha1JobSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/apis/batch/zz_generated.deepcopy.go
+++ b/pkg/apis/batch/zz_generated.deepcopy.go
@@ -36,41 +36,43 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_CronJob, InType: reflect.TypeOf(&CronJob{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_CronJobList, InType: reflect.TypeOf(&CronJobList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_CronJobSpec, InType: reflect.TypeOf(&CronJobSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_CronJobStatus, InType: reflect.TypeOf(&CronJobStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_Job, InType: reflect.TypeOf(&Job{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_JobCondition, InType: reflect.TypeOf(&JobCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_JobList, InType: reflect.TypeOf(&JobList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_JobSpec, InType: reflect.TypeOf(&JobSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_JobStatus, InType: reflect.TypeOf(&JobStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_JobTemplate, InType: reflect.TypeOf(&JobTemplate{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_batch_JobTemplateSpec, InType: reflect.TypeOf(&JobTemplateSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchCronJob, InType: reflect.TypeOf(&CronJob{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchCronJobList, InType: reflect.TypeOf(&CronJobList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchCronJobSpec, InType: reflect.TypeOf(&CronJobSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchCronJobStatus, InType: reflect.TypeOf(&CronJobStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchJob, InType: reflect.TypeOf(&Job{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchJobCondition, InType: reflect.TypeOf(&JobCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchJobList, InType: reflect.TypeOf(&JobList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchJobSpec, InType: reflect.TypeOf(&JobSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchJobStatus, InType: reflect.TypeOf(&JobStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchJobTemplate, InType: reflect.TypeOf(&JobTemplate{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopybatchJobTemplateSpec, InType: reflect.TypeOf(&JobTemplateSpec{})},
 	)
 }
 
-func DeepCopy_batch_CronJob(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchCronJob ...
+func DeepCopybatchCronJob(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CronJob)
 		out := out.(*CronJob)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_batch_CronJobSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_batch_CronJobStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopybatchCronJobSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopybatchCronJobStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_batch_CronJobList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchCronJobList ...
+func DeepCopybatchCronJobList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CronJobList)
 		out := out.(*CronJobList)
@@ -79,7 +81,7 @@ func DeepCopy_batch_CronJobList(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Items, &out.Items
 			*out = make([]CronJob, len(*in))
 			for i := range *in {
-				if err := DeepCopy_batch_CronJob(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopybatchCronJob(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -88,7 +90,8 @@ func DeepCopy_batch_CronJobList(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_batch_CronJobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchCronJobSpec ...
+func DeepCopybatchCronJobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CronJobSpec)
 		out := out.(*CronJobSpec)
@@ -103,14 +106,15 @@ func DeepCopy_batch_CronJobSpec(in interface{}, out interface{}, c *conversion.C
 			*out = new(bool)
 			**out = **in
 		}
-		if err := DeepCopy_batch_JobTemplateSpec(&in.JobTemplate, &out.JobTemplate, c); err != nil {
+		if err := DeepCopybatchJobTemplateSpec(&in.JobTemplate, &out.JobTemplate, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_batch_CronJobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchCronJobStatus ...
+func DeepCopybatchCronJobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CronJobStatus)
 		out := out.(*CronJobStatus)
@@ -129,27 +133,29 @@ func DeepCopy_batch_CronJobStatus(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_batch_Job(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchJob ...
+func DeepCopybatchJob(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Job)
 		out := out.(*Job)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_batch_JobSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_batch_JobStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopybatchJobSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopybatchJobStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_batch_JobCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchJobCondition ...
+func DeepCopybatchJobCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobCondition)
 		out := out.(*JobCondition)
@@ -160,7 +166,8 @@ func DeepCopy_batch_JobCondition(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_batch_JobList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchJobList ...
+func DeepCopybatchJobList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobList)
 		out := out.(*JobList)
@@ -169,7 +176,7 @@ func DeepCopy_batch_JobList(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.Items, &out.Items
 			*out = make([]Job, len(*in))
 			for i := range *in {
-				if err := DeepCopy_batch_Job(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopybatchJob(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -178,7 +185,8 @@ func DeepCopy_batch_JobList(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_batch_JobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchJobSpec ...
+func DeepCopybatchJobSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobSpec)
 		out := out.(*JobSpec)
@@ -200,10 +208,10 @@ func DeepCopy_batch_JobSpec(in interface{}, out interface{}, c *conversion.Clone
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		if in.ManualSelector != nil {
@@ -211,14 +219,15 @@ func DeepCopy_batch_JobSpec(in interface{}, out interface{}, c *conversion.Clone
 			*out = new(bool)
 			**out = **in
 		}
-		if err := api.DeepCopy_api_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api.DeepCopyapiPodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_batch_JobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchJobStatus ...
+func DeepCopybatchJobStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobStatus)
 		out := out.(*JobStatus)
@@ -227,7 +236,7 @@ func DeepCopy_batch_JobStatus(in interface{}, out interface{}, c *conversion.Clo
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]JobCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_batch_JobCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopybatchJobCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -246,34 +255,36 @@ func DeepCopy_batch_JobStatus(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_batch_JobTemplate(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchJobTemplate ...
+func DeepCopybatchJobTemplate(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobTemplate)
 		out := out.(*JobTemplate)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_batch_JobTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := DeepCopybatchJobTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_batch_JobTemplateSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopybatchJobTemplateSpec ...
+func DeepCopybatchJobTemplateSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*JobTemplateSpec)
 		out := out.(*JobTemplateSpec)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_batch_JobSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopybatchJobSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/apis/certificates/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.deepcopy.go
@@ -35,35 +35,37 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CertificateSigningRequest, InType: reflect.TypeOf(&CertificateSigningRequest{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CertificateSigningRequestCondition, InType: reflect.TypeOf(&CertificateSigningRequestCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CertificateSigningRequestList, InType: reflect.TypeOf(&CertificateSigningRequestList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CertificateSigningRequestSpec, InType: reflect.TypeOf(&CertificateSigningRequestSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CertificateSigningRequestStatus, InType: reflect.TypeOf(&CertificateSigningRequestStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CertificateSigningRequest, InType: reflect.TypeOf(&CertificateSigningRequest{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CertificateSigningRequestCondition, InType: reflect.TypeOf(&CertificateSigningRequestCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CertificateSigningRequestList, InType: reflect.TypeOf(&CertificateSigningRequestList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CertificateSigningRequestSpec, InType: reflect.TypeOf(&CertificateSigningRequestSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CertificateSigningRequestStatus, InType: reflect.TypeOf(&CertificateSigningRequestStatus{})},
 	)
 }
 
-func DeepCopy_v1beta1_CertificateSigningRequest(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CertificateSigningRequest ...
+func DeepCopyv1beta1CertificateSigningRequest(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequest)
 		out := out.(*CertificateSigningRequest)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1beta1_CertificateSigningRequestSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1beta1_CertificateSigningRequestStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1CertificateSigningRequestSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1beta1CertificateSigningRequestStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_CertificateSigningRequestCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CertificateSigningRequestCondition ...
+func DeepCopyv1beta1CertificateSigningRequestCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequestCondition)
 		out := out.(*CertificateSigningRequestCondition)
@@ -73,7 +75,8 @@ func DeepCopy_v1beta1_CertificateSigningRequestCondition(in interface{}, out int
 	}
 }
 
-func DeepCopy_v1beta1_CertificateSigningRequestList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CertificateSigningRequestList ...
+func DeepCopyv1beta1CertificateSigningRequestList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequestList)
 		out := out.(*CertificateSigningRequestList)
@@ -82,7 +85,7 @@ func DeepCopy_v1beta1_CertificateSigningRequestList(in interface{}, out interfac
 			in, out := &in.Items, &out.Items
 			*out = make([]CertificateSigningRequest, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_CertificateSigningRequest(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1CertificateSigningRequest(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -91,7 +94,8 @@ func DeepCopy_v1beta1_CertificateSigningRequestList(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_v1beta1_CertificateSigningRequestSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CertificateSigningRequestSpec ...
+func DeepCopyv1beta1CertificateSigningRequestSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequestSpec)
 		out := out.(*CertificateSigningRequestSpec)
@@ -115,7 +119,8 @@ func DeepCopy_v1beta1_CertificateSigningRequestSpec(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_v1beta1_CertificateSigningRequestStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CertificateSigningRequestStatus ...
+func DeepCopyv1beta1CertificateSigningRequestStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequestStatus)
 		out := out.(*CertificateSigningRequestStatus)
@@ -124,7 +129,7 @@ func DeepCopy_v1beta1_CertificateSigningRequestStatus(in interface{}, out interf
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]CertificateSigningRequestCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_CertificateSigningRequestCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1CertificateSigningRequestCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}

--- a/pkg/apis/certificates/zz_generated.deepcopy.go
+++ b/pkg/apis/certificates/zz_generated.deepcopy.go
@@ -35,35 +35,37 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_certificates_CertificateSigningRequest, InType: reflect.TypeOf(&CertificateSigningRequest{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_certificates_CertificateSigningRequestCondition, InType: reflect.TypeOf(&CertificateSigningRequestCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_certificates_CertificateSigningRequestList, InType: reflect.TypeOf(&CertificateSigningRequestList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_certificates_CertificateSigningRequestSpec, InType: reflect.TypeOf(&CertificateSigningRequestSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_certificates_CertificateSigningRequestStatus, InType: reflect.TypeOf(&CertificateSigningRequestStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycertificatesCertificateSigningRequest, InType: reflect.TypeOf(&CertificateSigningRequest{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycertificatesCertificateSigningRequestCondition, InType: reflect.TypeOf(&CertificateSigningRequestCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycertificatesCertificateSigningRequestList, InType: reflect.TypeOf(&CertificateSigningRequestList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycertificatesCertificateSigningRequestSpec, InType: reflect.TypeOf(&CertificateSigningRequestSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycertificatesCertificateSigningRequestStatus, InType: reflect.TypeOf(&CertificateSigningRequestStatus{})},
 	)
 }
 
-func DeepCopy_certificates_CertificateSigningRequest(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycertificatesCertificateSigningRequest ...
+func DeepCopycertificatesCertificateSigningRequest(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequest)
 		out := out.(*CertificateSigningRequest)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_certificates_CertificateSigningRequestSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_certificates_CertificateSigningRequestStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopycertificatesCertificateSigningRequestSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopycertificatesCertificateSigningRequestStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_certificates_CertificateSigningRequestCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycertificatesCertificateSigningRequestCondition ...
+func DeepCopycertificatesCertificateSigningRequestCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequestCondition)
 		out := out.(*CertificateSigningRequestCondition)
@@ -73,7 +75,8 @@ func DeepCopy_certificates_CertificateSigningRequestCondition(in interface{}, ou
 	}
 }
 
-func DeepCopy_certificates_CertificateSigningRequestList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycertificatesCertificateSigningRequestList ...
+func DeepCopycertificatesCertificateSigningRequestList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequestList)
 		out := out.(*CertificateSigningRequestList)
@@ -82,7 +85,7 @@ func DeepCopy_certificates_CertificateSigningRequestList(in interface{}, out int
 			in, out := &in.Items, &out.Items
 			*out = make([]CertificateSigningRequest, len(*in))
 			for i := range *in {
-				if err := DeepCopy_certificates_CertificateSigningRequest(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopycertificatesCertificateSigningRequest(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -91,7 +94,8 @@ func DeepCopy_certificates_CertificateSigningRequestList(in interface{}, out int
 	}
 }
 
-func DeepCopy_certificates_CertificateSigningRequestSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycertificatesCertificateSigningRequestSpec ...
+func DeepCopycertificatesCertificateSigningRequestSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequestSpec)
 		out := out.(*CertificateSigningRequestSpec)
@@ -115,7 +119,8 @@ func DeepCopy_certificates_CertificateSigningRequestSpec(in interface{}, out int
 	}
 }
 
-func DeepCopy_certificates_CertificateSigningRequestStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycertificatesCertificateSigningRequestStatus ...
+func DeepCopycertificatesCertificateSigningRequestStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CertificateSigningRequestStatus)
 		out := out.(*CertificateSigningRequestStatus)
@@ -124,7 +129,7 @@ func DeepCopy_certificates_CertificateSigningRequestStatus(in interface{}, out i
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]CertificateSigningRequestCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_certificates_CertificateSigningRequestCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopycertificatesCertificateSigningRequestCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -35,22 +35,23 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_AdmissionConfiguration, InType: reflect.TypeOf(&AdmissionConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_AdmissionPluginConfiguration, InType: reflect.TypeOf(&AdmissionPluginConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeProxyConfiguration, InType: reflect.TypeOf(&KubeProxyConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeSchedulerConfiguration, InType: reflect.TypeOf(&KubeSchedulerConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeletAnonymousAuthentication, InType: reflect.TypeOf(&KubeletAnonymousAuthentication{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeletAuthentication, InType: reflect.TypeOf(&KubeletAuthentication{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeletAuthorization, InType: reflect.TypeOf(&KubeletAuthorization{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeletConfiguration, InType: reflect.TypeOf(&KubeletConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeletWebhookAuthentication, InType: reflect.TypeOf(&KubeletWebhookAuthentication{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeletWebhookAuthorization, InType: reflect.TypeOf(&KubeletWebhookAuthorization{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_KubeletX509Authentication, InType: reflect.TypeOf(&KubeletX509Authentication{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_LeaderElectionConfiguration, InType: reflect.TypeOf(&LeaderElectionConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1AdmissionConfiguration, InType: reflect.TypeOf(&AdmissionConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1AdmissionPluginConfiguration, InType: reflect.TypeOf(&AdmissionPluginConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeProxyConfiguration, InType: reflect.TypeOf(&KubeProxyConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeSchedulerConfiguration, InType: reflect.TypeOf(&KubeSchedulerConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeletAnonymousAuthentication, InType: reflect.TypeOf(&KubeletAnonymousAuthentication{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeletAuthentication, InType: reflect.TypeOf(&KubeletAuthentication{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeletAuthorization, InType: reflect.TypeOf(&KubeletAuthorization{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeletConfiguration, InType: reflect.TypeOf(&KubeletConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeletWebhookAuthentication, InType: reflect.TypeOf(&KubeletWebhookAuthentication{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeletWebhookAuthorization, InType: reflect.TypeOf(&KubeletWebhookAuthorization{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1KubeletX509Authentication, InType: reflect.TypeOf(&KubeletX509Authentication{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1LeaderElectionConfiguration, InType: reflect.TypeOf(&LeaderElectionConfiguration{})},
 	)
 }
 
-func DeepCopy_v1alpha1_AdmissionConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1AdmissionConfiguration ...
+func DeepCopyv1alpha1AdmissionConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AdmissionConfiguration)
 		out := out.(*AdmissionConfiguration)
@@ -59,7 +60,7 @@ func DeepCopy_v1alpha1_AdmissionConfiguration(in interface{}, out interface{}, c
 			in, out := &in.Plugins, &out.Plugins
 			*out = make([]AdmissionPluginConfiguration, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_AdmissionPluginConfiguration(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1alpha1AdmissionPluginConfiguration(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -68,21 +69,23 @@ func DeepCopy_v1alpha1_AdmissionConfiguration(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_v1alpha1_AdmissionPluginConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1AdmissionPluginConfiguration ...
+func DeepCopyv1alpha1AdmissionPluginConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AdmissionPluginConfiguration)
 		out := out.(*AdmissionPluginConfiguration)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.Configuration); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.Configuration); err == nil {
 			out.Configuration = *newVal.(*runtime.RawExtension)
+		} else {
+			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1alpha1_KubeProxyConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeProxyConfiguration ...
+func DeepCopyv1alpha1KubeProxyConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeProxyConfiguration)
 		out := out.(*KubeProxyConfiguration)
@@ -101,7 +104,8 @@ func DeepCopy_v1alpha1_KubeProxyConfiguration(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_v1alpha1_KubeSchedulerConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeSchedulerConfiguration ...
+func DeepCopyv1alpha1KubeSchedulerConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeSchedulerConfiguration)
 		out := out.(*KubeSchedulerConfiguration)
@@ -111,14 +115,15 @@ func DeepCopy_v1alpha1_KubeSchedulerConfiguration(in interface{}, out interface{
 			*out = new(bool)
 			**out = **in
 		}
-		if err := DeepCopy_v1alpha1_LeaderElectionConfiguration(&in.LeaderElection, &out.LeaderElection, c); err != nil {
+		if err := DeepCopyv1alpha1LeaderElectionConfiguration(&in.LeaderElection, &out.LeaderElection, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1alpha1_KubeletAnonymousAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeletAnonymousAuthentication ...
+func DeepCopyv1alpha1KubeletAnonymousAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletAnonymousAuthentication)
 		out := out.(*KubeletAnonymousAuthentication)
@@ -132,22 +137,24 @@ func DeepCopy_v1alpha1_KubeletAnonymousAuthentication(in interface{}, out interf
 	}
 }
 
-func DeepCopy_v1alpha1_KubeletAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeletAuthentication ...
+func DeepCopyv1alpha1KubeletAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletAuthentication)
 		out := out.(*KubeletAuthentication)
 		*out = *in
-		if err := DeepCopy_v1alpha1_KubeletWebhookAuthentication(&in.Webhook, &out.Webhook, c); err != nil {
+		if err := DeepCopyv1alpha1KubeletWebhookAuthentication(&in.Webhook, &out.Webhook, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_v1alpha1_KubeletAnonymousAuthentication(&in.Anonymous, &out.Anonymous, c); err != nil {
+		if err := DeepCopyv1alpha1KubeletAnonymousAuthentication(&in.Anonymous, &out.Anonymous, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1alpha1_KubeletAuthorization(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeletAuthorization ...
+func DeepCopyv1alpha1KubeletAuthorization(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletAuthorization)
 		out := out.(*KubeletAuthorization)
@@ -156,7 +163,8 @@ func DeepCopy_v1alpha1_KubeletAuthorization(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeletConfiguration ...
+func DeepCopyv1alpha1KubeletConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletConfiguration)
 		out := out.(*KubeletConfiguration)
@@ -166,7 +174,7 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 			*out = new(bool)
 			**out = **in
 		}
-		if err := DeepCopy_v1alpha1_KubeletAuthentication(&in.Authentication, &out.Authentication, c); err != nil {
+		if err := DeepCopyv1alpha1KubeletAuthentication(&in.Authentication, &out.Authentication, c); err != nil {
 			return err
 		}
 		if in.AllowPrivileged != nil {
@@ -258,7 +266,7 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 			in, out := &in.RegisterWithTaints, &out.RegisterWithTaints
 			*out = make([]v1.Taint, len(*in))
 			for i := range *in {
-				if err := v1.DeepCopy_v1_Taint(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := v1.DeepCopyv1Taint(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -333,7 +341,8 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_v1alpha1_KubeletWebhookAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeletWebhookAuthentication ...
+func DeepCopyv1alpha1KubeletWebhookAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletWebhookAuthentication)
 		out := out.(*KubeletWebhookAuthentication)
@@ -347,7 +356,8 @@ func DeepCopy_v1alpha1_KubeletWebhookAuthentication(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_v1alpha1_KubeletWebhookAuthorization(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeletWebhookAuthorization ...
+func DeepCopyv1alpha1KubeletWebhookAuthorization(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletWebhookAuthorization)
 		out := out.(*KubeletWebhookAuthorization)
@@ -356,7 +366,8 @@ func DeepCopy_v1alpha1_KubeletWebhookAuthorization(in interface{}, out interface
 	}
 }
 
-func DeepCopy_v1alpha1_KubeletX509Authentication(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1KubeletX509Authentication ...
+func DeepCopyv1alpha1KubeletX509Authentication(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletX509Authentication)
 		out := out.(*KubeletX509Authentication)
@@ -365,7 +376,8 @@ func DeepCopy_v1alpha1_KubeletX509Authentication(in interface{}, out interface{}
 	}
 }
 
-func DeepCopy_v1alpha1_LeaderElectionConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1LeaderElectionConfiguration ...
+func DeepCopyv1alpha1LeaderElectionConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LeaderElectionConfiguration)
 		out := out.(*LeaderElectionConfiguration)

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -35,27 +35,28 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_AdmissionConfiguration, InType: reflect.TypeOf(&AdmissionConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_AdmissionPluginConfiguration, InType: reflect.TypeOf(&AdmissionPluginConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_IPVar, InType: reflect.TypeOf(&IPVar{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeControllerManagerConfiguration, InType: reflect.TypeOf(&KubeControllerManagerConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeProxyConfiguration, InType: reflect.TypeOf(&KubeProxyConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeSchedulerConfiguration, InType: reflect.TypeOf(&KubeSchedulerConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeletAnonymousAuthentication, InType: reflect.TypeOf(&KubeletAnonymousAuthentication{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeletAuthentication, InType: reflect.TypeOf(&KubeletAuthentication{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeletAuthorization, InType: reflect.TypeOf(&KubeletAuthorization{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeletConfiguration, InType: reflect.TypeOf(&KubeletConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeletWebhookAuthentication, InType: reflect.TypeOf(&KubeletWebhookAuthentication{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeletWebhookAuthorization, InType: reflect.TypeOf(&KubeletWebhookAuthorization{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_KubeletX509Authentication, InType: reflect.TypeOf(&KubeletX509Authentication{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_LeaderElectionConfiguration, InType: reflect.TypeOf(&LeaderElectionConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_PersistentVolumeRecyclerConfiguration, InType: reflect.TypeOf(&PersistentVolumeRecyclerConfiguration{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_PortRangeVar, InType: reflect.TypeOf(&PortRangeVar{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_componentconfig_VolumeConfiguration, InType: reflect.TypeOf(&VolumeConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigAdmissionConfiguration, InType: reflect.TypeOf(&AdmissionConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigAdmissionPluginConfiguration, InType: reflect.TypeOf(&AdmissionPluginConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigIPVar, InType: reflect.TypeOf(&IPVar{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeControllerManagerConfiguration, InType: reflect.TypeOf(&KubeControllerManagerConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeProxyConfiguration, InType: reflect.TypeOf(&KubeProxyConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeSchedulerConfiguration, InType: reflect.TypeOf(&KubeSchedulerConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeletAnonymousAuthentication, InType: reflect.TypeOf(&KubeletAnonymousAuthentication{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeletAuthentication, InType: reflect.TypeOf(&KubeletAuthentication{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeletAuthorization, InType: reflect.TypeOf(&KubeletAuthorization{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeletConfiguration, InType: reflect.TypeOf(&KubeletConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeletWebhookAuthentication, InType: reflect.TypeOf(&KubeletWebhookAuthentication{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeletWebhookAuthorization, InType: reflect.TypeOf(&KubeletWebhookAuthorization{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigKubeletX509Authentication, InType: reflect.TypeOf(&KubeletX509Authentication{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigLeaderElectionConfiguration, InType: reflect.TypeOf(&LeaderElectionConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigPersistentVolumeRecyclerConfiguration, InType: reflect.TypeOf(&PersistentVolumeRecyclerConfiguration{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigPortRangeVar, InType: reflect.TypeOf(&PortRangeVar{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopycomponentconfigVolumeConfiguration, InType: reflect.TypeOf(&VolumeConfiguration{})},
 	)
 }
 
-func DeepCopy_componentconfig_AdmissionConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigAdmissionConfiguration ...
+func DeepCopycomponentconfigAdmissionConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AdmissionConfiguration)
 		out := out.(*AdmissionConfiguration)
@@ -64,7 +65,7 @@ func DeepCopy_componentconfig_AdmissionConfiguration(in interface{}, out interfa
 			in, out := &in.Plugins, &out.Plugins
 			*out = make([]AdmissionPluginConfiguration, len(*in))
 			for i := range *in {
-				if err := DeepCopy_componentconfig_AdmissionPluginConfiguration(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopycomponentconfigAdmissionPluginConfiguration(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -73,24 +74,26 @@ func DeepCopy_componentconfig_AdmissionConfiguration(in interface{}, out interfa
 	}
 }
 
-func DeepCopy_componentconfig_AdmissionPluginConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigAdmissionPluginConfiguration ...
+func DeepCopycomponentconfigAdmissionPluginConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*AdmissionPluginConfiguration)
 		out := out.(*AdmissionPluginConfiguration)
 		*out = *in
 		// in.Configuration is kind 'Interface'
 		if in.Configuration != nil {
-			if newVal, err := c.DeepCopy(&in.Configuration); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(&in.Configuration); err == nil {
 				out.Configuration = *newVal.(*runtime.Object)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_componentconfig_IPVar(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigIPVar ...
+func DeepCopycomponentconfigIPVar(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IPVar)
 		out := out.(*IPVar)
@@ -104,7 +107,8 @@ func DeepCopy_componentconfig_IPVar(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_componentconfig_KubeControllerManagerConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeControllerManagerConfiguration ...
+func DeepCopycomponentconfigKubeControllerManagerConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeControllerManagerConfiguration)
 		out := out.(*KubeControllerManagerConfiguration)
@@ -118,7 +122,8 @@ func DeepCopy_componentconfig_KubeControllerManagerConfiguration(in interface{},
 	}
 }
 
-func DeepCopy_componentconfig_KubeProxyConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeProxyConfiguration ...
+func DeepCopycomponentconfigKubeProxyConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeProxyConfiguration)
 		out := out.(*KubeProxyConfiguration)
@@ -137,7 +142,8 @@ func DeepCopy_componentconfig_KubeProxyConfiguration(in interface{}, out interfa
 	}
 }
 
-func DeepCopy_componentconfig_KubeSchedulerConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeSchedulerConfiguration ...
+func DeepCopycomponentconfigKubeSchedulerConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeSchedulerConfiguration)
 		out := out.(*KubeSchedulerConfiguration)
@@ -146,7 +152,8 @@ func DeepCopy_componentconfig_KubeSchedulerConfiguration(in interface{}, out int
 	}
 }
 
-func DeepCopy_componentconfig_KubeletAnonymousAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeletAnonymousAuthentication ...
+func DeepCopycomponentconfigKubeletAnonymousAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletAnonymousAuthentication)
 		out := out.(*KubeletAnonymousAuthentication)
@@ -155,7 +162,8 @@ func DeepCopy_componentconfig_KubeletAnonymousAuthentication(in interface{}, out
 	}
 }
 
-func DeepCopy_componentconfig_KubeletAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeletAuthentication ...
+func DeepCopycomponentconfigKubeletAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletAuthentication)
 		out := out.(*KubeletAuthentication)
@@ -164,7 +172,8 @@ func DeepCopy_componentconfig_KubeletAuthentication(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_componentconfig_KubeletAuthorization(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeletAuthorization ...
+func DeepCopycomponentconfigKubeletAuthorization(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletAuthorization)
 		out := out.(*KubeletAuthorization)
@@ -173,7 +182,8 @@ func DeepCopy_componentconfig_KubeletAuthorization(in interface{}, out interface
 	}
 }
 
-func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeletConfiguration ...
+func DeepCopycomponentconfigKubeletConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletConfiguration)
 		out := out.(*KubeletConfiguration)
@@ -197,7 +207,7 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 			in, out := &in.RegisterWithTaints, &out.RegisterWithTaints
 			*out = make([]api.Taint, len(*in))
 			for i := range *in {
-				if err := api.DeepCopy_api_Taint(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := api.DeepCopyapiTaint(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -232,7 +242,8 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 	}
 }
 
-func DeepCopy_componentconfig_KubeletWebhookAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeletWebhookAuthentication ...
+func DeepCopycomponentconfigKubeletWebhookAuthentication(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletWebhookAuthentication)
 		out := out.(*KubeletWebhookAuthentication)
@@ -241,7 +252,8 @@ func DeepCopy_componentconfig_KubeletWebhookAuthentication(in interface{}, out i
 	}
 }
 
-func DeepCopy_componentconfig_KubeletWebhookAuthorization(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeletWebhookAuthorization ...
+func DeepCopycomponentconfigKubeletWebhookAuthorization(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletWebhookAuthorization)
 		out := out.(*KubeletWebhookAuthorization)
@@ -250,7 +262,8 @@ func DeepCopy_componentconfig_KubeletWebhookAuthorization(in interface{}, out in
 	}
 }
 
-func DeepCopy_componentconfig_KubeletX509Authentication(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigKubeletX509Authentication ...
+func DeepCopycomponentconfigKubeletX509Authentication(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*KubeletX509Authentication)
 		out := out.(*KubeletX509Authentication)
@@ -259,7 +272,8 @@ func DeepCopy_componentconfig_KubeletX509Authentication(in interface{}, out inte
 	}
 }
 
-func DeepCopy_componentconfig_LeaderElectionConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigLeaderElectionConfiguration ...
+func DeepCopycomponentconfigLeaderElectionConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LeaderElectionConfiguration)
 		out := out.(*LeaderElectionConfiguration)
@@ -268,7 +282,8 @@ func DeepCopy_componentconfig_LeaderElectionConfiguration(in interface{}, out in
 	}
 }
 
-func DeepCopy_componentconfig_PersistentVolumeRecyclerConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigPersistentVolumeRecyclerConfiguration ...
+func DeepCopycomponentconfigPersistentVolumeRecyclerConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PersistentVolumeRecyclerConfiguration)
 		out := out.(*PersistentVolumeRecyclerConfiguration)
@@ -277,7 +292,8 @@ func DeepCopy_componentconfig_PersistentVolumeRecyclerConfiguration(in interface
 	}
 }
 
-func DeepCopy_componentconfig_PortRangeVar(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigPortRangeVar ...
+func DeepCopycomponentconfigPortRangeVar(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PortRangeVar)
 		out := out.(*PortRangeVar)
@@ -291,7 +307,8 @@ func DeepCopy_componentconfig_PortRangeVar(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_componentconfig_VolumeConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopycomponentconfigVolumeConfiguration ...
+func DeepCopycomponentconfigVolumeConfiguration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*VolumeConfiguration)
 		out := out.(*VolumeConfiguration)

--- a/pkg/apis/extensions/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.deepcopy.go
@@ -37,66 +37,67 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_APIVersion, InType: reflect.TypeOf(&APIVersion{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CustomMetricCurrentStatus, InType: reflect.TypeOf(&CustomMetricCurrentStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CustomMetricCurrentStatusList, InType: reflect.TypeOf(&CustomMetricCurrentStatusList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CustomMetricTarget, InType: reflect.TypeOf(&CustomMetricTarget{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_CustomMetricTargetList, InType: reflect.TypeOf(&CustomMetricTargetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DaemonSet, InType: reflect.TypeOf(&DaemonSet{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DaemonSetList, InType: reflect.TypeOf(&DaemonSetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DaemonSetSpec, InType: reflect.TypeOf(&DaemonSetSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DaemonSetStatus, InType: reflect.TypeOf(&DaemonSetStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_Deployment, InType: reflect.TypeOf(&Deployment{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DeploymentCondition, InType: reflect.TypeOf(&DeploymentCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DeploymentList, InType: reflect.TypeOf(&DeploymentList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DeploymentRollback, InType: reflect.TypeOf(&DeploymentRollback{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DeploymentSpec, InType: reflect.TypeOf(&DeploymentSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DeploymentStatus, InType: reflect.TypeOf(&DeploymentStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_DeploymentStrategy, InType: reflect.TypeOf(&DeploymentStrategy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_FSGroupStrategyOptions, InType: reflect.TypeOf(&FSGroupStrategyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_HTTPIngressPath, InType: reflect.TypeOf(&HTTPIngressPath{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_HTTPIngressRuleValue, InType: reflect.TypeOf(&HTTPIngressRuleValue{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_HostPortRange, InType: reflect.TypeOf(&HostPortRange{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_IDRange, InType: reflect.TypeOf(&IDRange{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_Ingress, InType: reflect.TypeOf(&Ingress{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_IngressBackend, InType: reflect.TypeOf(&IngressBackend{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_IngressList, InType: reflect.TypeOf(&IngressList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_IngressRule, InType: reflect.TypeOf(&IngressRule{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_IngressRuleValue, InType: reflect.TypeOf(&IngressRuleValue{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_IngressSpec, InType: reflect.TypeOf(&IngressSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_IngressStatus, InType: reflect.TypeOf(&IngressStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_IngressTLS, InType: reflect.TypeOf(&IngressTLS{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_NetworkPolicy, InType: reflect.TypeOf(&NetworkPolicy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_NetworkPolicyIngressRule, InType: reflect.TypeOf(&NetworkPolicyIngressRule{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_NetworkPolicyList, InType: reflect.TypeOf(&NetworkPolicyList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_NetworkPolicyPeer, InType: reflect.TypeOf(&NetworkPolicyPeer{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_NetworkPolicyPort, InType: reflect.TypeOf(&NetworkPolicyPort{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_NetworkPolicySpec, InType: reflect.TypeOf(&NetworkPolicySpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PodSecurityPolicy, InType: reflect.TypeOf(&PodSecurityPolicy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PodSecurityPolicyList, InType: reflect.TypeOf(&PodSecurityPolicyList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PodSecurityPolicySpec, InType: reflect.TypeOf(&PodSecurityPolicySpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ReplicaSet, InType: reflect.TypeOf(&ReplicaSet{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ReplicaSetCondition, InType: reflect.TypeOf(&ReplicaSetCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ReplicaSetList, InType: reflect.TypeOf(&ReplicaSetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ReplicaSetSpec, InType: reflect.TypeOf(&ReplicaSetSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ReplicaSetStatus, InType: reflect.TypeOf(&ReplicaSetStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ReplicationControllerDummy, InType: reflect.TypeOf(&ReplicationControllerDummy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_RollbackConfig, InType: reflect.TypeOf(&RollbackConfig{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_RollingUpdateDeployment, InType: reflect.TypeOf(&RollingUpdateDeployment{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_RunAsUserStrategyOptions, InType: reflect.TypeOf(&RunAsUserStrategyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_SELinuxStrategyOptions, InType: reflect.TypeOf(&SELinuxStrategyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_Scale, InType: reflect.TypeOf(&Scale{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ScaleSpec, InType: reflect.TypeOf(&ScaleSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ScaleStatus, InType: reflect.TypeOf(&ScaleStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_SupplementalGroupsStrategyOptions, InType: reflect.TypeOf(&SupplementalGroupsStrategyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ThirdPartyResource, InType: reflect.TypeOf(&ThirdPartyResource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ThirdPartyResourceData, InType: reflect.TypeOf(&ThirdPartyResourceData{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ThirdPartyResourceDataList, InType: reflect.TypeOf(&ThirdPartyResourceDataList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ThirdPartyResourceList, InType: reflect.TypeOf(&ThirdPartyResourceList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1APIVersion, InType: reflect.TypeOf(&APIVersion{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CustomMetricCurrentStatus, InType: reflect.TypeOf(&CustomMetricCurrentStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CustomMetricCurrentStatusList, InType: reflect.TypeOf(&CustomMetricCurrentStatusList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CustomMetricTarget, InType: reflect.TypeOf(&CustomMetricTarget{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1CustomMetricTargetList, InType: reflect.TypeOf(&CustomMetricTargetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DaemonSet, InType: reflect.TypeOf(&DaemonSet{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DaemonSetList, InType: reflect.TypeOf(&DaemonSetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DaemonSetSpec, InType: reflect.TypeOf(&DaemonSetSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DaemonSetStatus, InType: reflect.TypeOf(&DaemonSetStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1Deployment, InType: reflect.TypeOf(&Deployment{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DeploymentCondition, InType: reflect.TypeOf(&DeploymentCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DeploymentList, InType: reflect.TypeOf(&DeploymentList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DeploymentRollback, InType: reflect.TypeOf(&DeploymentRollback{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DeploymentSpec, InType: reflect.TypeOf(&DeploymentSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DeploymentStatus, InType: reflect.TypeOf(&DeploymentStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1DeploymentStrategy, InType: reflect.TypeOf(&DeploymentStrategy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1FSGroupStrategyOptions, InType: reflect.TypeOf(&FSGroupStrategyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1HTTPIngressPath, InType: reflect.TypeOf(&HTTPIngressPath{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1HTTPIngressRuleValue, InType: reflect.TypeOf(&HTTPIngressRuleValue{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1HostPortRange, InType: reflect.TypeOf(&HostPortRange{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1IDRange, InType: reflect.TypeOf(&IDRange{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1Ingress, InType: reflect.TypeOf(&Ingress{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1IngressBackend, InType: reflect.TypeOf(&IngressBackend{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1IngressList, InType: reflect.TypeOf(&IngressList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1IngressRule, InType: reflect.TypeOf(&IngressRule{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1IngressRuleValue, InType: reflect.TypeOf(&IngressRuleValue{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1IngressSpec, InType: reflect.TypeOf(&IngressSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1IngressStatus, InType: reflect.TypeOf(&IngressStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1IngressTLS, InType: reflect.TypeOf(&IngressTLS{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1NetworkPolicy, InType: reflect.TypeOf(&NetworkPolicy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1NetworkPolicyIngressRule, InType: reflect.TypeOf(&NetworkPolicyIngressRule{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1NetworkPolicyList, InType: reflect.TypeOf(&NetworkPolicyList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1NetworkPolicyPeer, InType: reflect.TypeOf(&NetworkPolicyPeer{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1NetworkPolicyPort, InType: reflect.TypeOf(&NetworkPolicyPort{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1NetworkPolicySpec, InType: reflect.TypeOf(&NetworkPolicySpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PodSecurityPolicy, InType: reflect.TypeOf(&PodSecurityPolicy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PodSecurityPolicyList, InType: reflect.TypeOf(&PodSecurityPolicyList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PodSecurityPolicySpec, InType: reflect.TypeOf(&PodSecurityPolicySpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ReplicaSet, InType: reflect.TypeOf(&ReplicaSet{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ReplicaSetCondition, InType: reflect.TypeOf(&ReplicaSetCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ReplicaSetList, InType: reflect.TypeOf(&ReplicaSetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ReplicaSetSpec, InType: reflect.TypeOf(&ReplicaSetSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ReplicaSetStatus, InType: reflect.TypeOf(&ReplicaSetStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ReplicationControllerDummy, InType: reflect.TypeOf(&ReplicationControllerDummy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1RollbackConfig, InType: reflect.TypeOf(&RollbackConfig{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1RollingUpdateDeployment, InType: reflect.TypeOf(&RollingUpdateDeployment{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1RunAsUserStrategyOptions, InType: reflect.TypeOf(&RunAsUserStrategyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1SELinuxStrategyOptions, InType: reflect.TypeOf(&SELinuxStrategyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1Scale, InType: reflect.TypeOf(&Scale{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ScaleSpec, InType: reflect.TypeOf(&ScaleSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ScaleStatus, InType: reflect.TypeOf(&ScaleStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1SupplementalGroupsStrategyOptions, InType: reflect.TypeOf(&SupplementalGroupsStrategyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ThirdPartyResource, InType: reflect.TypeOf(&ThirdPartyResource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ThirdPartyResourceData, InType: reflect.TypeOf(&ThirdPartyResourceData{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ThirdPartyResourceDataList, InType: reflect.TypeOf(&ThirdPartyResourceDataList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ThirdPartyResourceList, InType: reflect.TypeOf(&ThirdPartyResourceList{})},
 	)
 }
 
-func DeepCopy_v1beta1_APIVersion(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1APIVersion ...
+func DeepCopyv1beta1APIVersion(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIVersion)
 		out := out.(*APIVersion)
@@ -105,7 +106,8 @@ func DeepCopy_v1beta1_APIVersion(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1beta1_CustomMetricCurrentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CustomMetricCurrentStatus ...
+func DeepCopyv1beta1CustomMetricCurrentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CustomMetricCurrentStatus)
 		out := out.(*CustomMetricCurrentStatus)
@@ -115,7 +117,8 @@ func DeepCopy_v1beta1_CustomMetricCurrentStatus(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_v1beta1_CustomMetricCurrentStatusList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CustomMetricCurrentStatusList ...
+func DeepCopyv1beta1CustomMetricCurrentStatusList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CustomMetricCurrentStatusList)
 		out := out.(*CustomMetricCurrentStatusList)
@@ -124,7 +127,7 @@ func DeepCopy_v1beta1_CustomMetricCurrentStatusList(in interface{}, out interfac
 			in, out := &in.Items, &out.Items
 			*out = make([]CustomMetricCurrentStatus, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_CustomMetricCurrentStatus(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1CustomMetricCurrentStatus(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -133,7 +136,8 @@ func DeepCopy_v1beta1_CustomMetricCurrentStatusList(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_v1beta1_CustomMetricTarget(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CustomMetricTarget ...
+func DeepCopyv1beta1CustomMetricTarget(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CustomMetricTarget)
 		out := out.(*CustomMetricTarget)
@@ -143,7 +147,8 @@ func DeepCopy_v1beta1_CustomMetricTarget(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_v1beta1_CustomMetricTargetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1CustomMetricTargetList ...
+func DeepCopyv1beta1CustomMetricTargetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CustomMetricTargetList)
 		out := out.(*CustomMetricTargetList)
@@ -152,7 +157,7 @@ func DeepCopy_v1beta1_CustomMetricTargetList(in interface{}, out interface{}, c 
 			in, out := &in.Items, &out.Items
 			*out = make([]CustomMetricTarget, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_CustomMetricTarget(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1CustomMetricTarget(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -161,24 +166,26 @@ func DeepCopy_v1beta1_CustomMetricTargetList(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1beta1_DaemonSet(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DaemonSet ...
+func DeepCopyv1beta1DaemonSet(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonSet)
 		out := out.(*DaemonSet)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1beta1_DaemonSetSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1beta1DaemonSetSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_DaemonSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DaemonSetList ...
+func DeepCopyv1beta1DaemonSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonSetList)
 		out := out.(*DaemonSetList)
@@ -187,7 +194,7 @@ func DeepCopy_v1beta1_DaemonSetList(in interface{}, out interface{}, c *conversi
 			in, out := &in.Items, &out.Items
 			*out = make([]DaemonSet, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_DaemonSet(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1DaemonSet(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -196,27 +203,29 @@ func DeepCopy_v1beta1_DaemonSetList(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1beta1_DaemonSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DaemonSetSpec ...
+func DeepCopyv1beta1DaemonSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonSetSpec)
 		out := out.(*DaemonSetSpec)
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := api_v1.DeepCopy_v1_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api_v1.DeepCopyv1PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_DaemonSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DaemonSetStatus ...
+func DeepCopyv1beta1DaemonSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonSetStatus)
 		out := out.(*DaemonSetStatus)
@@ -225,27 +234,29 @@ func DeepCopy_v1beta1_DaemonSetStatus(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1beta1_Deployment(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1Deployment ...
+func DeepCopyv1beta1Deployment(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Deployment)
 		out := out.(*Deployment)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1beta1_DeploymentSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1beta1_DeploymentStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1DeploymentSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1beta1DeploymentStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_DeploymentCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DeploymentCondition ...
+func DeepCopyv1beta1DeploymentCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentCondition)
 		out := out.(*DeploymentCondition)
@@ -256,7 +267,8 @@ func DeepCopy_v1beta1_DeploymentCondition(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_v1beta1_DeploymentList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DeploymentList ...
+func DeepCopyv1beta1DeploymentList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentList)
 		out := out.(*DeploymentList)
@@ -265,7 +277,7 @@ func DeepCopy_v1beta1_DeploymentList(in interface{}, out interface{}, c *convers
 			in, out := &in.Items, &out.Items
 			*out = make([]Deployment, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_Deployment(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1Deployment(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -274,7 +286,8 @@ func DeepCopy_v1beta1_DeploymentList(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1beta1_DeploymentRollback(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DeploymentRollback ...
+func DeepCopyv1beta1DeploymentRollback(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentRollback)
 		out := out.(*DeploymentRollback)
@@ -290,7 +303,8 @@ func DeepCopy_v1beta1_DeploymentRollback(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_v1beta1_DeploymentSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DeploymentSpec ...
+func DeepCopyv1beta1DeploymentSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentSpec)
 		out := out.(*DeploymentSpec)
@@ -302,16 +316,16 @@ func DeepCopy_v1beta1_DeploymentSpec(in interface{}, out interface{}, c *convers
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := api_v1.DeepCopy_v1_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api_v1.DeepCopyv1PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_v1beta1_DeploymentStrategy(&in.Strategy, &out.Strategy, c); err != nil {
+		if err := DeepCopyv1beta1DeploymentStrategy(&in.Strategy, &out.Strategy, c); err != nil {
 			return err
 		}
 		if in.RevisionHistoryLimit != nil {
@@ -333,7 +347,8 @@ func DeepCopy_v1beta1_DeploymentSpec(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1beta1_DeploymentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DeploymentStatus ...
+func DeepCopyv1beta1DeploymentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentStatus)
 		out := out.(*DeploymentStatus)
@@ -342,7 +357,7 @@ func DeepCopy_v1beta1_DeploymentStatus(in interface{}, out interface{}, c *conve
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]DeploymentCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_DeploymentCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1DeploymentCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -351,7 +366,8 @@ func DeepCopy_v1beta1_DeploymentStatus(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1beta1_DeploymentStrategy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1DeploymentStrategy ...
+func DeepCopyv1beta1DeploymentStrategy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentStrategy)
 		out := out.(*DeploymentStrategy)
@@ -359,7 +375,7 @@ func DeepCopy_v1beta1_DeploymentStrategy(in interface{}, out interface{}, c *con
 		if in.RollingUpdate != nil {
 			in, out := &in.RollingUpdate, &out.RollingUpdate
 			*out = new(RollingUpdateDeployment)
-			if err := DeepCopy_v1beta1_RollingUpdateDeployment(*in, *out, c); err != nil {
+			if err := DeepCopyv1beta1RollingUpdateDeployment(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -367,7 +383,8 @@ func DeepCopy_v1beta1_DeploymentStrategy(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_v1beta1_FSGroupStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1FSGroupStrategyOptions ...
+func DeepCopyv1beta1FSGroupStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FSGroupStrategyOptions)
 		out := out.(*FSGroupStrategyOptions)
@@ -381,7 +398,8 @@ func DeepCopy_v1beta1_FSGroupStrategyOptions(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1beta1_HTTPIngressPath(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1HTTPIngressPath ...
+func DeepCopyv1beta1HTTPIngressPath(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HTTPIngressPath)
 		out := out.(*HTTPIngressPath)
@@ -390,7 +408,8 @@ func DeepCopy_v1beta1_HTTPIngressPath(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1beta1_HTTPIngressRuleValue(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1HTTPIngressRuleValue ...
+func DeepCopyv1beta1HTTPIngressRuleValue(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HTTPIngressRuleValue)
 		out := out.(*HTTPIngressRuleValue)
@@ -404,7 +423,8 @@ func DeepCopy_v1beta1_HTTPIngressRuleValue(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_v1beta1_HostPortRange(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1HostPortRange ...
+func DeepCopyv1beta1HostPortRange(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HostPortRange)
 		out := out.(*HostPortRange)
@@ -413,7 +433,8 @@ func DeepCopy_v1beta1_HostPortRange(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_v1beta1_IDRange(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1IDRange ...
+func DeepCopyv1beta1IDRange(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IDRange)
 		out := out.(*IDRange)
@@ -422,27 +443,29 @@ func DeepCopy_v1beta1_IDRange(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1beta1_Ingress(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1Ingress ...
+func DeepCopyv1beta1Ingress(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Ingress)
 		out := out.(*Ingress)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1beta1_IngressSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1beta1_IngressStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1IngressSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1beta1IngressStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_IngressBackend(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1IngressBackend ...
+func DeepCopyv1beta1IngressBackend(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressBackend)
 		out := out.(*IngressBackend)
@@ -451,7 +474,8 @@ func DeepCopy_v1beta1_IngressBackend(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1beta1_IngressList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1IngressList ...
+func DeepCopyv1beta1IngressList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressList)
 		out := out.(*IngressList)
@@ -460,7 +484,7 @@ func DeepCopy_v1beta1_IngressList(in interface{}, out interface{}, c *conversion
 			in, out := &in.Items, &out.Items
 			*out = make([]Ingress, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_Ingress(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1Ingress(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -469,19 +493,21 @@ func DeepCopy_v1beta1_IngressList(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1beta1_IngressRule(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1IngressRule ...
+func DeepCopyv1beta1IngressRule(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressRule)
 		out := out.(*IngressRule)
 		*out = *in
-		if err := DeepCopy_v1beta1_IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, c); err != nil {
+		if err := DeepCopyv1beta1IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_IngressRuleValue(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1IngressRuleValue ...
+func DeepCopyv1beta1IngressRuleValue(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressRuleValue)
 		out := out.(*IngressRuleValue)
@@ -489,7 +515,7 @@ func DeepCopy_v1beta1_IngressRuleValue(in interface{}, out interface{}, c *conve
 		if in.HTTP != nil {
 			in, out := &in.HTTP, &out.HTTP
 			*out = new(HTTPIngressRuleValue)
-			if err := DeepCopy_v1beta1_HTTPIngressRuleValue(*in, *out, c); err != nil {
+			if err := DeepCopyv1beta1HTTPIngressRuleValue(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -497,7 +523,8 @@ func DeepCopy_v1beta1_IngressRuleValue(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1beta1_IngressSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1IngressSpec ...
+func DeepCopyv1beta1IngressSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressSpec)
 		out := out.(*IngressSpec)
@@ -511,7 +538,7 @@ func DeepCopy_v1beta1_IngressSpec(in interface{}, out interface{}, c *conversion
 			in, out := &in.TLS, &out.TLS
 			*out = make([]IngressTLS, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_IngressTLS(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1IngressTLS(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -520,7 +547,7 @@ func DeepCopy_v1beta1_IngressSpec(in interface{}, out interface{}, c *conversion
 			in, out := &in.Rules, &out.Rules
 			*out = make([]IngressRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_IngressRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1IngressRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -529,19 +556,21 @@ func DeepCopy_v1beta1_IngressSpec(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1beta1_IngressStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1IngressStatus ...
+func DeepCopyv1beta1IngressStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressStatus)
 		out := out.(*IngressStatus)
 		*out = *in
-		if err := api_v1.DeepCopy_v1_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, c); err != nil {
+		if err := api_v1.DeepCopyv1LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_IngressTLS(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1IngressTLS ...
+func DeepCopyv1beta1IngressTLS(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressTLS)
 		out := out.(*IngressTLS)
@@ -555,24 +584,26 @@ func DeepCopy_v1beta1_IngressTLS(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1beta1_NetworkPolicy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1NetworkPolicy ...
+func DeepCopyv1beta1NetworkPolicy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicy)
 		out := out.(*NetworkPolicy)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1beta1_NetworkPolicySpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1beta1NetworkPolicySpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_NetworkPolicyIngressRule(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1NetworkPolicyIngressRule ...
+func DeepCopyv1beta1NetworkPolicyIngressRule(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicyIngressRule)
 		out := out.(*NetworkPolicyIngressRule)
@@ -581,7 +612,7 @@ func DeepCopy_v1beta1_NetworkPolicyIngressRule(in interface{}, out interface{}, 
 			in, out := &in.Ports, &out.Ports
 			*out = make([]NetworkPolicyPort, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_NetworkPolicyPort(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1NetworkPolicyPort(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -590,7 +621,7 @@ func DeepCopy_v1beta1_NetworkPolicyIngressRule(in interface{}, out interface{}, 
 			in, out := &in.From, &out.From
 			*out = make([]NetworkPolicyPeer, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_NetworkPolicyPeer(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1NetworkPolicyPeer(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -599,7 +630,8 @@ func DeepCopy_v1beta1_NetworkPolicyIngressRule(in interface{}, out interface{}, 
 	}
 }
 
-func DeepCopy_v1beta1_NetworkPolicyList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1NetworkPolicyList ...
+func DeepCopyv1beta1NetworkPolicyList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicyList)
 		out := out.(*NetworkPolicyList)
@@ -608,7 +640,7 @@ func DeepCopy_v1beta1_NetworkPolicyList(in interface{}, out interface{}, c *conv
 			in, out := &in.Items, &out.Items
 			*out = make([]NetworkPolicy, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_NetworkPolicy(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1NetworkPolicy(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -617,32 +649,34 @@ func DeepCopy_v1beta1_NetworkPolicyList(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_v1beta1_NetworkPolicyPeer(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1NetworkPolicyPeer ...
+func DeepCopyv1beta1NetworkPolicyPeer(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicyPeer)
 		out := out.(*NetworkPolicyPeer)
 		*out = *in
 		if in.PodSelector != nil {
 			in, out := &in.PodSelector, &out.PodSelector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		if in.NamespaceSelector != nil {
 			in, out := &in.NamespaceSelector, &out.NamespaceSelector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_NetworkPolicyPort(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1NetworkPolicyPort ...
+func DeepCopyv1beta1NetworkPolicyPort(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicyPort)
 		out := out.(*NetworkPolicyPort)
@@ -661,21 +695,22 @@ func DeepCopy_v1beta1_NetworkPolicyPort(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_v1beta1_NetworkPolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1NetworkPolicySpec ...
+func DeepCopyv1beta1NetworkPolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicySpec)
 		out := out.(*NetworkPolicySpec)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.PodSelector); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.PodSelector); err == nil {
 			out.PodSelector = *newVal.(*v1.LabelSelector)
+		} else {
+			return err
 		}
 		if in.Ingress != nil {
 			in, out := &in.Ingress, &out.Ingress
 			*out = make([]NetworkPolicyIngressRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_NetworkPolicyIngressRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1NetworkPolicyIngressRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -684,24 +719,26 @@ func DeepCopy_v1beta1_NetworkPolicySpec(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_v1beta1_PodSecurityPolicy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PodSecurityPolicy ...
+func DeepCopyv1beta1PodSecurityPolicy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSecurityPolicy)
 		out := out.(*PodSecurityPolicy)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1beta1_PodSecurityPolicySpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1beta1PodSecurityPolicySpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_PodSecurityPolicyList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PodSecurityPolicyList ...
+func DeepCopyv1beta1PodSecurityPolicyList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSecurityPolicyList)
 		out := out.(*PodSecurityPolicyList)
@@ -710,7 +747,7 @@ func DeepCopy_v1beta1_PodSecurityPolicyList(in interface{}, out interface{}, c *
 			in, out := &in.Items, &out.Items
 			*out = make([]PodSecurityPolicy, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_PodSecurityPolicy(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1PodSecurityPolicy(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -719,7 +756,8 @@ func DeepCopy_v1beta1_PodSecurityPolicyList(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_v1beta1_PodSecurityPolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PodSecurityPolicySpec ...
+func DeepCopyv1beta1PodSecurityPolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSecurityPolicySpec)
 		out := out.(*PodSecurityPolicySpec)
@@ -749,43 +787,45 @@ func DeepCopy_v1beta1_PodSecurityPolicySpec(in interface{}, out interface{}, c *
 			*out = make([]HostPortRange, len(*in))
 			copy(*out, *in)
 		}
-		if err := DeepCopy_v1beta1_SELinuxStrategyOptions(&in.SELinux, &out.SELinux, c); err != nil {
+		if err := DeepCopyv1beta1SELinuxStrategyOptions(&in.SELinux, &out.SELinux, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_v1beta1_RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, c); err != nil {
+		if err := DeepCopyv1beta1RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_v1beta1_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
+		if err := DeepCopyv1beta1SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_v1beta1_FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, c); err != nil {
+		if err := DeepCopyv1beta1FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_ReplicaSet(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ReplicaSet ...
+func DeepCopyv1beta1ReplicaSet(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSet)
 		out := out.(*ReplicaSet)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1beta1_ReplicaSetSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1beta1_ReplicaSetStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1ReplicaSetSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1beta1ReplicaSetStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_ReplicaSetCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ReplicaSetCondition ...
+func DeepCopyv1beta1ReplicaSetCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSetCondition)
 		out := out.(*ReplicaSetCondition)
@@ -795,7 +835,8 @@ func DeepCopy_v1beta1_ReplicaSetCondition(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_v1beta1_ReplicaSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ReplicaSetList ...
+func DeepCopyv1beta1ReplicaSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSetList)
 		out := out.(*ReplicaSetList)
@@ -804,7 +845,7 @@ func DeepCopy_v1beta1_ReplicaSetList(in interface{}, out interface{}, c *convers
 			in, out := &in.Items, &out.Items
 			*out = make([]ReplicaSet, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_ReplicaSet(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1ReplicaSet(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -813,7 +854,8 @@ func DeepCopy_v1beta1_ReplicaSetList(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1beta1_ReplicaSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ReplicaSetSpec ...
+func DeepCopyv1beta1ReplicaSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSetSpec)
 		out := out.(*ReplicaSetSpec)
@@ -825,20 +867,21 @@ func DeepCopy_v1beta1_ReplicaSetSpec(in interface{}, out interface{}, c *convers
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := api_v1.DeepCopy_v1_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api_v1.DeepCopyv1PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_ReplicaSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ReplicaSetStatus ...
+func DeepCopyv1beta1ReplicaSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSetStatus)
 		out := out.(*ReplicaSetStatus)
@@ -847,7 +890,7 @@ func DeepCopy_v1beta1_ReplicaSetStatus(in interface{}, out interface{}, c *conve
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]ReplicaSetCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_ReplicaSetCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1ReplicaSetCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -856,7 +899,8 @@ func DeepCopy_v1beta1_ReplicaSetStatus(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1beta1_ReplicationControllerDummy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ReplicationControllerDummy ...
+func DeepCopyv1beta1ReplicationControllerDummy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerDummy)
 		out := out.(*ReplicationControllerDummy)
@@ -865,7 +909,8 @@ func DeepCopy_v1beta1_ReplicationControllerDummy(in interface{}, out interface{}
 	}
 }
 
-func DeepCopy_v1beta1_RollbackConfig(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1RollbackConfig ...
+func DeepCopyv1beta1RollbackConfig(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RollbackConfig)
 		out := out.(*RollbackConfig)
@@ -874,7 +919,8 @@ func DeepCopy_v1beta1_RollbackConfig(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_v1beta1_RollingUpdateDeployment(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1RollingUpdateDeployment ...
+func DeepCopyv1beta1RollingUpdateDeployment(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RollingUpdateDeployment)
 		out := out.(*RollingUpdateDeployment)
@@ -893,7 +939,8 @@ func DeepCopy_v1beta1_RollingUpdateDeployment(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_v1beta1_RunAsUserStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1RunAsUserStrategyOptions ...
+func DeepCopyv1beta1RunAsUserStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RunAsUserStrategyOptions)
 		out := out.(*RunAsUserStrategyOptions)
@@ -907,7 +954,8 @@ func DeepCopy_v1beta1_RunAsUserStrategyOptions(in interface{}, out interface{}, 
 	}
 }
 
-func DeepCopy_v1beta1_SELinuxStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1SELinuxStrategyOptions ...
+func DeepCopyv1beta1SELinuxStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SELinuxStrategyOptions)
 		out := out.(*SELinuxStrategyOptions)
@@ -921,24 +969,26 @@ func DeepCopy_v1beta1_SELinuxStrategyOptions(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1beta1_Scale(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1Scale ...
+func DeepCopyv1beta1Scale(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Scale)
 		out := out.(*Scale)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1beta1_ScaleStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1ScaleStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_ScaleSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ScaleSpec ...
+func DeepCopyv1beta1ScaleSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ScaleSpec)
 		out := out.(*ScaleSpec)
@@ -947,7 +997,8 @@ func DeepCopy_v1beta1_ScaleSpec(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1beta1_ScaleStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ScaleStatus ...
+func DeepCopyv1beta1ScaleStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ScaleStatus)
 		out := out.(*ScaleStatus)
@@ -963,7 +1014,8 @@ func DeepCopy_v1beta1_ScaleStatus(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1beta1_SupplementalGroupsStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1SupplementalGroupsStrategyOptions ...
+func DeepCopyv1beta1SupplementalGroupsStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SupplementalGroupsStrategyOptions)
 		out := out.(*SupplementalGroupsStrategyOptions)
@@ -977,15 +1029,16 @@ func DeepCopy_v1beta1_SupplementalGroupsStrategyOptions(in interface{}, out inte
 	}
 }
 
-func DeepCopy_v1beta1_ThirdPartyResource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ThirdPartyResource ...
+func DeepCopyv1beta1ThirdPartyResource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ThirdPartyResource)
 		out := out.(*ThirdPartyResource)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Versions != nil {
 			in, out := &in.Versions, &out.Versions
@@ -996,15 +1049,16 @@ func DeepCopy_v1beta1_ThirdPartyResource(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_v1beta1_ThirdPartyResourceData(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ThirdPartyResourceData ...
+func DeepCopyv1beta1ThirdPartyResourceData(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ThirdPartyResourceData)
 		out := out.(*ThirdPartyResourceData)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
@@ -1015,7 +1069,8 @@ func DeepCopy_v1beta1_ThirdPartyResourceData(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1beta1_ThirdPartyResourceDataList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ThirdPartyResourceDataList ...
+func DeepCopyv1beta1ThirdPartyResourceDataList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ThirdPartyResourceDataList)
 		out := out.(*ThirdPartyResourceDataList)
@@ -1024,7 +1079,7 @@ func DeepCopy_v1beta1_ThirdPartyResourceDataList(in interface{}, out interface{}
 			in, out := &in.Items, &out.Items
 			*out = make([]ThirdPartyResourceData, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_ThirdPartyResourceData(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1ThirdPartyResourceData(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1033,7 +1088,8 @@ func DeepCopy_v1beta1_ThirdPartyResourceDataList(in interface{}, out interface{}
 	}
 }
 
-func DeepCopy_v1beta1_ThirdPartyResourceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ThirdPartyResourceList ...
+func DeepCopyv1beta1ThirdPartyResourceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ThirdPartyResourceList)
 		out := out.(*ThirdPartyResourceList)
@@ -1042,7 +1098,7 @@ func DeepCopy_v1beta1_ThirdPartyResourceList(in interface{}, out interface{}, c 
 			in, out := &in.Items, &out.Items
 			*out = make([]ThirdPartyResource, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_ThirdPartyResource(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1ThirdPartyResource(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}

--- a/pkg/apis/extensions/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/zz_generated.deepcopy.go
@@ -37,66 +37,67 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_APIVersion, InType: reflect.TypeOf(&APIVersion{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_CustomMetricCurrentStatus, InType: reflect.TypeOf(&CustomMetricCurrentStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_CustomMetricCurrentStatusList, InType: reflect.TypeOf(&CustomMetricCurrentStatusList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_CustomMetricTarget, InType: reflect.TypeOf(&CustomMetricTarget{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_CustomMetricTargetList, InType: reflect.TypeOf(&CustomMetricTargetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DaemonSet, InType: reflect.TypeOf(&DaemonSet{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DaemonSetList, InType: reflect.TypeOf(&DaemonSetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DaemonSetSpec, InType: reflect.TypeOf(&DaemonSetSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DaemonSetStatus, InType: reflect.TypeOf(&DaemonSetStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_Deployment, InType: reflect.TypeOf(&Deployment{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DeploymentCondition, InType: reflect.TypeOf(&DeploymentCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DeploymentList, InType: reflect.TypeOf(&DeploymentList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DeploymentRollback, InType: reflect.TypeOf(&DeploymentRollback{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DeploymentSpec, InType: reflect.TypeOf(&DeploymentSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DeploymentStatus, InType: reflect.TypeOf(&DeploymentStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_DeploymentStrategy, InType: reflect.TypeOf(&DeploymentStrategy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_FSGroupStrategyOptions, InType: reflect.TypeOf(&FSGroupStrategyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_HTTPIngressPath, InType: reflect.TypeOf(&HTTPIngressPath{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_HTTPIngressRuleValue, InType: reflect.TypeOf(&HTTPIngressRuleValue{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_HostPortRange, InType: reflect.TypeOf(&HostPortRange{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_IDRange, InType: reflect.TypeOf(&IDRange{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_Ingress, InType: reflect.TypeOf(&Ingress{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_IngressBackend, InType: reflect.TypeOf(&IngressBackend{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_IngressList, InType: reflect.TypeOf(&IngressList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_IngressRule, InType: reflect.TypeOf(&IngressRule{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_IngressRuleValue, InType: reflect.TypeOf(&IngressRuleValue{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_IngressSpec, InType: reflect.TypeOf(&IngressSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_IngressStatus, InType: reflect.TypeOf(&IngressStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_IngressTLS, InType: reflect.TypeOf(&IngressTLS{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_NetworkPolicy, InType: reflect.TypeOf(&NetworkPolicy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_NetworkPolicyIngressRule, InType: reflect.TypeOf(&NetworkPolicyIngressRule{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_NetworkPolicyList, InType: reflect.TypeOf(&NetworkPolicyList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_NetworkPolicyPeer, InType: reflect.TypeOf(&NetworkPolicyPeer{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_NetworkPolicyPort, InType: reflect.TypeOf(&NetworkPolicyPort{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_NetworkPolicySpec, InType: reflect.TypeOf(&NetworkPolicySpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_PodSecurityPolicy, InType: reflect.TypeOf(&PodSecurityPolicy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_PodSecurityPolicyList, InType: reflect.TypeOf(&PodSecurityPolicyList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_PodSecurityPolicySpec, InType: reflect.TypeOf(&PodSecurityPolicySpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ReplicaSet, InType: reflect.TypeOf(&ReplicaSet{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ReplicaSetCondition, InType: reflect.TypeOf(&ReplicaSetCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ReplicaSetList, InType: reflect.TypeOf(&ReplicaSetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ReplicaSetSpec, InType: reflect.TypeOf(&ReplicaSetSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ReplicaSetStatus, InType: reflect.TypeOf(&ReplicaSetStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ReplicationControllerDummy, InType: reflect.TypeOf(&ReplicationControllerDummy{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_RollbackConfig, InType: reflect.TypeOf(&RollbackConfig{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_RollingUpdateDeployment, InType: reflect.TypeOf(&RollingUpdateDeployment{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_RunAsUserStrategyOptions, InType: reflect.TypeOf(&RunAsUserStrategyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_SELinuxStrategyOptions, InType: reflect.TypeOf(&SELinuxStrategyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_Scale, InType: reflect.TypeOf(&Scale{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ScaleSpec, InType: reflect.TypeOf(&ScaleSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ScaleStatus, InType: reflect.TypeOf(&ScaleStatus{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_SupplementalGroupsStrategyOptions, InType: reflect.TypeOf(&SupplementalGroupsStrategyOptions{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ThirdPartyResource, InType: reflect.TypeOf(&ThirdPartyResource{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ThirdPartyResourceData, InType: reflect.TypeOf(&ThirdPartyResourceData{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ThirdPartyResourceDataList, InType: reflect.TypeOf(&ThirdPartyResourceDataList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_extensions_ThirdPartyResourceList, InType: reflect.TypeOf(&ThirdPartyResourceList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsAPIVersion, InType: reflect.TypeOf(&APIVersion{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsCustomMetricCurrentStatus, InType: reflect.TypeOf(&CustomMetricCurrentStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsCustomMetricCurrentStatusList, InType: reflect.TypeOf(&CustomMetricCurrentStatusList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsCustomMetricTarget, InType: reflect.TypeOf(&CustomMetricTarget{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsCustomMetricTargetList, InType: reflect.TypeOf(&CustomMetricTargetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDaemonSet, InType: reflect.TypeOf(&DaemonSet{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDaemonSetList, InType: reflect.TypeOf(&DaemonSetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDaemonSetSpec, InType: reflect.TypeOf(&DaemonSetSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDaemonSetStatus, InType: reflect.TypeOf(&DaemonSetStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDeployment, InType: reflect.TypeOf(&Deployment{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDeploymentCondition, InType: reflect.TypeOf(&DeploymentCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDeploymentList, InType: reflect.TypeOf(&DeploymentList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDeploymentRollback, InType: reflect.TypeOf(&DeploymentRollback{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDeploymentSpec, InType: reflect.TypeOf(&DeploymentSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDeploymentStatus, InType: reflect.TypeOf(&DeploymentStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsDeploymentStrategy, InType: reflect.TypeOf(&DeploymentStrategy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsFSGroupStrategyOptions, InType: reflect.TypeOf(&FSGroupStrategyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsHTTPIngressPath, InType: reflect.TypeOf(&HTTPIngressPath{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsHTTPIngressRuleValue, InType: reflect.TypeOf(&HTTPIngressRuleValue{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsHostPortRange, InType: reflect.TypeOf(&HostPortRange{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIDRange, InType: reflect.TypeOf(&IDRange{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIngress, InType: reflect.TypeOf(&Ingress{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIngressBackend, InType: reflect.TypeOf(&IngressBackend{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIngressList, InType: reflect.TypeOf(&IngressList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIngressRule, InType: reflect.TypeOf(&IngressRule{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIngressRuleValue, InType: reflect.TypeOf(&IngressRuleValue{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIngressSpec, InType: reflect.TypeOf(&IngressSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIngressStatus, InType: reflect.TypeOf(&IngressStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsIngressTLS, InType: reflect.TypeOf(&IngressTLS{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsNetworkPolicy, InType: reflect.TypeOf(&NetworkPolicy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsNetworkPolicyIngressRule, InType: reflect.TypeOf(&NetworkPolicyIngressRule{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsNetworkPolicyList, InType: reflect.TypeOf(&NetworkPolicyList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsNetworkPolicyPeer, InType: reflect.TypeOf(&NetworkPolicyPeer{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsNetworkPolicyPort, InType: reflect.TypeOf(&NetworkPolicyPort{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsNetworkPolicySpec, InType: reflect.TypeOf(&NetworkPolicySpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsPodSecurityPolicy, InType: reflect.TypeOf(&PodSecurityPolicy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsPodSecurityPolicyList, InType: reflect.TypeOf(&PodSecurityPolicyList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsPodSecurityPolicySpec, InType: reflect.TypeOf(&PodSecurityPolicySpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsReplicaSet, InType: reflect.TypeOf(&ReplicaSet{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsReplicaSetCondition, InType: reflect.TypeOf(&ReplicaSetCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsReplicaSetList, InType: reflect.TypeOf(&ReplicaSetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsReplicaSetSpec, InType: reflect.TypeOf(&ReplicaSetSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsReplicaSetStatus, InType: reflect.TypeOf(&ReplicaSetStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsReplicationControllerDummy, InType: reflect.TypeOf(&ReplicationControllerDummy{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsRollbackConfig, InType: reflect.TypeOf(&RollbackConfig{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsRollingUpdateDeployment, InType: reflect.TypeOf(&RollingUpdateDeployment{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsRunAsUserStrategyOptions, InType: reflect.TypeOf(&RunAsUserStrategyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsSELinuxStrategyOptions, InType: reflect.TypeOf(&SELinuxStrategyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsScale, InType: reflect.TypeOf(&Scale{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsScaleSpec, InType: reflect.TypeOf(&ScaleSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsScaleStatus, InType: reflect.TypeOf(&ScaleStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsSupplementalGroupsStrategyOptions, InType: reflect.TypeOf(&SupplementalGroupsStrategyOptions{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsThirdPartyResource, InType: reflect.TypeOf(&ThirdPartyResource{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsThirdPartyResourceData, InType: reflect.TypeOf(&ThirdPartyResourceData{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsThirdPartyResourceDataList, InType: reflect.TypeOf(&ThirdPartyResourceDataList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyextensionsThirdPartyResourceList, InType: reflect.TypeOf(&ThirdPartyResourceList{})},
 	)
 }
 
-func DeepCopy_extensions_APIVersion(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsAPIVersion ...
+func DeepCopyextensionsAPIVersion(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIVersion)
 		out := out.(*APIVersion)
@@ -105,7 +106,8 @@ func DeepCopy_extensions_APIVersion(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_extensions_CustomMetricCurrentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsCustomMetricCurrentStatus ...
+func DeepCopyextensionsCustomMetricCurrentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CustomMetricCurrentStatus)
 		out := out.(*CustomMetricCurrentStatus)
@@ -115,7 +117,8 @@ func DeepCopy_extensions_CustomMetricCurrentStatus(in interface{}, out interface
 	}
 }
 
-func DeepCopy_extensions_CustomMetricCurrentStatusList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsCustomMetricCurrentStatusList ...
+func DeepCopyextensionsCustomMetricCurrentStatusList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CustomMetricCurrentStatusList)
 		out := out.(*CustomMetricCurrentStatusList)
@@ -124,7 +127,7 @@ func DeepCopy_extensions_CustomMetricCurrentStatusList(in interface{}, out inter
 			in, out := &in.Items, &out.Items
 			*out = make([]CustomMetricCurrentStatus, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_CustomMetricCurrentStatus(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsCustomMetricCurrentStatus(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -133,7 +136,8 @@ func DeepCopy_extensions_CustomMetricCurrentStatusList(in interface{}, out inter
 	}
 }
 
-func DeepCopy_extensions_CustomMetricTarget(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsCustomMetricTarget ...
+func DeepCopyextensionsCustomMetricTarget(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CustomMetricTarget)
 		out := out.(*CustomMetricTarget)
@@ -143,7 +147,8 @@ func DeepCopy_extensions_CustomMetricTarget(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_extensions_CustomMetricTargetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsCustomMetricTargetList ...
+func DeepCopyextensionsCustomMetricTargetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*CustomMetricTargetList)
 		out := out.(*CustomMetricTargetList)
@@ -152,7 +157,7 @@ func DeepCopy_extensions_CustomMetricTargetList(in interface{}, out interface{},
 			in, out := &in.Items, &out.Items
 			*out = make([]CustomMetricTarget, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_CustomMetricTarget(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsCustomMetricTarget(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -161,24 +166,26 @@ func DeepCopy_extensions_CustomMetricTargetList(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_extensions_DaemonSet(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDaemonSet ...
+func DeepCopyextensionsDaemonSet(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonSet)
 		out := out.(*DaemonSet)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_extensions_DaemonSetSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyextensionsDaemonSetSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_DaemonSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDaemonSetList ...
+func DeepCopyextensionsDaemonSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonSetList)
 		out := out.(*DaemonSetList)
@@ -187,7 +194,7 @@ func DeepCopy_extensions_DaemonSetList(in interface{}, out interface{}, c *conve
 			in, out := &in.Items, &out.Items
 			*out = make([]DaemonSet, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_DaemonSet(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsDaemonSet(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -196,27 +203,29 @@ func DeepCopy_extensions_DaemonSetList(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_extensions_DaemonSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDaemonSetSpec ...
+func DeepCopyextensionsDaemonSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonSetSpec)
 		out := out.(*DaemonSetSpec)
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := api.DeepCopy_api_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api.DeepCopyapiPodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_DaemonSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDaemonSetStatus ...
+func DeepCopyextensionsDaemonSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DaemonSetStatus)
 		out := out.(*DaemonSetStatus)
@@ -225,27 +234,29 @@ func DeepCopy_extensions_DaemonSetStatus(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_extensions_Deployment(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDeployment ...
+func DeepCopyextensionsDeployment(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Deployment)
 		out := out.(*Deployment)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_extensions_DeploymentSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_extensions_DeploymentStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyextensionsDeploymentSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyextensionsDeploymentStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_DeploymentCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDeploymentCondition ...
+func DeepCopyextensionsDeploymentCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentCondition)
 		out := out.(*DeploymentCondition)
@@ -256,7 +267,8 @@ func DeepCopy_extensions_DeploymentCondition(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_extensions_DeploymentList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDeploymentList ...
+func DeepCopyextensionsDeploymentList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentList)
 		out := out.(*DeploymentList)
@@ -265,7 +277,7 @@ func DeepCopy_extensions_DeploymentList(in interface{}, out interface{}, c *conv
 			in, out := &in.Items, &out.Items
 			*out = make([]Deployment, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_Deployment(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsDeployment(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -274,7 +286,8 @@ func DeepCopy_extensions_DeploymentList(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_extensions_DeploymentRollback(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDeploymentRollback ...
+func DeepCopyextensionsDeploymentRollback(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentRollback)
 		out := out.(*DeploymentRollback)
@@ -290,23 +303,24 @@ func DeepCopy_extensions_DeploymentRollback(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_extensions_DeploymentSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDeploymentSpec ...
+func DeepCopyextensionsDeploymentSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentSpec)
 		out := out.(*DeploymentSpec)
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := api.DeepCopy_api_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api.DeepCopyapiPodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_extensions_DeploymentStrategy(&in.Strategy, &out.Strategy, c); err != nil {
+		if err := DeepCopyextensionsDeploymentStrategy(&in.Strategy, &out.Strategy, c); err != nil {
 			return err
 		}
 		if in.RevisionHistoryLimit != nil {
@@ -328,7 +342,8 @@ func DeepCopy_extensions_DeploymentSpec(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_extensions_DeploymentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDeploymentStatus ...
+func DeepCopyextensionsDeploymentStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentStatus)
 		out := out.(*DeploymentStatus)
@@ -337,7 +352,7 @@ func DeepCopy_extensions_DeploymentStatus(in interface{}, out interface{}, c *co
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]DeploymentCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_DeploymentCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsDeploymentCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -346,7 +361,8 @@ func DeepCopy_extensions_DeploymentStatus(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_extensions_DeploymentStrategy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsDeploymentStrategy ...
+func DeepCopyextensionsDeploymentStrategy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeploymentStrategy)
 		out := out.(*DeploymentStrategy)
@@ -360,7 +376,8 @@ func DeepCopy_extensions_DeploymentStrategy(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_extensions_FSGroupStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsFSGroupStrategyOptions ...
+func DeepCopyextensionsFSGroupStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*FSGroupStrategyOptions)
 		out := out.(*FSGroupStrategyOptions)
@@ -374,7 +391,8 @@ func DeepCopy_extensions_FSGroupStrategyOptions(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_extensions_HTTPIngressPath(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsHTTPIngressPath ...
+func DeepCopyextensionsHTTPIngressPath(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HTTPIngressPath)
 		out := out.(*HTTPIngressPath)
@@ -383,7 +401,8 @@ func DeepCopy_extensions_HTTPIngressPath(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_extensions_HTTPIngressRuleValue(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsHTTPIngressRuleValue ...
+func DeepCopyextensionsHTTPIngressRuleValue(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HTTPIngressRuleValue)
 		out := out.(*HTTPIngressRuleValue)
@@ -397,7 +416,8 @@ func DeepCopy_extensions_HTTPIngressRuleValue(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_extensions_HostPortRange(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsHostPortRange ...
+func DeepCopyextensionsHostPortRange(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*HostPortRange)
 		out := out.(*HostPortRange)
@@ -406,7 +426,8 @@ func DeepCopy_extensions_HostPortRange(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_extensions_IDRange(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIDRange ...
+func DeepCopyextensionsIDRange(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IDRange)
 		out := out.(*IDRange)
@@ -415,27 +436,29 @@ func DeepCopy_extensions_IDRange(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_extensions_Ingress(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIngress ...
+func DeepCopyextensionsIngress(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Ingress)
 		out := out.(*Ingress)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_extensions_IngressSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_extensions_IngressStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyextensionsIngressSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyextensionsIngressStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_IngressBackend(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIngressBackend ...
+func DeepCopyextensionsIngressBackend(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressBackend)
 		out := out.(*IngressBackend)
@@ -444,7 +467,8 @@ func DeepCopy_extensions_IngressBackend(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_extensions_IngressList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIngressList ...
+func DeepCopyextensionsIngressList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressList)
 		out := out.(*IngressList)
@@ -453,7 +477,7 @@ func DeepCopy_extensions_IngressList(in interface{}, out interface{}, c *convers
 			in, out := &in.Items, &out.Items
 			*out = make([]Ingress, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_Ingress(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsIngress(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -462,19 +486,21 @@ func DeepCopy_extensions_IngressList(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_extensions_IngressRule(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIngressRule ...
+func DeepCopyextensionsIngressRule(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressRule)
 		out := out.(*IngressRule)
 		*out = *in
-		if err := DeepCopy_extensions_IngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, c); err != nil {
+		if err := DeepCopyextensionsIngressRuleValue(&in.IngressRuleValue, &out.IngressRuleValue, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_IngressRuleValue(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIngressRuleValue ...
+func DeepCopyextensionsIngressRuleValue(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressRuleValue)
 		out := out.(*IngressRuleValue)
@@ -482,7 +508,7 @@ func DeepCopy_extensions_IngressRuleValue(in interface{}, out interface{}, c *co
 		if in.HTTP != nil {
 			in, out := &in.HTTP, &out.HTTP
 			*out = new(HTTPIngressRuleValue)
-			if err := DeepCopy_extensions_HTTPIngressRuleValue(*in, *out, c); err != nil {
+			if err := DeepCopyextensionsHTTPIngressRuleValue(*in, *out, c); err != nil {
 				return err
 			}
 		}
@@ -490,7 +516,8 @@ func DeepCopy_extensions_IngressRuleValue(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_extensions_IngressSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIngressSpec ...
+func DeepCopyextensionsIngressSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressSpec)
 		out := out.(*IngressSpec)
@@ -504,7 +531,7 @@ func DeepCopy_extensions_IngressSpec(in interface{}, out interface{}, c *convers
 			in, out := &in.TLS, &out.TLS
 			*out = make([]IngressTLS, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_IngressTLS(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsIngressTLS(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -513,7 +540,7 @@ func DeepCopy_extensions_IngressSpec(in interface{}, out interface{}, c *convers
 			in, out := &in.Rules, &out.Rules
 			*out = make([]IngressRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_IngressRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsIngressRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -522,19 +549,21 @@ func DeepCopy_extensions_IngressSpec(in interface{}, out interface{}, c *convers
 	}
 }
 
-func DeepCopy_extensions_IngressStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIngressStatus ...
+func DeepCopyextensionsIngressStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressStatus)
 		out := out.(*IngressStatus)
 		*out = *in
-		if err := api.DeepCopy_api_LoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, c); err != nil {
+		if err := api.DeepCopyapiLoadBalancerStatus(&in.LoadBalancer, &out.LoadBalancer, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_IngressTLS(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsIngressTLS ...
+func DeepCopyextensionsIngressTLS(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*IngressTLS)
 		out := out.(*IngressTLS)
@@ -548,24 +577,26 @@ func DeepCopy_extensions_IngressTLS(in interface{}, out interface{}, c *conversi
 	}
 }
 
-func DeepCopy_extensions_NetworkPolicy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsNetworkPolicy ...
+func DeepCopyextensionsNetworkPolicy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicy)
 		out := out.(*NetworkPolicy)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_extensions_NetworkPolicySpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyextensionsNetworkPolicySpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_NetworkPolicyIngressRule(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsNetworkPolicyIngressRule ...
+func DeepCopyextensionsNetworkPolicyIngressRule(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicyIngressRule)
 		out := out.(*NetworkPolicyIngressRule)
@@ -574,7 +605,7 @@ func DeepCopy_extensions_NetworkPolicyIngressRule(in interface{}, out interface{
 			in, out := &in.Ports, &out.Ports
 			*out = make([]NetworkPolicyPort, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_NetworkPolicyPort(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsNetworkPolicyPort(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -583,7 +614,7 @@ func DeepCopy_extensions_NetworkPolicyIngressRule(in interface{}, out interface{
 			in, out := &in.From, &out.From
 			*out = make([]NetworkPolicyPeer, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_NetworkPolicyPeer(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsNetworkPolicyPeer(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -592,7 +623,8 @@ func DeepCopy_extensions_NetworkPolicyIngressRule(in interface{}, out interface{
 	}
 }
 
-func DeepCopy_extensions_NetworkPolicyList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsNetworkPolicyList ...
+func DeepCopyextensionsNetworkPolicyList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicyList)
 		out := out.(*NetworkPolicyList)
@@ -601,7 +633,7 @@ func DeepCopy_extensions_NetworkPolicyList(in interface{}, out interface{}, c *c
 			in, out := &in.Items, &out.Items
 			*out = make([]NetworkPolicy, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_NetworkPolicy(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsNetworkPolicy(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -610,32 +642,34 @@ func DeepCopy_extensions_NetworkPolicyList(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_extensions_NetworkPolicyPeer(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsNetworkPolicyPeer ...
+func DeepCopyextensionsNetworkPolicyPeer(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicyPeer)
 		out := out.(*NetworkPolicyPeer)
 		*out = *in
 		if in.PodSelector != nil {
 			in, out := &in.PodSelector, &out.PodSelector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		if in.NamespaceSelector != nil {
 			in, out := &in.NamespaceSelector, &out.NamespaceSelector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_NetworkPolicyPort(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsNetworkPolicyPort ...
+func DeepCopyextensionsNetworkPolicyPort(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicyPort)
 		out := out.(*NetworkPolicyPort)
@@ -654,21 +688,22 @@ func DeepCopy_extensions_NetworkPolicyPort(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_extensions_NetworkPolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsNetworkPolicySpec ...
+func DeepCopyextensionsNetworkPolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*NetworkPolicySpec)
 		out := out.(*NetworkPolicySpec)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.PodSelector); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.PodSelector); err == nil {
 			out.PodSelector = *newVal.(*v1.LabelSelector)
+		} else {
+			return err
 		}
 		if in.Ingress != nil {
 			in, out := &in.Ingress, &out.Ingress
 			*out = make([]NetworkPolicyIngressRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_NetworkPolicyIngressRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsNetworkPolicyIngressRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -677,24 +712,26 @@ func DeepCopy_extensions_NetworkPolicySpec(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_extensions_PodSecurityPolicy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsPodSecurityPolicy ...
+func DeepCopyextensionsPodSecurityPolicy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSecurityPolicy)
 		out := out.(*PodSecurityPolicy)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_extensions_PodSecurityPolicySpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyextensionsPodSecurityPolicySpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_PodSecurityPolicyList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsPodSecurityPolicyList ...
+func DeepCopyextensionsPodSecurityPolicyList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSecurityPolicyList)
 		out := out.(*PodSecurityPolicyList)
@@ -703,7 +740,7 @@ func DeepCopy_extensions_PodSecurityPolicyList(in interface{}, out interface{}, 
 			in, out := &in.Items, &out.Items
 			*out = make([]PodSecurityPolicy, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_PodSecurityPolicy(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsPodSecurityPolicy(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -712,7 +749,8 @@ func DeepCopy_extensions_PodSecurityPolicyList(in interface{}, out interface{}, 
 	}
 }
 
-func DeepCopy_extensions_PodSecurityPolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsPodSecurityPolicySpec ...
+func DeepCopyextensionsPodSecurityPolicySpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSecurityPolicySpec)
 		out := out.(*PodSecurityPolicySpec)
@@ -742,43 +780,45 @@ func DeepCopy_extensions_PodSecurityPolicySpec(in interface{}, out interface{}, 
 			*out = make([]HostPortRange, len(*in))
 			copy(*out, *in)
 		}
-		if err := DeepCopy_extensions_SELinuxStrategyOptions(&in.SELinux, &out.SELinux, c); err != nil {
+		if err := DeepCopyextensionsSELinuxStrategyOptions(&in.SELinux, &out.SELinux, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_extensions_RunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, c); err != nil {
+		if err := DeepCopyextensionsRunAsUserStrategyOptions(&in.RunAsUser, &out.RunAsUser, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_extensions_SupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
+		if err := DeepCopyextensionsSupplementalGroupsStrategyOptions(&in.SupplementalGroups, &out.SupplementalGroups, c); err != nil {
 			return err
 		}
-		if err := DeepCopy_extensions_FSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, c); err != nil {
+		if err := DeepCopyextensionsFSGroupStrategyOptions(&in.FSGroup, &out.FSGroup, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_ReplicaSet(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsReplicaSet ...
+func DeepCopyextensionsReplicaSet(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSet)
 		out := out.(*ReplicaSet)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_extensions_ReplicaSetSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_extensions_ReplicaSetStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyextensionsReplicaSetSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyextensionsReplicaSetStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_ReplicaSetCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsReplicaSetCondition ...
+func DeepCopyextensionsReplicaSetCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSetCondition)
 		out := out.(*ReplicaSetCondition)
@@ -788,7 +828,8 @@ func DeepCopy_extensions_ReplicaSetCondition(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_extensions_ReplicaSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsReplicaSetList ...
+func DeepCopyextensionsReplicaSetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSetList)
 		out := out.(*ReplicaSetList)
@@ -797,7 +838,7 @@ func DeepCopy_extensions_ReplicaSetList(in interface{}, out interface{}, c *conv
 			in, out := &in.Items, &out.Items
 			*out = make([]ReplicaSet, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_ReplicaSet(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsReplicaSet(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -806,27 +847,29 @@ func DeepCopy_extensions_ReplicaSetList(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_extensions_ReplicaSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsReplicaSetSpec ...
+func DeepCopyextensionsReplicaSetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSetSpec)
 		out := out.(*ReplicaSetSpec)
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
-		if err := api.DeepCopy_api_PodTemplateSpec(&in.Template, &out.Template, c); err != nil {
+		if err := api.DeepCopyapiPodTemplateSpec(&in.Template, &out.Template, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_ReplicaSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsReplicaSetStatus ...
+func DeepCopyextensionsReplicaSetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicaSetStatus)
 		out := out.(*ReplicaSetStatus)
@@ -835,7 +878,7 @@ func DeepCopy_extensions_ReplicaSetStatus(in interface{}, out interface{}, c *co
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]ReplicaSetCondition, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_ReplicaSetCondition(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsReplicaSetCondition(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -844,7 +887,8 @@ func DeepCopy_extensions_ReplicaSetStatus(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_extensions_ReplicationControllerDummy(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsReplicationControllerDummy ...
+func DeepCopyextensionsReplicationControllerDummy(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ReplicationControllerDummy)
 		out := out.(*ReplicationControllerDummy)
@@ -853,7 +897,8 @@ func DeepCopy_extensions_ReplicationControllerDummy(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_extensions_RollbackConfig(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsRollbackConfig ...
+func DeepCopyextensionsRollbackConfig(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RollbackConfig)
 		out := out.(*RollbackConfig)
@@ -862,7 +907,8 @@ func DeepCopy_extensions_RollbackConfig(in interface{}, out interface{}, c *conv
 	}
 }
 
-func DeepCopy_extensions_RollingUpdateDeployment(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsRollingUpdateDeployment ...
+func DeepCopyextensionsRollingUpdateDeployment(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RollingUpdateDeployment)
 		out := out.(*RollingUpdateDeployment)
@@ -871,7 +917,8 @@ func DeepCopy_extensions_RollingUpdateDeployment(in interface{}, out interface{}
 	}
 }
 
-func DeepCopy_extensions_RunAsUserStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsRunAsUserStrategyOptions ...
+func DeepCopyextensionsRunAsUserStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RunAsUserStrategyOptions)
 		out := out.(*RunAsUserStrategyOptions)
@@ -885,7 +932,8 @@ func DeepCopy_extensions_RunAsUserStrategyOptions(in interface{}, out interface{
 	}
 }
 
-func DeepCopy_extensions_SELinuxStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsSELinuxStrategyOptions ...
+func DeepCopyextensionsSELinuxStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SELinuxStrategyOptions)
 		out := out.(*SELinuxStrategyOptions)
@@ -899,24 +947,26 @@ func DeepCopy_extensions_SELinuxStrategyOptions(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_extensions_Scale(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsScale ...
+func DeepCopyextensionsScale(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Scale)
 		out := out.(*Scale)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_extensions_ScaleStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyextensionsScaleStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_ScaleSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsScaleSpec ...
+func DeepCopyextensionsScaleSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ScaleSpec)
 		out := out.(*ScaleSpec)
@@ -925,24 +975,26 @@ func DeepCopy_extensions_ScaleSpec(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_extensions_ScaleStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsScaleStatus ...
+func DeepCopyextensionsScaleStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ScaleStatus)
 		out := out.(*ScaleStatus)
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_extensions_SupplementalGroupsStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsSupplementalGroupsStrategyOptions ...
+func DeepCopyextensionsSupplementalGroupsStrategyOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*SupplementalGroupsStrategyOptions)
 		out := out.(*SupplementalGroupsStrategyOptions)
@@ -956,15 +1008,16 @@ func DeepCopy_extensions_SupplementalGroupsStrategyOptions(in interface{}, out i
 	}
 }
 
-func DeepCopy_extensions_ThirdPartyResource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsThirdPartyResource ...
+func DeepCopyextensionsThirdPartyResource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ThirdPartyResource)
 		out := out.(*ThirdPartyResource)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Versions != nil {
 			in, out := &in.Versions, &out.Versions
@@ -975,15 +1028,16 @@ func DeepCopy_extensions_ThirdPartyResource(in interface{}, out interface{}, c *
 	}
 }
 
-func DeepCopy_extensions_ThirdPartyResourceData(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsThirdPartyResourceData ...
+func DeepCopyextensionsThirdPartyResourceData(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ThirdPartyResourceData)
 		out := out.(*ThirdPartyResourceData)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
@@ -994,7 +1048,8 @@ func DeepCopy_extensions_ThirdPartyResourceData(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_extensions_ThirdPartyResourceDataList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsThirdPartyResourceDataList ...
+func DeepCopyextensionsThirdPartyResourceDataList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ThirdPartyResourceDataList)
 		out := out.(*ThirdPartyResourceDataList)
@@ -1003,7 +1058,7 @@ func DeepCopy_extensions_ThirdPartyResourceDataList(in interface{}, out interfac
 			in, out := &in.Items, &out.Items
 			*out = make([]ThirdPartyResourceData, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_ThirdPartyResourceData(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsThirdPartyResourceData(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -1012,7 +1067,8 @@ func DeepCopy_extensions_ThirdPartyResourceDataList(in interface{}, out interfac
 	}
 }
 
-func DeepCopy_extensions_ThirdPartyResourceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyextensionsThirdPartyResourceList ...
+func DeepCopyextensionsThirdPartyResourceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ThirdPartyResourceList)
 		out := out.(*ThirdPartyResourceList)
@@ -1021,7 +1077,7 @@ func DeepCopy_extensions_ThirdPartyResourceList(in interface{}, out interface{},
 			in, out := &in.Items, &out.Items
 			*out = make([]ThirdPartyResource, len(*in))
 			for i := range *in {
-				if err := DeepCopy_extensions_ThirdPartyResource(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyextensionsThirdPartyResource(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}

--- a/pkg/apis/imagepolicy/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/imagepolicy/v1alpha1/zz_generated.deepcopy.go
@@ -35,31 +35,33 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ImageReview, InType: reflect.TypeOf(&ImageReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ImageReviewContainerSpec, InType: reflect.TypeOf(&ImageReviewContainerSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ImageReviewSpec, InType: reflect.TypeOf(&ImageReviewSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ImageReviewStatus, InType: reflect.TypeOf(&ImageReviewStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ImageReview, InType: reflect.TypeOf(&ImageReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ImageReviewContainerSpec, InType: reflect.TypeOf(&ImageReviewContainerSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ImageReviewSpec, InType: reflect.TypeOf(&ImageReviewSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ImageReviewStatus, InType: reflect.TypeOf(&ImageReviewStatus{})},
 	)
 }
 
-func DeepCopy_v1alpha1_ImageReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ImageReview ...
+func DeepCopyv1alpha1ImageReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ImageReview)
 		out := out.(*ImageReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_v1alpha1_ImageReviewSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyv1alpha1ImageReviewSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1alpha1_ImageReviewContainerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ImageReviewContainerSpec ...
+func DeepCopyv1alpha1ImageReviewContainerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ImageReviewContainerSpec)
 		out := out.(*ImageReviewContainerSpec)
@@ -68,7 +70,8 @@ func DeepCopy_v1alpha1_ImageReviewContainerSpec(in interface{}, out interface{},
 	}
 }
 
-func DeepCopy_v1alpha1_ImageReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ImageReviewSpec ...
+func DeepCopyv1alpha1ImageReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ImageReviewSpec)
 		out := out.(*ImageReviewSpec)
@@ -89,7 +92,8 @@ func DeepCopy_v1alpha1_ImageReviewSpec(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1alpha1_ImageReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ImageReviewStatus ...
+func DeepCopyv1alpha1ImageReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ImageReviewStatus)
 		out := out.(*ImageReviewStatus)

--- a/pkg/apis/imagepolicy/zz_generated.deepcopy.go
+++ b/pkg/apis/imagepolicy/zz_generated.deepcopy.go
@@ -35,31 +35,33 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_imagepolicy_ImageReview, InType: reflect.TypeOf(&ImageReview{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_imagepolicy_ImageReviewContainerSpec, InType: reflect.TypeOf(&ImageReviewContainerSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_imagepolicy_ImageReviewSpec, InType: reflect.TypeOf(&ImageReviewSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_imagepolicy_ImageReviewStatus, InType: reflect.TypeOf(&ImageReviewStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyimagepolicyImageReview, InType: reflect.TypeOf(&ImageReview{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyimagepolicyImageReviewContainerSpec, InType: reflect.TypeOf(&ImageReviewContainerSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyimagepolicyImageReviewSpec, InType: reflect.TypeOf(&ImageReviewSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyimagepolicyImageReviewStatus, InType: reflect.TypeOf(&ImageReviewStatus{})},
 	)
 }
 
-func DeepCopy_imagepolicy_ImageReview(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyimagepolicyImageReview ...
+func DeepCopyimagepolicyImageReview(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ImageReview)
 		out := out.(*ImageReview)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
-		if err := DeepCopy_imagepolicy_ImageReviewSpec(&in.Spec, &out.Spec, c); err != nil {
+		if err := DeepCopyimagepolicyImageReviewSpec(&in.Spec, &out.Spec, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_imagepolicy_ImageReviewContainerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyimagepolicyImageReviewContainerSpec ...
+func DeepCopyimagepolicyImageReviewContainerSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ImageReviewContainerSpec)
 		out := out.(*ImageReviewContainerSpec)
@@ -68,7 +70,8 @@ func DeepCopy_imagepolicy_ImageReviewContainerSpec(in interface{}, out interface
 	}
 }
 
-func DeepCopy_imagepolicy_ImageReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyimagepolicyImageReviewSpec ...
+func DeepCopyimagepolicyImageReviewSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ImageReviewSpec)
 		out := out.(*ImageReviewSpec)
@@ -89,7 +92,8 @@ func DeepCopy_imagepolicy_ImageReviewSpec(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_imagepolicy_ImageReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyimagepolicyImageReviewStatus ...
+func DeepCopyimagepolicyImageReviewStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ImageReviewStatus)
 		out := out.(*ImageReviewStatus)

--- a/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.deepcopy.go
@@ -35,57 +35,60 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_Eviction, InType: reflect.TypeOf(&Eviction{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PodDisruptionBudget, InType: reflect.TypeOf(&PodDisruptionBudget{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PodDisruptionBudgetList, InType: reflect.TypeOf(&PodDisruptionBudgetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PodDisruptionBudgetSpec, InType: reflect.TypeOf(&PodDisruptionBudgetSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PodDisruptionBudgetStatus, InType: reflect.TypeOf(&PodDisruptionBudgetStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1Eviction, InType: reflect.TypeOf(&Eviction{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PodDisruptionBudget, InType: reflect.TypeOf(&PodDisruptionBudget{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PodDisruptionBudgetList, InType: reflect.TypeOf(&PodDisruptionBudgetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PodDisruptionBudgetSpec, InType: reflect.TypeOf(&PodDisruptionBudgetSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PodDisruptionBudgetStatus, InType: reflect.TypeOf(&PodDisruptionBudgetStatus{})},
 	)
 }
 
-func DeepCopy_v1beta1_Eviction(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1Eviction ...
+func DeepCopyv1beta1Eviction(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Eviction)
 		out := out.(*Eviction)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.DeleteOptions != nil {
 			in, out := &in.DeleteOptions, &out.DeleteOptions
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.DeleteOptions)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_PodDisruptionBudget(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PodDisruptionBudget ...
+func DeepCopyv1beta1PodDisruptionBudget(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodDisruptionBudget)
 		out := out.(*PodDisruptionBudget)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_v1beta1_PodDisruptionBudgetSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_v1beta1_PodDisruptionBudgetStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopyv1beta1PodDisruptionBudgetSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopyv1beta1PodDisruptionBudgetStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_PodDisruptionBudgetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PodDisruptionBudgetList ...
+func DeepCopyv1beta1PodDisruptionBudgetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodDisruptionBudgetList)
 		out := out.(*PodDisruptionBudgetList)
@@ -94,7 +97,7 @@ func DeepCopy_v1beta1_PodDisruptionBudgetList(in interface{}, out interface{}, c
 			in, out := &in.Items, &out.Items
 			*out = make([]PodDisruptionBudget, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_PodDisruptionBudget(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1PodDisruptionBudget(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -103,24 +106,26 @@ func DeepCopy_v1beta1_PodDisruptionBudgetList(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_v1beta1_PodDisruptionBudgetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PodDisruptionBudgetSpec ...
+func DeepCopyv1beta1PodDisruptionBudgetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodDisruptionBudgetSpec)
 		out := out.(*PodDisruptionBudgetSpec)
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1beta1_PodDisruptionBudgetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PodDisruptionBudgetStatus ...
+func DeepCopyv1beta1PodDisruptionBudgetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodDisruptionBudgetStatus)
 		out := out.(*PodDisruptionBudgetStatus)

--- a/pkg/apis/policy/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/zz_generated.deepcopy.go
@@ -35,57 +35,60 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_policy_Eviction, InType: reflect.TypeOf(&Eviction{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_policy_PodDisruptionBudget, InType: reflect.TypeOf(&PodDisruptionBudget{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_policy_PodDisruptionBudgetList, InType: reflect.TypeOf(&PodDisruptionBudgetList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_policy_PodDisruptionBudgetSpec, InType: reflect.TypeOf(&PodDisruptionBudgetSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_policy_PodDisruptionBudgetStatus, InType: reflect.TypeOf(&PodDisruptionBudgetStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopypolicyEviction, InType: reflect.TypeOf(&Eviction{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopypolicyPodDisruptionBudget, InType: reflect.TypeOf(&PodDisruptionBudget{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopypolicyPodDisruptionBudgetList, InType: reflect.TypeOf(&PodDisruptionBudgetList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopypolicyPodDisruptionBudgetSpec, InType: reflect.TypeOf(&PodDisruptionBudgetSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopypolicyPodDisruptionBudgetStatus, InType: reflect.TypeOf(&PodDisruptionBudgetStatus{})},
 	)
 }
 
-func DeepCopy_policy_Eviction(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopypolicyEviction ...
+func DeepCopypolicyEviction(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Eviction)
 		out := out.(*Eviction)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.DeleteOptions != nil {
 			in, out := &in.DeleteOptions, &out.DeleteOptions
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.DeleteOptions)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_policy_PodDisruptionBudget(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopypolicyPodDisruptionBudget ...
+func DeepCopypolicyPodDisruptionBudget(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodDisruptionBudget)
 		out := out.(*PodDisruptionBudget)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if err := DeepCopy_policy_PodDisruptionBudgetSpec(&in.Spec, &out.Spec, c); err != nil {
+		} else {
 			return err
 		}
-		if err := DeepCopy_policy_PodDisruptionBudgetStatus(&in.Status, &out.Status, c); err != nil {
+		if err := DeepCopypolicyPodDisruptionBudgetSpec(&in.Spec, &out.Spec, c); err != nil {
+			return err
+		}
+		if err := DeepCopypolicyPodDisruptionBudgetStatus(&in.Status, &out.Status, c); err != nil {
 			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_policy_PodDisruptionBudgetList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopypolicyPodDisruptionBudgetList ...
+func DeepCopypolicyPodDisruptionBudgetList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodDisruptionBudgetList)
 		out := out.(*PodDisruptionBudgetList)
@@ -94,7 +97,7 @@ func DeepCopy_policy_PodDisruptionBudgetList(in interface{}, out interface{}, c 
 			in, out := &in.Items, &out.Items
 			*out = make([]PodDisruptionBudget, len(*in))
 			for i := range *in {
-				if err := DeepCopy_policy_PodDisruptionBudget(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopypolicyPodDisruptionBudget(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -103,24 +106,26 @@ func DeepCopy_policy_PodDisruptionBudgetList(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_policy_PodDisruptionBudgetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopypolicyPodDisruptionBudgetSpec ...
+func DeepCopypolicyPodDisruptionBudgetSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodDisruptionBudgetSpec)
 		out := out.(*PodDisruptionBudgetSpec)
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*v1.LabelSelector)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_policy_PodDisruptionBudgetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopypolicyPodDisruptionBudgetStatus ...
+func DeepCopypolicyPodDisruptionBudgetStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodDisruptionBudgetStatus)
 		out := out.(*PodDisruptionBudgetStatus)

--- a/pkg/apis/rbac/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.deepcopy.go
@@ -35,35 +35,36 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ClusterRole, InType: reflect.TypeOf(&ClusterRole{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ClusterRoleBinding, InType: reflect.TypeOf(&ClusterRoleBinding{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ClusterRoleBindingList, InType: reflect.TypeOf(&ClusterRoleBindingList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_ClusterRoleList, InType: reflect.TypeOf(&ClusterRoleList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_PolicyRule, InType: reflect.TypeOf(&PolicyRule{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_Role, InType: reflect.TypeOf(&Role{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_RoleBinding, InType: reflect.TypeOf(&RoleBinding{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_RoleBindingList, InType: reflect.TypeOf(&RoleBindingList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_RoleList, InType: reflect.TypeOf(&RoleList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_RoleRef, InType: reflect.TypeOf(&RoleRef{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1alpha1_Subject, InType: reflect.TypeOf(&Subject{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ClusterRole, InType: reflect.TypeOf(&ClusterRole{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ClusterRoleBinding, InType: reflect.TypeOf(&ClusterRoleBinding{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ClusterRoleBindingList, InType: reflect.TypeOf(&ClusterRoleBindingList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1ClusterRoleList, InType: reflect.TypeOf(&ClusterRoleList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1PolicyRule, InType: reflect.TypeOf(&PolicyRule{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1Role, InType: reflect.TypeOf(&Role{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1RoleBinding, InType: reflect.TypeOf(&RoleBinding{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1RoleBindingList, InType: reflect.TypeOf(&RoleBindingList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1RoleList, InType: reflect.TypeOf(&RoleList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1RoleRef, InType: reflect.TypeOf(&RoleRef{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1alpha1Subject, InType: reflect.TypeOf(&Subject{})},
 	)
 }
 
-func DeepCopy_v1alpha1_ClusterRole(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ClusterRole ...
+func DeepCopyv1alpha1ClusterRole(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRole)
 		out := out.(*ClusterRole)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Rules != nil {
 			in, out := &in.Rules, &out.Rules
 			*out = make([]PolicyRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1alpha1PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -72,15 +73,16 @@ func DeepCopy_v1alpha1_ClusterRole(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_v1alpha1_ClusterRoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ClusterRoleBinding ...
+func DeepCopyv1alpha1ClusterRoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleBinding)
 		out := out.(*ClusterRoleBinding)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Subjects != nil {
 			in, out := &in.Subjects, &out.Subjects
@@ -91,7 +93,8 @@ func DeepCopy_v1alpha1_ClusterRoleBinding(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_v1alpha1_ClusterRoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ClusterRoleBindingList ...
+func DeepCopyv1alpha1ClusterRoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleBindingList)
 		out := out.(*ClusterRoleBindingList)
@@ -100,7 +103,7 @@ func DeepCopy_v1alpha1_ClusterRoleBindingList(in interface{}, out interface{}, c
 			in, out := &in.Items, &out.Items
 			*out = make([]ClusterRoleBinding, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_ClusterRoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1alpha1ClusterRoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -109,7 +112,8 @@ func DeepCopy_v1alpha1_ClusterRoleBindingList(in interface{}, out interface{}, c
 	}
 }
 
-func DeepCopy_v1alpha1_ClusterRoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1ClusterRoleList ...
+func DeepCopyv1alpha1ClusterRoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleList)
 		out := out.(*ClusterRoleList)
@@ -118,7 +122,7 @@ func DeepCopy_v1alpha1_ClusterRoleList(in interface{}, out interface{}, c *conve
 			in, out := &in.Items, &out.Items
 			*out = make([]ClusterRole, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_ClusterRole(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1alpha1ClusterRole(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -127,7 +131,8 @@ func DeepCopy_v1alpha1_ClusterRoleList(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1alpha1_PolicyRule(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1PolicyRule ...
+func DeepCopyv1alpha1PolicyRule(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PolicyRule)
 		out := out.(*PolicyRule)
@@ -161,21 +166,22 @@ func DeepCopy_v1alpha1_PolicyRule(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1alpha1_Role(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1Role ...
+func DeepCopyv1alpha1Role(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Role)
 		out := out.(*Role)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Rules != nil {
 			in, out := &in.Rules, &out.Rules
 			*out = make([]PolicyRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1alpha1PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -184,15 +190,16 @@ func DeepCopy_v1alpha1_Role(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1alpha1_RoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1RoleBinding ...
+func DeepCopyv1alpha1RoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleBinding)
 		out := out.(*RoleBinding)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Subjects != nil {
 			in, out := &in.Subjects, &out.Subjects
@@ -203,7 +210,8 @@ func DeepCopy_v1alpha1_RoleBinding(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_v1alpha1_RoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1RoleBindingList ...
+func DeepCopyv1alpha1RoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleBindingList)
 		out := out.(*RoleBindingList)
@@ -212,7 +220,7 @@ func DeepCopy_v1alpha1_RoleBindingList(in interface{}, out interface{}, c *conve
 			in, out := &in.Items, &out.Items
 			*out = make([]RoleBinding, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_RoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1alpha1RoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -221,7 +229,8 @@ func DeepCopy_v1alpha1_RoleBindingList(in interface{}, out interface{}, c *conve
 	}
 }
 
-func DeepCopy_v1alpha1_RoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1RoleList ...
+func DeepCopyv1alpha1RoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleList)
 		out := out.(*RoleList)
@@ -230,7 +239,7 @@ func DeepCopy_v1alpha1_RoleList(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Items, &out.Items
 			*out = make([]Role, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_Role(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1alpha1Role(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -239,7 +248,8 @@ func DeepCopy_v1alpha1_RoleList(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1alpha1_RoleRef(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1RoleRef ...
+func DeepCopyv1alpha1RoleRef(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleRef)
 		out := out.(*RoleRef)
@@ -248,7 +258,8 @@ func DeepCopy_v1alpha1_RoleRef(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1alpha1_Subject(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1alpha1Subject ...
+func DeepCopyv1alpha1Subject(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Subject)
 		out := out.(*Subject)

--- a/pkg/apis/rbac/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.deepcopy.go
@@ -35,35 +35,36 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ClusterRole, InType: reflect.TypeOf(&ClusterRole{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ClusterRoleBinding, InType: reflect.TypeOf(&ClusterRoleBinding{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ClusterRoleBindingList, InType: reflect.TypeOf(&ClusterRoleBindingList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_ClusterRoleList, InType: reflect.TypeOf(&ClusterRoleList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_PolicyRule, InType: reflect.TypeOf(&PolicyRule{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_Role, InType: reflect.TypeOf(&Role{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_RoleBinding, InType: reflect.TypeOf(&RoleBinding{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_RoleBindingList, InType: reflect.TypeOf(&RoleBindingList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_RoleList, InType: reflect.TypeOf(&RoleList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_RoleRef, InType: reflect.TypeOf(&RoleRef{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_Subject, InType: reflect.TypeOf(&Subject{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ClusterRole, InType: reflect.TypeOf(&ClusterRole{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ClusterRoleBinding, InType: reflect.TypeOf(&ClusterRoleBinding{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ClusterRoleBindingList, InType: reflect.TypeOf(&ClusterRoleBindingList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1ClusterRoleList, InType: reflect.TypeOf(&ClusterRoleList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1PolicyRule, InType: reflect.TypeOf(&PolicyRule{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1Role, InType: reflect.TypeOf(&Role{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1RoleBinding, InType: reflect.TypeOf(&RoleBinding{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1RoleBindingList, InType: reflect.TypeOf(&RoleBindingList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1RoleList, InType: reflect.TypeOf(&RoleList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1RoleRef, InType: reflect.TypeOf(&RoleRef{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1Subject, InType: reflect.TypeOf(&Subject{})},
 	)
 }
 
-func DeepCopy_v1beta1_ClusterRole(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ClusterRole ...
+func DeepCopyv1beta1ClusterRole(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRole)
 		out := out.(*ClusterRole)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Rules != nil {
 			in, out := &in.Rules, &out.Rules
 			*out = make([]PolicyRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -72,15 +73,16 @@ func DeepCopy_v1beta1_ClusterRole(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1beta1_ClusterRoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ClusterRoleBinding ...
+func DeepCopyv1beta1ClusterRoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleBinding)
 		out := out.(*ClusterRoleBinding)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Subjects != nil {
 			in, out := &in.Subjects, &out.Subjects
@@ -91,7 +93,8 @@ func DeepCopy_v1beta1_ClusterRoleBinding(in interface{}, out interface{}, c *con
 	}
 }
 
-func DeepCopy_v1beta1_ClusterRoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ClusterRoleBindingList ...
+func DeepCopyv1beta1ClusterRoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleBindingList)
 		out := out.(*ClusterRoleBindingList)
@@ -100,7 +103,7 @@ func DeepCopy_v1beta1_ClusterRoleBindingList(in interface{}, out interface{}, c 
 			in, out := &in.Items, &out.Items
 			*out = make([]ClusterRoleBinding, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_ClusterRoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1ClusterRoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -109,7 +112,8 @@ func DeepCopy_v1beta1_ClusterRoleBindingList(in interface{}, out interface{}, c 
 	}
 }
 
-func DeepCopy_v1beta1_ClusterRoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1ClusterRoleList ...
+func DeepCopyv1beta1ClusterRoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleList)
 		out := out.(*ClusterRoleList)
@@ -118,7 +122,7 @@ func DeepCopy_v1beta1_ClusterRoleList(in interface{}, out interface{}, c *conver
 			in, out := &in.Items, &out.Items
 			*out = make([]ClusterRole, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_ClusterRole(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1ClusterRole(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -127,7 +131,8 @@ func DeepCopy_v1beta1_ClusterRoleList(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1beta1_PolicyRule(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1PolicyRule ...
+func DeepCopyv1beta1PolicyRule(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PolicyRule)
 		out := out.(*PolicyRule)
@@ -161,21 +166,22 @@ func DeepCopy_v1beta1_PolicyRule(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1beta1_Role(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1Role ...
+func DeepCopyv1beta1Role(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Role)
 		out := out.(*Role)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Rules != nil {
 			in, out := &in.Rules, &out.Rules
 			*out = make([]PolicyRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -184,15 +190,16 @@ func DeepCopy_v1beta1_Role(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1beta1_RoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1RoleBinding ...
+func DeepCopyv1beta1RoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleBinding)
 		out := out.(*RoleBinding)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Subjects != nil {
 			in, out := &in.Subjects, &out.Subjects
@@ -203,7 +210,8 @@ func DeepCopy_v1beta1_RoleBinding(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1beta1_RoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1RoleBindingList ...
+func DeepCopyv1beta1RoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleBindingList)
 		out := out.(*RoleBindingList)
@@ -212,7 +220,7 @@ func DeepCopy_v1beta1_RoleBindingList(in interface{}, out interface{}, c *conver
 			in, out := &in.Items, &out.Items
 			*out = make([]RoleBinding, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_RoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1RoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -221,7 +229,8 @@ func DeepCopy_v1beta1_RoleBindingList(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1beta1_RoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1RoleList ...
+func DeepCopyv1beta1RoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleList)
 		out := out.(*RoleList)
@@ -230,7 +239,7 @@ func DeepCopy_v1beta1_RoleList(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.Items, &out.Items
 			*out = make([]Role, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_Role(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1Role(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -239,7 +248,8 @@ func DeepCopy_v1beta1_RoleList(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1beta1_RoleRef(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1RoleRef ...
+func DeepCopyv1beta1RoleRef(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleRef)
 		out := out.(*RoleRef)
@@ -248,7 +258,8 @@ func DeepCopy_v1beta1_RoleRef(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1beta1_Subject(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1Subject ...
+func DeepCopyv1beta1Subject(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Subject)
 		out := out.(*Subject)

--- a/pkg/apis/rbac/zz_generated.deepcopy.go
+++ b/pkg/apis/rbac/zz_generated.deepcopy.go
@@ -35,35 +35,36 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_ClusterRole, InType: reflect.TypeOf(&ClusterRole{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_ClusterRoleBinding, InType: reflect.TypeOf(&ClusterRoleBinding{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_ClusterRoleBindingList, InType: reflect.TypeOf(&ClusterRoleBindingList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_ClusterRoleList, InType: reflect.TypeOf(&ClusterRoleList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_PolicyRule, InType: reflect.TypeOf(&PolicyRule{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_Role, InType: reflect.TypeOf(&Role{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_RoleBinding, InType: reflect.TypeOf(&RoleBinding{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_RoleBindingList, InType: reflect.TypeOf(&RoleBindingList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_RoleList, InType: reflect.TypeOf(&RoleList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_RoleRef, InType: reflect.TypeOf(&RoleRef{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_rbac_Subject, InType: reflect.TypeOf(&Subject{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacClusterRole, InType: reflect.TypeOf(&ClusterRole{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacClusterRoleBinding, InType: reflect.TypeOf(&ClusterRoleBinding{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacClusterRoleBindingList, InType: reflect.TypeOf(&ClusterRoleBindingList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacClusterRoleList, InType: reflect.TypeOf(&ClusterRoleList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacPolicyRule, InType: reflect.TypeOf(&PolicyRule{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacRole, InType: reflect.TypeOf(&Role{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacRoleBinding, InType: reflect.TypeOf(&RoleBinding{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacRoleBindingList, InType: reflect.TypeOf(&RoleBindingList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacRoleList, InType: reflect.TypeOf(&RoleList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacRoleRef, InType: reflect.TypeOf(&RoleRef{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyrbacSubject, InType: reflect.TypeOf(&Subject{})},
 	)
 }
 
-func DeepCopy_rbac_ClusterRole(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacClusterRole ...
+func DeepCopyrbacClusterRole(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRole)
 		out := out.(*ClusterRole)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Rules != nil {
 			in, out := &in.Rules, &out.Rules
 			*out = make([]PolicyRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_rbac_PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyrbacPolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -72,15 +73,16 @@ func DeepCopy_rbac_ClusterRole(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_rbac_ClusterRoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacClusterRoleBinding ...
+func DeepCopyrbacClusterRoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleBinding)
 		out := out.(*ClusterRoleBinding)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Subjects != nil {
 			in, out := &in.Subjects, &out.Subjects
@@ -91,7 +93,8 @@ func DeepCopy_rbac_ClusterRoleBinding(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_rbac_ClusterRoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacClusterRoleBindingList ...
+func DeepCopyrbacClusterRoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleBindingList)
 		out := out.(*ClusterRoleBindingList)
@@ -100,7 +103,7 @@ func DeepCopy_rbac_ClusterRoleBindingList(in interface{}, out interface{}, c *co
 			in, out := &in.Items, &out.Items
 			*out = make([]ClusterRoleBinding, len(*in))
 			for i := range *in {
-				if err := DeepCopy_rbac_ClusterRoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyrbacClusterRoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -109,7 +112,8 @@ func DeepCopy_rbac_ClusterRoleBindingList(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_rbac_ClusterRoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacClusterRoleList ...
+func DeepCopyrbacClusterRoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ClusterRoleList)
 		out := out.(*ClusterRoleList)
@@ -118,7 +122,7 @@ func DeepCopy_rbac_ClusterRoleList(in interface{}, out interface{}, c *conversio
 			in, out := &in.Items, &out.Items
 			*out = make([]ClusterRole, len(*in))
 			for i := range *in {
-				if err := DeepCopy_rbac_ClusterRole(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyrbacClusterRole(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -127,7 +131,8 @@ func DeepCopy_rbac_ClusterRoleList(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_rbac_PolicyRule(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacPolicyRule ...
+func DeepCopyrbacPolicyRule(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PolicyRule)
 		out := out.(*PolicyRule)
@@ -161,21 +166,22 @@ func DeepCopy_rbac_PolicyRule(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_rbac_Role(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacRole ...
+func DeepCopyrbacRole(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Role)
 		out := out.(*Role)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Rules != nil {
 			in, out := &in.Rules, &out.Rules
 			*out = make([]PolicyRule, len(*in))
 			for i := range *in {
-				if err := DeepCopy_rbac_PolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyrbacPolicyRule(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -184,15 +190,16 @@ func DeepCopy_rbac_Role(in interface{}, out interface{}, c *conversion.Cloner) e
 	}
 }
 
-func DeepCopy_rbac_RoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacRoleBinding ...
+func DeepCopyrbacRoleBinding(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleBinding)
 		out := out.(*RoleBinding)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Subjects != nil {
 			in, out := &in.Subjects, &out.Subjects
@@ -203,7 +210,8 @@ func DeepCopy_rbac_RoleBinding(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_rbac_RoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacRoleBindingList ...
+func DeepCopyrbacRoleBindingList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleBindingList)
 		out := out.(*RoleBindingList)
@@ -212,7 +220,7 @@ func DeepCopy_rbac_RoleBindingList(in interface{}, out interface{}, c *conversio
 			in, out := &in.Items, &out.Items
 			*out = make([]RoleBinding, len(*in))
 			for i := range *in {
-				if err := DeepCopy_rbac_RoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyrbacRoleBinding(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -221,7 +229,8 @@ func DeepCopy_rbac_RoleBindingList(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_rbac_RoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacRoleList ...
+func DeepCopyrbacRoleList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleList)
 		out := out.(*RoleList)
@@ -230,7 +239,7 @@ func DeepCopy_rbac_RoleList(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.Items, &out.Items
 			*out = make([]Role, len(*in))
 			for i := range *in {
-				if err := DeepCopy_rbac_Role(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyrbacRole(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}
@@ -239,7 +248,8 @@ func DeepCopy_rbac_RoleList(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_rbac_RoleRef(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacRoleRef ...
+func DeepCopyrbacRoleRef(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RoleRef)
 		out := out.(*RoleRef)
@@ -248,7 +258,8 @@ func DeepCopy_rbac_RoleRef(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_rbac_Subject(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyrbacSubject ...
+func DeepCopyrbacSubject(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Subject)
 		out := out.(*Subject)

--- a/pkg/apis/storage/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.deepcopy.go
@@ -35,20 +35,21 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_StorageClass, InType: reflect.TypeOf(&StorageClass{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1beta1_StorageClassList, InType: reflect.TypeOf(&StorageClassList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1StorageClass, InType: reflect.TypeOf(&StorageClass{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1beta1StorageClassList, InType: reflect.TypeOf(&StorageClassList{})},
 	)
 }
 
-func DeepCopy_v1beta1_StorageClass(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1StorageClass ...
+func DeepCopyv1beta1StorageClass(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StorageClass)
 		out := out.(*StorageClass)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Parameters != nil {
 			in, out := &in.Parameters, &out.Parameters
@@ -61,7 +62,8 @@ func DeepCopy_v1beta1_StorageClass(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_v1beta1_StorageClassList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1beta1StorageClassList ...
+func DeepCopyv1beta1StorageClassList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StorageClassList)
 		out := out.(*StorageClassList)
@@ -70,7 +72,7 @@ func DeepCopy_v1beta1_StorageClassList(in interface{}, out interface{}, c *conve
 			in, out := &in.Items, &out.Items
 			*out = make([]StorageClass, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1beta1_StorageClass(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopyv1beta1StorageClass(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}

--- a/pkg/apis/storage/zz_generated.deepcopy.go
+++ b/pkg/apis/storage/zz_generated.deepcopy.go
@@ -35,20 +35,21 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_storage_StorageClass, InType: reflect.TypeOf(&StorageClass{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_storage_StorageClassList, InType: reflect.TypeOf(&StorageClassList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopystorageStorageClass, InType: reflect.TypeOf(&StorageClass{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopystorageStorageClassList, InType: reflect.TypeOf(&StorageClassList{})},
 	)
 }
 
-func DeepCopy_storage_StorageClass(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopystorageStorageClass ...
+func DeepCopystorageStorageClass(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StorageClass)
 		out := out.(*StorageClass)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
+		} else {
+			return err
 		}
 		if in.Parameters != nil {
 			in, out := &in.Parameters, &out.Parameters
@@ -61,7 +62,8 @@ func DeepCopy_storage_StorageClass(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_storage_StorageClassList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopystorageStorageClassList ...
+func DeepCopystorageStorageClassList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StorageClassList)
 		out := out.(*StorageClassList)
@@ -70,7 +72,7 @@ func DeepCopy_storage_StorageClassList(in interface{}, out interface{}, c *conve
 			in, out := &in.Items, &out.Items
 			*out = make([]StorageClass, len(*in))
 			for i := range *in {
-				if err := DeepCopy_storage_StorageClass(&(*in)[i], &(*out)[i], c); err != nil {
+				if err := DeepCopystorageStorageClass(&(*in)[i], &(*out)[i], c); err != nil {
 					return err
 				}
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/zz_generated.deepcopy.go
@@ -30,43 +30,44 @@ import (
 // GetGeneratedDeepCopyFuncs returns the generated funcs, since we aren't registering them.
 func GetGeneratedDeepCopyFuncs() []conversion.GeneratedDeepCopyFunc {
 	return []conversion.GeneratedDeepCopyFunc{
-		{Fn: DeepCopy_v1_APIGroup, InType: reflect.TypeOf(&APIGroup{})},
-		{Fn: DeepCopy_v1_APIGroupList, InType: reflect.TypeOf(&APIGroupList{})},
-		{Fn: DeepCopy_v1_APIResource, InType: reflect.TypeOf(&APIResource{})},
-		{Fn: DeepCopy_v1_APIResourceList, InType: reflect.TypeOf(&APIResourceList{})},
-		{Fn: DeepCopy_v1_APIVersions, InType: reflect.TypeOf(&APIVersions{})},
-		{Fn: DeepCopy_v1_DeleteOptions, InType: reflect.TypeOf(&DeleteOptions{})},
-		{Fn: DeepCopy_v1_Duration, InType: reflect.TypeOf(&Duration{})},
-		{Fn: DeepCopy_v1_ExportOptions, InType: reflect.TypeOf(&ExportOptions{})},
-		{Fn: DeepCopy_v1_GetOptions, InType: reflect.TypeOf(&GetOptions{})},
-		{Fn: DeepCopy_v1_GroupKind, InType: reflect.TypeOf(&GroupKind{})},
-		{Fn: DeepCopy_v1_GroupResource, InType: reflect.TypeOf(&GroupResource{})},
-		{Fn: DeepCopy_v1_GroupVersion, InType: reflect.TypeOf(&GroupVersion{})},
-		{Fn: DeepCopy_v1_GroupVersionForDiscovery, InType: reflect.TypeOf(&GroupVersionForDiscovery{})},
-		{Fn: DeepCopy_v1_GroupVersionKind, InType: reflect.TypeOf(&GroupVersionKind{})},
-		{Fn: DeepCopy_v1_GroupVersionResource, InType: reflect.TypeOf(&GroupVersionResource{})},
-		{Fn: DeepCopy_v1_InternalEvent, InType: reflect.TypeOf(&InternalEvent{})},
-		{Fn: DeepCopy_v1_LabelSelector, InType: reflect.TypeOf(&LabelSelector{})},
-		{Fn: DeepCopy_v1_LabelSelectorRequirement, InType: reflect.TypeOf(&LabelSelectorRequirement{})},
-		{Fn: DeepCopy_v1_ListMeta, InType: reflect.TypeOf(&ListMeta{})},
-		{Fn: DeepCopy_v1_ListOptions, InType: reflect.TypeOf(&ListOptions{})},
-		{Fn: DeepCopy_v1_ObjectMeta, InType: reflect.TypeOf(&ObjectMeta{})},
-		{Fn: DeepCopy_v1_OwnerReference, InType: reflect.TypeOf(&OwnerReference{})},
-		{Fn: DeepCopy_v1_Patch, InType: reflect.TypeOf(&Patch{})},
-		{Fn: DeepCopy_v1_Preconditions, InType: reflect.TypeOf(&Preconditions{})},
-		{Fn: DeepCopy_v1_RootPaths, InType: reflect.TypeOf(&RootPaths{})},
-		{Fn: DeepCopy_v1_ServerAddressByClientCIDR, InType: reflect.TypeOf(&ServerAddressByClientCIDR{})},
-		{Fn: DeepCopy_v1_Status, InType: reflect.TypeOf(&Status{})},
-		{Fn: DeepCopy_v1_StatusCause, InType: reflect.TypeOf(&StatusCause{})},
-		{Fn: DeepCopy_v1_StatusDetails, InType: reflect.TypeOf(&StatusDetails{})},
-		{Fn: DeepCopy_v1_Time, InType: reflect.TypeOf(&Time{})},
-		{Fn: DeepCopy_v1_Timestamp, InType: reflect.TypeOf(&Timestamp{})},
-		{Fn: DeepCopy_v1_TypeMeta, InType: reflect.TypeOf(&TypeMeta{})},
-		{Fn: DeepCopy_v1_WatchEvent, InType: reflect.TypeOf(&WatchEvent{})},
+		{Fn: DeepCopyv1APIGroup, InType: reflect.TypeOf(&APIGroup{})},
+		{Fn: DeepCopyv1APIGroupList, InType: reflect.TypeOf(&APIGroupList{})},
+		{Fn: DeepCopyv1APIResource, InType: reflect.TypeOf(&APIResource{})},
+		{Fn: DeepCopyv1APIResourceList, InType: reflect.TypeOf(&APIResourceList{})},
+		{Fn: DeepCopyv1APIVersions, InType: reflect.TypeOf(&APIVersions{})},
+		{Fn: DeepCopyv1DeleteOptions, InType: reflect.TypeOf(&DeleteOptions{})},
+		{Fn: DeepCopyv1Duration, InType: reflect.TypeOf(&Duration{})},
+		{Fn: DeepCopyv1ExportOptions, InType: reflect.TypeOf(&ExportOptions{})},
+		{Fn: DeepCopyv1GetOptions, InType: reflect.TypeOf(&GetOptions{})},
+		{Fn: DeepCopyv1GroupKind, InType: reflect.TypeOf(&GroupKind{})},
+		{Fn: DeepCopyv1GroupResource, InType: reflect.TypeOf(&GroupResource{})},
+		{Fn: DeepCopyv1GroupVersion, InType: reflect.TypeOf(&GroupVersion{})},
+		{Fn: DeepCopyv1GroupVersionForDiscovery, InType: reflect.TypeOf(&GroupVersionForDiscovery{})},
+		{Fn: DeepCopyv1GroupVersionKind, InType: reflect.TypeOf(&GroupVersionKind{})},
+		{Fn: DeepCopyv1GroupVersionResource, InType: reflect.TypeOf(&GroupVersionResource{})},
+		{Fn: DeepCopyv1InternalEvent, InType: reflect.TypeOf(&InternalEvent{})},
+		{Fn: DeepCopyv1LabelSelector, InType: reflect.TypeOf(&LabelSelector{})},
+		{Fn: DeepCopyv1LabelSelectorRequirement, InType: reflect.TypeOf(&LabelSelectorRequirement{})},
+		{Fn: DeepCopyv1ListMeta, InType: reflect.TypeOf(&ListMeta{})},
+		{Fn: DeepCopyv1ListOptions, InType: reflect.TypeOf(&ListOptions{})},
+		{Fn: DeepCopyv1ObjectMeta, InType: reflect.TypeOf(&ObjectMeta{})},
+		{Fn: DeepCopyv1OwnerReference, InType: reflect.TypeOf(&OwnerReference{})},
+		{Fn: DeepCopyv1Patch, InType: reflect.TypeOf(&Patch{})},
+		{Fn: DeepCopyv1Preconditions, InType: reflect.TypeOf(&Preconditions{})},
+		{Fn: DeepCopyv1RootPaths, InType: reflect.TypeOf(&RootPaths{})},
+		{Fn: DeepCopyv1ServerAddressByClientCIDR, InType: reflect.TypeOf(&ServerAddressByClientCIDR{})},
+		{Fn: DeepCopyv1Status, InType: reflect.TypeOf(&Status{})},
+		{Fn: DeepCopyv1StatusCause, InType: reflect.TypeOf(&StatusCause{})},
+		{Fn: DeepCopyv1StatusDetails, InType: reflect.TypeOf(&StatusDetails{})},
+		{Fn: DeepCopyv1Time, InType: reflect.TypeOf(&Time{})},
+		{Fn: DeepCopyv1Timestamp, InType: reflect.TypeOf(&Timestamp{})},
+		{Fn: DeepCopyv1TypeMeta, InType: reflect.TypeOf(&TypeMeta{})},
+		{Fn: DeepCopyv1WatchEvent, InType: reflect.TypeOf(&WatchEvent{})},
 	}
 }
 
-func DeepCopy_v1_APIGroup(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1APIGroup ...
+func DeepCopyv1APIGroup(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIGroup)
 		out := out.(*APIGroup)
@@ -85,7 +86,8 @@ func DeepCopy_v1_APIGroup(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_v1_APIGroupList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1APIGroupList ...
+func DeepCopyv1APIGroupList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIGroupList)
 		out := out.(*APIGroupList)
@@ -94,10 +96,10 @@ func DeepCopy_v1_APIGroupList(in interface{}, out interface{}, c *conversion.Clo
 			in, out := &in.Groups, &out.Groups
 			*out = make([]APIGroup, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*APIGroup)
+				} else {
+					return err
 				}
 			}
 		}
@@ -105,7 +107,8 @@ func DeepCopy_v1_APIGroupList(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_APIResource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1APIResource ...
+func DeepCopyv1APIResource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIResource)
 		out := out.(*APIResource)
@@ -124,7 +127,8 @@ func DeepCopy_v1_APIResource(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_APIResourceList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1APIResourceList ...
+func DeepCopyv1APIResourceList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIResourceList)
 		out := out.(*APIResourceList)
@@ -133,10 +137,10 @@ func DeepCopy_v1_APIResourceList(in interface{}, out interface{}, c *conversion.
 			in, out := &in.APIResources, &out.APIResources
 			*out = make([]APIResource, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*APIResource)
+				} else {
+					return err
 				}
 			}
 		}
@@ -144,7 +148,8 @@ func DeepCopy_v1_APIResourceList(in interface{}, out interface{}, c *conversion.
 	}
 }
 
-func DeepCopy_v1_APIVersions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1APIVersions ...
+func DeepCopyv1APIVersions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*APIVersions)
 		out := out.(*APIVersions)
@@ -163,7 +168,8 @@ func DeepCopy_v1_APIVersions(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_DeleteOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1DeleteOptions ...
+func DeepCopyv1DeleteOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*DeleteOptions)
 		out := out.(*DeleteOptions)
@@ -175,10 +181,10 @@ func DeepCopy_v1_DeleteOptions(in interface{}, out interface{}, c *conversion.Cl
 		}
 		if in.Preconditions != nil {
 			in, out := &in.Preconditions, &out.Preconditions
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*Preconditions)
+			} else {
+				return err
 			}
 		}
 		if in.OrphanDependents != nil {
@@ -190,7 +196,8 @@ func DeepCopy_v1_DeleteOptions(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_Duration(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Duration ...
+func DeepCopyv1Duration(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Duration)
 		out := out.(*Duration)
@@ -199,7 +206,8 @@ func DeepCopy_v1_Duration(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_v1_ExportOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ExportOptions ...
+func DeepCopyv1ExportOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ExportOptions)
 		out := out.(*ExportOptions)
@@ -208,7 +216,8 @@ func DeepCopy_v1_ExportOptions(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_GetOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GetOptions ...
+func DeepCopyv1GetOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GetOptions)
 		out := out.(*GetOptions)
@@ -217,7 +226,8 @@ func DeepCopy_v1_GetOptions(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1_GroupKind(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GroupKind ...
+func DeepCopyv1GroupKind(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GroupKind)
 		out := out.(*GroupKind)
@@ -226,7 +236,8 @@ func DeepCopy_v1_GroupKind(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_GroupResource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GroupResource ...
+func DeepCopyv1GroupResource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GroupResource)
 		out := out.(*GroupResource)
@@ -235,7 +246,8 @@ func DeepCopy_v1_GroupResource(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_GroupVersion(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GroupVersion ...
+func DeepCopyv1GroupVersion(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GroupVersion)
 		out := out.(*GroupVersion)
@@ -244,7 +256,8 @@ func DeepCopy_v1_GroupVersion(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_GroupVersionForDiscovery(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GroupVersionForDiscovery ...
+func DeepCopyv1GroupVersionForDiscovery(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GroupVersionForDiscovery)
 		out := out.(*GroupVersionForDiscovery)
@@ -253,7 +266,8 @@ func DeepCopy_v1_GroupVersionForDiscovery(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_v1_GroupVersionKind(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GroupVersionKind ...
+func DeepCopyv1GroupVersionKind(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GroupVersionKind)
 		out := out.(*GroupVersionKind)
@@ -262,7 +276,8 @@ func DeepCopy_v1_GroupVersionKind(in interface{}, out interface{}, c *conversion
 	}
 }
 
-func DeepCopy_v1_GroupVersionResource(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1GroupVersionResource ...
+func DeepCopyv1GroupVersionResource(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*GroupVersionResource)
 		out := out.(*GroupVersionResource)
@@ -271,24 +286,26 @@ func DeepCopy_v1_GroupVersionResource(in interface{}, out interface{}, c *conver
 	}
 }
 
-func DeepCopy_v1_InternalEvent(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1InternalEvent ...
+func DeepCopyv1InternalEvent(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*InternalEvent)
 		out := out.(*InternalEvent)
 		*out = *in
 		// in.Object is kind 'Interface'
 		if in.Object != nil {
-			if newVal, err := c.DeepCopy(&in.Object); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(&in.Object); err == nil {
 				out.Object = *newVal.(*runtime.Object)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_LabelSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LabelSelector ...
+func DeepCopyv1LabelSelector(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LabelSelector)
 		out := out.(*LabelSelector)
@@ -304,10 +321,10 @@ func DeepCopy_v1_LabelSelector(in interface{}, out interface{}, c *conversion.Cl
 			in, out := &in.MatchExpressions, &out.MatchExpressions
 			*out = make([]LabelSelectorRequirement, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*LabelSelectorRequirement)
+				} else {
+					return err
 				}
 			}
 		}
@@ -315,7 +332,8 @@ func DeepCopy_v1_LabelSelector(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_LabelSelectorRequirement(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1LabelSelectorRequirement ...
+func DeepCopyv1LabelSelectorRequirement(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*LabelSelectorRequirement)
 		out := out.(*LabelSelectorRequirement)
@@ -329,7 +347,8 @@ func DeepCopy_v1_LabelSelectorRequirement(in interface{}, out interface{}, c *co
 	}
 }
 
-func DeepCopy_v1_ListMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ListMeta ...
+func DeepCopyv1ListMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ListMeta)
 		out := out.(*ListMeta)
@@ -338,7 +357,8 @@ func DeepCopy_v1_ListMeta(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_v1_ListOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ListOptions ...
+func DeepCopyv1ListOptions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ListOptions)
 		out := out.(*ListOptions)
@@ -352,7 +372,8 @@ func DeepCopy_v1_ListOptions(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_ObjectMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ObjectMeta ...
+func DeepCopyv1ObjectMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ObjectMeta)
 		out := out.(*ObjectMeta)
@@ -386,10 +407,10 @@ func DeepCopy_v1_ObjectMeta(in interface{}, out interface{}, c *conversion.Clone
 			in, out := &in.OwnerReferences, &out.OwnerReferences
 			*out = make([]OwnerReference, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*OwnerReference)
+				} else {
+					return err
 				}
 			}
 		}
@@ -402,7 +423,8 @@ func DeepCopy_v1_ObjectMeta(in interface{}, out interface{}, c *conversion.Clone
 	}
 }
 
-func DeepCopy_v1_OwnerReference(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1OwnerReference ...
+func DeepCopyv1OwnerReference(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*OwnerReference)
 		out := out.(*OwnerReference)
@@ -416,7 +438,8 @@ func DeepCopy_v1_OwnerReference(in interface{}, out interface{}, c *conversion.C
 	}
 }
 
-func DeepCopy_v1_Patch(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Patch ...
+func DeepCopyv1Patch(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Patch)
 		out := out.(*Patch)
@@ -425,7 +448,8 @@ func DeepCopy_v1_Patch(in interface{}, out interface{}, c *conversion.Cloner) er
 	}
 }
 
-func DeepCopy_v1_Preconditions(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Preconditions ...
+func DeepCopyv1Preconditions(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Preconditions)
 		out := out.(*Preconditions)
@@ -439,7 +463,8 @@ func DeepCopy_v1_Preconditions(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_RootPaths(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1RootPaths ...
+func DeepCopyv1RootPaths(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RootPaths)
 		out := out.(*RootPaths)
@@ -453,7 +478,8 @@ func DeepCopy_v1_RootPaths(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_ServerAddressByClientCIDR(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1ServerAddressByClientCIDR ...
+func DeepCopyv1ServerAddressByClientCIDR(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*ServerAddressByClientCIDR)
 		out := out.(*ServerAddressByClientCIDR)
@@ -462,24 +488,26 @@ func DeepCopy_v1_ServerAddressByClientCIDR(in interface{}, out interface{}, c *c
 	}
 }
 
-func DeepCopy_v1_Status(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Status ...
+func DeepCopyv1Status(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Status)
 		out := out.(*Status)
 		*out = *in
 		if in.Details != nil {
 			in, out := &in.Details, &out.Details
-			if newVal, err := c.DeepCopy(*in); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(*in); err == nil {
 				*out = newVal.(*StatusDetails)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_StatusCause(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1StatusCause ...
+func DeepCopyv1StatusCause(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatusCause)
 		out := out.(*StatusCause)
@@ -488,7 +516,8 @@ func DeepCopy_v1_StatusCause(in interface{}, out interface{}, c *conversion.Clon
 	}
 }
 
-func DeepCopy_v1_StatusDetails(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1StatusDetails ...
+func DeepCopyv1StatusDetails(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*StatusDetails)
 		out := out.(*StatusDetails)
@@ -502,7 +531,8 @@ func DeepCopy_v1_StatusDetails(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_v1_Time(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Time ...
+func DeepCopyv1Time(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Time)
 		out := out.(*Time)
@@ -511,7 +541,8 @@ func DeepCopy_v1_Time(in interface{}, out interface{}, c *conversion.Cloner) err
 	}
 }
 
-func DeepCopy_v1_Timestamp(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Timestamp ...
+func DeepCopyv1Timestamp(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Timestamp)
 		out := out.(*Timestamp)
@@ -520,7 +551,8 @@ func DeepCopy_v1_Timestamp(in interface{}, out interface{}, c *conversion.Cloner
 	}
 }
 
-func DeepCopy_v1_TypeMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1TypeMeta ...
+func DeepCopyv1TypeMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TypeMeta)
 		out := out.(*TypeMeta)
@@ -529,15 +561,16 @@ func DeepCopy_v1_TypeMeta(in interface{}, out interface{}, c *conversion.Cloner)
 	}
 }
 
-func DeepCopy_v1_WatchEvent(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1WatchEvent ...
+func DeepCopyv1WatchEvent(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*WatchEvent)
 		out := out.(*WatchEvent)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.Object); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.Object); err == nil {
 			out.Object = *newVal.(*runtime.RawExtension)
+		} else {
+			return err
 		}
 		return nil
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/zz_generated.deepcopy.go
@@ -28,13 +28,14 @@ import (
 // GetGeneratedDeepCopyFuncs returns the generated funcs, since we aren't registering them.
 func GetGeneratedDeepCopyFuncs() []conversion.GeneratedDeepCopyFunc {
 	return []conversion.GeneratedDeepCopyFunc{
-		{Fn: DeepCopy_runtime_RawExtension, InType: reflect.TypeOf(&RawExtension{})},
-		{Fn: DeepCopy_runtime_TypeMeta, InType: reflect.TypeOf(&TypeMeta{})},
-		{Fn: DeepCopy_runtime_Unknown, InType: reflect.TypeOf(&Unknown{})},
+		{Fn: DeepCopyruntimeRawExtension, InType: reflect.TypeOf(&RawExtension{})},
+		{Fn: DeepCopyruntimeTypeMeta, InType: reflect.TypeOf(&TypeMeta{})},
+		{Fn: DeepCopyruntimeUnknown, InType: reflect.TypeOf(&Unknown{})},
 	}
 }
 
-func DeepCopy_runtime_RawExtension(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyruntimeRawExtension ...
+func DeepCopyruntimeRawExtension(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*RawExtension)
 		out := out.(*RawExtension)
@@ -46,17 +47,18 @@ func DeepCopy_runtime_RawExtension(in interface{}, out interface{}, c *conversio
 		}
 		// in.Object is kind 'Interface'
 		if in.Object != nil {
-			if newVal, err := c.DeepCopy(&in.Object); err != nil {
-				return err
-			} else {
+			if newVal, err := c.DeepCopy(&in.Object); err == nil {
 				out.Object = *newVal.(*Object)
+			} else {
+				return err
 			}
 		}
 		return nil
 	}
 }
 
-func DeepCopy_runtime_TypeMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyruntimeTypeMeta ...
+func DeepCopyruntimeTypeMeta(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*TypeMeta)
 		out := out.(*TypeMeta)
@@ -65,7 +67,8 @@ func DeepCopy_runtime_TypeMeta(in interface{}, out interface{}, c *conversion.Cl
 	}
 }
 
-func DeepCopy_runtime_Unknown(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyruntimeUnknown ...
+func DeepCopyruntimeUnknown(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Unknown)
 		out := out.(*Unknown)

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.deepcopy.go
@@ -35,39 +35,41 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_Pod, InType: reflect.TypeOf(&Pod{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodCondition, InType: reflect.TypeOf(&PodCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodList, InType: reflect.TypeOf(&PodList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodSpec, InType: reflect.TypeOf(&PodSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_v1_PodStatus, InType: reflect.TypeOf(&PodStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1Pod, InType: reflect.TypeOf(&Pod{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodCondition, InType: reflect.TypeOf(&PodCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodList, InType: reflect.TypeOf(&PodList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodSpec, InType: reflect.TypeOf(&PodSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyv1PodStatus, InType: reflect.TypeOf(&PodStatus{})},
 	)
 }
 
-func DeepCopy_v1_Pod(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1Pod ...
+func DeepCopyv1Pod(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Pod)
 		out := out.(*Pod)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*meta_v1.ObjectMeta)
-		}
-		if newVal, err := c.DeepCopy(&in.Spec); err != nil {
-			return err
 		} else {
+			return err
+		}
+		if newVal, err := c.DeepCopy(&in.Spec); err == nil {
 			out.Spec = *newVal.(*PodSpec)
-		}
-		if newVal, err := c.DeepCopy(&in.Status); err != nil {
-			return err
 		} else {
+			return err
+		}
+		if newVal, err := c.DeepCopy(&in.Status); err == nil {
 			out.Status = *newVal.(*PodStatus)
+		} else {
+			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_v1_PodCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodCondition ...
+func DeepCopyv1PodCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodCondition)
 		out := out.(*PodCondition)
@@ -78,7 +80,8 @@ func DeepCopy_v1_PodCondition(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_v1_PodList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodList ...
+func DeepCopyv1PodList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodList)
 		out := out.(*PodList)
@@ -87,10 +90,10 @@ func DeepCopy_v1_PodList(in interface{}, out interface{}, c *conversion.Cloner) 
 			in, out := &in.Items, &out.Items
 			*out = make([]Pod, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*Pod)
+				} else {
+					return err
 				}
 			}
 		}
@@ -98,7 +101,8 @@ func DeepCopy_v1_PodList(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodSpec ...
+func DeepCopyv1PodSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSpec)
 		out := out.(*PodSpec)
@@ -124,7 +128,8 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 	}
 }
 
-func DeepCopy_v1_PodStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyv1PodStatus ...
+func DeepCopyv1PodStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodStatus)
 		out := out.(*PodStatus)
@@ -133,10 +138,10 @@ func DeepCopy_v1_PodStatus(in interface{}, out interface{}, c *conversion.Cloner
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]PodCondition, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*PodCondition)
+				} else {
+					return err
 				}
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/zz_generated.deepcopy.go
@@ -35,39 +35,41 @@ func init() {
 // to allow building arbitrary schemes.
 func RegisterDeepCopies(scheme *runtime.Scheme) error {
 	return scheme.AddGeneratedDeepCopyFuncs(
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_example_Pod, InType: reflect.TypeOf(&Pod{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_example_PodCondition, InType: reflect.TypeOf(&PodCondition{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_example_PodList, InType: reflect.TypeOf(&PodList{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_example_PodSpec, InType: reflect.TypeOf(&PodSpec{})},
-		conversion.GeneratedDeepCopyFunc{Fn: DeepCopy_example_PodStatus, InType: reflect.TypeOf(&PodStatus{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyexamplePod, InType: reflect.TypeOf(&Pod{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyexamplePodCondition, InType: reflect.TypeOf(&PodCondition{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyexamplePodList, InType: reflect.TypeOf(&PodList{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyexamplePodSpec, InType: reflect.TypeOf(&PodSpec{})},
+		conversion.GeneratedDeepCopyFunc{Fn: DeepCopyexamplePodStatus, InType: reflect.TypeOf(&PodStatus{})},
 	)
 }
 
-func DeepCopy_example_Pod(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyexamplePod ...
+func DeepCopyexamplePod(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*Pod)
 		out := out.(*Pod)
 		*out = *in
-		if newVal, err := c.DeepCopy(&in.ObjectMeta); err != nil {
-			return err
-		} else {
+		if newVal, err := c.DeepCopy(&in.ObjectMeta); err == nil {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
-		}
-		if newVal, err := c.DeepCopy(&in.Spec); err != nil {
-			return err
 		} else {
+			return err
+		}
+		if newVal, err := c.DeepCopy(&in.Spec); err == nil {
 			out.Spec = *newVal.(*PodSpec)
-		}
-		if newVal, err := c.DeepCopy(&in.Status); err != nil {
-			return err
 		} else {
+			return err
+		}
+		if newVal, err := c.DeepCopy(&in.Status); err == nil {
 			out.Status = *newVal.(*PodStatus)
+		} else {
+			return err
 		}
 		return nil
 	}
 }
 
-func DeepCopy_example_PodCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyexamplePodCondition ...
+func DeepCopyexamplePodCondition(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodCondition)
 		out := out.(*PodCondition)
@@ -78,7 +80,8 @@ func DeepCopy_example_PodCondition(in interface{}, out interface{}, c *conversio
 	}
 }
 
-func DeepCopy_example_PodList(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyexamplePodList ...
+func DeepCopyexamplePodList(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodList)
 		out := out.(*PodList)
@@ -87,10 +90,10 @@ func DeepCopy_example_PodList(in interface{}, out interface{}, c *conversion.Clo
 			in, out := &in.Items, &out.Items
 			*out = make([]Pod, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*Pod)
+				} else {
+					return err
 				}
 			}
 		}
@@ -98,7 +101,8 @@ func DeepCopy_example_PodList(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_example_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyexamplePodSpec ...
+func DeepCopyexamplePodSpec(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodSpec)
 		out := out.(*PodSpec)
@@ -124,7 +128,8 @@ func DeepCopy_example_PodSpec(in interface{}, out interface{}, c *conversion.Clo
 	}
 }
 
-func DeepCopy_example_PodStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
+// DeepCopyexamplePodStatus ...
+func DeepCopyexamplePodStatus(in interface{}, out interface{}, c *conversion.Cloner) error {
 	{
 		in := in.(*PodStatus)
 		out := out.(*PodStatus)
@@ -133,10 +138,10 @@ func DeepCopy_example_PodStatus(in interface{}, out interface{}, c *conversion.C
 			in, out := &in.Conditions, &out.Conditions
 			*out = make([]PodCondition, len(*in))
 			for i := range *in {
-				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
-					return err
-				} else {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err == nil {
 					(*out)[i] = *newVal.(*PodCondition)
+				} else {
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Project like https://github.com/kubernetes-incubator/service-catalog/ uses
kubernetes vendor code, which generates certain files like default, deepcopy
and conversion generated files (e.g. zz_generated.deepcopy.go). Currently
this results into several golint errors.
The changes in this patch takes care of lint failures resulted due to
deepcopy generated files. The total numbers of such lint failures are
around fifty errors. There are main three types of lint errors,
1. Generated functions name have underscore in them.
2. Generated functions are missing comment.
3. Some of the generated functions have unnecessary 'else' block for a given
   'if' loop.

For example, few of fifty some total failures are:
/zz_generated.deepcopy.go:60:6: don't use underscores in Go names;
/zz_generated.deepcopy.go:60:1: exported function should have comment or
be unexported
/zz_generated.deepcopy.go:116:10: if block ends with a return statement,
so drop this else and outdent its block

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Since it's not major code change, no issue is opened. 
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
