### PR TITLE
cluster/gce: run kube-proxy on master

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -1152,8 +1152,8 @@ if [[ -z "${is_push}" ]]; then
     create-salt-master-kubelet-auth
   else
     create-salt-kubelet-auth
-    create-salt-kubeproxy-auth
   fi
+  create-salt-kubeproxy-auth
   download-release
   configure-salt
   remove-docker-artifacts

--- a/cluster/gce/container-linux/configure.sh
+++ b/cluster/gce/container-linux/configure.sh
@@ -96,9 +96,8 @@ function install-kube-binary-config {
   dst_dir="${KUBE_HOME}/kube-docker-files"
   mkdir -p "${dst_dir}"
   cp "${src_dir}/"*.docker_tag "${dst_dir}"
-  if [[ "${KUBERNETES_MASTER:-}" == "false" ]]; then
-    cp "${src_dir}/kube-proxy.tar" "${dst_dir}"
-  else
+  cp "${src_dir}/kube-proxy.tar" "${dst_dir}"
+  if [[ "${KUBERNETES_MASTER:-}" == "true" ]]; then
     cp "${src_dir}/kube-apiserver.tar" "${dst_dir}"
     cp "${src_dir}/kube-controller-manager.tar" "${dst_dir}"
     cp "${src_dir}/kube-scheduler.tar" "${dst_dir}"

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -167,8 +167,8 @@ function install-kube-binary-config {
   dst_dir="${KUBE_HOME}/kube-docker-files"
   mkdir -p "${dst_dir}"
   cp "${src_dir}/"*.docker_tag "${dst_dir}"
+  cp "${src_dir}/kube-proxy.tar" "${dst_dir}"
   if [[ "${KUBERNETES_MASTER:-}" == "false" ]]; then
-    cp "${src_dir}/kube-proxy.tar" "${dst_dir}"
     if [[ "${ENABLE_NODE_PROBLEM_DETECTOR:-}" == "standalone" ]]; then
       install-node-problem-detector
     fi
@@ -228,7 +228,7 @@ function install-kube-binary-config {
 
   # Install gci mounter related artifacts to allow mounting storage volumes in GCI
   install-gci-mounter-tools
-  
+
   # Clean up.
   rm -rf "${KUBE_HOME}/kubernetes"
   rm -f "${KUBE_HOME}/${server_binary_tar}"

--- a/cluster/gce/trusty/configure-helper.sh
+++ b/cluster/gce/trusty/configure-helper.sh
@@ -48,9 +48,7 @@ create_dirs() {
   # Create required directories.
   mkdir -p /var/lib/kubelet
   mkdir -p /etc/kubernetes/manifests
-  if [ "${KUBERNETES_MASTER:-}" = "false" ]; then
-    mkdir -p /var/lib/kube-proxy
-  fi
+  mkdir -p /var/lib/kube-proxy
 }
 
 create_kubelet_kubeconfig() {

--- a/cluster/gce/trusty/configure.sh
+++ b/cluster/gce/trusty/configure.sh
@@ -89,7 +89,7 @@ download_or_bust() {
 }
 
 # Downloads kubernetes binaries and kube-system manifest tarball, unpacks them,
-# and places them into suitable directories. Files are placed in /home/kubernetes. 
+# and places them into suitable directories. Files are placed in /home/kubernetes.
 install_kube_binary_config() {
   # Upstart does not support shell array well. Put urls in a temp file with one
   # url at a line, and we will use 'read' command to get them one-by-one.
@@ -118,9 +118,8 @@ install_kube_binary_config() {
   dst_dir="${kube_home}/kube-docker-files"
   mkdir -p "${dst_dir}"
   cp "${src_dir}/"*.docker_tag "${dst_dir}"
-  if [ "${KUBERNETES_MASTER:-}" = "false" ]; then
-    cp "${src_dir}/kube-proxy.tar" "${dst_dir}"
-  else
+  cp "${src_dir}/kube-proxy.tar" "${dst_dir}"
+  if [ "${KUBERNETES_MASTER:-}" = "true" ]; then
     cp "${src_dir}/kube-apiserver.tar" "${dst_dir}"
     cp "${src_dir}/kube-controller-manager.tar" "${dst_dir}"
     cp "${src_dir}/kube-scheduler.tar" "${dst_dir}"

--- a/cluster/gce/trusty/master.yaml
+++ b/cluster/gce/trusty/master.yaml
@@ -67,6 +67,8 @@ script
 	create_master_kubelet_auth
 	echo "Creating auth files for etcd"
 	create-master-etcd-auth
+	echo "Creating kube-proxy kubeconfig file"
+	create_kubeproxy_kubeconfig
 	echo "Assemble kubelet command line"
 	# Kubelet command flags will be written in /etc/default/kubelet
 	assemble_kubelet_flags
@@ -164,6 +166,66 @@ script
 	. /etc/kube-configure-helper.sh
 	. /etc/kube-env
 	restart_docker_daemon
+} 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
+end script
+
+--====================================
+MIME-Version: 1.0
+Content-Type: text/upstart-job; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+Content-Disposition: attachment; filename="kube-proxy.conf"
+
+#upstart-job
+
+description "Start kube-proxy static pod"
+
+start on stopped kube-docker
+
+script
+{
+	set -o errexit
+	set -o nounset
+
+	. /etc/kube-configure-helper.sh
+	. /etc/kube-env
+	prepare_log_file "/var/log/kube-proxy.log"
+	# Load the docker image from file /home/kubernetes/kube-docker-files/kube-proxy.tar.
+	echo "Try to load docker image file kube-proxy.tar"
+	timeout 30 docker load -i /home/kubernetes/kube-docker-files/kube-proxy.tar
+	# Copy the manifest to /tmp to manipulate
+	tmp_file="/tmp/kube-proxy.manifest"
+	cp -f /home/kubernetes/kube-manifests/kubernetes/kube-proxy.manifest ${tmp_file}
+	# Remove the lines of salt configuration and replace variables with values.
+	# NOTE: Changes to variable names in cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+	# may break this upstart job.
+	sed -i "/^ *{%/d" ${tmp_file}
+	kubeconfig="--kubeconfig=\/var\/lib\/kube-proxy\/kubeconfig"
+	kube_docker_registry="gcr.io\/google_containers"
+	if [ -n "${KUBE_DOCKER_REGISTRY:-}" ]; then
+		kube_docker_registry=${KUBE_DOCKER_REGISTRY}
+	fi
+	kube_proxy_docker_tag=$(cat /home/kubernetes/kube-docker-files/kube-proxy.docker_tag)
+	test_args=""
+	if [ -n "${KUBEPROXY_TEST_ARGS:-}" ]; then
+		test_args="${KUBEPROXY_TEST_ARGS}"
+	fi
+	log_level="--v=2"
+	if [ -n "${KUBEPROXY_TEST_LOG_LEVEL:-}" ]; then
+		log_level="${KUBEPROXY_TEST_LOG_LEVEL}"
+	fi
+	api_servers="--master=https://${KUBERNETES_MASTER_NAME}"
+	sed -i -e "s@{{kubeconfig}}@${kubeconfig}@g" ${tmp_file}
+	sed -i -e "s@{{pillar\['kube_docker_registry'\]}}@${kube_docker_registry}@g" ${tmp_file}
+	sed -i -e "s@{{pillar\['kube-proxy_docker_tag'\]}}@${kube_proxy_docker_tag}@g" ${tmp_file}
+	sed -i -e "s@{{test_args}}@${test_args}@g" ${tmp_file}
+	sed -i -e "s@{{ cpurequest }}@100m@g" ${tmp_file}
+	sed -i -e "s@{{log_level}}@${log_level}@g" ${tmp_file}
+	sed -i -e "s@{{api_servers_with_port}}@${api_servers}@g" ${tmp_file}
+	if [ -n "${CLUSTER_IP_RANGE:-}" ]; then
+		sed -i -e "s@{{cluster_cidr}}@--cluster-cidr=${CLUSTER_IP_RANGE}@g" ${tmp_file}
+	fi
+
+	mv -f ${tmp_file} /etc/kubernetes/manifests/
 } 2>&1 | logger --priority daemon.info -t ${UPSTART_JOB}
 end script
 

--- a/cluster/saltbase/salt/top.sls
+++ b/cluster/saltbase/salt/top.sls
@@ -80,6 +80,8 @@ base:
 {% endif %}
 {% if pillar.get('network_provider', '').lower() == 'opencontrail' %}
     - opencontrail-networking-master
+{% else %}
+    - kube-proxy
 {% endif %}
 {% if pillar.get('enable_cluster_autoscaler', '').lower() == 'true' %}
     - cluster-autoscaler


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently on GCE when a cluster is spun up via `kube-up.sh`, `kube-proxy` is not deployed on the master.  This creates a problem for any Pods running on master and needing connectivity to the k8s API, DNS and any other thing using a VIP.  Seeing that the master deploys some static Pods and there are Pods running on master via DaemonSets, like fluentd and CNI plugins, `kube-proxy` should be running on master.

**Which issue this PR fixes**

#41943

**Special notes for your reviewer**:

NONE

**Release note**:

```release-note
kube-up.sh on GCE will now deploy the kube-proxy on master to alleviate
issues related to Pods _(fluentd, CNI, ...)_ running on master and attempting
to communicate with VIPs.
```
