### PR TITLE
Fix broken OpenJDK-8 install in Cassandra Dockerfile

### DIFF
--- a/examples/storage/cassandra/image/Dockerfile
+++ b/examples/storage/cassandra/image/Dockerfile
@@ -20,7 +20,7 @@ ENV DI_VERSION="1.1.1" DI_SHA="dec8167091671df0dd3748a8938102479db5fffc"
 
 RUN mv /java.list /etc/apt/sources.list.d/java.list \
   && apt-get update \
-  && apt-get -qq -y --force-yes install --no-install-recommends procps openjdk-8-jre-headless libjemalloc1 curl localepurge \
+  && apt-get -qq -y --force-yes install --no-install-recommends -t jessie-backports procps openjdk-8-jre-headless libjemalloc1 curl localepurge \
   && curl -L https://github.com/Yelp/dumb-init/releases/download/v${DI_VERSION}/dumb-init_${DI_VERSION}_amd64 > /sbin/dumb-init \
   && echo "$DI_SHA  /sbin/dumb-init" | sha1sum -c - \
   && mv /cassandra.list /etc/apt/sources.list.d/cassandra.list \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Example Cassandra Dockerfile is broken (see attached screenshot):
PR adds jessie-backports to openjkd-8 install ( see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=851667 for debian change )

<img width="812" alt="screen shot 2017-02-24 at 15 10 49" src="https://cloud.githubusercontent.com/assets/1479098/23307103/957a456c-faa6-11e6-9e3a-8e317d6f5029.png">

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```