### PR TITLE
client-go tools/record example

### DIFF
--- a/staging/src/k8s.io/client-go/examples/recorder/BUILD
+++ b/staging/src/k8s.io/client-go/examples/recorder/BUILD
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+)
+
+go_binary(
+    name = "recorder",
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/pkg/api:go_default_library",
+        "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
+    ],
+)

--- a/staging/src/k8s.io/client-go/examples/recorder/README.md
+++ b/staging/src/k8s.io/client-go/examples/recorder/README.md
@@ -1,0 +1,21 @@
+# Recorder/Events Example
+
+This example demonstrates how to send and receive events. By default it will
+print all events associated to the pod `kube-apiserver-master`. Further, it
+will check every 10 seconds if this pod exists at all, and if it finds the pod,
+it emits a `PodDiscovered` event, which is will be bound to that pod.
+
+The result is, that you will see all events associated with that pod,
+printed to `stdout`, including the `PodDiscovered` event.
+
+It demonstrates how to:
+ * use an event recorder for sending events to the cluster
+ * watch for events in general
+ * watch for events belonging to a specific object
+
+## Running
+
+```
+# if outside of the cluster
+go run *.go -kubeconfig=/my/config -logtostderr=true
+```

--- a/staging/src/k8s.io/client-go/examples/recorder/main.go
+++ b/staging/src/k8s.io/client-go/examples/recorder/main.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	core_v1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/record"
+)
+
+func main() {
+	var kubeconfig string
+	var podName string
+	var namespace string
+	var server string
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	flag.StringVar(&server, "server", "", "API server url")
+	flag.StringVar(&podName, "pod", "kube-apiserver-master", "Name of the pod")
+	flag.StringVar(&namespace, "namespace", api.NamespaceSystem, "Namespace of the pod")
+	flag.Parse()
+	// uses the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags(server, kubeconfig)
+	if err != nil {
+		glog.Fatal(err)
+	}
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	// Create a new broadcaster which will send events we generate to the apiserver
+	broadcaster := record.NewBroadcaster()
+	broadcaster.StartRecordingToSink(&core_v1.EventSinkImpl{Interface: clientset.Events(namespace)})
+	recorder := broadcaster.NewRecorder(api.Scheme, v1.EventSource{Component: "pod-watcher", Host: "localhost"})
+
+	// Create a watcher which will give us events from an object with the name of the Pod
+	watcher, err := clientset.CoreV1().Events(namespace).
+		Watch(meta_v1.ListOptions{FieldSelector: "involvedObject.name=" + podName})
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	defer watcher.Stop()
+
+	// Watch for events associated with the specified pod name and print the output
+	go func() {
+		for obj := range watcher.ResultChan() {
+			event := obj.Object.(*v1.Event)
+			fmt.Printf("Reason: %s; Message: %s \n", event.Reason, event.Message)
+		}
+	}()
+
+	// Every 10 seconds fetch the specified pod and emit a PodDiscovered event of severity `Normal`
+	for {
+		glog.V(2).Infof("Fetching pod %s", podName)
+		pod, err := clientset.CoreV1().Pods(namespace).Get(podName, meta_v1.GetOptions{})
+		if err != nil {
+			glog.Fatal(err)
+		}
+		glog.V(2).Infof("Emitting event for pod %s", podName)
+		recorder.Eventf(pod, "Normal", "PodDiscovered", "Discovered pod %s in namespace %s", podName, namespace)
+		time.Sleep(10 * time.Second)
+	}
+}


### PR DESCRIPTION
Periodically fetch a via the commandline specifed pod and emit an event.

In parallel listen for all events associated with this pod and print
them to stdout.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

An example on how to use tools/record in client-go. This is part of https://github.com/kubernetes/client-go/issues/128, which aims to increate the example coverage of client-go.