### PR TITLE
kubeadm: Remove an outdated comment

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -186,9 +186,6 @@ func (i *Init) Run(out io.Writer) error {
 
 	// PHASE 2: Generate kubeconfig files for the admin and the kubelet
 
-	// TODO this is not great, but there is only one address we can use here
-	// so we'll pick the first one, there is much of chance to have an empty
-	// slice by the time this gets called
 	masterEndpoint := fmt.Sprintf("https://%s:%d", i.cfg.API.AdvertiseAddress, i.cfg.API.BindPort)
 	err = kubeconfigphase.CreateInitKubeConfigFiles(masterEndpoint, kubeadmapi.GlobalEnvParams.HostPKIPath, kubeadmapi.GlobalEnvParams.KubernetesDir)
 	if err != nil {


### PR DESCRIPTION
Now that `AdvertiseAddress` is a `string` and not
`AdvertiseAddresses` a `[]string` this comment is no longer
necessary.

@k8s-mirror-cluster-lifecycle-misc RFR 

**What this PR does / why we need it**

Just a little house cleaning by removing an outdated comment.

**Release note**:
```release-note
NONE
```
