### PR TITLE
Build gke-certificates-controller image

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -67,6 +67,10 @@ DOCKERIZED_BINARIES = {
         "base": ":busybox-net",
         "target": "//cmd/kube-proxy:kube-proxy",
     },
+    "gke-certificates-controller": {
+        "base": ":busybox-libc",
+        "target": "//cmd/gke-certificates-controller:gke-certificates-controller",
+    },
 }
 
 [genrule(

--- a/build/common.sh
+++ b/build/common.sh
@@ -94,6 +94,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-scheduler,busybox
           kube-aggregator,busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-amd64:${debian_iptables_version}
+          gke-certificates-controller,busybox
         );;
     "arm")
         local targets=(
@@ -102,6 +103,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-scheduler,armel/busybox
           kube-aggregator,armel/busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-arm:${debian_iptables_version}
+          gke-certificates-controller,armel/busybox
         );;
     "arm64")
         local targets=(
@@ -110,6 +112,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-scheduler,aarch64/busybox
           kube-aggregator,aarch64/busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-arm64:${debian_iptables_version}
+          gke-certificates-controller,aarch64/busybox
         );;
     "ppc64le")
         local targets=(
@@ -118,6 +121,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-scheduler,ppc64le/busybox
           kube-aggregator,ppc64le/busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-ppc64le:${debian_iptables_version}
+          gke-certificates-controller,ppc64le/busybox
         );;
     "s390x")
         local targets=(
@@ -126,7 +130,8 @@ kube::build::get_docker_wrapped_binaries() {
           kube-scheduler,s390x/busybox
           kube-aggregator,s390x/busybox
           kube-proxy,gcr.io/google_containers/debian-iptables-s390x:${debian_iptables_version}
-        );;		
+          gke-certificates-controller,s390x/busybox
+        );;
   esac
 
   echo "${targets[@]}"

