### PR TITLE
Standard Debian base image

### DIFF
--- a/build/debian-base/Dockerfile
+++ b/build/debian-base/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM scratch
+
+ADD rootfs.tar /
+
+CMD ["/bin/sh"]

--- a/build/debian-base/Dockerfile.build
+++ b/build/debian-base/Dockerfile.build
@@ -1,0 +1,102 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so
+# e.g. CROSS_BUILD_COPY turns into COPY
+# If we're building normally, for amd64, CROSS_BUILD lines are removed
+CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Smaller package install size.
+COPY excludes /etc/dpkg/dpkg.cfg.d/excludes
+
+# Convenience script for building on this base image.
+COPY clean-install /usr/local/bin/clean-install
+
+# Update system packages.
+RUN apt-get update \
+    && apt-get dist-upgrade -y
+
+# Hold required packages to avoid breaking the installation of packages
+RUN apt-mark hold apt gnupg adduser passwd libsemanage1
+
+# Remove unnecessary packages.
+# This list was generated manually by listing the installed packages (`apt list --installed`),
+# then running `apt-cache rdepends --installed --no-recommends` to find the "root" packages.
+# The root packages were evaluated based on whether they were needed in the container image.
+# Several utilities (e.g. ping) were kept for usefulness, but may be removed in later versions.
+RUN echo "Yes, do as I say!" | apt-get purge \
+    bash \
+    debconf-i18n \
+    e2fslibs \
+    e2fsprogs \
+    gcc-4.8-base \
+    init \
+    initscripts \
+    libcap2-bin \
+    libkmod2 \
+    libmount1 \
+    libsmartcols1 \
+    libudev1 \
+    libblkid1 \
+    libncursesw5 \
+    libprocps3 \
+    libslang2 \
+    libss2 \
+    libtext-charwidth-perl libtext-iconv-perl libtext-wrapi18n-perl \
+    ncurses-base \
+    ncurses-bin \
+    systemd \
+    systemd-sysv \
+    sysv-rc \
+    tzdata
+
+# No-op stubs replace some unnecessary binaries that may be depended on in the install process (in
+# particular we don't run an init process).
+WORKDIR /usr/local/bin
+RUN touch noop && \
+    chmod 555 noop && \
+    ln -s noop runlevel && \
+    ln -s noop invoke-rc.d && \
+    ln -s noop update-rc.d
+WORKDIR /
+
+# Cleanup cached and unnecessary files.
+RUN apt-get autoremove -y && \
+    apt-get clean -y && \
+    tar -czf /usr/share/copyrights.tar.gz /usr/share/common-licenses /usr/share/doc/*/copyright && \
+    rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/info \
+        /usr/share/locale \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/cache/debconf/* \
+        /usr/share/common-licenses* \
+        /usr/share/bash-completion \
+        ~/.bashrc \
+        ~/.profile \
+        /etc/systemd \
+        /lib/lsb \
+        /lib/udev \
+        /usr/lib/x86_64-linux-gnu/gconv/IBM* \
+        /usr/lib/x86_64-linux-gnu/gconv/EBC* && \
+    mkdir -p /usr/share/man/man1 /usr/share/man/man2 \
+        /usr/share/man/man3 /usr/share/man/man4 \
+        /usr/share/man/man5 /usr/share/man/man6 \
+        /usr/share/man/man7 /usr/share/man/man8

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -1,0 +1,76 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: build
+
+REGISTRY ?= gcr.io/google-containers
+IMAGE ?= debian-base
+BUILD_IMAGE ?= debian-build
+
+TAG ?= 0.1.0
+
+TAR_FILE ?= rootfs.tar
+ARCH?=amd64
+TEMP_DIR:=$(shell mktemp -d)
+QEMUVERSION=v2.7.0
+
+ifeq ($(ARCH),amd64)
+	BASEIMAGE?=debian:jessie
+endif
+ifeq ($(ARCH),arm)
+	BASEIMAGE?=armhf/debian:jessie
+	QEMUARCH=arm
+endif
+ifeq ($(ARCH),arm64)
+	BASEIMAGE?=aarch64/debian:jessie
+	QEMUARCH=aarch64
+endif
+ifeq ($(ARCH),ppc64le)
+	BASEIMAGE?=ppc64le/debian:jessie
+	QEMUARCH=ppc64le
+endif
+ifeq ($(ARCH),s390x)
+	BASEIMAGE?=s390x/debian:jessie
+	QEMUARCH=s390x
+endif
+
+build: clean
+	cp ./* $(TEMP_DIR)
+	cat Dockerfile.build \
+		| sed "s|BASEIMAGE|$(BASEIMAGE)|g" \
+		| sed "s|ARCH|$(QEMUARCH)|g" \
+		> $(TEMP_DIR)/Dockerfile.build
+
+ifeq ($(ARCH),amd64)
+	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
+	sed "/CROSS_BUILD_/d" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
+else
+	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
+	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
+	curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-$(QEMUARCH)-static.tar.gz | tar -xz -C $(TEMP_DIR)
+	sed "s/CROSS_BUILD_//g" $(TEMP_DIR)/Dockerfile.build > $(TEMP_DIR)/Dockerfile.build.tmp
+endif
+	mv $(TEMP_DIR)/Dockerfile.build.tmp $(TEMP_DIR)/Dockerfile.build
+
+	docker build --pull -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.build $(TEMP_DIR)
+	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
+	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(TAR_FILE)
+	docker build -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+clean:
+	docker rmi -f $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) || true
+	docker rmi -f $(BUILD_IMAGE)   || true
+	docker rm  -f $(BUILD_IMAGE)   || true

--- a/build/debian-base/README.md
+++ b/build/debian-base/README.md
@@ -1,0 +1,12 @@
+# Kubernetes Debian Base
+
+The Kubernetes debian-base image provides a common base for Kubernetes system images that require
+external dependencies (such as `iptables`, `sh`, or anything that is more than a static go-binary).
+
+This image differs from the standard debian image by removing a lot of packages and files that are
+generally not necessary in containers. The end result is an image that is just over 40 MB, down from
+123 MB.
+
+The image also provides a convenience script `/usr/local/bin/clean-install` that encapsulates the
+process of updating apt repositories, installing the packages, and then cleaning up unnecessary
+caches & logs.

--- a/build/debian-base/clean-install
+++ b/build/debian-base/clean-install
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
+
+set -o errexit
+
+if [ $# = 0 ]; then
+  echo >&2 "No packages specified"
+  exit 1
+fi
+
+apt-get update
+apt-get install -y --no-install-recommends $@
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/*

--- a/build/debian-base/excludes
+++ b/build/debian-base/excludes
@@ -1,0 +1,10 @@
+path-exclude /usr/share/doc/*
+path-include /usr/share/doc/*/copyright
+path-exclude /usr/share/groff/*
+path-exclude /usr/share/i18n/locales/*
+path-include /usr/share/i18n/locales/en_US*
+path-exclude /usr/share/info/*
+path-exclude /usr/share/locale/*
+path-include /usr/share/locale/en_US*
+path-include /usr/share/locale/locale.alias
+path-exclude /usr/share/man/*


### PR DESCRIPTION
**What this PR does / why we need it**:

The goal of this new image is to provide a standard base image for Kubernetes system images that require substantial external dependencies (e.g. kube-proxy and fluentd). The image is significantly reduced from the standard `debian:jessie-slim` image (40 MB vs 80 MB), and removes a number of unnecessary dependencies such as e2fsprogs, systemd, and sysv-rc. In the future we may consider further reducing it to the bare minimum to run the package manager, with the requirement that images based on it add all the dependencies they need.

I tested this by rebasing kube-proxy on this image and running the e2e tests. I'm targeting 1.6 for rebasing kube-proxy & fluentd on this.

For the rational behind basing on Debian, see https://github.com/kubernetes/kubernetes/issues/40248#issuecomment-280781931

Largely based off [debian-iptables](https://github.com/kubernetes/kubernetes/tree/master/build/debian-iptables/) and [ubuntu-slim](https://github.com/kubernetes/ingress/tree/master/images/ubuntu-slim).

**Which issue this PR fixes**
https://github.com/kubernetes/kubernetes/issues/40248

**Special notes for your reviewer**:
@luxas Please review the qemu cross-build logic in the Makefile. It's copied from [debian-iptables](https://github.com/kubernetes/kubernetes/blob/master/build/debian-iptables/Makefile), but I'm not sure exactly what it's doing.

/cc @jessfraz @dlorenc 