### PR TITLE
Add approvers to StatefulSet

### DIFF
--- a/pkg/controller/statefulset/OWNERS
+++ b/pkg/controller/statefulset/OWNERS
@@ -1,6 +1,16 @@
-reviewers:
-- foxish
+approvers:
 - bprashanth
-- smarterclayton
+- enisoc
+- foxish
 - janetkuo
 - kargakis
+- kow3ns
+- smarterclayton
+reviewers:
+- bprashanth
+- enisoc
+- foxish
+- janetkuo
+- kargakis
+- kow3ns
+- smarterclayton


### PR DESCRIPTION
The owners file has no approvers at the moment, adding people from workloads