### PR TITLE
Adds owners for hack/verify-flags

### DIFF
--- a/hack/verify-flags/OWNERS
+++ b/hack/verify-flags/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- sig-cli-maintainers
+reviewers:
+- sig-cli


### PR DESCRIPTION
SIG-CLI as the owners of `hack/verify-flags`.

```release-note
NONE
```
