### PR TITLE
cloudprovider: print warning if no config file is given

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -404,7 +404,13 @@ func StartControllers(controllers map[string]InitFunc, s *options.CMServer, root
 	}
 
 	cloud, err := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
-	if err != nil {
+
+	switch err {
+	case cloudprovider.ErrNoConfig:
+		cloud = nil
+		glog.Warningf("Disabling cloud provider: %v", err)
+	case nil: // success
+	default:
 		return fmt.Errorf("cloud provider could not be initialized: %v", err)
 	}
 

--- a/pkg/cloudprovider/plugins.go
+++ b/pkg/cloudprovider/plugins.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cloudprovider
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,10 +26,14 @@ import (
 	"github.com/golang/glog"
 )
 
+var ErrNoConfig = errors.New("no cloud provider config file given")
+
 // Factory is a function that returns a cloudprovider.Interface.
 // The config parameter provides an io.Reader handler to the factory in
 // order to load specific configurations. If no configuration is provided
 // the parameter is nil.
+// If the cloudprovider does not support no configuration
+// it must return cloudprovider.ErrNoConfig.
 type Factory func(config io.Reader) (Interface, error)
 
 // All registered cloud providers.
@@ -112,8 +117,9 @@ func InitCloudProvider(name string, configFilePath string) (Interface, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("could not init cloud provider %q: %v", name, err)
+		return nil, err
 	}
+
 	if cloud == nil {
 		return nil, fmt.Errorf("unknown cloud provider %q", name)
 	}

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -22,12 +22,13 @@ import (
 
 	"k8s.io/kubernetes/pkg/cloudprovider"
 
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/Azure/azure-sdk-for-go/arm/storage"
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/ghodss/yaml"
-	"time"
 )
 
 // CloudProviderName is the value used for the --cloud-provider flag
@@ -88,6 +89,10 @@ func init() {
 
 // NewCloud returns a Cloud with initialized clients
 func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
+	if configReader == nil {
+		return nil, cloudprovider.ErrNoConfig
+	}
+
 	var az Cloud
 
 	configContents, err := ioutil.ReadAll(configReader)

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cloudstack
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/golang/glog"
@@ -61,11 +60,11 @@ func init() {
 
 func readConfig(config io.Reader) (*CSConfig, error) {
 	if config == nil {
-		err := fmt.Errorf("no cloud provider config given")
-		return nil, err
+		return nil, cloudprovider.ErrNoConfig
 	}
 
 	cfg := &CSConfig{}
+
 	if err := gcfg.ReadInto(cfg, config); err != nil {
 		glog.Errorf("Couldn't parse config: %v", err)
 		return nil, err

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -132,6 +132,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
+
 		return newOpenStack(cfg)
 	})
 }
@@ -165,12 +166,11 @@ func (cfg Config) toAuth3Options() tokens3.AuthOptions {
 }
 
 func readConfig(config io.Reader) (Config, error) {
-	if config == nil {
-		err := fmt.Errorf("no OpenStack cloud provider config file given")
-		return Config{}, err
-	}
-
 	var cfg Config
+
+	if config == nil {
+		return cfg, cloudprovider.ErrNoConfig
+	}
 
 	// Set default values for config params
 	cfg.BlockStorage.TrustDevicePath = false

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -88,7 +88,7 @@ func init() {
 
 func newOVirtCloud(config io.Reader) (*OVirtCloud, error) {
 	if config == nil {
-		return nil, fmt.Errorf("missing configuration file for ovirt cloud provider")
+		return nil, cloudprovider.ErrNoConfig
 	}
 
 	oVirtConfig := OVirtApiConfig{}

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -120,12 +120,12 @@ type VolumeOptions struct {
 }
 
 func readConfig(config io.Reader) (PCConfig, error) {
+	var cfg PCConfig
+
 	if config == nil {
-		err := fmt.Errorf("cloud provider config file is missing. Please restart kubelet with --cloud-provider=photon --cloud-config=[path_to_config_file]")
-		return PCConfig{}, err
+		return cfg, cloudprovider.ErrNoConfig
 	}
 
-	var cfg PCConfig
 	err := gcfg.ReadInto(&cfg, config)
 	return cfg, err
 }

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -164,10 +164,15 @@ func readInstanceID() (string, error) {
 
 func init() {
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+		if config == nil {
+			return nil, cloudprovider.ErrNoConfig
+		}
+
 		cfg, err := readConfig(config)
 		if err != nil {
 			return nil, err
 		}
+
 		return newRackspace(cfg)
 	})
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -185,12 +185,12 @@ func generateDiskFormatValidOptions() string {
 
 // Parses vSphere cloud config file and stores it into VSphereConfig.
 func readConfig(config io.Reader) (VSphereConfig, error) {
+	var cfg VSphereConfig
+
 	if config == nil {
-		err := fmt.Errorf("no vSphere cloud provider config file given")
-		return VSphereConfig{}, err
+		return cfg, cloudprovider.ErrNoConfig
 	}
 
-	var cfg VSphereConfig
 	err := gcfg.ReadInto(&cfg, config)
 	return cfg, err
 }
@@ -201,6 +201,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
+
 		return newVSphere(cfg)
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

Currently some cloud providers panic (azure), some fail with an error (openstack)
when no config is provided and some are tolerant being config-less (aws).

This unifies the behavior for those providers who usually error out when no config
is provided, giving a warning and disabling the cloud provider if no config is given.

Fixes #42483

**Release note:**
```
Log a warning if a cloud provider but no cloud config is specified instead of hard-failing.
```