### PR TITLE
update names for kube plugin initializer to avoid conflicts

### DIFF
--- a/pkg/kubeapiserver/admission/initializer.go
+++ b/pkg/kubeapiserver/admission/initializer.go
@@ -25,15 +25,15 @@ import (
 
 // TODO add a `WantsToRun` which takes a stopCh.  Might make it generic.
 
-// WantsInformerFactory defines a function which sets InformerFactory for admission plugins that need it
-type WantsInternalClientSet interface {
-	SetInternalClientSet(internalclientset.Interface)
+// WantsInternalKubeClientSet defines a function which sets ClientSet for admission plugins that need it
+type WantsInternalKubeClientSet interface {
+	SetInternalKubeClientSet(internalclientset.Interface)
 	admission.Validator
 }
 
-// WantsInformerFactory defines a function which sets InformerFactory for admission plugins that need it
-type WantsInformerFactory interface {
-	SetInformerFactory(informers.SharedInformerFactory)
+// WantsInternalKubeInformerFactory defines a function which sets InformerFactory for admission plugins that need it
+type WantsInternalKubeInformerFactory interface {
+	SetInternalKubeInformerFactory(informers.SharedInformerFactory)
 	admission.Validator
 }
 
@@ -70,12 +70,12 @@ func NewPluginInitializer(internalClient internalclientset.Interface, sharedInfo
 // Initialize checks the initialization interfaces implemented by each plugin
 // and provide the appropriate initialization data
 func (i pluginInitializer) Initialize(plugin admission.Interface) {
-	if wants, ok := plugin.(WantsInternalClientSet); ok {
-		wants.SetInternalClientSet(i.internalClient)
+	if wants, ok := plugin.(WantsInternalKubeClientSet); ok {
+		wants.SetInternalKubeClientSet(i.internalClient)
 	}
 
-	if wants, ok := plugin.(WantsInformerFactory); ok {
-		wants.SetInformerFactory(i.informers)
+	if wants, ok := plugin.(WantsInternalKubeInformerFactory); ok {
+		wants.SetInternalKubeInformerFactory(i.informers)
 	}
 
 	if wants, ok := plugin.(WantsAuthorizer); ok {

--- a/plugin/pkg/admission/exec/admission.go
+++ b/plugin/pkg/admission/exec/admission.go
@@ -53,7 +53,7 @@ type denyExec struct {
 	privileged bool
 }
 
-var _ = kubeapiserveradmission.WantsInternalClientSet(&denyExec{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&denyExec{})
 
 // NewDenyEscalatingExec creates a new admission controller that denies an exec operation on a pod
 // using host based configurations.
@@ -128,7 +128,7 @@ func isPrivileged(pod *api.Pod) bool {
 	return false
 }
 
-func (d *denyExec) SetInternalClientSet(client internalclientset.Interface) {
+func (d *denyExec) SetInternalKubeClientSet(client internalclientset.Interface) {
 	d.client = client
 }
 

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -68,7 +68,7 @@ type liveLookupEntry struct {
 	items  []*api.LimitRange
 }
 
-func (l *limitRanger) SetInformerFactory(f informers.SharedInformerFactory) {
+func (l *limitRanger) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	limitRangeInformer := f.Core().InternalVersion().LimitRanges()
 	l.SetReadyFunc(limitRangeInformer.Informer().HasSynced)
 	l.lister = limitRangeInformer.Lister()
@@ -167,10 +167,10 @@ func NewLimitRanger(actions LimitRangerActions) (admission.Interface, error) {
 	}, nil
 }
 
-var _ = kubeapiserveradmission.WantsInformerFactory(&limitRanger{})
-var _ = kubeapiserveradmission.WantsInternalClientSet(&limitRanger{})
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&limitRanger{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&limitRanger{})
 
-func (a *limitRanger) SetInternalClientSet(client internalclientset.Interface) {
+func (a *limitRanger) SetInternalKubeClientSet(client internalclientset.Interface) {
 	a.client = client
 }
 

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -45,8 +45,8 @@ type provision struct {
 	namespaceLister corelisters.NamespaceLister
 }
 
-var _ = kubeapiserveradmission.WantsInformerFactory(&provision{})
-var _ = kubeapiserveradmission.WantsInternalClientSet(&provision{})
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&provision{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&provision{})
 
 func (p *provision) Admit(a admission.Attributes) error {
 	// if we're here, then we've already passed authentication, so we're allowed to do what we're trying to do
@@ -92,11 +92,11 @@ func NewProvision() admission.Interface {
 	}
 }
 
-func (p *provision) SetInternalClientSet(client internalclientset.Interface) {
+func (p *provision) SetInternalKubeClientSet(client internalclientset.Interface) {
 	p.client = client
 }
 
-func (p *provision) SetInformerFactory(f informers.SharedInformerFactory) {
+func (p *provision) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	namespaceInformer := f.Core().InternalVersion().Namespaces()
 	p.namespaceLister = namespaceInformer.Lister()
 	p.SetReadyFunc(namespaceInformer.Informer().HasSynced)

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -45,8 +45,8 @@ type exists struct {
 	namespaceLister corelisters.NamespaceLister
 }
 
-var _ = kubeapiserveradmission.WantsInformerFactory(&exists{})
-var _ = kubeapiserveradmission.WantsInternalClientSet(&exists{})
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&exists{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&exists{})
 
 func (e *exists) Admit(a admission.Attributes) error {
 	// if we're here, then we've already passed authentication, so we're allowed to do what we're trying to do
@@ -87,11 +87,11 @@ func NewExists() admission.Interface {
 	}
 }
 
-func (e *exists) SetInternalClientSet(client internalclientset.Interface) {
+func (e *exists) SetInternalKubeClientSet(client internalclientset.Interface) {
 	e.client = client
 }
 
-func (e *exists) SetInformerFactory(f informers.SharedInformerFactory) {
+func (e *exists) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	namespaceInformer := f.Core().InternalVersion().Namespaces()
 	e.namespaceLister = namespaceInformer.Lister()
 	e.SetReadyFunc(namespaceInformer.Informer().HasSynced)

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -72,8 +72,8 @@ type forceLiveLookupEntry struct {
 	expiry time.Time
 }
 
-var _ = kubeapiserveradmission.WantsInformerFactory(&lifecycle{})
-var _ = kubeapiserveradmission.WantsInternalClientSet(&lifecycle{})
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&lifecycle{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&lifecycle{})
 
 func makeNamespaceKey(namespace string) *api.Namespace {
 	return &api.Namespace{
@@ -193,13 +193,13 @@ func newLifecycleWithClock(immortalNamespaces sets.String, clock utilcache.Clock
 	}, nil
 }
 
-func (l *lifecycle) SetInformerFactory(f informers.SharedInformerFactory) {
+func (l *lifecycle) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	namespaceInformer := f.Core().InternalVersion().Namespaces()
 	l.namespaceLister = namespaceInformer.Lister()
 	l.SetReadyFunc(namespaceInformer.Informer().HasSynced)
 }
 
-func (l *lifecycle) SetInternalClientSet(client internalclientset.Interface) {
+func (l *lifecycle) SetInternalKubeClientSet(client internalclientset.Interface) {
 	l.client = client
 }
 

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -57,8 +57,8 @@ type podNodeSelector struct {
 	clusterNodeSelectors map[string]string
 }
 
-var _ = kubeapiserveradmission.WantsInternalClientSet(&podNodeSelector{})
-var _ = kubeapiserveradmission.WantsInformerFactory(&podNodeSelector{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&podNodeSelector{})
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&podNodeSelector{})
 
 type pluginConfig struct {
 	PodNodeSelectorPluginConfig map[string]string
@@ -162,11 +162,11 @@ func NewPodNodeSelector(clusterNodeSelectors map[string]string) *podNodeSelector
 	}
 }
 
-func (a *podNodeSelector) SetInternalClientSet(client internalclientset.Interface) {
+func (a *podNodeSelector) SetInternalKubeClientSet(client internalclientset.Interface) {
 	a.client = client
 }
 
-func (p *podNodeSelector) SetInformerFactory(f informers.SharedInformerFactory) {
+func (p *podNodeSelector) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	namespaceInformer := f.Core().InternalVersion().Namespaces()
 	p.namespaceLister = namespaceInformer.Lister()
 	p.SetReadyFunc(namespaceInformer.Informer().HasSynced)

--- a/plugin/pkg/admission/podpreset/admission.go
+++ b/plugin/pkg/admission/podpreset/admission.go
@@ -54,8 +54,8 @@ type podPresetPlugin struct {
 	lister settingslisters.PodPresetLister
 }
 
-var _ = kubeapiserveradmission.WantsInformerFactory(&podPresetPlugin{})
-var _ = kubeapiserveradmission.WantsInternalClientSet(&podPresetPlugin{})
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&podPresetPlugin{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&podPresetPlugin{})
 
 // NewPlugin creates a new pod preset admission plugin.
 func NewPlugin() *podPresetPlugin {
@@ -74,11 +74,11 @@ func (plugin *podPresetPlugin) Validate() error {
 	return nil
 }
 
-func (a *podPresetPlugin) SetInternalClientSet(client internalclientset.Interface) {
+func (a *podPresetPlugin) SetInternalKubeClientSet(client internalclientset.Interface) {
 	a.client = client
 }
 
-func (a *podPresetPlugin) SetInformerFactory(f informers.SharedInformerFactory) {
+func (a *podPresetPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	podPresetInformer := f.Settings().InternalVersion().PodPresets()
 	a.lister = podPresetInformer.Lister()
 	a.SetReadyFunc(podPresetInformer.Informer().HasSynced)

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -64,7 +64,7 @@ type quotaAdmission struct {
 	evaluator     Evaluator
 }
 
-var _ = kubeapiserveradmission.WantsInternalClientSet(&quotaAdmission{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&quotaAdmission{})
 
 type liveLookupEntry struct {
 	expiry time.Time
@@ -91,11 +91,11 @@ func NewResourceQuota(registry quota.Registry, config *resourcequotaapi.Configur
 	}, nil
 }
 
-func (a *quotaAdmission) SetInternalClientSet(client internalclientset.Interface) {
+func (a *quotaAdmission) SetInternalKubeClientSet(client internalclientset.Interface) {
 	a.quotaAccessor.client = client
 }
 
-func (a *quotaAdmission) SetInformerFactory(f informers.SharedInformerFactory) {
+func (a *quotaAdmission) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	a.quotaAccessor.lister = f.Core().InternalVersion().ResourceQuotas().Lister()
 }
 

--- a/plugin/pkg/admission/resourcequota/resource_access.go
+++ b/plugin/pkg/admission/resourcequota/resource_access.go
@@ -69,7 +69,7 @@ func newQuotaAccessor() (*quotaAccessor, error) {
 		return nil, err
 	}
 
-	// client and lister will be set when SetInternalClientSet and SetInformerFactory are invoked
+	// client and lister will be set when SetInternalKubeClientSet and SetInternalKubeInformerFactory are invoked
 	return &quotaAccessor{
 		liveLookupCache: liveLookupCache,
 		liveTTL:         time.Duration(30 * time.Second),

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -82,7 +82,7 @@ func (plugin *podSecurityPolicyPlugin) Validate() error {
 
 var _ admission.Interface = &podSecurityPolicyPlugin{}
 var _ kubeapiserveradmission.WantsAuthorizer = &podSecurityPolicyPlugin{}
-var _ kubeapiserveradmission.WantsInformerFactory = &podSecurityPolicyPlugin{}
+var _ kubeapiserveradmission.WantsInternalKubeInformerFactory = &podSecurityPolicyPlugin{}
 
 // NewPlugin creates a new PSP admission plugin.
 func NewPlugin(strategyFactory psp.StrategyFactory, pspMatcher PSPMatchFn, failOnNoPolicies bool) *podSecurityPolicyPlugin {
@@ -94,7 +94,7 @@ func NewPlugin(strategyFactory psp.StrategyFactory, pspMatcher PSPMatchFn, failO
 	}
 }
 
-func (a *podSecurityPolicyPlugin) SetInformerFactory(f informers.SharedInformerFactory) {
+func (a *podSecurityPolicyPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	podSecurityPolicyInformer := f.Extensions().InternalVersion().PodSecurityPolicies()
 	a.lister = podSecurityPolicyInformer.Lister()
 	a.SetReadyFunc(podSecurityPolicyInformer.Informer().HasSynced)

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -79,8 +79,8 @@ type serviceAccount struct {
 	secretLister         corelisters.SecretLister
 }
 
-var _ = kubeapiserveradmission.WantsInternalClientSet(&serviceAccount{})
-var _ = kubeapiserveradmission.WantsInformerFactory(&serviceAccount{})
+var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&serviceAccount{})
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&serviceAccount{})
 
 // NewServiceAccount returns an admission.Interface implementation which limits admission of Pod CREATE requests based on the pod's ServiceAccount:
 // 1. If the pod does not specify a ServiceAccount, it sets the pod's ServiceAccount to "default"
@@ -100,11 +100,11 @@ func NewServiceAccount() *serviceAccount {
 	}
 }
 
-func (a *serviceAccount) SetInternalClientSet(cl internalclientset.Interface) {
+func (a *serviceAccount) SetInternalKubeClientSet(cl internalclientset.Interface) {
 	a.client = cl
 }
 
-func (a *serviceAccount) SetInformerFactory(f informers.SharedInformerFactory) {
+func (a *serviceAccount) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	serviceAccountInformer := f.Core().InternalVersion().ServiceAccounts()
 	a.serviceAccountLister = serviceAccountInformer.Lister()
 

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -133,7 +133,7 @@ func TestAssignsDefaultServiceAccountAndToleratesMissingAPIToken(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.MountServiceAccountToken = true
 	admit.RequireAPIToken = false
 
@@ -161,7 +161,7 @@ func TestAssignsDefaultServiceAccountAndRejectsMissingAPIToken(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.MountServiceAccountToken = true
 	admit.RequireAPIToken = true
 
@@ -194,7 +194,7 @@ func TestFetchesUncachedServiceAccount(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.client = client
 	admit.RequireAPIToken = false
 
@@ -216,9 +216,9 @@ func TestDeniesInvalidServiceAccount(t *testing.T) {
 	client := fake.NewSimpleClientset()
 
 	admit := NewServiceAccount()
-	admit.SetInternalClientSet(client)
+	admit.SetInternalKubeClientSet(client)
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 
 	pod := &api.Pod{}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
@@ -248,7 +248,7 @@ func TestAutomountsAPIToken(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.MountServiceAccountToken = true
 	admit.RequireAPIToken = true
 
@@ -349,7 +349,7 @@ func TestRespectsExistingMount(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.MountServiceAccountToken = true
 	admit.RequireAPIToken = true
 
@@ -447,7 +447,7 @@ func TestAllowsReferencedSecret(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.LimitSecretReferences = true
 	admit.RequireAPIToken = false
 
@@ -528,7 +528,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.LimitSecretReferences = true
 	admit.RequireAPIToken = false
 
@@ -606,7 +606,7 @@ func TestAllowUnreferencedSecretVolumesForPermissiveSAs(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.LimitSecretReferences = false
 	admit.RequireAPIToken = false
 
@@ -638,7 +638,7 @@ func TestAllowsReferencedImagePullSecrets(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.LimitSecretReferences = true
 	admit.RequireAPIToken = false
 
@@ -670,7 +670,7 @@ func TestRejectsUnreferencedImagePullSecrets(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.LimitSecretReferences = true
 	admit.RequireAPIToken = false
 
@@ -699,7 +699,7 @@ func TestDoNotAddImagePullSecrets(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.LimitSecretReferences = true
 	admit.RequireAPIToken = false
 
@@ -736,7 +736,7 @@ func TestAddImagePullSecrets(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.LimitSecretReferences = true
 	admit.RequireAPIToken = false
 
@@ -781,7 +781,7 @@ func TestMultipleReferencedSecrets(t *testing.T) {
 
 	admit := NewServiceAccount()
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	admit.SetInformerFactory(informerFactory)
+	admit.SetInternalKubeInformerFactory(informerFactory)
 	admit.MountServiceAccountToken = true
 	admit.RequireAPIToken = true
 

--- a/plugin/pkg/admission/storageclass/default/admission.go
+++ b/plugin/pkg/admission/storageclass/default/admission.go
@@ -52,7 +52,7 @@ type claimDefaulterPlugin struct {
 }
 
 var _ admission.Interface = &claimDefaulterPlugin{}
-var _ = kubeapiserveradmission.WantsInformerFactory(&claimDefaulterPlugin{})
+var _ = kubeapiserveradmission.WantsInternalKubeInformerFactory(&claimDefaulterPlugin{})
 
 // newPlugin creates a new admission plugin.
 func newPlugin() *claimDefaulterPlugin {
@@ -61,7 +61,7 @@ func newPlugin() *claimDefaulterPlugin {
 	}
 }
 
-func (a *claimDefaulterPlugin) SetInformerFactory(f informers.SharedInformerFactory) {
+func (a *claimDefaulterPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	informer := f.Storage().InternalVersion().StorageClasses()
 	a.lister = informer.Lister()
 	a.SetReadyFunc(informer.Informer().HasSynced)

--- a/plugin/pkg/admission/storageclass/default/admission_test.go
+++ b/plugin/pkg/admission/storageclass/default/admission_test.go
@@ -199,7 +199,7 @@ func TestAdmission(t *testing.T) {
 
 		ctrl := newPlugin()
 		informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-		ctrl.SetInformerFactory(informerFactory)
+		ctrl.SetInternalKubeInformerFactory(informerFactory)
 		for _, c := range test.classes {
 			informerFactory.Storage().InternalVersion().StorageClasses().Informer().GetStore().Add(c)
 		}

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -73,9 +73,9 @@ func TestQuota(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	admission.(kubeadmission.WantsInternalClientSet).SetInternalClientSet(internalClientset)
+	admission.(kubeadmission.WantsInternalKubeClientSet).SetInternalKubeClientSet(internalClientset)
 	internalInformers := internalinformers.NewSharedInformerFactory(internalClientset, controller.NoResyncPeriodFunc())
-	admission.(kubeadmission.WantsInformerFactory).SetInformerFactory(internalInformers)
+	admission.(kubeadmission.WantsInternalKubeInformerFactory).SetInternalKubeInformerFactory(internalInformers)
 	defer close(admissionCh)
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()
@@ -258,9 +258,9 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	admission.(kubeadmission.WantsInternalClientSet).SetInternalClientSet(internalClientset)
+	admission.(kubeadmission.WantsInternalKubeClientSet).SetInternalKubeClientSet(internalClientset)
 	internalInformers := internalinformers.NewSharedInformerFactory(internalClientset, controller.NoResyncPeriodFunc())
-	admission.(kubeadmission.WantsInformerFactory).SetInformerFactory(internalInformers)
+	admission.(kubeadmission.WantsInternalKubeInformerFactory).SetInternalKubeInformerFactory(internalInformers)
 	defer close(admissionCh)
 
 	masterConfig := framework.NewIntegrationTestMasterConfig()

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -407,9 +407,9 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 
 	// Set up admission plugin to auto-assign serviceaccounts to pods
 	serviceAccountAdmission := serviceaccountadmission.NewServiceAccount()
-	serviceAccountAdmission.SetInternalClientSet(internalRootClientset)
+	serviceAccountAdmission.SetInternalKubeClientSet(internalRootClientset)
 	internalInformers := internalinformers.NewSharedInformerFactory(internalRootClientset, controller.NoResyncPeriodFunc())
-	serviceAccountAdmission.SetInformerFactory(internalInformers)
+	serviceAccountAdmission.SetInternalKubeInformerFactory(internalInformers)
 
 	masterConfig := framework.NewMasterConfig()
 	masterConfig.GenericConfig.EnableIndex = true


### PR DESCRIPTION
Fixes #42581

Other API servers are likely to create admission plugin initializers and so the names we choose for our interfaces matter (they may want to run multiple initializers in the chain).  This updates the names for the plugin initializers to be more specific.  No other changes.

@ncdc