### PR TITLE
Cleanup some of the tarball producing code for e2e node tests

### DIFF
--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -29,6 +29,8 @@ import (
 	"k8s.io/kubernetes/test/e2e_node/builder"
 )
 
+const localCOSMounterPath = "cluster/gce/gci/mounter/mounter"
+
 // NodeE2ERemote contains the specific functions in the node e2e test suite.
 type NodeE2ERemote struct{}
 
@@ -36,8 +38,6 @@ func InitNodeE2ERemote() TestSuite {
 	// TODO: Register flags.
 	return &NodeE2ERemote{}
 }
-
-const localCOSMounterPath = "cluster/gce/gci/mounter/mounter"
 
 // SetupTestPackage sets up the test package with binaries k8s required for node e2e tests
 func (n *NodeE2ERemote) SetupTestPackage(tardir string) error {
@@ -66,10 +66,37 @@ func (n *NodeE2ERemote) SetupTestPackage(tardir string) error {
 	}
 
 	// Include the GCI/COS mounter artifacts in the deployed tarball
+	err = tarAddCOSMounter(tardir)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// dest is relative to the root of the tar
+func tarAddFile(tar, source, dest string) error {
+	dir := filepath.Dir(dest)
+	tardir := filepath.Join(tar, dir)
+	tardest := filepath.Join(tar, dest)
+
+	out, err := exec.Command("mkdir", "-p", tardir).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to create archive bin subdir %q, was dest for file %q. Err: %v. Output:\n%s", tardir, source, err, out)
+	}
+	out, err = exec.Command("cp", source, tardest).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to copy file %q to the archive bin subdir %q. Err: %v. Output:\n%s", source, tardir, err, out)
+	}
+	return nil
+}
+
+// Includes the GCI/COS mounter artifacts in the deployed tarball
+func tarAddCOSMounter(tar string) error {
 	k8sDir, err := builder.GetK8sRootDir()
 	if err != nil {
 		return fmt.Errorf("Could not find K8s root dir! Err: %v", err)
 	}
+
 	source := filepath.Join(k8sDir, localCOSMounterPath)
 
 	// Require the GCI/COS mounter script, we want to make sure the remote test runner stays up to date if the mounter file moves
@@ -77,18 +104,7 @@ func (n *NodeE2ERemote) SetupTestPackage(tardir string) error {
 		return fmt.Errorf("Could not find GCI/COS mounter script at %q! If this script has been (re)moved, please update the e2e node remote test runner accordingly! Err: %v", source, err)
 	}
 
-	bindir := "cluster/gce/gci/mounter"
-	bin := "mounter"
-	destdir := filepath.Join(tardir, bindir)
-	dest := filepath.Join(destdir, bin)
-	out, err := exec.Command("mkdir", "-p", filepath.Join(tardir, bindir)).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to create directory %q for GCI/COS mounter script. Err: %v. Output:\n%s", destdir, err, out)
-	}
-	out, err = exec.Command("cp", source, dest).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to copy GCI/COS mounter script to the archive bin. Err: %v. Output:\n%s", err, out)
-	}
+	tarAddFile(tar, source, localCOSMounterPath)
 	return nil
 }
 


### PR DESCRIPTION
This is some e2e node cleanup work I found sitting in a local branch while deleting old local git branches. It looks like it's still useful.