### PR TITLE
Fix panic on nil invalid field error

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -50,7 +50,10 @@ func (v *Error) ErrorBody() string {
 		s = fmt.Sprintf("%s", v.Type)
 	default:
 		value := v.BadValue
-		if reflect.TypeOf(value).Kind() == reflect.Ptr {
+		valueType := reflect.TypeOf(value)
+		if value == nil || valueType == nil {
+			value = "null"
+		} else if valueType.Kind() == reflect.Ptr {
 			if reflectValue := reflect.ValueOf(value); reflectValue.IsNil() {
 				value = "null"
 			} else {

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors_test.go
@@ -62,6 +62,14 @@ func TestMakeFuncs(t *testing.T) {
 }
 
 func TestErrorUsefulMessage(t *testing.T) {
+	{
+		s := Invalid(nil, nil, "").Error()
+		t.Logf("message: %v", s)
+		if !strings.Contains(s, "null") {
+			t.Errorf("error message did not contain 'null': %s", s)
+		}
+	}
+
 	s := Invalid(NewPath("foo"), "bar", "deet").Error()
 	t.Logf("message: %v", s)
 	for _, part := range []string{"foo", "bar", "deet", ErrorTypeInvalid.String()} {


### PR DESCRIPTION
bug fix for validation panic

if a field.Invalid is constructed with a nil badvalue, the Error() method panics, since reflect.TypeOf() returns nil