### PR TITLE
Restore wait for etcd in rbac initialization

### DIFF
--- a/pkg/registry/rbac/rest/BUILD
+++ b/pkg/registry/rbac/rest/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//pkg/registry/rbac/validation:go_default_library",
         "//plugin/pkg/auth/authorizer/rbac/bootstrappolicy:go_default_library",
         "//vendor:github.com/golang/glog",
+        "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apimachinery/pkg/util/runtime",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -131,7 +132,16 @@ func PostStartHook(hookContext genericapiserver.PostStartHookContext) error {
 	err := wait.Poll(1*time.Second, 30*time.Second, func() (done bool, err error) {
 		clientset, err := rbacclient.NewForConfig(hookContext.LoopbackClientConfig)
 		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("unable to initialize client: %v", err))
+			return false, nil
+		}
+		// Make sure etcd is responding before we start reconciling
+		if _, err := clientset.ClusterRoles().List(metav1.ListOptions{}); err != nil {
 			utilruntime.HandleError(fmt.Errorf("unable to initialize clusterroles: %v", err))
+			return false, nil
+		}
+		if _, err := clientset.ClusterRoleBindings().List(metav1.ListOptions{}); err != nil {
+			utilruntime.HandleError(fmt.Errorf("unable to initialize clusterrolebindings: %v", err))
 			return false, nil
 		}
 


### PR DESCRIPTION
Wait for etcd was accidentally removed in https://github.com/kubernetes/kubernetes/commit/26b42d350d8071bf84840023065bc600ac9ad273#diff-efb2aa0040291a41fcf922efc886ea13L136

Related to https://github.com/kubernetes/kubernetes/issues/37704 and https://github.com/kubernetes/kubernetes/pull/39821