### PR TITLE
controller/podautoscale: fix informer mutation

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -276,6 +276,13 @@ func (a *HorizontalController) computeReplicasForMetrics(hpa *autoscalingv2.Hori
 }
 
 func (a *HorizontalController) reconcileAutoscaler(hpav1 *autoscalingv1.HorizontalPodAutoscaler) error {
+	// make a copy so that we don't mutate the shared informer cache. NOTE: UnsafeConvertToVersionVia below mutates!
+	hpaCopy, err := api.Scheme.DeepCopy(hpav1)
+	if err != nil {
+		return nil
+	}
+	hpav1 = hpaCopy.(*autoscalingv1.HorizontalPodAutoscaler)
+
 	// first, convert to autoscaling/v2, which makes our lives easier when calculating metrics
 	hpaRaw, err := UnsafeConvertToVersionVia(hpav1, autoscalingv2.SchemeGroupVersion)
 	if err != nil {


### PR DESCRIPTION
Unsafe conversion reuses parts of the input, i.e. custom conversion might (accidentily) modify the input. For the HorizontalPodAutoscaler controller the input comes from the shared informer => kaboom.

Compare e.g.: https://github.com/kubernetes/kubernetes/blob/caa78e0b3e3a68b84456120e04d4f219e25ce20d/pkg/apis/autoscaling/v1/conversion.go#L138 or https://github.com/kubernetes/kubernetes/blob/caa78e0b3e3a68b84456120e04d4f219e25ce20d/pkg/apis/autoscaling/v1/conversion.go#L94. These change the input.