### PR TITLE
Verify pkg/version/base.go is updated

### DIFF
--- a/staging/copy.sh
+++ b/staging/copy.sh
@@ -215,8 +215,6 @@ find "${CLIENT_REPO_TEMP}" -type f \( \
 
 if [ "${FAIL_ON_CHANGES}" = true ]; then
   echo "running FAIL_ON_CHANGES"
-  # ignore base.go in diff
-  cp "${CLIENT_REPO}/pkg/version/base.go" "${CLIENT_REPO_TEMP}/pkg/version/"
   if diff -NauprB  -I '^\s*\"Comment\"' -I "GoVersion.*\|GodepVersion.*" "${CLIENT_REPO}" "${CLIENT_REPO_TEMP}"; then
     echo "${CLIENT_REPO} up to date."
     exit 0


### PR DESCRIPTION
This file affects the user-agent set by a released version of kubectl (similar to https://github.com/kubernetes/kubernetes/issues/40813), so it should be verified.

Partially revert #42300.

The original bug #42290 should be fixed now because we included update-staging-client-go.sh in update-all.sh.