### PR TITLE
[Federation][Kubefed] Cleanup objects on failure before exiting

### DIFF
--- a/federation/pkg/kubefed/BUILD
+++ b/federation/pkg/kubefed/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//federation/apis/federation:go_default_library",
         "//federation/pkg/kubefed/init:go_default_library",
         "//federation/pkg/kubefed/util:go_default_library",
+        "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd:go_default_library",
         "//pkg/kubectl/cmd/templates:go_default_library",

--- a/federation/pkg/kubefed/util/BUILD
+++ b/federation/pkg/kubefed/util/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/kubectl/cmd/util:go_default_library",
         "//vendor:github.com/spf13/cobra",
         "//vendor:github.com/spf13/pflag",
+        "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/client-go/tools/clientcmd",
         "//vendor:k8s.io/client-go/tools/clientcmd/api",

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -17,8 +17,9 @@ limitations under the License.
 package util
 
 import (
-	"github.com/spf13/pflag"
+	"net/url"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -29,6 +30,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 const (
@@ -143,4 +145,13 @@ func CreateKubeconfigSecret(clientset *client.Clientset, kubeconfig *clientcmdap
 		return clientset.Core().Secrets(namespace).Create(secret)
 	}
 	return secret, nil
+}
+
+// isNotFound checks if the given error is a NotFound status error.
+func IsNotFound(err error) bool {
+	statusErr := err
+	if urlErr, ok := err.(*url.Error); ok {
+		statusErr = urlErr.Err
+	}
+	return errors.IsNotFound(statusErr)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes item number 3 in https://github.com/kubernetes/kubernetes/issues/41725

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/41725

**Special notes for your reviewer**:
@madhusudancs @marun 

I would raise separate PRs for 2 and 4 but would wait for other PRs (which are in pipeline) to get merged.
2 and 4 are pretty simple to implement. I just dont want to do too many rebases, when those in pipeline get merged.

cc @perotinus 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
NONE
```
