### PR TITLE
volumes: add comment on getNodeAndVolume

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -380,6 +380,13 @@ func (asw *actualStateOfWorld) SetDetachRequestTime(
 
 // Get the volume and node object from actual state of world
 // This is an internal function and caller should acquire and release the lock
+//
+// Note that this returns disconnected objects, so if you change the volume object you must set it back with
+// `asw.attachedVolumes[volumeName]=volumeObj`.
+//
+// If you change the node object you must use `volumeObj.nodesAttachedTo[nodeName] = nodeObj`
+// This is correct, because if volumeObj is empty this function returns an error, and nodesAttachedTo
+// map is a reference type, and thus mutating the copy changes the original map.
 func (asw *actualStateOfWorld) getNodeAndVolume(
 	volumeName v1.UniqueVolumeName, nodeName types.NodeName) (attachedVolume, nodeAttachedTo, error) {
 


### PR DESCRIPTION
Add comments on getNodeAndVolume to explain the code - it is a little
subtle, and it confused me on first reading.

Part of #40583

```release-note
NONE
```
