### PR TITLE
Update owners file to reflect Juju/Charm knowledgable reviewers

### DIFF
--- a/cluster/juju/OWNERS
+++ b/cluster/juju/OWNERS
@@ -4,13 +4,14 @@ approvers:
 - marcoceppi
 - mbruzek
 reviewers:
+- chuckbutler
+- marcoceppi
+- mbruzek
 - thockin
 - mikedanese
 - nikhiljindal
-- pmorie
 - eparis
 - jlowdermilk
-- jsafrane
 - krousey
 - david-mcmahon
 - Cynerva


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Several reviewers have expressed confusion on why they're being added to pull requests related to cluster/juju. This is likely because the cluster OWNER wasn't updated from the original when created. This removes those who have expressed confusion to avoid noise in future updates to this directory.

Removed:
 - @pmorie [ref](https://github.com/kubernetes/kubernetes/pull/40814#issuecomment-282107925)
 - @jsafrane [ref](https://github.com/kubernetes/kubernetes/pull/42007#issuecomment-282246574)

Added:
 - @marcoceppi
 - @chuckbutler 
 - @mbruzek  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
