### PR TITLE
allow `hack/lib/etcd.sh` to print version mismatch error message

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -40,7 +40,6 @@ kube::etcd::validate() {
    export PATH=$KUBE_ROOT/third_party/etcd:$PATH
    hash etcd
    echo $PATH
-   ls $KUBE_ROOT/third_party/etcd
    version=$(etcd --version | head -n 1 | cut -d " " -f 3)
    if [[ "${version}" < "${ETCD_VERSION}" ]]; then
     kube::log::usage "etcd version ${ETCD_VERSION} or greater required."


### PR DESCRIPTION
**What this PR does / why we need it**:  `third_party/etcd` isn't guaranteed to be present, this was causing the `hack/lib/etcd.sh` script to fail on `ls` prior to printing out the error message about
etcd version mismatch

**Which issue this PR fixes**: fixes #41989

**Release note**:
```release-note
NONE
```
