### PR TITLE
Dropped docker 1.9.x support. Changed the minimumDockerAPIVersion to

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -81,8 +81,8 @@ const (
 	DockerType = "docker"
 
 	// https://docs.docker.com/engine/reference/api/docker_remote_api/
-	// docker version should be at least 1.9.x
-	minimumDockerAPIVersion = "1.21"
+	// docker version should be at least 1.10.x
+	minimumDockerAPIVersion = "1.22"
 
 	// Remote API version for docker daemon versions
 	// https://docs.docker.com/engine/reference/api/docker_remote_api/


### PR DESCRIPTION
1.22

cc/ @Random-Liu @yujuhong 

We talked about dropping docker 1.9.x support for a while. I just realized that we haven't really done it yet. 

```release-note
Dropped the support for docker 1.9.x and the belows. 
```
