### PR TITLE
[WIP] Add RWO volume support to glusterfs plugin.

### DIFF
--- a/examples/persistent-volume-provisioning/README.md
+++ b/examples/persistent-volume-provisioning/README.md
@@ -81,6 +81,7 @@ parameters:
   gidMin: "40000"
   gidMax: "50000"
   volumetype: "replicate:3"
+  volume: "rwo"
 ```
 
 * `resturl` : Gluster REST service/Heketi service url which provision gluster volumes on demand. The general format should be `IPaddress:Port` and this is a mandatory parameter for GlusterFS dynamic provisioner. If Heketi service is exposed as a routable service in openshift/kubernetes setup, this can have a format similar to
@@ -107,6 +108,8 @@ For example:
     `volumetype: none`
 
 For available volume types and it's administration options refer: ([Administration Guide](https://access.redhat.com/documentation/en-US/Red_Hat_Storage/3.1/html/Administration_Guide/part-Overview.html))
+
+*`volume` : The `volume` should be set to `rwo` if provisioner has to create block volumes from gluster backend. If this parameter has not specified, file volumes will be provisioned by the provisioner by default. This is an optional parameter.
 
 Reference : ([How to configure Heketi](https://github.com/heketi/heketi/wiki/Setting-up-the-topology))
 

--- a/examples/persistent-volume-provisioning/glusterfs-dp.yaml
+++ b/examples/persistent-volume-provisioning/glusterfs-dp.yaml
@@ -12,3 +12,4 @@ parameters:
   gidMin: "40000"
   gidMax: "50000"
   volumetype: "replicate:3"
+  volume: "rwo"

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -379,6 +379,7 @@ type provisionerConfig struct {
 	gidMin          int
 	gidMax          int
 	volumeType      gapi.VolumeDurabilityInfo
+	volume 			string
 }
 
 type glusterfsVolumeProvisioner struct {
@@ -885,6 +886,12 @@ func parseClassParameters(params map[string]string, kubeClient clientset.Interfa
 			cfg.secretName = v
 		case "secretnamespace":
 			cfg.secretNamespace = v
+		case "volume":
+			if v == "rwo" || v == "rwx" {
+				cfg.volume = v
+			} else {
+				return nil, fmt.Errorf("glusterfs: invalid value %q for volume plugin %s", k, glusterfsPluginName)
+			}
 		case "clusterid":
 			if len(v) != 0 {
 				cfg.clusterId = v


### PR DESCRIPTION
At present GlusterFS plugin provision and delete file volumes which are `rwx` capable. However gluster is also capable of creating block volumes which are `rwo` in nature. This patch allows gluster plugin to provision or delete both `rwx` and `rwo` volumes based on a storage class parameter ( `volume: rwo`) provided in SC parameter list. `rwx` volumes are mapped to glusterfs volume source and `rwo` volumes are mapped to `iscsi volume source`.

Pending: heketi cli api call to provision/delete  `rwo` volumes. 

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

