### PR TITLE
get-kube-local.sh checks pods with option "--namespace=kube-system"

### DIFF
--- a/cluster/get-kube-local.sh
+++ b/cluster/get-kube-local.sh
@@ -80,7 +80,7 @@ function create_cluster {
 
   echo -e -n "\tWaiting for master components to start..."
   while true; do
-    local running_count=$(kubectl -s=http://${KUBE_HOST}:8080 get pods --no-headers 2>/dev/null | grep "Running" | wc -l)
+    local running_count=$(kubectl -s=http://${KUBE_HOST}:8080 get pods --no-headers --namespace=kube-system 2>/dev/null | grep "Running" | wc -l)
     # We expect to have 3 running pods - etcd, master and kube-proxy.
     if [ "$running_count" -ge 3 ]; then
       break


### PR DESCRIPTION
**What this PR does / why we need it**:

Local cluster creation using get-kube-local.sh is never finished.
The get-kube-local.sh monitors running_count of pods such as etcd,
master and kube-proxy, but these pods are created under the namespace
kube-system. Therefore kubectl can't find these pods then cluster
creation isn't completed.

The get-kube-local.sh should monitor created pods with option
"--namespace=kube-system".

**Which issue this PR fixes** : fixes #42517

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->


**Release note**: 
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
`NONE`
```