### PR TITLE
Enable secrets in federation kubectl tests

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1812,6 +1812,9 @@ run_secrets_test() {
   kubectl delete secret test-secret --namespace=test-secrets
 
   ### Create a docker-registry secret in a specific namespace
+  if [[ "${WAIT_FOR_DELETION:-}" == "true" ]]; then
+    kube::test::wait_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
+  fi
   # Pre-condition: no SECRET exists
   kube::test::get_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
@@ -1824,6 +1827,9 @@ run_secrets_test() {
   kubectl delete secret test-secret --namespace=test-secrets
 
   ### Create a tls secret
+  if [[ "${WAIT_FOR_DELETION:-}" == "true" ]]; then
+    kube::test::wait_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
+  fi
   # Pre-condition: no SECRET exists
   kube::test::get_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
@@ -1858,6 +1864,9 @@ __EOF__
   kubectl delete secret secret-string-data --namespace=test-secrets
 
   ### Create a secret using output flags
+  if [[ "${WAIT_FOR_DELETION:-}" == "true" ]]; then
+    kube::test::wait_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
+  fi
   # Pre-condition: no secret exists
   kube::test::get_object_assert 'secrets --namespace=test-secrets' "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command

--- a/hack/make-rules/test-federation-cmd.sh
+++ b/hack/make-rules/test-federation-cmd.sh
@@ -77,6 +77,10 @@ run_federation_apiserver
 run_federation_controller_manager
 # TODO: Fix for secrets, replicasets and deployments.
 SUPPORTED_RESOURCES=("configmaps" "daemonsets" "events" "ingress" "namespaces" "services")
+# Set wait for deletion to true for federation apiserver since resources are
+# deleted asynchronously.
+# This is a temporary workaround until https://github.com/kubernetes/kubernetes/issues/42594 is fixed.
+WAIT_FOR_DELETION="true"
 # WARNING: Do not wrap this call in a subshell to capture output, e.g. output=$(runTests)
 # Doing so will suppress errexit behavior inside runTests
 runTests

--- a/hack/make-rules/test-federation-cmd.sh
+++ b/hack/make-rules/test-federation-cmd.sh
@@ -75,8 +75,8 @@ kube::log::status "Running kubectl tests for federation-apiserver"
 setup
 run_federation_apiserver
 run_federation_controller_manager
-# TODO: Fix for secrets, replicasets and deployments.
-SUPPORTED_RESOURCES=("configmaps" "daemonsets" "events" "ingress" "namespaces" "services")
+# TODO: Fix for replicasets and deployments.
+SUPPORTED_RESOURCES=("configmaps" "daemonsets" "events" "ingress" "namespaces" "services" "secrets")
 # Set wait for deletion to true for federation apiserver since resources are
 # deleted asynchronously.
 # This is a temporary workaround until https://github.com/kubernetes/kubernetes/issues/42594 is fixed.


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/40568
Superseedes https://github.com/kubernetes/kubernetes/pull/40714

Updating kubectl tests to wait for deletion if WAIT_FOR_DELETION is set to true. WAIT_FOR_DELETION will be set to true only when the tests are being run for federation apiserver.
This change will not impact kube apiserver tests and still enable federation and kubernetes to share the same test code.
This is a workaround until https://github.com/kubernetes/kubernetes/issues/42594 is fixed.

cc @kubernetes/sig-federation-pr-reviews
cc @liggitt as he reviewed https://github.com/kubernetes/kubernetes/pull/40714