### PR TITLE
cluster/gce: set cni-bin-dir for kubelet on debian

### DIFF
--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -138,9 +138,9 @@
 {% if pillar.get('network_provider', '').lower() == 'opencontrail' %}
   {% set network_plugin = "--network-plugin=opencontrail" %}
 {% elif pillar.get('network_provider', '').lower() == 'cni' %}
-  {% set network_plugin = "--network-plugin=cni --network-plugin-dir=/etc/cni/net.d/" %}
+  {% set network_plugin = "--network-plugin=cni --network-plugin-dir=/etc/cni/net.d/ --cni-bin-dir=/opt/cni/bin" %}
 {%elif pillar.get('network_policy_provider', '').lower() == 'calico' and grains['roles'][0] != 'kubernetes-master' -%}
-  {% set network_plugin = "--network-plugin=cni --network-plugin-dir=/etc/cni/net.d/" %}
+  {% set network_plugin = "--network-plugin=cni --network-plugin-dir=/etc/cni/net.d/ --cni-bin-dir=/opt/cni/bin" %}
 {% elif pillar.get('network_provider', '').lower() == 'kubenet' %}
   {% set network_plugin = "--network-plugin=kubenet" -%}
 {% endif -%}


### PR DESCRIPTION
**What this PR does / why we need it**:

When using CNI, the nodes spun up on debian hosts are not setting the
`--cni-bin-dir` flag for the `kubelet` which results in CNI not loading
properly.  This commit fixes that.

**Which issue this PR fixes**

NONE

**Special notes for your reviewer**:

**Release note**:
```release-note
kube-up.sh now properly configures the CNI bin dir for kubelets
running on debian.
```
