### PR TITLE
Don't filter items when resources requested by name

### DIFF
--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -41,13 +41,27 @@ type Result struct {
 	err     error
 	visitor Visitor
 
-	sources           []Visitor
-	singleItemImplied bool
+	sources            []Visitor
+	singleItemImplied  bool
+	targetsSingleItems bool
 
 	ignoreErrors []utilerrors.Matcher
 
 	// populated by a call to Infos
 	info []*Info
+}
+
+// withError allows a fluent style for internal result code.
+func (r *Result) withError(err error) *Result {
+	r.err = err
+	return r
+}
+
+// TargetsSingleItems returns true if any of the builder arguments pointed
+// to non-list calls (if the user explicitly asked for any object by name).
+// This includes directories, streams, URLs, and resource name tuples.
+func (r *Result) TargetsSingleItems() bool {
+	return r.targetsSingleItems
 }
 
 // IgnoreErrors will filter errors that occur when by visiting the result


### PR DESCRIPTION
Add tracking on resource.Builder if a "named" item is requested (from
file, stream, url, or resource args) and use that in `get` to accurately
determine whether to filter resources. Add tests.

Fixes #41150, #40492

```release-note
Completed pods should not be hidden when requested by name via `kubectl get`.
```