### PR TITLE
Automated cherry pick of #42506

### DIFF
--- a/pkg/storage/etcd/etcd_helper_test.go
+++ b/pkg/storage/etcd/etcd_helper_test.go
@@ -567,3 +567,20 @@ func TestDeleteWithRetry(t *testing.T) {
 		t.Errorf("Expect an NotFound error, got %v", err)
 	}
 }
+
+func TestPrefix(t *testing.T) {
+	server := etcdtesting.NewEtcdTestClientServer(t)
+	defer server.Terminate(t)
+
+	testcases := map[string]string{
+		"custom/prefix":     "/custom/prefix",
+		"/custom//prefix//": "/custom/prefix",
+		"/registry":         "/registry",
+	}
+	for configuredPrefix, effectivePrefix := range testcases {
+		helper := newEtcdHelper(server.Client, testapi.Default.Codec(), configuredPrefix)
+		if helper.pathPrefix != effectivePrefix {
+			t.Errorf("configured prefix of %s, expected effective prefix of %s, got %s", configuredPrefix, effectivePrefix, helper.pathPrefix)
+		}
+	}
+}

--- a/pkg/storage/etcd3/store.go
+++ b/pkg/storage/etcd3/store.go
@@ -76,10 +76,13 @@ func NewWithNoQuorumRead(c *clientv3.Client, codec runtime.Codec, prefix string)
 func newStore(c *clientv3.Client, quorumRead bool, codec runtime.Codec, prefix string) *store {
 	versioner := etcd.APIObjectVersioner{}
 	result := &store{
-		client:     c,
-		versioner:  versioner,
-		codec:      codec,
-		pathPrefix: prefix,
+		client:    c,
+		versioner: versioner,
+		codec:     codec,
+		// for compatibility with etcd2 impl.
+		// no-op for default prefix of '/registry'.
+		// keeps compatibility with etcd2 impl for custom prefixes that don't start with '/'
+		pathPrefix: path.Join("/", prefix),
 		watcher:    newWatcher(c, codec, versioner),
 	}
 	if !quorumRead {

--- a/pkg/storage/etcd3/store_test.go
+++ b/pkg/storage/etcd3/store_test.go
@@ -555,3 +555,18 @@ func testPropogateStore(ctx context.Context, t *testing.T, store *store, obj *ap
 	}
 	return key, setOutput
 }
+
+func TestPrefix(t *testing.T) {
+	cluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	testcases := map[string]string{
+		"custom/prefix":     "/custom/prefix",
+		"/custom//prefix//": "/custom/prefix",
+		"/registry":         "/registry",
+	}
+	for configuredPrefix, effectivePrefix := range testcases {
+		store := newStore(cluster.RandClient(), false, testapi.Default.Codec(), configuredPrefix)
+		if store.pathPrefix != effectivePrefix {
+			t.Errorf("configured prefix of %s, expected effective prefix of %s, got %s", configuredPrefix, effectivePrefix, store.pathPrefix)
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick of #42506 on release-1.5.

#42506: Preserve custom etcd prefix compatibility for etcd3

```release-note
restored normalization of custom `--etcd-prefix` when `--storage-backend` is set to etcd3
```