### PR TITLE
vSphere supports a maximum of 16 adapters

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -515,6 +515,21 @@ func (i *Instances) NodeAddresses(nodeName k8stypes.NodeName) ([]v1.NodeAddress,
 			)
 		}
 	}
+
+	// ensure that the "primary" IP address of the machine is always included, since the above
+	// guest.net call is limited to 16 unsorted interfaces and the e.g. eth0 iface may not have
+	// been included.
+	err = getVirtualMachineManagedObjectReference(ctx, i.client, vm, "guest.ipAddress", &mvm)
+	if err != nil {
+		return nil, err
+	}
+	v1.AddToNodeAddresses(&addrs,
+		v1.NodeAddress{
+			Type:    v1.NodeInternalIP,
+			Address: mvm.Guest.IpAddress,
+		},
+	)
+
 	return addrs, nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

When open-vm-tools / VMware Tools reports in, it includes a maximum of 16 host interfaces, which include the veth* interfaces, which do not have IP addresses. This will cause NodeAddresses() to return hosts with no IP addresses present.

Grab the primary IP address from the vSphere API, and guarantee that it's always included in the response.

If you are experiencing this issue, you will see the following in a kubelet log:

```
I0217 08:46:52.906350    3359 kubelet_node_status.go:204] Setting node annotation to enable volume controller attach/detach
I0217 08:46:53.122263    3359 kubelet_node_status.go:74] Attempting to register node hcp-kubernetes-node-d301154c-f4ec-11e6-a682-00505681c8ef
I0217 08:46:53.133554    3359 kubelet_node_status.go:77] Successfully registered node hcp-kubernetes-node-d301154c-f4ec-11e6-a682-00505681c8ef
I0217 08:46:55.840679    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:00.840812    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:05.865272    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:10.865461    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:15.865616    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:20.865890    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:25.866053    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:30.866383    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:35.866617    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:40.885710    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:45.955161    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
I0217 08:47:50.955409    3359 kubelet.go:1725] skipping pod synchronization - [Kubelet failed to get node info.]
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Returns the primary IP address in all cases for every VM when NodeAddresses() is called to work around a vSphere limitation, increases stability of kubelet on vSphere
```