--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -33,6 +33,7 @@ filegroup(
     "kube-controller-manager",
     "kube-proxy",
     "kube-aggregator",
+    "gke-certificates-controller",
 ]]
 
 deb_data(
@@ -89,6 +90,11 @@ k8s_deb(
     description = """Kubernetes Command Line Tool
 The Kubernetes command line tool for interacting with the Kubernetes API.
 """,
+)
+
+k8s_deb(
+    name = "gke-certificates-controller",
+    description = "GKE Certificates Controller",
 )
 
 k8s_deb(

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -571,6 +571,7 @@ function load-docker-images {
     try-load-docker-image "${img_dir}/kube-apiserver.tar"
     try-load-docker-image "${img_dir}/kube-controller-manager.tar"
     try-load-docker-image "${img_dir}/kube-scheduler.tar"
+    try-load-docker-image "${img_dir}/gke-certificates-controller.tar"
   else
     try-load-docker-image "${img_dir}/kube-proxy.tar"
   fi

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -176,6 +176,7 @@ function install-kube-binary-config {
     cp "${src_dir}/kube-apiserver.tar" "${dst_dir}"
     cp "${src_dir}/kube-controller-manager.tar" "${dst_dir}"
     cp "${src_dir}/kube-scheduler.tar" "${dst_dir}"
+    cp "${src_dir}/gke-certificates-controller.tar" "${dst_dir}"
     cp -r "${KUBE_HOME}/kubernetes/addons" "${dst_dir}"
   fi
   local -r kube_bin="${KUBE_HOME}/bin"

--- a/cluster/saltbase/install.sh
+++ b/cluster/saltbase/install.sh
@@ -29,6 +29,7 @@ readonly KUBE_DOCKER_WRAPPED_BINARIES=(
   kube-controller-manager
   kube-scheduler
   kube-proxy
+  gke-certificates-controller
 )
 
 readonly SERVER_BIN_TAR=${1-}

--- a/cluster/saltbase/pillar/docker-images.sls
+++ b/cluster/saltbase/pillar/docker-images.sls
@@ -3,3 +3,4 @@ kube-apiserver_docker_tag: #kube-apiserver_docker_tag_value#
 kube-controller-manager_docker_tag: #kube-controller-manager_docker_tag_value#
 kube-scheduler_docker_tag: #kube-scheduler_docker_tag_value#
 kube-proxy_docker_tag: #kube-proxy_docker_tag_value#
+gke-certificates-controller_docker_tag: #gke-certificates-controller_docker_tag_value#

--- a/cmd/BUILD
+++ b/cmd/BUILD
@@ -22,6 +22,7 @@ filegroup(
         "//cmd/genswaggertypedocs:all-srcs",
         "//cmd/genutils:all-srcs",
         "//cmd/genyaml:all-srcs",
+        "//cmd/gke-certificates-controller:all-srcs",
         "//cmd/hyperkube:all-srcs",
         "//cmd/kube-apiserver:all-srcs",
         "//cmd/kube-controller-manager:all-srcs",

--- a/cmd/gke-certificates-controller/BUILD
+++ b/cmd/gke-certificates-controller/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//cmd/gke-certificates-controller/app:go_default_library",
+        "//pkg/util/logs:go_default_library",
+        "//pkg/version/verflag:go_default_library",
+        "//vendor:github.com/spf13/pflag",
+        "//vendor:k8s.io/apiserver/pkg/util/flag",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//cmd/gke-certificates-controller/app:all-srcs",
+    ],
+    tags = ["automanaged"],
+)
+
+go_binary(
+    name = "gke-certificates-controller",
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)

--- a/cmd/gke-certificates-controller/OWNERS
+++ b/cmd/gke-certificates-controller/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- pipejakob
+- mikedanese
+- roberthbailey
+reviewers:
+- pipejakob
+- mikedanese
+- roberthbailey

--- a/cmd/gke-certificates-controller/app/BUILD
+++ b/cmd/gke-certificates-controller/app/BUILD
@@ -1,0 +1,60 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "gke_certificates_controller.go",
+        "gke_signer.go",
+        "options.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/apis/certificates/install:go_default_library",
+        "//pkg/apis/certificates/v1beta1:go_default_library",
+        "//pkg/client/clientset_generated/clientset:go_default_library",
+        "//pkg/client/informers/informers_generated/externalversions:go_default_library",
+        "//pkg/controller:go_default_library",
+        "//pkg/controller/certificates:go_default_library",
+        "//vendor:github.com/golang/glog",
+        "//vendor:github.com/spf13/cobra",
+        "//vendor:github.com/spf13/pflag",
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/apiserver/pkg/util/webhook",
+        "//vendor:k8s.io/client-go/kubernetes/typed/core/v1",
+        "//vendor:k8s.io/client-go/plugin/pkg/client/auth",
+        "//vendor:k8s.io/client-go/rest",
+        "//vendor:k8s.io/client-go/tools/clientcmd",
+        "//vendor:k8s.io/client-go/tools/record",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["gke_signer_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//pkg/apis/certificates/v1beta1:go_default_library"],
+)

--- a/cmd/gke-certificates-controller/app/gke_certificates_controller.go
+++ b/cmd/gke-certificates-controller/app/gke_certificates_controller.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app implements a server that runs a stand-alone version of the
+// certificates controller for GKE clusters.
+package app
+
+import (
+	"time"
+
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/certificates"
+
+	// Install all auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+)
+
+// NewGKECertificatesControllerCommand creates a new *cobra.Command with default parameters.
+func NewGKECertificatesControllerCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "gke-certificates-controller",
+		Long: `The Kubernetes GKE certificates controller is a daemon that
+handles auto-approving and signing certificates for GKE clusters.`,
+	}
+
+	return cmd
+}
+
+// Run runs the GKECertificatesController. This should never exit.
+func Run(s *GKECertificatesController) error {
+	kubeconfig, err := clientcmd.BuildConfigFromFlags("", s.Kubeconfig)
+	if err != nil {
+		return err
+	}
+
+	kubeClient, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, "gke-certificates-controller"))
+	if err != nil {
+		return err
+	}
+
+	eventBroadcaster := record.NewBroadcaster()
+	eventBroadcaster.StartLogging(glog.Infof)
+	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.Core().RESTClient()).Events("")})
+
+	clientBuilder := controller.SimpleControllerClientBuilder{ClientConfig: kubeconfig}
+	client := clientBuilder.ClientOrDie("certificate-controller")
+
+	sharedInformers := informers.NewSharedInformerFactory(client, time.Duration(12)*time.Hour)
+
+	signer, err := NewGKESigner(s.ClusterSigningGKEKubeconfig, s.ClusterSigningGKERetryBackoff.Duration)
+	if err != nil {
+		return err
+	}
+
+	controller, err := certificates.NewCertificateController(
+		client,
+		sharedInformers.Certificates().V1beta1().CertificateSigningRequests(),
+		signer,
+		certificates.NewGroupApprover(s.ApproveAllKubeletCSRsForGroup),
+	)
+	if err != nil {
+		return err
+	}
+
+	sharedInformers.Start(nil)
+	controller.Run(1, nil) // runs forever
+	return nil
+}

