### PR TITLE
print warning when delete current context

### DIFF
--- a/pkg/kubectl/cmd/config/config.go
+++ b/pkg/kubectl/cmd/config/config.go
@@ -63,7 +63,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *co
 	cmd.AddCommand(NewCmdConfigGetContexts(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigGetClusters(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigDeleteCluster(out, pathOptions))
-	cmd.AddCommand(NewCmdConfigDeleteContext(out, pathOptions))
+	cmd.AddCommand(NewCmdConfigDeleteContext(out, errOut, pathOptions))
 
 	return cmd
 }

--- a/pkg/kubectl/cmd/config/delete_context.go
+++ b/pkg/kubectl/cmd/config/delete_context.go
@@ -33,14 +33,14 @@ var (
 		kubectl config delete-context minikube`)
 )
 
-func NewCmdConfigDeleteContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigDeleteContext(out, errOut io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete-context NAME",
 		Short:   i18n.T("Delete the specified context from the kubeconfig"),
 		Long:    "Delete the specified context from the kubeconfig",
 		Example: delete_context_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := runDeleteContext(out, configAccess, cmd)
+			err := runDeleteContext(out, errOut, configAccess, cmd)
 			cmdutil.CheckErr(err)
 		},
 	}
@@ -48,7 +48,7 @@ func NewCmdConfigDeleteContext(out io.Writer, configAccess clientcmd.ConfigAcces
 	return cmd
 }
 
-func runDeleteContext(out io.Writer, configAccess clientcmd.ConfigAccess, cmd *cobra.Command) error {
+func runDeleteContext(out, errOut io.Writer, configAccess clientcmd.ConfigAccess, cmd *cobra.Command) error {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {
 		return err
@@ -69,6 +69,10 @@ func runDeleteContext(out io.Writer, configAccess clientcmd.ConfigAccess, cmd *c
 	_, ok := config.Contexts[name]
 	if !ok {
 		return fmt.Errorf("cannot delete context %s, not in %s", name, configFile)
+	}
+
+	if config.CurrentContext == name {
+		fmt.Fprint(errOut, "warning: this removed your active context, use \"kubectl config use-context\" to select a different one\n")
 	}
 
 	delete(config.Contexts, name)

--- a/pkg/kubectl/cmd/config/delete_context_test.go
+++ b/pkg/kubectl/cmd/config/delete_context_test.go
@@ -65,7 +65,8 @@ func (test deleteContextTest) run(t *testing.T) {
 	pathOptions.EnvVar = ""
 
 	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigDeleteContext(buf, pathOptions)
+	errBuf := bytes.NewBuffer([]byte{})
+	cmd := NewCmdConfigDeleteContext(buf, errBuf, pathOptions)
 	cmd.SetArgs([]string{test.contextToDelete})
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v", err)


### PR DESCRIPTION
mirror update to kubectl. fix #42012 @smarterclayton ptal.

**Release Note**:
```
print warning when delete current context
```