### PR TITLE
Fix failing kubectl skew tests

### DIFF
--- a/cluster/kubectl.sh
+++ b/cluster/kubectl.sh
@@ -68,4 +68,10 @@ if false; then
   echo "Running:" "${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}" >&2
 fi
 
+if [[ "${1:-}" =~ ^(path)$ ]]; then
+  echo "${kubectl}"
+  exit 0
+fi
+
 "${kubectl}" "${config[@]:+${config[@]}}" "${@+$@}"
+


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/42697

Skew kubectl tests [are broken](https://k8s-testgrid.appspot.com/release-1.6-upgrade-skew#gce-1.6-master-cvm-kubectl-skew&width=80) in "Simple pod should handle in-cluster config" for trying to copy the `kubectl.sh` script instead of the actual `kubectl` binary.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
