### PR TITLE
Use `docker logs` directly if the docker logging driver is not `json-file`

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -18,6 +18,7 @@ package dockershim
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"time"
 
@@ -415,4 +416,47 @@ func toAPIProtocol(protocol Protocol) v1.Protocol {
 	}
 	glog.Warningf("Unknown protocol %q: defaulting to TCP", protocol)
 	return v1.ProtocolTCP
+}
+
+// DockerLegacyService interface embeds some legacy methods for backward compatibility.
+type DockerLegacyService interface {
+	// GetContainerLogs gets logs for a specific container.
+	GetContainerLogs(*v1.Pod, kubecontainer.ContainerID, *v1.PodLogOptions, io.Writer, io.Writer) error
+}
+
+// dockerLegacyService implements the DockerLegacyService. We add this for non json-log driver
+// support. (See #41996)
+type dockerLegacyService struct {
+	client dockertools.DockerInterface
+}
+
+func NewDockerLegacyService(client dockertools.DockerInterface) DockerLegacyService {
+	return &dockerLegacyService{client: client}
+}
+
+// GetContainerLogs get container logs directly from docker daemon.
+func (d *dockerLegacyService) GetContainerLogs(pod *v1.Pod, containerID kubecontainer.ContainerID, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error {
+	container, err := d.client.InspectContainer(containerID.ID)
+	if err != nil {
+		return err
+	}
+	return dockertools.GetContainerLogs(d.client, pod, containerID, logOptions, stdout, stderr, container.Config.Tty)
+}
+
+// criSupportedLogDrivers are log drivers supported by native CRI integration.
+var criSupportedLogDrivers = []string{"json-file"}
+
+// IsCRISupportedLogDriver checks whether the logging driver used by docker is
+// suppoted by native CRI integration.
+func IsCRISupportedLogDriver(client dockertools.DockerInterface) (bool, error) {
+	info, err := client.Info()
+	if err != nil {
+		return false, fmt.Errorf("failed to get docker info: %v", err)
+	}
+	for _, driver := range criSupportedLogDrivers {
+		if info.LoggingDriver == driver {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1022,6 +1022,12 @@ func (kl *Kubelet) GetKubeletContainerLogs(podFullName, containerName string, lo
 		return err
 	}
 
+	if kl.dockerLegacyService != nil {
+		// dockerLegacyService should only be non-nil when we actually need it, so
+		// inject it into the runtimeService.
+		// TODO(random-liu): Remove this hack after deprecating unsupported log driver.
+		return kl.dockerLegacyService.GetContainerLogs(pod, containerID, logOptions, stdout, stderr)
+	}
 	return kl.containerRuntime.GetContainerLogs(pod, containerID, logOptions, stdout, stderr)
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/41996.

Post the PR first, I still need to manually test this, because we don't have test coverage for journald logging pluggin.

@yujuhong @dchen1107 
/cc @kubernetes/sig-node-pr-reviews 