### PR TITLE
kubeadm: Delete the dummy Deployment properly

### DIFF
--- a/cmd/kubeadm/app/master/apiclient.go
+++ b/cmd/kubeadm/app/master/apiclient.go
@@ -139,9 +139,9 @@ func createAndWaitForADummyDeployment(client *clientset.Clientset) error {
 
 	fmt.Println("[apiclient] Test deployment succeeded")
 
-	falseVar := false
+	foreground := metav1.DeletePropagationForeground
 	if err := client.ExtensionsV1beta1().Deployments(metav1.NamespaceSystem).Delete("dummy", &metav1.DeleteOptions{
-		OrphanDependents: &falseVar,
+		PropagationPolicy: &foreground,
 	}); err != nil {
 		fmt.Printf("[apiclient] Failed to delete test deployment [%v] (will ignore)\n", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubeadm/issues/149

**Special notes for your reviewer**:

Earlier, the Pod created by the Deployment wasn't deleted. With this option it is.
As suggested by @deads2k, thank you!

This is a bug fix for v1.6

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
@mikedanese @jbeda @dmmcquay @pires @errordeveloper @deads2k @caesarxuchao 