### PR TITLE
Add metric collection to cluster/juju for autoscalling

### DIFF
--- a/cluster/juju/.gitignore
+++ b/cluster/juju/.gitignore
@@ -1,0 +1,2 @@
+builds
+deps

--- a/cluster/juju/layers/kubeapi-load-balancer/layer.yaml
+++ b/cluster/juju/layers/kubeapi-load-balancer/layer.yaml
@@ -1,5 +1,6 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
+  - 'layer:metrics'
   - 'layer:nagios'
   - 'layer:nginx'
   - 'layer:tls-client'

--- a/cluster/juju/layers/kubeapi-load-balancer/metrics.yaml
+++ b/cluster/juju/layers/kubeapi-load-balancer/metrics.yaml
@@ -1,0 +1,2 @@
+metrics:
+  juju-units: {}

--- a/cluster/juju/layers/kubernetes-master/layer.yaml
+++ b/cluster/juju/layers/kubernetes-master/layer.yaml
@@ -1,10 +1,11 @@
 repo: https://github.com/kubernetes/kubernetes.git
 includes:
   - 'layer:basic'
-  - 'layer:tls-client'
-  - 'layer:leadership'
   - 'layer:debug'
+  - 'layer:leadership'
+  - 'layer:metrics'
   - 'layer:nagios'
+  - 'layer:tls-client'
   - 'interface:ceph-admin'
   - 'interface:etcd'
   - 'interface:http'

--- a/cluster/juju/layers/kubernetes-master/metrics.yaml
+++ b/cluster/juju/layers/kubernetes-master/metrics.yaml
@@ -1,0 +1,34 @@
+metrics:
+  juju-units: {}
+  pods:
+    type: gauge
+    description: number of pods
+    command: kubectl get po --all-namespaces | tail -n+2 | wc -l
+  services:
+    type: gauge
+    description: number of services
+    command: kubectl get svc --all-namespaces | tail -n+2 | wc -l
+  replicasets:
+    type: gauge
+    description: number of replicasets
+    command: kubectl get rs --all-namespaces | tail -n+2 | wc -l
+  replicationcontrollers:
+    type: gauge
+    description: number of replicationcontrollers
+    command: kubectl get rc --all-namespaces | tail -n+2 | wc -l
+  nodes:
+    type: gauge
+    description: number of kubernetes nodes
+    command: kubectl get nodes | tail -n+2 | wc -l
+  persistentvolume:
+    type: gauge
+    description: number of pv
+    command: kubectl get pv --all-namespaces | tail -n+2 | wc -l
+  persistentvolumeclaims:
+    type: gauge
+    description: number of claims
+    command: kubectl get pvc --all-namespaces | tail -n+2 | wc -l
+  serviceaccounts:
+    type: gauge
+    description: number of sa
+    command: kubectl get sa --all-namespaces | tail -n+2 | wc -l

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -3,6 +3,7 @@ includes:
   - 'layer:basic'
   - 'layer:debug'
   - 'layer:docker'
+  - 'layer:metrics'
   - 'layer:nagios'
   - 'layer:tls-client'
   - 'interface:http'

--- a/cluster/juju/layers/kubernetes-worker/metrics.yaml
+++ b/cluster/juju/layers/kubernetes-worker/metrics.yaml
@@ -1,0 +1,2 @@
+metrics:
+  juju-units: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This exposes the following metrics to the juju model:

 * persistentvolumeclaims
 * pods
 * replicationcontrollers
 * persistentvolume
 * services
 * nodes
 * replicasets
 * serviceaccounts

Using these values an autoscaler can be implemented to help to scale the infrastructure layer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Once deployed, issue the following command to confirm metrics are being collected:

```
juju metrics kubernetes-master
```

The result should be:

```
UNIT                               TIMESTAMP                    METRIC  VALUE
kubernetes-master/0     2017-02-23T21:04:34Z               deployments      0
kubernetes-master/0     2017-02-23T21:04:34Z                     nodes      1
kubernetes-master/0     2017-02-23T21:04:34Z                      pods      2
kubernetes-master/0     2017-02-23T21:04:34Z               replicasets      0
kubernetes-master/0     2017-02-23T21:04:34Z    replicationcontrollers      2
kubernetes-master/0     2017-02-23T21:04:34Z                  services      2
kubernetes-master/0     2017-02-23T21:04:34Z           serviceaccounts      0
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Juju: Expose key kubernetes metrics to enable autoscaling
```
