### PR TITLE
Revert "Use watch param instead of deprecated /watch/ prefix"

### DIFF
--- a/cmd/libs/go2idl/client-gen/generators/generator_for_type.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_type.go
@@ -321,8 +321,8 @@ func (c *$.type|privatePlural$) UpdateStatus($.type|private$ *$.type|raw$) (resu
 var watchTemplate = `
 // Watch returns a $.watchInterface|raw$ that watches the requested $.type|privatePlural$.
 func (c *$.type|privatePlural$) Watch(opts $.ListOptions|raw$) ($.watchInterface|raw$, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		$if .namespaced$Namespace(c.ns).$end$
 		Resource("$.type|allLowercasePlural$").
 		VersionedParams(&opts, $.apiParameterCodec|raw$).

--- a/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/testtype.go
+++ b/cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/testtype.go
@@ -149,8 +149,8 @@ func (c *testTypes) List(opts v1.ListOptions) (result *testgroup.TestTypeList, e
 
 // Watch returns a watch.Interface that watches the requested testTypes.
 func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("testtypes").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -149,8 +149,8 @@ func (c *horizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v1.Ho
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
 func (c *horizontalPodAutoscalers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/batch/v1/job.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/batch/v1/job.go
@@ -149,8 +149,8 @@ func (c *jobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error) {
 
 // Watch returns a watch.Interface that watches the requested jobs.
 func (c *jobs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("jobs").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/configmap.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/configmap.go
@@ -132,8 +132,8 @@ func (c *configMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapList, e
 
 // Watch returns a watch.Interface that watches the requested configMaps.
 func (c *configMaps) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("configmaps").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/event.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/event.go
@@ -132,8 +132,8 @@ func (c *events) List(opts meta_v1.ListOptions) (result *v1.EventList, err error
 
 // Watch returns a watch.Interface that watches the requested events.
 func (c *events) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("events").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/namespace.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/namespace.go
@@ -140,8 +140,8 @@ func (c *namespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceList, e
 
 // Watch returns a watch.Interface that watches the requested namespaces.
 func (c *namespaces) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("namespaces").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/secret.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/secret.go
@@ -132,8 +132,8 @@ func (c *secrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err err
 
 // Watch returns a watch.Interface that watches the requested secrets.
 func (c *secrets) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("secrets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/service.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/service.go
@@ -149,8 +149,8 @@ func (c *services) List(opts meta_v1.ListOptions) (result *v1.ServiceList, err e
 
 // Watch returns a watch.Interface that watches the requested services.
 func (c *services) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("services").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/daemonset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/daemonset.go
@@ -149,8 +149,8 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 
 // Watch returns a watch.Interface that watches the requested daemonSets.
 func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("daemonsets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
@@ -149,8 +149,8 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 
 // Watch returns a watch.Interface that watches the requested deployments.
 func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("deployments").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/ingress.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/ingress.go
@@ -149,8 +149,8 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 
 // Watch returns a watch.Interface that watches the requested ingresses.
 func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("ingresses").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
@@ -149,8 +149,8 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList,
 
 // Watch returns a watch.Interface that watches the requested replicaSets.
 func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("replicasets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1/cluster.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1/cluster.go
@@ -140,8 +140,8 @@ func (c *clusters) List(opts v1.ListOptions) (result *v1beta1.ClusterList, err e
 
 // Watch returns a watch.Interface that watches the requested clusters.
 func (c *clusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("clusters").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
@@ -149,8 +149,8 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscalin
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
 func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion/job.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion/job.go
@@ -149,8 +149,8 @@ func (c *jobs) List(opts v1.ListOptions) (result *batch.JobList, err error) {
 
 // Watch returns a watch.Interface that watches the requested jobs.
 func (c *jobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("jobs").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/configmap.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/configmap.go
@@ -131,8 +131,8 @@ func (c *configMaps) List(opts v1.ListOptions) (result *api.ConfigMapList, err e
 
 // Watch returns a watch.Interface that watches the requested configMaps.
 func (c *configMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("configmaps").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/event.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/event.go
@@ -131,8 +131,8 @@ func (c *events) List(opts v1.ListOptions) (result *api.EventList, err error) {
 
 // Watch returns a watch.Interface that watches the requested events.
 func (c *events) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("events").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/namespace.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/namespace.go
@@ -139,8 +139,8 @@ func (c *namespaces) List(opts v1.ListOptions) (result *api.NamespaceList, err e
 
 // Watch returns a watch.Interface that watches the requested namespaces.
 func (c *namespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("namespaces").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/secret.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/secret.go
@@ -131,8 +131,8 @@ func (c *secrets) List(opts v1.ListOptions) (result *api.SecretList, err error) 
 
 // Watch returns a watch.Interface that watches the requested secrets.
 func (c *secrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("secrets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/service.go
@@ -148,8 +148,8 @@ func (c *services) List(opts v1.ListOptions) (result *api.ServiceList, err error
 
 // Watch returns a watch.Interface that watches the requested services.
 func (c *services) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("services").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/daemonset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/daemonset.go
@@ -149,8 +149,8 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *extensions.DaemonSetList
 
 // Watch returns a watch.Interface that watches the requested daemonSets.
 func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("daemonsets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/deployment.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/deployment.go
@@ -149,8 +149,8 @@ func (c *deployments) List(opts v1.ListOptions) (result *extensions.DeploymentLi
 
 // Watch returns a watch.Interface that watches the requested deployments.
 func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("deployments").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/ingress.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/ingress.go
@@ -149,8 +149,8 @@ func (c *ingresses) List(opts v1.ListOptions) (result *extensions.IngressList, e
 
 // Watch returns a watch.Interface that watches the requested ingresses.
 func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("ingresses").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/replicaset.go
@@ -149,8 +149,8 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *extensions.ReplicaSetLi
 
 // Watch returns a watch.Interface that watches the requested replicaSets.
 func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("replicasets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/cluster.go
@@ -140,8 +140,8 @@ func (c *clusters) List(opts v1.ListOptions) (result *federation.ClusterList, er
 
 // Watch returns a watch.Interface that watches the requested clusters.
 func (c *clusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("clusters").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/apps/v1beta1/statefulset.go
+++ b/pkg/client/clientset_generated/clientset/typed/apps/v1beta1/statefulset.go
@@ -149,8 +149,8 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetLis
 
 // Watch returns a watch.Interface that watches the requested statefulSets.
 func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("statefulsets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -149,8 +149,8 @@ func (c *horizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v1.Ho
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
 func (c *horizontalPodAutoscalers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/autoscaling/v2alpha1/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/clientset/typed/autoscaling/v2alpha1/horizontalpodautoscaler.go
@@ -149,8 +149,8 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2alpha1.H
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
 func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/batch/v1/job.go
+++ b/pkg/client/clientset_generated/clientset/typed/batch/v1/job.go
@@ -149,8 +149,8 @@ func (c *jobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error) {
 
 // Watch returns a watch.Interface that watches the requested jobs.
 func (c *jobs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("jobs").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/batch/v2alpha1/cronjob.go
+++ b/pkg/client/clientset_generated/clientset/typed/batch/v2alpha1/cronjob.go
@@ -149,8 +149,8 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err 
 
 // Watch returns a watch.Interface that watches the requested cronJobs.
 func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("cronjobs").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/batch/v2alpha1/job.go
+++ b/pkg/client/clientset_generated/clientset/typed/batch/v2alpha1/job.go
@@ -149,8 +149,8 @@ func (c *jobs) List(opts v1.ListOptions) (result *v2alpha1.JobList, err error) {
 
 // Watch returns a watch.Interface that watches the requested jobs.
 func (c *jobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("jobs").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/clientset/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -140,8 +140,8 @@ func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.
 
 // Watch returns a watch.Interface that watches the requested certificateSigningRequests.
 func (c *certificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/componentstatus.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/componentstatus.go
@@ -124,8 +124,8 @@ func (c *componentStatuses) List(opts meta_v1.ListOptions) (result *v1.Component
 
 // Watch returns a watch.Interface that watches the requested componentStatuses.
 func (c *componentStatuses) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("componentstatuses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/configmap.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/configmap.go
@@ -132,8 +132,8 @@ func (c *configMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapList, e
 
 // Watch returns a watch.Interface that watches the requested configMaps.
 func (c *configMaps) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("configmaps").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/endpoints.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/endpoints.go
@@ -132,8 +132,8 @@ func (c *endpoints) List(opts meta_v1.ListOptions) (result *v1.EndpointsList, er
 
 // Watch returns a watch.Interface that watches the requested endpoints.
 func (c *endpoints) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("endpoints").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/event.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/event.go
@@ -132,8 +132,8 @@ func (c *events) List(opts meta_v1.ListOptions) (result *v1.EventList, err error
 
 // Watch returns a watch.Interface that watches the requested events.
 func (c *events) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("events").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/limitrange.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/limitrange.go
@@ -132,8 +132,8 @@ func (c *limitRanges) List(opts meta_v1.ListOptions) (result *v1.LimitRangeList,
 
 // Watch returns a watch.Interface that watches the requested limitRanges.
 func (c *limitRanges) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("limitranges").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/namespace.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/namespace.go
@@ -140,8 +140,8 @@ func (c *namespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceList, e
 
 // Watch returns a watch.Interface that watches the requested namespaces.
 func (c *namespaces) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("namespaces").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/node.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/node.go
@@ -140,8 +140,8 @@ func (c *nodes) List(opts meta_v1.ListOptions) (result *v1.NodeList, err error) 
 
 // Watch returns a watch.Interface that watches the requested nodes.
 func (c *nodes) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("nodes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/persistentvolume.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/persistentvolume.go
@@ -140,8 +140,8 @@ func (c *persistentVolumes) List(opts meta_v1.ListOptions) (result *v1.Persisten
 
 // Watch returns a watch.Interface that watches the requested persistentVolumes.
 func (c *persistentVolumes) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("persistentvolumes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/persistentvolumeclaim.go
@@ -149,8 +149,8 @@ func (c *persistentVolumeClaims) List(opts meta_v1.ListOptions) (result *v1.Pers
 
 // Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
 func (c *persistentVolumeClaims) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/pod.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/pod.go
@@ -149,8 +149,8 @@ func (c *pods) List(opts meta_v1.ListOptions) (result *v1.PodList, err error) {
 
 // Watch returns a watch.Interface that watches the requested pods.
 func (c *pods) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("pods").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/podtemplate.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/podtemplate.go
@@ -132,8 +132,8 @@ func (c *podTemplates) List(opts meta_v1.ListOptions) (result *v1.PodTemplateLis
 
 // Watch returns a watch.Interface that watches the requested podTemplates.
 func (c *podTemplates) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("podtemplates").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/replicationcontroller.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/replicationcontroller.go
@@ -149,8 +149,8 @@ func (c *replicationControllers) List(opts meta_v1.ListOptions) (result *v1.Repl
 
 // Watch returns a watch.Interface that watches the requested replicationControllers.
 func (c *replicationControllers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/resourcequota.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/resourcequota.go
@@ -149,8 +149,8 @@ func (c *resourceQuotas) List(opts meta_v1.ListOptions) (result *v1.ResourceQuot
 
 // Watch returns a watch.Interface that watches the requested resourceQuotas.
 func (c *resourceQuotas) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("resourcequotas").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/secret.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/secret.go
@@ -132,8 +132,8 @@ func (c *secrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err err
 
 // Watch returns a watch.Interface that watches the requested secrets.
 func (c *secrets) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("secrets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/service.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/service.go
@@ -149,8 +149,8 @@ func (c *services) List(opts meta_v1.ListOptions) (result *v1.ServiceList, err e
 
 // Watch returns a watch.Interface that watches the requested services.
 func (c *services) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("services").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/core/v1/serviceaccount.go
+++ b/pkg/client/clientset_generated/clientset/typed/core/v1/serviceaccount.go
@@ -132,8 +132,8 @@ func (c *serviceAccounts) List(opts meta_v1.ListOptions) (result *v1.ServiceAcco
 
 // Watch returns a watch.Interface that watches the requested serviceAccounts.
 func (c *serviceAccounts) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("serviceaccounts").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/daemonset.go
+++ b/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/daemonset.go
@@ -149,8 +149,8 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 
 // Watch returns a watch.Interface that watches the requested daemonSets.
 func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("daemonsets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/deployment.go
+++ b/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/deployment.go
@@ -149,8 +149,8 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 
 // Watch returns a watch.Interface that watches the requested deployments.
 func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("deployments").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/ingress.go
+++ b/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/ingress.go
@@ -149,8 +149,8 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 
 // Watch returns a watch.Interface that watches the requested ingresses.
 func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("ingresses").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -124,8 +124,8 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 
 // Watch returns a watch.Interface that watches the requested podSecurityPolicies.
 func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/replicaset.go
+++ b/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/replicaset.go
@@ -149,8 +149,8 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList,
 
 // Watch returns a watch.Interface that watches the requested replicaSets.
 func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("replicasets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/thirdpartyresource.go
@@ -124,8 +124,8 @@ func (c *thirdPartyResources) List(opts v1.ListOptions) (result *v1beta1.ThirdPa
 
 // Watch returns a watch.Interface that watches the requested thirdPartyResources.
 func (c *thirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("thirdpartyresources").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/clientset/typed/policy/v1beta1/poddisruptionbudget.go
@@ -149,8 +149,8 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDis
 
 // Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
 func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/clusterrole.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/clusterrole.go
@@ -124,8 +124,8 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleLi
 
 // Watch returns a watch.Interface that watches the requested clusterRoles.
 func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("clusterroles").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -124,8 +124,8 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cluste
 
 // Watch returns a watch.Interface that watches the requested clusterRoleBindings.
 func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/role.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/role.go
@@ -132,8 +132,8 @@ func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error)
 
 // Watch returns a watch.Interface that watches the requested roles.
 func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("roles").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/rolebinding.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/rolebinding.go
@@ -132,8 +132,8 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingLi
 
 // Watch returns a watch.Interface that watches the requested roleBindings.
 func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("rolebindings").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/clusterrole.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/clusterrole.go
@@ -124,8 +124,8 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleLis
 
 // Watch returns a watch.Interface that watches the requested clusterRoles.
 func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("clusterroles").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/clusterrolebinding.go
@@ -124,8 +124,8 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.Cluster
 
 // Watch returns a watch.Interface that watches the requested clusterRoleBindings.
 func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/role.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/role.go
@@ -132,8 +132,8 @@ func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) 
 
 // Watch returns a watch.Interface that watches the requested roles.
 func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("roles").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/rolebinding.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/rolebinding.go
@@ -132,8 +132,8 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingLis
 
 // Watch returns a watch.Interface that watches the requested roleBindings.
 func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("rolebindings").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/clientset/typed/storage/v1beta1/storageclass.go
+++ b/pkg/client/clientset_generated/clientset/typed/storage/v1beta1/storageclass.go
@@ -124,8 +124,8 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 
 // Watch returns a watch.Interface that watches the requested storageClasses.
 func (c *storageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("storageclasses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
@@ -149,8 +149,8 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *apps.StatefulSetList, 
 
 // Watch returns a watch.Interface that watches the requested statefulSets.
 func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("statefulsets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
@@ -149,8 +149,8 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscalin
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
 func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/cronjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/cronjob.go
@@ -149,8 +149,8 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *batch.CronJobList, err err
 
 // Watch returns a watch.Interface that watches the requested cronJobs.
 func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("cronjobs").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/job.go
@@ -149,8 +149,8 @@ func (c *jobs) List(opts v1.ListOptions) (result *batch.JobList, err error) {
 
 // Watch returns a watch.Interface that watches the requested jobs.
 func (c *jobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("jobs").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/certificatesigningrequest.go
@@ -140,8 +140,8 @@ func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *certific
 
 // Watch returns a watch.Interface that watches the requested certificateSigningRequests.
 func (c *certificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/componentstatus.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/componentstatus.go
@@ -123,8 +123,8 @@ func (c *componentStatuses) List(opts v1.ListOptions) (result *api.ComponentStat
 
 // Watch returns a watch.Interface that watches the requested componentStatuses.
 func (c *componentStatuses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("componentstatuses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/configmap.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/configmap.go
@@ -131,8 +131,8 @@ func (c *configMaps) List(opts v1.ListOptions) (result *api.ConfigMapList, err e
 
 // Watch returns a watch.Interface that watches the requested configMaps.
 func (c *configMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("configmaps").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/endpoints.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/endpoints.go
@@ -131,8 +131,8 @@ func (c *endpoints) List(opts v1.ListOptions) (result *api.EndpointsList, err er
 
 // Watch returns a watch.Interface that watches the requested endpoints.
 func (c *endpoints) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("endpoints").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/event.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/event.go
@@ -131,8 +131,8 @@ func (c *events) List(opts v1.ListOptions) (result *api.EventList, err error) {
 
 // Watch returns a watch.Interface that watches the requested events.
 func (c *events) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("events").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/limitrange.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/limitrange.go
@@ -131,8 +131,8 @@ func (c *limitRanges) List(opts v1.ListOptions) (result *api.LimitRangeList, err
 
 // Watch returns a watch.Interface that watches the requested limitRanges.
 func (c *limitRanges) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("limitranges").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/namespace.go
@@ -139,8 +139,8 @@ func (c *namespaces) List(opts v1.ListOptions) (result *api.NamespaceList, err e
 
 // Watch returns a watch.Interface that watches the requested namespaces.
 func (c *namespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("namespaces").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/node.go
@@ -139,8 +139,8 @@ func (c *nodes) List(opts v1.ListOptions) (result *api.NodeList, err error) {
 
 // Watch returns a watch.Interface that watches the requested nodes.
 func (c *nodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("nodes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolume.go
@@ -139,8 +139,8 @@ func (c *persistentVolumes) List(opts v1.ListOptions) (result *api.PersistentVol
 
 // Watch returns a watch.Interface that watches the requested persistentVolumes.
 func (c *persistentVolumes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("persistentvolumes").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolumeclaim.go
@@ -148,8 +148,8 @@ func (c *persistentVolumeClaims) List(opts v1.ListOptions) (result *api.Persiste
 
 // Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
 func (c *persistentVolumeClaims) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/pod.go
@@ -148,8 +148,8 @@ func (c *pods) List(opts v1.ListOptions) (result *api.PodList, err error) {
 
 // Watch returns a watch.Interface that watches the requested pods.
 func (c *pods) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("pods").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/podtemplate.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/podtemplate.go
@@ -131,8 +131,8 @@ func (c *podTemplates) List(opts v1.ListOptions) (result *api.PodTemplateList, e
 
 // Watch returns a watch.Interface that watches the requested podTemplates.
 func (c *podTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("podtemplates").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/replicationcontroller.go
@@ -148,8 +148,8 @@ func (c *replicationControllers) List(opts v1.ListOptions) (result *api.Replicat
 
 // Watch returns a watch.Interface that watches the requested replicationControllers.
 func (c *replicationControllers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/resourcequota.go
@@ -148,8 +148,8 @@ func (c *resourceQuotas) List(opts v1.ListOptions) (result *api.ResourceQuotaLis
 
 // Watch returns a watch.Interface that watches the requested resourceQuotas.
 func (c *resourceQuotas) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("resourcequotas").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/secret.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/secret.go
@@ -131,8 +131,8 @@ func (c *secrets) List(opts v1.ListOptions) (result *api.SecretList, err error) 
 
 // Watch returns a watch.Interface that watches the requested secrets.
 func (c *secrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("secrets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/service.go
@@ -148,8 +148,8 @@ func (c *services) List(opts v1.ListOptions) (result *api.ServiceList, err error
 
 // Watch returns a watch.Interface that watches the requested services.
 func (c *services) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("services").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/serviceaccount.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/serviceaccount.go
@@ -131,8 +131,8 @@ func (c *serviceAccounts) List(opts v1.ListOptions) (result *api.ServiceAccountL
 
 // Watch returns a watch.Interface that watches the requested serviceAccounts.
 func (c *serviceAccounts) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("serviceaccounts").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/daemonset.go
@@ -149,8 +149,8 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *extensions.DaemonSetList
 
 // Watch returns a watch.Interface that watches the requested daemonSets.
 func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("daemonsets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
@@ -149,8 +149,8 @@ func (c *deployments) List(opts v1.ListOptions) (result *extensions.DeploymentLi
 
 // Watch returns a watch.Interface that watches the requested deployments.
 func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("deployments").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/ingress.go
@@ -149,8 +149,8 @@ func (c *ingresses) List(opts v1.ListOptions) (result *extensions.IngressList, e
 
 // Watch returns a watch.Interface that watches the requested ingresses.
 func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("ingresses").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/networkpolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/networkpolicy.go
@@ -132,8 +132,8 @@ func (c *networkPolicies) List(opts v1.ListOptions) (result *extensions.NetworkP
 
 // Watch returns a watch.Interface that watches the requested networkPolicies.
 func (c *networkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("networkpolicies").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/podsecuritypolicy.go
@@ -124,8 +124,8 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *extensions.PodS
 
 // Watch returns a watch.Interface that watches the requested podSecurityPolicies.
 func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
@@ -149,8 +149,8 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *extensions.ReplicaSetLi
 
 // Watch returns a watch.Interface that watches the requested replicaSets.
 func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("replicasets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/thirdpartyresource.go
@@ -124,8 +124,8 @@ func (c *thirdPartyResources) List(opts v1.ListOptions) (result *extensions.Thir
 
 // Watch returns a watch.Interface that watches the requested thirdPartyResources.
 func (c *thirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("thirdpartyresources").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/poddisruptionbudget.go
@@ -149,8 +149,8 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *policy.PodDisr
 
 // Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
 func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/clusterrole.go
@@ -124,8 +124,8 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *rbac.ClusterRoleList, 
 
 // Watch returns a watch.Interface that watches the requested clusterRoles.
 func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("clusterroles").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/clusterrolebinding.go
@@ -124,8 +124,8 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *rbac.ClusterRol
 
 // Watch returns a watch.Interface that watches the requested clusterRoleBindings.
 func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/role.go
@@ -132,8 +132,8 @@ func (c *roles) List(opts v1.ListOptions) (result *rbac.RoleList, err error) {
 
 // Watch returns a watch.Interface that watches the requested roles.
 func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("roles").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/rolebinding.go
@@ -132,8 +132,8 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *rbac.RoleBindingList, 
 
 // Watch returns a watch.Interface that watches the requested roleBindings.
 func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Namespace(c.ns).
 		Resource("rolebindings").
 		VersionedParams(&opts, api.ParameterCodec).

--- a/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/storageclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/storageclass.go
@@ -124,8 +124,8 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *storage.StorageClass
 
 // Watch returns a watch.Interface that watches the requested storageClasses.
 func (c *storageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("storageclasses").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/pkg/client/tests/listwatch_test.go
+++ b/pkg/client/tests/listwatch_test.go
@@ -122,8 +122,8 @@ func TestListWatchesCanWatch(t *testing.T) {
 		// Node
 		{
 			location: buildLocation(
-				testapi.Default.ResourcePath("nodes", metav1.NamespaceAll, ""),
-				buildQueryValues(url.Values{"watch": []string{"true"}})),
+				testapi.Default.ResourcePathWithPrefix("watch", "nodes", metav1.NamespaceAll, ""),
+				buildQueryValues(url.Values{})),
 			rv:            "",
 			resource:      "nodes",
 			namespace:     metav1.NamespaceAll,
@@ -131,8 +131,8 @@ func TestListWatchesCanWatch(t *testing.T) {
 		},
 		{
 			location: buildLocation(
-				testapi.Default.ResourcePath("nodes", metav1.NamespaceAll, ""),
-				buildQueryValues(url.Values{"resourceVersion": []string{"42"}, "watch": []string{"true"}})),
+				testapi.Default.ResourcePathWithPrefix("watch", "nodes", metav1.NamespaceAll, ""),
+				buildQueryValues(url.Values{"resourceVersion": []string{"42"}})),
 			rv:            "42",
 			resource:      "nodes",
 			namespace:     metav1.NamespaceAll,
@@ -141,8 +141,8 @@ func TestListWatchesCanWatch(t *testing.T) {
 		// pod with "assigned" field selector.
 		{
 			location: buildLocation(
-				testapi.Default.ResourcePath("pods", metav1.NamespaceAll, ""),
-				buildQueryValues(url.Values{fieldSelectorQueryParamName: []string{"spec.host="}, "resourceVersion": []string{"0"}, "watch": []string{"true"}})),
+				testapi.Default.ResourcePathWithPrefix("watch", "pods", metav1.NamespaceAll, ""),
+				buildQueryValues(url.Values{fieldSelectorQueryParamName: []string{"spec.host="}, "resourceVersion": []string{"0"}})),
 			rv:            "0",
 			resource:      "pods",
 			namespace:     metav1.NamespaceAll,
@@ -151,8 +151,8 @@ func TestListWatchesCanWatch(t *testing.T) {
 		// pod with namespace foo and assigned field selector
 		{
 			location: buildLocation(
-				testapi.Default.ResourcePath("pods", "foo", ""),
-				buildQueryValues(url.Values{fieldSelectorQueryParamName: []string{"spec.host="}, "resourceVersion": []string{"0"}, "watch": []string{"true"}})),
+				testapi.Default.ResourcePathWithPrefix("watch", "pods", "foo", ""),
+				buildQueryValues(url.Values{fieldSelectorQueryParamName: []string{"spec.host="}, "resourceVersion": []string{"0"}})),
 			rv:            "0",
 			resource:      "pods",
 			namespace:     "foo",

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -460,7 +460,7 @@ func gcListWatcher(client *dynamic.Client, resource schema.GroupVersionResource)
 			apiResource := metav1.APIResource{Name: resource.Resource}
 			return client.ParameterCodec(dynamic.VersionedParameterEncoderWithV1Fallback).
 				Resource(&apiResource, metav1.NamespaceAll).
-				List(options)
+				List(&options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			// APIResource.Kind is not used by the dynamic client, so
@@ -470,7 +470,7 @@ func gcListWatcher(client *dynamic.Client, resource schema.GroupVersionResource)
 			apiResource := metav1.APIResource{Name: resource.Resource}
 			return client.ParameterCodec(dynamic.VersionedParameterEncoderWithV1Fallback).
 				Resource(&apiResource, metav1.NamespaceAll).
-				Watch(options)
+				Watch(&options)
 		},
 	}
 }

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -354,7 +354,7 @@ func TestGCListWatcher(t *testing.T) {
 	if e, a := 2, len(testHandler.actions); e != a {
 		t.Errorf("expect %d requests, got %d", e, a)
 	}
-	if e, a := "resourceVersion=1&watch=true", testHandler.actions[0].query; e != a {
+	if e, a := "resourceVersion=1", testHandler.actions[0].query; e != a {
 		t.Errorf("expect %s, got %s", e, a)
 	}
 	if e, a := "resourceVersion=1", testHandler.actions[1].query; e != a {

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -341,7 +341,7 @@ func (d *namespacedResourcesDeleter) deleteCollection(
 	// resource deletions generically.  it will ensure all resources in the namespace are purged prior to releasing
 	// namespace itself.
 	orphanDependents := false
-	err := dynamicClient.Resource(&apiResource, namespace).DeleteCollection(&metav1.DeleteOptions{OrphanDependents: &orphanDependents}, metav1.ListOptions{})
+	err := dynamicClient.Resource(&apiResource, namespace).DeleteCollection(&metav1.DeleteOptions{OrphanDependents: &orphanDependents}, &metav1.ListOptions{})
 
 	if err == nil {
 		return true, nil
@@ -379,7 +379,7 @@ func (d *namespacedResourcesDeleter) listCollection(
 	}
 
 	apiResource := metav1.APIResource{Name: gvr.Resource, Namespaced: true}
-	obj, err := dynamicClient.Resource(&apiResource, namespace).List(metav1.ListOptions{})
+	obj, err := dynamicClient.Resource(&apiResource, namespace).List(&metav1.ListOptions{})
 	if err == nil {
 		unstructuredList, ok := obj.(*unstructured.UnstructuredList)
 		if !ok {

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -720,11 +720,9 @@ func TestWatchSelector(t *testing.T) {
 			}
 			switch req.URL.Path {
 			case "/namespaces/test/pods":
-				if req.URL.Query().Get("watch") == "true" {
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[2:])}, nil
-				} else {
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, podList)}, nil
-				}
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, podList)}, nil
+			case "/watch/namespaces/test/pods":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[2:])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil
@@ -762,12 +760,8 @@ func TestWatchResource(t *testing.T) {
 			switch req.URL.Path {
 			case "/namespaces/test/pods/foo":
 				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &pods[1])}, nil
-			case "/namespaces/test/pods":
-				if req.URL.Query().Get("watch") == "true" && req.URL.Query().Get("fieldSelector") == "metadata.name=foo" {
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[1:])}, nil
-				}
-				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-				return nil, nil
+			case "/watch/namespaces/test/pods/foo":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[1:])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil
@@ -804,12 +798,8 @@ func TestWatchResourceIdentifiedByFile(t *testing.T) {
 			switch req.URL.Path {
 			case "/namespaces/test/replicationcontrollers/cassandra":
 				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &pods[1])}, nil
-			case "/namespaces/test/replicationcontrollers":
-				if req.URL.Query().Get("watch") == "true" && req.URL.Query().Get("fieldSelector") == "metadata.name=cassandra" {
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[1:])}, nil
-				}
-				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-				return nil, nil
+			case "/watch/namespaces/test/replicationcontrollers/cassandra":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[1:])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil
@@ -847,12 +837,8 @@ func TestWatchOnlyResource(t *testing.T) {
 			switch req.URL.Path {
 			case "/namespaces/test/pods/foo":
 				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, &pods[1])}, nil
-			case "/namespaces/test/pods":
-				if req.URL.Query().Get("watch") == "true" && req.URL.Query().Get("fieldSelector") == "metadata.name=foo" {
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[1:])}, nil
-				}
-				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-				return nil, nil
+			case "/watch/namespaces/test/pods/foo":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[1:])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil
@@ -894,11 +880,9 @@ func TestWatchOnlyList(t *testing.T) {
 		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 			switch req.URL.Path {
 			case "/namespaces/test/pods":
-				if req.URL.Query().Get("watch") == "true" {
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[2:])}, nil
-				} else {
-					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, podList)}, nil
-				}
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, podList)}, nil
+			case "/watch/namespaces/test/pods":
+				return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: watchBody(codec, events[2:])}, nil
 			default:
 				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
 				return nil, nil

--- a/pkg/kubectl/resource/BUILD
+++ b/pkg/kubectl/resource/BUILD
@@ -31,7 +31,6 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/api/meta",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
-        "//vendor:k8s.io/apimachinery/pkg/fields",
         "//vendor:k8s.io/apimachinery/pkg/labels",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -1069,7 +1069,7 @@ func TestListObjectWithDifferentVersions(t *testing.T) {
 func TestWatch(t *testing.T) {
 	_, svc := testData()
 	w, err := NewBuilder(testapi.Default.RESTMapper(), api.Scheme, fakeClientWith("", t, map[string]string{
-		"/namespaces/test/services?fieldSelector=metadata.name%3Dredis-master&resourceVersion=12&watch=true": watchBody(watch.Event{
+		"/watch/namespaces/test/services/redis-master?resourceVersion=12": watchBody(watch.Event{
 			Type:   watch.Added,
 			Object: &svc.Items[0],
 		}),

--- a/pkg/kubectl/resource/helper.go
+++ b/pkg/kubectl/resource/helper.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -76,21 +75,21 @@ func (m *Helper) List(namespace, apiVersion string, selector labels.Selector, ex
 
 func (m *Helper) Watch(namespace, resourceVersion, apiVersion string, labelSelector labels.Selector) (watch.Interface, error) {
 	return m.RESTClient.Get().
+		Prefix("watch").
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
 		Param("resourceVersion", resourceVersion).
-		Param("watch", "true").
 		LabelsSelectorParam(labelSelector).
 		Watch()
 }
 
 func (m *Helper) WatchSingle(namespace, name, resourceVersion string) (watch.Interface, error) {
 	return m.RESTClient.Get().
+		Prefix("watch").
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
+		Name(name).
 		Param("resourceVersion", resourceVersion).
-		Param("watch", "true").
-		FieldsSelectorParam(fields.OneTermEqualSelector("metadata.name", name)).
 		Watch()
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -737,7 +737,6 @@ func TestNotFound(t *testing.T) {
 		"groupless namespaced PUT with extra segment":       {"PUT", "/" + grouplessPrefix + "/" + grouplessGroupVersion.Version + "/namespaces/ns/simples/bar/baz", http.StatusNotFound},
 		"groupless namespaced watch missing storage":        {"GET", "/" + grouplessPrefix + "/" + grouplessGroupVersion.Version + "/watch/", http.StatusNotFound},
 		"groupless namespaced watch with bad method":        {"POST", "/" + grouplessPrefix + "/" + grouplessGroupVersion.Version + "/watch/namespaces/ns/simples/bar", http.StatusMethodNotAllowed},
-		"groupless namespaced watch param with bad method":  {"POST", "/" + grouplessPrefix + "/" + grouplessGroupVersion.Version + "/namespaces/ns/simples/bar?watch=true", http.StatusMethodNotAllowed},
 
 		// Positive checks to make sure everything is wired correctly
 		"GET root": {"GET", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simpleroots", http.StatusOK},
@@ -769,7 +768,6 @@ func TestNotFound(t *testing.T) {
 		"namespaced PUT with extra segment":       {"PUT", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/ns/simples/bar/baz", http.StatusNotFound},
 		"namespaced watch missing storage":        {"GET", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/", http.StatusNotFound},
 		"namespaced watch with bad method":        {"POST", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/watch/namespaces/ns/simples/bar", http.StatusMethodNotAllowed},
-		"namespaced watch param with bad method":  {"POST", "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/namespaces/ns/simples/bar?watch=true", http.StatusMethodNotAllowed},
 	}
 	handler := handle(map[string]rest.Storage{
 		"simples":     &SimpleRESTStorage{},

--- a/staging/src/k8s.io/client-go/dynamic/client.go
+++ b/staging/src/k8s.io/client-go/dynamic/client.go
@@ -112,7 +112,7 @@ type ResourceClient struct {
 }
 
 // List returns a list of objects for this resource.
-func (rc *ResourceClient) List(opts metav1.ListOptions) (runtime.Object, error) {
+func (rc *ResourceClient) List(opts runtime.Object) (runtime.Object, error) {
 	parameterEncoder := rc.parameterCodec
 	if parameterEncoder == nil {
 		parameterEncoder = defaultParameterEncoder
@@ -120,7 +120,7 @@ func (rc *ResourceClient) List(opts metav1.ListOptions) (runtime.Object, error) 
 	return rc.cl.Get().
 		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
 		Resource(rc.resource.Name).
-		VersionedParams(&opts, parameterEncoder).
+		VersionedParams(opts, parameterEncoder).
 		Do().
 		Get()
 }
@@ -149,7 +149,7 @@ func (rc *ResourceClient) Delete(name string, opts *metav1.DeleteOptions) error 
 }
 
 // DeleteCollection deletes a collection of objects.
-func (rc *ResourceClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (rc *ResourceClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, listOptions runtime.Object) error {
 	parameterEncoder := rc.parameterCodec
 	if parameterEncoder == nil {
 		parameterEncoder = defaultParameterEncoder
@@ -157,7 +157,7 @@ func (rc *ResourceClient) DeleteCollection(deleteOptions *metav1.DeleteOptions, 
 	return rc.cl.Delete().
 		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
 		Resource(rc.resource.Name).
-		VersionedParams(&listOptions, parameterEncoder).
+		VersionedParams(listOptions, parameterEncoder).
 		Body(deleteOptions).
 		Do().
 		Error()
@@ -192,16 +192,16 @@ func (rc *ResourceClient) Update(obj *unstructured.Unstructured) (*unstructured.
 }
 
 // Watch returns a watch.Interface that watches the resource.
-func (rc *ResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (rc *ResourceClient) Watch(opts runtime.Object) (watch.Interface, error) {
 	parameterEncoder := rc.parameterCodec
 	if parameterEncoder == nil {
 		parameterEncoder = defaultParameterEncoder
 	}
-	opts.Watch = true
 	return rc.cl.Get().
+		Prefix("watch").
 		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
 		Resource(rc.resource.Name).
-		VersionedParams(&opts, parameterEncoder).
+		VersionedParams(opts, parameterEncoder).
 		Watch()
 }
 

--- a/staging/src/k8s.io/client-go/dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_test.go
@@ -136,7 +136,7 @@ func TestList(t *testing.T) {
 		}
 		defer srv.Close()
 
-		got, err := cl.Resource(resource, tc.namespace).List(metav1.ListOptions{})
+		got, err := cl.Resource(resource, tc.namespace).List(&metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when listing %q: %v", tc.name, err)
 			continue
@@ -293,7 +293,7 @@ func TestDeleteCollection(t *testing.T) {
 		}
 		defer srv.Close()
 
-		err = cl.Resource(resource, tc.namespace).DeleteCollection(nil, metav1.ListOptions{})
+		err = cl.Resource(resource, tc.namespace).DeleteCollection(nil, &metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when deleting collection %q: %v", tc.name, err)
 			continue
@@ -425,12 +425,10 @@ func TestWatch(t *testing.T) {
 		namespace string
 		events    []watch.Event
 		path      string
-		query     string
 	}{
 		{
-			name:  "normal_watch",
-			path:  "/api/gtest/vtest/rtest",
-			query: "watch=true",
+			name: "normal_watch",
+			path: "/api/gtest/vtest/watch/rtest",
 			events: []watch.Event{
 				{Type: watch.Added, Object: getObject("vTest", "rTest", "normal_watch")},
 				{Type: watch.Modified, Object: getObject("vTest", "rTest", "normal_watch")},
@@ -440,8 +438,7 @@ func TestWatch(t *testing.T) {
 		{
 			name:      "namespaced_watch",
 			namespace: "nstest",
-			path:      "/api/gtest/vtest/namespaces/nstest/rtest",
-			query:     "watch=true",
+			path:      "/api/gtest/vtest/watch/namespaces/nstest/rtest",
 			events: []watch.Event{
 				{Type: watch.Added, Object: getObject("vTest", "rTest", "namespaced_watch")},
 				{Type: watch.Modified, Object: getObject("vTest", "rTest", "namespaced_watch")},
@@ -460,9 +457,6 @@ func TestWatch(t *testing.T) {
 			if r.URL.Path != tc.path {
 				t.Errorf("Watch(%q) got path %s. wanted %s", tc.name, r.URL.Path, tc.path)
 			}
-			if r.URL.RawQuery != tc.query {
-				t.Errorf("Watch(%q) got query %s. wanted %s", tc.name, r.URL.RawQuery, tc.query)
-			}
 
 			enc := restclientwatch.NewEncoder(streaming.NewEncoder(w, dynamicCodec{}), dynamicCodec{})
 			for _, e := range tc.events {
@@ -475,7 +469,7 @@ func TestWatch(t *testing.T) {
 		}
 		defer srv.Close()
 
-		watcher, err := cl.Resource(resource, tc.namespace).Watch(metav1.ListOptions{})
+		watcher, err := cl.Resource(resource, tc.namespace).Watch(&metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when watching %q: %v", tc.name, err)
 			continue

--- a/staging/src/k8s.io/client-go/tools/cache/listwatch.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listwatch.go
@@ -67,8 +67,8 @@ func NewListWatchFromClient(c Getter, resource string, namespace string, fieldSe
 			Get()
 	}
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
-		options.Watch = true
 		return c.Get().
+			Prefix("watch").
 			Namespace(namespace).
 			Resource(resource).
 			VersionedParams(&options, metav1.ParameterCodec).

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1alpha1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1alpha1/apiservice.go
@@ -140,8 +140,8 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *v1alpha1.APIServiceList
 
 // Watch returns a watch.Interface that watches the requested aPIServices.
 func (c *aPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("apiservices").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
@@ -140,8 +140,8 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServ
 
 // Watch returns a watch.Interface that watches the requested aPIServices.
 func (c *aPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
 	return c.client.Get().
+		Prefix("watch").
 		Resource("apiservices").
 		VersionedParams(&opts, api.ParameterCodec).
 		Watch()

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -363,7 +363,7 @@ func SkipIfMissingResource(clientPool dynamic.ClientPool, gvr schema.GroupVersio
 		Failf("Unexpected error getting dynamic client for %v: %v", gvr.GroupVersion(), err)
 	}
 	apiResource := metav1.APIResource{Name: gvr.Resource, Namespaced: true}
-	_, err = dynamicClient.Resource(&apiResource, namespace).List(metav1.ListOptions{})
+	_, err = dynamicClient.Resource(&apiResource, namespace).List(&metav1.ListOptions{})
 	if err != nil {
 		// not all resources support list, so we ignore those
 		if apierrs.IsMethodNotSupported(err) || apierrs.IsNotFound(err) || apierrs.IsForbidden(err) {
@@ -1080,7 +1080,7 @@ func hasRemainingContent(c clientset.Interface, clientPool dynamic.ClientPool, n
 			Logf("namespace: %s, resource: %s, ignored listing per whitelist", namespace, apiResource.Name)
 			continue
 		}
-		obj, err := dynamicClient.Resource(&apiResource, namespace).List(metav1.ListOptions{})
+		obj, err := dynamicClient.Resource(&apiResource, namespace).List(&metav1.ListOptions{})
 		if err != nil {
 			// not all resources support list, so we ignore those
 			if apierrs.IsMethodNotSupported(err) || apierrs.IsNotFound(err) || apierrs.IsForbidden(err) {

--- a/test/integration/client/client_test.go
+++ b/test/integration/client/client_test.go
@@ -29,7 +29,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -492,11 +491,11 @@ func TestSingleWatch(t *testing.T) {
 	}
 
 	w, err := client.Core().RESTClient().Get().
+		Prefix("watch").
 		Namespace(ns.Name).
 		Resource("events").
+		Name("event-9").
 		Param("resourceVersion", rv1).
-		Param("watch", "true").
-		FieldsSelectorParam(fields.OneTermEqualSelector("metadata.name", "event-9")).
 		Watch()
 
 	if err != nil {

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -93,7 +93,7 @@ func TestDynamicClient(t *testing.T) {
 	}
 
 	// check dynamic list
-	obj, err := dynamicClient.Resource(&resource, ns.Name).List(metav1.ListOptions{})
+	obj, err := dynamicClient.Resource(&resource, ns.Name).List(&metav1.ListOptions{})
 	unstructuredList, ok := obj.(*unstructured.UnstructuredList)
 	if !ok {
 		t.Fatalf("expected *unstructured.UnstructuredList, got %#v", obj)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#41722

This broke the api calls latency metrics (which in turn completely broke scalability tests and blocked submit queue).

The issue is that with this change, all "watch" requests are actually reported in metrics as "LIST" requests.
The problem in fact is that here:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go#L600
we  don't know whether the request is list or watch, before we actually get the request and check parameter.
So the way InstrumentRouteFunc is currently done, will not work and I don't have an idea for quick fix to unblock submit queue.

@liggitt @smarterclayton 