### PR TITLE
Add default storageclass tests

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -119,6 +119,7 @@ go_library(
         "//pkg/apis/rbac/v1beta1:go_default_library",
         "//pkg/apis/settings/v1alpha1:go_default_library",
         "//pkg/apis/storage/v1beta1:go_default_library",
+        "//pkg/apis/storage/v1beta1/util:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/client/clientset_generated/clientset/typed/core/v1:go_default_library",
         "//pkg/client/clientset_generated/clientset/typed/extensions/v1beta1:go_default_library",

--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 	rbacv1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 	storage "k8s.io/kubernetes/pkg/apis/storage/v1beta1"
+	storageutil "k8s.io/kubernetes/pkg/apis/storage/v1beta1/util"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -164,7 +165,7 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 
 		// NOTE: Slow!  The test will wait up to 5 minutes (framework.ClaimProvisionTimeout) when there is
 		// no regression.
-		It("should not provision a volume in an unmanaged GCE zone. [Slow]", func() {
+		It("should not provision a volume in an unmanaged GCE zone. [Slow] [Volume]", func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
 			var suffix string = "unmananged"
 
@@ -243,7 +244,7 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 	})
 
 	framework.KubeDescribe("DynamicProvisioner External", func() {
-		It("should let an external dynamic provisioner create and delete persistent volumes [Slow]", func() {
+		It("should let an external dynamic provisioner create and delete persistent volumes [Slow] [Volume]", func() {
 			// external dynamic provisioner pods need additional permissions provided by the
 			// persistent-volume-provisioner role
 			framework.BindClusterRole(c.Rbac(), "system:persistent-volume-provisioner", ns,
@@ -281,7 +282,102 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 			testDynamicProvisioning(c, claim, requestedSize)
 		})
 	})
+
+	framework.KubeDescribe("DynamicProvisioner Default", func() {
+		It("should create and delete default persistent volumes [Slow] [Volume]", func() {
+			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
+
+			By("creating a claim with no annotation")
+			claim := newClaim(ns)
+			defer c.Core().PersistentVolumeClaims(ns).Delete(claim.Name, nil)
+			claim, err := c.Core().PersistentVolumeClaims(ns).Create(claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			if framework.ProviderIs("vsphere") {
+				testDynamicProvisioning(c, claim, requestedSize)
+			} else {
+				testDynamicProvisioning(c, claim, "2Gi")
+			}
+		})
+
+		// Modifying the default storage class can be disruptive to other tests that depend on it
+		It("should be disabled by changing the default annotation[Slow] [Serial] [Disruptive] [Volume]", func() {
+			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere")
+
+			By("setting the is-default StorageClass annotation to false")
+			verifyDefaultStorageClass(c, true)
+			defer updateDefaultStorageClass(c, "true")
+			updateDefaultStorageClass(c, "false")
+
+			By("creating a claim with default storageclass and expecting it to timeout")
+			claim := newClaim(ns)
+			defer c.Core().PersistentVolumeClaims(ns).Delete(claim.Name, nil)
+			claim, err := c.Core().PersistentVolumeClaims(ns).Create(claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			// The claim should timeout phase:Pending
+			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionTimeout)
+			Expect(err).To(HaveOccurred())
+			framework.Logf(err.Error())
+			claim, err = c.Core().PersistentVolumeClaims(ns).Get(claim.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(claim.Status.Phase).To(Equal(v1.ClaimPending))
+		})
+
+		// Modifying the default storage class can be disruptive to other tests that depend on it
+		It("should be disabled by removing the default annotation[Slow] [Serial] [Disruptive] [Volume]", func() {
+			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere")
+
+			By("removing the is-default StorageClass annotation")
+			verifyDefaultStorageClass(c, true)
+			defer updateDefaultStorageClass(c, "true")
+			updateDefaultStorageClass(c, "")
+
+			By("creating a claim with default storageclass and expecting it to timeout")
+			claim := newClaim(ns)
+			defer c.Core().PersistentVolumeClaims(ns).Delete(claim.Name, nil)
+			claim, err := c.Core().PersistentVolumeClaims(ns).Create(claim)
+			Expect(err).NotTo(HaveOccurred())
+
+			// The claim should timeout phase:Pending
+			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, c, ns, claim.Name, 2*time.Second, framework.ClaimProvisionTimeout)
+			Expect(err).To(HaveOccurred())
+			framework.Logf(err.Error())
+			claim, err = c.Core().PersistentVolumeClaims(ns).Get(claim.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(claim.Status.Phase).To(Equal(v1.ClaimPending))
+		})
+	})
 })
+
+func verifyDefaultStorageClass(c clientset.Interface, expectedDefault bool) {
+	sc, err := c.StorageV1().StorageClasses().Get("default", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(storageutil.IsDefaultAnnotation(sc.ObjectMeta)).To(Equal(expectedDefault))
+}
+
+func updateDefaultStorageClass(c clientset.Interface, defaultStr string) {
+	sc, err := c.StorageV1().StorageClasses().Get("default", metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	if defaultStr == "" {
+		delete(sc.Annotations, storageutil.IsDefaultStorageClassAnnotation)
+	} else {
+		if sc.Annotations == nil {
+			sc.Annotations = make(map[string]string)
+		}
+		sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = defaultStr
+	}
+
+	sc, err = c.StorageV1().StorageClasses().Update(sc)
+	Expect(err).NotTo(HaveOccurred())
+
+	expectedDefault := false
+	if defaultStr == "true" {
+		expectedDefault = true
+	}
+	verifyDefaultStorageClass(c, expectedDefault)
+}
 
 func newClaim(ns string) *v1.PersistentVolumeClaim {
 	claim := v1.PersistentVolumeClaim{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Adds test cases for using and disabling the default storageclass.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
NONE