### PR TITLE
Update fluentd-gcp addon to 1.25.2

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -20,7 +20,7 @@
 # scope and that the Logging API has been enabled for the project
 # in the Google Developer Console.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.4
+FROM gcr.io/google_containers/ubuntu-slim:0.6
 MAINTAINER Alex Robinson "arob@google.com"
 
 # Disable prompts from apt.

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -28,7 +28,7 @@
 
 .PHONY:	kbuild kpush
 
-TAG = 1.25
+TAG = 1.25.2
 
 # Rules for building the test image for deployment to Dockerhub with user kubernetes.
 

--- a/cluster/addons/gci/fluentd-gcp.yaml
+++ b/cluster/addons/gci/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.21.1
+    image: gcr.io/google_containers/fluentd-gcp:1.25.2
     command:
       - '/bin/sh'
       - '-c'

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.25.1
+    image: gcr.io/google_containers/fluentd-gcp:1.25.2
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
**What this PR does / why we need it**: creates a new version of the `fluentd-gcp` image based on the `1.25` version, with newer upstream dependencies pulled in. Same basic idea as #39705.

The definition for `1.21.2` comes from #41862. I'm not sure why `release-1.4` uses two different versions of `fluentd-gcp`.

cc @timstclair 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Update fluentd-gcp addon to 1.25.2
```
