### PR TITLE
Adjust parameters of GCL cluster logging load tests

### DIFF
--- a/test/e2e/cluster_logging_gcl_load.go
+++ b/test/e2e/cluster_logging_gcl_load.go
@@ -39,11 +39,12 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Slow] [Flaky]",
 		gclLogsProvider, err := newGclLogsProvider(f)
 		framework.ExpectNoError(err, "Failed to create GCL logs provider")
 
-		podCount := 30
+		nodeCount := len(framework.GetReadySchedulableNodesOrDie(f.ClientSet).Items)
+		podCount := 30 * nodeCount
 		loggingDuration := 10 * time.Minute
-		linesPerSecond := 1000
+		linesPerSecond := 1000 * nodeCount
 		linesPerPod := linesPerSecond * int(loggingDuration.Seconds()) / podCount
-		ingestionTimeout := 1 * time.Hour
+		ingestionTimeout := 30 * time.Minute
 
 		By("Running logs generator pods")
 		pods := []*loggingPod{}
@@ -70,11 +71,12 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Slow] [Flaky]",
 		gclLogsProvider, err := newGclLogsProvider(f)
 		framework.ExpectNoError(err, "Failed to create GCL logs provider")
 
-		maxPodCount := 10
+		nodeCount := len(framework.GetReadySchedulableNodesOrDie(f.ClientSet).Items)
+		maxPodCount := 10 * nodeCount
 		jobDuration := 1 * time.Minute
-		linesPerPodPerSecond := 10
-		testDuration := 1 * time.Hour
-		ingestionTimeout := 1 * time.Hour
+		linesPerPodPerSecond := 100
+		testDuration := 10 * time.Minute
+		ingestionTimeout := 30 * time.Minute
 
 		podRunDelay := time.Duration(int64(jobDuration) / int64(maxPodCount))
 		podRunCount := int(testDuration.Seconds())/int(podRunDelay.Seconds()) - 1


### PR DESCRIPTION
This PR increases the amount of logs produced in load tests to match the number of nodes and provide the predictable load of 100 KB/sec on each node.

Also this PR reduces in half amount of time, given for ingesting logs.