### PR TITLE
Allow minion floating IPs to be optional

### DIFF
--- a/cluster/openstack-heat/config-default.sh
+++ b/cluster/openstack-heat/config-default.sh
@@ -73,3 +73,6 @@ SOCKS_PROXY=${SOCKS_PROXY:-}
 
 # IPs and Domains that bypass the proxy.
 NO_PROXY=${NO_PROXY:-}
+
+# Whether to assign floating IPs to minions
+ASSIGN_FLOATING_IP=${ASSIGN_FLOATING_IP:-true}

--- a/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
@@ -161,6 +161,11 @@ parameters:
     type: string
     description: Comma seperated list of domains/addresses that bypass proxying.
     default: localhost
+    
+  assign_floating_ip:
+    type: boolean
+    description: Indicates whether floating IPs will be generated for minions
+    default: true
 
 resources:
 
@@ -435,6 +440,7 @@ resources:
           https_proxy: {get_param: https_proxy }
           socks_proxy: {get_param: socks_proxy }
           no_proxy: {get_param: no_proxy }
+          assign_floating_ip: {get_param: assign_floating_ip }
       min_size: {get_param: number_of_minions}
       desired_capacity: {get_param: number_of_minions}
       max_size: {get_param: max_number_of_minions}

--- a/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
@@ -100,6 +100,11 @@ parameters:
     description: Comma seperated list of domains/addresses that bypass proxying.
     default: localhost
 
+  assign_floating_ip:
+    type: boolean
+    description: Indicates whether floating IPs will be generated for minions
+    default: true
+
   # The following are all generated in the parent template.
   kube_master_ip:
     type: string
@@ -126,6 +131,9 @@ parameters:
     type: string
   secgroup_node:
     type: string
+
+conditions:
+  assign_floating_ip: {equals : [{get_param: assign_floating_ip}, true]}
 
 resources:
 
@@ -294,10 +302,13 @@ resources:
     properties:
       floating_network: {get_param: external_network}
       port_id: {get_resource: kube_minion_eth0}
+    condition: assign_floating_ip
 
 outputs:
 
   kube_minion_ip:
     value: {get_attr: [kube_minion_eth0, fixed_ips, 0, ip_address]}
+
   kube_minion_external_ip:
     value: {get_attr: [kube_minion_floating, floating_ip_address]}
+    condition: assign_floating_ip

--- a/cluster/openstack-heat/util.sh
+++ b/cluster/openstack-heat/util.sh
@@ -233,6 +233,7 @@ function run-heat-script() {
       --parameter https_proxy="${HTTPS_PROXY}" \
       --parameter socks_proxy="${SOCKS_PROXY}" \
       --parameter no_proxy="${NO_PROXY}" \
+      --parameter assign_floating_ip="${ASSIGN_FLOATING_IP}" \
       --template kubecluster.yaml \
       ${STACK_NAME}
     )


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the generation of floating IPs for worker nodes optional, based on an env var. To quote the original issue:

> Currently, the OpenStack installation method assigns a floating IP to every single worker node. While this is fine for smaller clusters with a good sized IP pool, it can cause issues in environments with high node counts or less IPs available.

**Which issue this PR fixes**:

https://github.com/kubernetes/kubernetes/issues/40737

**Special notes for your reviewer**:

I used the conditions section of the Heat spec: https://docs.openstack.org/developer/heat/template_guide/hot_spec.html#conditions-section

**Release note**:
```release-note
OpenStack clusters can now specify whether worker nodes are assigned a floating IP
```
