### PR TITLE
Kubelet: return container runtime's version instead of CRI's one

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -225,7 +225,7 @@ func (m *kubeGenericRuntimeManager) Version() (kubecontainer.Version, error) {
 		return nil, err
 	}
 
-	return newRuntimeVersion(typedVersion.Version)
+	return newRuntimeVersion(typedVersion.RuntimeVersion)
 }
 
 // APIVersion returns the cached API version information of the container


### PR DESCRIPTION
**What this PR does / why we need it**:

With CRI enabled by default, kubelet reports the version of CRI instead of container runtime version. This PR fixes this problem.

**Which issue this PR fixes** 

Fixes #42396.

**Special notes for your reviewer**:

Should also cherry-pick to 1.6 branch.

**Release note**:

```release-note
NONE
```

cc @yujuhong  @kubernetes/sig-node-bugs