### PR TITLE
add WATCH to list of excluded verbs for latency metrics

### DIFF
--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -221,7 +221,7 @@ func readLatencyMetrics(c clientset.Interface) (APIResponsiveness, error) {
 
 	ignoredResources := sets.NewString("events")
 	// TODO: figure out why we're getting non-capitalized proxy and fix this.
-	ignoredVerbs := sets.NewString("WATCHLIST", "PROXY", "proxy", "CONNECT")
+	ignoredVerbs := sets.NewString("WATCH", "WATCHLIST", "PROXY", "proxy", "CONNECT")
 
 	for _, sample := range samples {
 		// Example line:


### PR DESCRIPTION
Alternative to https://github.com/kubernetes/kubernetes/pull/41999 for latency metrics.

@wojtek-t @liggitt @k8s-oncall 