### PR TITLE
kubeadm: update token to use '.' in discovery pkg

### DIFF
--- a/cmd/kubeadm/app/discovery/flags.go
+++ b/cmd/kubeadm/app/discovery/flags.go
@@ -46,7 +46,7 @@ func (d *discoveryValue) String() string {
 	case d.v.File != nil:
 		return "file://" + d.v.File.Path
 	case d.v.Token != nil:
-		return fmt.Sprintf("token://%s:%s@%s", d.v.Token.ID, d.v.Token.Secret, strings.Join(d.v.Token.Addresses, ","))
+		return fmt.Sprintf("token://%s.%s@%s", d.v.Token.ID, d.v.Token.Secret, strings.Join(d.v.Token.Addresses, ","))
 	default:
 		return "unknown"
 	}

--- a/cmd/kubeadm/app/discovery/flags_test.go
+++ b/cmd/kubeadm/app/discovery/flags_test.go
@@ -60,7 +60,7 @@ func TestNewDiscoveryValue(t *testing.T) {
 						Addresses: []string{"foobar"},
 					},
 				},
-			}, expect: "token://foo:bar@foobar",
+			}, expect: "token://foo.bar@foobar",
 		},
 	}
 	for _, rt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**: While working on getting https://github.com/kubernetes/community/pull/381 implemented, I noticed the kubeadm discovery pkg was printing out tokens incorrectly. Corrected and fixed up corresponding test. 

**Special notes for your reviewer**: /cc @luxas @jbeda 

**Release note**:
```release-note
NONE
```
