### PR TITLE
Update addon-manager for supporting taints/tolerations api fields

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 6.4-alpha.3 (Thu February 23 2017 Zihong Zheng <zihongz@google.com>)
+ - Update kubectl to HEAD (GitCommit:"17375fc59fff39135af63bd1750bb07c36ef873b")
+   for supporting taints/tolerations api fields.
+
 ### Version 6.4-alpha.2 (Wed February 16 2017 Zihong Zheng <zihongz@google.com>)
  - Update kubectl to v1.6.0-alpha.2 to use HPA in autoscaling/v1 instead of extensions/v1beta1.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,7 +15,10 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v6.4-alpha.2
+VERSION=v6.4-alpha.3
+# TODO: Current Addon Manager is built with kubectl on head
+# (GitCommit:"17375fc59fff39135af63bd1750bb07c36ef873b").
+# Should use next released kubectl once available.
 KUBECTL_VERSION?=v1.6.0-alpha.2
 
 ifeq ($(ARCH),amd64)

--- a/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.4-alpha.2",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.4-alpha.3",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v6.4-alpha.2",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v6.4-alpha.3",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -13,7 +13,7 @@ spec:
     # - cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
     # - cluster/images/hyperkube/static-pods/addon-manager-multinode.json
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: gcr.io/google-containers/kube-addon-manager:v6.4-alpha.2
+    image: gcr.io/google-containers/kube-addon-manager:v6.4-alpha.3
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v6.4-alpha.2
+    image: {{kube_docker_registry}}/kube-addon-manager:v6.4-alpha.3
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
Bumping up kubectl binary to HEAD(commit: 17375fc59fff39135af63bd1750bb07c36ef873b) to unblock #41765, which tries to use the new added taints/tolerations api fields in addons.

Sorry for the meaningless addon-manager bump-ups recently, I opened issue #41817 for discussion :(

@mikedanese @gmarek

cc @aveshagarwal

Below images are pushed:
- gcr.io/google-containers/kube-addon-manager:v6.4-alpha.3
- gcr.io/google-containers/kube-addon-manager-amd64:v6.4-alpha.3
- gcr.io/google-containers/kube-addon-manager-arm:v6.4-alpha.3
- gcr.io/google-containers/kube-addon-manager-arm64:v6.4-alpha.3
- gcr.io/google-containers/kube-addon-manager-ppc64le:v6.4-alpha.3
- gcr.io/google-containers/kube-addon-manager-s390x:v6.4-alpha.3

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
