### PR TITLE
add "external" cloud provider

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -420,7 +420,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.KubeletDeps) (err error) {
 		var externalKubeClient clientgoclientset.Interface
 		var cloud cloudprovider.Interface
 
-		if s.CloudProvider != componentconfigv1alpha1.AutoDetectCloudProvider {
+		if !cloudprovider.IsExternal(s.CloudProvider) && s.CloudProvider != componentconfigv1alpha1.AutoDetectCloudProvider {
 			cloud, err = cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
 			if err != nil {
 				return err

--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -37,6 +37,8 @@ var (
 	providers      = make(map[string]Factory)
 )
 
+const externalCloudProvider = "external"
+
 // RegisterCloudProvider registers a cloudprovider.Factory by name.  This
 // is expected to happen during app startup.
 func RegisterCloudProvider(name string, cloud Factory) {
@@ -85,6 +87,11 @@ func GetCloudProvider(name string, config io.Reader) (Interface, error) {
 	return f(config)
 }
 
+// Detects if the string is an external cloud provider
+func IsExternal(name string) bool {
+	return name == externalCloudProvider
+}
+
 // InitCloudProvider creates an instance of the named cloud provider.
 func InitCloudProvider(name string, configFilePath string) (Interface, error) {
 	var cloud Interface
@@ -92,6 +99,11 @@ func InitCloudProvider(name string, configFilePath string) (Interface, error) {
 
 	if name == "" {
 		glog.Info("No cloud provider specified.")
+		return nil, nil
+	}
+
+	if IsExternal(name) {
+		glog.Info("External cloud provider specified")
 		return nil, nil
 	}
 


### PR DESCRIPTION
@thockin @justinsb @luxas @joonas

This is the discussion we had in our last meeting about moving the cloud provider dependent parts out of kubelet

1. Flex Volume v2 will not be done anytime soon, until then it is okay to leave the volume code as it is. i.e. Volume plugins with cloudprovider dependencies will continue to reside in the core kubernetes repository, and new volume plugins will be allowed.
2. We are moving forward with the previous decision to move the cloudprovider dependencies from kubelet into a new controller loop in the cloud-controller-manager.
3. The kubelet will set a taint using the flag (--register-with-taints, https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/options/options.go#L238) when it starts. @luxas, we decided to go with a different approach last week, but it turns out that the other approach will not work. There is a hold on PRs that set taints in the admission controller (kubernetes/kubernetes: Pull Request 40288). Due to the uncertain nature of this hold, the kubelet flag is our only alternative. Also, since this is an alpha feature that is not fully baked, kubeadm has a lot of time to make the changes to support this, i.e. it need not support it right away. It can support it in the future releases of k8s.
4. A new flag will be added in kubelet to explicitly denote that no cloudprovider initialization should be done (--no-cloud-init). This is required to clearly indicate to the user that kubelet will not perform any cloudprovider specific calls to initialize the node object.
5. A new flag will be added in kubelet to set uniquely identifying information about the host (--external-id?). This will be required for clouds like openstack, where uniquely identifying information is only available from the host itself.
6. The upgrade scenario with these changes is straightforward, as we all are working under the assumption that the user upgrades the master before upgrading the kubelet.

In this PR, I have added the `--do-cloud-init` flag. (Item 4)