### PR TITLE
WIP Fix genericapiserver_test depenency on openapigen

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	// "github.com/go-openapi/spec"
+	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -49,6 +49,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
+	"k8s.io/client-go/pkg/api"
 	restclient "k8s.io/client-go/rest"
 )
 
@@ -77,10 +78,6 @@ func init() {
 	examplev1.AddToScheme(scheme)
 }
 
-func testGetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.OpenAPIDefinition {
-	return map[string]openapi.OpenAPIDefinition{}
-}
-
 // setUp is a convience function for setting up for (most) tests.
 func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
 	etcdServer, _ := etcdtesting.NewUnsecuredEtcd3TestClientServer(t, scheme)
@@ -91,14 +88,17 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.LoopbackClientConfig = &restclient.Config{}
 
-	// TODO restore this test, but right now, eliminate our cycle
-	// config.OpenAPIConfig = DefaultOpenAPIConfig(testGetOpenAPIDefinitions, runtime.NewScheme())
-	// config.OpenAPIConfig.Info = &spec.Info{
-	// 	InfoProps: spec.InfoProps{
-	// 		Title:   "Kubernetes",
-	// 		Version: "unversioned",
-	// 	},
-	// }
+	config.OpenAPIConfig = DefaultOpenAPIConfig(
+		func(ref openapi.ReferenceCallback) map[string]openapi.OpenAPIDefinition {
+			return map[string]openapi.OpenAPIDefinition{}
+		},
+		api.Scheme)
+	config.OpenAPIConfig.Info = &spec.Info{
+		InfoProps: spec.InfoProps{
+			Title:   "Kubernetes",
+			Version: "unversioned",
+		},
+	}
 	config.SwaggerConfig = DefaultSwaggerConfig()
 
 	return etcdServer, *config, assert.New(t)
@@ -301,7 +301,7 @@ func TestPrepareRun(t *testing.T) {
 	defer etcdserver.Terminate(t)
 
 	assert.NotNil(config.SwaggerConfig)
-	// assert.NotNil(config.OpenAPIConfig)
+	assert.NotNil(config.OpenAPIConfig)
 
 	server := httptest.NewServer(s.HandlerContainer.ServeMux)
 	defer server.Close()
@@ -309,12 +309,12 @@ func TestPrepareRun(t *testing.T) {
 	s.PrepareRun()
 
 	// openapi is installed in PrepareRun
-	// resp, err := http.Get(server.URL + "/swagger.json")
-	// assert.NoError(err)
-	// assert.Equal(http.StatusOK, resp.StatusCode)
+	resp, err := http.Get(server.URL + "/swagger.json")
+	assert.NoError(err)
+	assert.Equal(http.StatusOK, resp.StatusCode)
 
 	// swagger is installed in PrepareRun
-	resp, err := http.Get(server.URL + "/swaggerapi/")
+	resp, err = http.Get(server.URL + "/swaggerapi/")
 	assert.NoError(err)
 	assert.Equal(http.StatusOK, resp.StatusCode)
 


### PR DESCRIPTION
genericapiserver_test depends on generated openapi models to test if OpenAPI endpoint is registered. Look like this dependency is not required and an empty model list still passes the test.

fix #41748