### PR TITLE
Set `User-Agent` header when fetching remote HTTP resources

### DIFF
--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -38,6 +38,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api/validation"
 )
 
@@ -286,7 +287,13 @@ type httpget func(url string) (int, string, io.ReadCloser, error)
 
 // httpgetImpl Implements a function to retrieve a url and return the results.
 func httpgetImpl(url string) (int, string, io.ReadCloser, error) {
-	resp, err := http.Get(url)
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return 0, "", nil, err
+	}
+	req.Header.Set("User-Agent", rest.DefaultKubernetesUserAgent())
+	resp, err := client.Do(req)
 	if err != nil {
 		return 0, "", nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Some of API changes being introduced in 1.6 will dramatically affect add-ons.
Many add-ons require access to the API, hence will require certain RBAC objects to be created.
Certain add-ons, such as Weave Cloud add-on, are normally installed from a remote URL, e.g.:
```
kubectl create -f 'https://cloud.weave.works/k8s.yaml?service-token=<redacted>'
```
Passing agent string that include Kubernetes version to the add-on server enables the add-on server to improve user experience by auto-detecting which version of the API will be most suitable. 
By no means this is an ultimate solution to all of the problems add-on providers have to overcome, however it is a simples things we can do right now that doesn't pose any foreseeable risks in the given timeline prior to 1.6 release.

**Release note**:
```release-note
Set `User-Agent` header when fetching remote resources
```