### PR TITLE
controller: drop redundant requeues from rc/rs controllers

### DIFF
--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -445,7 +445,7 @@ func (rsc *ReplicaSetController) processNextWorkItem() bool {
 		return true
 	}
 
-	utilruntime.HandleError(fmt.Errorf("Sync %q failed with %v", key, err))
+	utilruntime.HandleError(fmt.Errorf("sync %q failed: %v", key, err))
 	rsc.queue.AddRateLimited(key)
 
 	return true
@@ -595,9 +595,6 @@ func (rsc *ReplicaSetController) syncReplicaSet(key string) error {
 	cm := controller.NewPodControllerRefManager(rsc.podControl, rs, selector, getRSKind())
 	filteredPods, err = cm.ClaimPods(pods)
 	if err != nil {
-		// Something went wrong with adoption or release.
-		// Requeue and try again so we don't leave orphans sitting around.
-		rsc.queue.Add(key)
 		return err
 	}
 

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -423,29 +423,27 @@ func (rm *ReplicationManager) enqueueControllerAfter(obj interface{}, after time
 // worker runs a worker thread that just dequeues items, processes them, and marks them done.
 // It enforces that the syncHandler is never invoked concurrently with the same key.
 func (rm *ReplicationManager) worker() {
-	workFunc := func() bool {
-		key, quit := rm.queue.Get()
-		if quit {
-			return true
-		}
-		defer rm.queue.Done(key)
+	for rm.processNextWorkItem() {
+	}
+}
 
-		err := rm.syncHandler(key.(string))
-		if err == nil {
-			rm.queue.Forget(key)
-			return false
-		}
-
-		rm.queue.AddRateLimited(key)
-		utilruntime.HandleError(err)
+func (rm *ReplicationManager) processNextWorkItem() bool {
+	key, quit := rm.queue.Get()
+	if quit {
 		return false
 	}
-	for {
-		if quit := workFunc(); quit {
-			glog.Infof("replication controller worker shutting down")
-			return
-		}
+	defer rm.queue.Done(key)
+
+	err := rm.syncHandler(key.(string))
+	if err == nil {
+		rm.queue.Forget(key)
+		return true
 	}
+
+	utilruntime.HandleError(fmt.Errorf("sync %q failed: %v", key, err))
+	rm.queue.AddRateLimited(key)
+
+	return true
 }
 
 // manageReplicas checks and updates replicas for the given replication controller.
@@ -605,16 +603,11 @@ func (rm *ReplicationManager) syncReplicationController(key string) error {
 	// anymore but has the stale controller ref.
 	pods, err := rm.podLister.Pods(rc.Namespace).List(labels.Everything())
 	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Error getting pods for rc %q: %v", key, err))
-		rm.queue.Add(key)
 		return err
 	}
 	cm := controller.NewPodControllerRefManager(rm.podControl, rc, labels.Set(rc.Spec.Selector).AsSelectorPreValidated(), getRCKind())
 	filteredPods, err = cm.ClaimPods(pods)
 	if err != nil {
-		// Something went wrong with adoption or release.
-		// Requeue and try again so we don't leave orphans sitting around.
-		rm.queue.Add(key)
 		return err
 	}
 


### PR DESCRIPTION
The rc/rs controllers already enqueue a rc/rs in case of a failure with a rate limit.
https://github.com/kubernetes/kubernetes/blob/6d9e2afedab933641833e9614bde362416072183/pkg/controller/replicaset/replica_set.go#L449
https://github.com/kubernetes/kubernetes/blob/6d9e2afedab933641833e9614bde362416072183/pkg/controller/replication/replication_controller.go#L439

@kubernetes/sig-apps-misc 