### PR TITLE
Update kube-proxy to debian-iptables:v5

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -97,7 +97,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-apiserver,busybox
           kube-controller-manager,busybox
           kube-scheduler,busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-amd64:v3
+          kube-proxy,gcr.io/google_containers/debian-iptables-amd64:v5
           federation-apiserver,busybox
           federation-controller-manager,busybox
         );;
@@ -106,7 +106,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-apiserver,armel/busybox
           kube-controller-manager,armel/busybox
           kube-scheduler,armel/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-arm:v3
+          kube-proxy,gcr.io/google_containers/debian-iptables-arm:v5
           federation-apiserver,armel/busybox
           federation-controller-manager,armel/busybox
         );;
@@ -115,7 +115,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-apiserver,aarch64/busybox
           kube-controller-manager,aarch64/busybox
           kube-scheduler,aarch64/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-arm64:v3
+          kube-proxy,gcr.io/google_containers/debian-iptables-arm64:v5
           federation-apiserver,aarch64/busybox
           federation-controller-manager,aarch64/busybox
         );;
@@ -124,7 +124,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-apiserver,ppc64le/busybox
           kube-controller-manager,ppc64le/busybox
           kube-scheduler,ppc64le/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-ppc64le:v3
+          kube-proxy,gcr.io/google_containers/debian-iptables-ppc64le:v5
           federation-apiserver,ppc64le/busybox
           federation-controller-manager,ppc64le/busybox
         );;


### PR DESCRIPTION
Update kube-proxy to be based off the more recent debian-iptables:v5, which includes lots of CVE fixes.

This is based off https://github.com/kubernetes/kubernetes/pull/39760, but creating a manual patch seemed cleaner than grabbing those cherry-picks.

@thockin - Are aware of any issues that could be caused by updating iptables (or any other dependencies) with an old kube-proxy?

/cc @ixdy @bprashanth 