### PR TITLE
kubeadm: update token separator to '.'

### DIFF
--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	TokenExpectedRegex = "^\\S{6}\\:\\S{16}\n$"
+	TokenExpectedRegex = "^\\S{6}\\.\\S{16}\n$"
 )
 
 func TestRunGenerateToken(t *testing.T) {

--- a/cmd/kubeadm/app/util/token/tokens.go
+++ b/cmd/kubeadm/app/util/token/tokens.go
@@ -34,7 +34,7 @@ const (
 var (
 	tokenIDRegexpString = "^([a-z0-9]{6})$"
 	tokenIDRegexp       = regexp.MustCompile(tokenIDRegexpString)
-	tokenRegexpString   = "^([a-z0-9]{6})\\:([a-z0-9]{16})$"
+	tokenRegexpString   = "^([a-z0-9]{6})\\.([a-z0-9]{16})$"
 	tokenRegexp         = regexp.MustCompile(tokenRegexpString)
 )
 
@@ -87,13 +87,13 @@ func ParseToken(s string) (string, string, error) {
 
 // BearerToken returns a string representation of the passed token.
 func BearerToken(d *kubeadmapi.TokenDiscovery) string {
-	return fmt.Sprintf("%s:%s", d.ID, d.Secret)
+	return fmt.Sprintf("%s.%s", d.ID, d.Secret)
 }
 
 // ValidateToken validates whether a token is well-formed.
 // In case it's not, the corresponding error is returned as well.
 func ValidateToken(d *kubeadmapi.TokenDiscovery) (bool, error) {
-	if _, _, err := ParseToken(d.ID + ":" + d.Secret); err != nil {
+	if _, _, err := ParseToken(d.ID + "." + d.Secret); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cmd/kubeadm/app/util/token/tokens_test.go
+++ b/cmd/kubeadm/app/util/token/tokens_test.go
@@ -28,14 +28,14 @@ func TestTokenParse(t *testing.T) {
 		expected bool
 	}{
 		{token: "1234567890123456789012", expected: false},   // invalid parcel size
-		{token: "12345:1234567890123456", expected: false},   // invalid parcel size
+		{token: "12345.1234567890123456", expected: false},   // invalid parcel size
 		{token: ".1234567890123456", expected: false},        // invalid parcel size
 		{token: "123456:1234567890.123456", expected: false}, // invalid separation
-		{token: "abcdef.1234567890123456", expected: false},  // invalid separation
-		{token: "Abcdef:1234567890123456", expected: false},  // invalid token id
-		{token: "123456:AABBCCDDEEFFGGHH", expected: false},  // invalid token secret
-		{token: "abcdef:1234567890123456", expected: true},
-		{token: "123456:aabbccddeeffgghh", expected: true},
+		{token: "abcdef:1234567890123456", expected: false},  // invalid separation
+		{token: "Abcdef.1234567890123456", expected: false},  // invalid token id
+		{token: "123456.AABBCCDDEEFFGGHH", expected: false},  // invalid token secret
+		{token: "abcdef.1234567890123456", expected: true},
+		{token: "123456.aabbccddeeffgghh", expected: true},
 	}
 
 	for _, rt := range tests {
@@ -154,7 +154,7 @@ func TestBearerToken(t *testing.T) {
 		token    *kubeadmapi.TokenDiscovery
 		expected string
 	}{
-		{token: &kubeadmapi.TokenDiscovery{ID: "foo", Secret: "bar"}, expected: "foo:bar"}, // should use default
+		{token: &kubeadmapi.TokenDiscovery{ID: "foo", Secret: "bar"}, expected: "foo.bar"}, // should use default
 	}
 	for _, rt := range tests {
 		actual := BearerToken(rt.token)

--- a/cmd/kubeadm/test/cmd/token_test.go
+++ b/cmd/kubeadm/test/cmd/token_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	TokenExpectedRegex = "^\\S{6}\\:\\S{16}\n$"
+	TokenExpectedRegex = "^\\S{6}\\.\\S{16}\n$"
 )
 
 var kubeadmPath = flag.String("kubeadm-path", filepath.Join(os.Getenv("KUBE_ROOT"), "cluster/kubeadm.sh"), "Location of kubeadm")


### PR DESCRIPTION
**What this PR does / why we need it**: From SIG meetings, it was agreed upon to have '.' be the separator for tokens. This PR updates that. 

**Special notes for your reviewer**: /cc @luxas @jbeda

**Release note**:
```release-note
NONE
```
