### PR TITLE
Switch influxdb storage to PersistentVolume to retain monitoring data

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: monitoring-influxdb-grafana-v4
   namespace: kube-system
@@ -8,12 +8,11 @@ metadata:
     version: v4
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-spec: 
+spec:
   replicas: 1
-  selector: 
-    k8s-app: influxGrafana
-    version: v4
-  template: 
+  strategy:
+    type: Recreate
+  template:
     metadata: 
       labels: 
         k8s-app: influxGrafana
@@ -69,7 +68,7 @@ spec:
             mountPath: /var
       volumes:
       - name: influxdb-persistent-storage
-        emptyDir: {}
+        persistentVolumeClaim:
+          claimName: influxdb-pvc
       - name: grafana-persistent-storage
         emptyDir: {}
-

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-pv.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-pv.yaml
@@ -1,0 +1,21 @@
+{% set pd_prefix = pillar.get('instance_prefix', '') -%}
+{% set pd_name = pd_prefix + '-influxdb-pd') -%}
+
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: influxdb-pv
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "influxdb-pv"
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  gcePersistentDisk:
+    pdName: {{ pd_name }}
+    fsType: ext4
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: ""

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-pvc.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-pvc.yaml
@@ -1,0 +1,17 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: influxdb-pvc
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: ""
+  selector:
+    matchLabels:
+      kubernetes.io/name: "influxdb-pv"

--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -1242,6 +1242,12 @@ function start-kube-addons {
     sed -i -e "s@{{ *nanny_memory *}}@${nanny_memory}@g" "${controller_yaml}"
     sed -i -e "s@{{ *metrics_cpu_per_node *}}@${metrics_cpu_per_node}@g" "${controller_yaml}"
   fi
+  if [[ "${ENABLE_CLUSTER_MONITORING:-}" == "influxdb" ]]; then
+    pv_yaml="${dst_dir}/${file_dir}/influxdb-pv.yaml"
+    pd_name="${INSTANCE_PREFIX}-influxdb-pd"
+    remove-salt-config-comments "${pv_yaml}"
+    sed -i -e "s@{{ *pd_name *}}@${pd_name}@g" "${pv_yaml}"
+  fi
   if [[ "${ENABLE_CLUSTER_DNS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "dns"
     local -r dns_controller_file="${dst_dir}/dns/kubedns-controller.yaml"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1676,6 +1676,12 @@ function start-kube-addons {
     sed -i -e "s@{{ *nanny_memory *}}@${nanny_memory}@g" "${controller_yaml}"
     sed -i -e "s@{{ *metrics_cpu_per_node *}}@${metrics_cpu_per_node}@g" "${controller_yaml}"
   fi
+  if [[ "${ENABLE_CLUSTER_MONITORING:-}" == "influxdb" ]]; then
+    pv_yaml="${dst_dir}/${file_dir}/influxdb-pv.yaml"
+    pd_name="${INSTANCE_PREFIX}-influxdb-pd"
+    remove-salt-config-comments "${pv_yaml}"
+    sed -i -e "s@{{ *pd_name *}}@${pd_name}@g" "${pv_yaml}"
+  fi
   if [[ "${ENABLE_CLUSTER_DNS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "dns"
     local -r dns_controller_file="${dst_dir}/dns/kubedns-controller.yaml"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1008,6 +1008,14 @@ function create-master() {
       --size "${CLUSTER_REGISTRY_DISK_SIZE}" &
   fi
 
+ # Create disk for influxdb if enabled
+ if [[ "${ENABLE_CLUSTER_MONITORING:-}" == "influxdb" ]]; then
+   gcloud compute disks create "${INSTANCE_PREFIX}-influxdb-pd" \
+     --project "${PROJECT}" \
+     --zone "${ZONE}" \
+     --size "10GiB" &
+ fi
+
   # Create rule for accessing and securing etcd servers.
   if ! gcloud compute firewall-rules --project "${PROJECT}" describe "${MASTER_NAME}-etcd" &>/dev/null; then
     gcloud compute firewall-rules create "${MASTER_NAME}-etcd" \
@@ -1680,6 +1688,7 @@ function kube-down() {
 
     # Delete persistent disk for influx-db.
     if gcloud compute disks describe "${INSTANCE_PREFIX}"-influxdb-pd --zone "${ZONE}" --project "${PROJECT}" &>/dev/null; then
+      echo Deleting persistent disk "${INSTANCE_PREFIX}"-influxdb-pd
       gcloud compute disks delete \
         --project "${PROJECT}" \
         --quiet \
@@ -1843,6 +1852,11 @@ function check-resources() {
 
   if gcloud compute disks describe --project "${PROJECT}" "${CLUSTER_REGISTRY_DISK}" --zone "${ZONE}" &>/dev/null; then
     KUBE_RESOURCE_FOUND="Persistent disk ${CLUSTER_REGISTRY_DISK}"
+    return 1
+  fi
+
+  if gcloud compute disks describe --project "${PROJECT}" "${INSTANCE_PREFIX}-influxdb-pd" --zone "${ZONE}" &>/dev/null; then
+    KUBE_RESOURCE_FOUND="Persistent disk ${INSTANCE_PREFIX}-influxdb-pd"
     return 1
   fi
 

--- a/test/e2e/instrumentation/monitoring/influxdb.go
+++ b/test/e2e/instrumentation/monitoring/influxdb.go
@@ -142,11 +142,11 @@ func verifyExpectedRcsExistAndGetExpectedPods(c clientset.Interface) ([]string, 
 		if err != nil {
 			return nil, err
 		}
-		psList, err := c.AppsV1beta1().StatefulSets(metav1.NamespaceSystem).List(options)
+		ssList, err := c.AppsV1beta1().StatefulSets(metav1.NamespaceSystem).List(options)
 		if err != nil {
 			return nil, err
 		}
-		if (len(rcList.Items) + len(deploymentList.Items) + len(psList.Items)) != 1 {
+		if (len(rcList.Items) + len(deploymentList.Items) + len(ssList.Items)) != 1 {
 			return nil, fmt.Errorf("expected to find one replica for RC or deployment with label %s but got %d",
 				rcLabel, len(rcList.Items))
 		}
@@ -180,8 +180,8 @@ func verifyExpectedRcsExistAndGetExpectedPods(c clientset.Interface) ([]string, 
 				expectedPods = append(expectedPods, pod.Name)
 			}
 		}
-		// And for pet sets.
-		for _, ps := range psList.Items {
+		// And for stateful sets.
+		for _, ps := range ssList.Items {
 			selector := labels.Set(ps.Spec.Selector.MatchLabels).AsSelector()
 			options := metav1.ListOptions{LabelSelector: selector.String()}
 			podList, err := c.Core().Pods(metav1.NamespaceSystem).List(options)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Switch influxdb from ReplicationController to StatefulSet with manually provisioned PersistentVolume. Thanks to that, monitoring data will be retained between influx/grafana pod restarts.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1197

**Special notes for your reviewer**:
cc @piosz 
StatefulSet + dynamic PersistentVolume provisioning does not delete disks during kube-down.sh which was causing "disks leak".  That is why I creade and delete influxdb disk manually in `cluster/gce/util.sh`


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
