### PR TITLE
Revert "kubemark: enable CRI for the hollow nodes"

### DIFF
--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -159,6 +159,8 @@ func GetHollowKubeletConfig(
 	c.SerializeImagePulls = true
 	c.SystemCgroups = ""
 	c.ProtectKernelDefaults = false
+	// TODO: This is a temporary workaround until we fix CRI+kubemark properly.
+	c.EnableCRI = false
 
 	// TODO(mtaufen): Note that PodInfraContainerImage was being set to the empty value before,
 	//                but this may not have been intentional. (previous code (SimpleKubelet)


### PR DESCRIPTION
This reverts commit c89e9cdbf109c569bff06e5db8354402bd440ffd.
