### PR TITLE
kubectl: Adding IPv6 brackets for IPv6 endpoints

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -20,7 +20,9 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -223,7 +225,8 @@ func formatEndpoints(endpoints *api.Endpoints, ports sets.String) string {
 					}
 					addr := &ss.Addresses[i]
 					if !more {
-						list = append(list, fmt.Sprintf("%s:%d", addr.IP, port.Port))
+						hostPort := net.JoinHostPort(addr.IP, strconv.Itoa(int(port.Port)))
+						list = append(list, hostPort)
 					}
 					count++
 				}


### PR DESCRIPTION
This fixes the lack of IPv6 when printing the IP:Port tuple with kubectl
describe command.

Signed-off-by: André Martins <aanm90@gmail.com>

**What this PR does / why we need it**: This adds IPv6 brackets on IPv6 endpoints when using `kubectl describe service`

**Special notes for your reviewer**: Since the IP is a string I think the fastest way to detect if it's an IPv6 was to check for the presence of : in it. Let me know what you think.