### PR TITLE
Don't use base64 encoding with etcd v3

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_codec.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_codec.go
@@ -56,7 +56,7 @@ func NewStorageCodec(opts StorageCodecConfig) (runtime.Codec, error) {
 
 	// etcd2 only supports string data - we must wrap any result before returning
 	// TODO: storagebackend should return a boolean indicating whether it supports binary data
-	if !serializer.EncodesAsText && (opts.Config.Type == storagebackend.StorageTypeUnset || opts.Config.Type == storagebackend.StorageTypeETCD2) {
+	if !serializer.EncodesAsText && opts.Config.Type == storagebackend.StorageTypeETCD2 {
 		glog.V(4).Infof("Wrapping the underlying binary storage serializer with a base64 encoding for etcd2")
 		s = runtime.NewBase64Serializer(s)
 	}


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/pull/36229 we changed the default storage to etcd v3.

This in fact is a fix to that PR.

With etcd v3, the base64-encoding is no longer needed - so we use it only if etcd v2 is explicitly requested as storage format.

@lavalamp 