### PR TITLE
Resolved test fail for TestEvaluateTypes in k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/json for go1.8

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/json/json_test.go
@@ -101,12 +101,12 @@ func TestEvaluateTypes(t *testing.T) {
 		{
 			In:   `9223372036854775808`, // MaxInt64 + 1
 			Data: float64(9223372036854775808),
-			Out:  strconv.FormatFloat(9223372036854775808, 'g', -1, 64),
+			Out:  strconv.FormatFloat(9223372036854775808, 'f', -1, 64),
 		},
 		{
 			In:   `-9223372036854775809`, // MinInt64 - 1
 			Data: float64(math.MinInt64),
-			Out:  strconv.FormatFloat(-9223372036854775809, 'g', -1, 64),
+			Out:  strconv.FormatFloat(-9223372036854775809, 'f', -1, 64),
 		},
 
 		// Floats


### PR DESCRIPTION

Signed-off-by: Abhishek Dasgupta <a10gupta@linux.vnet.ibm.com>

Run the following error with Go1.8:
```make test WHAT="k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/json" KUBE_TEST_ARGS="-run TestEvaluateTypes" GOFLAGS=-v```

Output of the failing test:
```
Running tests for APIVersion: v1,apps/v1beta1,authentication.k8s.io/v1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1,authorization.k8s.io/v1beta1,autoscaling/v1,autoscaling/v2alpha1,batch/v1,batch/v2alpha1,certificates.k8s.io/v1beta1,extensions/v1beta1,imagepolicy.k8s.io/v1alpha1,policy/v1beta1,rbac.authorization.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,storage.k8s.io/v1beta1,federation/v1beta1
+++ [0224 06:51:06] Running tests without code coverage
=== RUN   TestEvaluateTypes
--- FAIL: TestEvaluateTypes (0.00s)
	json_test.go:313: 9223372036854775808: expected
			{"data":9.223372036854776e+18}, got
			{"data":9223372036854776000}
	json_test.go:313: -9223372036854775809: expected
			{"data":-9.223372036854776e+18}, got
			{"data":-9223372036854776000}
FAIL
exit status 1
FAIL	k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/json	0.002s
make: *** [test] Error 1

```

This PR resolve this failing test while running with Go1.8.
