### PR TITLE
Simplify and fix hack/{verify,update}-staging-{client-go,godeps}.sh

### DIFF
--- a/hack/update-staging-client-go.sh
+++ b/hack/update-staging-client-go.sh
@@ -19,4 +19,18 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-"${KUBE_ROOT}"/staging/copy.sh
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
+kube::util::ensure_clean_working_dir
+kube::util::ensure_godep_version v74
+
+cd ${KUBE_ROOT}
+
+echo "Checking whether godeps are restored"
+if ! kube::util::godep_restored 2>&1 | sed 's/^/  /'; then
+  echo -e '\nRun 'godep restore' to download dependencies.' 1>&2
+  exit 1
+fi
+
+echo "Running staging/copy.sh"
+staging/copy.sh -u "$@" 2>&1 | sed 's/^/  /'

--- a/hack/update-staging-godeps.sh
+++ b/hack/update-staging-godeps.sh
@@ -23,102 +23,84 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+V=""
+DRY_RUN=false
+FAIL_ON_DIFF=false
+while getopts ":vdf" opt; do
+  case $opt in
+    v) # increase verbosity
+      V="-v"
+      ;;
+    d) # do not godep-restore into a temporary directory, but use the existing GOPATH
+      DRY_RUN=true
+      ;;
+    f) # fail if something in the Godeps.json files changed
+      FAIL_ON_DIFF=true
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+readonly V IN_PLACE
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
+source "${KUBE_ROOT}/hack/lib/util.sh"
 
-kube::golang::setup_env
-
-ORIGINAL_GOPATH="${GOPATH}"
-
-godepBinDir=${TMPDIR:-/tmp/}/kube-godep-bin
-mkdir -p "${godepBinDir}"
-godep=${godepBinDir}/bin/godep
-pushd "${godepBinDir}" 2>&1 > /dev/null
-	# Build the godep tool
-	GOPATH="${godepBinDir}"
-	rm -rf *
-	go get -u github.com/tools/godep 2>/dev/null
-	export GODEP="${GOPATH}/bin/godep"
-	pin-godep() {
-		pushd "${GOPATH}/src/github.com/tools/godep" > /dev/null
-			git checkout "$1"
-			"${GODEP}" go install
-		popd > /dev/null
-	}
-	# Use to following if we ever need to pin godep to a specific version again
-	pin-godep 'v74'
-	"${godep}" version
-popd 2>&1 > /dev/null
-
-# keep the godep restore path reasonably stable to avoid unnecessary restores
-godepRestoreDir=${TMPDIR:-/tmp/}/kube-godep-restore
-
-TARGET_DIR=${TARGET_DIR:-${KUBE_ROOT}/staging}
-echo "working in ${TARGET_DIR}"
-
-SKIP_RESTORE=${SKIP_RESTORE:-}
-if [ "${SKIP_RESTORE}" != "true" ]; then
-	echo "starting godep restore"
-	mkdir -p "${godepRestoreDir}"
-
-	# add the vendor folder so that we don't redownload things during restore
-	GOPATH="${godepRestoreDir}:${KUBE_ROOT}/staging:${ORIGINAL_GOPATH}"
-	# restore from kubernetes godeps to ensure we get the correct levels
-	# you get errors about the staging repos not using a known version control system
-	${godep} restore > ${godepRestoreDir}/godep-restore.log
-	echo "finished godep restore"
+echo "Checking whether godeps are restored"
+if ! kube::util::godep_restored 2>&1 | sed 's/^/  /'; then
+  echo -e '\nRun 'godep restore' to download dependencies.' 1>&2
+  exit 1
 fi
 
-echo "forcing fake godep folders to match the current state of master in tmp"
-for stagingRepo in $(ls ${KUBE_ROOT}/staging/src/k8s.io); do
-	echo "    creating ${stagingRepo}"
-	rm -rf ${godepRestoreDir}/src/k8s.io/${stagingRepo}
-	cp -a ${KUBE_ROOT}/staging/src/k8s.io/${stagingRepo} ${godepRestoreDir}/src/k8s.io
+kube::util::ensure_clean_working_dir
+kube::util::ensure-temp-dir
+kube::util::ensure_godep_version v74
 
