### PR TITLE
Add RBAC roles for bootstrap controllers

### DIFF
--- a/pkg/apis/rbac/helpers.go
+++ b/pkg/apis/rbac/helpers.go
@@ -282,6 +282,22 @@ func NewRoleBinding(roleName, namespace string) *RoleBindingBuilder {
 	}
 }
 
+func NewRoleBindingForClusterRole(roleName, namespace string) *RoleBindingBuilder {
+	return &RoleBindingBuilder{
+		RoleBinding: RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      roleName,
+				Namespace: namespace,
+			},
+			RoleRef: RoleRef{
+				APIGroup: GroupName,
+				Kind:     "ClusterRole",
+				Name:     roleName,
+			},
+		},
+	}
+}
+
 // Groups adds the specified groups as the subjects of the RoleBinding.
 func (r *RoleBindingBuilder) Groups(groups ...string) *RoleBindingBuilder {
 	for _, group := range groups {

--- a/pkg/registry/rbac/reconciliation/BUILD
+++ b/pkg/registry/rbac/reconciliation/BUILD
@@ -11,8 +11,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
-        "reconcile_clusterrolebindings_test.go",
         "reconcile_role_test.go",
+        "reconcile_rolebindings_test.go",
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
@@ -26,9 +26,12 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
-        "reconcile_clusterrolebindings.go",
+        "clusterrole_interfaces.go",
+        "clusterrolebinding_interfaces.go",
         "reconcile_role.go",
+        "reconcile_rolebindings.go",
         "role_interfaces.go",
+        "rolebinding_interfaces.go",
     ],
     tags = ["automanaged"],
     deps = [
@@ -38,6 +41,7 @@ go_library(
         "//pkg/registry/rbac/validation:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/apimachinery/pkg/types",
     ],
 )
 

--- a/pkg/registry/rbac/reconciliation/clusterrole_interfaces.go
+++ b/pkg/registry/rbac/reconciliation/clusterrole_interfaces.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciliation
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
+)
+
+type ClusterRoleRuleOwner struct {
+	ClusterRole *rbac.ClusterRole
+}
+
+func (o ClusterRoleRuleOwner) GetNamespace() string {
+	return o.ClusterRole.Namespace
+}
+
+func (o ClusterRoleRuleOwner) GetName() string {
+	return o.ClusterRole.Name
+}
+
+func (o ClusterRoleRuleOwner) GetLabels() map[string]string {
+	return o.ClusterRole.Labels
+}
+
+func (o ClusterRoleRuleOwner) SetLabels(in map[string]string) {
+	o.ClusterRole.Labels = in
+}
+
+func (o ClusterRoleRuleOwner) GetAnnotations() map[string]string {
+	return o.ClusterRole.Annotations
+}
+
+func (o ClusterRoleRuleOwner) SetAnnotations(in map[string]string) {
+	o.ClusterRole.Annotations = in
+}
+
+func (o ClusterRoleRuleOwner) GetRules() []rbac.PolicyRule {
+	return o.ClusterRole.Rules
+}
+
+func (o ClusterRoleRuleOwner) SetRules(in []rbac.PolicyRule) {
+	o.ClusterRole.Rules = in
+}
+
+type ClusterRoleModifier struct {
+	Client internalversion.ClusterRoleInterface
+}
+
+func (c ClusterRoleModifier) Get(namespace, name string) (RuleOwner, error) {
+	ret, err := c.Client.Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return ClusterRoleRuleOwner{ClusterRole: ret}, err
+}
+
+func (c ClusterRoleModifier) Create(in RuleOwner) (RuleOwner, error) {
+	ret, err := c.Client.Create(in.(ClusterRoleRuleOwner).ClusterRole)
+	if err != nil {
+		return nil, err
+	}
+	return ClusterRoleRuleOwner{ClusterRole: ret}, err
+}
+
+func (c ClusterRoleModifier) Update(in RuleOwner) (RuleOwner, error) {
+	ret, err := c.Client.Update(in.(ClusterRoleRuleOwner).ClusterRole)
+	if err != nil {
+		return nil, err
+	}
+	return ClusterRoleRuleOwner{ClusterRole: ret}, err
+
+}

