### PR TITLE
hack/verify-staging-client-go.sh: fail verbosely if working dir is dirty

### DIFF
--- a/hack/verify-staging-client-go.sh
+++ b/hack/verify-staging-client-go.sh
@@ -34,6 +34,11 @@ readonly V
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 cd ${KUBE_ROOT}
 
+if ! git diff --exit-code; then
+    echo "ERROR: $0 cannot be run on a dirty working directory."
+    exit 1
+fi
+
 # Smoke test client-go examples
 go install ./staging/src/k8s.io/client-go/examples/...
 


### PR DESCRIPTION
Fail early and show verbose error message if repository is dirty.