### PR TITLE
Trim source filename if necessary

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -191,6 +191,10 @@ func makeTar(filepath string, writer io.Writer) error {
 	// TODO: use compression here?
 	tarWriter := tar.NewWriter(writer)
 	defer tarWriter.Close()
+
+	if strings.HasSuffix(filepath, "/") {
+		filepath += "."
+	}
 	return recursiveTar(path.Dir(filepath), path.Base(filepath), tarWriter)
 }
 


### PR DESCRIPTION
Since the source path is split we want to make sure we don't incorrectly
split when a directory has the ending /.

fixes #41752
