### PR TITLE
[Federation] Create integration test fixture for api

### DIFF
--- a/cmd/hyperkube/federation-apiserver.go
+++ b/cmd/hyperkube/federation-apiserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
 )
@@ -30,7 +31,7 @@ func NewFederationAPIServer() *Server {
 		SimpleUsage: "federation-apiserver",
 		Long:        "The API entrypoint for the federation control plane",
 		Run: func(_ *Server, args []string) error {
-			return app.Run(s)
+			return app.Run(s, wait.NeverStop)
 		},
 	}
 	s.AddFlags(hks.Flags())

--- a/federation/cmd/federation-apiserver/apiserver.go
+++ b/federation/cmd/federation-apiserver/apiserver.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
@@ -45,7 +46,7 @@ func main() {
 
 	verflag.PrintAndExitIfRequested()
 
-	if err := app.Run(s); err != nil {
+	if err := app.Run(s, wait.NeverStop); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/federation/cmd/federation-apiserver/app/BUILD
+++ b/federation/cmd/federation-apiserver/app/BUILD
@@ -67,7 +67,6 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apimachinery/pkg/util/errors",
         "//vendor:k8s.io/apimachinery/pkg/util/sets",
-        "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/apiserver/pkg/admission",
         "//vendor:k8s.io/apiserver/pkg/registry/generic",
         "//vendor:k8s.io/apiserver/pkg/registry/rest",

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -56,20 +56,6 @@ var groupVersionForDiscovery = metav1.GroupVersionForDiscovery{
 	Version:      groupVersion.Version,
 }
 
-func localPort() (int, error) {
-	l, err := net.Listen("tcp", ":0")
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	addr := strings.Split(l.Addr().String(), ":")
-	port, err := strconv.Atoi(addr[len(addr)-1])
-	if err != nil {
-		return 0, err
-	}
-	return port, nil
-}
-
 func TestAggregatedAPIServer(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -106,7 +92,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 	go func() {
 		for {
 			// always get a fresh port in case something claimed the old one
-			kubePort, err := localPort()
+			kubePort, err := framework.FindFreeLocalPort()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -179,7 +165,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 	go func() {
 		for {
 			// always get a fresh port in case something claimed the old one
-			wardlePortInt, err := localPort()
+			wardlePortInt, err := framework.FindFreeLocalPort()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -256,7 +242,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 	go func() {
 		for {
 			// always get a fresh port in case something claimed the old one
-			aggregatorPortInt, err := localPort()
+			aggregatorPortInt, err := framework.FindFreeLocalPort()
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/federation/BUILD
+++ b/test/integration/federation/BUILD
@@ -9,16 +9,15 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["server_test.go"],
+    srcs = ["api_test.go"],
     tags = ["automanaged"],
     deps = [
         "//federation/apis/federation/v1beta1:go_default_library",
-        "//federation/cmd/federation-apiserver/app:go_default_library",
-        "//federation/cmd/federation-apiserver/app/options:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/autoscaling/v1:go_default_library",
         "//pkg/apis/batch/v1:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//test/integration/federation/framework:go_default_library",
         "//vendor:github.com/stretchr/testify/assert",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
@@ -34,6 +33,9 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//test/integration/federation/framework:all-srcs",
+    ],
     tags = ["automanaged"],
 )

--- a/test/integration/federation/framework/BUILD
+++ b/test/integration/federation/framework/BUILD
@@ -4,28 +4,22 @@ licenses(["notice"])
 
 load(
     "@io_bazel_rules_go//go:def.bzl",
-    "go_binary",
     "go_library",
-)
-
-go_binary(
-    name = "federation-apiserver",
-    library = ":go_default_library",
-    tags = ["automanaged"],
 )
 
 go_library(
     name = "go_default_library",
-    srcs = ["apiserver.go"],
+    srcs = [
+        "api.go",
+        "util.go",
+    ],
     tags = ["automanaged"],
     deps = [
         "//federation/cmd/federation-apiserver/app:go_default_library",
         "//federation/cmd/federation-apiserver/app/options:go_default_library",
-        "//pkg/version/verflag:go_default_library",
-        "//vendor:github.com/spf13/pflag",
+        "//test/integration/framework:go_default_library",
+        "//vendor:github.com/pborman/uuid",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",
-        "//vendor:k8s.io/apiserver/pkg/util/flag",
-        "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],
 )
 
@@ -38,9 +32,6 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//federation/cmd/federation-apiserver/app:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
 )

--- a/test/integration/federation/framework/api.go
+++ b/test/integration/federation/framework/api.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/pborman/uuid"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
+	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+const (
+	apiNoun      = "federation apiserver"
+	waitInterval = 50 * time.Millisecond
+)
+
+func getRunOptions() *options.ServerRunOptions {
+	r := options.NewServerRunOptions()
+	r.Etcd.StorageConfig.ServerList = []string{framework.GetEtcdURLFromEnv()}
+	// Use a unique prefix to ensure isolation from other tests using the same etcd instance
+	r.Etcd.StorageConfig.Prefix = uuid.New()
+	// Disable secure serving
+	r.SecureServing.ServingOptions.BindPort = 0
+	return r
+}
+
+// FederationAPIFixture manages a federation api server
+type FederationAPIFixture struct {
+	Host     string
+	stopChan chan struct{}
+}
+
+func (f *FederationAPIFixture) Setup(t *testing.T) {
+	if f.stopChan != nil {
+		t.Fatal("Setup() already called")
+	}
+	defer TeardownOnPanic(t, f)
+
+	f.stopChan = make(chan struct{})
+
+	runOptions := getRunOptions()
+
+	err := startServer(t, runOptions, f.stopChan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f.Host = fmt.Sprintf("http://%s:%d", runOptions.InsecureServing.BindAddress, runOptions.InsecureServing.BindPort)
+
+	err = waitForServer(t, f.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *FederationAPIFixture) Teardown(t *testing.T) {
+	if f.stopChan != nil {
+		close(f.stopChan)
+		f.stopChan = nil
+	}
+}
+
+func startServer(t *testing.T, runOptions *options.ServerRunOptions, stopChan <-chan struct{}) error {
+	err := wait.PollImmediate(waitInterval, wait.ForeverTestTimeout, func() (bool, error) {
+		port, err := framework.FindFreeLocalPort()
+		if err != nil {
+			t.Logf("Error allocating an ephemeral port: %v", err)
+			return false, nil
+		}
+
+		runOptions.InsecureServing.BindPort = port
+
+		err = app.NonBlockingRun(runOptions, stopChan)
+		if err != nil {
+			t.Logf("Error starting the %s: %v", apiNoun, err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("Timed out waiting for the %s: %v", apiNoun, err)
+	}
+	return nil
+}
+
+func waitForServer(t *testing.T, host string) error {
+	err := wait.PollImmediate(waitInterval, wait.ForeverTestTimeout, func() (bool, error) {
+		_, err := http.Get(host)
+		if err != nil {
+			t.Logf("Error when trying to contact the API: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("Timed out waiting for the %s: %v", apiNoun, err)
+	}
+	return nil
+}

--- a/test/integration/federation/framework/util.go
+++ b/test/integration/federation/framework/util.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"testing"
+)
+
+// Setup is likely to be fixture-specific, but Teardown needs to be
+// consistent to enable TeardownOnPanic.
+type TestFixture interface {
+	Teardown(t *testing.T)
+}
+
+// TeardownOnPanic can be used to ensure cleanup on setup failure.
+func TeardownOnPanic(t *testing.T, f TestFixture) {
+	if r := recover(); r != nil {
+		f.Teardown(t)
+		panic(r)
+	}
+}

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	goruntime "runtime"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -508,4 +509,26 @@ func RunParallel(task Task, numTasks, numWorkers int) {
 	}
 	wg.Wait()
 	close(semCh)
+}
+
+// FindFreeLocalPort returns the number of an available port number on
+// the loopback interface.  Useful for determining the port to launch
+// a server on.  Error handling required - there is a non-zero chance
+// that the returned port number will be bound by another process
+// after this function returns.
+func FindFreeLocalPort() (int, error) {
+	l, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	_, portStr, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		return 0, err
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0, err
+	}
+	return port, nil
 }


### PR DESCRIPTION
This PR factors a reusable fixture for the federation api server out of the existing integration test.

Targets #40705

cc: @kubernetes/sig-federation-pr-reviews