### PR TITLE
Allow to change logging damonset

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-app: fluentd-es
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
     version: v1.22
 spec:
   template:

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -388,4 +388,4 @@ metadata:
   name: fluentd-gcp-config
   namespace: kube-system
   labels:
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     k8s-app: fluentd-gcp
     kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
+    addonmanager.kubernetes.io/mode: EnsureExists
     version: v2.0
 spec:
   template:


### PR DESCRIPTION
Users should be able to change the configuration of fluentd and fluentd daemonset, therefore, according to the [adddon manager documentation](https://github.com/kubernetes/kubernetes/tree/master/cluster/addons/addon-manager), only existence should be checked, not the contents of the addon.