### PR TITLE
[federation][e2e] Increase timeout waiting for service shard to appear

### DIFF
--- a/test/e2e_federation/service.go
+++ b/test/e2e_federation/service.go
@@ -37,13 +37,8 @@ import (
 )
 
 const (
-	FederatedServiceTimeout = 60 * time.Second
-
 	FederatedServiceName    = "federated-service"
 	FederatedServicePodName = "federated-service-test-pod"
-
-	KubeDNSConfigMapName      = "kube-dns"
-	KubeDNSConfigMapNamespace = "kube-system"
 )
 
 var FederatedServiceLabels = map[string]string{


### PR DESCRIPTION
Most of recent federation service tests are failing with timeouts. although some times they do pass, giving kind of flaky nature. So increasing the timeout waiting for service shard to appear in federated cluster from 1 min to 5 mins.

cc @madhusudancs @kubernetes/sig-federation-bugs
