### PR TITLE
Retry a few times before killing docker daemon

### DIFF
--- a/cluster/gce/gci/health-monitor.sh
+++ b/cluster/gce/gci/health-monitor.sh
@@ -26,7 +26,19 @@ set -o pipefail
 # automatically restart the process.
 function docker_monitoring {
   while [ 1 ]; do
-    if ! timeout 60 docker ps > /dev/null; then
+    n=0
+    dockerpscheck=1
+    until [ $n -ge 10 ]; do
+      if ! timeout 60 docker ps > /dev/null; then
+        echo 'Docker ps failed, attempt ' $((n + 1))
+        sleep "${SLEEP_SECONDS}"
+        n=$[$n+1]
+      else
+        dockerpscheck=0
+        break
+      fi
+    done
+    if [ $dockerpscheck = 1 ]; then
       echo "Docker daemon failed!"
       pkill docker
       # Wait for a while, as we don't want to kill it again before it is really up.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
In our k8s setup, sometime docker becomes very unresponsive, and recovers after a while. So timeout after 60s doesn't help much. We retry a few times before killing docker daemon.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```