-	# we need a git commit in the godep folder, otherwise godep won't save
-	pushd ${godepRestoreDir}/src/k8s.io/${stagingRepo}
-	git init > /dev/null
-	# we need this so later commands work, but nothing should ever actually include these commits
-	# these are local only, not global
-	git config user.email "you@example.com"
-	git config user.name "Your Name"
-	git add . > /dev/null
-	git commit -qm "fake commit"
-	popd
-done
+TMP_GOPATH="${KUBE_TEMP}/go"
 
 function updateGodepManifest() {
-	local repo=${1}
+  local repo="${1}"
+  pushd "${TMP_GOPATH}/src/k8s.io/${repo}" >/dev/null
+    echo "Updating godeps for k8s.io/${repo}"
+    rm -rf Godeps # remove the current Godeps.json so we always rebuild it
+    GOPATH="${TMP_GOPATH}:${GOPATH}:${KUBE_ROOT}/staging" godep save ${V} ./... 2>&1 | sed 's/^/  /'
 
-	echo "starting ${repo} save"
-	mkdir -p ${TARGET_DIR}/src/k8s.io
-	# if target_dir isn't the same as source dir, you need copy
-	test "${KUBE_ROOT}/staging" = "${TARGET_DIR}" || cp -a ${KUBE_ROOT}/staging/src/${repo} ${TARGET_DIR}/src/k8s.io
-	# remove the current Godeps.json so we always rebuild it
-	rm -rf ${TARGET_DIR}/src/${repo}/Godeps
-	GOPATH="${godepRestoreDir}:${TARGET_DIR}"
-	pushd ${TARGET_DIR}/src/${repo}
-	${godep} save ./...
+    echo "Rewriting Godeps.json to remove commits that don't really exist because we haven't pushed the prereqs yet"
+    go run "${KUBE_ROOT}/staging/godeps-json-updater.go" --godeps-file="${TMP_GOPATH}/src/k8s.io/${repo}/Godeps/Godeps.json" --client-go-import-path="k8s.io/${repo}"
 
-	# now remove all the go files.	We'll re-run a restore, go get, godep save cycle in the sync scripts
-	# to get the commits for other staging k8s.io repos anyway, so we don't need the added files
-	rm -rf vendor
-
-	echo "rewriting Godeps.json to remove commits that don't really exist because we haven't pushed the prereqs yet"
-	GOPATH="${ORIGINAL_GOPATH}"
-	go run "${KUBE_ROOT}/staging/godeps-json-updater.go" --godeps-file="${TARGET_DIR}/src/${repo}/Godeps/Godeps.json" --client-go-import-path="${repo}"
-
-	popd
-	echo "finished ${repo} save"
+    # commit so that following repos do not see this repo as dirty
+    git add vendor >/dev/null
+    git commit -a -m "Updated Godeps.json" >/dev/null
+  popd >/dev/null
 }
 
 # move into staging and save the dependencies for everything in order
-for stagingRepo in $(ls ${KUBE_ROOT}/staging/src/k8s.io); do
-	# we have to skip client-go because it does unusual manipulation of its godeps
-	if [ "${stagingRepo}" == "client-go" ]; then
-		continue
-	fi
+mkdir -p "${TMP_GOPATH}/src/k8s.io"
+for repo in $(ls ${KUBE_ROOT}/staging/src/k8s.io); do
+  # we have to skip client-go because it does unusual manipulation of its godeps
+  if [ "${repo}" == "client-go" ]; then
+    continue
+  fi
 
