### PR TITLE
Preserve custom etcd prefix compatibility for etcd3

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper_test.go
@@ -674,3 +674,22 @@ func TestDeleteWithRetry(t *testing.T) {
 		t.Errorf("Expect an NotFound error, got %v", err)
 	}
 }
+
+func TestPrefix(t *testing.T) {
+	scheme, codecs := testScheme(t)
+	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
+	server := etcdtesting.NewEtcdTestClientServer(t)
+	defer server.Terminate(t)
+
+	testcases := map[string]string{
+		"custom/prefix":     "/custom/prefix",
+		"/custom//prefix//": "/custom/prefix",
+		"/registry":         "/registry",
+	}
+	for configuredPrefix, effectivePrefix := range testcases {
+		helper := newEtcdHelper(server.Client, scheme, codec, configuredPrefix)
+		if helper.pathPrefix != effectivePrefix {
+			t.Errorf("configured prefix of %s, expected effective prefix of %s, got %s", configuredPrefix, effectivePrefix, helper.pathPrefix)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -102,8 +102,11 @@ func newStore(c *clientv3.Client, quorumRead bool, codec runtime.Codec, prefix s
 		codec:       codec,
 		versioner:   versioner,
 		transformer: transformer,
-		pathPrefix:  prefix,
-		watcher:     newWatcher(c, codec, versioner, transformer),
+		// for compatibility with etcd2 impl.
+		// no-op for default prefix of '/registry'.
+		// keeps compatibility with etcd2 impl for custom prefixes that don't start with '/'
+		pathPrefix: path.Join("/", prefix),
+		watcher:    newWatcher(c, codec, versioner, transformer),
 	}
 	if !quorumRead {
 		// In case of non-quorum reads, we can set WithSerializable()

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -688,3 +688,20 @@ func testPropogateStore(ctx context.Context, t *testing.T, store *store, obj *ex
 	}
 	return key, setOutput
 }
+
+func TestPrefix(t *testing.T) {
+	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
+	cluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	transformer := prefixTransformer{prefix: []byte("test!")}
+	testcases := map[string]string{
+		"custom/prefix":     "/custom/prefix",
+		"/custom//prefix//": "/custom/prefix",
+		"/registry":         "/registry",
+	}
+	for configuredPrefix, effectivePrefix := range testcases {
+		store := newStore(cluster.RandClient(), false, codec, configuredPrefix, transformer)
+		if store.pathPrefix != effectivePrefix {
+			t.Errorf("configured prefix of %s, expected effective prefix of %s, got %s", configuredPrefix, effectivePrefix, store.pathPrefix)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #42505

```release-note
restored normalization of custom `--etcd-prefix` when `--storage-backend` is set to etcd3
```