### PR TITLE
[Bug Fix] Garbage Collect Node e2e Failing

### DIFF
--- a/test/e2e_node/garbage_collector_test.go
+++ b/test/e2e_node/garbage_collector_test.go
@@ -231,7 +231,7 @@ func containerGCTest(f *framework.Framework, test testRun) {
 		AfterEach(func() {
 			for _, pod := range test.testPods {
 				By(fmt.Sprintf("Deleting Pod %v", pod.podName))
-				f.PodClient().DeleteSync(pod.podName, &metav1.DeleteOptions{}, defaultRuntimeRequestTimeoutDuration)
+				f.PodClient().DeleteSync(pod.podName, &metav1.DeleteOptions{}, podDisappearTimeout)
 			}
 
 			By("Making sure all containers get cleaned up")


### PR DESCRIPTION
This node e2e test uses its own deletion timeout (1 minute) instead of the default (3 minutes).
#41644 likely increased time for deletion.  See that PR for analysis on that.
There may be other problems with this test, but those are difficult to pick apart from hitting this low timeout.

This PR changes the Garbage Collector test to use the default timeout.  This should allow us to discern if there are any actual bugs to fix.

cc @kubernetes/sig-node-bugs @calebamiles @derekwaynecarr 