### PR TITLE
Revert "[Federation][kubefed] Add label selector for etcd pvc"

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -549,7 +549,6 @@ func createPVC(clientset *client.Clientset, namespace, svcName, etcdPVCapacity s
 					api.ResourceStorage: capacity,
 				},
 			},
-			Selector: &metav1.LabelSelector{MatchLabels: apiserverSvcSelector},
 		},
 	}
 

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -672,7 +672,6 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 					v1.ResourceStorage: capacity,
 				},
 			},
-			Selector: &metav1.LabelSelector{MatchLabels: apiserverSvcSelector},
 		},
 	}
 


### PR DESCRIPTION
Reverts kubernetes/kubernetes#41651

Reverting the commit as it is causing issues on GCE.
label selector is not supported with dynamic provisioning yet. we might need to revisit this sometime later.

cc @madhusudancs @perotinus @kubernetes/sig-federation-bugs 