### PR TITLE
make storm examples use gcr image registry

### DIFF
--- a/examples/storm/images/Makefile
+++ b/examples/storm/images/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TAG = 1.0
+PREFIX = gcr.io/google-samples
+MODULES =  storm-base zookeeper storm-worker storm-nimbus
+
+all: 
+	@$(foreach image, $(MODULES),\
+	    echo $(image); cd $(image) && docker build -t $(PREFIX)/$(image) . && cd .. ; docker tag $(PREFIX)/$(image) $(PREFIX)/$(image):$(TAG); gcloud docker -- push $(PREFIX)/$(image);  gcloud docker -- push $(PREFIX)/$(image):$(TAG);)
+
+
+clean:

--- a/examples/storm/images/storm-base/Dockerfile
+++ b/examples/storm/images/storm-base/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM fedora:21
+
+MAINTAINER Matthew Farrellee <matt@cs.wisc.edu>
+
+RUN yum update -y ; yum install -y java tar ; yum clean all
+
+RUN curl -s http://archive.apache.org/dist/storm/apache-storm-0.9.3/apache-storm-0.9.3.tar.gz | \
+      tar zxf - -C /opt && \
+      mv /opt/apache-storm-0.9.3 /opt/apache-storm
+
+ADD configure.sh /

--- a/examples/storm/images/storm-base/configure.sh
+++ b/examples/storm/images/storm-base/configure.sh
@@ -1,0 +1,34 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/sh
+
+cat >> conf/storm.yaml <<EOF
+storm.local.dir: "/tmp"
+EOF
+
+if [ -n "$1" ]; then
+   cat >> conf/storm.yaml <<EOF
+storm.zookeeper.servers:
+- "$1"
+EOF
+fi
+
+if [ -n "$2" ]; then
+   cat >> conf/storm.yaml <<EOF
+nimbus.host: "$2"
+EOF
+fi   
+
+cat conf/storm.yaml

--- a/examples/storm/images/storm-nimbus/Dockerfile
+++ b/examples/storm/images/storm-nimbus/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google-samples/storm-base
+
+MAINTAINER Matthew Farrellee <matt@cs.wisc.edu>
+
+ADD start.sh /
+
+EXPOSE 3772 6627
+
+WORKDIR /opt/apache-storm
+
+ENTRYPOINT ["/start.sh"]

--- a/examples/storm/images/storm-nimbus/start.sh
+++ b/examples/storm/images/storm-nimbus/start.sh
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/sh
+
+/configure.sh ${ZOOKEEPER_SERVICE_HOST:-$1}
+
+exec bin/storm nimbus

--- a/examples/storm/images/storm-worker/Dockerfile
+++ b/examples/storm/images/storm-worker/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/google-samples/storm-base
+
+MAINTAINER Matthew Farrellee <matt@cs.wisc.edu>
+
+ADD start.sh /
+
+EXPOSE 6700 6701 6702 6703
+
+WORKDIR /opt/apache-storm
+
+ENTRYPOINT ["/start.sh"]

--- a/examples/storm/images/storm-worker/start.sh
+++ b/examples/storm/images/storm-worker/start.sh
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#!/bin/sh
+
+/configure.sh ${ZOOKEEPER_SERVICE_HOST:-$1} ${NIMBUS_SERVICE_HOST:-$2}
+
+exec bin/storm supervisor

--- a/examples/storm/images/zookeeper/Dockerfile
+++ b/examples/storm/images/zookeeper/Dockerfile
@@ -1,0 +1,28 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM fedora:21 
+
+MAINTAINER Matthew Farrellee <matt@cs.wisc.edu>
+
+RUN yum update -y; yum install -y java tar; yum install -y zookeeper; yum clean all
+RUN cp /etc/zookeeper/zoo_sample.cfg /etc/zookeeper/zoo.cfg
+
+# workaround packaging issue
+RUN sed -i 's,/usr/share/java/log4j.jar,/usr/share/java/log4j-1.jar,' /usr/libexec/zkEnv.sh
+
+EXPOSE 2181 2888 3888
+
+ENTRYPOINT ["/bin/zkServer.sh"]
+CMD ["start-foreground"]

--- a/examples/storm/storm-nimbus.json
+++ b/examples/storm/storm-nimbus.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "nimbus",
-        "image": "mattf/storm-nimbus",
+        "image": "gcr.io/google-samples/storm-nimbus:1.0",
         "ports": [
           {
             "containerPort": 6627

--- a/examples/storm/storm-worker-controller.json
+++ b/examples/storm/storm-worker-controller.json
@@ -23,7 +23,7 @@
         "containers": [
           {
             "name": "storm-worker",
-            "image": "mattf/storm-worker",
+            "image": "gcr.io/google-samples/storm-worker:1.0",
             "ports": [
               {
                 "hostPort": 6700,

--- a/examples/storm/zookeeper.json
+++ b/examples/storm/zookeeper.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "zookeeper",
-        "image": "mattf/zookeeper",
+        "image": "gcr.io/google-samples/zookeeper:1.0",
         "ports": [
           {
             "containerPort": 2181


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
e2e example test occasionally failed due to image pull timeout.
This fix move storm examples from docker registry to gcr.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #38047

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
