### PR TITLE
RC/RS: Fix ignoring inactive Pods.

### DIFF
--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -553,13 +553,13 @@ func (rsc *ReplicaSetController) syncReplicaSet(key string) error {
 	// list all pods to include the pods that don't match the rs`s selector
 	// anymore but has the stale controller ref.
 	// TODO: Do the List and Filter in a single pass, or use an index.
-	pods, err := rsc.podLister.Pods(rs.Namespace).List(labels.Everything())
+	allPods, err := rsc.podLister.Pods(rs.Namespace).List(labels.Everything())
 	if err != nil {
 		return err
 	}
 	// Ignore inactive pods.
 	var filteredPods []*v1.Pod
-	for _, pod := range pods {
+	for _, pod := range allPods {
 		if controller.IsPodActive(pod) {
 			filteredPods = append(filteredPods, pod)
 		}

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -571,13 +571,13 @@ func (rm *ReplicationManager) syncReplicationController(key string) error {
 	// list all pods to include the pods that don't match the rc's selector
 	// anymore but has the stale controller ref.
 	// TODO: Do the List and Filter in a single pass, or use an index.
-	pods, err := rm.podLister.Pods(rc.Namespace).List(labels.Everything())
+	allPods, err := rm.podLister.Pods(rc.Namespace).List(labels.Everything())
 	if err != nil {
 		return err
 	}
 	// Ignore inactive pods.
 	var filteredPods []*v1.Pod
-	for _, pod := range pods {
+	for _, pod := range allPods {
 		if controller.IsPodActive(pod) {
 			filteredPods = append(filteredPods, pod)
 		}
@@ -585,7 +585,7 @@ func (rm *ReplicationManager) syncReplicationController(key string) error {
 	cm := controller.NewPodControllerRefManager(rm.podControl, rc, labels.Set(rc.Spec.Selector).AsSelectorPreValidated(), controllerKind)
 	// NOTE: filteredPods are pointing to objects from cache - if you need to
 	// modify them, you need to copy it first.
-	filteredPods, err = cm.ClaimPods(pods)
+	filteredPods, err = cm.ClaimPods(filteredPods)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix typo that broke ignoring of inactive Pods in RC, and add unit test for that case.

**Which issue this PR fixes**:

Fixes #37479

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
