### PR TITLE
Create "framework" per upgrade test

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -45,6 +45,13 @@ var upgradeTests = []upgrades.Test{
 var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {
 	f := framework.NewDefaultFramework("cluster-upgrade")
 
+	// Create the frameworks here because we can only create them
+	// in a "Describe".
+	testFrameworks := map[string]*framework.Framework{}
+	for _, t := range upgradeTests {
+		testFrameworks[t.Name()] = framework.NewDefaultFramework(t.Name())
+	}
+
 	framework.KubeDescribe("master upgrade", func() {
 		It("should maintain a functioning cluster [Feature:MasterUpgrade]", func() {
 			cm := chaosmonkey.New(func() {
@@ -56,7 +63,7 @@ var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {
 			for _, t := range upgradeTests {
 				cm.RegisterInterface(&chaosMonkeyAdapter{
 					test:        t,
-					framework:   f,
+					framework:   testFrameworks[t.Name()],
 					upgradeType: upgrades.MasterUpgrade,
 				})
 			}
@@ -76,7 +83,7 @@ var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {
 			for _, t := range upgradeTests {
 				cm.RegisterInterface(&chaosMonkeyAdapter{
 					test:        t,
-					framework:   f,
+					framework:   testFrameworks[t.Name()],
 					upgradeType: upgrades.NodeUpgrade,
 				})
 			}
@@ -97,7 +104,7 @@ var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {
 			for _, t := range upgradeTests {
 				cm.RegisterInterface(&chaosMonkeyAdapter{
 					test:        t,
-					framework:   f,
+					framework:   testFrameworks[t.Name()],
 					upgradeType: upgrades.ClusterUpgrade,
 				})
 			}
@@ -107,7 +114,12 @@ var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {
 })
 
 var _ = framework.KubeDescribe("etcd Upgrade [Feature:EtcdUpgrade]", func() {
-	f := framework.NewDefaultFramework("etcd-upgrade")
+	// Create the frameworks here because we can only create them
+	// in a "Describe".
+	testFrameworks := map[string]*framework.Framework{}
+	for _, t := range upgradeTests {
+		testFrameworks[t.Name()] = framework.NewDefaultFramework(t.Name())
+	}
 
 	framework.KubeDescribe("etcd upgrade", func() {
 		It("should maintain a functioning cluster", func() {
@@ -118,7 +130,7 @@ var _ = framework.KubeDescribe("etcd Upgrade [Feature:EtcdUpgrade]", func() {
 			for _, t := range upgradeTests {
 				cm.RegisterInterface(&chaosMonkeyAdapter{
 					test:        t,
-					framework:   f,
+					framework:   testFrameworks[t.Name()],
 					upgradeType: upgrades.EtcdUpgrade,
 				})
 			}

--- a/test/e2e/upgrades/configmaps.go
+++ b/test/e2e/upgrades/configmaps.go
@@ -33,13 +33,13 @@ type ConfigMapUpgradeTest struct {
 	configMap *v1.ConfigMap
 }
 
+func (ConfigMapUpgradeTest) Name() string { return "configmap-upgrade" }
+
 // Setup creates a ConfigMap and then verifies that a pod can consume it.
 func (t *ConfigMapUpgradeTest) Setup(f *framework.Framework) {
 	configMapName := "upgrade-configmap"
 
-	// Grab a unique namespace so we don't collide.
-	ns, err := f.CreateNamespace("configmap-upgrade", nil)
-	framework.ExpectNoError(err)
+	ns := f.Namespace
 
 	t.configMap = &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -52,6 +52,7 @@ func (t *ConfigMapUpgradeTest) Setup(f *framework.Framework) {
 	}
 
 	By("Creating a ConfigMap")
+	var err error
 	if t.configMap, err = f.ClientSet.Core().ConfigMaps(ns.Name).Create(t.configMap); err != nil {
 		framework.Failf("unable to create test ConfigMap %s: %v", t.configMap.Name, err)
 	}

--- a/test/e2e/upgrades/daemonsets.go
+++ b/test/e2e/upgrades/daemonsets.go
@@ -36,16 +36,15 @@ type DaemonSetUpgradeTest struct {
 	daemonSet *extensions.DaemonSet
 }
 
+func (DaemonSetUpgradeTest) Name() string { return "daemonset-upgrade" }
+
 // Setup creates a DaemonSet and verifies that it's running
 func (t *DaemonSetUpgradeTest) Setup(f *framework.Framework) {
-	namespace := "daemonset-upgrade"
 	daemonSetName := "ds1"
 	labelSet := map[string]string{"ds-name": daemonSetName}
 	image := "gcr.io/google_containers/serve_hostname:v1.4"
 
-	// Grab a unique namespace so we don't collide.
-	ns, err := f.CreateNamespace(namespace, nil)
-	framework.ExpectNoError(err)
+	ns := f.Namespace
 
 	t.daemonSet = &extensions.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -71,6 +70,7 @@ func (t *DaemonSetUpgradeTest) Setup(f *framework.Framework) {
 	}
 
 	By("Creating a DaemonSet")
+	var err error
 	if t.daemonSet, err = f.ClientSet.Extensions().DaemonSets(ns.Name).Create(t.daemonSet); err != nil {
 		framework.Failf("unable to create test DaemonSet %s: %v", t.daemonSet.Name, err)
 	}

--- a/test/e2e/upgrades/deployments.go
+++ b/test/e2e/upgrades/deployments.go
@@ -39,16 +39,15 @@ type DeploymentUpgradeTest struct {
 	newRS    *extensions.ReplicaSet
 }
 
+func (DeploymentUpgradeTest) Name() string { return "deployment-upgrade" }
+
 // Setup creates a deployment and makes sure it has a new and an old replica set running.
 func (t *DeploymentUpgradeTest) Setup(f *framework.Framework) {
 	deploymentName := "deployment-hash-test"
 	c := f.ClientSet
 	nginxImage := "gcr.io/google_containers/nginx-slim:0.8"
 
-	// Grab a unique namespace so we don't collide.
-	namespace, err := f.CreateNamespace("deployment-upgrade", nil)
-	framework.ExpectNoError(err)
-	ns := namespace.Name
+	ns := f.Namespace.Name
 
 	By(fmt.Sprintf("Creating a deployment %q in namespace %q", deploymentName, ns))
 	d := framework.NewDeployment(deploymentName, int32(1), map[string]string{"test": "upgrade"}, "nginx", nginxImage, extensions.RollingUpdateDeploymentStrategyType)

--- a/test/e2e/upgrades/horizontal_pod_autoscalers.go
+++ b/test/e2e/upgrades/horizontal_pod_autoscalers.go
@@ -18,6 +18,7 @@ package upgrades
 
 import (
 	"fmt"
+
 	"k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -28,6 +29,8 @@ import (
 type HPAUpgradeTest struct {
 	rc *common.ResourceConsumer
 }
+
+func (HPAUpgradeTest) Name() string { return "hpa-upgrade" }
 
 // Creates a resource consumer and an HPA object that autoscales the consumer.
 func (t *HPAUpgradeTest) Setup(f *framework.Framework) {

--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -35,6 +35,8 @@ type IngressUpgradeTest struct {
 	ip            string
 }
 
+func (IngressUpgradeTest) Name() string { return "ingress-upgrade" }
+
 // Setup creates a GLBC, allocates an ip, and an ingress resource,
 // then waits for a successful connectivity check to the ip.
 func (t *IngressUpgradeTest) Setup(f *framework.Framework) {
@@ -43,8 +45,7 @@ func (t *IngressUpgradeTest) Setup(f *framework.Framework) {
 	// jig handles all Kubernetes testing logic
 	jig := framework.NewIngressTestJig(f.ClientSet)
 
-	ns, err := f.CreateNamespace("ingress-upgrade", nil)
-	framework.ExpectNoError(err)
+	ns := f.Namespace
 
 	// gceController handles all cloud testing logic
 	gceController := &framework.GCEIngressController{

--- a/test/e2e/upgrades/job.go
+++ b/test/e2e/upgrades/job.go
@@ -31,11 +31,11 @@ type JobUpgradeTest struct {
 	namespace string
 }
 
+func (JobUpgradeTest) Name() string { return "job-upgrade" }
+
 // Setup starts a Job with a parallelism of 2 and 2 completions running.
 func (t *JobUpgradeTest) Setup(f *framework.Framework) {
-	ns, err := f.CreateNamespace("service-upgrade", nil)
-	Expect(err).NotTo(HaveOccurred())
-	t.namespace = ns.Name
+	t.namespace = f.Namespace.Name
 
 	By("Creating a job")
 	t.job = framework.NewTestJob("notTerminate", "foo", v1.RestartPolicyOnFailure, 2, 2)

--- a/test/e2e/upgrades/persistent_volumes.go
+++ b/test/e2e/upgrades/persistent_volumes.go
@@ -30,6 +30,8 @@ type PersistentVolumeUpgradeTest struct {
 	pvc      *v1.PersistentVolumeClaim
 }
 
+func (PersistentVolumeUpgradeTest) Name() string { return "persistent-volume-upgrade" }
+
 const (
 	pvTestFile string = "/mnt/pv_upgrade_test"
 	pvTestData string = "keep it pv"

--- a/test/e2e/upgrades/secrets.go
+++ b/test/e2e/upgrades/secrets.go
@@ -33,13 +33,13 @@ type SecretUpgradeTest struct {
 	secret *v1.Secret
 }
 
+func (SecretUpgradeTest) Name() string { return "secret-upgrade" }
+
 // Setup creates a secret and then verifies that a pod can consume it.
 func (t *SecretUpgradeTest) Setup(f *framework.Framework) {
 	secretName := "upgrade-secret"
 
-	// Grab a unique namespace so we don't collide.
-	ns, err := f.CreateNamespace("secret-upgrade", nil)
-	framework.ExpectNoError(err)
+	ns := f.Namespace
 
 	t.secret = &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -52,6 +52,7 @@ func (t *SecretUpgradeTest) Setup(f *framework.Framework) {
 	}
 
 	By("Creating a secret")
+	var err error
 	if t.secret, err = f.ClientSet.Core().Secrets(ns.Name).Create(t.secret); err != nil {
 		framework.Failf("unable to create test secret %s: %v", t.secret.Name, err)
 	}

--- a/test/e2e/upgrades/services.go
+++ b/test/e2e/upgrades/services.go
@@ -34,14 +34,14 @@ type ServiceUpgradeTest struct {
 	svcPort      int
 }
 
+func (ServiceUpgradeTest) Name() string { return "service-upgrade" }
+
 // Setup creates a service with a load balancer and makes sure it's reachable.
 func (t *ServiceUpgradeTest) Setup(f *framework.Framework) {
 	serviceName := "service-test"
 	jig := framework.NewServiceTestJig(f.ClientSet, serviceName)
 
-	// Grab a unique namespace so we don't collide.
-	ns, err := f.CreateNamespace("service-upgrade", nil)
-	framework.ExpectNoError(err)
+	ns := f.Namespace
 
 	By("creating a TCP service " + serviceName + " with type=LoadBalancer in namespace " + ns.Name)
 	tcpService := jig.CreateTCPServiceOrFail(ns.Name, func(s *v1.Service) {

--- a/test/e2e/upgrades/statefulset.go
+++ b/test/e2e/upgrades/statefulset.go
@@ -33,6 +33,8 @@ type StatefulSetUpgradeTest struct {
 	set     *apps.StatefulSet
 }
 
+func (StatefulSetUpgradeTest) Name() string { return "statefulset-upgrade" }
+
 // Setup creates a StatefulSet and a HeadlessService. It verifies the basic SatefulSet properties
 func (t *StatefulSetUpgradeTest) Setup(f *framework.Framework) {
 	ssName := "ss"

--- a/test/e2e/upgrades/upgrade.go
+++ b/test/e2e/upgrades/upgrade.go
@@ -41,6 +41,9 @@ const (
 
 // Test is an interface for upgrade tests.
 type Test interface {
+	// Name should return a test name sans spaces.
+	Name() string
+
 	// Setup should create and verify whatever objects need to
 	// exist before the upgrade disruption starts.
 	Setup(f *framework.Framework)


### PR DESCRIPTION
There were already a few tests just using the default framework
namespace instead of creating a new one. Also there are several
testing libraries that use the default framework's default namespace
as well. It's just easier this way.
