### PR TITLE
Keep using storage v1beta1 until GKE enables it

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -121,6 +121,7 @@ go_library(
         "//pkg/apis/storage/util:go_default_library",
         "//pkg/apis/storage/v1:go_default_library",
         "//pkg/apis/storage/v1/util:go_default_library",
+        "//pkg/apis/storage/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/client/clientset_generated/clientset/typed/core/v1:go_default_library",
         "//pkg/client/clientset_generated/clientset/typed/extensions/v1beta1:go_default_library",

--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -27,8 +27,8 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/v1"
 	rbacv1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
-	storage "k8s.io/kubernetes/pkg/apis/storage/v1"
 	storageutil "k8s.io/kubernetes/pkg/apis/storage/v1/util"
+	storage "k8s.io/kubernetes/pkg/apis/storage/v1beta1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -111,8 +111,9 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 
 			By("creating a StorageClass")
 			class := newStorageClass("", "internal")
-			_, err := c.Storage().StorageClasses().Create(class)
-			defer c.Storage().StorageClasses().Delete(class.Name, nil)
+			// TODO change to StorageV1 once it's enabled in GKE
+			_, err := c.StorageV1beta1().StorageClasses().Create(class)
+			defer c.StorageV1beta1().StorageClasses().Delete(class.Name, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a claim with a dynamic provisioning annotation")
@@ -170,8 +171,9 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 			sc := newStorageClass("kubernetes.io/gce-pd", suffix)
 			// Set an unmanaged zone.
 			sc.Parameters = map[string]string{"zone": unmanagedZone}
-			sc, err = c.Storage().StorageClasses().Create(sc)
-			defer Expect(c.Storage().StorageClasses().Delete(sc.Name, nil)).To(Succeed())
+			// TODO change to StorageV1 once it's enabled in GKE
+			sc, err = c.StorageV1beta1().StorageClasses().Create(sc)
+			defer Expect(c.StorageV1beta1().StorageClasses().Delete(sc.Name, nil)).To(Succeed())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating a claim and expecting it to timeout")
@@ -225,8 +227,9 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 
 			By("creating a StorageClass")
 			class := newStorageClass(externalPluginName, "external")
-			_, err = c.Storage().StorageClasses().Create(class)
-			defer c.Storage().StorageClasses().Delete(class.Name, nil)
+			// TODO change to StorageV1 once it's enabled in GKE
+			_, err = c.StorageV1beta1().StorageClasses().Create(class)
+			defer c.StorageV1beta1().StorageClasses().Delete(class.Name, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating a claim with a dynamic provisioning annotation")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: roll back e2e's usage of the storage api from v1 to v1beta1, as v1 isn't enabled in GKE yet.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: in #40088 we enabled storage v1beta1, and the generated client for Storage() uses v1 now by default. We need to keep using v1beta1 in e2e tests because v1 isn't enabled in GKE yet. This should fix (at least part of) the failing ci-kubernetes-e2e-gci-gke-slow.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```