### PR TITLE
fix kubectl describe pod, show tolerationSeconds

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -2893,6 +2893,9 @@ func printTolerationsMultilineWithIndent(w *PrefixWriter, initialIndent, title, 
 				if len(toleration.Effect) != 0 {
 					w.Write(LEVEL_0, ":%s", toleration.Effect)
 				}
+				if toleration.TolerationSeconds != nil {
+					w.Write(LEVEL_0, " for %ds", *toleration.TolerationSeconds)
+				}
 				w.Write(LEVEL_0, "\n")
 				i++
 			}

--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -78,7 +78,7 @@ func TestDescribePodTolerations(t *testing.T) {
 		Spec: api.PodSpec{
 			Tolerations: []api.Toleration{
 				{Key: "key1", Value: "value1"},
-				{Key: "key2", Value: "value2"},
+				{Key: "key2", Value: "value2", Effect: api.TaintEffectNoExecute, TolerationSeconds: &[]int64{300}[0]},
 			},
 		},
 	})
@@ -88,7 +88,7 @@ func TestDescribePodTolerations(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if !strings.Contains(out, "key1=value1") || !strings.Contains(out, "key2=value2") || !strings.Contains(out, "Tolerations:") {
+	if !strings.Contains(out, "key1=value1") || !strings.Contains(out, "key2=value2:NoExecute for 300s") || !strings.Contains(out, "Tolerations:") {
 		t.Errorf("unexpected out: %s", out)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
tolerationSeconds is now not shown in kubectl describe resutl, this PR is to fix it.

With this fix, pod toleration with tolerationSeconds would like below:
```yaml
Name:           bar
Namespace:      foo
Node:           /
Labels:         <none>
Status:
IP:
Controllers:    <none>
Containers:     <none>
No volumes.
QoS Class:
Node-Selectors: <none>
Tolerations:    key1=value1
				key2=value2:NoSchedule
				key3=value3:NoExecute for 300s
```


**Which issue this PR fixes** : 
Related issue: #1574
Related PR: #39469

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
make kubectl describe pod show tolerationSeconds
```
