### PR TITLE
kubeadm: Add a --ca-cert-path flag to kubeadm join [test 2]

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -34,5 +34,10 @@ func KubeadmFuzzerFuncs(t apitesting.TestingCommon) []interface{} {
 			obj.AuthorizationMode = "foo"
 			obj.Discovery.Token = &kubeadm.TokenDiscovery{}
 		},
+		func(obj *kubeadm.NodeConfiguration, c fuzz.Continue) {
+			c.FuzzNoCustom(obj)
+			obj.CACertPath = "foo"
+			obj.Discovery.Token = &kubeadm.TokenDiscovery{}
+		},
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -84,7 +84,8 @@ type Etcd struct {
 type NodeConfiguration struct {
 	metav1.TypeMeta
 
-	Discovery Discovery
+	Discovery  Discovery
+	CACertPath string
 }
 
 // ClusterInfo TODO add description

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -27,12 +27,14 @@ const (
 	DefaultAPIBindPort               = 6443
 	DefaultDiscoveryBindPort         = 9898
 	DefaultAuthorizationMode         = "RBAC"
+	DefaultCACertPath                = "/etc/kubernetes/pki/ca.crt"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	RegisterDefaults(scheme)
 	return scheme.AddDefaultingFuncs(
 		SetDefaults_MasterConfiguration,
+		SetDefaults_NodeConfiguration,
 	)
 }
 
@@ -59,5 +61,11 @@ func SetDefaults_MasterConfiguration(obj *MasterConfiguration) {
 
 	if obj.AuthorizationMode == "" {
 		obj.AuthorizationMode = DefaultAuthorizationMode
+	}
+}
+
+func SetDefaults_NodeConfiguration(obj *NodeConfiguration) {
+	if obj.CACertPath == "" {
+		obj.CACertPath = DefaultCACertPath
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -74,7 +74,8 @@ type Etcd struct {
 type NodeConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
-	Discovery Discovery `json:"discovery"`
+	Discovery  Discovery `json:"discovery"`
+	CACertPath string    `json:"caCertPath"`
 }
 
 // ClusterInfo TODO add description

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -18,6 +18,8 @@ package validation
 
 import (
 	"net"
+	"path"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -51,6 +53,10 @@ func ValidateMasterConfiguration(c *kubeadm.MasterConfiguration) field.ErrorList
 func ValidateNodeConfiguration(c *kubeadm.NodeConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, ValidateDiscovery(&c.Discovery, field.NewPath("discovery"))...)
+
+	if !path.IsAbs(c.CACertPath) || !strings.HasSuffix(c.CACertPath, ".crt") {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("ca-cert-path"), nil, "the ca certificate path must be an absolute path"))
+	}
 	return allErrs
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -160,16 +160,25 @@ func TestValidateNodeConfiguration(t *testing.T) {
 					Addresses: []string{"foobar"},
 				},
 			},
+			CACertPath: "/some/cert.crt",
 		}, false},
 		{&kubeadm.NodeConfiguration{
 			Discovery: kubeadm.Discovery{
 				HTTPS: &kubeadm.HTTPSDiscovery{URL: "foo"},
 			},
+			CACertPath: "/some/path", // no .crt suffix
+		}, false},
+		{&kubeadm.NodeConfiguration{
+			Discovery: kubeadm.Discovery{
+				HTTPS: &kubeadm.HTTPSDiscovery{URL: "foo"},
+			},
+			CACertPath: "/some/cert.crt",
 		}, true},
 		{&kubeadm.NodeConfiguration{
 			Discovery: kubeadm.Discovery{
 				File: &kubeadm.FileDiscovery{Path: "foo"},
 			},
+			CACertPath: "/some/other/cert.crt",
 		}, true},
 		{&kubeadm.NodeConfiguration{
 			Discovery: kubeadm.Discovery{
@@ -179,6 +188,7 @@ func TestValidateNodeConfiguration(t *testing.T) {
 					Addresses: []string{"foobar"},
 				},
 			},
+			CACertPath: "/a/third/cert.crt",
 		}, true},
 	}
 	for _, rt := range tests {

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -78,6 +78,11 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 		"skip preflight checks normally run before modifying the system",
 	)
 
+	cmd.PersistentFlags().StringVar(
+		&cfg.CACertPath, "ca-cert-path", kubeadmapiext.DefaultCACertPath,
+		"Path where the ca certificate of the cluster should be stored",
+	)
+
 	cmd.PersistentFlags().Var(
 		discovery.NewDiscoveryValue(&cfg.Discovery), "discovery",
 		"The discovery method kubeadm will use for connecting nodes to the master",
@@ -146,8 +151,7 @@ func (j *Join) Run(out io.Writer) error {
 
 	// Write the ca certificate to disk so kubelet can use it for authentication
 	cluster := cfg.Contexts[cfg.CurrentContext].Cluster
-	caCertFile := filepath.Join(kubeadmapi.GlobalEnvParams.HostPKIPath, kubeadmconstants.CACertName)
-	err = certutil.WriteCert(caCertFile, cfg.Clusters[cluster].CertificateAuthorityData)
+	err = certutil.WriteCert(j.cfg.CACertPath, cfg.Clusters[cluster].CertificateAuthorityData)
 	if err != nil {
 		return fmt.Errorf("couldn't save the CA certificate to disk: %v", err)
 	}

--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -40,16 +40,15 @@ cluster/gce/trusty/configure-helper.sh:    sed -i -e "s@{{ *pillar\.get('storage
 cluster/gce/trusty/configure-helper.sh:  sed -i -e "s@{{pillar\['allow_privileged'\]}}@true@g" "${src_file}"
 cluster/gce/util.sh:    local node_ip=$(gcloud compute instances describe --project "${PROJECT}" --zone "${ZONE}" \
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:            context['pillar'] = {'num_nodes': get_node_count()}
-cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:    db.set('kubernetes-master.service-cidr', service_cidr())
-cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:    api_opts.add('--service-cluster-ip-range', service_cidr())
-cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:    elif hookenv.config('service-cidr') != service_cidr():
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:        msg = "Cannot change {0} to {1}".format(service_cidr(),
+cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:    ca_cert_path = layer_options.get('ca_certificate_path')
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:    cluster_dns.set_dns_info(53, hookenv.config('dns_domain'), dns_ip)
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:    ip = service_cidr().split('/')[0]
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:    ip = service_cidr().split('/')[0]
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:def send_cluster_dns_detail(cluster_dns):
 cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py:def service_cidr():
 cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py:    context.update({'kube_api_endpoint': ','.join(api_servers),
+cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py:    context['ca_cert_path'] = layer_options.get('ca_certificate_path')
 cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py:def render_init_scripts(api_servers):
 cluster/lib/logging.sh:      local source_file=${BASH_SOURCE[$frame_no]}
 cluster/lib/logging.sh:    local source_file=${BASH_SOURCE[$stack_skip]}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -59,6 +59,7 @@ bounding-dirs
 build-dependencies
 build-only
 build-tag
+ca-cert-path
 cadvisor-port
 cert-dir
 certificate-authority


### PR DESCRIPTION
**Special notes for your reviewer**:

This is exactly the same PR as https://github.com/kubernetes/kubernetes/pull/41721, but that one fails consequently on a strange godep failure, which is totally unrelated. Testing to send a new PR to "fix" it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
@mikedanese 