### PR TITLE
ignore base.go in client-verify

### DIFF
--- a/staging/copy.sh
+++ b/staging/copy.sh
@@ -223,8 +223,9 @@ rm -rf "${CLIENT_REPO_TEMP}/staging"
 
 if [ "${FAIL_ON_CHANGES}" = true ]; then
   echo "running FAIL_ON_CHANGES"
-  ret=0
-  if diff --ignore-matching-lines='^\s*\"Comment\"' -NauprB -I "GoVersion.*\|GodepVersion.*" "${CLIENT_REPO}" "${CLIENT_REPO_TEMP}"; then
+  # ignore base.go in diff
+  cp "${CLIENT_REPO}/pkg/version/base.go" "${CLIENT_REPO_TEMP}/pkg/version/"
+  if diff -NauprB  -I '^\s*\"Comment\"' -I "GoVersion.*\|GodepVersion.*" "${CLIENT_REPO}" "${CLIENT_REPO_TEMP}"; then
     echo "${CLIENT_REPO} up to date."
     cleanup
     exit 0


### PR DESCRIPTION
We need to cherry-pick it to 1.6 to fix #42290.