-	updateGodepManifest "k8s.io/${stagingRepo}"
+  cp -a "${KUBE_ROOT}/staging/src/k8s.io/${repo}" "${TMP_GOPATH}/src/k8s.io/"
+
+  pushd "${TMP_GOPATH}/src/k8s.io/${repo}" >/dev/null
+    git init >/dev/null
+    git config --local user.email "nobody@k8s.io"
+    git config --local user.name "$0"
+    git add . >/dev/null
+    git commit -q -m "Snapshot" >/dev/null
+  popd >/dev/null
+
+  updateGodepManifest "${repo}"
+
+  if [ "${FAIL_ON_DIFF}" == true ]; then
+    diff --ignore-matching-lines='^\s*\"Comment\"' -u "${KUBE_ROOT}/staging/src/k8s.io/${repo}/Godeps" "${TMP_GOPATH}/src/k8s.io/${repo}/Godeps/Godeps.json"
+  fi
+  if [ "${DRY_RUN}" != true ]; then
+    cp "${TMP_GOPATH}/src/k8s.io/${repo}/Godeps/Godeps.json" "${KUBE_ROOT}/staging/src/k8s.io/${repo}/Godeps"
+  fi
 done

--- a/hack/verify-staging-client-go.sh
+++ b/hack/verify-staging-client-go.sh
@@ -18,65 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-V=""
-while getopts ":v" opt; do
-  case $opt in
-    v) # increase verbosity
-      V="-v"
-      ;;
-    \?)
-      echo "Invalid option: -$OPTARG" >&2
-      ;;
-  esac
-done
-readonly V
-
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd ${KUBE_ROOT}
 
-if ! git diff --exit-code; then
-    echo "ERROR: $0 cannot be run on a dirty working directory."
-    exit 1
-fi
-
 # Smoke test client-go examples
-go install ./staging/src/k8s.io/client-go/examples/...
+echo "Smoke testing client-go examples"
+go install ./staging/src/k8s.io/client-go/examples/... 2>&1 | sed 's/^/  /'
 
-# Create a temporary GOPATH for apimachinery and client-go, copy the current HEAD into each and turn them
-# into a git repo. Then we can run copy.sh with this additional GOPATH. The Godeps.json will
-# have invalid git SHA1s, but it's good enough as a smoke test of copy.sh.
-if [ "${USE_TEMP_DIR:-1}" = 1 ]; then
-    TEMP_STAGING_GOPATH=$(mktemp -d -t verify-staging-client-go.XXXXX)
-    echo "Creating the temporary staging GOPATH directory: ${TEMP_STAGING_GOPATH}"
-    cleanup() {
-        if [ "${KEEP_TEMP_DIR:-0}" != 1 ]; then
-            rm -rf "${TEMP_STAGING_GOPATH}"
-        fi
-    }
-    trap cleanup EXIT SIGINT
-    mkdir -p "${TEMP_STAGING_GOPATH}/src/k8s.io"
-    ln -s "${PWD}" "${TEMP_STAGING_GOPATH}/src/k8s.io"
-else
-    TEMP_STAGING_GOPATH="${GOPATH}"
-fi
-for PACKAGE in apimachinery client-go; do
-    PACKAGE_PATH="${TEMP_STAGING_GOPATH}/src/k8s.io/${PACKAGE}"
-    echo "Creating a temporary ${PACKAGE} repo with a snapshot of HEAD"
-    rm -rf "${PACKAGE_PATH}"
-    mkdir -p "${PACKAGE_PATH}"
-    git archive --format=tar "HEAD:staging/src/k8s.io/${PACKAGE}" | tar -xf - -C "${PACKAGE_PATH}"
-    pushd "${PACKAGE_PATH}" >/dev/null
-    git init >/dev/null
-    git add *
-    git -c user.email="nobody@k8s.io" -c user.name="verify-staging-client-go.sh" commit -q -m "Snapshot"
-    popd >/dev/null
-done
-
-echo "Running godep restore"
-pushd "${TEMP_STAGING_GOPATH}/src/k8s.io/kubernetes" >/dev/null
-export GOPATH="${TEMP_STAGING_GOPATH}"
-godep restore ${V} 2>&1 | sed 's/^/  /'
-
-echo "Testing staging/copy.sh"
-staging/copy.sh -d 2>&1 | sed 's/^/  /'
-popd
+# Run update-staging-client-go.sh in dry-run mode, copy nothing into the staging dir
+hack/update-staging-client-go.sh -d "$@"

