### PR TITLE
Adding OWNERS file for test/integration/federation

### DIFF
--- a/test/integration/federation/OWNERS
+++ b/test/integration/federation/OWNERS
@@ -1,0 +1,16 @@
+reviewers:
+  - colhom
+  - csbell
+  - irfanurrehman
+  - madhusudancs
+  - marun
+  - mwielgus
+  - nikhiljindal
+  - quinton-hoole
+  - shashidharatd
+approvers:
+  - csbell
+  - madhusudancs
+  - mwielgus
+  - nikhiljindal
+  - quinton-hoole


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/40705

File copied from federation/OWNERS.

Existing pending PRs for this diectory:
https://github.com/kubernetes/kubernetes/pull/42278 and https://github.com/kubernetes/kubernetes/pull/42225

cc @kubernetes/sig-federation-pr-reviews 