### PR TITLE
Juju: Disable anonymous auth on kubelet

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -252,7 +252,7 @@ def idle_status():
 
 
 @when('etcd.available', 'kubernetes-master.components.installed',
-      'certificates.server.cert.available')
+      'certificates.server.cert.available', 'authentication.setup')
 @when_not('kubernetes-master.components.started')
 def start_master(etcd, tls):
     '''Run the Kubernetes master components.'''
@@ -647,6 +647,8 @@ def render_files():
     # Get the tls paths from the layer data.
     layer_options = layer.options('tls-client')
     ca_cert_path = layer_options.get('ca_certificate_path')
+    client_cert_path = layer_options.get('client_certificate_path')
+    client_key_path = layer_options.get('client_key_path')
     server_cert_path = layer_options.get('server_certificate_path')
     server_key_path = layer_options.get('server_key_path')
 
@@ -656,6 +658,9 @@ def render_files():
     api_opts.add('--client-ca-file', ca_cert_path)
     api_opts.add('--tls-cert-file', server_cert_path)
     api_opts.add('--tls-private-key-file', server_key_path)
+    api_opts.add('--kubelet-certificate-authority', ca_cert_path)
+    api_opts.add('--kubelet-client-certificate', client_cert_path)
+    api_opts.add('--kubelet-client-key', client_key_path)
 
     scheduler_opts.add('--v', '2')
 

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -146,9 +146,31 @@ def update_kubelet_status():
         hookenv.status_set('waiting', 'Waiting for kubelet to start.')
 
 
+@when('certificates.available')
+def send_data(tls):
+    '''Send the data that is required to create a server certificate for
+    this server.'''
+    # Use the public ip of this unit as the Common Name for the certificate.
+    common_name = hookenv.unit_public_ip()
+
+    # Create SANs that the tls layer will add to the server cert.
+    sans = [
+        hookenv.unit_public_ip(),
+        hookenv.unit_private_ip(),
+        gethostname()
+    ]
+
+    # Create a path safe name by removing path characters from the unit name.
+    certificate_name = hookenv.local_unit().replace('/', '_')
+
+    # Request a server cert with this information.
+    tls.request_server_cert(common_name, sans, certificate_name)
+
+
 @when('kubernetes-worker.components.installed', 'kube-api-endpoint.available',
       'tls_client.ca.saved', 'tls_client.client.certificate.saved',
-      'tls_client.client.key.saved', 'kube-dns.available', 'cni.available')
+      'tls_client.client.key.saved', 'tls_client.server.certificate.saved',
+      'tls_client.server.key.saved', 'kube-dns.available', 'cni.available')
 def start_worker(kube_api, kube_dns, cni):
     ''' Start kubelet using the provided API and DNS info.'''
     servers = get_kube_api_servers(kube_api)
@@ -301,39 +323,37 @@ def render_init_scripts(api_servers):
     context = {}
     context.update(hookenv.config())
 
-    # Get the tls paths from the layer data.
     layer_options = layer.options('tls-client')
-    context['ca_cert_path'] = layer_options.get('ca_certificate_path')
-    context['client_cert_path'] = layer_options.get('client_certificate_path')
-    context['client_key_path'] = layer_options.get('client_key_path')
+    ca_cert_path = layer_options.get('ca_certificate_path')
+    server_cert_path = layer_options.get('server_certificate_path')
+    server_key_path = layer_options.get('server_key_path')
 
     unit_name = os.getenv('JUJU_UNIT_NAME').replace('/', '-')
     context.update({'kube_api_endpoint': ','.join(api_servers),
                     'JUJU_UNIT_NAME': unit_name})
 
-    # Create a flag manager for kubelet to render kubelet_opts.
     kubelet_opts = FlagManager('kubelet')
-    # Declare to kubelet it needs to read from kubeconfig
     kubelet_opts.add('--require-kubeconfig', None)
     kubelet_opts.add('--kubeconfig', kubeconfig_path)
     kubelet_opts.add('--network-plugin', 'cni')
+    kubelet_opts.add('--anonymous-auth', 'false')
+    kubelet_opts.add('--client-ca-file', ca_cert_path)
+    kubelet_opts.add('--tls-cert-file', server_cert_path)
+    kubelet_opts.add('--tls-private-key-file', server_key_path)
     context['kubelet_opts'] = kubelet_opts.to_s()
-    # Create a flag manager for kube-proxy to render kube_proxy_opts.
+
     kube_proxy_opts = FlagManager('kube-proxy')
     kube_proxy_opts.add('--kubeconfig', kubeconfig_path)
     context['kube_proxy_opts'] = kube_proxy_opts.to_s()
 
     os.makedirs('/var/lib/kubelet', exist_ok=True)
-    # Set the user when rendering config
-    context['user'] = 'kubelet'
-    # Set the user when rendering config
-    context['user'] = 'kube-proxy'
+
     render('kube-default', '/etc/default/kube-default', context)
     render('kubelet.defaults', '/etc/default/kubelet', context)
+    render('kubelet.service', '/lib/systemd/system/kubelet.service', context)
     render('kube-proxy.defaults', '/etc/default/kube-proxy', context)
     render('kube-proxy.service', '/lib/systemd/system/kube-proxy.service',
            context)
-    render('kubelet.service', '/lib/systemd/system/kubelet.service', context)
 
 
 def create_kubeconfig(kubeconfig, server, ca, key, certificate, user='ubuntu',

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -48,7 +48,7 @@ cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:    ip = ser
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:def send_cluster_dns_detail(cluster_dns):
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:def service_cidr():
 cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py:    context.update({'kube_api_endpoint': ','.join(api_servers),
-cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py:    context['ca_cert_path'] = layer_options.get('ca_certificate_path')
+cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py:    ca_cert_path = layer_options.get('ca_certificate_path')
 cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py:def render_init_scripts(api_servers):
 cluster/lib/logging.sh:      local source_file=${BASH_SOURCE[$frame_no]}
 cluster/lib/logging.sh:    local source_file=${BASH_SOURCE[$stack_skip]}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This disables anonymous authentication on kubelet when deployed via Juju.

I've also adjusted a few other TLS options for kubelet and kube-apiserver. The end result is that:
1. kube-apiserver can now authenticate with kubelet
2. kube-apiserver now verifies the integrity of kubelet

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/219

**Special notes for your reviewer**:

This is dependent on PR #41251, where the tactics changes are being merged in separately.

Some useful pages from the documentation:
* [apiserver -> kubelet](https://kubernetes.io/docs/admin/master-node-communication/#apiserver---kubelet)
* [Kubelet authentication/authorization](https://kubernetes.io/docs/admin/kubelet-authentication-authorization/)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Juju: Disable anonymous auth on kubelet
```
