### PR TITLE
Remove unused variable and rename other (glusterfs)

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -68,8 +68,7 @@ const (
 	glusterfsPluginName         = "kubernetes.io/glusterfs"
 	volPrefix                   = "vol_"
 	dynamicEpSvcPrefix          = "glusterfs-dynamic-"
-	replicaCount                = 3
-	durabilityType              = "replicate"
+	defaultReplicaCount         = 3
 	secretKeyName               = "key" // key name used in secret
 	gciGlusterMountBinariesPath = "/sbin/mount.glusterfs"
 	defaultGidMin               = 2000
@@ -928,7 +927,7 @@ func parseClassParameters(params map[string]string, kubeClient clientset.Interfa
 	}
 
 	if len(parseVolumeType) == 0 {
-		cfg.volumeType = gapi.VolumeDurabilityInfo{Type: gapi.DurabilityReplicate, Replicate: gapi.ReplicaDurability{Replica: replicaCount}}
+		cfg.volumeType = gapi.VolumeDurabilityInfo{Type: gapi.DurabilityReplicate, Replicate: gapi.ReplicaDurability{Replica: defaultReplicaCount}}
 	} else {
 		parseVolumeTypeInfo := dstrings.Split(parseVolumeType, ":")
 
@@ -941,7 +940,7 @@ func parseClassParameters(params map[string]string, kubeClient clientset.Interfa
 				}
 				cfg.volumeType = gapi.VolumeDurabilityInfo{Type: gapi.DurabilityReplicate, Replicate: gapi.ReplicaDurability{Replica: newReplicaCount}}
 			} else {
-				cfg.volumeType = gapi.VolumeDurabilityInfo{Type: gapi.DurabilityReplicate, Replicate: gapi.ReplicaDurability{Replica: replicaCount}}
+				cfg.volumeType = gapi.VolumeDurabilityInfo{Type: gapi.DurabilityReplicate, Replicate: gapi.ReplicaDurability{Replica: defaultReplicaCount}}
 			}
 		case "disperse":
 			if len(parseVolumeTypeInfo) >= 3 {


### PR DESCRIPTION
**What this PR does / why we need it**:

This is just a cosmetic PR. I remove unused variable from code and rename the other one, so it better explains what it does. When reading the source I initially thought kubernetes forces replica count to 3.

btw. it might be a broader issue, as I'd think go would remove unused variables by default

Unimportant side node: I think replica count of 2 would be a better default (it is in Heketi, and replica count of 2 gives us high availability that tolerates failure of one node, just like setups of 3 raft nodes in other cases).