### PR TITLE
Fix federation controller-manager initialization

### DIFF
--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -403,10 +403,12 @@ func (s *ServiceController) Run(workers int, stopCh <-chan struct{}) error {
 	go wait.Until(s.clusterEndpointWorker, time.Second, stopCh)
 	go wait.Until(s.clusterServiceWorker, time.Second, stopCh)
 	go wait.Until(s.clusterSyncLoop, time.Second, stopCh)
-	<-stopCh
-	glog.Infof("Shutting down Federation Service Controller")
-	s.queue.ShutDown()
-	s.federatedInformer.Stop()
+	go func() {
+		<-stopCh
+		glog.Infof("Shutting down Federation Service Controller")
+		s.queue.ShutDown()
+		s.federatedInformer.Stop()
+	}()
 	return nil
 }
 


### PR DESCRIPTION
Due to #42375, the e2e tests for federation started failing. The cause is that servicecontroller.Run blocks on stopCh. In #42375, the code is reorganized and servicecontroller which was initialized last is moved to top, so all the controllers below it are not initialized.

This pr fixes the issue by calling stopCh of servicecontroller in a goroutine.

cc @kubernetes/sig-federation-bugs @nikhiljindal @madhusudancs 


