### PR TITLE
test: move deployment e2e test out of the flaky suite

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -95,8 +95,7 @@ var _ = framework.KubeDescribe("Deployment", func() {
 	It("overlapping deployment should not fight with each other", func() {
 		testOverlappingDeployment(f)
 	})
-	// Flaky issue #39785.
-	It("lack of progress should be reported in the deployment status [Flaky]", func() {
+	It("lack of progress should be reported in the deployment status", func() {
 		testFailedDeployment(f)
 	})
 	It("iterative rollouts should eventually progress", func() {


### PR DESCRIPTION
Moves the deployment test that was marked as flaky in https://github.com/kubernetes/kubernetes/pull/41257 out of the flaky suite.

Haven't seen this flake for some time now:
https://k8s-testgrid.appspot.com/google-gce#gci-gce-flaky
https://k8s-testgrid.appspot.com/google-gce#gce-flaky

Also https://github.com/kubernetes/kubernetes/pull/41510 is merged.

Closes https://github.com/kubernetes/kubernetes/issues/39785 

@spxtr @janetkuo 