### PR TITLE
Logging for the scheduler election process, and lease election, to co…

### DIFF
--- a/pkg/client/leaderelection/leaderelection.go
+++ b/pkg/client/leaderelection/leaderelection.go
@@ -214,6 +214,7 @@ func (le *LeaderElector) renew() {
 // else it tries to renew the lease if it has already been acquired. Returns true
 // on success else returns false.
 func (le *LeaderElector) tryAcquireOrRenew() bool {
+	glog.V(3).Info("Trying to acquire or renew ... ")
 	now := metav1.Now()
 	leaderElectionRecord := rl.LeaderElectionRecord{
 		HolderIdentity:       le.config.Lock.Identity(),

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -85,6 +85,8 @@ func Run(s *options.SchedulerServer) error {
 	if err != nil {
 		return fmt.Errorf("unable to get hostname: %v", err)
 	}
+	glog.V(3).Info("Initiating leader election process to startup the scheduler server.")
+
 	// TODO: enable other lock types
 	rl := &resourcelock.EndpointsLock{
 		EndpointsMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:
Add v 3 logs to contextualize the lower level REST API calls that log individual calls...  Otherwise, lower level logs leak the REST calls which fill up logging without clarifying the context... like this...

*Before* 

```
I0223 10:39:36.480704   12288 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.184789ms) 200 [[scheduler_perf.test/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] 127.0.0.1:34518]
I0223 10:39:36.483538   12288 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (2.084913ms) 200 [[scheduler_perf.test/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] 127.0.0.1:34518]
I0223 10:39:38.485762   12288 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.206457ms) 200 [[scheduler_perf.test/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] 127.0.0.1:34518]
I0223 10:39:38.488640   12288 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (2.11405ms) 200 [[scheduler_perf.test/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] 127.0.0.1:34518]
```

*After* 

End result is something much more understandable: 

```
I0223 10:39:36.479134   12288 leaderelection.go:217] Trying to acquire or renew ...
I0223 10:39:36.480704   12288 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.184789ms) 200 [[scheduler_perf.test/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] 127.0.0.1:34518]
I0223 10:39:36.483538   12288 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (2.084913ms) 200 [[scheduler_perf.test/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] 127.0.0.1:34518]
I0223 10:39:38.484174   12288 leaderelection.go:217] Trying to acquire or renew ...
I0223 10:39:38.485762   12288 wrap.go:75] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.206457ms) 200 [[scheduler_perf.test/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] 127.0.0.1:34518]
I0223 10:39:38.488640   12288 wrap.go:75] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (2.11405ms) 200 [[scheduler_perf.test/v0.0.0 (linux/amd64) kubernetes/$Format/leader-election] 127.0.0.1:34518]
```

