### PR TITLE
Default E2E_ZONES to empty string.

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # required:
-# KUBE_ROOT: path of the root of the Kubernetes reposiitory
+# KUBE_ROOT: path of the root of the Kubernetes repository
 
 : "${KUBE_ROOT?Must set KUBE_ROOT env var}"
 
@@ -29,13 +29,19 @@ HOST_CLUSTER_ZONE="${FEDERATION_HOST_CLUSTER_ZONE:-}"
 # If $HOST_CLUSTER_ZONE isn't specified, arbitrarily choose
 # last zone as the host cluster zone.
 if [[ -z "${HOST_CLUSTER_ZONE}" ]]; then
-  E2E_ZONES_ARR=($E2E_ZONES)
-  HOST_CLUSTER_ZONE=${E2E_ZONES_ARR[-1]}
+  E2E_ZONES_ARR=(${E2E_ZONES:-})
+  if [[ ${#E2E_ZONES_ARR[@]} > 0 ]]; then
+    HOST_CLUSTER_ZONE=${E2E_ZONES_ARR[-1]}
+  fi
 fi
 
 HOST_CLUSTER_CONTEXT="${FEDERATION_HOST_CLUSTER_CONTEXT:-}"
 if [[ -z "${HOST_CLUSTER_CONTEXT}" ]]; then
   # Sets ${CLUSTER_CONTEXT}
+  if [[ -z "${HOST_CLUSTER_ZONE:-}" ]]; then
+    echo "At least one of FEDERATION_HOST_CLUSTER_CONTEXT, FEDERATION_HOST_CLUSTER_ZONE or E2E_ZONES is required."
+    exit 1
+  fi
   kubeconfig-federation-context "${HOST_CLUSTER_ZONE:-}"
   HOST_CLUSTER_CONTEXT="${CLUSTER_CONTEXT}"
 fi


### PR DESCRIPTION
Also print an error message and exit if host cluster context cannot be derived.

I don't think we should do any of this magic. This is a stop gap solution to get all our tests to stable state. I will actively get rid of all this defaulting magic once our main tests are stable.

cc @kubernetes/sig-federation-pr-reviews 