### PR TITLE
install/kube-up: fix some errors while install k8s through kube-up/down.sh

### DIFF
--- a/cluster/ubuntu/download-release.sh
+++ b/cluster/ubuntu/download-release.sh
@@ -48,7 +48,7 @@ grep -q "^${FLANNEL_VERSION}\$" binaries/.flannel 2>/dev/null || {
 }
 
 # ectd
-ETCD_VERSION=${ETCD_VERSION:-"2.3.1"}
+ETCD_VERSION=${ETCD_VERSION:-"3.0.17"}
 ETCD="etcd-v${ETCD_VERSION}-linux-amd64"
 echo "Prepare etcd ${ETCD_VERSION} release ..."
 grep -q "^${ETCD_VERSION}\$" binaries/.etcd 2>/dev/null || {


### PR DESCRIPTION
What this PR does / why we need it:

     etcd2.3.1 will be installed follow this scripts, but k8s use etcd3 as default storage backend, so the next error will always be apprear: 
     API server: rpc error: code = 13 desc = transport is closing
     so i think we should change the version of etcd

    thank you!
