### PR TITLE
Update defaultbackend image to 1.3

### DIFF
--- a/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
+++ b/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
@@ -23,7 +23,7 @@ spec:
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: gcr.io/google_containers/defaultbackend:1.3
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
Update `gcr.io/google-containers/defaultbackend` to the latest version.

See https://github.com/kubernetes/contrib/pull/2386

/cc @ixdy 