### PR TITLE
GCE will properly regenerate basic_auth.csv on kube-apiserver start.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -201,3 +201,7 @@ ENABLE_DEFAULT_STORAGE_CLASS="${ENABLE_DEFAULT_STORAGE_CLASS:-true}"
 # TODO(dawn1107): Remove this once the flag is built into CVM image.
 # Kernel panic upon soft lockup issue
 SOFTLOCKUP_PANIC="${SOFTLOCKUP_PANIC:-false}" # true, false
+
+# Indicates if the values (eg. kube password) in metadata should be treated as
+# canonical, and therefore disk copies ought to be recreated/clobbered.
+METADATA_CLOBBERS_CONFIG=${METADATA_CLOBBERS_CONFIG:-false}

--- a/cluster/gke/config-default.sh
+++ b/cluster/gke/config-default.sh
@@ -42,3 +42,7 @@ ENABLE_L7_LOADBALANCING="${KUBE_ENABLE_L7_LOADBALANCING:-glbc}"
 ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}"
 
 KUBE_DELETE_NETWORK=${KUBE_DELETE_NETWORK:-false}
+
+# Indicates if the values (eg. kube password) in metadata should be treated as
+# canonical, and therefore disk copies ought to be recreated/clobbered.
+METADATA_CLOBBERS_CONFIG=true


### PR DESCRIPTION
**What this PR does / why we need it**:

If basic_auth.csv does not exist we will generate it as normal.
If basic_auth.csv exists we will remove the old admin password before adding the "new" one. (Turns in to a no-op if the password exists).
This did not work properly before because we were replacing by key, where the key was the password. New password would not match and so not replace the old password.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #41935

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
