### PR TITLE
e2e/framework: Deflake cleanup of RCs in service_util.

### DIFF
--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -844,13 +844,9 @@ func (t *ServiceTestFixture) Cleanup() []error {
 	for rcName := range t.rcs {
 		By("stopping RC " + rcName + " in namespace " + t.Namespace)
 		// First, resize the RC to 0.
-		old, err := t.Client.Core().ReplicationControllers(t.Namespace).Get(rcName, metav1.GetOptions{})
+		patch := `{"spec":{"replicas":0}}`
+		_, err := t.Client.Core().ReplicationControllers(t.Namespace).Patch(rcName, types.StrategicMergePatchType, []byte(patch))
 		if err != nil {
-			errs = append(errs, err)
-		}
-		x := int32(0)
-		old.Spec.Replicas = &x
-		if _, err := t.Client.Core().ReplicationControllers(t.Namespace).Update(old); err != nil {
 			errs = append(errs, err)
 		}
 		// TODO(mikedanese): Wait.


### PR DESCRIPTION
The previous Get/Update pattern with no retry on resource version mismatch
would flake with the following error:

"the object has been modified; please apply your changes to the latest
version and try again"

**What this PR does / why we need it**:

Remove one source of flakiness in e2e/framework/service_util:

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-etcd3/6448/

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
