### PR TITLE
Only set a groupresource on errors if a resource was specified

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -1035,13 +1035,15 @@ func (r *Request) newUnstructuredResponseError(body []byte, isTextResponse bool,
 	if isTextResponse {
 		message = strings.TrimSpace(string(body))
 	}
+	var groupResource schema.GroupResource
+	if len(r.resource) > 0 {
+		groupResource.Group = r.content.GroupVersion.Group
+		groupResource.Resource = r.resource
+	}
 	return errors.NewGenericServerResponse(
 		statusCode,
 		method,
-		schema.GroupResource{
-			Group:    r.content.GroupVersion.Group,
-			Resource: r.resource,
-		},
+		groupResource,
 		r.resourceName,
 		message,
 		retryAfter,


### PR DESCRIPTION
@deads2k this gets rid of the weird .meta.k8s.io error on unauthorized errors