### PR TITLE
Move push-federation-images.sh to federation and implement similar functionality in jenkins build directory for presubmits.

### DIFF
--- a/federation/develop/push-federation-images.sh
+++ b/federation/develop/push-federation-images.sh
@@ -20,7 +20,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 
 make -C "${KUBE_ROOT}/federation/" build_image
 make -C "${KUBE_ROOT}/federation/" push

--- a/hack/jenkins/build-federation.sh
+++ b/hack/jenkins/build-federation.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+make -C "${KUBE_ROOT}/federation/" build
+make -C "${KUBE_ROOT}/federation/" push


### PR DESCRIPTION
This is required for federation presubmit e2es.

```release-note
NONE
```
