### PR TITLE
Sort slices before comparing in deployment util test

### DIFF
--- a/pkg/controller/deployment/util/BUILD
+++ b/pkg/controller/deployment/util/BUILD
@@ -57,6 +57,7 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset/fake:go_default_library",
+        "//pkg/controller:go_default_library",
         "//vendor:github.com/stretchr/testify/assert",
         "//vendor:k8s.io/apimachinery/pkg/api/equality",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",


### PR DESCRIPTION
Follow up #41851, should sort the slice before comparing them 

Fixes #42021

@kargakis @mwielgus 