### PR TITLE
Remove unnecessary metrics (http/process/go) from being exposed by etcd-version-monitor

### DIFF
--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.go
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.go
@@ -218,7 +218,7 @@ func main() {
 	// Register the metrics we defined above with prometheus.
 	prometheus.MustRegister(etcdVersion)
 	prometheus.MustRegister(etcdGRPCRequestsTotal)
-	prometheus.Unregister(prometheus.NewGoCollector()) // Unregister go metrics.
+	prometheus.Unregister(prometheus.NewGoCollector())
 
 	// Spawn threads for periodically scraping etcd version metrics.
 	stopCh := make(chan struct{})
@@ -228,6 +228,6 @@ func main() {
 
 	// Serve our metrics on listenAddress/metricsPath.
 	glog.Infof("Listening on: %v", listenAddress)
-	http.Handle(metricsPath, prometheus.Handler())
+	http.Handle(metricsPath, prometheus.UninstrumentedHandler())
 	glog.Errorf("Stopped listening/serving metrics: %v", http.ListenAndServe(listenAddress, nil))
 }


### PR DESCRIPTION
Unregister metrics we do not want from the etcd version metrics handler.

cc @wojtek-t @piosz 