### PR TITLE
Use NoSchedule taint in Node controller instead of filter node in scheduler

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -1002,6 +1002,29 @@ func WaitForCacheSync(controllerName string, stopCh <-chan struct{}, cacheSyncs 
 	return true
 }
 
+// isSchedulable is a flight check for node readiness, disk, and network.
+func isSchedulable(cond *v1.NodeCondition) bool {
+	if (cond.Type == v1.NodeReady) && (cond.Status != v1.ConditionTrue) {
+		return false
+	} else if (cond.Type == v1.NodeOutOfDisk) && (cond.Status != v1.ConditionFalse) {
+		return false
+	} else if (cond.Type == v1.NodeNetworkUnavailable) && (cond.Status != v1.ConditionFalse) {
+		return false
+	}
+	return true
+}
+
+// CheckSchedulable calculates the result of scheduling flag by condition
+// 1. changedToSchedulable
+// 2. changedToUnSchedulable
+func CheckSchedulable(condition *v1.NodeCondition) (bool, bool) {
+	if !isSchedulable(condition) {
+		return false, true
+	} else {
+		return true, false
+	}
+}
+
 // ComputeHash returns a hash value calculated from pod template and a collisionCount to avoid hash collision
 func ComputeHash(template *v1.PodTemplateSpec, collisionCount *int64) uint32 {
 	podTemplateSpecHasher := fnv.New32a()

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -119,6 +119,7 @@ const (
 	// alpha: v1.8
 	//
 	// Add priority to pods. Priority affects scheduling and preemption of pods.
+
 	PodPriority utilfeature.Feature = "PodPriority"
 
 	// owner: @resouer
@@ -126,6 +127,12 @@ const (
 	//
 	// Enable equivalence class cache for scheduler.
 	EnableEquivalenceClassCache utilfeature.Feature = "EnableEquivalenceClassCache"
+
+	// owner: @resouer
+	// beta: v1.8
+	//
+	// Add/remove NoSchedule taint by node controller
+	EnableNodeControllerTaint utilfeature.Feature = "EnableNodeControllerTaint"
 )
 
 func init() {
@@ -151,6 +158,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	DebugContainers:                             {Default: false, PreRelease: utilfeature.Alpha},
 	PodPriority:                                 {Default: false, PreRelease: utilfeature.Alpha},
 	EnableEquivalenceClassCache:                 {Default: false, PreRelease: utilfeature.Alpha},
+	EnableNodeControllerTaint:                   {Default: true, PreRelease: utilfeature.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/plugin/cmd/kube-scheduler/app/configurator.go
+++ b/plugin/cmd/kube-scheduler/app/configurator.go
@@ -32,14 +32,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	clientv1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api"
-
-	clientv1 "k8s.io/api/core/v1"
-
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/plugin/pkg/scheduler"
 	_ "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider"
@@ -107,6 +105,7 @@ func CreateScheduler(
 		serviceInformer,
 		s.HardPodAffinitySymmetricWeight,
 		utilfeature.DefaultFeatureGate.Enabled(features.EnableEquivalenceClassCache),
+		utilfeature.DefaultFeatureGate.Enabled(features.EnableNodeControllerTaint),
 	)
 
 	// Rebuild the configurator with a default Create(...) method.

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/compatibility_test.go
@@ -435,6 +435,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			informerFactory.Core().V1().Services(),
 			v1.DefaultHardPodAffinitySymmetricWeight,
 			enableEquivalenceCache,
+			// enable node controller to set NoSchedule taint
+			true,
 		).CreateFromConfig(policy); err != nil {
 			t.Errorf("%s: Error constructing: %v", v, err)
 			continue

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -65,6 +65,8 @@ func TestCreate(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	factory.Create()
 }
@@ -97,6 +99,8 @@ func TestCreateFromConfig(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 
 	// Pre-register some predicate and priority functions
@@ -156,6 +160,8 @@ func TestCreateFromConfigWithHardPodAffinitySymmetricWeight(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 
 	// Pre-register some predicate and priority functions
@@ -216,6 +222,8 @@ func TestCreateFromEmptyConfig(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 
 	configData = []byte(`{}`)
@@ -273,6 +281,8 @@ func TestDefaultErrorFunc(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	queue := cache.NewFIFO(cache.MetaNamespaceKeyFunc)
 	podBackoff := util.CreatePodBackoff(1*time.Millisecond, 1*time.Second)
@@ -386,6 +396,8 @@ func TestResponsibleForPod(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	// factory of "foo-scheduler"
 	factoryFooScheduler := NewConfigFactory(
@@ -401,6 +413,8 @@ func TestResponsibleForPod(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	// scheduler annotations to be tested
 	schedulerFitsDefault := "default-scheduler"
@@ -471,6 +485,8 @@ func TestInvalidHardPodAffinitySymmetricWeight(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		-1,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	_, err := factory.Create()
 	if err == nil {
@@ -517,6 +533,8 @@ func TestInvalidFactoryArgs(t *testing.T) {
 			informerFactory.Core().V1().Services(),
 			test.hardPodAffinitySymmetricWeight,
 			enableEquivalenceCache,
+			// enable node controller to set NoSchedule taint
+			true,
 		)
 		_, err := factory.Create()
 		if err == nil {
@@ -527,7 +545,8 @@ func TestInvalidFactoryArgs(t *testing.T) {
 }
 
 func TestNodeConditionPredicate(t *testing.T) {
-	nodeFunc := getNodeConditionPredicate()
+	// disable node controller to set NoExecute taint
+	nodeFunc := getNodeConditionPredicate(false)
 	nodeList := &v1.NodeList{
 		Items: []v1.Node{
 			// node1 considered

--- a/test/integration/scheduler/extender_test.go
+++ b/test/integration/scheduler/extender_test.go
@@ -371,6 +371,8 @@ func TestSchedulerExtender(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	schedulerConfig, err := schedulerConfigFactory.CreateFromConfig(policy)
 	if err != nil {

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -19,7 +19,6 @@ package scheduler
 // This file tests the scheduler.
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -260,6 +259,8 @@ func TestUnschedulableNodes(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	schedulerConfig, err := schedulerConfigFactory.Create()
 	if err != nil {
@@ -327,18 +328,6 @@ func DoTestUnschedulableNodes(t *testing.T, cs clientset.Interface, ns *v1.Names
 	// non-namespaced objects (Nodes).
 	defer cs.Core().Nodes().DeleteCollection(nil, metav1.ListOptions{})
 
-	goodCondition := v1.NodeCondition{
-		Type:              v1.NodeReady,
-		Status:            v1.ConditionTrue,
-		Reason:            fmt.Sprintf("schedulable condition"),
-		LastHeartbeatTime: metav1.Time{Time: time.Now()},
-	}
-	badCondition := v1.NodeCondition{
-		Type:              v1.NodeReady,
-		Status:            v1.ConditionUnknown,
-		Reason:            fmt.Sprintf("unschedulable condition"),
-		LastHeartbeatTime: metav1.Time{Time: time.Now()},
-	}
 	// Create a new schedulable node, since we're first going to apply
 	// the unschedulable condition and verify that pods aren't scheduled.
 	node := &v1.Node{
@@ -348,7 +337,6 @@ func DoTestUnschedulableNodes(t *testing.T, cs clientset.Interface, ns *v1.Names
 			Capacity: v1.ResourceList{
 				v1.ResourcePods: *resource.NewQuantity(32, resource.DecimalSI),
 			},
-			Conditions: []v1.NodeCondition{goodCondition},
 		},
 	}
 	nodeKey, err := cache.MetaNamespaceKeyFunc(node)
@@ -394,43 +382,6 @@ func DoTestUnschedulableNodes(t *testing.T, cs clientset.Interface, ns *v1.Names
 				})
 				if err != nil {
 					t.Fatalf("Failed to observe reflected update for setting unschedulable=false: %v", err)
-				}
-			},
-		},
-		// Test node.Status.Conditions=ConditionTrue/Unknown
-		{
-			makeUnSchedulable: func(t *testing.T, n *v1.Node, nodeLister corelisters.NodeLister, c clientset.Interface) {
-				n.Status = v1.NodeStatus{
-					Capacity: v1.ResourceList{
-						v1.ResourcePods: *resource.NewQuantity(32, resource.DecimalSI),
-					},
-					Conditions: []v1.NodeCondition{badCondition},
-				}
-				if _, err = c.Core().Nodes().UpdateStatus(n); err != nil {
-					t.Fatalf("Failed to update node with bad status condition: %v", err)
-				}
-				err = waitForReflection(t, nodeLister, nodeKey, func(node interface{}) bool {
-					return node != nil && node.(*v1.Node).Status.Conditions[0].Status == v1.ConditionUnknown
-				})
-				if err != nil {
-					t.Fatalf("Failed to observe reflected update for status condition update: %v", err)
-				}
-			},
-			makeSchedulable: func(t *testing.T, n *v1.Node, nodeLister corelisters.NodeLister, c clientset.Interface) {
-				n.Status = v1.NodeStatus{
-					Capacity: v1.ResourceList{
-						v1.ResourcePods: *resource.NewQuantity(32, resource.DecimalSI),
-					},
-					Conditions: []v1.NodeCondition{goodCondition},
-				}
-				if _, err = c.Core().Nodes().UpdateStatus(n); err != nil {
-					t.Fatalf("Failed to update node with healthy status condition: %v", err)
-				}
-				err = waitForReflection(t, nodeLister, nodeKey, func(node interface{}) bool {
-					return node != nil && node.(*v1.Node).Status.Conditions[0].Status == v1.ConditionTrue
-				})
-				if err != nil {
-					t.Fatalf("Failed to observe reflected update for status condition update: %v", err)
 				}
 			},
 		},
@@ -544,6 +495,8 @@ func TestMultiScheduler(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	schedulerConfig, err := schedulerConfigFactory.Create()
 	if err != nil {
@@ -631,6 +584,8 @@ func TestMultiScheduler(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	schedulerConfig2, err := schedulerConfigFactory2.Create()
 	if err != nil {
@@ -742,6 +697,8 @@ func TestAllocatable(t *testing.T) {
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 	schedulerConfig, err := schedulerConfigFactory.Create()
 	if err != nil {

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -77,6 +77,8 @@ func mustSetupScheduler() (schedulerConfigurator scheduler.Configurator, destroy
 		informerFactory.Core().V1().Services(),
 		v1.DefaultHardPodAffinitySymmetricWeight,
 		enableEquivalenceCache,
+		// enable node controller to set NoSchedule taint
+		true,
 	)
 
 	eventBroadcaster := record.NewBroadcaster()


### PR DESCRIPTION
**What this PR does / why we need it**:
Use NoSchedule taint in Node controller instead of filter node in scheduler

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #42001

 cc @gmarek 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