--- a/cmd/gke-certificates-controller/app/gke_signer.go
+++ b/cmd/gke-certificates-controller/app/gke_signer.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/api"
+	_ "k8s.io/kubernetes/pkg/apis/certificates/install"
+	certificates "k8s.io/kubernetes/pkg/apis/certificates/v1beta1"
+)
+
+var (
+	groupVersions = []schema.GroupVersion{certificates.SchemeGroupVersion}
+)
+
+// GKESigner uses external calls to GKE in order to sign certificate signing
+// requests.
+type GKESigner struct {
+	webhook        *webhook.GenericWebhook
+	kubeConfigFile string
+	retryBackoff   time.Duration
+}
+
+// NewGKESigner will create a new instance of a GKESigner.
+func NewGKESigner(kubeConfigFile string, retryBackoff time.Duration) (*GKESigner, error) {
+	webhook, err := webhook.NewGenericWebhook(api.Registry, api.Codecs, kubeConfigFile, groupVersions, retryBackoff)
+	if err != nil {
+		return nil, err
+	}
+
+	return &GKESigner{
+		webhook:        webhook,
+		kubeConfigFile: kubeConfigFile,
+		retryBackoff:   retryBackoff,
+	}, nil
+}
+
+// Sign will make an external call to GKE order to sign the given
+// *certificates.CertificateSigningRequest, using the GKESigner's
+// kubeConfigFile.
+func (s *GKESigner) Sign(csr *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, error) {
+	result := s.webhook.WithExponentialBackoff(func() rest.Result {
+		return s.webhook.RestClient.Post().Body(csr).Do()
+	})
+
+	if err := result.Error(); err != nil {
+		return nil, s.webhookError(csr, err)
+	}
+
+	var statusCode int
+	if result.StatusCode(&statusCode); statusCode < 200 || statusCode >= 300 {
+		return nil, s.webhookError(csr, fmt.Errorf("received unsuccessful response code from webhook: %d", statusCode))
+	}
+
+	result_csr := &certificates.CertificateSigningRequest{}
+
+	if err := result.Into(result_csr); err != nil {
+		return nil, s.webhookError(result_csr, err)
+	}
+
+	// Keep the original CSR intact, and only update fields we expect to change.
+	csr.Status.Certificate = result_csr.Status.Certificate
+	return csr, nil
+}
+
+func (s *GKESigner) webhookError(csr *certificates.CertificateSigningRequest, err error) error {
+	glog.V(2).Infof("error contacting webhook backend: %s", err)
+	return err
+}

