### PR TITLE
kubeadm: update docker version for CE and EE

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -323,6 +323,7 @@ func (sysver SystemVerificationCheck) Check() (warnings, errors []error) {
 	reporter := &system.StreamReporter{WriteStream: bufw}
 
 	var errs []error
+	var warns []error
 	// All the validators we'd like to run:
 	var validators = []system.Validator{
 		&system.OSValidator{Reporter: reporter},
@@ -333,7 +334,9 @@ func (sysver SystemVerificationCheck) Check() (warnings, errors []error) {
 
 	// Run all validators
 	for _, v := range validators {
-		errs = append(errs, v.Validate(system.DefaultSysSpec))
+		warn, err := v.Validate(system.DefaultSysSpec)
+		errs = append(errs, err)
+		warns = append(warns, warn)
 	}
 
 	err := utilerrors.NewAggregate(errs)
@@ -341,9 +344,9 @@ func (sysver SystemVerificationCheck) Check() (warnings, errors []error) {
 		// Only print the output from the system verification check if the check failed
 		fmt.Println("[preflight] The system verification failed. Printing the output from the verification:")
 		bufw.Flush()
-		return nil, []error{err}
+		return warns, []error{err}
 	}
-	return nil, nil
+	return warns, nil
 }
 
 type etcdVersionResponse struct {

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -98,7 +98,7 @@ func TestE2eNode(t *testing.T) {
 				glog.Exitf("chroot %q failed: %v", rootfs, err)
 			}
 		}
-		if err := system.ValidateDefault(framework.TestContext.ContainerRuntime); err != nil {
+		if _, err := system.ValidateDefault(framework.TestContext.ContainerRuntime); err != nil {
 			glog.Exitf("system validation failed: %v", err)
 		}
 		return

--- a/test/e2e_node/system/cgroup_validator.go
+++ b/test/e2e_node/system/cgroup_validator.go
@@ -37,12 +37,12 @@ const (
 	cgroupsConfigPrefix = "CGROUPS_"
 )
 
-func (c *CgroupsValidator) Validate(spec SysSpec) error {
+func (c *CgroupsValidator) Validate(spec SysSpec) (error, error) {
 	subsystems, err := c.getCgroupSubsystems()
 	if err != nil {
-		return fmt.Errorf("failed to get cgroup subsystems: %v", err)
+		return nil, fmt.Errorf("failed to get cgroup subsystems: %v", err)
 	}
-	return c.validateCgroupSubsystems(spec.Cgroups, subsystems)
+	return nil, c.validateCgroupSubsystems(spec.Cgroups, subsystems)
 }
 
 func (c *CgroupsValidator) validateCgroupSubsystems(cgroupSpec, subsystems []string) error {

--- a/test/e2e_node/system/docker_validator_test.go
+++ b/test/e2e_node/system/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.(9|\d{2,})\..*`},
+		Version:     []string{`1\.(9|\d?[0-2]{2,})\..*`}, // Requires 1.9+
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -45,6 +45,16 @@ func TestValidateDockerInfo(t *testing.T) {
 		},
 		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "1.8.1"},
+			err:  true,
+		},
+		// TODO remove once sig-node supports 1.13
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "1.13.1"},
+			err:  true,
+		},
+		// TODO remove once sig-node supports 17.03-0-ce
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "17.03.0-ce"},
 			err:  true,
 		},
 	} {

--- a/test/e2e_node/system/docker_validator_test.go
+++ b/test/e2e_node/system/docker_validator_test.go
@@ -28,41 +28,52 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.(9|\d?[0-2]{2,})\..*`}, // Requires 1.9+
+		Version:     []string{`1\.(9|1[0-2])\..*`}, // Requires 1.9+
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
 		info types.Info
 		err  bool
+		warn bool
 	}{
 		{
 			info: types.Info{Driver: "driver_1", ServerVersion: "1.10.1"},
 			err:  false,
+			warn: false,
 		},
 		{
 			info: types.Info{Driver: "bad_driver", ServerVersion: "1.9.1"},
 			err:  true,
+			warn: false,
 		},
 		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "1.8.1"},
 			err:  true,
+			warn: false,
 		},
-		// TODO remove once sig-node supports 1.13
+		// TODO remove/change warn value  once sig-node supports 1.13
 		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "1.13.1"},
-			err:  true,
+			err:  false,
+			warn: true,
 		},
-		// TODO remove once sig-node supports 17.03-0-ce
+		// TODO remove/change warn value once sig-node supports 17.03-0-ce
 		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "17.03.0-ce"},
