### PR TITLE
[Federation] Use and return created replicaset instead of the passed object.

### DIFF
--- a/test/e2e_federation/replicaset.go
+++ b/test/e2e_federation/replicaset.go
@@ -400,10 +400,10 @@ func createReplicaSetOrFail(clientset *fedclientset.Clientset, replicaset *v1bet
 	}
 	By(fmt.Sprintf("Creating federation replicaset %q in namespace %q", replicaset.Name, namespace))
 
-	_, err := clientset.Extensions().ReplicaSets(namespace).Create(replicaset)
+	newRS, err := clientset.Extensions().ReplicaSets(namespace).Create(replicaset)
 	framework.ExpectNoError(err, "Creating replicaset %q in namespace %q", replicaset.Name, namespace)
-	By(fmt.Sprintf("Successfully created federation replicaset %q in namespace %q", replicaset.Name, namespace))
-	return replicaset
+	By(fmt.Sprintf("Successfully created federation replicaset %q in namespace %q", newRS.Name, namespace))
+	return newRS
 }
 
 func deleteReplicaSetOrFail(clientset *fedclientset.Clientset, nsName string, replicaSetName string, orphanDependents *bool) {


### PR DESCRIPTION
Passed replicaset object doesn't contain object name, but has a prefix set in `GenerateName`. However, we need to operate on the object name later to uniquely identified the created object. So we need the created object with the name set by the API server.

```release-note
NONE
```
