### PR TITLE
Improved code coverage for plugin/pkg/scheduler/algorithm

### DIFF
--- a/plugin/pkg/scheduler/algorithm/BUILD
+++ b/plugin/pkg/scheduler/algorithm/BUILD
@@ -28,10 +28,17 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["scheduler_interface_test.go"],
+    srcs = [
+        "scheduler_interface_test.go",
+        "types_test.go",
+    ],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//pkg/api/v1:go_default_library"],
+    deps = [
+        "//pkg/api/v1:go_default_library",
+        "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+    ],
 )
 
 filegroup(

--- a/plugin/pkg/scheduler/algorithm/types_test.go
+++ b/plugin/pkg/scheduler/algorithm/types_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package algorithm
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+)
+
+// EmptyMetadataProducer should returns a no-op MetadataProducer type.
+func TestEmptyMetadataProducer(t *testing.T) {
+	fakePod := new(v1.Pod)
+	fakeLabelSelector := labels.SelectorFromSet(labels.Set{"foo": "bar"})
+
+	nodeNameToInfo := map[string]*schedulercache.NodeInfo{
+		"2": schedulercache.NewNodeInfo(fakePod),
+		"1": schedulercache.NewNodeInfo(),
+	}
+	// Test EmptyMetadataProducer
+	metadata := EmptyMetadataProducer(fakePod, nodeNameToInfo)
+	if metadata != nil {
+		t.Errorf("failed to produce empty metadata: got %v, expected nil", metadata)
+	}
+	// Test EmptyControllerLister should return nill
+	controllerLister := EmptyControllerLister{}
+	nilController, nilError := controllerLister.List(fakeLabelSelector)
+	if nilController != nil || nilError != nil {
+		t.Errorf("failed to produce empty controller lister: got %v, expected nil", nilController)
+	}
+	// Test GetPodControllers on empty controller lister should return nill
+	nilController, nilError = controllerLister.GetPodControllers(fakePod)
+	if nilController != nil || nilError != nil {
+		t.Errorf("failed to produce empty controller lister: got %v, expected nil", nilController)
+	}
+	// Test GetPodReplicaSets on empty replica sets should return nill
+	replicaSetLister := EmptyReplicaSetLister{}
+	nilRss, nilErrRss := replicaSetLister.GetPodReplicaSets(fakePod)
+	if nilRss != nil || nilErrRss != nil {
+		t.Errorf("failed to produce empty replicaSetLister: got %v, expected nil", nilRss)
+	}
+
+	// Test GetPodStatefulSets on empty replica sets should return nill
+	statefulSetLister := EmptyStatefulSetLister{}
+	nilSSL, nilErrSSL := statefulSetLister.GetPodStatefulSets(fakePod)
+	if nilSSL != nil || nilErrSSL != nil {
+		t.Errorf("failed to produce empty statefulSetLister: got %v, expected nil", nilSSL)
+	}
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
Part of #39559 , code coverage improved from 0% to 100%
**Special notes for your reviewer**:
Improved coverage for scheduler/algorithm to 100%
Test cover output:
```
make test WHAT=./plugin/pkg/scheduler/algorithm KUBE_COVER=y
Running tests for APIVersion: v1,apps/v1beta1,authentication.k8s.io/v1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1,authorization.k8s.io/v1beta1,autoscaling/v1,autoscaling/v2alpha1,batch/v1,batch/v2alpha1,certificates.k8s.io/v1beta1,extensions/v1beta1,imagepolicy.k8s.io/v1alpha1,policy/v1beta1,rbac.authorization.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,storage.k8s.io/v1beta1,federation/v1beta1
+++ [0302 10:43:05] Saving coverage output in '/tmp/k8s_coverage/v1,apps/v1beta1,authentication.k8s.io/v1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1,authorization.k8s.io/v1beta1,autoscaling/v1,autoscaling/v2alpha1,batch/v1,batch/v2alpha1,certificates.k8s.io/v1beta1,extensions/v1beta1,imagepolicy.k8s.io/v1alpha1,policy/v1beta1,rbac.authorization.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,storage.k8s.io/v1beta1,federation/v1beta1/20170302-104305'
skipped	k8s.io/kubernetes/cmd/libs/go2idl/generator
skipped	k8s.io/kubernetes/vendor/k8s.io/client-go/1.4/rest
ok  	k8s.io/kubernetes/plugin/pkg/scheduler/algorithm	0.061s	coverage: 100.0% of statements
+++ [0302 10:43:07] Combined coverage report: /tmp/k8s_coverage/v1,apps/v1beta1,authentication.k8s.io/v1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1,authorization.k8s.io/v1beta1,autoscaling/v1,autoscaling/v2alpha1,batch/v1,batch/v2alpha1,certificates.k8s.io/v1beta1,extensions/v1beta1,imagepolicy.k8s.io/v1alpha1,policy/v1beta1,rbac.authorization.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,storage.k8s.io/v1beta1,federation/v1beta1/20170302-104305/combined-coverage.html
```