-			err:  true,
+			err:  false,
+			warn: true,
 		},
 	} {
-		err := v.validateDockerInfo(spec, test.info)
+		warn, err := v.validateDockerInfo(spec, test.info)
 		if !test.err {
 			assert.Nil(t, err, "Expect error not to occur with docker info %+v", test.info)
 		} else {
 			assert.NotNil(t, err, "Expect error to occur with docker info %+v", test.info)
+		}
+		if !test.warn {
+			assert.Nil(t, warn, "Expect error not to occur with docker info %+v", test.info)
+		} else {
+			assert.NotNil(t, warn, "Expect error to occur with docker info %+v", test.info)
 		}
 
 	}

--- a/test/e2e_node/system/kernel_validator.go
+++ b/test/e2e_node/system/kernel_validator.go
@@ -60,16 +60,16 @@ const (
 	kConfigPrefix = "CONFIG_"
 )
 
-func (k *KernelValidator) Validate(spec SysSpec) error {
+func (k *KernelValidator) Validate(spec SysSpec) (error, error) {
 	release, err := exec.Command("uname", "-r").CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to get kernel release: %v", err)
+		return nil, fmt.Errorf("failed to get kernel release: %v", err)
 	}
 	k.kernelRelease = strings.TrimSpace(string(release))
 	var errs []error
 	errs = append(errs, k.validateKernelVersion(spec.KernelSpec))
 	errs = append(errs, k.validateKernelConfig(spec.KernelSpec))
-	return errors.NewAggregate(errs)
+	return nil, errors.NewAggregate(errs)
 }
 
 // validateKernelVersion validates the kernel version.

--- a/test/e2e_node/system/os_validator.go
+++ b/test/e2e_node/system/os_validator.go
@@ -32,12 +32,12 @@ func (o *OSValidator) Name() string {
 	return "os"
 }
 
-func (o *OSValidator) Validate(spec SysSpec) error {
+func (o *OSValidator) Validate(spec SysSpec) (error, error) {
 	os, err := exec.Command("uname").CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to get os name: %v", err)
+		return nil, fmt.Errorf("failed to get os name: %v", err)
 	}
-	return o.validateOS(strings.TrimSpace(string(os)), spec.OS)
+	return nil, o.validateOS(strings.TrimSpace(string(os)), spec.OS)
 }
 
 func (o *OSValidator) validateOS(os, specOS string) error {

--- a/test/e2e_node/system/types.go
+++ b/test/e2e_node/system/types.go
@@ -114,7 +114,7 @@ var DefaultSysSpec = SysSpec{
 	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version: []string{`1\.(9|\d{2,})\..*`}, // Requires 1.9+
+			Version: []string{`1\.(9|1[0-2])\..*`}, // Requires 1.9+
 			// TODO(random-liu): Validate overlay2.
 			GraphDriver: []string{"aufs", "overlay", "devicemapper"},
 		},

--- a/test/e2e_node/system/validators.go
+++ b/test/e2e_node/system/validators.go
@@ -26,7 +26,7 @@ type Validator interface {
 	// Name is the name of the validator.
 	Name() string
 	// Validate is the validate function.
-	Validate(SysSpec) error
+	Validate(SysSpec) (error, error)
 }
 
 // Reporter is the interface for the reporters for the validators.
@@ -35,19 +35,22 @@ type Reporter interface {
 	Report(string, string, ValidationResultType) error
 }
 
-// Validate uses validators to validate the system.
-func Validate(spec SysSpec, validators []Validator) error {
+// Validate uses validators to validate the system and returns a warning or error.
+func Validate(spec SysSpec, validators []Validator) (error, error) {
 	var errs []error
+	var warns []error
 
 	for _, v := range validators {
 		glog.Infof("Validating %s...", v.Name())
-		errs = append(errs, v.Validate(spec))
+		warn, err := v.Validate(spec)
+		errs = append(errs, err)
+		warns = append(warns, warn)
 	}
-	return errors.NewAggregate(errs)
+	return errors.NewAggregate(warns), errors.NewAggregate(errs)
 }
 
 // ValidateDefault uses all default validators to validate the system and writes to stdout.
-func ValidateDefault(runtime string) error {
+func ValidateDefault(runtime string) (error, error) {
 	// OS-level validators.
 	var osValidators = []Validator{
 		&OSValidator{Reporter: DefaultReporter},


### PR DESCRIPTION
**What this PR does / why we need it**: Update regex for docker version to also capture new CE and EE versions. 

**Which issue this PR fixes**: fixes #https://github.com/kubernetes/kubeadm/issues/189

**Special notes for your reviewer**: /cc @jbeda @luxas

**Release note**:
```release-note
NONE
```
