### PR TITLE
make azure storage account publicly accessible

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_storage.go
+++ b/pkg/cloudprovider/providers/azure/azure_storage.go
@@ -197,7 +197,7 @@ func (az *Cloud) CreateVolume(name, storageAccount, storageType, location string
 		accounts = append(accounts, accountWithLocation{Name: storageAccount})
 	} else {
 		// find a storage account
-		accounts, err = az.getStorageAccounts()
+		accounts, err = az.GetStorageAccounts()
 		if err != nil {
 			// TODO: create a storage account and container
 			return "", "", 0, err
@@ -207,7 +207,7 @@ func (az *Cloud) CreateVolume(name, storageAccount, storageType, location string
 		glog.V(4).Infof("account %s type %s location %s", account.Name, account.StorageType, account.Location)
 		if ((storageType == "" || account.StorageType == storageType) && (location == "" || account.Location == location)) || len(storageAccount) > 0 {
 			// find the access key with this account
-			key, err := az.getStorageAccesskey(account.Name)
+			key, err := az.GetStorageAccesskey(account.Name)
 			if err != nil {
 				glog.V(2).Infof("no key found for storage account %s", account.Name)
 				continue
@@ -232,7 +232,7 @@ func (az *Cloud) DeleteVolume(name, uri string) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse vhd URI %v", err)
 	}
-	key, err := az.getStorageAccesskey(accountName)
+	key, err := az.GetStorageAccesskey(accountName)
 	if err != nil {
 		return fmt.Errorf("no key for storage account %s, err %v", accountName, err)
 	}

--- a/pkg/cloudprovider/providers/azure/azure_storageaccount.go
+++ b/pkg/cloudprovider/providers/azure/azure_storageaccount.go
@@ -26,7 +26,7 @@ type accountWithLocation struct {
 }
 
 // getStorageAccounts gets the storage accounts' name, type, location in a resource group
-func (az *Cloud) getStorageAccounts() ([]accountWithLocation, error) {
+func (az *Cloud) GetStorageAccounts() ([]accountWithLocation, error) {
 	result, err := az.StorageAccountClient.ListByResourceGroup(az.ResourceGroup)
 	if err != nil {
 		return nil, err
@@ -55,7 +55,7 @@ func (az *Cloud) getStorageAccounts() ([]accountWithLocation, error) {
 }
 
 // getStorageAccesskey gets the storage account access key
-func (az *Cloud) getStorageAccesskey(account string) (string, error) {
+func (az *Cloud) GetStorageAccesskey(account string) (string, error) {
 	result, err := az.StorageAccountClient.ListKeys(az.ResourceGroup, account)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Making azure storage account functions public so external azure file provisioner can reuse them

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@colemickens 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
