### PR TITLE
Take into account number of restarts in cluster logging tests

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -208,6 +208,7 @@ go_library(
         "//vendor:k8s.io/client-go/tools/cache",
         "//vendor:k8s.io/client-go/transport",
         "//vendor:k8s.io/client-go/util/flowcontrol",
+        "//vendor:k8s.io/client-go/util/integer",
         "//vendor:k8s.io/client-go/util/workqueue",
     ],
 )

--- a/test/e2e/cluster_logging_es.go
+++ b/test/e2e/cluster_logging_es.go
@@ -51,11 +51,14 @@ var _ = framework.KubeDescribe("Cluster level logging using Elasticsearch [Featu
 		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to succeed", podName))
 
 		By("Waiting for logs to ingest")
-		err = waitForLogsIngestion(esLogsProvider, []*loggingPod{pod}, 10*time.Minute, 0)
-		framework.ExpectNoError(err, "Failed to ingest logs")
-
-		if err != nil {
-			reportLogsFromFluentdPod(f, pod)
+		config := &loggingTestConfig{
+			LogsProvider:              esLogsProvider,
+			Pods:                      []*loggingPod{pod},
+			IngestionTimeout:          10 * time.Minute,
+			MaxAllowedLostFraction:    0,
+			MaxAllowedFluentdRestarts: 0,
 		}
+		err = waitForLogsIngestion(f, config)
+		framework.ExpectNoError(err, "Failed to ingest logs")
 	})
 })

--- a/test/e2e/cluster_logging_es_utils.go
+++ b/test/e2e/cluster_logging_es_utils.go
@@ -46,6 +46,10 @@ func newEsLogsProvider(f *framework.Framework) (*esLogsProvider, error) {
 	return &esLogsProvider{Framework: f}, nil
 }
 
+func (logsProvider *esLogsProvider) FluentdApplicationName() string {
+	return "fluentd-es"
+}
+
 // Ensures that elasticsearch is running and ready to serve requests
 func (logsProvider *esLogsProvider) EnsureWorking() error {
 	f := logsProvider.Framework

--- a/test/e2e/cluster_logging_gcl.go
+++ b/test/e2e/cluster_logging_gcl.go
@@ -50,11 +50,14 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Flaky]", func()
 		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to succeed", podName))
 
 		By("Waiting for logs to ingest")
-		err = waitForLogsIngestion(gclLogsProvider, []*loggingPod{pod}, 10*time.Minute, 0)
-		framework.ExpectNoError(err, "Failed to ingest logs")
-
-		if err != nil {
-			reportLogsFromFluentdPod(f, pod)
+		config := &loggingTestConfig{
+			LogsProvider:              gclLogsProvider,
+			Pods:                      []*loggingPod{pod},
+			IngestionTimeout:          10 * time.Minute,
+			MaxAllowedLostFraction:    0,
+			MaxAllowedFluentdRestarts: 0,
 		}
+		err = waitForLogsIngestion(f, config)
+		framework.ExpectNoError(err, "Failed to ingest logs")
 	})
 })

--- a/test/e2e/cluster_logging_gcl_load.go
+++ b/test/e2e/cluster_logging_gcl_load.go
@@ -28,7 +28,8 @@ import (
 
 const (
 	// TODO(crassirostris): Once test is stable, decrease allowed loses
-	loadTestMaxAllowedLostFraction = 0.1
+	loadTestMaxAllowedLostFraction    = 0.1
+	loadTestMaxAllowedFluentdRestarts = 1
 )
 
 // TODO(crassirostris): Remove Flaky once test is stable
@@ -58,7 +59,14 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Slow] [Flaky]",
 		time.Sleep(loggingDuration)
 
 		By("Waiting for all log lines to be ingested")
-		err = waitForLogsIngestion(gclLogsProvider, pods, ingestionTimeout, loadTestMaxAllowedLostFraction)
+		config := &loggingTestConfig{
+			LogsProvider:              gclLogsProvider,
+			Pods:                      pods,
+			IngestionTimeout:          ingestionTimeout,
+			MaxAllowedLostFraction:    loadTestMaxAllowedLostFraction,
+			MaxAllowedFluentdRestarts: loadTestMaxAllowedFluentdRestarts,
+		}
+		err = waitForLogsIngestion(f, config)
 		if err != nil {
 			framework.Failf("Failed to ingest logs: %v", err)
 		} else {
@@ -96,7 +104,14 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Slow] [Flaky]",
 		time.Sleep(jobDuration)
 
 		By("Waiting for all log lines to be ingested")
-		err = waitForLogsIngestion(gclLogsProvider, pods, ingestionTimeout, loadTestMaxAllowedLostFraction)
+		config := &loggingTestConfig{
+			LogsProvider:              gclLogsProvider,
+			Pods:                      pods,
+			IngestionTimeout:          ingestionTimeout,
+			MaxAllowedLostFraction:    loadTestMaxAllowedLostFraction,
+			MaxAllowedFluentdRestarts: loadTestMaxAllowedFluentdRestarts,
+		}
+		err = waitForLogsIngestion(f, config)
 		if err != nil {
 			framework.Failf("Failed to ingest logs: %v", err)
 		} else {

--- a/test/e2e/cluster_logging_gcl_utils.go
+++ b/test/e2e/cluster_logging_gcl_utils.go
@@ -64,6 +64,10 @@ func newGclLogsProvider(f *framework.Framework) (*gclLogsProvider, error) {
 	return provider, nil
 }
 
+func (logsProvider *gclLogsProvider) FluentdApplicationName() string {
+	return "fluentd-gcp"
+}
+
 // Since GCL API is not easily available from the outside of cluster
 // we use gcloud command to perform search with filter
 func (gclLogsProvider *gclLogsProvider) ReadEntries(pod *loggingPod) []*logEntry {


### PR DESCRIPTION
Before, in cluster logging tests, we only measured e2e number of lines delivered to the backend.

Also, befure https://github.com/kubernetes/kubernetes/pull/41795 was merged, from the k8s perspective, fluentd was always working properly, even if it's crashlooping inside.

Now we can detect whether fluentd is truly working properly, experiencing no, or almost no OOMs duing its operation.