### PR TITLE
Prevent caching empty discovery docs

### DIFF
--- a/pkg/kubectl/cmd/util/cached_discovery.go
+++ b/pkg/kubectl/cmd/util/cached_discovery.go
@@ -75,6 +75,11 @@ func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion stri
 
 	liveResources, err := d.delegate.ServerResourcesForGroupVersion(groupVersion)
 	if err != nil {
+		glog.V(3).Infof("skipped caching discovery info due to %v", err)
+		return liveResources, err
+	}
+	if liveResources == nil || len(liveResources.APIResources) == 0 {
+		glog.V(3).Infof("skipped caching discovery info, no resources found")
 		return liveResources, err
 	}
 
@@ -117,6 +122,11 @@ func (d *CachedDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
 
 	liveGroups, err := d.delegate.ServerGroups()
 	if err != nil {
+		glog.V(3).Infof("skipped caching discovery info due to %v", err)
+		return liveGroups, err
+	}
+	if liveGroups == nil || len(liveGroups.Groups) == 0 {
+		glog.V(3).Infof("skipped caching discovery info, no groups found")
 		return liveGroups, err
 	}
 

--- a/pkg/kubectl/cmd/util/cached_discovery_test.go
+++ b/pkg/kubectl/cmd/util/cached_discovery_test.go
@@ -135,7 +135,7 @@ func (c *fakeDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
 func (c *fakeDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
 	c.resourceCalls = c.resourceCalls + 1
 	if groupVersion == "a/v1" {
-		return &metav1.APIResourceList{}, nil
+		return &metav1.APIResourceList{APIResources: []metav1.APIResource{{Name: "widgets", Kind: "Widget"}}}, nil
 	}
 
 	return nil, errors.NewNotFound(schema.GroupResource{}, "")


### PR DESCRIPTION
If kubectl makes requests before a server fully initialized, it could cache bad discovery responses (results of a partially forbidden discovery call, etc)

This changes to only cache responses that included at least one group or resource so that total failure doesn't get cached for 5 minutes