### PR TITLE
kubeadm: Fix the nodeSelector and scheduler mounts when using the self-hosted mode

### DIFF
--- a/cmd/kubeadm/app/master/selfhosted.go
+++ b/cmd/kubeadm/app/master/selfhosted.go
@@ -138,7 +138,7 @@ func launchSelfHostedControllerManager(cfg *kubeadmapi.MasterConfiguration, clie
 
 func launchSelfHostedScheduler(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset, volumes []v1.Volume, volumeMounts []v1.VolumeMount) error {
 	start := time.Now()
-	scheduler := getSchedulerDeployment(cfg)
+	scheduler := getSchedulerDeployment(cfg, volumes, volumeMounts)
 	if _, err := client.Extensions().Deployments(metav1.NamespaceSystem).Create(&scheduler); err != nil {
 		return fmt.Errorf("failed to create self-hosted %q deployment [%v]", kubeScheduler, err)
 	}
@@ -204,7 +204,7 @@ func getAPIServerDS(cfg *kubeadmapi.MasterConfiguration, volumes []v1.Volume, vo
 					},
 				},
 				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{metav1.NodeLabelKubeadmAlphaRole: metav1.NodeLabelRoleMaster},
+					NodeSelector: map[string]string{kubeadmconstants.LabelNodeRoleMaster: ""},
 					HostNetwork:  true,
 					Volumes:      volumes,
 					Containers: []v1.Container{
@@ -255,7 +255,7 @@ func getControllerManagerDeployment(cfg *kubeadmapi.MasterConfiguration, volumes
 					},
 				},
 				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{metav1.NodeLabelKubeadmAlphaRole: metav1.NodeLabelRoleMaster},
+					NodeSelector: map[string]string{kubeadmconstants.LabelNodeRoleMaster: ""},
 					HostNetwork:  true,
 					Volumes:      volumes,
 					Containers: []v1.Container{
@@ -278,7 +278,7 @@ func getControllerManagerDeployment(cfg *kubeadmapi.MasterConfiguration, volumes
 	return d
 }
 
-func getSchedulerDeployment(cfg *kubeadmapi.MasterConfiguration) ext.Deployment {
+func getSchedulerDeployment(cfg *kubeadmapi.MasterConfiguration, volumes []v1.Volume, volumeMounts []v1.VolumeMount) ext.Deployment {
 	d := ext.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "extensions/v1beta1",
@@ -307,13 +307,15 @@ func getSchedulerDeployment(cfg *kubeadmapi.MasterConfiguration) ext.Deployment 
 					},
 				},
 				Spec: v1.PodSpec{
-					NodeSelector: map[string]string{metav1.NodeLabelKubeadmAlphaRole: metav1.NodeLabelRoleMaster},
+					NodeSelector: map[string]string{kubeadmconstants.LabelNodeRoleMaster: ""},
 					HostNetwork:  true,
+					Volumes:      volumes,
 					Containers: []v1.Container{
 						{
 							Name:          "self-hosted-" + kubeScheduler,
 							Image:         images.GetCoreImage(images.KubeSchedulerImage, cfg, kubeadmapi.GlobalEnvParams.HyperkubeImage),
 							Command:       getSchedulerCommand(cfg, true),
+							VolumeMounts:  volumeMounts,
 							LivenessProbe: componentProbe(10251, "/healthz", v1.URISchemeHTTP),
 							Resources:     componentResources("100m"),
 							Env:           getProxyEnvVars(),
@@ -324,6 +326,7 @@ func getSchedulerDeployment(cfg *kubeadmapi.MasterConfiguration) ext.Deployment 
 			},
 		},
 	}
+
 	return d
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
The self-hosted option in `kubeadm` was broken.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #42528
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```


/cc @luxas 