### PR TITLE
fix scheduling metrics error for E2eSchedulingLatency

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -205,7 +205,9 @@ func (sched *Scheduler) scheduleOne() {
 	}
 
 	go func() {
-		defer metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
+		defer func() {
+			metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
+		}()
 
 		b := &v1.Binding{
 			ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name},


### PR DESCRIPTION
If we get the scheduling metrics, which is "SchedulingAlgorithmLatency, E2eSchedulingLatency, BindingLatency". The E2eSchedulingLatency should be the sum of SchedulingAlgorithmLatency and BindingLatency, while we found E2eSchedulingLatency is almost the same as E2eSchedulingLatency for some optimization.
