### PR TITLE
Output of `kubectl get` is inconsistent for pods

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -76,7 +76,7 @@ kube::test::object_assert() {
   local args=${5:-}
 
   for j in $(seq 1 ${tries}); do
-    res=$(eval kubectl get "${kube_flags[@]}" ${args} $object -o go-template=\"$request\")
+    res=$(eval kubectl get -a "${kube_flags[@]}" ${args} $object -o go-template=\"$request\")
     if [[ "$res" =~ ^$expected$ ]]; then
         echo -n ${green}
         echo "$(kube::test::get_caller 3): Successful get $object $request: $res"
@@ -103,7 +103,7 @@ kube::test::get_object_jsonpath_assert() {
   local request=$2
   local expected=$3
 
-  res=$(eval kubectl get "${kube_flags[@]}" $object -o jsonpath=\"$request\")
+  res=$(eval kubectl get -a "${kube_flags[@]}" $object -o jsonpath=\"$request\")
 
   if [[ "$res" =~ ^$expected$ ]]; then
       echo -n ${green}

--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1106,6 +1106,10 @@ run_kubectl_get_tests() {
   # Post-condition: The text "No resources found" should be part of the output
   kube::test::if_has_string "${output_message}" 'No resources found'
   # Command
+  output_message=$(kubectl get pods --ignore-not-found 2>&1 "${kube_flags[@]}")
+  # Post-condition: The text "No resources found" should not be part of the output
+  kube::test::if_has_not_string "${output_message}" 'No resources found'
+  # Command
   output_message=$(kubectl get pods 2>&1 "${kube_flags[@]}" -o wide)
   # Post-condition: The text "No resources found" should be part of the output
   kube::test::if_has_string "${output_message}" 'No resources found'

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -54,11 +54,12 @@ var (
 
 		` + valid_resources + `
 
-		This command will hide resources that have completed. For instance, pods that are in the Succeeded or Failed phases.
-		You can see the full results for any resource by providing the '--show-all' flag.
+		This command will hide resources that have completed, such as pods that are
+		in the Succeeded or Failed phases. You can see the full results for any
+		resource by providing the '--show-all' flag.
 
 		By specifying the output as 'template' and providing a Go template as the value
-		of the --template flag, you can filter the attributes of the fetched resource(s).`)
+		of the --template flag, you can filter the attributes of the fetched resources.`)
 
 	get_example = templates.Examples(`
 		# List all pods in ps output format.
@@ -184,13 +185,6 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 		return cmdutil.UsageError(cmd, usageString)
 	}
 
-	// always show resources when getting by name or filename, or if the output
-	// is machine-consumable, or if multiple resource kinds were requested.
-	if cmdutil.OutputsRawFormat(cmd) {
-		if !cmd.Flag("show-all").Changed {
-			cmd.Flag("show-all").Value.Set("true")
-		}
-	}
 	export := cmdutil.GetFlagBool(cmd, "export")
 
 	filterFuncs := f.DefaultResourceFilterFunc()

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -229,10 +229,11 @@ func TestGetObjectsFiltered(t *testing.T) {
 		{args: []string{"pods", "foo"}, flags: map[string]string{"show-all": "false"}, resp: first, expect: []runtime.Object{first}},
 		{args: []string{"pods"}, flags: map[string]string{"show-all": "true"}, resp: pods, expect: []runtime.Object{first, second}},
 		{args: []string{"pods/foo"}, resp: first, expect: []runtime.Object{first}},
-		{args: []string{"pods"}, flags: map[string]string{"output": "yaml"}, resp: pods, expect: []runtime.Object{first, second}},
+		{args: []string{"pods"}, flags: map[string]string{"output": "yaml"}, resp: pods, expect: []runtime.Object{second}},
 		{args: []string{}, flags: map[string]string{"filename": "../../../examples/storage/cassandra/cassandra-controller.yaml"}, resp: pods, expect: []runtime.Object{first, second}},
 
 		{args: []string{"pods"}, resp: pods, expect: []runtime.Object{second}},
+		{args: []string{"pods"}, flags: map[string]string{"show-all": "true", "output": "yaml"}, resp: pods, expect: []runtime.Object{first, second}},
 		{args: []string{"pods"}, flags: map[string]string{"show-all": "false"}, resp: pods, expect: []runtime.Object{second}},
 	}
 
@@ -731,8 +732,8 @@ func TestGetByFormatForcesFlag(t *testing.T) {
 	cmd.Run(cmd, []string{"pods"})
 
 	showAllFlag, _ := cmd.Flags().GetBool("show-all")
-	if !showAllFlag {
-		t.Errorf("expected showAll to be true when getting resource by name")
+	if showAllFlag {
+		t.Errorf("expected showAll to not be true when getting resource")
 	}
 }
 

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -698,9 +698,26 @@ func FilterResourceList(obj runtime.Object, filterFuncs kubectl.Filters, filterO
 	return filterCount, list, nil
 }
 
-func PrintFilterCount(hiddenObjNum int, resource string, options *printers.PrintOptions) {
-	if !options.NoHeaders && !options.ShowAll && hiddenObjNum > 0 {
-		glog.V(2).Infof("  info: %d completed object(s) was(were) not shown in %s list. Pass --show-all to see all objects.\n\n", hiddenObjNum, resource)
+// PrintFilterCount displays informational messages based on the number of resources found, hidden, or
+// config flags shown.
+func PrintFilterCount(out io.Writer, found, hidden, errors int, resource string, options *printers.PrintOptions, ignoreNotFound bool) {
+	switch {
+	case errors > 0 || ignoreNotFound:
+		// print nothing
+	case found <= hidden:
+		if found == 0 {
+			fmt.Fprintln(out, "No resources found.")
+		} else {
+			fmt.Fprintln(out, "No resources found, use --show-all to see completed objects.")
+		}
+	case hidden > 0 && !options.ShowAll && !options.NoHeaders:
+		if glog.V(2) {
+			if hidden > 1 {
+				fmt.Fprintf(out, "info: %d objects not shown, use --show-all to see completed objects.\n", hidden)
+			} else {
+				fmt.Fprintf(out, "info: 1 object not shown, use --show-all to see completed objects.\n")
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Builds on top of fixes from #42283, only the last two commits are new. Reverts behavior of #39042 which was inconsistent and confusing.

Fixes #15853