--- a/cmd/gke-certificates-controller/app/gke_signer_test.go
+++ b/cmd/gke-certificates-controller/app/gke_signer_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"text/template"
+	"time"
+
+	certificates "k8s.io/kubernetes/pkg/apis/certificates/v1beta1"
+)
+
+const kubeConfigTmpl = `
+clusters:
+- cluster:
+    server: {{ .Server }}
+    name: testcluster
+users:
+- user:
+    username: admin
+    password: mypass
+`
+
+func TestGKESigner(t *testing.T) {
+	goodResponse := &certificates.CertificateSigningRequest{
+		Status: certificates.CertificateSigningRequestStatus{
+			Certificate: []byte("fake certificate"),
+		},
+	}
+
+	invalidResponse := "{ \"status\": \"Not a properly formatted CSR response\" }"
+
+	cases := []struct {
+		mockResponse interface{}
+		expected     []byte
+		failCalls    int
+		wantErr      bool
+	}{
+		{
+			mockResponse: goodResponse,
+			expected:     goodResponse.Status.Certificate,
+			wantErr:      false,
+		},
+		{
+			mockResponse: goodResponse,
+			expected:     goodResponse.Status.Certificate,
+			failCalls:    3,
+			wantErr:      false,
+		},
+		{
+			mockResponse: goodResponse,
+			failCalls:    20,
+			wantErr:      true,
+		},
+		{
+			mockResponse: invalidResponse,
+			wantErr:      true,
+		},
+	}
+
+	for _, c := range cases {
+		server, err := newTestServer(c.mockResponse, c.failCalls)
+		if err != nil {
+			t.Fatalf("error creating test server")
+		}
+
+		kubeConfig, err := ioutil.TempFile("", "kubeconfig")
+		if err != nil {
+			t.Fatalf("error creating kubeconfig tempfile: %v", err)
+		}
+
+		tmpl, err := template.New("kubeconfig").Parse(kubeConfigTmpl)
+		if err != nil {
+			t.Fatalf("error creating kubeconfig template: %v", err)
+		}
+
+		data := struct{ Server string }{server.httpserver.URL}
+
+		if err := tmpl.Execute(kubeConfig, data); err != nil {
+			t.Fatalf("error executing kubeconfig template: %v", err)
+		}
+
+		if err := kubeConfig.Close(); err != nil {
+			t.Fatalf("error closing kubeconfig template: %v", err)
+		}
+
+		signer, err := NewGKESigner(kubeConfig.Name(), time.Duration(500)*time.Millisecond)
+		if err != nil {
+			t.Fatalf("error creating GKESigner: %v", err)
+		}
+
+		cert, err := signer.Sign(&certificates.CertificateSigningRequest{})
+
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("wanted error during GKE.Sign() call, got not none")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("error while signing: %v", err)
+			}
+
+			if !bytes.Equal(cert.Status.Certificate, c.expected) {
+				t.Errorf("response certificate didn't match expected %v: %v", c.expected, cert)
+			}
+		}
+	}
+}
+
+type testServer struct {
+	httpserver *httptest.Server
+	failCalls  int
+	response   interface{}
+}
+
+func newTestServer(response interface{}, failCalls int) (*testServer, error) {
+	server := &testServer{
+		response:  response,
+		failCalls: failCalls,
+	}
+
+	server.httpserver = httptest.NewServer(server)
+	return server, nil
+}
+
+func (s *testServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.failCalls > 0 {
+		http.Error(w, "Service unavailable", 500)
+		s.failCalls--
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(s.response)
+	}
+}

