### PR TITLE
Automated cherry pick of #41911

### DIFF
--- a/cluster/saltbase/salt/rescheduler/rescheduler.manifest
+++ b/cluster/saltbase/salt/rescheduler/rescheduler.manifest
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: rescheduler-v0.2.1
+  name: rescheduler-v0.2.2
   namespace: kube-system
   labels:
     k8s-app: rescheduler
-    version: v0.2.1
+    version: v0.2.2
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Rescheduler"
 spec:
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/rescheduler:v0.2.1
+  - image: gcr.io/google-containers/rescheduler:v0.2.2
     name: rescheduler
     volumeMounts:
     - mountPath: /var/log/rescheduler.log


### PR DESCRIPTION
Cherry pick of #41911 on release-1.4.

#41911: Bump gcr.io/google-containers/rescheduler to v0.2.2