### PR TITLE
make kubectl taint command respect effect NoExecute

### DIFF
--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -43,7 +43,7 @@ func ParseTaint(st string) (v1.Taint, error) {
 		return taint, fmt.Errorf("invalid taint spec: %v, %s", st, strings.Join(errs, "; "))
 	}
 
-	if effect != v1.TaintEffectNoSchedule && effect != v1.TaintEffectPreferNoSchedule {
+	if effect != v1.TaintEffectNoSchedule && effect != v1.TaintEffectPreferNoSchedule && effect != v1.TaintEffectNoExecute {
 		return taint, fmt.Errorf("invalid taint spec: %v, unsupported taint effect", st)
 	}
 

--- a/pkg/util/taints/taints_test.go
+++ b/pkg/util/taints/taints_test.go
@@ -47,6 +47,10 @@ func TestTaintsVar(t *testing.T) {
 				{Key: "bing", Value: "bang", Effect: api.TaintEffectPreferNoSchedule},
 			},
 		},
+		{
+			f: "--t=dedicated-for=user1:NoExecute",
+			t: []api.Taint{{Key: "dedicated-for", Value: "user1", Effect: "NoExecute"}},
+		},
 	}
 
 	for i, c := range cases {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -1467,6 +1467,24 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			}
 			checkOutput(output, requiredStrings)
 
+			noExecuteTaint := v1.Taint{
+				Key:    testTaint.Key,
+				Value:  "testing-taint-value-no-execute",
+				Effect: v1.TaintEffectNoExecute,
+			}
+			By("adding NoExecute taint " + noExecuteTaint.ToString() + " to the node")
+			runKubectlRetryOrDie("taint", "nodes", nodeName, noExecuteTaint.ToString())
+			defer framework.RemoveTaintOffNode(f.ClientSet, nodeName, noExecuteTaint)
+
+			By("verifying the node has the taint " + noExecuteTaint.ToString())
+			output = runKubectlRetryOrDie("describe", "node", nodeName)
+			requiredStrings = [][]string{
+				{"Name:", nodeName},
+				{"Taints:"},
+				{noExecuteTaint.ToString()},
+			}
+			checkOutput(output, requiredStrings)
+
 			By("removing all taints that have the same key " + testTaint.Key + " of the node")
 			runKubectlRetryOrDie("taint", "nodes", nodeName, testTaint.Key+"-")
 			By("verifying the node doesn't have the taints that have the same key " + testTaint.Key)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Part of feature forgiveness implementation, make kubectl taint command respect effect NoExecute.

**Which issue this PR fixes**: 
Related Issue: #1574
Related PR: #39469

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
make kubectl taint command respect effect NoExecute
```
