### PR TITLE
e2e: require minimum completeness in deployment tests

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3161,9 +3161,7 @@ func WaitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deploymen
 		}
 
 		// When the deployment status and its underlying resources reach the desired state, we're done
-		if deployment.Status.Replicas == *(deployment.Spec.Replicas) &&
-			deployment.Status.UpdatedReplicas == *(deployment.Spec.Replicas) &&
-			deployment.Status.AvailableReplicas == *(deployment.Spec.Replicas) {
+		if deploymentutil.DeploymentComplete(deployment, &deployment.Status) {
 			return true, nil
 		}
 
@@ -3229,11 +3227,7 @@ func WaitForDeploymentStatus(c clientset.Interface, d *extensions.Deployment) er
 		}
 
 		// When the deployment status and its underlying resources reach the desired state, we're done
-		if deployment.Status.Replicas == *(deployment.Spec.Replicas) &&
-			deployment.Status.UpdatedReplicas == *(deployment.Spec.Replicas) {
-			return true, nil
-		}
-		return false, nil
+		return deploymentutil.DeploymentComplete(deployment, &deployment.Status), nil
 	})
 
 	if err == wait.ErrWaitTimeout {


### PR DESCRIPTION
@janetkuo should reduce deployment-related flakes

For example:
https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gke/5334#k8sio-deployment-scaled-rollout-deployment-should-not-block-on-annotation-check
Deployment with 5 pods, all of them updated to the latest replica set. For some reason one of them is never scheduled and even though the strategy parameters in the Deployment allow 2 maxUnavailable the test is stuck for 5mins waiting for the last pod.
```
I0228 12:33:31.406] Feb 28 12:33:20.255: INFO: Pod nginx-2629236890-r7z5n is not available:
I0228 12:33:31.406] {TypeMeta:{Kind: APIVersion:} ObjectMeta:{Name:nginx-2629236890-r7z5n GenerateName:nginx-2629236890- Namespace:e2e-tests-deployment-gctjw SelfLink:/api/v1/namespaces/e2e-tests-deployment-gctjw/pods/nginx-2629236890-r7z5n UID:7095ad3e-fdf4-11e6-af4a-42010af00010 ResourceVersion:7804 Generation:0 CreationTimestamp:2017-02-28 12:28:18.408376434 -0800 PST DeletionTimestamp:<nil> DeletionGracePeriodSeconds:<nil> Labels:map[pod-template-hash:2629236890 name:nginx] Annotations:map[kubernetes.io/created-by:{"kind":"SerializedReference","apiVersion":"v1","reference":{"kind":"ReplicaSet","namespace":"e2e-tests-deployment-gctjw","name":"nginx-2629236890","uid":"7085ba3f-fdf4-11e6-af4a-42010af00010","apiVersion":"extensions","resourceVersion":"7743"}}
I0228 12:33:31.407] ] OwnerReferences:[{APIVersion:extensions/v1beta1 Kind:ReplicaSet Name:nginx-2629236890 UID:7085ba3f-fdf4-11e6-af4a-42010af00010 Controller:0xc420beccf0}] Finalizers:[] ClusterName:} Spec:{Volumes:[{Name:default-token-58h80 VolumeSource:{HostPath:nil EmptyDir:nil GCEPersistentDisk:nil AWSElasticBlockStore:nil GitRepo:nil Secret:&SecretVolumeSource{SecretName:default-token-58h80,Items:[],DefaultMode:*420,Optional:nil,} NFS:nil ISCSI:nil Glusterfs:nil PersistentVolumeClaim:nil RBD:nil FlexVolume:nil Cinder:nil CephFS:nil Flocker:nil DownwardAPI:nil FC:nil AzureFile:nil ConfigMap:nil VsphereVolume:nil Quobyte:nil AzureDisk:nil PhotonPersistentDisk:nil Projected:nil}}] InitContainers:[] Containers:[{Name:nginx Image:gcr.io/google_containers/update-demo:kitten Command:[] Args:[] WorkingDir: Ports:[] EnvFrom:[] Env:[] Resources:{Limits:map[] Requests:map[]} VolumeMounts:[{Name:default-token-58h80 ReadOnly:true MountPath:/var/run/secrets/kubernetes.io/serviceaccount SubPath:}] LivenessProbe:nil ReadinessProbe:nil Lifecycle:nil TerminationMessagePath:/dev/termination-log TerminationMessagePolicy:File ImagePullPolicy:IfNotPresent SecurityContext:nil Stdin:false StdinOnce:false TTY:false}] RestartPolicy:Always TerminationGracePeriodSeconds:0xc420becd28 ActiveDeadlineSeconds:<nil> DNSPolicy:ClusterFirst NodeSelector:map[] ServiceAccountName:default DeprecatedServiceAccount:default AutomountServiceAccountToken:<nil> NodeName:gke-bootstrap-e2e-default-pool-800b6140-fsl5 HostNetwork:false HostPID:false HostIPC:false SecurityContext:&PodSecurityContext{SELinuxOptions:nil,RunAsUser:nil,RunAsNonRoot:nil,SupplementalGroups:[],FSGroup:nil,} ImagePullSecrets:[] Hostname: Subdomain: Affinity:nil SchedulerName:default-scheduler Tolerations:[]} Status:{Phase:Pending Conditions:[{Type:Initialized Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-02-28 12:28:18 -0800 PST Reason: Message:} {Type:Ready Status:False LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-02-28 12:28:18 -0800 PST Reason:ContainersNotReady Message:containers with unready status: [nginx]} {Type:PodScheduled Status:True LastProbeTime:0001-01-01 00:00:00 +0000 UTC LastTransitionTime:2017-02-28 12:28:18 -0800 PST Reason: Message:}] Message: Reason: HostIP:10.240.0.2 PodIP: StartTime:2017-02-28 12:28:18 -0800 PST InitContainerStatuses:[] ContainerStatuses:[{Name:nginx State:{Waiting:&ContainerStateWaiting{Reason:ContainerCreating,Message:,} Running:nil Terminated:nil} LastTerminationState:{Waiting:nil Running:nil Terminated:nil} Ready:false RestartCount:0 Image:gcr.io/google_containers/update-demo:kitten ImageID: ContainerID:}] QOSClass:BestEffort}}
```

@kubernetes/sig-apps-misc 