### PR TITLE
WIP: kubeadm: fix panic from field error type

### DIFF
--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -21,12 +21,14 @@ import (
 	"os"
 	"strings"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 )
 
 const (
 	DefaultErrorExitCode = 1
 	PreFlightExitCode    = 2
+	ValidationExitCode   = 3
 )
 
 type debugError interface {
@@ -63,6 +65,9 @@ func checkErr(prefix string, err error, handleErr func(string, int)) {
 		return
 	case *preflight.Error:
 		handleErr(err.Error(), PreFlightExitCode)
+	case utilerrors.Aggregate:
+		e := fmt.Sprintf("API Validation error: %v", err)
+		handleErr(e, ValidationExitCode)
 	default:
 		handleErr(err.Error(), DefaultErrorExitCode)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: The `k8s.io/apimachinery/pkg/util/errors` errors.Aggregate interface will panic when attempting to get the `err.Error()` in how we currently use it in kubeadm api validation. This change handles the errors.Aggregate type and avoids a panic while still printing out the errors. 

**Special notes for your reviewer**: /cc @luxas 

**Release note**:
```release-note
NONE
```