--- a/hack/verify-staging-godeps.sh
+++ b/hack/verify-staging-godeps.sh
@@ -14,36 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO this does not address client-go, since it takes a different approach to vendoring
-# TODO client-go should probably be made consistent
-
 set -o errexit
 set -o nounset
 set -o pipefail
 
-
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-source "${KUBE_ROOT}/hack/lib/init.sh"
-
-
-TARGET_DIR=$(mktemp -d "${TMPDIR:-/tmp/}$(basename 0).XXXXXXXXXXXX")
-# Register function to be called on EXIT to remove folder.
-function cleanup {
-	SKIP_CLEANUP=${SKIP_CLEANUP:-}
-	if [ "${SKIP_CLEANUP}" != "true" ]; then
-		rm -rf "${TARGET_DIR}"
-	fi
-}
-trap cleanup EXIT
-
-TARGET_DIR=${TARGET_DIR} ${KUBE_ROOT}/hack/update-staging-godeps.sh
-
-# check each staging repo to make sure its Godeps.json is correct
-for stagingRepo in $(ls ${KUBE_ROOT}/staging/src/k8s.io); do
-	# we have to skip client-go because it does unusual manipulation of its godeps
-	if [ "${stagingRepo}" == "client-go" ]; then
-		continue
-	fi
-
-	diff --ignore-matching-lines='^\s*\"Comment\"' ${KUBE_ROOT}/staging/src/k8s.io/${stagingRepo}/Godeps/Godeps.json ${TARGET_DIR}/src/k8s.io/${stagingRepo}/Godeps/Godeps.json
-done
+${KUBE_ROOT}/hack/update-staging-godeps.sh -d -f "$@"

--- a/staging/copy.sh
+++ b/staging/copy.sh
@@ -69,7 +69,7 @@ else
 fi
 
 cleanup() {
-    rm -rf "${CLIENT_REPO_TEMP}"
+  rm -rf "${CLIENT_REPO_TEMP}"
 }
 
 trap cleanup EXIT SIGINT
@@ -88,8 +88,8 @@ cd "${CLIENT_REPO}"
 # save copies code from client-go into the temp folder to make sure we don't lose it by accident
 # TODO this is temporary until everything in certain directories is authoritative
 function save() {
-    mkdir -p "$(dirname "${CLIENT_REPO_TEMP}/$1")"
-    cp -r "${CLIENT_REPO}/$1"* "${CLIENT_REPO_TEMP}/"
+  mkdir -p "$(dirname "${CLIENT_REPO_TEMP}/$1")"
+  cp -r "${CLIENT_REPO}/$1"* "${CLIENT_REPO_TEMP}/"
 }
 
 # save everything for which the staging directory is the source of truth
@@ -107,7 +107,7 @@ save "OWNERS"
 
 # mkcp copies file from the main repo to the client repo, it creates the directory if it doesn't exist in the client repo.
 function mkcp() {
-    mkdir -p "${CLIENT_REPO_TEMP}/$2" && cp -r "${MAIN_REPO}/$1" "${CLIENT_REPO_TEMP}/$2"
+  mkdir -p "${CLIENT_REPO_TEMP}/$2" && cp -r "${MAIN_REPO}/$1" "${CLIENT_REPO_TEMP}/$2"
 }
 
 # assemble all the other parts of the staging directory
