### PR TITLE
Add liveness probe for fluentd-gcp

### DIFF
--- a/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
@@ -46,6 +46,38 @@ spec:
       mountPath: /var/log/journal
     - name: libsystemddir
       mountPath: /host/lib
+    # Liveness probe is aimed to help in situarions where fluentd
+    # silently hangs for no apparent reasons until manual restart.
+    # The idea of this probe is that if fluentd is not queueing or
+    # flushing chunks for 5 minutes, something is not right. If
+    # you want to change the fluentd configuration, reducing amount of
+    # logs fluentd collects, consider changing the threshold or turning
+    # liveness probe off completely.
+    livenessProbe:
+      initialDelaySeconds: 600
+      periodSeconds: 60
+      exec:
+        command:
+        - '/bin/sh'
+        - '-c'
+        - >
+          LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+          STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
+          if [ ! -e /var/log/fluentd-buffers ];
+          then
+            exit 1;
+          fi;
+          LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
+          LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
+          if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
+          then
+            rm -rf /var/log/fluentd-buffers;
+            exit 1;
+          fi;
+          if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ];
+          then
+            exit 1;
+          fi;
   terminationGracePeriodSeconds: 30
   volumes:
   - name: varlog

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -37,6 +37,38 @@ spec:
     - name: varlibdockercontainers
       mountPath: /var/lib/docker/containers
       readOnly: true
+    # Liveness probe is aimed to help in situarions where fluentd
+    # silently hangs for no apparent reasons until manual restart.
+    # The idea of this probe is that if fluentd is not queueing or
+    # flushing chunks for 5 minutes, something is not right. If
+    # you want to change the fluentd configuration, reducing amount of
+    # logs fluentd collects, consider changing the threshold or turning
+    # liveness probe off completely.
+    livenessProbe:
+      initialDelaySeconds: 600
+      periodSeconds: 60
+      exec:
+        command:
+        - '/bin/sh'
+        - '-c'
+        - >
+          LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+          STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
+          if [ ! -e /var/log/fluentd-buffers ];
+          then
+            exit 1;
+          fi;
+          LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
+          LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
+          if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
+          then
+            rm -rf /var/log/fluentd-buffers;
+            exit 1;
+          fi;
+          if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ];
+          then
+            exit 1;
+          fi;
   terminationGracePeriodSeconds: 30
   volumes:
   - name: varlog


### PR DESCRIPTION
This is a cherrypick of these two PRs: https://github.com/kubernetes/kubernetes/pull/38622 and https://github.com/kubernetes/kubernetes/pull/39949 since https://github.com/kubernetes/kubernetes/pull/39976 was closed.

This PR doesn't contain any features, just increases fluentd resiliency in case of internal failure, causing it to hang.

CC @roberthbailey @piosz @mwielgus 