### PR TITLE
bump version numbers for heapster/influxdb/grafana images

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -14,30 +14,30 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0-beta.0
+  name: heapster-v1.3.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0-beta.0
+    version: v1.3.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0-beta.0
+      version: v1.3.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0-beta.0
+        version: v1.3.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.3.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -57,7 +57,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.3.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
           name: eventer
           command:
             - /eventer
@@ -95,7 +95,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0-beta.0
+            - --deployment=heapster-v1.3.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -124,7 +124,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.3.0-beta.0
+            - --deployment=heapster-v1.3.0-beta.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -14,30 +14,30 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0-beta.0
+  name: heapster-v1.3.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0-beta.0
+    version: v1.3.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0-beta.0
+      version: v1.3.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0-beta.0
+        version: v1.3.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.3.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -58,7 +58,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster:v1.3.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
           name: eventer
           command:
             - /eventer
@@ -96,7 +96,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0-beta.0
+            - --deployment=heapster-v1.3.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -125,7 +125,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.3.0-beta.0
+            - --deployment=heapster-v1.3.0-beta.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -14,30 +14,30 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0-beta.0
+  name: heapster-v1.3.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0-beta.0
+    version: v1.3.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0-beta.0
+      version: v1.3.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0-beta.0
+        version: v1.3.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.3.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -50,7 +50,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/heapster:v1.3.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
           name: eventer
           command:
             - /eventer
@@ -81,7 +81,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0-beta.0
+            - --deployment=heapster-v1.3.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -110,7 +110,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.3.0-beta.0
+            - --deployment=heapster-v1.3.0-beta.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/cluster-service: "true"
     spec: 
       containers: 
-        - image: gcr.io/google_containers/heapster_influxdb:v0.7
+        - image: gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1
           name: influxdb
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -37,7 +37,7 @@ spec:
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data
-        - image: gcr.io/google_containers/heapster_grafana:v3.1.1
+        - image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
           name: grafana
           env:
           resources:

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -12,30 +12,30 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0-beta.0
+  name: heapster-v1.3.0-beta.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0-beta.0
+    version: v1.3.0-beta.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0-beta.0
+      version: v1.3.0-beta.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0-beta.0
+        version: v1.3.0-beta.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster:v1.3.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -72,7 +72,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0-beta.0
+            - --deployment=heapster-v1.3.0-beta.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
It updates version of monitoring components (heapster/influxdb/grafana) to the latest one used by heapster

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
[e2e/monitoring.go](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/monitoring.go) test seems to be passing without modifications

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
