### PR TITLE
switch to k8s json to avoid number decoding issue

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -17,12 +17,12 @@ limitations under the License.
 package handlers
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/conversion/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 
 	"github.com/evanphx/json-patch"

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -10023,6 +10023,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/runtime/serializer/streaming",
         "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/apimachinery/pkg/util/httpstream",
+        "//vendor:k8s.io/apimachinery/pkg/util/json",
         "//vendor:k8s.io/apimachinery/pkg/util/mergepatch",
         "//vendor:k8s.io/apimachinery/pkg/util/net",
         "//vendor:k8s.io/apimachinery/pkg/util/runtime",


### PR DESCRIPTION
Fixes #42488
Fixes #42282

> use "k8s.io/apimachinery/pkg/util/json" to avoid number conversion issues

@liggitt Same reason as https://github.com/kubernetes/kubernetes/pull/40666#pullrequestreview-19186078

```release-note
NONE
```