### PR TITLE
sort token usages in kubeadm

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -287,6 +288,7 @@ func RunListTokens(out io.Writer, errW io.Writer, client *clientset.Clientset) e
 			}
 			usages = append(usages, strings.TrimPrefix(k, bootstrapapi.BootstrapTokenUsagePrefix))
 		}
+		sort.Strings(usages)
 		usageString := strings.Join(usages, ",")
 		if len(usageString) == 0 {
 			usageString = "<none>"


### PR DESCRIPTION
```
kubeadm token list
TOKEN                     TTL         EXPIRES   USAGES                   DESCRIPTION
0f97a4.2230bb81a54f470f   <forever>   <never>   authentication,signing   <none>
1ee905.3ffae0f3e189ebf3   <forever>   <never>   signing,authentication   <none>
2fc984.66a220428aed0794   <forever>   <never>   authentication,signing   <none>
6b8f54.11d2bc3cec1c2b40   <forever>   <never>   signing,authentication   <none>
81a8f9.c3fa30dd1ed05d96   <forever>   <never>   authentication,signing   The default bootstrap token generated by 'kubeadm init'.
b04eec.2b2337a87558d3f7   <forever>   <never>   signing,authentication   <none>
b186e5.7a19ae1a82652643   <forever>   <never>   authentication,signing   <none>
```