### PR TITLE
Curate owners for pkg/volume/aws_ebs

### DIFF
--- a/pkg/volume/aws_ebs/OWNERS
+++ b/pkg/volume/aws_ebs/OWNERS
@@ -1,18 +1,13 @@
 approvers:
+- gnufied
+- jingxu97
 - jsafrane
 - justinsb
-- chrislovecnm
-- jingxu97
 reviewers:
-- thockin
-- smarterclayton
-- deads2k
-- pmorie
-- saad-ali
+- chrislovecnm
+- gnufied
+- jingxu97
 - justinsb
 - jsafrane
 - rootfs
-- jingxu97
-- chakri-nelluri
-- screeley44
-- gnufied
+- saad-ali


### PR DESCRIPTION
The previous list was algorithmically generated; applying some curation.

```release-note
NONE
```
