### PR TITLE
Change an Errorf to a Fatalf to prevent a panic.

### DIFF
--- a/pkg/registry/core/service/rest_test.go
+++ b/pkg/registry/core/service/rest_test.go
@@ -1012,7 +1012,7 @@ func TestServiceRegistryExternalTrafficBetaAnnotationHealthCheckNodePortUserAllo
 	}
 	created_svc, err := storage.Create(ctx, svc)
 	if created_svc == nil || err != nil {
-		t.Errorf("Unexpected failure creating service %v", err)
+		t.Fatalf("Unexpected failure creating service: %v", err)
 	}
 	created_service := created_svc.(*api.Service)
 	if !service.NeedsHealthCheck(created_service) {


### PR DESCRIPTION
In #37982 we see that if this error is hit then we will panic on the next line. Lets use `Fatalf` where appropriate :)

This does *not* fix the flake, since that's caused by the test assuming that a particular port is free.