### PR TITLE
Update fluentd-gcp addon to 1.21.2

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -28,12 +28,12 @@
 
 .PHONY:	kbuild kpush
 
-TAG = 1.21
+TAG = 1.21.2
 
 # Rules for building the test image for deployment to Dockerhub with user kubernetes.
 
 kbuild:
-	docker build -t kubernetes/fluentd-gcp:$(TAG) .
+	docker build --pull -t kubernetes/fluentd-gcp:$(TAG) .
 
 
 kpush:
@@ -43,7 +43,7 @@ kpush:
 # Rules for building the real image for deployment to gcr.io
 
 build:
-	docker build -t gcr.io/google_containers/fluentd-gcp:$(TAG) .
+	docker build --pull -t gcr.io/google_containers/fluentd-gcp:$(TAG) .
 
 
 push:

--- a/cluster/addons/gci/fluentd-gcp.yaml
+++ b/cluster/addons/gci/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.21.1
+    image: gcr.io/google_containers/fluentd-gcp:1.21.2
     command:
       - '/bin/sh'
       - '-c'

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.21.1
+    image: gcr.io/google_containers/fluentd-gcp:1.21.2
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
**What this PR does / why we need it**: creates a new version of the `fluentd-gcp` image based on the `1.21` version, with newer upstream dependencies pulled in. Same basic idea as #39707.

cc @timstclair 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