--- a/cmd/gke-certificates-controller/app/options.go
+++ b/cmd/gke-certificates-controller/app/options.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app implements a server that runs a stand-alone version of the
+// certificates controller.
+package app
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/spf13/pflag"
+)
+
+// GKECertificatesController is the main context object for the package.
+type GKECertificatesController struct {
+	Kubeconfig                    string
+	ClusterSigningGKEKubeconfig   string
+	ClusterSigningGKERetryBackoff metav1.Duration
+	ApproveAllKubeletCSRsForGroup string
+}
+
+// Create a new instance of a GKECertificatesController with default parameters.
+func NewGKECertificatesController() *GKECertificatesController {
+	s := &GKECertificatesController{
+		ClusterSigningGKERetryBackoff: metav1.Duration{Duration: 500 * time.Millisecond},
+	}
+	return s
+}
+
+// AddFlags adds flags for a specific GKECertificatesController to the
+// specified FlagSet.
+func (s *GKECertificatesController) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")
+
+	fs.StringVar(&s.ClusterSigningGKEKubeconfig, "cluster-signing-gke-kubeconfig", s.ClusterSigningGKEKubeconfig, "If set, use the kubeconfig file to call GKE to sign cluster-scoped certificates instead of using a local private key.")
+	fs.DurationVar(&s.ClusterSigningGKERetryBackoff.Duration, "cluster-signing-gke-retry-backoff", s.ClusterSigningGKERetryBackoff.Duration, "The initial backoff to use when retrying requests to GKE. Additional attempts will use exponential backoff.")
+
+	fs.StringVar(&s.ApproveAllKubeletCSRsForGroup, "insecure-experimental-approve-all-kubelet-csrs-for-group", s.ApproveAllKubeletCSRsForGroup, "The group for which the controller-manager will auto approve all CSRs for kubelet client certificates.")
+}

--- a/cmd/gke-certificates-controller/main.go
+++ b/cmd/gke-certificates-controller/main.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// The GKE certificates controller is responsible for monitoring certificate
+// signing requests and (potentially) auto-approving and signing them within
+// GKE.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/apiserver/pkg/util/flag"
+	"k8s.io/kubernetes/cmd/gke-certificates-controller/app"
+	"k8s.io/kubernetes/pkg/util/logs"
+	"k8s.io/kubernetes/pkg/version/verflag"
+
+	"github.com/spf13/pflag"
+)
+
+// TODO(pipejakob): Move this entire cmd directory into its own repo
+func main() {
+	s := app.NewGKECertificatesController()
+	s.AddFlags(pflag.CommandLine)
+
+	flag.InitFlags()
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
+	verflag.PrintAndExitIfRequested()
+
+	if err := app.Run(s); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -8,6 +8,7 @@ cmd/genkubedocs
 cmd/genman
 cmd/genswaggertypedocs
 cmd/genyaml
+cmd/gke-certificates-controller
 cmd/kube-apiserver
 cmd/kube-apiserver/app
 cmd/kube-apiserver/app/options

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -193,6 +193,7 @@ readonly KUBE_STATIC_LIBRARIES=(
   kube-aggregator
   kubeadm
   kubectl
+  gke-certificates-controller
 )
 
 # Add any files with those //generate annotations in the array below.

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -24,6 +24,7 @@ readonly KUBE_GOPATH="${KUBE_OUTPUT}/go"
 # If you update this list, please also update build/release-tars/BUILD.
 kube::golang::server_targets() {
   local targets=(
+    cmd/gke-certificates-controller
     cmd/kube-proxy
     cmd/kube-apiserver
     cmd/kube-controller-manager

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -86,6 +86,8 @@ cluster-ip
 cluster-monitor-period
 cluster-name
 cluster-signing-cert-file
+cluster-signing-gke-kubeconfig
+cluster-signing-gke-retry-backoff
 cluster-signing-key-file
 cluster-tag
 cni-bin-dir


### PR DESCRIPTION
Build gke-certificates-controller image.
    
- Build and distribute new Docker image for command
- Make sure the binary is statically built

This PR builds on top of https://github.com/kubernetes/kubernetes/pull/41160, which I didn't want to keep adding to, so please only look at the latest commit. This is a step toward being able to optionally run the `gke-certificates-controller` on masters, which I'll send a separate PR for.

CC @mikedanese @liggitt 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
