### PR TITLE
provide active pods to cgroup cleanup

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -687,11 +687,7 @@ func (kl *Kubelet) podIsTerminated(pod *v1.Pod) bool {
 		// restarted.
 		status = pod.Status
 	}
-	if status.Phase == v1.PodFailed || status.Phase == v1.PodSucceeded {
-		return true
-	}
-
-	return false
+	return status.Phase == v1.PodFailed || status.Phase == v1.PodSucceeded || (pod.DeletionTimestamp != nil && notRunning(status.ContainerStatuses))
 }
 
 // OkToDeletePod returns true if all required node-level resources that a pod was consuming have
@@ -848,7 +844,7 @@ func (kl *Kubelet) HandlePodCleanups() error {
 
 	// Remove any cgroups in the hierarchy for pods that are no longer running.
 	if kl.cgroupsPerQOS {
-		kl.cleanupOrphanedPodCgroups(cgroupPods, runningPods)
+		kl.cleanupOrphanedPodCgroups(cgroupPods, activePods)
 	}
 
 	kl.backOff.GC()
@@ -1511,13 +1507,12 @@ func (kl *Kubelet) GetPortForward(podName, podNamespace string, podUID types.UID
 
 // cleanupOrphanedPodCgroups removes cgroups that should no longer exist.
 // it reconciles the cached state of cgroupPods with the specified list of runningPods
-func (kl *Kubelet) cleanupOrphanedPodCgroups(cgroupPods map[types.UID]cm.CgroupName, runningPods []*kubecontainer.Pod) {
+func (kl *Kubelet) cleanupOrphanedPodCgroups(cgroupPods map[types.UID]cm.CgroupName, activePods []*v1.Pod) {
 	// Add all running pods to the set that we want to preserve
 	podSet := sets.NewString()
-	for _, pod := range runningPods {
-		podSet.Insert(string(pod.ID))
+	for _, pod := range activePods {
+		podSet.Insert(string(pod.UID))
 	}
-
 	pcm := kl.containerManager.NewPodContainerManager()
 
 	// Iterate over all the found pods to verify if they should be running


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR provides more information for when a pod cgroup is considered orphaned.  The running pods cache is based on the runtime's view of the world.  we create pod cgroups before containers so we should just be looking at activePods.

**Which issue this PR fixes**
Fixes https://github.com/kubernetes/kubernetes/issues/42431