### PR TITLE
add "bind" to validResourceVerbs in "create role" cli 

### DIFF
--- a/pkg/kubectl/cmd/create_role.go
+++ b/pkg/kubectl/cmd/create_role.go
@@ -43,10 +43,10 @@ var (
 		kubectl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods
 
 		# Create a Role named "pod-reader" with ResourceName specified
-		kubectl create role pod-reader --verb=get --verg=list --verb=watch --resource=pods --resource-name=readablepod`))
+		kubectl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods --resource-name=readablepod`))
 
 	// Valid resource verb list for validation.
-	validResourceVerbs = []string{"*", "get", "delete", "list", "create", "update", "patch", "watch", "proxy", "redirect", "deletecollection", "use"}
+	validResourceVerbs = []string{"*", "get", "delete", "list", "create", "update", "patch", "watch", "proxy", "redirect", "deletecollection", "use", "bind", "impersonate"}
 )
 
 type CreateRoleOptions struct {

--- a/pkg/kubectl/cmd/create_role_test.go
+++ b/pkg/kubectl/cmd/create_role_test.go
@@ -203,11 +203,12 @@ func TestValidate(t *testing.T) {
 		},
 		"test-valid-case": {
 			roleOptions: &CreateRoleOptions{
-				Name:  "my-role",
-				Verbs: []string{"get", "list"},
+				Name:  "role-binder",
+				Verbs: []string{"get", "list", "bind"},
 				Resources: []schema.GroupVersionResource{
 					{
-						Resource: "pods",
+						Resource: "roles",
+						Group:    "rbac.authorization.k8s.io",
 					},
 				},
 				ResourceNames: []string{"foo"},


### PR DESCRIPTION
"bind" and "impersonate" are also a legal verbs according this:
https://github.com/kubernetes/kubernetes.github.io/pull/2771/files
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
