### PR TITLE
Change the default pull policy to Always.

### DIFF
--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -110,12 +110,16 @@ func SetDefaults_ContainerPort(obj *ContainerPort) {
 func SetDefaults_Container(obj *Container) {
 	if obj.ImagePullPolicy == "" {
 		// Ignore error and assume it has been validated elsewhere
-		_, tag, _, _ := parsers.ParseImageName(obj.Image)
+		_, _, digest, _ := parsers.ParseImageName(obj.Image)
 
-		// Check image tag
-		if tag == "latest" {
+		if digest == "" {
+			// If we aren't pulling by digest, then our reference to the
+			// image is mutable and must be revalidated in case it has changed.
 			obj.ImagePullPolicy = PullAlways
 		} else {
+			// For digest-based pulls, if we already have the digest, then it is impossible
+			// for a registry to give us anything difference from what we have based on the
+			// cryptographic guarantees of content addressing.
 			obj.ImagePullPolicy = PullIfNotPresent
 		}
 	}


### PR DESCRIPTION
This changes the default pull policy to Always, unless the image reference is a
digest (e.g. gcr.io/foo/bar@sha256:deadbeef), in which case it cannot change
without failing image verification.

The reason for this change is that the current default is tantamount to bad
caching, and often leads to user confusion because it relies on outdated best
practice (using immutable labels).

When users update an existing tag (e.g. gcr.io/foo/bar:prod) and issue an update
the current default would result in some subset of nodes (in practice very few)
getting the update because many nodes would have the prior image in their local
daemon's cache.  This can also result in inconsistencies during auto-scaling and
auto-healing for similar reasons.

This change shouldn't be particularly contentious because either:
 - A user has drunk the immutable-label Kool-aid and pulls now have a no-op tag
  verification before they are run.  For the extremely performance conscious and
  those running in airlocked environments with the images pre-pulled, you can still
  opt into IfNotPresent to elide this check.

 - A user has not drunk the immutable-label Kool-aid and expects new pulls to get
 new images.  This is the class of usage that is often burned by today's default
 policy.

It is notable that the mutability of tags can lead to all of the same
inconsistency problems as listed above for IfNotPresent, if used improperly.
The only sure way to avoid these inconsistencies is the new best practice:
deploy by digest.

To include some history...  V1 of the Docker Registry specification didn't have
any way to reference images by anything except a tag.  The "best practice" of
using immutable tags was born from this limitation.  However, in V2 of the
Docker Registry specification and in Docker clients 1.6+ the concept of pulling
by digest was introduced.

Digest references provide cryptographic guarantees of consistency across
deployments, as well as auto-scaling and auto-healing events.  They also needn't
be pulled if they are available.

The ultimate balance here is using tags for development and even referencing
tags from the yaml templates used to stamp out deployment, but having a single
point of resolution after which what Nodes get is a digest reference.  For this
panacea see: https://github.com/kubernetes/kubernetes/issues/1697

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
