### PR TITLE
Re-enable OIR e2e tests.

### DIFF
--- a/test/e2e/scheduling/opaque_resource.go
+++ b/test/e2e/scheduling/opaque_resource.go
@@ -33,7 +33,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("Opaque resources [Feature:OpaqueResources]", func() {
+var _ = SIGDescribe("Opaque resources", func() {
 	f := framework.NewDefaultFramework("opaque-resource")
 	opaqueResName := v1helper.OpaqueIntResourceName("foo")
 	var node *v1.Node


### PR DESCRIPTION
Re-enabling test skeleton for opaque integer resources originally submitted as part of #41870. The e2e was disabled since it was flaky. This is the first step toward re-enabling them. Currently all cases are skipped, so this exercises only the BeforeEach behavior and the deferred removal of OIRs from a node.

cc @timothysc 