### PR TITLE
list-resources: don't fail if the grep fails to match any resources

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -49,7 +49,7 @@ function gcloud-compute-list() {
   while true; do
     if result=$(gcloud compute ${resource} list --project=${PROJECT} ${@:2}); then
       if [[ ! -z "${GREP_REGEX}" ]]; then
-        result=$(echo "${result}" | grep "${GREP_REGEX}")
+        result=$(echo "${result}" | grep "${GREP_REGEX}" || true)
       fi
       echo "${result}"
       return


### PR DESCRIPTION
**What this PR does / why we need it**: if no resources are found, the `grep` call will exit nonzero, so guard it with ` || true`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #41917

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->


cc @krzyzacy @ncdc 