### PR TITLE
kubenet return proper error message on Status hook for pods that alre…

### DIFF
--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -551,6 +551,8 @@ func (plugin *kubenetNetworkPlugin) GetPodNetworkStatus(namespace string, name s
 	netnsPath, err := plugin.host.GetNetNS(id.ID)
 	if err != nil {
 		return nil, fmt.Errorf("Kubenet failed to retrieve network namespace path: %v", err)
+	} else if len(netnsPath) == 0 {
+		return nil, fmt.Errorf("Kubenet cannot retrieve pod IP with empty network namespace for %s/%s. This is usually because sandbox container has been torn down.", namespace, name)
 	}
 	ip, err := network.GetPodIP(plugin.execer, plugin.nsenterPath, netnsPath, network.DefaultInterfaceName)
 	if err != nil {

--- a/pkg/kubelet/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux_test.go
@@ -56,23 +56,34 @@ func TestGetPodNetworkStatus(t *testing.T) {
 
 	testCases := []struct {
 		id          string
+		netns       string
 		expectError bool
 		expectIP    string
 	}{
 		//in podCIDR map
 		{
 			"1",
+			"",
 			false,
 			"10.245.0.2",
 		},
 		{
 			"2",
+			"",
 			false,
 			"10.245.0.3",
 		},
-		//not in podCIDR map
+		//not in podCIDR map, retrieve non-exist network namespace
 		{
 			"3",
+			"/proc/0/net/ns",
+			true,
+			"",
+		},
+		//not in podCIDR map, retrieve empty network namespace
+		{
+			"4",
+			"",
 			true,
 			"",
 		},
@@ -108,6 +119,7 @@ func TestGetPodNetworkStatus(t *testing.T) {
 	fakeKubenet := newFakeKubenetPlugin(podIPMap, &fexec, fhost)
 
 	for i, tc := range testCases {
+		fhost.NetNs = tc.netns
 		out, err := fakeKubenet.GetPodNetworkStatus("", "", kubecontainer.ContainerID{ID: tc.id})
 		if tc.expectError {
 			if err == nil {

--- a/pkg/kubelet/network/testing/fake_host.go
+++ b/pkg/kubelet/network/testing/fake_host.go
@@ -57,11 +57,11 @@ func (nh *fakeNetworkHost) SupportsLegacyFeatures() bool {
 }
 
 type fakeNamespaceGetter struct {
-	ns string
+	NetNs string
 }
 
 func (nh *fakeNamespaceGetter) GetNetNS(containerID string) (string, error) {
-	return nh.ns, nil
+	return nh.NetNs, nil
 }
 
 type FakePortMappingGetter struct {


### PR DESCRIPTION
refer: https://github.com/kubernetes/kubernetes/issues/41839

I feel like a proper error message is still needed. Cannot simply emit the error. 