### PR TITLE
Ensure a fixed godep version in hack/*-godep*.sh

### DIFF
--- a/hack/godep-restore.sh
+++ b/hack/godep-restore.sh
@@ -20,9 +20,10 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
-export GOPATH=${GOPATH}:${KUBE_ROOT}/staging
-GODEP="${GODEP:-godep}"
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
+kube::util::ensure_godep_version v74
 
 echo "Starting to download all kubernetes godeps. This takes a while"
-"${GODEP}" restore "$@"
+GOPATH=${GOPATH}:${KUBE_ROOT}/staging godep restore "$@"
 echo "Download finished"

--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -20,9 +20,9 @@ set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
-export GOPATH=${GOPATH}:${KUBE_ROOT}/staging
-GODEP="${GODEP:-godep}"
+source "${KUBE_ROOT}/hack/lib/util.sh"
 
+kube::util::ensure_godep_version v74
 
 # Some things we want in godeps aren't code dependencies, so ./...
 # won't pick them up.
@@ -34,8 +34,8 @@ REQUIRED_BINS=(
 )
 
 pushd "${KUBE_ROOT}" > /dev/null
-  "${GODEP}" version
-  GO15VENDOREXPERIMENT=1 ${GODEP} save "${REQUIRED_BINS[@]}"
+  GOPATH=${GOPATH}:${KUBE_ROOT}/staging godep save "${REQUIRED_BINS[@]}"
+
   # create a symlink in vendor directory pointing to the staging client. This
   # let other packages use the staging client as if it were vendored.
   if [ ! -e "vendor/k8s.io/client-go" ]; then


### PR DESCRIPTION
No godep pinning asks for trouble when godep changes behaviour once again.

Moreover, call `hack/godep-restore.go` from `hack/update-all-staging.sh`. This was an actual bug.