### PR TITLE
Move the scheduler Fake* to testing folder

### DIFF
--- a/plugin/pkg/scheduler/algorithm/BUILD
+++ b/plugin/pkg/scheduler/algorithm/BUILD
@@ -12,7 +12,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
-        "listers.go",
         "scheduler_interface.go",
         "types.go",
     ],
@@ -22,7 +21,6 @@ go_library(
         "//pkg/apis/extensions/v1beta1:go_default_library",
         "//plugin/pkg/scheduler/api:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
-        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/labels",
     ],
 )

--- a/plugin/pkg/scheduler/algorithm/predicates/BUILD
+++ b/plugin/pkg/scheduler/algorithm/predicates/BUILD
@@ -44,6 +44,7 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//plugin/pkg/scheduler/testing:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/resource",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/labels",

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+	schedulertesting "k8s.io/kubernetes/plugin/pkg/scheduler/testing"
 )
 
 type FakeNodeInfo v1.Node
@@ -116,7 +117,7 @@ func newResourceInitPod(pod *v1.Pod, usage ...schedulercache.Resource) *v1.Pod {
 }
 
 func PredicateMetadata(p *v1.Pod, nodeInfo map[string]*schedulercache.NodeInfo) interface{} {
-	pm := PredicateMetadataFactory{algorithm.FakePodLister{p}}
+	pm := PredicateMetadataFactory{schedulertesting.FakePodLister{p}}
 	return pm.GetMetadata(p, nodeInfo)
 }
 
