### PR TITLE
Remove kube-dns ConfigMap modification code from federation-{up,down}.sh scripts

### DIFF
--- a/federation/cluster/federation-down.sh
+++ b/federation/cluster/federation-down.sh
@@ -33,17 +33,6 @@ function unjoin_clusters() {
         "${context}" \
         --context="${FEDERATION_KUBE_CONTEXT}" \
         --host-cluster-context="${HOST_CLUSTER_CONTEXT}"
-
-    # Delete kube-dns configmap that contains federation
-    # configuration from each cluster.
-    # TODO: This shouldn't be required after
-    # https://github.com/kubernetes/kubernetes/pull/39338.
-    # Remove this after the PR is merged.
-    kube::log::status "Deleting \"kube-dns\" ConfigMap from \"kube-system\" namespace in cluster \"${context}\""
-    "${KUBE_ROOT}/cluster/kubectl.sh" delete configmap \
-        --context="${context}" \
-        --namespace="${KUBEDNS_CONFIGMAP_NAMESPACE}" \
-        "${KUBEDNS_CONFIGMAP_NAME}"
   done
 }
 

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -99,18 +99,6 @@ function join_clusters() {
         --host-cluster-context="${HOST_CLUSTER_CONTEXT}" \
         --context="${FEDERATION_NAME}" \
         --secret-name="${context//_/-}"    # Replace "_" by "-"
-
-    # Create kube-dns configmap in each cluster for kube-dns to accept
-    # federation queries.
-    # TODO: This shouldn't be required after
-    # https://github.com/kubernetes/kubernetes/pull/39338.
-    # Remove this after the PR is merged.
-    kube::log::status "Creating \"kube-dns\" ConfigMap in \"kube-system\" namespace in cluster \"${context}\""
-    "${KUBE_ROOT}/cluster/kubectl.sh" create configmap \
-        --context="${context}" \
-        --namespace="${KUBEDNS_CONFIGMAP_NAMESPACE}" \
-        "${KUBEDNS_CONFIGMAP_NAME}" \
-        --from-literal="${KUBEDNS_FEDERATION_FLAG}"="${FEDERATIONS_DOMAIN_MAP}"
   done
 }
 


### PR DESCRIPTION
PR #39338 has merged now. This shouldn't be necessary. This unbreaks federation tests.

```release-note
NONE
```
