### PR TITLE
Fix adding disks to more than one scsi adapter. Fixes #42399

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -761,7 +761,15 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, nodeName k8stypes.NodeName) (di
 			return "", "", err
 		}
 
-		scsiController = getSCSIController(vmDevices, vs.cfg.Disk.SCSIControllerType)
+		// Get VM device list
+		_, vmDevices, _, err := getVirtualMachineDevices(ctx, vs.cfg, vs.client, vSphereInstance)
+		if err != nil {
+			glog.Errorf("cannot get vmDevices for VM err=%s", err)
+			return "", "", fmt.Errorf("cannot get vmDevices for VM err=%s", err)
+		}
+
+		scsiControllersOfRequiredType := getSCSIControllersOfType(vmDevices, diskControllerType)
+		scsiController := getAvailableSCSIController(scsiControllersOfRequiredType)
 		if scsiController == nil {
 			glog.Errorf("cannot find SCSI controller in VM")
 			// attempt clean up of scsi controller
@@ -1021,7 +1029,7 @@ func (vs *VSphere) DisksAreAttached(volPaths []string, nodeName k8stypes.NodeNam
 }
 
 func checkDiskAttached(volPath string, vmdevices object.VirtualDeviceList, dc *object.Datacenter, client *govmomi.Client) (bool, error) {
-	virtualDiskControllerKey, err := getVirtualDiskControllerKey(volPath, vmdevices, dc, client)
+	_, err := getVirtualDiskControllerKey(volPath, vmdevices, dc, client)
 	if err != nil {
 		if err == ErrNoDevicesFound {
 			return false, nil
@@ -1029,14 +1037,7 @@ func checkDiskAttached(volPath string, vmdevices object.VirtualDeviceList, dc *o
 		glog.Errorf("Failed to check whether disk is attached. err: %s", err)
 		return false, err
 	}
-	for _, controllerType := range supportedSCSIControllerType {
-		controllerkey, _ := getControllerKey(controllerType, vmdevices)
-		if controllerkey == virtualDiskControllerKey {
-			return true, nil
-		}
-	}
-	return false, ErrNonSupportedControllerType
-
+	return true, nil
 }
 
 // Returns the object key that denotes the controller object to which vmdk is attached.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Allows a single node to use more than 16 disks.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #42399

**Special notes for your reviewer**: 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fix adding disks to more than one scsi adapter.
```