### PR TITLE
Fixed the #42412 issue.

### DIFF
--- a/pkg/kubelet/gpu/gpu_manager_stub.go
+++ b/pkg/kubelet/gpu/gpu_manager_stub.go
@@ -36,6 +36,10 @@ func (gms *gpuManagerStub) AllocateGPU(_ *v1.Pod, _ *v1.Container) ([]string, er
 	return nil, fmt.Errorf("GPUs are not supported")
 }
 
+func (gms *gpuManagerStub) UpdateDevices(podUID string, exitedContainerID string) {
+	fmt.Printf("update GPUs devices mapping.")
+}
+
 func NewGPUManagerStub() GPUManager {
 	return &gpuManagerStub{}
 }

--- a/pkg/kubelet/gpu/gpu_manager_stub.go
+++ b/pkg/kubelet/gpu/gpu_manager_stub.go
@@ -18,7 +18,9 @@ package gpu
 
 import (
 	"fmt"
-
+	dockertypes "github.com/docker/engine-api/types"
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -36,8 +38,8 @@ func (gms *gpuManagerStub) AllocateGPU(_ *v1.Pod, _ *v1.Container) ([]string, er
 	return nil, fmt.Errorf("GPUs are not supported")
 }
 
-func (gms *gpuManagerStub) UpdateDevices(podUID string, exitedContainerID string) {
-	fmt.Printf("update GPUs devices mapping.")
+func (gms *gpuManagerStub) UpdateDevices(podUID types.UID, inspectJSON *dockertypes.ContainerJSON) {
+	glog.V(4).Infof("Update GPUs devices mapping cache.")
 }
 
 func NewGPUManagerStub() GPUManager {

--- a/pkg/kubelet/gpu/types.go
+++ b/pkg/kubelet/gpu/types.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package gpu
 
-import "k8s.io/kubernetes/pkg/api/v1"
+import (
+	dockertypes "github.com/docker/engine-api/types"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/api/v1"
+)
 
 // GPUManager manages GPUs on a local node.
 // Implementations are expected to be thread safe.
@@ -29,5 +33,6 @@ type GPUManager interface {
 	// Returns paths to allocated GPUs and nil on success.
 	// Returns an error on failure.
 	AllocateGPU(*v1.Pod, *v1.Container) ([]string, error)
-	UpdateDevices(podUID string, exitedContainerID string)
+	// UpdateDevices aim to update the GPUs mapping cache when a container exited in Pod.
+	UpdateDevices(podUID types.UID, inspectJSON *dockertypes.ContainerJSON)
 }

--- a/pkg/kubelet/gpu/types.go
+++ b/pkg/kubelet/gpu/types.go
@@ -29,4 +29,5 @@ type GPUManager interface {
 	// Returns paths to allocated GPUs and nil on success.
 	// Returns an error on failure.
 	AllocateGPU(*v1.Pod, *v1.Container) ([]string, error)
+	UpdateDevices(podUID string, exitedContainerID string)
 }

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -2138,6 +2138,9 @@ func (kl *Kubelet) cleanUpContainersInPod(podId types.UID, exitedContainerID str
 			removeAll = eviction.PodIsEvicted(syncedPod.Status)
 		}
 		kl.containerDeletor.deleteContainersInPod(exitedContainerID, podStatus, removeAll)
+		if kl.gpuManager != nil {
+			kl.gpuManager.UpdateDevices(string(podId), exitedContainerID)
+		}
 	}
 }
 


### PR DESCRIPTION
The origin issue is here [GPU allocation failed after container in Pod restart](https://github.com/kubernetes/kubernetes/issues/42412), I added the [UpdateDevice interface](https://github.com/jianzhangbjz/kubernetes/blob/fix-42412/pkg/kubelet/gpu/nvidia/nvidia_gpu_manager.go#L132) to update the mapping cache when the container crashed. I test it manually and now it works well, comments are welcome! Example:
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: gpu
  labels:
    name: gpu
spec:
  containers:
  - name: gpu
    image: nvidia/cuda:jian
    command: ["/bin/sh", "-c"]
    #args: ["tail -f /dev/null"]
    args: ["sleep 10"]
    resources:
      limits:
        cpu: 0.5
        memory: 128Mi
        alpha.kubernetes.io/nvidia-gpu: 4
    ports:
    - containerPort: 6379
```
After task completed, restart successfully.
```
root@slave2:/home/zhangjian/testK8s# kubectl get pods
NAME      READY     STATUS    RESTARTS   AGE
gpu       1/1       Running   0          11s
root@slave2:/home/zhangjian/testK8s# kubectl get pods
NAME      READY     STATUS      RESTARTS   AGE
gpu       0/1       Completed   0          12s
root@slave2:/home/zhangjian/testK8s# kubectl get pods
NAME      READY     STATUS    RESTARTS   AGE
gpu       1/1       Running   1          14s
```
