### PR TITLE
Revert conditional updates to configmap that breaks ingress

### DIFF
--- a/federation/pkg/federation-controller/ingress/ingress_controller_test.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller_test.go
@@ -130,14 +130,14 @@ func TestIngressController(t *testing.T) {
 	t.Log("Adding Ingress UID ConfigMap to cluster 1")
 	cluster1ConfigMapWatch.Add(cfg1)
 
-	// Test add federated ingress.
-	t.Log("Adding Federated Ingress")
-	fedIngressWatch.Add(&fedIngress)
-
-	t.Log("Checking that UID annotation on Cluster 1 annotation was correctly updated after adding Federated Ingress")
+	t.Log("Checking that UID annotation on Cluster 1 annotation was correctly updated prior to adding Federated Ingress")
 	cluster := GetClusterFromChan(fedClusterUpdateChan)
 	assert.NotNil(t, cluster)
 	assert.Equal(t, cluster.ObjectMeta.Annotations[uidAnnotationKey], cfg1.Data[uidKey])
+
+	// Test add federated ingress.
+	t.Log("Adding Federated Ingress")
+	fedIngressWatch.Add(&fedIngress)
 
 	t.Logf("Checking that appropriate finalizers are added")
 	// There should be an update to add both the finalizers.


### PR DESCRIPTION
Don't prevent configmap updates to happen on existing ingress-uid configmap despite the lack of ingress objects. Otherwise, ingress objects get created with the wrong name.