### PR TITLE
Fix bool parse warning in apimachinery

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/converter.go
@@ -82,6 +82,9 @@ var (
 )
 
 func parseBool(key string) bool {
+	if len(key) == 0 {
+		return false
+	}
 	value, err := strconv.ParseBool(key)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("Couldn't parse '%s' as bool for unstructured mismatch detection", key))


### PR DESCRIPTION
```golang
var DefaultConverter = NewConverter(parseBool(os.Getenv("KUBE_PATCH_CONVERSION_DETECTOR")))
func parseBool(key string) bool {
	value, err := strconv.ParseBool(key)
	if err != nil {
		utilruntime.HandleError(fmt.Errorf("Couldn't parse '%s' as bool for unstructured mismatch detection", key))
	}
	return value
}
````

leading to

```
W0227 10:06:01.037] E0227 10:06:01.023502   16550 converter.go:87] Couldn't parse '' as bool for unstructured mismatch detection
```