### PR TITLE
kubelet requires json-file docker logging driver

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -553,7 +553,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 			// Create and start the CRI shim running as a grpc server.
 			streamingConfig := getStreamingConfig(kubeCfg, kubeDeps)
 			ds, err := dockershim.NewDockerService(klet.dockerClient, kubeCfg.SeccompProfileRoot, kubeCfg.PodInfraContainerImage,
-				streamingConfig, &pluginSettings, kubeCfg.RuntimeCgroups, kubeCfg.CgroupDriver, dockerExecHandler)
+				streamingConfig, &pluginSettings, kubeCfg.RuntimeCgroups, kubeCfg.CgroupDriver, kubeCfg.EnableCRI, dockerExecHandler)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
With the CRI enabled by default, the kubelet CRI currently only supports the `json-file` logging driver.  Lets enforce it so people running the `journald` driver know to change their docker config rather than having pod logging break for no apparent reason.

@derekwaynecarr @ncdc