### PR TITLE
hot fix patched prompt not correct with `patch -p '{}'`

### DIFF
--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -180,6 +180,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 		if !options.Local {
 			dataChangedMsg := "not patched"
 			helper := resource.NewHelper(client, mapping)
+			emptyPatchObj, err := helper.Patch(namespace, name, patchType, []byte("{}"))
 			patchedObj, err := helper.Patch(namespace, name, patchType, patchBytes)
 			if err != nil {
 				return err
@@ -200,11 +201,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 			}
 			count++
 
-			if err := info.Refresh(patchedObj, true); err != nil {
-				return err
-			}
-
-			oldData, err := json.Marshal(info.Object)
+			oldData, err := json.Marshal(emptyPatchObj)
 			if err != nil {
 				return err
 			}
@@ -214,6 +211,10 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 			}
 			if !reflect.DeepEqual(oldData, newData) {
 				dataChangedMsg = "patched"
+			}
+
+			if err := info.Refresh(patchedObj, true); err != nil {
+				return err
 			}
 
 			if len(options.OutputFormat) > 0 && options.OutputFormat != "name" {


### PR DESCRIPTION
Fixes part of https://github.com/kubernetes/kubernetes/issues/42384 introduced in https://github.com/kubernetes/kubernetes/pull/38538
the problem is the `patchedObj` has some informations return from server, and `info.Obj` hasn't. (read from stream) 
see my spew.Dump()
```
    {"apiVersion":"extensions/v1beta1","kind":"Deployment","metadata":{"annotations":{"deployment.kubernetes.io/revision":"1"},"creationTimestamp":"2017-03-02T07:27:30Z","generation":4,"labels":{"app":"haha"},"name":"no-match","namespace":"rgam5","resourceVersion":"3967004","selfLink":"/apis/extensions/v1beta1/namespaces/rgam5/deployments/no-match","uid":"b22ba1a7-ff19-11e6-8932-0a5f8afc5d79"},"spec":{"replicas":3,"selector":{"matchLabels":{"app":"haha"}},"strategy":{"rollingUpdate":{"maxSurge":1,"maxUnavailable":1},"type":"RollingUpdate"},"template":{"metadata":{"creationTimestamp":null,"labels":{"app":"haha"}},"spec":{"containers":[{"image":"nginx:9.10","imagePullPolicy":"IfNotPresent","name":"nginx123","ports":[{"containerPort":80,"protocol":"TCP"}],"resources":{},"terminationMessagePath":"/dev/termination-log"}],"dnsPolicy":"ClusterFirst","restartPolicy":"Always","securityContext":{},"terminationGracePeriodSeconds":30}}},"status":{"observedGeneration":4,"replicas":3,"unavailableReplicas":3,"updatedReplicas":3}}
    {"apiVersion":"extensions/v1beta1","kind":"Deployment","metadata":{"name":"no-match","namespace":"rgam5"},"spec":{"template":{"metadata":{"labels":{"app":"haha"}},"spec":{"containers":[{"image":"nginx:9.10","name":"nginx123","ports":[{"containerPort":80}]}]}}}}
```
it maybe a clumsy hotfix, I'm not sure if there is better way to do that, some api validate/convert function ?
cc @ymqytw @liggitt @fabianofranz @juanvallejo 