### PR TITLE
Whitelist kubemark in node_ssh_supported_providers for log dump

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -34,7 +34,7 @@ else
 fi
 
 readonly master_ssh_supported_providers="gce aws kubemark"
-readonly node_ssh_supported_providers="gce gke aws"
+readonly node_ssh_supported_providers="gce gke aws kubemark"
 
 readonly master_logfiles="kube-apiserver kube-scheduler rescheduler kube-controller-manager etcd etcd-events glbc cluster-autoscaler kube-addon-manager fluentd"
 readonly node_logfiles="kube-proxy fluentd"
@@ -129,7 +129,7 @@ function save-logs() {
       case "${KUBERNETES_PROVIDER}" in
         gce|gke|kubemark)
           files="${files} ${gce_logfiles}"
-          if [[ "${KUBERNETES_PROVIDER}" -eq "kubemark" && "${ENABLE_HOLLOW_NODE_LOGS:-}" -eq "true" ]]; then
+          if [[ "${KUBERNETES_PROVIDER}" == "kubemark" && "${ENABLE_HOLLOW_NODE_LOGS:-}" == "true" ]]; then
             files="${files} ${hollow_node_logfiles}"
           fi
           ;;


### PR DESCRIPTION
Seems like PR https://github.com/kubernetes/kubernetes/pull/41739 did not truly enable hollow node logging, as there were a couple of issues:
- kubemark is not whitelisted as a k8s provider for which we can perform node SSH (because that's the case with hollow nodes), but we can still SSH to real nodes. So added it to `node_ssh_supported_providers`
- The `if [[ "${KUBERNETES_PROVIDER}" -eq "kubemark" && "${ENABLE_HOLLOW_NODE_LOGS:-}" -eq "true" ]];` in bash didn't work as I expected. Fixed it now and checked.

With these changes, it should work now.

cc @kubernetes/sig-scalability-misc @wojtek-t @gmarek 