### PR TITLE
[Federation] Make --dns-provider mandatory for kubefed

### DIFF
--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -35,6 +35,7 @@ source "${KUBE_ROOT}/cluster/common.sh"
 source "${KUBE_ROOT}/federation/cluster/common.sh"
 
 DNS_ZONE_NAME="${FEDERATION_DNS_ZONE_NAME:-}"
+DNS_PROVIDER="${FEDERATION_DNS_PROVIDER:-google-clouddns}"
 FEDERATIONS_DOMAIN_MAP="${FEDERATIONS_DOMAIN_MAP:-}"
 
 # get_version returns the version in KUBERNETES_RELEASE or defaults to the
@@ -82,6 +83,7 @@ function init() {
       "${FEDERATION_NAME}" \
       --host-cluster-context="${HOST_CLUSTER_CONTEXT}" \
       --dns-zone-name="${DNS_ZONE_NAME}" \
+      --dns-provider="${DNS_PROVIDER}" \
       --image="${kube_registry}/hyperkube-amd64:${kube_version}"
 }
 

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -156,7 +156,7 @@ func (o *initFederationOptions) Bind(flags *pflag.FlagSet) {
 
 	flags.StringVar(&o.dnsZoneName, "dns-zone-name", "", "DNS suffix for this federation. Federated Service DNS names are published with this suffix.")
 	flags.StringVar(&o.image, "image", defaultImage, "Image to use for federation API server and controller manager binaries.")
-	flags.StringVar(&o.dnsProvider, "dns-provider", "google-clouddns", "Dns provider to be used for this deployment.")
+	flags.StringVar(&o.dnsProvider, "dns-provider", "", "Dns provider to be used for this deployment.")
 	flags.StringVar(&o.dnsProviderConfig, "dns-provider-config", "", "Config file path on local file system for configuring DNS provider.")
 	flags.StringVar(&o.etcdPVCapacity, "etcd-pv-capacity", "10Gi", "Size of persistent volume claim to be used for etcd.")
 	flags.BoolVar(&o.etcdPersistentStorage, "etcd-persistent-storage", true, "Use persistent volume for etcd. Defaults to 'true'.")
@@ -200,6 +200,10 @@ type entityKeyPairs struct {
 
 // Complete ensures that options are valid and marshals them if necessary.
 func (i *initFederation) Complete(cmd *cobra.Command, args []string) error {
+	if len(i.options.dnsProvider) == 0 {
+		return fmt.Errorf("--dns-provider is mandatory")
+	}
+
 	err := i.commonOptions.SetName(cmd, args)
 	if err != nil {
 		return err

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -67,7 +67,7 @@ const (
 
 func TestInitFederation(t *testing.T) {
 	cmdErrMsg := ""
-	dnsProvider := ""
+	dnsProvider := "google-clouddns"
 	cmdutil.BehaviorOnFatal(func(str string, code int) {
 		cmdErrMsg = str
 	})
@@ -90,7 +90,6 @@ func TestInitFederation(t *testing.T) {
 		etcdPVCapacity        string
 		etcdPersistence       string
 		expectedErr           string
-		dnsProvider           string
 		dnsProviderConfig     string
 		storageBackend        string
 		dryRun                string
@@ -108,7 +107,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:        "5Gi",
 			etcdPersistence:       "true",
 			expectedErr:           "",
-			dnsProvider:           "test-dns-provider",
 			dnsProviderConfig:     "dns-provider.conf",
 			storageBackend:        "etcd2",
 			dryRun:                "",
@@ -126,7 +124,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "", //test for default value of pvc-size
 			etcdPersistence:      "true",
 			expectedErr:          "",
-			dnsProvider:          "", //test for default value of dns provider
 			storageBackend:       "etcd2",
 			dryRun:               "",
 		},
@@ -141,7 +138,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "",
 			etcdPersistence:      "true",
 			expectedErr:          "",
-			dnsProvider:          "test-dns-provider",
 			storageBackend:       "etcd2",
 			dryRun:               "valid-run",
 		},
@@ -156,7 +152,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "false",
 			expectedErr:          "",
-			dnsProvider:          "test-dns-provider",
 			storageBackend:       "etcd3",
 			dryRun:               "",
 		},
@@ -170,7 +165,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "true",
 			expectedErr:          "",
-			dnsProvider:          "test-dns-provider",
 			storageBackend:       "etcd3",
 			dryRun:               "",
 		},
@@ -185,7 +179,6 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "true",
 			expectedErr:          "",
-			dnsProvider:          "test-dns-provider",
 			storageBackend:       "etcd3",
 			dryRun:               "",
 		},
@@ -195,14 +188,8 @@ func TestInitFederation(t *testing.T) {
 
 	for i, tc := range testCases {
 		cmdErrMsg = ""
-		dnsProvider = ""
 		buf := bytes.NewBuffer([]byte{})
 
-		if "" != tc.dnsProvider {
-			dnsProvider = tc.dnsProvider
-		} else {
-			dnsProvider = "google-clouddns" //default value of dns-provider
-		}
 		if tc.dnsProviderConfig != "" {
 			tmpfile, err := ioutil.TempFile("", tc.dnsProviderConfig)
 			if err != nil {
@@ -227,14 +214,12 @@ func TestInitFederation(t *testing.T) {
 		cmd.Flags().Set("host-cluster-context", "substrate")
 		cmd.Flags().Set("dns-zone-name", tc.dnsZoneName)
 		cmd.Flags().Set("image", tc.image)
+		cmd.Flags().Set("dns-provider", dnsProvider)
 		cmd.Flags().Set("apiserver-arg-overrides", tc.apiserverArgOverrides)
 		cmd.Flags().Set("controllermanager-arg-overrides", tc.cmArgOverrides)
 
 		if tc.storageBackend != "" {
 			cmd.Flags().Set("storage-backend", tc.storageBackend)
-		}
-		if tc.dnsProvider != "" {
-			cmd.Flags().Set("dns-provider", tc.dnsProvider)
 		}
 		if tc.dnsProviderConfig != "" {
 			cmd.Flags().Set("dns-provider-config", tc.dnsProviderConfig)


### PR DESCRIPTION
Targets #40757

I thought about adding a test for this but I decided it wasn't worth it.  There's too much setup involved in being able to run ``Complete`` for such a simple change.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
The --dns-provider argument of 'kubefed init' is now mandatory and does not default to `google-clouddns`. To initialize a Federation control plane with Google Cloud DNS, use the following invocation: 'kubefed init --dns-provider=google-clouddns'
```

cc: @kubernetes/sig-federation-pr-reviews @madhusudancs 