--- a/pkg/registry/rbac/reconciliation/clusterrolebinding_interfaces.go
+++ b/pkg/registry/rbac/reconciliation/clusterrolebinding_interfaces.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciliation
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
+)
+
+type ClusterRoleBindingAdapter struct {
+	ClusterRoleBinding *rbac.ClusterRoleBinding
+}
+
+func (o ClusterRoleBindingAdapter) GetNamespace() string {
+	return o.ClusterRoleBinding.Namespace
+}
+
+func (o ClusterRoleBindingAdapter) GetName() string {
+	return o.ClusterRoleBinding.Name
+}
+
+func (o ClusterRoleBindingAdapter) GetUID() types.UID {
+	return o.ClusterRoleBinding.UID
+}
+
+func (o ClusterRoleBindingAdapter) GetLabels() map[string]string {
+	return o.ClusterRoleBinding.Labels
+}
+
+func (o ClusterRoleBindingAdapter) SetLabels(in map[string]string) {
+	o.ClusterRoleBinding.Labels = in
+}
+
+func (o ClusterRoleBindingAdapter) GetAnnotations() map[string]string {
+	return o.ClusterRoleBinding.Annotations
+}
+
+func (o ClusterRoleBindingAdapter) SetAnnotations(in map[string]string) {
+	o.ClusterRoleBinding.Annotations = in
+}
+
+func (o ClusterRoleBindingAdapter) GetRoleRef() rbac.RoleRef {
+	return o.ClusterRoleBinding.RoleRef
+}
+
+func (o ClusterRoleBindingAdapter) GetSubjects() []rbac.Subject {
+	return o.ClusterRoleBinding.Subjects
+}
+
+func (o ClusterRoleBindingAdapter) SetSubjects(in []rbac.Subject) {
+	o.ClusterRoleBinding.Subjects = in
+}
+
+type ClusterRoleBindingClientAdapter struct {
+	Client internalversion.ClusterRoleBindingInterface
+}
+
+func (c ClusterRoleBindingClientAdapter) Get(namespace, name string) (RoleBinding, error) {
+	ret, err := c.Client.Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return ClusterRoleBindingAdapter{ClusterRoleBinding: ret}, err
+}
+
+func (c ClusterRoleBindingClientAdapter) Create(in RoleBinding) (RoleBinding, error) {
+	ret, err := c.Client.Create(in.(ClusterRoleBindingAdapter).ClusterRoleBinding)
+	if err != nil {
+		return nil, err
+	}
+	return ClusterRoleBindingAdapter{ClusterRoleBinding: ret}, err
+}
+
+func (c ClusterRoleBindingClientAdapter) Update(in RoleBinding) (RoleBinding, error) {
+	ret, err := c.Client.Update(in.(ClusterRoleBindingAdapter).ClusterRoleBinding)
+	if err != nil {
+		return nil, err
+	}
+	return ClusterRoleBindingAdapter{ClusterRoleBinding: ret}, err
+
+}
+
+func (c ClusterRoleBindingClientAdapter) Delete(namespace, name string, uid types.UID) error {
+	return c.Client.Delete(name, &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}})
+}

