### PR TITLE
Bump version of Cluster Autoscaler to 0.5.0-beta1

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.4.0",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.5.0-beta1",
                 "command": [
                     "/bin/sh",
                     "-c",


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a part of Cluster Autoscaler release for K8S 1.6
