### PR TITLE
Ensure invalid username/password returns 401 error, not 403

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -201,7 +201,8 @@ func (config AuthenticatorConfig) New() (authenticator.Request, *spec.SecurityDe
 	authenticator = group.NewGroupAdder(authenticator, []string{user.AllAuthenticated})
 
 	if config.Anonymous {
-		// If the authenticator chain returns an error, return an error (don't consider a bad bearer token anonymous).
+		// If the authenticator chain returns an error, return an error (don't consider a bad bearer token
+		// or invalid username/password combination anonymous).
 		authenticator = union.NewFailOnError(authenticator, anonymous.NewAuthenticator())
 	}
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth_test.go
@@ -60,11 +60,13 @@ func TestBasicAuth(t *testing.T) {
 			ExpectedCalled:   true,
 			ExpectedUsername: "user_with_empty_password",
 			ExpectedPassword: "",
+			ExpectedErr:      true,
 		},
 		"valid basic header": {
 			ExpectedCalled:   true,
 			ExpectedUsername: "myuser",
 			ExpectedPassword: "mypassword:withcolon",
+			ExpectedErr:      true,
 		},
 		"password auth returned user": {
 			Password:         testPassword{User: &user.DefaultInfo{Name: "returneduser"}, OK: true},


### PR DESCRIPTION
If a user attempts to use basic auth, and the username/password combination
is rejected, the authenticator should return an error. This distinguishes
requests that did not provide username/passwrod (and are unauthenticated
without error) from ones that attempted to, and failed.

Related to:
https://github.com/kubernetes/kubernetes/pull/39408