### PR TITLE
add deads2k and sttts to kubeapiserver owners

### DIFF
--- a/pkg/kubeapiserver/OWNERS
+++ b/pkg/kubeapiserver/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- deads2k
+- lavalamp
+- sttts
+reviewers:
+- deads2k
+- lavalamp
+- sttts

--- a/pkg/master/OWNERS
+++ b/pkg/master/OWNERS
@@ -1,8 +1,10 @@
 approvers:
+- deads2k
 - derekwaynecarr
 - lavalamp
 - mikedanese
 - nikhiljindal
+- sttts
 - wojtek-t
 reviewers:
 - thockin


### PR DESCRIPTION
Adds @deads2k and @sttts to packages we authored or significantly modified.

@lavalamp @smarterclayton 