### PR TITLE
Should wrap the calculation of elapsed time

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -188,7 +188,9 @@ func (s *Scheduler) scheduleOne() {
 	}
 
 	go func() {
-		defer metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
+		defer func() {
+			metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start))
+		}()
 
 		b := &v1.Binding{
 			ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name},


### PR DESCRIPTION
This PR try to fix the wrong latency of `scheduleOne`. 

At https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/scheduler/scheduler.go#L191
```
	go func() {
		defer metrics.E2eSchedulingLatency.Observe(metrics.SinceInMicroseconds(start)) /** I think this code wants to get the total time of invoking `scheduleOne`**/

		b := &v1.Binding{
			ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name},
			Target: v1.ObjectReference{
				Kind: "Node",
				Name: dest,
			},
		}

		bindingStart := time.Now()
		// If binding succeeded then PodScheduled condition will be updated in apiserver so that
		// it's atomic with setting host.
		err := s.config.Binder.Bind(b)
		if err := s.config.SchedulerCache.FinishBinding(&assumed); err != nil {
			glog.Errorf("scheduler cache FinishBinding failed: %v", err)
		}
		if err != nil {
			glog.V(1).Infof("Failed to bind pod: %v/%v", pod.Namespace, pod.Name)
			if err := s.config.SchedulerCache.ForgetPod(&assumed); err != nil {
				glog.Errorf("scheduler cache ForgetPod failed: %v", err)
			}
			s.config.Error(pod, err)
			s.config.Recorder.Eventf(pod, v1.EventTypeNormal, "FailedScheduling", "Binding rejected: %v", err)
			s.config.PodConditionUpdater.Update(pod, &v1.PodCondition{
				Type:   v1.PodScheduled,
				Status: v1.ConditionFalse,
				Reason: "BindingRejected",
			})
			return
		}
		metrics.BindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))
		s.config.Recorder.Eventf(pod, v1.EventTypeNormal, "Scheduled", "Successfully assigned %v to %v", pod.Name, dest)
	}()
```
It seems that the keyword `defer` has tried to pre-calculate the parameters. So the reported latency was wrong.  
Here is an example:
```
package main

import (
	"fmt"
	"sync"
	"time"
)

var (
	wg = sync.WaitGroup{}
)

func elapsed(t time.Time) float64 {
	return time.Since(t).Seconds()
}

func report(pass float64, msg string) {
	fmt.Printf("%s duration: %e\n", msg, pass)
}

func test() {
	startWithoutFix := time.Now()

	wg.Add(2)

	// Without fix
	go func() {
		defer report(elapsed(startWithoutFix), "Without fix")
		time.Sleep(time.Second * 5)
		wg.Done()
	}()

	// With fix
	startWithFix := time.Now()
	go func() {
		defer func() {
			report(elapsed(startWithFix), "With fix")
		}()

		time.Sleep(time.Second * 5)
		wg.Done()
	}()
}

func main() {
	test()
	wg.Wait()
}

# go run test.go
With fix duration: 5.000262e+00
Without fix duration: 3.062900e-05
```
Signed-off-by: thomassong <thomassong@tencent.com>
