### PR TITLE
[WIP] [do-not-merge] Lightweight metrics server in scheduler_perf

### DIFF
--- a/test/integration/scheduler_perf/test-performance.sh
+++ b/test/integration/scheduler_perf/test-performance.sh
@@ -48,5 +48,5 @@ if ${RUN_BENCHMARK:-false}; then
 fi
 # Running density tests. It might take a long time.
 kube::log::status "performance test (density) start"
-go test -test.run=. -test.timeout=60m -test.short=false
+go test -test.run=. -test.timeout=60m -test.short=false -args -v 3
 kube::log::status "...density tests finished"


### PR DESCRIPTION
**What this PR does / why we need it**:

Starts a metrics server in scheduler perf so we can grab the performance numbers.

**Which issue this PR fixes** 

#42213 

**Special notes for your reviewer**:

n/a , this might be suboptimal b/c it doesnt launch a regular scheduler server, but it seems like the scheduler server doesnt fire up properly. 

*no release note needed*