@@ -1500,7 +1501,7 @@ func TestServiceAffinity(t *testing.T) {
 			nodeInfo.SetNode(test.node)
 			nodeInfoMap := map[string]*schedulercache.NodeInfo{test.node.Name: nodeInfo}
 			// Reimplementing the logic that the scheduler implements: Any time it makes a predicate, it registers any precomputations.
-			predicate, precompute := NewServiceAffinityPredicate(algorithm.FakePodLister(test.pods), algorithm.FakeServiceLister(test.services), FakeNodeListInfo(nodes), test.labels)
+			predicate, precompute := NewServiceAffinityPredicate(schedulertesting.FakePodLister(test.pods), schedulertesting.FakeServiceLister(test.services), FakeNodeListInfo(nodes), test.labels)
 			// Register a precomputation or Rewrite the precomputation to a no-op, depending on the state we want to test.
 			RegisterPredicatePrecomputation("checkServiceAffinity-unitTestPredicate", func(pm *predicateMetadata) {
 				if !skipPrecompute {
@@ -2572,7 +2573,7 @@ func TestInterPodAffinity(t *testing.T) {
 
 		fit := PodAffinityChecker{
 			info:      FakeNodeInfo(*node),
-			podLister: algorithm.FakePodLister(test.pods),
+			podLister: schedulertesting.FakePodLister(test.pods),
 		}
 		nodeInfo := schedulercache.NewNodeInfo(podsOnNode...)
 		nodeInfo.SetNode(test.node)
@@ -2901,7 +2902,7 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 
 			testFit := PodAffinityChecker{
 				info:      nodeListInfo,
-				podLister: algorithm.FakePodLister(test.pods),
+				podLister: schedulertesting.FakePodLister(test.pods),
 			}
 			nodeInfo := schedulercache.NewNodeInfo(podsOnNode...)
 			nodeInfo.SetNode(&node)
@@ -4427,7 +4428,7 @@ func TestInterPodAffinityAnnotations(t *testing.T) {
 
 		fit := PodAffinityChecker{
 			info:      FakeNodeInfo(*node),
-			podLister: algorithm.FakePodLister(test.pods),
+			podLister: schedulertesting.FakePodLister(test.pods),
 		}
 		nodeInfo := schedulercache.NewNodeInfo(podsOnNode...)
 		nodeInfo.SetNode(test.node)
@@ -4673,7 +4674,7 @@ func TestInterPodAffinityAnnotationsWithMultipleNodes(t *testing.T) {
 
 			testFit := PodAffinityChecker{
 				info:      nodeListInfo,
-				podLister: algorithm.FakePodLister(test.pods),
+				podLister: schedulertesting.FakePodLister(test.pods),
 			}
 			nodeInfo := schedulercache.NewNodeInfo(podsOnNode...)
 			nodeInfo.SetNode(&node)

--- a/plugin/pkg/scheduler/algorithm/priorities/BUILD
+++ b/plugin/pkg/scheduler/algorithm/priorities/BUILD
@@ -61,10 +61,10 @@ go_test(
     deps = [
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
-        "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//plugin/pkg/scheduler/algorithm/priorities/util:go_default_library",
         "//plugin/pkg/scheduler/api:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//plugin/pkg/scheduler/testing:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/resource",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apiserver/pkg/util/feature",

--- a/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
@@ -24,9 +24,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+	schedulertesting "k8s.io/kubernetes/plugin/pkg/scheduler/testing"
 )
 
 type FakeNodeListInfo []*v1.Node
@@ -513,8 +513,8 @@ func TestInterPodAffinityPriority(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		interPodAffinity := InterPodAffinity{
 			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            algorithm.FakeNodeLister(test.nodes),
-			podLister:             algorithm.FakePodLister(test.pods),
+			nodeLister:            schedulertesting.FakeNodeLister(test.nodes),
+			podLister:             schedulertesting.FakePodLister(test.pods),
 			hardPodAffinityWeight: v1.DefaultHardPodAffinitySymmetricWeight,
 		}
 		list, err := interPodAffinity.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
@@ -601,8 +601,8 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		ipa := InterPodAffinity{
 			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            algorithm.FakeNodeLister(test.nodes),
-			podLister:             algorithm.FakePodLister(test.pods),
+			nodeLister:            schedulertesting.FakeNodeLister(test.nodes),
+			podLister:             schedulertesting.FakePodLister(test.pods),
 			hardPodAffinityWeight: test.hardPodAffinityWeight,
 		}
 		list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
@@ -1075,8 +1075,8 @@ func TestInterPodAffinityAnnotationsPriority(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		interPodAffinity := InterPodAffinity{
 			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            algorithm.FakeNodeLister(test.nodes),
-			podLister:             algorithm.FakePodLister(test.pods),
+			nodeLister:            schedulertesting.FakeNodeLister(test.nodes),
+			podLister:             schedulertesting.FakePodLister(test.pods),
 			hardPodAffinityWeight: v1.DefaultHardPodAffinitySymmetricWeight,
 		}
 		list, err := interPodAffinity.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
@@ -1165,8 +1165,8 @@ func TestHardPodAffinityAnnotationsSymmetricWeight(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		ipa := InterPodAffinity{
 			info:                  FakeNodeListInfo(test.nodes),
-			nodeLister:            algorithm.FakeNodeLister(test.nodes),
-			podLister:             algorithm.FakePodLister(test.pods),
+			nodeLister:            schedulertesting.FakeNodeLister(test.nodes),
+			podLister:             schedulertesting.FakePodLister(test.pods),
 			hardPodAffinityWeight: test.hardPodAffinityWeight,
 		}
 		list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)

--- a/plugin/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -24,9 +24,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api/v1"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
-	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+	schedulertesting "k8s.io/kubernetes/plugin/pkg/scheduler/testing"
 )
 
 func controllerRef(kind, name, uid string) []metav1.OwnerReference {
@@ -286,9 +286,9 @@ func TestSelectorSpreadPriority(t *testing.T) {
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, nil)
 		selectorSpread := SelectorSpread{
-			serviceLister:    algorithm.FakeServiceLister(test.services),
-			controllerLister: algorithm.FakeControllerLister(test.rcs),
-			replicaSetLister: algorithm.FakeReplicaSetLister(test.rss),
+			serviceLister:    schedulertesting.FakeServiceLister(test.services),
+			controllerLister: schedulertesting.FakeControllerLister(test.rcs),
+			replicaSetLister: schedulertesting.FakeReplicaSetLister(test.rss),
 		}
 		list, err := selectorSpread.CalculateSpreadPriority(test.pod, nodeNameToInfo, makeNodeList(test.nodes))
 		if err != nil {
@@ -493,9 +493,9 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, nil)
 		selectorSpread := SelectorSpread{
-			serviceLister:    algorithm.FakeServiceLister(test.services),
-			controllerLister: algorithm.FakeControllerLister(test.rcs),
-			replicaSetLister: algorithm.FakeReplicaSetLister(test.rss),
+			serviceLister:    schedulertesting.FakeServiceLister(test.services),
+			controllerLister: schedulertesting.FakeControllerLister(test.rcs),
+			replicaSetLister: schedulertesting.FakeReplicaSetLister(test.rss),
 		}
 		list, err := selectorSpread.CalculateSpreadPriority(test.pod, nodeNameToInfo, makeLabeledNodeList(labeledNodes))
 		if err != nil {
@@ -668,7 +668,7 @@ func TestZoneSpreadPriority(t *testing.T) {
 
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, nil)
-		zoneSpread := ServiceAntiAffinity{podLister: algorithm.FakePodLister(test.pods), serviceLister: algorithm.FakeServiceLister(test.services), label: "zone"}
+		zoneSpread := ServiceAntiAffinity{podLister: schedulertesting.FakePodLister(test.pods), serviceLister: schedulertesting.FakeServiceLister(test.services), label: "zone"}
 		list, err := zoneSpread.CalculateAntiAffinityPriority(test.pod, nodeNameToInfo, makeLabeledNodeList(test.nodes))
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)

--- a/plugin/pkg/scheduler/algorithm/types.go
+++ b/plugin/pkg/scheduler/algorithm/types.go
@@ -17,7 +17,9 @@ limitations under the License.
 package algorithm
 
 import (
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/api/v1"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
@@ -64,3 +66,64 @@ type PredicateFailureReason interface {
 }
 
 type GetEquivalencePodFunc func(pod *v1.Pod) interface{}
+
+// NodeLister interface represents anything that can list nodes for a scheduler.
+type NodeLister interface {
+	// We explicitly return []*v1.Node, instead of v1.NodeList, to avoid
+	// performing expensive copies that are unneeded.
+	List() ([]*v1.Node, error)
+}
+
+// PodLister interface represents anything that can list pods for a scheduler.
+type PodLister interface {
+	// We explicitly return []*v1.Pod, instead of v1.PodList, to avoid
+	// performing expensive copies that are unneeded.
+	List(labels.Selector) ([]*v1.Pod, error)
+}
+
+// ServiceLister interface represents anything that can produce a list of services; the list is consumed by a scheduler.
+type ServiceLister interface {
+	// Lists all the services
+	List(labels.Selector) ([]*v1.Service, error)
+	// Gets the services for the given pod
+	GetPodServices(*v1.Pod) ([]*v1.Service, error)
+}
+
+// ControllerLister interface represents anything that can produce a list of ReplicationController; the list is consumed by a scheduler.
+type ControllerLister interface {
+	// Lists all the replication controllers
+	List(labels.Selector) ([]*v1.ReplicationController, error)
+	// Gets the services for the given pod
+	GetPodControllers(*v1.Pod) ([]*v1.ReplicationController, error)
+}
+
+// ReplicaSetLister interface represents anything that can produce a list of ReplicaSet; the list is consumed by a scheduler.
+type ReplicaSetLister interface {
+	// Gets the replicasets for the given pod
+	GetPodReplicaSets(*v1.Pod) ([]*extensions.ReplicaSet, error)
+}
+
+var _ ControllerLister = &EmptyControllerLister{}
+
+// EmptyControllerLister implements ControllerLister on []v1.ReplicationController returning empty data
+type EmptyControllerLister struct{}
+
+// List returns nil
+func (f EmptyControllerLister) List(labels.Selector) ([]*v1.ReplicationController, error) {
+	return nil, nil
+}
+
+// GetPodControllers returns nil
+func (f EmptyControllerLister) GetPodControllers(pod *v1.Pod) (controllers []*v1.ReplicationController, err error) {
+	return nil, nil
+}
+
+var _ ReplicaSetLister = &EmptyReplicaSetLister{}
+
+// EmptyReplicaSetLister implements ReplicaSetLister on []extensions.ReplicaSet returning empty data
+type EmptyReplicaSetLister struct{}
+
+// GetPodReplicaSets returns nil
+func (f EmptyReplicaSetLister) GetPodReplicaSets(pod *v1.Pod) (rss []*extensions.ReplicaSet, err error) {
+	return nil, nil
+}

--- a/plugin/pkg/scheduler/core/BUILD
+++ b/plugin/pkg/scheduler/core/BUILD
@@ -25,6 +25,7 @@ go_test(
         "//plugin/pkg/scheduler/algorithm/priorities/util:go_default_library",
         "//plugin/pkg/scheduler/api:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//plugin/pkg/scheduler/testing:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/resource",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/util/sets",

--- a/plugin/pkg/scheduler/core/extender_test.go
+++ b/plugin/pkg/scheduler/core/extender_test.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+	schedulertesting "k8s.io/kubernetes/plugin/pkg/scheduler/testing"
 )
 
 type fitPredicate func(pod *v1.Pod, node *v1.Node) (bool, error)
@@ -289,7 +290,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 		scheduler := NewGenericScheduler(
 			cache, test.predicates, algorithm.EmptyMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer, extenders)
 		podIgnored := &v1.Pod{}
-		machine, err := scheduler.Schedule(podIgnored, algorithm.FakeNodeLister(makeNodeList(test.nodes)))
+		machine, err := scheduler.Schedule(podIgnored, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {
 			if err == nil {
 				t.Errorf("Unexpected non-error for %s, machine %s", test.name, machine)

--- a/plugin/pkg/scheduler/core/generic_scheduler_test.go
+++ b/plugin/pkg/scheduler/core/generic_scheduler_test.go
@@ -37,6 +37,7 @@ import (
 	priorityutil "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities/util"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+	schedulertesting "k8s.io/kubernetes/plugin/pkg/scheduler/testing"
 )
 
 func falsePredicate(pod *v1.Pod, meta interface{}, nodeInfo *schedulercache.NodeInfo) (bool, []algorithm.PredicateFailureReason, error) {
@@ -307,7 +308,7 @@ func TestGenericScheduler(t *testing.T) {
 		scheduler := NewGenericScheduler(
 			cache, test.predicates, algorithm.EmptyMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer,
 			[]algorithm.SchedulerExtender{})
-		machine, err := scheduler.Schedule(test.pod, algorithm.FakeNodeLister(makeNodeList(test.nodes)))
+		machine, err := scheduler.Schedule(test.pod, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 
 		if !reflect.DeepEqual(err, test.wErr) {
 			t.Errorf("Failed : %s, Unexpected error: %v, expected: %v", test.name, err, test.wErr)
@@ -515,16 +516,16 @@ func TestZeroRequest(t *testing.T) {
 			{Map: algorithmpriorities.BalancedResourceAllocationMap, Weight: 1},
 			{
 				Function: algorithmpriorities.NewSelectorSpreadPriority(
-					algorithm.FakeServiceLister([]*v1.Service{}),
-					algorithm.FakeControllerLister([]*v1.ReplicationController{}),
-					algorithm.FakeReplicaSetLister([]*extensions.ReplicaSet{})),
+					schedulertesting.FakeServiceLister([]*v1.Service{}),
+					schedulertesting.FakeControllerLister([]*v1.ReplicationController{}),
+					schedulertesting.FakeReplicaSetLister([]*extensions.ReplicaSet{})),
 				Weight: 1,
 			},
 		}
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		list, err := PrioritizeNodes(
 			test.pod, nodeNameToInfo, algorithm.EmptyMetadataProducer, priorityConfigs,
-			algorithm.FakeNodeLister(test.nodes), []algorithm.SchedulerExtender{})
+			schedulertesting.FakeNodeLister(test.nodes), []algorithm.SchedulerExtender{})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -153,7 +153,7 @@ func TestScheduler(t *testing.T) {
 					gotAssumedPod = pod
 				},
 			},
-			NodeLister: algorithm.FakeNodeLister(
+			NodeLister: schedulertesting.FakeNodeLister(
 				[]*v1.Node{&testNode},
 			),
 			Algorithm: item.algo,
@@ -205,7 +205,7 @@ func TestSchedulerNoPhantomPodAfterExpire(t *testing.T) {
 	pod := podWithPort("pod.Name", "", 8080)
 	node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "machine1"}}
 	scache.AddNode(&node)
-	nodeLister := algorithm.FakeNodeLister([]*v1.Node{&node})
+	nodeLister := schedulertesting.FakeNodeLister([]*v1.Node{&node})
 	predicateMap := map[string]algorithm.FitPredicate{"PodFitsHostPorts": predicates.PodFitsHostPorts}
 	scheduler, bindingChan, _ := setupTestSchedulerWithOnePodOnNode(t, queuedPodStore, scache, nodeLister, predicateMap, pod, &node)
 
@@ -263,7 +263,7 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 	firstPod := podWithPort("pod.Name", "", 8080)
 	node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "machine1"}}
 	scache.AddNode(&node)
-	nodeLister := algorithm.FakeNodeLister([]*v1.Node{&node})
+	nodeLister := schedulertesting.FakeNodeLister([]*v1.Node{&node})
 	predicateMap := map[string]algorithm.FitPredicate{"PodFitsHostPorts": predicates.PodFitsHostPorts}
 	scheduler, bindingChan, errChan := setupTestSchedulerWithOnePodOnNode(t, queuedPodStore, scache, nodeLister, predicateMap, firstPod, &node)
 
@@ -346,7 +346,7 @@ func TestSchedulerErrorWithLongBinding(t *testing.T) {
 		node := v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "machine1"}}
 		scache.AddNode(&node)
 
-		nodeLister := algorithm.FakeNodeLister([]*v1.Node{&node})
+		nodeLister := schedulertesting.FakeNodeLister([]*v1.Node{&node})
 		predicateMap := map[string]algorithm.FitPredicate{"PodFitsHostPorts": predicates.PodFitsHostPorts}
 
 		scheduler, bindingChan := setupTestSchedulerLongBindingWithRetry(
@@ -377,7 +377,7 @@ func TestSchedulerErrorWithLongBinding(t *testing.T) {
 // queuedPodStore: pods queued before processing.
 // cache: scheduler cache that might contain assumed pods.
 func setupTestSchedulerWithOnePodOnNode(t *testing.T, queuedPodStore *clientcache.FIFO, scache schedulercache.Cache,
-	nodeLister algorithm.FakeNodeLister, predicateMap map[string]algorithm.FitPredicate, pod *v1.Pod, node *v1.Node) (*Scheduler, chan *v1.Binding, chan error) {
+	nodeLister schedulertesting.FakeNodeLister, predicateMap map[string]algorithm.FitPredicate, pod *v1.Pod, node *v1.Node) (*Scheduler, chan *v1.Binding, chan error) {
 
 	scheduler, bindingChan, errChan := setupTestScheduler(queuedPodStore, scache, nodeLister, predicateMap)
 
@@ -441,7 +441,7 @@ func TestSchedulerFailedSchedulingReasons(t *testing.T) {
 		scache.AddNode(&node)
 		nodes = append(nodes, &node)
 	}
-	nodeLister := algorithm.FakeNodeLister(nodes)
+	nodeLister := schedulertesting.FakeNodeLister(nodes)
 	predicateMap := map[string]algorithm.FitPredicate{
 		"PodFitsResources": predicates.PodFitsResources,
 	}
@@ -477,7 +477,7 @@ func TestSchedulerFailedSchedulingReasons(t *testing.T) {
 
 // queuedPodStore: pods queued before processing.
 // scache: scheduler cache that might contain assumed pods.
-func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.Cache, nodeLister algorithm.FakeNodeLister, predicateMap map[string]algorithm.FitPredicate) (*Scheduler, chan *v1.Binding, chan error) {
+func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.Cache, nodeLister schedulertesting.FakeNodeLister, predicateMap map[string]algorithm.FitPredicate) (*Scheduler, chan *v1.Binding, chan error) {
 	algo := core.NewGenericScheduler(
 		scache,
 		predicateMap,
@@ -507,7 +507,7 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.
 	return New(cfg), bindingChan, errChan
 }
 
-func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, scache schedulercache.Cache, nodeLister algorithm.FakeNodeLister, predicateMap map[string]algorithm.FitPredicate, stop chan struct{}, bindingTime time.Duration) (*Scheduler, chan *v1.Binding) {
+func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, scache schedulercache.Cache, nodeLister schedulertesting.FakeNodeLister, predicateMap map[string]algorithm.FitPredicate, stop chan struct{}, bindingTime time.Duration) (*Scheduler, chan *v1.Binding) {
 	algo := core.NewGenericScheduler(
 		scache,
 		predicateMap,

--- a/plugin/pkg/scheduler/testing/BUILD
+++ b/plugin/pkg/scheduler/testing/BUILD
@@ -11,12 +11,16 @@ go_library(
     name = "go_default_library",
     srcs = [
         "fake_cache.go",
+        "fake_lister.go",
         "pods_to_cache.go",
     ],
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
+        "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/labels",
     ],
 )

--- a/plugin/pkg/scheduler/testing/fake_cache.go
+++ b/plugin/pkg/scheduler/testing/fake_cache.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package schedulercache
+package testing
 
 import (
 	"k8s.io/apimachinery/pkg/labels"

--- a/plugin/pkg/scheduler/testing/fake_lister.go
+++ b/plugin/pkg/scheduler/testing/fake_lister.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package algorithm
+package testing
 
 import (
 	"fmt"
@@ -23,14 +23,10 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/api/v1"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+	. "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 )
 
-// NodeLister interface represents anything that can list nodes for a scheduler.
-type NodeLister interface {
-	// We explicitly return []*v1.Node, instead of v1.NodeList, to avoid
-	// performing expensive copies that are unneeded.
-	List() ([]*v1.Node, error)
-}
+var _ NodeLister = &FakeNodeLister{}
 
 // FakeNodeLister implements NodeLister on a []string for test purposes.
 type FakeNodeLister []*v1.Node
@@ -40,12 +36,7 @@ func (f FakeNodeLister) List() ([]*v1.Node, error) {
 	return f, nil
 }
 
-// PodLister interface represents anything that can list pods for a scheduler.
-type PodLister interface {
-	// We explicitly return []*v1.Pod, instead of v1.PodList, to avoid
-	// performing expensive copies that are unneeded.
-	List(labels.Selector) ([]*v1.Pod, error)
-}
+var _ PodLister = &FakePodLister{}
 
 // FakePodLister implements PodLister on an []v1.Pods for test purposes.
 type FakePodLister []*v1.Pod
@@ -60,13 +51,7 @@ func (f FakePodLister) List(s labels.Selector) (selected []*v1.Pod, err error) {
 	return selected, nil
 }
 
-// ServiceLister interface represents anything that can produce a list of services; the list is consumed by a scheduler.
-type ServiceLister interface {
-	// Lists all the services
-	List(labels.Selector) ([]*v1.Service, error)
-	// Gets the services for the given pod
-	GetPodServices(*v1.Pod) ([]*v1.Service, error)
-}
+var _ ServiceLister = &FakeServiceLister{}
 
 // FakeServiceLister implements ServiceLister on []v1.Service for test purposes.
 type FakeServiceLister []*v1.Service
@@ -94,26 +79,7 @@ func (f FakeServiceLister) GetPodServices(pod *v1.Pod) (services []*v1.Service, 
 	return
 }
 
-// ControllerLister interface represents anything that can produce a list of ReplicationController; the list is consumed by a scheduler.
-type ControllerLister interface {
-	// Lists all the replication controllers
-	List(labels.Selector) ([]*v1.ReplicationController, error)
-	// Gets the services for the given pod
-	GetPodControllers(*v1.Pod) ([]*v1.ReplicationController, error)
-}
-
-// EmptyControllerLister implements ControllerLister on []v1.ReplicationController returning empty data
-type EmptyControllerLister struct{}
-
-// List returns nil
-func (f EmptyControllerLister) List(labels.Selector) ([]*v1.ReplicationController, error) {
-	return nil, nil
-}
-
-// GetPodControllers returns nil
-func (f EmptyControllerLister) GetPodControllers(pod *v1.Pod) (controllers []*v1.ReplicationController, err error) {
-	return nil, nil
-}
+var _ ControllerLister = &FakeControllerLister{}
 
 // FakeControllerLister implements ControllerLister on []v1.ReplicationController for test purposes.
 type FakeControllerLister []*v1.ReplicationController
@@ -144,19 +110,7 @@ func (f FakeControllerLister) GetPodControllers(pod *v1.Pod) (controllers []*v1.
 	return
 }
 
-// ReplicaSetLister interface represents anything that can produce a list of ReplicaSet; the list is consumed by a scheduler.
-type ReplicaSetLister interface {
-	// Gets the replicasets for the given pod
-	GetPodReplicaSets(*v1.Pod) ([]*extensions.ReplicaSet, error)
-}
-
-// EmptyReplicaSetLister implements ReplicaSetLister on []extensions.ReplicaSet returning empty data
-type EmptyReplicaSetLister struct{}
-
-// GetPodReplicaSets returns nil
-func (f EmptyReplicaSetLister) GetPodReplicaSets(pod *v1.Pod) (rss []*extensions.ReplicaSet, err error) {
-	return nil, nil
-}
+var _ ReplicaSetLister = &FakeReplicaSetLister{}
 
 // FakeReplicaSetLister implements ControllerLister on []extensions.ReplicaSet for test purposes.
 type FakeReplicaSetLister []*extensions.ReplicaSet

--- a/plugin/pkg/scheduler/testing/pods_to_cache.go
+++ b/plugin/pkg/scheduler/testing/pods_to_cache.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package schedulercache
+package testing
 
 import (
 	"k8s.io/apimachinery/pkg/labels"


### PR DESCRIPTION
Address this issue: https://github.com/kubernetes/kubernetes/issues/41662
@timothysc I moved the interface to the types.go, and the Fake* to the testing package, not sure whether you like or not.