### PR TITLE
Include events when describing configmap

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -2564,10 +2564,6 @@ func (d *ConfigMapDescriber) Describe(namespace, name string, describerSettings 
 		return "", err
 	}
 
-	return describeConfigMap(configMap)
-}
-
-func describeConfigMap(configMap *api.ConfigMap) (string, error) {
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", configMap.Name)
@@ -2580,7 +2576,15 @@ func describeConfigMap(configMap *api.ConfigMap) (string, error) {
 			w.Write(LEVEL_0, "%s:\n----\n", k)
 			w.Write(LEVEL_0, "%s\n", string(v))
 		}
-
+		if describerSettings.ShowEvents {
+			events, err := d.Core().Events(namespace).Search(api.Scheme, configMap)
+			if err != nil {
+				return err
+			}
+			if events != nil {
+				DescribeEvents(events, w)
+			}
+		}
 		return nil
 	})
 }

--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -1245,6 +1245,14 @@ func TestDescribeEvents(t *testing.T) {
 				},
 			}, events),
 		},
+		"ConfigMap": &ConfigMapDescriber{
+			fake.NewSimpleClientset(&api.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "foo",
+				},
+			}, events),
+		},
 	}
 
 	for name, d := range m {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently `kubectl describe configmap/xxx` does not list events, even if there are events related to this congfigmap (and --show-events=true is explicitly passed). This PR makes it include events, same as for other resource types.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
