### PR TITLE
fix VolumeSource value set by mountPath arg in ConstructVolumeSpec

### DIFF
--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -162,7 +162,7 @@ func (plugin *cephfsPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*
 		VolumeSource: v1.VolumeSource{
 			CephFS: &v1.CephFSVolumeSource{
 				Monitors: []string{},
-				Path:     volumeName,
+				Path:     mountPath,
 			},
 		},
 	}

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -191,7 +191,7 @@ func (plugin *glusterfsPlugin) ConstructVolumeSpec(volumeName, mountPath string)
 		VolumeSource: v1.VolumeSource{
 			Glusterfs: &v1.GlusterfsVolumeSource{
 				EndpointsName: volumeName,
-				Path:          volumeName,
+				Path:          mountPath,
 			},
 		},
 	}

--- a/pkg/volume/host_path/host_path.go
+++ b/pkg/volume/host_path/host_path.go
@@ -142,7 +142,7 @@ func (plugin *hostPathPlugin) ConstructVolumeSpec(volumeName, mountPath string) 
 		Name: volumeName,
 		VolumeSource: v1.VolumeSource{
 			HostPath: &v1.HostPathVolumeSource{
-				Path: volumeName,
+				Path: mountPath,
 			},
 		},
 	}

--- a/pkg/volume/nfs/nfs.go
+++ b/pkg/volume/nfs/nfs.go
@@ -158,7 +158,7 @@ func (plugin *nfsPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*vol
 		Name: volumeName,
 		VolumeSource: v1.VolumeSource{
 			NFS: &v1.NFSVolumeSource{
-				Path: volumeName,
+				Path: mountPath,
 			},
 		},
 	}


### PR DESCRIPTION
We should assign mountPath to Path in VolumeSource
More Infos as below:
https://kubernetes.io/docs/user-guide/volumes/#hostpath
http://kubernetes.io/docs/user-guide/volumes#nfs
http://releases.k8s.io/HEAD/examples/volumes/cephfs/README.md#how-to-use-it
http://releases.k8s.io/HEAD/examples/volumes/glusterfs/README.md#create-a-pod


**Release note**:

```release-note
NONE
```
