### PR TITLE
Remove ivan4th from reviewers

### DIFF
--- a/cluster/juju/OWNERS
+++ b/cluster/juju/OWNERS
@@ -13,7 +13,6 @@ reviewers:
 - jsafrane
 - krousey
 - david-mcmahon
-- ivan4th
 - Cynerva
 - wwwtyro
 - tvansteenburgh


### PR DESCRIPTION
**What this PR does / why we need it**:

Per @ivan4th request in #41351 he would like to be removed from the
reviewers list in this directory tree. This commit addresses that
request.

**Special notes for your reviewer**:

As Ivan has already investigated the PR in question under 41351 I would like to see that driven to landing before landing this OWNERS file change, unless another reviewer would like to step in and help land that open PR.

**Release note**:

```release-note
NONE
```