### PR TITLE
Distribute load in cluster load tests uniformly

### DIFF
--- a/test/e2e/cluster_logging_es.go
+++ b/test/e2e/cluster_logging_es.go
@@ -45,7 +45,7 @@ var _ = framework.KubeDescribe("Cluster level logging using Elasticsearch [Featu
 		framework.ExpectNoError(err, "Elasticsearch is not working")
 
 		By("Running synthetic logger")
-		pod := createLoggingPod(f, podName, 10*60, 10*time.Minute)
+		pod := createLoggingPod(f, podName, "", 10*60, 10*time.Minute)
 		defer f.PodClient().Delete(podName, &meta_v1.DeleteOptions{})
 		err = framework.WaitForPodNameRunningInNamespace(f.ClientSet, podName, f.Namespace.Name)
 		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to be running", podName))

--- a/test/e2e/cluster_logging_gcl.go
+++ b/test/e2e/cluster_logging_gcl.go
@@ -43,7 +43,7 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL", func() {
 		framework.ExpectNoError(err, "GCL is not working")
 
 		By("Running synthetic logger")
-		pod := createLoggingPod(f, podName, 10*60, 10*time.Minute)
+		pod := createLoggingPod(f, podName, "", 10*60, 10*time.Minute)
 		defer f.PodClient().Delete(podName, &meta_v1.DeleteOptions{})
 		err = framework.WaitForPodNameRunningInNamespace(f.ClientSet, podName, f.Namespace.Name)
 		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to be running", podName))

--- a/test/e2e/cluster_logging_utils.go
+++ b/test/e2e/cluster_logging_utils.go
@@ -91,9 +91,9 @@ func (entry *logEntry) getLogEntryNumber() (int, bool) {
 	return lineNumber, err == nil
 }
 
-func createLoggingPod(f *framework.Framework, podName string, totalLines int, loggingDuration time.Duration) *loggingPod {
+func createLoggingPod(f *framework.Framework, podName string, nodeName string, totalLines int, loggingDuration time.Duration) *loggingPod {
 	framework.Logf("Starting pod %s", podName)
-	createLogsGeneratorPod(f, podName, totalLines, loggingDuration)
+	createLogsGeneratorPod(f, podName, nodeName, totalLines, loggingDuration)
 
 	return &loggingPod{
 		Name: podName,
@@ -104,7 +104,7 @@ func createLoggingPod(f *framework.Framework, podName string, totalLines int, lo
 	}
 }
 
-func createLogsGeneratorPod(f *framework.Framework, podName string, linesCount int, duration time.Duration) {
+func createLogsGeneratorPod(f *framework.Framework, podName string, nodeName string, linesCount int, duration time.Duration) {
 	f.PodClient().Create(&api_v1.Pod{
 		ObjectMeta: meta_v1.ObjectMeta{
 			Name: podName,
@@ -137,6 +137,7 @@ func createLogsGeneratorPod(f *framework.Framework, podName string, linesCount i
 					},
 				},
 			},
+			NodeName: nodeName,
 		},
 	})
 }


### PR DESCRIPTION
This PR makes cluster logging load tests distribute logging uniformly, to avoid situation, where 80% of pods are allocated on one node and overall results are worse then it could be.