### PR TITLE
Adding an integration test for runtime-config flag

### DIFF
--- a/cmd/hyperkube/kube-apiserver.go
+++ b/cmd/hyperkube/kube-apiserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 )
@@ -32,7 +33,7 @@ func NewKubeAPIServer() *Server {
 		SimpleUsage:     "apiserver",
 		Long:            "The main API entrypoint and interface to the storage system.  The API server is also the focal point for all authorization decisions.",
 		Run: func(_ *Server, args []string) error {
-			return app.Run(s)
+			return app.Run(s, wait.NeverStop)
 		},
 	}
 	s.AddFlags(hks.Flags())

--- a/cmd/kube-apiserver/BUILD
+++ b/cmd/kube-apiserver/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//vendor:github.com/spf13/pflag",
+        "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/apiserver/pkg/util/flag",
         "//vendor:k8s.io/apiserver/pkg/util/logs",
     ],

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
@@ -47,7 +48,7 @@ func main() {
 
 	verflag.PrintAndExitIfRequested()
 
-	if err := app.Run(s); err != nil {
+	if err := app.Run(s, wait.NeverStop); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -42,7 +42,6 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -90,14 +89,14 @@ cluster's shared state through which all other components interact.`,
 	return cmd
 }
 
-// Run runs the specified APIServer.  This should never exit.
-func Run(s *options.ServerRunOptions) error {
+// Run runs the apiserver and configures it to stop with the given channel.
+func Run(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 	config, sharedInformers, err := BuildMasterConfig(s)
 	if err != nil {
 		return err
 	}
 
-	return RunServer(config, sharedInformers, wait.NeverStop)
+	return RunServer(config, sharedInformers, stopCh)
 }
 
 // RunServer uses the provided config and shared informers to run the apiserver.  It does not return.

--- a/test/e2e_node/services/BUILD
+++ b/test/e2e_node/services/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//vendor:github.com/coreos/pkg/capnslog",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/kardianos/osext",
+        "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/apiserver/pkg/util/feature",
         "//vendor:k8s.io/client-go/dynamic",
         "//vendor:k8s.io/client-go/rest",

--- a/test/e2e_node/services/apiserver.go
+++ b/test/e2e_node/services/apiserver.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	apiserver "k8s.io/kubernetes/cmd/kube-apiserver/app"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 )
@@ -55,7 +56,7 @@ func (a *APIServer) Start() error {
 	errCh := make(chan error)
 	go func() {
 		defer close(errCh)
-		err := apiserver.Run(config)
+		err := apiserver.Run(config, wait.NeverStop)
 		if err != nil {
 			errCh <- fmt.Errorf("run apiserver error: %v", err)
 		}

--- a/test/integration/apiserver/runtime_config_test.go
+++ b/test/integration/apiserver/runtime_config_test.go
@@ -1,0 +1,175 @@
+// +build integration,!no-etcd
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/pborman/uuid"
+
+	"k8s.io/kubernetes/cmd/kube-apiserver/app"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+// Starts the apiserver. It takes an index to start the apiserver on a different port each time.
+// Returns the server IP and a channel to stop it.
+func run(t *testing.T, runtimeConfig string, index int) (string, chan struct{}) {
+	certDir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Failed to create temporary certificate directory: %v", err)
+	}
+	defer os.RemoveAll(certDir)
+
+	s := options.NewServerRunOptions()
+	_, serviceClusterIPRange, err := net.ParseCIDR("10.0.0.0/24")
+	if err != nil {
+		t.Fatalf("unexpected error in generation service cluster IP range: %v", err)
+	}
+	s.ServiceClusterIPRange = *serviceClusterIPRange
+	securePort := 6450 + index
+	insecurePort := 8090 + index
+	serverIP := fmt.Sprintf("http://localhost:%v", insecurePort)
+	s.SecureServing.ServingOptions.BindPort = securePort
+	s.InsecureServing.BindPort = insecurePort
+	s.Etcd.StorageConfig.ServerList = []string{framework.GetEtcdURLFromEnv()}
+	// Use a unique prefix to ensure isolation from other tests using the same etcd instance
+	s.Etcd.StorageConfig.Prefix = uuid.New()
+	s.SecureServing.ServerCert.CertDirectory = certDir
+	s.APIEnablement.RuntimeConfig.Set(runtimeConfig)
+
+	stopCh := make(chan struct{})
+	go func() {
+		if err := app.Run(s, stopCh); err != nil {
+			t.Fatalf("Error in bringing up the server: %v", err)
+		}
+	}()
+	if err := waitForApiserverUp(serverIP); err != nil {
+		t.Fatalf("%v", err)
+	}
+	return serverIP, stopCh
+}
+
+func waitForApiserverUp(serverIP string) error {
+	for start := time.Now(); time.Since(start) < time.Minute; time.Sleep(5 * time.Second) {
+		_, err := http.Get(serverIP)
+		if err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("waiting for apiserver timed out")
+}
+
+func corePath(resource, namespace, name string) string {
+	return testapi.Default.ResourcePath(resource, namespace, name)
+}
+func extensionsPath(resource, namespace, name string) string {
+	return testapi.Extensions.ResourcePath(resource, namespace, name)
+}
+func batchPath(resource, namespace, name string) string {
+	return testapi.Batch.ResourcePath(resource, namespace, name)
+}
+
+// Tests that the apiserver enables/disables the API as per runtime-config.
+func TestRuntimeConfig(t *testing.T) {
+	testCases := []struct {
+		runtimeConfig string
+		statusCodes   map[string]int
+	}{
+		{
+			// Verify that expected resources are enabled by default.
+			"",
+			map[string]int{
+				corePath("pods", "default", ""):              200,
+				extensionsPath("replicasets", "default", ""): 200,
+				batchPath("jobs", "default", ""):             200,
+			},
+		},
+		{
+			// Setting all=true should enable all resources.
+			"api/all=true",
+			map[string]int{
+				corePath("pods", "default", ""):              200,
+				extensionsPath("replicasets", "default", ""): 200,
+				batchPath("jobs", "default", ""):             200,
+			},
+		},
+		{
+			// Setting all=false should disable all resources.
+			"api/all=false",
+			map[string]int{
+				corePath("pods", "default", ""):              404,
+				extensionsPath("replicasets", "default", ""): 404,
+				batchPath("jobs", "default", ""):             404,
+			},
+		},
+		{
+			// Should be able to disable all but one group version.
+			"api/all=false,api/v1=true",
+			map[string]int{
+				corePath("pods", "default", ""):              200,
+				extensionsPath("replicasets", "default", ""): 404,
+				batchPath("jobs", "default", ""):             404,
+			},
+		},
+		{
+			// Should be able to disable a group version.
+			"batch/v1=false",
+			map[string]int{
+				corePath("pods", "default", ""):              200,
+				extensionsPath("replicasets", "default", ""): 200,
+				batchPath("jobs", "default", ""):             404,
+			},
+		},
+		{
+			// Should be able to disable a specific resource.
+			"extensions/v1beta1/ingresses=false",
+			map[string]int{
+				corePath("pods", "default", ""):              200,
+				extensionsPath("replicasets", "default", ""): 200,
+				extensionsPath("ingresses", "default", ""):   404,
+				batchPath("jobs", "default", ""):             200,
+			},
+		},
+		{
+			// Disabling specific resources should not work with core group.
+			"api/v1/secrets=false",
+			map[string]int{
+				corePath("pods", "default", ""):              200,
+				corePath("secrets", "default", ""):           200,
+				extensionsPath("replicasets", "default", ""): 200,
+				batchPath("jobs", "default", ""):             200,
+			},
+		},
+	}
+	for index, test := range testCases {
+		serverIP, stopCh := run(t, test.runtimeConfig, index)
+		for path, code := range test.statusCodes {
+			verifyStatusCode(t, "GET", serverIP+path, "", code)
+		}
+		close(stopCh)
+	}
+}


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/32226 https://github.com/kubernetes/kubernetes/pull/42225 and https://github.com/kubernetes/kubernetes/issues/38593

Adding an integration test for `--runtime-config` flag for kube-apiserver.

~~Disabling a specific resource is broken for core resources which is being fixed in https://github.com/kubernetes/kubernetes/pull/42225~~


cc @lavalamp @krousey @kubernetes/sig-api-machinery-pr-reviews 