### PR TITLE
Delete offline restclient from clusterKubeClientMap

### DIFF
--- a/federation/pkg/federation-controller/cluster/clustercontroller.go
+++ b/federation/pkg/federation-controller/cluster/clustercontroller.go
@@ -85,14 +85,22 @@ func NewclusterController(federationClient federationclientset.Interface, cluste
 // delete the corresponding restclient from the map clusterKubeClientMap
 func (cc *ClusterController) delFromClusterSet(obj interface{}) {
 	cluster := obj.(*federationv1beta1.Cluster)
-	cc.knownClusterSet.Delete(cluster.Name)
-	delete(cc.clusterKubeClientMap, cluster.Name)
+	cc.delFromClusterSetByName(cluster.Name)
+}
+
+// delFromClusterSetByName delete a cluster from clusterSet by name and
+// delete the corresponding restclient from the map clusterKubeClientMap
+func (cc *ClusterController) delFromClusterSetByName(clusterName string) {
+	glog.V(1).Infof("ClusterController observed a cluster deletion: %v", clusterName)
+	cc.knownClusterSet.Delete(clusterName)
+	delete(cc.clusterKubeClientMap, clusterName)
 }
 
 // addToClusterSet insert the new cluster to clusterSet and create a corresponding
 // restclient to map clusterKubeClientMap
 func (cc *ClusterController) addToClusterSet(obj interface{}) {
 	cluster := obj.(*federationv1beta1.Cluster)
+	glog.V(1).Infof("ClusterController observed a new cluster: %v", cluster.Name)
 	cc.knownClusterSet.Insert(cluster.Name)
 	// create the restclient of cluster
 	restClient, err := NewClusterClientSet(cluster)
@@ -115,9 +123,9 @@ func (cc *ClusterController) Run() {
 	}, cc.clusterMonitorPeriod, wait.NeverStop)
 }
 
-func (cc *ClusterController) GetClusterStatus(cluster *federationv1beta1.Cluster) (*federationv1beta1.ClusterStatus, error) {
-	// just get the status of cluster, by requesting the restapi "/healthz"
+func (cc *ClusterController) GetClusterClient(cluster *federationv1beta1.Cluster) (*ClusterClient, error) {
 	clusterClient, found := cc.clusterKubeClientMap[cluster.Name]
+	client := &clusterClient
 	if !found {
 		glog.Infof("It's a new cluster, a cluster client will be created")
 		client, err := NewClusterClientSet(cluster)
@@ -125,8 +133,15 @@ func (cc *ClusterController) GetClusterStatus(cluster *federationv1beta1.Cluster
 			glog.Errorf("Failed to create cluster client, err: %v", err)
 			return nil, err
 		}
-		clusterClient = *client
-		cc.clusterKubeClientMap[cluster.Name] = clusterClient
+	}
+	return client, nil
+}
+
+func (cc *ClusterController) GetClusterStatus(cluster *federationv1beta1.Cluster) (*federationv1beta1.ClusterStatus, error) {
+	// just get the status of cluster, by requesting the restapi "/healthz"
+	clusterClient, err := cc.GetClusterClient(cluster)
+	if err != nil {
+		return nil, err
 	}
 	clusterStatus := clusterClient.GetClusterHealthStatus()
 	return clusterStatus, nil
@@ -140,8 +155,7 @@ func (cc *ClusterController) UpdateClusterStatus() error {
 	}
 	for _, cluster := range clusters.Items {
 		if !cc.knownClusterSet.Has(cluster.Name) {
-			glog.V(1).Infof("ClusterController observed a new cluster: %#v", cluster)
-			cc.knownClusterSet.Insert(cluster.Name)
+			cc.addToClusterSet(&cluster)
 		}
 	}
 
@@ -153,8 +167,7 @@ func (cc *ClusterController) UpdateClusterStatus() error {
 		}
 		deleted := cc.knownClusterSet.Difference(observedSet)
 		for clusterName := range deleted {
-			glog.V(1).Infof("ClusterController observed a Cluster deletion: %v", clusterName)
-			cc.knownClusterSet.Delete(clusterName)
+			cc.delFromClusterSetByName(clusterName)
 		}
 	}
 	for _, cluster := range clusters.Items {


### PR DESCRIPTION
When federation controller manager checks cluster status, it will
delete the offline cluster from clusterSet, but do not delete the
corresponding restclient from the map clusterKubeClientMap for
the offline cluster. This patch can fix it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
