### PR TITLE
bill-of-materials: add a bill of materials file

### DIFF
--- a/bill-of-materials.json
+++ b/bill-of-materials.json
@@ -1,0 +1,587 @@
+[
+	{
+		"project": "k8s.io/kubernetes",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "k8s.io/kubernetes/third_party/forked/golang/expansion",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "cloud.google.com/go",
+		"license": "Apache License 2.0",
+		"confidence": 0.999
+	},
+	{
+		"project": "github.com/Azure/azure-sdk-for-go",
+		"license": "Apache License 2.0",
+		"confidence": 0.999
+	},
+	{
+		"project": "github.com/Azure/go-autorest/autorest",
+		"license": "Apache License 2.0",
+		"confidence": 0.968
+	},
+	{
+		"project": "github.com/MakeNowJust/heredoc",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/PuerkitoBio/purell",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.992
+	},
+	{
+		"project": "github.com/PuerkitoBio/urlesc",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/Sirupsen/logrus",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/appc/spec/schema",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/armon/circbuf",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/aws/aws-sdk-go",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/beorn7/perks/quantile",
+		"license": "MIT License",
+		"confidence": 0.989
+	},
+	{
+		"project": "github.com/blang/semver",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/chai2010/gettext-go/gettext",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/cloudflare/cfssl",
+		"license": "BSD 2-clause \"Simplified\" License",
+		"confidence": 0.985
+	},
+	{
+		"project": "github.com/clusterhq/flocker-go",
+		"license": "Apache License 2.0",
+		"confidence": 0.968
+	},
+	{
+		"project": "github.com/codedellemc/goscaleio/types/v1",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/containernetworking/cni",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/coreos/etcd",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/coreos/go-oidc",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/coreos/go-semver/semver",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/coreos/go-systemd",
+		"license": "Apache License 2.0",
+		"confidence": 0.997
+	},
+	{
+		"project": "github.com/coreos/pkg",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/coreos/rkt/api/v1alpha",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/davecgh/go-spew/spew",
+		"license": "ISC License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/daviddengcn/go-colortext",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.844
+	},
+	{
+		"project": "github.com/dgrijalva/jwt-go",
+		"license": "MIT License",
+		"confidence": 0.989
+	},
+	{
+		"project": "github.com/docker/distribution",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/docker/docker/pkg",
+		"license": "Apache License 2.0",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/docker/engine-api",
+		"license": "Apache License 2.0",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/docker/engine-api/client/transport/cancellable",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/docker/go-connections",
+		"license": "Apache License 2.0",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/docker/go-units",
+		"license": "Apache License 2.0",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/docker/spdystream/spdy",
+		"license": "Apache License 2.0",
+		"confidence": 0.968
+	},
+	{
+		"project": "github.com/elazarl/go-bindata-assetfs",
+		"license": "BSD 2-clause \"Simplified\" License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/emicklei/go-restful",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/evanphx/json-patch",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.979
+	},
+	{
+		"project": "github.com/exponent-io/jsonpath",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/fsnotify/fsnotify",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/ghodss/yaml",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.836
+	},
+	{
+		"project": "github.com/go-ini/ini",
+		"license": "Apache License 2.0",
+		"confidence": 0.997
+	},
+	{
+		"project": "github.com/go-openapi/jsonpointer",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/go-openapi/jsonreference",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/go-openapi/spec",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/go-openapi/swag",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/godbus/dbus",
+		"license": "BSD 2-clause \"Simplified\" License",
+		"confidence": 0.99
+	},
+	{
+		"project": "github.com/gogo/protobuf",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.891
+	},
+	{
+		"project": "github.com/golang/glog",
+		"license": "Apache License 2.0",
+		"confidence": 0.997
+	},
+	{
+		"project": "github.com/golang/groupcache/lru",
+		"license": "Apache License 2.0",
+		"confidence": 0.997
+	},
+	{
+		"project": "github.com/golang/protobuf",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.92
+	},
+	{
+		"project": "github.com/google/cadvisor",
+		"license": "Apache License 2.0",
+		"confidence": 0.968
+	},
+	{
+		"project": "github.com/google/certificate-transparency/go",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/google/gofuzz",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/gophercloud/gophercloud",
+		"license": "Apache License 2.0",
+		"confidence": 0.968
+	},
+	{
+		"project": "github.com/grpc-ecosystem/grpc-gateway",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.979
+	},
+	{
+		"project": "github.com/hashicorp/golang-lru/simplelru",
+		"license": "Mozilla Public License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/hawkular/hawkular-client-go/metrics",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/heketi/heketi",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/howeyc/gopass",
+		"license": "ISC License",
+		"confidence": 0.985
+	},
+	{
+		"project": "github.com/imdario/mergo",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/influxdata/influxdb",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/jmespath/go-jmespath",
+		"license": "The Unlicense",
+		"confidence": 0.353
+	},
+	{
+		"project": "github.com/jonboulle/clockwork",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/juju/ratelimit",
+		"license": "GNU Lesser General Public License v3.0",
+		"confidence": 0.941
+	},
+	{
+		"project": "github.com/libopenstorage/openstorage",
+		"license": "Apache License 2.0",
+		"confidence": 0.968
+	},
+	{
+		"project": "github.com/lpabon/godbc",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/mailru/easyjson",
+		"license": "MIT License",
+		"confidence": 0.989
+	},
+	{
+		"project": "github.com/matttproud/golang_protobuf_extensions/pbutil",
+		"license": "Apache License 2.0",
+		"confidence": 0.999
+	},
+	{
+		"project": "github.com/mesos/mesos-go",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/miekg/coredns/middleware/etcd/msg",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/miekg/dns",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.931
+	},
+	{
+		"project": "github.com/mitchellh/go-wordwrap",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/mitchellh/mapstructure",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/mreiferson/go-httpclient",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/mxk/go-flowrate/flowrate",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.971
+	},
+	{
+		"project": "github.com/pborman/uuid",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/pkg/errors",
+		"license": "BSD 2-clause \"Simplified\" License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/prometheus/client_golang/prometheus",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/prometheus/client_model/go",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/prometheus/common",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/prometheus/procfs",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/quobyte/api",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.988
+	},
+	{
+		"project": "github.com/rackspace/gophercloud",
+		"license": "Apache License 2.0",
+		"confidence": 0.968
+	},
+	{
+		"project": "github.com/renstrom/dedent",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/robfig/cron",
+		"license": "MIT License",
+		"confidence": 0.995
+	},
+	{
+		"project": "github.com/rubiojr/go-vhd/vhd",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/russross/blackfriday",
+		"license": "BSD 2-clause \"Simplified\" License",
+		"confidence": 0.963
+	},
+	{
+		"project": "github.com/samuel/go-zookeeper/zk",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.992
+	},
+	{
+		"project": "github.com/shurcooL/sanitized_anchor_name",
+		"license": "MIT License",
+		"confidence": 0.989
+	},
+	{
+		"project": "github.com/spf13/cobra",
+		"license": "Apache License 2.0",
+		"confidence": 0.957
+	},
+	{
+		"project": "github.com/spf13/pflag",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/square/go-jose/cipher",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/square/go-jose/json",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/ugorji/go/codec",
+		"license": "MIT License",
+		"confidence": 0.995
+	},
+	{
+		"project": "github.com/vmware/govmomi",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/vmware/govmomi/vim25/xml",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "github.com/vmware/photon-controller-go-sdk/photon/lightwave",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "github.com/xanzy/go-cloudstack/cloudstack",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "go.pedge.io/pb/go/google/protobuf",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "go4.org/errorutil",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "golang.org/x/crypto",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "golang.org/x/net",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "golang.org/x/oauth2",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "golang.org/x/sys/unix",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "golang.org/x/text",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "google.golang.org/api",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.966
+	},
+	{
+		"project": "google.golang.org/api/googleapi/internal/uritemplates",
+		"license": "MIT License",
+		"confidence": 0.989
+	},
+	{
+		"project": "google.golang.org/grpc",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.979
+	},
+	{
+		"project": "gopkg.in/gcfg.v1",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.975
+	},
+	{
+		"project": "gopkg.in/inf.v0",
+		"license": "BSD 3-clause \"New\" or \"Revised\" License",
+		"confidence": 0.975
+	},
+	{
+		"project": "gopkg.in/natefinch/lumberjack.v2",
+		"license": "MIT License",
+		"confidence": 1
+	},
+	{
+		"project": "gopkg.in/yaml.v2",
+		"license": "GNU Lesser General Public License v3.0",
+		"confidence": 0.953
+	},
+	{
+		"project": "k8s.io/client-go",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "k8s.io/heapster/metrics",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "k8s.io/metrics/pkg",
+		"license": "Apache License 2.0",
+		"confidence": 1
+	},
+	{
+		"project": "vbom.ml/util/sortorder",
+		"license": "MIT License",
+		"confidence": 1
+	}
+]

--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -52,6 +52,7 @@ fi
 
 BASH_TARGETS="
 	update-generated-protobuf
+	update-bill-of-materials
 	update-codegen
 	update-codecgen
 	update-generated-docs

--- a/hack/update-bill-of-materials.sh
+++ b/hack/update-bill-of-materials.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+cd "${KUBE_ROOT}"
+# TODO: vendor this package instead?
+go get github.com/coreos/license-bill-of-materials
+license-bill-of-materials k8s.io/kubernetes/cmd/hyperkube > ${KUBE_ROOT}/bill-of-materials.json


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds a file called a bill-of-materials that lists all of the licenses of Kubernetes.

**Special notes for your reviewer**:

This is a WIP on the build side and mostly want to see if this tool and file is useful first.

The bill-of-materials file is a machine readable file that lists all of
the licenses used by this project. Maybe there is an existing file
format for this but we are exploring tools at CoreOS to document the
downstream dependencies and think this tool and format is usefl.

I can cleanup the hack scripts and figure out a way to remove the `go
get` if people like the overall idea.