### PR TITLE
Return nil when deleting non-exist GCE PD

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -152,7 +152,10 @@ type Routes interface {
 	DeleteRoute(clusterName string, route *Route) error
 }
 
-var InstanceNotFound = errors.New("instance not found")
+var (
+	InstanceNotFound = errors.New("instance not found")
+	DiskNotFound     = errors.New("disk is not found")
+)
 
 // Zone represents the location of a particular machine.
 type Zone struct {

--- a/test/e2e/pd.go
+++ b/test/e2e/pd.go
@@ -524,6 +524,13 @@ var _ = framework.KubeDescribe("Pod Disks", func() {
 		By("Waiting for pd to detach from host0")
 		framework.ExpectNoError(waitForPDDetach(diskName, host0Name), "Timed out waiting for detach pd")
 	})
+
+	It("should be able to delete a non-existent PD without error", func() {
+		framework.SkipUnlessProviderIs("gce")
+
+		By("delete a PD")
+		framework.DeletePDWithRetry("non-exist")
+	})
 })
 
 func verifyPDContentsViaContainer(f *framework.Framework, podName, containerName string, fileAndContentToVerify map[string]string) {


### PR DESCRIPTION
When gce cloud tries to delete a disk, if the disk could not be found
from the zones, the function should return nil error. This modified behavior is also consistent with AWS