@@ -119,6 +119,12 @@ find "${MAIN_REPO}/pkg/version" -maxdepth 1 -type f | xargs -I{} cp {} "${CLIENT
 # need to copy clientsets, though later we should copy APIs and later generate clientsets
 mkcp "pkg/client/clientset_generated/${CLIENTSET}" "pkg/client/clientset_generated"
 mkcp "pkg/client/informers/informers_generated/externalversions" "pkg/client/informers/informers_generated"
+
+# safety check that we don't have another apimachinery in the GOPATH
+if go list -f '{{.Dir}}' k8s.io/apimachinery/pkg/runtime &>/dev/null; then
+  echo "ERROR: unexpected k8s.io/apimachinery in GOPATH '$GOPATH'" 1>&2
+  exit 1
+fi
 
 pushd "${CLIENT_REPO_TEMP}" > /dev/null
 echo "generating vendor/"
@@ -143,9 +149,9 @@ go run "${KUBE_ROOT}/staging/godeps-json-updater.go" --godeps-file="${CLIENT_REP
 
 echo "rewriting imports"
 grep -Rl "\"${MAIN_REPO_FROM_SRC}" "${CLIENT_REPO_TEMP}" | \
-    grep "\.go" | \
-    grep -v "vendor/" | \
-    xargs ${SED} -i "s|\"${MAIN_REPO_FROM_SRC}|\"${CLIENT_REPO_FROM_SRC}|g"
+  grep "\.go" | \
+  grep -v "vendor/" | \
+  xargs ${SED} -i "s|\"${MAIN_REPO_FROM_SRC}|\"${CLIENT_REPO_FROM_SRC}|g"
 
 echo "rewrite proto names in proto.RegisterType"
 find "${CLIENT_REPO_TEMP}" -type f -name "generated.pb.go" -print0 | xargs -0 ${SED} -i "s/k8s\.io\.kubernetes/k8s.io.client-go/g"
