### PR TITLE
Rebase kube-proxy and debian-iptables on debian-base

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -85,7 +85,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 #
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
-  debian_iptables_version=v6
+  debian_iptables_version=v7
   case $1 in
     "amd64")
         local targets=(
@@ -93,7 +93,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,busybox
           kube-scheduler,busybox
           kube-aggregator,busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-amd64:${debian_iptables_version}
+          kube-proxy,gcr.io/google-containers/debian-iptables-amd64:${debian_iptables_version}
         );;
     "arm")
         local targets=(
@@ -101,7 +101,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,armel/busybox
           kube-scheduler,armel/busybox
           kube-aggregator,armel/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-arm:${debian_iptables_version}
+          kube-proxy,gcr.io/google-containers/debian-iptables-arm:${debian_iptables_version}
         );;
     "arm64")
         local targets=(
@@ -109,7 +109,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,aarch64/busybox
           kube-scheduler,aarch64/busybox
           kube-aggregator,aarch64/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-arm64:${debian_iptables_version}
+          kube-proxy,gcr.io/google-containers/debian-iptables-arm64:${debian_iptables_version}
         );;
     "ppc64le")
         local targets=(
@@ -117,7 +117,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,ppc64le/busybox
           kube-scheduler,ppc64le/busybox
           kube-aggregator,ppc64le/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-ppc64le:${debian_iptables_version}
+          kube-proxy,gcr.io/google-containers/debian-iptables-ppc64le:${debian_iptables_version}
         );;
     "s390x")
         local targets=(
@@ -125,8 +125,8 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,s390x/busybox
           kube-scheduler,s390x/busybox
           kube-aggregator,s390x/busybox
-          kube-proxy,gcr.io/google_containers/debian-iptables-s390x:${debian_iptables_version}
-        );;		
+          kube-proxy,gcr.io/google-containers/debian-iptables-s390x:${debian_iptables_version}
+        );;
   esac
 
   echo "${targets[@]}"

--- a/build/debian-iptables/Dockerfile
+++ b/build/debian-iptables/Dockerfile
@@ -18,11 +18,7 @@ FROM BASEIMAGE
 # If we're building normally, for amd64, CROSS_BUILD lines are removed
 CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
 
-# All apt-get's must be in one run command or the
-# cleanup has no effect.
-RUN DEBIAN_FRONTEND=noninteractive apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+RUN clean-install \
     iptables \
     ebtables \
-    conntrack \
-    && rm -rf /var/lib/apt/lists/*
+    conntrack

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -14,32 +14,27 @@
 
 .PHONY:	build push
 
-REGISTRY?="gcr.io/google_containers"
+REGISTRY?="gcr.io/google-containers"
 IMAGE=debian-iptables
-TAG=v6
+TAG=v7
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 QEMUVERSION=v2.7.0
 
-ifeq ($(ARCH),amd64)
-	BASEIMAGE?=debian:jessie
-endif
 ifeq ($(ARCH),arm)
-	BASEIMAGE?=armhf/debian:jessie
 	QEMUARCH=arm
 endif
 ifeq ($(ARCH),arm64)
-	BASEIMAGE?=aarch64/debian:jessie
 	QEMUARCH=aarch64
 endif
 ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/debian:jessie
 	QEMUARCH=ppc64le
 endif
 ifeq ($(ARCH),s390x)
-	BASEIMAGE?=s390x/debian:jessie
 	QEMUARCH=s390x
 endif
+
+BASEIMAGE=gcr.io/google-containers/debian-base-$(ARCH):0.1
 
 build:
 	cp ./* $(TEMP_DIR)


### PR DESCRIPTION
**What this PR does / why we need it**:

Slimmer images are generally preferred, but it's a minor optimization. The larger advantage to this change is the reduced attack surface from removing unnecessary packages, and easier maintenance from sharing a common base image.

Size comparison:
```
gcr.io/google-containers/debian-iptables-amd64:v6         127.9 MB
gcr.io/google-containers/debian-iptables-amd64:v7          45.1 MB
```

**Which issue this PR fixes** https://github.com/kubernetes/kubernetes/issues/40248

**Special notes for your reviewer**:
Tested by deploying to a private test cluster and running the e2es. This will fail the jenkins builds until I push the `gcr.io/google-containers/debian-iptables-amd64:v7` image, which I will do once I have an LGTM.

**Release note**:
```release-note
Clean up the kube-proxy container image by removing unnecessary packages and files.
```

/cc @luxas @ixdy 