### PR TITLE
fixes a unit test for deployment_util

### DIFF
--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -705,7 +705,7 @@ func TestResolveFenceposts(t *testing.T) {
 			desired:           10,
 			expectSurge:       0,
 			expectUnavailable: 0,
-			expectError:       "invalid value for IntOrString: invalid value \"oops\": strconv.ParseInt: parsing \"oops\": invalid syntax",
+			expectError:       "invalid value for IntOrString: invalid value \"oops\": strconv.Atoi: parsing \"oops\": invalid syntax",
 		},
 		{
 			maxSurge:          "55%",
@@ -713,7 +713,7 @@ func TestResolveFenceposts(t *testing.T) {
 			desired:           10,
 			expectSurge:       0,
 			expectUnavailable: 0,
-			expectError:       "invalid value for IntOrString: invalid value \"urg\": strconv.ParseInt: parsing \"urg\": invalid syntax",
+			expectError:       "invalid value for IntOrString: invalid value \"urg\": strconv.Atoi: parsing \"urg\": invalid syntax",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a unit test for the line
( https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go#L170 )
I cannot pass `make test` because of this issue.