### PR TITLE
Bump gcr.io/google-containers/rescheduler to v0.2.2

### DIFF
--- a/cluster/saltbase/salt/rescheduler/rescheduler.manifest
+++ b/cluster/saltbase/salt/rescheduler/rescheduler.manifest
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: rescheduler-v0.2.1
+  name: rescheduler-v0.2.2
   namespace: kube-system
   labels:
     k8s-app: rescheduler
-    version: v0.2.1
+    version: v0.2.2
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Rescheduler"
 spec:
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/rescheduler:v0.2.1
+  - image: gcr.io/google-containers/rescheduler:v0.2.2
     name: rescheduler
     volumeMounts:
     - mountPath: /var/log/rescheduler.log


### PR DESCRIPTION
**What this PR does / why we need it**: updates the rescheduler image to one based on busybox instead of ubuntu-slim. Changes for the image were in https://github.com/kubernetes/contrib/pull/2390.

Do you think this merits a release note? I'm leaning towards no.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu.
```

cc @timstclair 