### PR TITLE
New e2e node test suite with memcg turned on

### DIFF
--- a/test/e2e_node/jenkins/jenkins-memcg-serial.properties
+++ b/test/e2e_node/jenkins/jenkins-memcg-serial.properties
@@ -1,0 +1,19 @@
+GCI_IMAGE_PROJECT=container-vm-image-staging
+GCI_IMAGE_FAMILY=gci-canary-test
+GCI_IMAGE=$(gcloud compute images describe-from-family ${GCI_IMAGE_FAMILY} --project=${GCI_IMAGE_PROJECT} --format="value(name)")
+DOCKER_VERSION=$(curl -fsSL --retry 3 https://api.github.com/repos/docker/docker/releases | tac | tac | grep -m 1 "\"tag_name\"\:" | grep -Eo "[0-9\.rc-]+")
+GCI_CLOUD_INIT=test/e2e_node/jenkins/gci-init.yaml
+GCE_HOSTS=
+GCE_IMAGES=${GCI_IMAGE}
+GCE_IMAGE_PROJECT=${GCI_IMAGE_PROJECT}
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ci-node-e2e
+CLEANUP=true
+# user-data is the GCI cloud init config file.
+# gci-docker-version specifies docker version in GCI image.
+GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION},gci-update-strategy=update_disabled"
+GINKGO_FLAGS='--focus="MemoryEviction" --skip=""'
+TEST_ARGS='--kubelet-flags=--experimental-kernel-memcg-notification=true --feature-gates=DynamicKubeletConfig=true'
+KUBELET_ARGS='--cgroups-per-qos=true --cgroup-root=/'
+PARALLELISM=1
+TIMEOUT=1h


### PR DESCRIPTION
The flag --experimental-kernal-memcg-notification was initially added to allow disabling an eviction feature which used memcg notifications to make memory evictions more reactive.
As documented in #37853, memcg notifications increased the likelihood of encountering soft lockups, especially on CVM.

This feature would valuable to turn on, at least for GCI, since soft lockup issues were less prevalent on GCI and appeared (at the time) to be unrelated to memcg notifications.

In the interest of caution, I would like to monitor serial tests on GCI with --experimental-kernal-memcg-notification=true.

cc @vishh @Random-Liu @dchen1107 @kubernetes/sig-node-pr-reviews 