### PR TITLE
Turn fluentd supervisor off for fluentd-gcp

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -35,6 +35,9 @@ spec:
           - '/bin/sh'
           - '-c'
           - '/run.sh $FLUENTD_ARGS 2>&1 >>/var/log/fluentd.log'
+        env:
+        - name: FLUENTD_ARGS
+          value: --no-supervisor
         resources:
           limits:
             memory: 200Mi

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -25,6 +25,9 @@ spec:
       - '/bin/sh'
       - '-c'
       - '/run.sh $FLUENTD_ARGS 2>&1 >>/var/log/fluentd.log'
+    env:
+    - name: FLUENTD_ARGS
+      value: --no-supervisor
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
By default, turn fluentd supervisor off so that when fluentd process fails, for example due to OOM, container fails completely and it would be easy to detect.

CC @igorpeshansky @qingling128