### PR TITLE
Use Secrets for files that self-hosted pods depend on

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -271,7 +271,7 @@ func (i *Init) Run(out io.Writer) error {
 		// Temporary control plane is up, now we create our self hosted control
 		// plane components and remove the static manifests:
 		fmt.Println("[self-hosted] Creating self-hosted control plane...")
-		if err := selfhostingphase.CreateSelfHostedControlPlane(client); err != nil {
+		if err := selfhostingphase.CreateSelfHostedControlPlane(i.cfg, client); err != nil {
 			return err
 		}
 	}

--- a/cmd/kubeadm/app/phases/selfhosting/BUILD
+++ b/cmd/kubeadm/app/phases/selfhosting/BUILD
@@ -13,10 +13,12 @@ go_test(
     srcs = [
         "podspec_mutation_test.go",
         "selfhosting_test.go",
+        "selfhosting_volumes_test.go",
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
@@ -28,9 +30,11 @@ go_library(
     srcs = [
         "podspec_mutation.go",
         "selfhosting.go",
+        "selfhosting_volumes.go",
     ],
     tags = ["automanaged"],
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/api:go_default_library",

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
@@ -71,8 +72,9 @@ func TestMutatePodSpec(t *testing.T) {
 		},
 	}
 
+	cfg := &kubeadmapi.MasterConfiguration{}
 	for _, rt := range tests {
-		mutatePodSpec(rt.component, rt.podSpec)
+		mutatePodSpec(cfg, rt.component, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed mutatePodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -108,8 +110,9 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 		},
 	}
 
+	cfg := &kubeadmapi.MasterConfiguration{}
 	for _, rt := range tests {
-		addNodeSelectorToPodSpec(rt.podSpec)
+		addNodeSelectorToPodSpec(cfg, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed addNodeSelectorToPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -145,8 +148,9 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 		},
 	}
 
+	cfg := &kubeadmapi.MasterConfiguration{}
 	for _, rt := range tests {
-		setMasterTolerationOnPodSpec(rt.podSpec)
+		setMasterTolerationOnPodSpec(cfg, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed setMasterTolerationOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -175,8 +179,9 @@ func TestSetRightDNSPolicyOnPodSpec(t *testing.T) {
 		},
 	}
 
+	cfg := &kubeadmapi.MasterConfiguration{}
 	for _, rt := range tests {
-		setRightDNSPolicyOnPodSpec(rt.podSpec)
+		setRightDNSPolicyOnPodSpec(cfg, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed setRightDNSPolicyOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfhosting
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+)
+
+type tlsKeyPair struct {
+	name string
+	cert string
+	key  string
+}
+
+func k8sSelfHostedVolumeMount() v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      "k8s",
+		MountPath: kubeadmapi.GlobalEnvParams.KubernetesDir,
+		ReadOnly:  true,
+	}
+}
+
+func apiServerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
+	return v1.Volume{
+		Name: "k8s",
+		VolumeSource: v1.VolumeSource{
+			Projected: &v1.ProjectedVolumeSource{
+				Sources: []v1.VolumeProjection{
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.CACertAndKeyBaseName,
+							},
+							Items: []v1.KeyToPath{
+								{
+									Key:  v1.TLSCertKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.CACertName),
+								},
+								{
+									Key:  v1.TLSPrivateKeyKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.CAKeyName),
+								},
+							},
+						},
+					},
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.APIServerCertAndKeyBaseName,
+							},
+							Items: []v1.KeyToPath{
+								{
+									Key:  v1.TLSCertKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.APIServerCertName),
+								},
+								{
+									Key:  v1.TLSPrivateKeyKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.APIServerKeyName),
+								},
+							},
+						},
+					},
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.APIServerKubeletClientCertAndKeyBaseName,
+							},
+							Items: []v1.KeyToPath{
+								{
+									Key:  v1.TLSCertKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.APIServerKubeletClientCertName),
+								},
+								{
+									Key:  v1.TLSPrivateKeyKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.APIServerKubeletClientKeyName),
+								},
+							},
+						},
+					},
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.ServiceAccountKeyBaseName,
+							},
+							Items: []v1.KeyToPath{
+								{
+									Key:  v1.TLSCertKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.ServiceAccountPublicKeyName),
+								},
+								{
+									Key:  v1.TLSPrivateKeyKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.ServiceAccountPrivateKeyName),
+								},
+							},
+						},
+					},
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.FrontProxyCACertAndKeyBaseName,
+							},
+							Items: []v1.KeyToPath{
+								{
+									Key:  v1.TLSCertKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.FrontProxyCACertName),
+								},
+							},
+						},
+					},
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.FrontProxyClientCertAndKeyBaseName,
+							},
+							Items: []v1.KeyToPath{
+								{
+									Key:  v1.TLSCertKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.FrontProxyClientCertName),
+								},
+								{
+									Key:  v1.TLSPrivateKeyKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.FrontProxyClientKeyName),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func schedulerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
+	return v1.Volume{
+		Name: "k8s",
+		VolumeSource: v1.VolumeSource{
+			Projected: &v1.ProjectedVolumeSource{
+				Sources: []v1.VolumeProjection{
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.SchedulerKubeConfigFileName,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func controllerManagerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
+	return v1.Volume{
+		Name: "k8s",
+		VolumeSource: v1.VolumeSource{
+			Projected: &v1.ProjectedVolumeSource{
+				Sources: []v1.VolumeProjection{
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.ControllerManagerKubeConfigFileName,
+							},
+						},
+					},
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.CACertAndKeyBaseName,
+							},
+							Items: []v1.KeyToPath{
+								{
+									Key:  v1.TLSCertKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.CACertName),
+								},
+								{
+									Key:  v1.TLSPrivateKeyKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.CAKeyName),
+								},
+							},
+						},
+					},
+					{
+						Secret: &v1.SecretProjection{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: kubeadmconstants.ServiceAccountKeyBaseName,
+							},
+							Items: []v1.KeyToPath{
+								{
+									Key:  v1.TLSPrivateKeyKey,
+									Path: path.Join(path.Base(cfg.CertificatesDir), kubeadmconstants.ServiceAccountPrivateKeyName),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createTLSSecrets(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
+	for _, tlsKeyPair := range getTLSKeyPairs() {
+		secret, err := createTLSSecretFromFiles(
+			tlsKeyPair.name,
+			path.Join(cfg.CertificatesDir, tlsKeyPair.cert),
+			path.Join(cfg.CertificatesDir, tlsKeyPair.key),
+		)
+		if err != nil {
+			return err
+		}
+
+		if _, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Create(secret); err != nil {
+			return err
+		}
+		fmt.Printf("[self-hosted] Created TLS secret %q from %s and %s\n", tlsKeyPair.name, tlsKeyPair.cert, tlsKeyPair.key)
+	}
+
+	return nil
+}
+
+func createOpaqueSecrets(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
+	files := []string{
+		kubeadmconstants.SchedulerKubeConfigFileName,
+		kubeadmconstants.ControllerManagerKubeConfigFileName,
+	}
+	for _, file := range files {
+		secret, err := createOpaqueSecretFromFile(
+			file,
+			path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, file),
+		)
+		if err != nil {
+			return err
+		}
+
+		if _, err := client.CoreV1().Secrets(metav1.NamespaceSystem).Create(secret); err != nil {
+			return err
+		}
+		fmt.Printf("[self-hosted] Created secret %q\n", file)
+	}
+
+	return nil
+}
+
+func createTLSSecretFromFiles(secretName, crt, key string) (*v1.Secret, error) {
+	crtBytes, err := ioutil.ReadFile(crt)
+	if err != nil {
+		return nil, err
+	}
+	keyBytes, err := ioutil.ReadFile(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: metav1.NamespaceSystem,
+		},
+		Type: v1.SecretTypeTLS,
+		Data: map[string][]byte{
+			v1.TLSCertKey:       crtBytes,
+			v1.TLSPrivateKeyKey: keyBytes,
+		},
+	}, nil
+}
+
+func createOpaqueSecretFromFile(secretName, file string) (*v1.Secret, error) {
+	fileBytes, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: metav1.NamespaceSystem,
+		},
+		Type: v1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			path.Base(file): fileBytes,
+		},
+	}, nil
+}
+
+func getTLSKeyPairs() []*tlsKeyPair {
+	return []*tlsKeyPair{
+		{
+			name: kubeadmconstants.CACertAndKeyBaseName,
+			cert: kubeadmconstants.CACertName,
+			key:  kubeadmconstants.CAKeyName,
+		},
+		{
+			name: kubeadmconstants.APIServerCertAndKeyBaseName,
+			cert: kubeadmconstants.APIServerCertName,
+			key:  kubeadmconstants.APIServerKeyName,
+		},
+		{
+			name: kubeadmconstants.APIServerKubeletClientCertAndKeyBaseName,
+			cert: kubeadmconstants.APIServerKubeletClientCertName,
+			key:  kubeadmconstants.APIServerKubeletClientKeyName,
+		},
+		{
+			name: kubeadmconstants.ServiceAccountKeyBaseName,
+			cert: kubeadmconstants.ServiceAccountPublicKeyName,
+			key:  kubeadmconstants.ServiceAccountPrivateKeyName,
+		},
+		{
+			name: kubeadmconstants.FrontProxyCACertAndKeyBaseName,
+			cert: kubeadmconstants.FrontProxyCACertName,
+			key:  kubeadmconstants.FrontProxyCAKeyName,
+		},
+		{
+			name: kubeadmconstants.FrontProxyClientCertAndKeyBaseName,
+			cert: kubeadmconstants.FrontProxyClientCertName,
+			key:  kubeadmconstants.FrontProxyClientKeyName,
+		},
+	}
+}

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfhosting
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+)
+
+func createTemporaryFile(name string) *os.File {
+	content := []byte("foo")
+	tmpfile, err := ioutil.TempFile("", name)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if _, err := tmpfile.Write(content); err != nil {
+		log.Fatal(err)
+	}
+
+	return tmpfile
+}
+
+func TestCreateTLSSecretFromFile(t *testing.T) {
+	tmpCert := createTemporaryFile("foo.crt")
+	defer os.Remove(tmpCert.Name())
+	tmpKey := createTemporaryFile("foo.key")
+	defer os.Remove(tmpKey.Name())
+
+	_, err := createTLSSecretFromFiles("foo", tmpCert.Name(), tmpKey.Name())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := tmpCert.Close(); err != nil {
+		log.Fatal(err)
+	}
+
+	if err := tmpKey.Close(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func TestCreateOpaqueSecretFromFile(t *testing.T) {
+	tmpFile := createTemporaryFile("foo")
+	defer os.Remove(tmpFile.Name())
+
+	_, err := createOpaqueSecretFromFile("foo", tmpFile.Name())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/kubernetes/kubeadm/issues/194

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

```
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf get pods -n kube-system
NAME                                                   READY     STATUS    RESTARTS   AGE
dummy-1628042694-6ghbq                                 1/1       Running   0          42m
kube-dns-1853130399-4nzx4                              3/3       Running   0          9m
kube-flannel-ds-mnq10                                  2/2       Running   2          12m
kube-flannel-ds-n3tl8                                  2/2       Running   0          42m
kube-proxy-lqpcb                                       1/1       Running   0          42m
kube-proxy-pw0pw                                       1/1       Running   0          12m
self-hosted-kube-apiserver-fkkwd                       1/1       Running   1          42m
self-hosted-kube-controller-manager-1387498942-mzg41   1/1       Running   1          42m
self-hosted-kube-scheduler-2588609441-cwhqb            1/1       Running   1          42m
```

### API Server
```
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-apiserver-fkkwd -n kube-system -- ls /etc/pki
ca-trust
java
nssdb
rpm-gpg
tls
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-apiserver-fkkwd -n kube-system -- ls /etc/ssl
certs
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-apiserver-fkkwd -n kube-system -- ls /etc/kubernetes/
pki
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-apiserver-fkkwd -n kube-system -- ls /etc/kubernetes/pki/
apiserver-kubelet-client.crt
apiserver-kubelet-client.key
apiserver.crt
apiserver.key
ca.crt
front-proxy-ca.crt
sa.pub
```

### Scheduler
```
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-scheduler-2588609441-cwhqb -n kube-system -- ls /etc/kubernetes/
scheduler.conf
```

### Controller Manager
```
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-controller-manager-1387498942-mzg41 -n kube-system -- ls /etc/ssl
certs
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-controller-manager-1387498942-mzg41 -n kube-system -- ls /etc/pki
ca-trust
java
nssdb
rpm-gpg
tls
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-controller-manager-1387498942-mzg41 -n kube-system -- ls /etc/kubernetes/
controller-manager.conf
pki
bash-4.2# kubectl --kubeconfig /etc/kubernetes/admin.conf exec self-hosted-kube-controller-manager-1387498942-mzg41 -n kube-system -- ls /etc/kubernetes/pki/
ca.crt
ca.key
sa.key
```

/cc @luxas @liggitt @pires @timothysc 
