### PR TITLE
fix LeaderTransitions always zero

### DIFF
--- a/pkg/client/leaderelection/leaderelection.go
+++ b/pkg/client/leaderelection/leaderelection.go
@@ -253,6 +253,7 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 	// here. Let's correct it before updating.
 	if oldLeaderElectionRecord.HolderIdentity == le.config.Lock.Identity() {
 		leaderElectionRecord.AcquireTime = oldLeaderElectionRecord.AcquireTime
+		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions
 	} else {
 		leaderElectionRecord.LeaderTransitions = oldLeaderElectionRecord.LeaderTransitions + 1
 	}


### PR DESCRIPTION
on leader transition, LeaderTransitions is increased to 1, but
then cleared to zero by next renew.

External monitoring system may watch LeaderTransitions and rely
on it's facticity.