--- a/pkg/registry/rbac/reconciliation/reconcile_rolebindings_test.go
+++ b/pkg/registry/rbac/reconciliation/reconcile_rolebindings_test.go
@@ -161,13 +161,15 @@ func TestComputeUpdate(t *testing.T) {
 	}
 
 	for k, tc := range tests {
-		result, err := computeReconciledRoleBinding(tc.ActualBinding, tc.ExpectedBinding, tc.RemoveExtraSubjects)
+		actualRoleBinding := ClusterRoleBindingAdapter{ClusterRoleBinding: tc.ActualBinding}
+		expectedRoleBinding := ClusterRoleBindingAdapter{ClusterRoleBinding: tc.ExpectedBinding}
+		result, err := computeReconciledRoleBinding(actualRoleBinding, expectedRoleBinding, tc.RemoveExtraSubjects)
 		if err != nil {
 			t.Errorf("%s: %v", k, err)
 			continue
 		}
 		updateNeeded := result.Operation != ReconcileNone
-		updatedBinding := result.RoleBinding
+		updatedBinding := result.RoleBinding.(ClusterRoleBindingAdapter).ClusterRoleBinding
 		if updateNeeded != tc.ExpectedUpdateNeeded {
 			t.Errorf("%s: Expected\n\t%v\ngot\n\t%v (%v)", k, tc.ExpectedUpdateNeeded, updateNeeded, result.Operation)
 			continue

--- a/pkg/registry/rbac/reconciliation/role_interfaces.go
+++ b/pkg/registry/rbac/reconciliation/role_interfaces.go
@@ -79,7 +79,7 @@ func (c RoleModifier) Create(in RuleOwner) (RuleOwner, error) {
 }
 
 func (c RoleModifier) Update(in RuleOwner) (RuleOwner, error) {
-	ret, err := c.Client.Roles(in.GetNamespace()).Create(in.(RoleRuleOwner).Role)
+	ret, err := c.Client.Roles(in.GetNamespace()).Update(in.(RoleRuleOwner).Role)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/rbac/reconciliation/rolebinding_interfaces.go
+++ b/pkg/registry/rbac/reconciliation/rolebinding_interfaces.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciliation
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
+)
+
+type RoleBindingAdapter struct {
+	RoleBinding *rbac.RoleBinding
+}
+
+func (o RoleBindingAdapter) GetNamespace() string {
+	return o.RoleBinding.Namespace
+}
+
+func (o RoleBindingAdapter) GetName() string {
+	return o.RoleBinding.Name
+}
+
+func (o RoleBindingAdapter) GetUID() types.UID {
+	return o.RoleBinding.UID
+}
+
+func (o RoleBindingAdapter) GetLabels() map[string]string {
+	return o.RoleBinding.Labels
+}
+
+func (o RoleBindingAdapter) SetLabels(in map[string]string) {
+	o.RoleBinding.Labels = in
+}
+
+func (o RoleBindingAdapter) GetAnnotations() map[string]string {
+	return o.RoleBinding.Annotations
+}
+
+func (o RoleBindingAdapter) SetAnnotations(in map[string]string) {
+	o.RoleBinding.Annotations = in
+}
+
+func (o RoleBindingAdapter) GetRoleRef() rbac.RoleRef {
+	return o.RoleBinding.RoleRef
+}
+
+func (o RoleBindingAdapter) GetSubjects() []rbac.Subject {
+	return o.RoleBinding.Subjects
+}
+
+func (o RoleBindingAdapter) SetSubjects(in []rbac.Subject) {
+	o.RoleBinding.Subjects = in
+}
+
+type RoleBindingClientAdapter struct {
+	Client internalversion.RoleBindingsGetter
+}
+
+func (c RoleBindingClientAdapter) Get(namespace, name string) (RoleBinding, error) {
+	ret, err := c.Client.RoleBindings(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return RoleBindingAdapter{RoleBinding: ret}, err
+}
+
+func (c RoleBindingClientAdapter) Create(in RoleBinding) (RoleBinding, error) {
+	ret, err := c.Client.RoleBindings(in.GetNamespace()).Create(in.(RoleBindingAdapter).RoleBinding)
+	if err != nil {
+		return nil, err
+	}
+	return RoleBindingAdapter{RoleBinding: ret}, err
+}
+
+func (c RoleBindingClientAdapter) Update(in RoleBinding) (RoleBinding, error) {
+	ret, err := c.Client.RoleBindings(in.GetNamespace()).Update(in.(RoleBindingAdapter).RoleBinding)
+	if err != nil {
+		return nil, err
+	}
+	return RoleBindingAdapter{RoleBinding: ret}, err
+
+}
+
+func (c RoleBindingClientAdapter) Delete(namespace, name string, uid types.UID) error {
+	return c.Client.RoleBindings(namespace).Delete(name, &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}})
+}

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -147,7 +147,7 @@ func PostStartHook(hookContext genericapiserver.PostStartHookContext) error {
 
 		// ensure bootstrap roles are created or reconciled
 		for _, clusterRole := range append(bootstrappolicy.ClusterRoles(), bootstrappolicy.ControllerRoles()...) {
-			opts := reconciliation.ReconcileClusterRoleOptions{
+			opts := reconciliation.ReconcileRoleOptions{
 				Role:    reconciliation.ClusterRoleRuleOwner{ClusterRole: &clusterRole},
 				Client:  reconciliation.ClusterRoleModifier{Client: clientset.ClusterRoles()},
 				Confirm: true,
@@ -175,9 +175,9 @@ func PostStartHook(hookContext genericapiserver.PostStartHookContext) error {
 
 		// ensure bootstrap rolebindings are created or reconciled
 		for _, clusterRoleBinding := range append(bootstrappolicy.ClusterRoleBindings(), bootstrappolicy.ControllerRoleBindings()...) {
-			opts := reconciliation.ReconcileClusterRoleBindingOptions{
-				RoleBinding: &clusterRoleBinding,
-				Client:      clientset.ClusterRoleBindings(),
+			opts := reconciliation.ReconcileRoleBindingOptions{
+				RoleBinding: reconciliation.ClusterRoleBindingAdapter{ClusterRoleBinding: &clusterRoleBinding},
+				Client:      reconciliation.ClusterRoleBindingClientAdapter{Client: clientset.ClusterRoleBindings()},
 				Confirm:     true,
 			}
 			err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
@@ -206,7 +206,7 @@ func PostStartHook(hookContext genericapiserver.PostStartHookContext) error {
 		// ensure bootstrap namespaced roles are created or reconciled
 		for namespace, roles := range bootstrappolicy.NamespaceRoles() {
 			for _, role := range roles {
-				opts := reconciliation.ReconcileClusterRoleOptions{
+				opts := reconciliation.ReconcileRoleOptions{
 					Role:    reconciliation.RoleRuleOwner{Role: &role},
 					Client:  reconciliation.RoleModifier{Client: clientset},
 					Confirm: true,

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/namespace_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/namespace_policy.go
@@ -78,6 +78,38 @@ func init() {
 			rbac.NewRule("get").Groups(legacyGroup).Resources("configmaps").Names("extension-apiserver-authentication").RuleOrDie(),
 		},
 	})
+	addNamespaceRole(metav1.NamespaceSystem, rbac.Role{
+		// role for the bootstrap signer to be able to inspect kube-system secrets
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "bootstrap-signer"},
+		Rules: []rbac.PolicyRule{
+			rbac.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
+		},
+	})
+	addNamespaceRole(metav1.NamespaceSystem, rbac.Role{
+		// role for the token-cleaner to be able to remove secrets, but only in kube-system
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "token-cleaner"},
+		Rules: []rbac.PolicyRule{
+			rbac.NewRule("get", "list", "watch", "delete").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
+			eventsRule(),
+		},
+	})
+	addNamespaceRoleBinding(metav1.NamespaceSystem,
+		rbac.NewRoleBinding(saRolePrefix+"bootstrap-signer", metav1.NamespaceSystem).SAs(metav1.NamespaceSystem, "bootstrap-signer").BindingOrDie())
+	addNamespaceRoleBinding(metav1.NamespaceSystem,
+		rbac.NewRoleBinding(saRolePrefix+"token-cleaner", metav1.NamespaceSystem).SAs(metav1.NamespaceSystem, "token-cleaner").BindingOrDie())
+
+	addNamespaceRole(metav1.NamespacePublic, rbac.Role{
+		// role for the bootstrap signer to be able to write its configmap
+		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "bootstrap-signer"},
+		Rules: []rbac.PolicyRule{
+			rbac.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("configmaps").RuleOrDie(),
+			rbac.NewRule("update").Groups(legacyGroup).Resources("configmaps").Names("cluster-info").RuleOrDie(),
+			eventsRule(),
+		},
+	})
+	addNamespaceRoleBinding(metav1.NamespacePublic,
+		rbac.NewRoleBinding(saRolePrefix+"bootstrap-signer", metav1.NamespacePublic).SAs(metav1.NamespaceSystem, "bootstrap-signer").BindingOrDie())
+
 }
 
 // NamespaceRoles returns a map of namespace to slice of roles to create

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy_test.go
@@ -173,6 +173,28 @@ func TestBootstrapNamespaceRoles(t *testing.T) {
 	testObjects(t, list, "namespace-roles.yaml")
 }
 
+func TestBootstrapNamespaceRoleBindings(t *testing.T) {
+	list := &api.List{}
+	names := sets.NewString()
+	roleBindings := map[string]runtime.Object{}
+
+	namespaceRoleBindings := bootstrappolicy.NamespaceRoleBindings()
+	for _, namespace := range sets.StringKeySet(namespaceRoleBindings).List() {
+		bootstrapRoleBindings := namespaceRoleBindings[namespace]
+		for i := range bootstrapRoleBindings {
+			roleBinding := bootstrapRoleBindings[i]
+			names.Insert(roleBinding.Name)
+			roleBindings[roleBinding.Name] = &roleBinding
+		}
+
+		for _, name := range names.List() {
+			list.Items = append(list.Items, roleBindings[name])
+		}
+	}
+
+	testObjects(t, list, "namespace-role-bindings.yaml")
+}
+
 func TestBootstrapClusterRoles(t *testing.T) {
 	list := &api.List{}
 	names := sets.NewString()

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-role-bindings.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-role-bindings.yaml
@@ -1,4 +1,58 @@
 apiVersion: v1
-items: null
+items:
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: RoleBinding
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: system:controller:bootstrap-signer
+    namespace: kube-public
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: system:controller:bootstrap-signer
+  subjects:
+  - kind: ServiceAccount
+    name: bootstrap-signer
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: RoleBinding
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: system:controller:bootstrap-signer
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: system:controller:bootstrap-signer
+  subjects:
+  - kind: ServiceAccount
+    name: bootstrap-signer
+    namespace: kube-system
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: RoleBinding
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: system:controller:token-cleaner
+    namespace: kube-system
+  roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: system:controller:token-cleaner
+  subjects:
+  - kind: ServiceAccount
+    name: token-cleaner
+    namespace: kube-system
 kind: List
 metadata: {}

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-role-bindings.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-role-bindings.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+items: null
+kind: List
+metadata: {}

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-roles.yaml
@@ -8,6 +8,41 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: system:controller:bootstrap-signer
+    namespace: kube-public
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resourceNames:
+    - cluster-info
+    resources:
+    - configmaps
+    verbs:
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: Role
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: extension-apiserver-authentication-reader
     namespace: kube-system
   rules:
@@ -19,5 +54,52 @@ items:
     - configmaps
     verbs:
     - get
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: Role
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: system:controller:bootstrap-signer
+    namespace: kube-system
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - get
+    - list
+    - watch
+- apiVersion: rbac.authorization.k8s.io/v1beta1
+  kind: Role
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
+    name: system:controller:token-cleaner
+    namespace: kube-system
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - delete
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
 kind: List
 metadata: {}

--- a/staging/src/k8s.io/client-go/pkg/apis/rbac/helpers.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/rbac/helpers.go
@@ -279,6 +279,22 @@ func NewRoleBinding(roleName, namespace string) *RoleBindingBuilder {
 	}
 }
 
+func NewRoleBindingForClusterRole(roleName, namespace string) *RoleBindingBuilder {
+	return &RoleBindingBuilder{
+		RoleBinding: RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      roleName,
+				Namespace: namespace,
+			},
+			RoleRef: RoleRef{
+				APIGroup: GroupName,
+				Kind:     "ClusterRole",
+				Name:     roleName,
+			},
+		},
+	}
+}
+
 // Groups adds the specified groups as the subjects of the RoleBinding.
 func (r *RoleBindingBuilder) Groups(groups ...string) *RoleBindingBuilder {
 	for _, group := range groups {


### PR DESCRIPTION
Supercedes https://github.com/kubernetes/kubernetes/pull/42221

When locking down controllers to individual RBAC roles we need to make sure that the bootstrap controllers have the right permissions.

This adds the roles and bindings at the correct namespace scopes for the bootstrap-signer and token-cleaner controllers.

@liggitt ptal
@jbeda @luxas you got a good way to test this?  It must not be covered in normal e2e or we'd've seen the issue before.