@@ -160,37 +166,37 @@ find "${CLIENT_REPO_TEMP}" -type f -name "*.go" -print0 | xargs -0 ${SED} -i '/^
 echo "rearranging directory layout"
 # $1 and $2 are relative to ${CLIENT_REPO_TEMP}
 function mvfolder {
-    local src=${1%/#/}
-    local dst=${2%/#/}
-    mkdir -p "${CLIENT_REPO_TEMP}/${dst}"
-    # move
-    mv "${CLIENT_REPO_TEMP}/${src}"/* "${CLIENT_REPO_TEMP}/${dst}"
-    # rewrite package
-    local src_package="${src##*/}"
-    local dst_package="${dst##*/}"
-    find "${CLIENT_REPO_TEMP}/${dst}" -type f -name "*.go" -print0 | xargs -0 ${SED} -i "s,package ${src_package},package ${dst_package},g"
+  local src=${1%/#/}
+  local dst=${2%/#/}
+  mkdir -p "${CLIENT_REPO_TEMP}/${dst}"
+  # move
+  mv "${CLIENT_REPO_TEMP}/${src}"/* "${CLIENT_REPO_TEMP}/${dst}"
+  # rewrite package
+  local src_package="${src##*/}"
+  local dst_package="${dst##*/}"
+  find "${CLIENT_REPO_TEMP}/${dst}" -type f -name "*.go" -print0 | xargs -0 ${SED} -i "s,package ${src_package},package ${dst_package},g"
 
-    { grep -Rl "\"${CLIENT_REPO_FROM_SRC}/${src}" "${CLIENT_REPO_TEMP}" || true ; } | while read -r target ; do
-        # rewrite imports
-        # the first rule is to convert import lines like `restclient "k8s.io/client-go/pkg/client/restclient"`,
-        # where a package alias is the same the package name.
-        ${SED} -i "s,\<${src_package} \"${CLIENT_REPO_FROM_SRC}/${src},${dst_package} \"${CLIENT_REPO_FROM_SRC}/${dst},g" "${target}"
-        ${SED} -i "s,\"${CLIENT_REPO_FROM_SRC}/${src},\"${CLIENT_REPO_FROM_SRC}/${dst},g" "${target}"
-        # rewrite import invocation
-        if [ "${src_package}" != "${dst_package}" ]; then
-            ${SED} -i "s,\<${src_package}\.\([a-zA-Z]\),${dst_package}\.\1,g" "${target}"
-        fi
-    done
+  { grep -Rl "\"${CLIENT_REPO_FROM_SRC}/${src}" "${CLIENT_REPO_TEMP}" || true ; } | while read -r target ; do
+    # rewrite imports
+    # the first rule is to convert import lines like `restclient "k8s.io/client-go/pkg/client/restclient"`,
+    # where a package alias is the same the package name.
+    ${SED} -i "s,\<${src_package} \"${CLIENT_REPO_FROM_SRC}/${src},${dst_package} \"${CLIENT_REPO_FROM_SRC}/${dst},g" "${target}"
+    ${SED} -i "s,\"${CLIENT_REPO_FROM_SRC}/${src},\"${CLIENT_REPO_FROM_SRC}/${dst},g" "${target}"
+    # rewrite import invocation
+    if [ "${src_package}" != "${dst_package}" ]; then
+      ${SED} -i "s,\<${src_package}\.\([a-zA-Z]\),${dst_package}\.\1,g" "${target}"
+    fi
+  done
 }
 
 mvfolder "pkg/client/clientset_generated/${CLIENTSET}" kubernetes
 mvfolder "pkg/client/informers/informers_generated/externalversions" informers
 mvfolder "pkg/client/listers" listers
 if [ "$(find "${CLIENT_REPO_TEMP}"/pkg/client -type f -name "*.go")" ]; then
-    echo "${CLIENT_REPO_TEMP}/pkg/client is expected to be empty"
-    exit 1
+  echo "${CLIENT_REPO_TEMP}/pkg/client is expected to be empty"
+  exit 1
 else
-    rm -r "${CLIENT_REPO_TEMP}"/pkg/client
+  rm -r "${CLIENT_REPO_TEMP}"/pkg/client
 fi
 
 echo "running gofmt"
@@ -198,12 +204,12 @@ find "${CLIENT_REPO_TEMP}" -type f -name "*.go" -print0 | xargs -0 gofmt -w
 
 echo "remove black listed files"
 find "${CLIENT_REPO_TEMP}" -type f \( \
-    -name "*BUILD" -o \
-    -name "*.json" -not -name "Godeps.json" -o \
-    -name "*.yaml" -o \
-    -name "*.yml" -o \
-    -name "*.sh" \
-    \) -delete
+  -name "*BUILD" -o \
+  -name "*.json" -not -name "Godeps.json" -o \
+  -name "*.yaml" -o \
+  -name "*.yml" -o \
+  -name "*.sh" \
+  \) -delete
 
 echo "remove cyclical godep"
 rm -rf "${CLIENT_REPO_TEMP}/_vendor/k8s.io/client-go"
@@ -232,8 +238,8 @@ fi
 # clean the ${CLIENT_REPO}
 echo "move to the client repo"
 if [ "${DRY_RUN}" = false ]; then
-    ls "${CLIENT_REPO}" | { grep -v '_tmp' || true; } | xargs rm -rf
-    mv "${CLIENT_REPO_TEMP}"/* "${CLIENT_REPO}"
+  ls "${CLIENT_REPO}" | { grep -v '_tmp' || true; } | xargs rm -rf
+  mv "${CLIENT_REPO_TEMP}"/* "${CLIENT_REPO}"
 fi
 
 cleanup


### PR DESCRIPTION
- merge `hack/{verify,update}-staging-client-go.sh`
- pin godep with shared code
- remove godep-restore completely from the process and replace with a simple check that godeps are restored
- add safety check in `staging/copy.sh` that there is no lingering `k8s.io/apimachinery` in the GOPATH which would lead to inconsistent client-go builds (!)
- check that all these scripts only operate in a clean working dir.
