### PR TITLE
Fixed too long name in HPA e2e upgrade test.

### DIFF
--- a/test/e2e/upgrades/horizontal_pod_autoscalers.go
+++ b/test/e2e/upgrades/horizontal_pod_autoscalers.go
@@ -32,7 +32,7 @@ type HPAUpgradeTest struct {
 // Creates a resource consumer and an HPA object that autoscales the consumer.
 func (t *HPAUpgradeTest) Setup(f *framework.Framework) {
 	t.rc = common.NewDynamicResourceConsumer(
-		"resource-consumer-upgrade-test",
+		"res-cons-upgrade",
 		common.KindRC,
 		1,   /* replicas */
 		250, /* initCPUTotal */


### PR DESCRIPTION
Fixed too long name in HPA e2e upgrade test.

```release-note
NONE
```
