### PR TITLE
Adding note saying client-go examples only work with the code in the same branch

### DIFF
--- a/staging/src/k8s.io/client-go/examples/in-cluster/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Note: the example only works with the code within the same release/branch.
 package main
 
 import (

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Note: the example only works with the code within the same release/branch.
 package main
 
 import (

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/main.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Note: the example only works with the code within the same release/branch.
 package main
 
 import (


### PR DESCRIPTION
Adding this note because the problem has confused many users.

It's doc change and only affects client-go examples, so adding the milestone.