### PR TITLE
Make make quick-release quick again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -368,7 +368,8 @@ ifeq ($(PRINT_HELP),y)
 release-skip-tests quick-release:
 	@echo "$$RELEASE_SKIP_TESTS_HELP_INFO"
 else
-release-skip-tests quick-release: KUBE_RELEASE_RUN_TESTS = n KUBE_FASTBUILD = true
+release-skip-tests quick-release: KUBE_RELEASE_RUN_TESTS = n
+release-skip-tests quick-release: KUBE_FASTBUILD = true
 release-skip-tests quick-release:
 	build/release.sh
 endif


### PR DESCRIPTION
**What this PR does / why we need it**: fix bug in #39257 which was causing `make quick-release` to build for all platforms.

It seems like the `make` target variable line was setting `KUBE_RELEASE_RUN_TESTS` to `n KUBE_FASTBUILD = true`, rather than setting both variables.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
