### PR TITLE
Remove VCenterPort from vsphere cloud provider.

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -272,6 +272,9 @@ func newVSphere(cfg VSphereConfig) (*VSphere, error) {
 	if cfg.Global.RoundTripperCount == 0 {
 		cfg.Global.RoundTripperCount = RoundTripperDefaultCount
 	}
+	if cfg.Global.VCenterPort != "" {
+		glog.Warningf("port is a deprecated field in vsphere.conf and will be removed in future release.")
+	}
 
 	c, err := newClient(context.TODO(), &cfg)
 	if err != nil {
@@ -309,7 +312,7 @@ func logout(vs *VSphere) {
 
 func newClient(ctx context.Context, cfg *VSphereConfig) (*govmomi.Client, error) {
 	// Parse URL from string
-	u, err := url.Parse(fmt.Sprintf("https://%s:%s/sdk", cfg.Global.VCenterIP, cfg.Global.VCenterPort))
+	u, err := url.Parse(fmt.Sprintf("https://%s/sdk", cfg.Global.VCenterIP))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -33,7 +33,6 @@ func configFromEnv() (cfg VSphereConfig, ok bool) {
 	var InsecureFlag bool
 	var err error
 	cfg.Global.VCenterIP = os.Getenv("VSPHERE_VCENTER")
-	cfg.Global.VCenterPort = os.Getenv("VSPHERE_VCENTER_PORT")
 	cfg.Global.User = os.Getenv("VSPHERE_USER")
 	cfg.Global.Password = os.Getenv("VSPHERE_PASSWORD")
 	cfg.Global.Datacenter = os.Getenv("VSPHERE_DATACENTER")
@@ -79,10 +78,6 @@ vm-uuid = 1234
 
 	if cfg.Global.VCenterIP != "0.0.0.0" {
 		t.Errorf("incorrect vcenter ip: %s", cfg.Global.VCenterIP)
-	}
-
-	if cfg.Global.VCenterPort != "443" {
-		t.Errorf("incorrect vcenter port: %s", cfg.Global.VCenterPort)
 	}
 
 	if cfg.Global.Datacenter != "us-west" {

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -43,7 +43,6 @@ func GetVSphere() (*VSphere, error) {
 func getVSphereConfig() *VSphereConfig {
 	var cfg VSphereConfig
 	cfg.Global.VCenterIP = os.Getenv("VSPHERE_VCENTER")
-	cfg.Global.VCenterPort = os.Getenv("VSPHERE_VCENTER_PORT")
 	cfg.Global.User = os.Getenv("VSPHERE_USER")
 	cfg.Global.Password = os.Getenv("VSPHERE_PASSWORD")
 	cfg.Global.Datacenter = os.Getenv("VSPHERE_DATACENTER")


### PR DESCRIPTION
**What this PR does / why we need it**:
Address a bug inside vsphere cloud provider when a port number other than 443 is specified inside the config file.
The url which is used for communicating with govmomi should not include port number.
A port number other than 443 will result in 404 error.
VCenterPort stays in VSphereConfig structure for backward compatibility.

**Which issue this PR fixes** : fixes https://github.com/kubernetes/kubernetes-anywhere/issues/338
