### PR TITLE
discovery restmapping should always prefer /v1

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/restmapper.go
+++ b/staging/src/k8s.io/client-go/discovery/restmapper.go
@@ -43,8 +43,9 @@ func NewRESTMapper(groupResources []*APIGroupResources, versionInterfaces meta.V
 	unionMapper := meta.MultiRESTMapper{}
 
 	var groupPriority []string
-	var resourcePriority []schema.GroupVersionResource
-	var kindPriority []schema.GroupVersionKind
+	// /v1 is special.  It should always come first
+	resourcePriority := []schema.GroupVersionResource{{Group: "", Version: "v1", Resource: meta.AnyResource}}
+	kindPriority := []schema.GroupVersionKind{{Group: "", Version: "v1", Kind: meta.AnyKind}}
 
 	for _, group := range groupResources {
 		groupPriority = append(groupPriority, group.Group.Name)

--- a/staging/src/k8s.io/client-go/discovery/restmapper_test.go
+++ b/staging/src/k8s.io/client-go/discovery/restmapper_test.go
@@ -37,6 +37,21 @@ func TestRESTMapper(t *testing.T) {
 	resources := []*APIGroupResources{
 		{
 			Group: metav1.APIGroup{
+				Name: "extensions",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{Version: "v1beta"},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{Version: "v1beta"},
+			},
+			VersionedResources: map[string][]metav1.APIResource{
+				"v1beta": {
+					{Name: "jobs", Namespaced: true, Kind: "Job"},
+					{Name: "pods", Namespaced: true, Kind: "Pod"},
+				},
+			},
+		},
+		{
+			Group: metav1.APIGroup{
 				Versions: []metav1.GroupVersionForDiscovery{
 					{Version: "v1"},
 					{Version: "v2"},
@@ -52,20 +67,6 @@ func TestRESTMapper(t *testing.T) {
 				},
 			},
 		},
-		{
-			Group: metav1.APIGroup{
-				Name: "extensions",
-				Versions: []metav1.GroupVersionForDiscovery{
-					{Version: "v1beta"},
-				},
-				PreferredVersion: metav1.GroupVersionForDiscovery{Version: "v1beta"},
-			},
-			VersionedResources: map[string][]metav1.APIResource{
-				"v1beta": {
-					{Name: "jobs", Namespaced: true, Kind: "Job"},
-				},
-			},
-		},
 	}
 
 	restMapper := NewRESTMapper(resources, nil)
@@ -74,6 +75,15 @@ func TestRESTMapper(t *testing.T) {
 		input schema.GroupVersionResource
 		want  schema.GroupVersionKind
 	}{
+		{
+			input: schema.GroupVersionResource{
+				Resource: "pods",
+			},
+			want: schema.GroupVersionKind{
+				Version: "v1",
+				Kind:    "Pod",
+			},
+		},
 		{
 			input: schema.GroupVersionResource{
 				Version:  "v1",
@@ -131,6 +141,15 @@ func TestRESTMapper(t *testing.T) {
 		input schema.GroupVersionResource
 		want  schema.GroupVersionResource
 	}{
+		{
+			input: schema.GroupVersionResource{
+				Resource: "pods",
+			},
+			want: schema.GroupVersionResource{
+				Version:  "v1",
+				Resource: "pods",
+			},
+		},
 		{
 			input: schema.GroupVersionResource{
 				Version:  "v1",


### PR DESCRIPTION
The core kube API, empty group, version==v1 should always be the most preferred group and resource from a rest mapper.  This special cases that.  All the others should be based on discovery order as we previously agreed.

@kubernetes/sig-cli-pr-reviews @kubernetes/sig-api-machinery-pr-reviews 
@enj