### PR TITLE
Update npd in kubemark since #42201 is merged.

### DIFF
--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -96,7 +96,7 @@ spec:
             cpu: {{HOLLOW_PROXY_CPU}}m
             memory: {{HOLLOW_PROXY_MEM}}Ki
       - name: hollow-node-problem-detector
-        image: gcr.io/google_containers/node-problem-detector:v0.3.0-alpha.0
+        image: gcr.io/google_containers/node-problem-detector:v0.3.0-alpha.1
         env:
         - name: NODE_NAME
           valueFrom:
@@ -105,7 +105,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - /node-problem-detector --kernel-monitor=/config/kernel.monitor --apiserver-override="https://{{master_ip}}:443?inClusterConfig=false&auth=/kubeconfig/npd.kubeconfig" --alsologtostderr 1>>/var/log/npd-$(NODE_NAME).log 2>&1
+        - /node-problem-detector --system-log-monitors=/config/kernel.monitor --apiserver-override="https://{{master_ip}}:443?inClusterConfig=false&auth=/kubeconfig/npd.kubeconfig" --alsologtostderr 1>>/var/log/npd-$(NODE_NAME).log 2>&1
         volumeMounts:
         - name: kubeconfig-volume
           mountPath: /kubeconfig

--- a/test/kubemark/resources/kernel-monitor.json
+++ b/test/kubemark/resources/kernel-monitor.json
@@ -1,7 +1,12 @@
 {
-	"logPath": "/var/log/faillog",
+	"plugin": "filelog",
+	"pluginConfig": {
+		"timestamp": "dummy",
+		"message": "dummy",
+		"timestampFormat": "dummy"
+	},
+	"logPath": "/dev/null",
 	"lookback": "10m",
-	"startPattern": "Initializing cgroup subsys cpuset",
 	"bufferSize": 10,
 	"source": "kernel-monitor",
 	"conditions": [],


### PR DESCRIPTION
Revert https://github.com/kubernetes/kubernetes/pull/41716.

#42201 has been merged, and #41713 is fixed. Now we could retry update npd in kubemark.

/cc @shyamjvs @wojtek-t @dchen1107 