### PR TITLE
Add ENABLE_CRI for customizing CRI

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -187,6 +187,7 @@ LOG_LEVEL=${LOG_LEVEL:-3}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"docker"}
 CONTAINER_RUNTIME_ENDPOINT=${CONTAINER_RUNTIME_ENDPOINT:-""}
 IMAGE_SERVICE_ENDPOINT=${IMAGE_SERVICE_ENDPOINT:-""}
+ENABLE_CRI=${ENABLE_CRI:-"true"}
 RKT_PATH=${RKT_PATH:-""}
 RKT_STAGE1_IMAGE=${RKT_STAGE1_IMAGE:-""}
 CHAOS_CHANCE=${CHAOS_CHANCE:-0.0}
@@ -576,7 +577,7 @@ function start_kubelet {
       fi
 
       sudo -E "${GO_OUT}/hyperkube" kubelet ${priv_arg}\
-        --enable-cri=false \
+        --enable-cri="${ENABLE_CRI}" \
         --v=${LOG_LEVEL} \
         --chaos-chance="${CHAOS_CHANCE}" \
         --container-runtime="${CONTAINER_RUNTIME}" \


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new environmental variable `ENABLE_CRI` for customizing CRI (e.g. switching between dockershim and dockertools) and sets `--enable-cri=true` by default.

**Which issue this PR fixes** 

Fixes #42315.

**Release note**:

```release-note
NONE
```

Maybe we should also cherry-pick this to 1.6 branch.

cc @yujuhong @Random-Liu 