### PR TITLE
Make 'docker-email' optional on dockercfg secrets

### DIFF
--- a/pkg/kubectl/cmd/create_secret.go
+++ b/pkg/kubectl/cmd/create_secret.go
@@ -126,7 +126,7 @@ var (
 		    $ docker login DOCKER_REGISTRY_SERVER --username=DOCKER_USER --password=DOCKER_PASSWORD --email=DOCKER_EMAIL'.
 
     That produces a ~/.dockercfg file that is used by subsequent 'docker push' and 'docker pull' commands to
-		authenticate to the registry.
+		authenticate to the registry. The email address is optional.
 
 		When creating applications, you may have a Docker registry that requires authentication.  In order for the
 		nodes to pull images on your behalf, they have to have the credentials.  You can provide this information
@@ -158,7 +158,6 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, cmdOut io.Writer) *cobr
 	cmd.Flags().String("docker-password", "", i18n.T("Password for Docker registry authentication"))
 	cmd.MarkFlagRequired("docker-password")
 	cmd.Flags().String("docker-email", "", i18n.T("Email for Docker registry"))
-	cmd.MarkFlagRequired("docker-email")
 	cmd.Flags().String("docker-server", "https://index.docker.io/v1/", i18n.T("Server location for Docker registry"))
 	cmdutil.AddInclude3rdPartyFlags(cmd)
 	return cmd

--- a/pkg/kubectl/secret_for_docker_registry.go
+++ b/pkg/kubectl/secret_for_docker_registry.go
@@ -31,7 +31,7 @@ type SecretForDockerRegistryGeneratorV1 struct {
 	Name string
 	// Username for registry (required)
 	Username string
-	// Email for registry (required)
+	// Email for registry (optional)
 	Email string
 	// Password for registry (required)
 	Password string
@@ -91,7 +91,7 @@ func (s SecretForDockerRegistryGeneratorV1) ParamNames() []GeneratorParam {
 	return []GeneratorParam{
 		{"name", true},
 		{"docker-username", true},
-		{"docker-email", true},
+		{"docker-email", false},
 		{"docker-password", true},
 		{"docker-server", true},
 	}
@@ -104,9 +104,6 @@ func (s SecretForDockerRegistryGeneratorV1) validate() error {
 	}
 	if len(s.Username) == 0 {
 		return fmt.Errorf("username must be specified")
-	}
-	if len(s.Email) == 0 {
-		return fmt.Errorf("email must be specified")
 	}
 	if len(s.Password) == 0 {
 		return fmt.Errorf("password must be specified")

--- a/pkg/kubectl/secret_for_docker_registry_test.go
+++ b/pkg/kubectl/secret_for_docker_registry_test.go
@@ -30,6 +30,10 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
+	secretDataNoEmail, err := handleDockercfgContent(username, password, "", server)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	tests := map[string]struct {
 		params    map[string]interface{}
@@ -50,6 +54,24 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					api.DockerConfigKey: secretData,
+				},
+				Type: api.SecretTypeDockercfg,
+			},
+			expectErr: false,
+		},
+		"test-valid-use-no-email": {
+			params: map[string]interface{}{
+				"name":            "foo",
+				"docker-server":   server,
+				"docker-username": username,
+				"docker-password": password,
+			},
+			expected: &api.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Data: map[string][]byte{
+					api.DockerConfigKey: secretDataNoEmail,
 				},
 				Type: api.SecretTypeDockercfg,
 			},


### PR DESCRIPTION
It is not required for most username/password registries.

Fixes #41727