### PR TITLE
[Federation][e2e] Generate name for federated service instead of fixed name

### DIFF
--- a/test/e2e_federation/authn.go
+++ b/test/e2e_federation/authn.go
@@ -44,7 +44,7 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 			framework.ExpectNoError(err)
 
 			nsName := f.FederationNamespace.Name
-			svc := createServiceOrFail(fcs, nsName, FederatedServiceName)
+			svc := createServiceOrFail(fcs, nsName, FederatedServicePrefix)
 			deleteServiceOrFail(f.FederationClientset, nsName, svc.Name, nil)
 		})
 
@@ -53,7 +53,7 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 			framework.ExpectNoError(err)
 
 			nsName := f.FederationNamespace.Name
-			svc, err := createService(fcs, nsName, FederatedServiceName)
+			svc, err := createService(fcs, nsName, FederatedServicePrefix)
 			Expect(err).NotTo(HaveOccurred())
 			deleteServiceOrFail(fcs, nsName, svc.Name, nil)
 		})
@@ -63,7 +63,7 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 			framework.ExpectNoError(err)
 
 			nsName := f.FederationNamespace.Name
-			svc, err := createService(fcs, nsName, FederatedServiceName)
+			svc, err := createService(fcs, nsName, FederatedServicePrefix)
 			Expect(err).NotTo(HaveOccurred())
 			deleteServiceOrFail(fcs, nsName, svc.Name, nil)
 		})
@@ -73,7 +73,7 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 			framework.ExpectNoError(err)
 
 			nsName := f.FederationNamespace.Name
-			_, err = createService(fcs, nsName, FederatedServiceName)
+			_, err = createService(fcs, nsName, FederatedServicePrefix)
 			Expect(errors.IsUnauthorized(err)).To(BeTrue())
 		})
 
@@ -85,7 +85,7 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 			framework.ExpectNoError(err)
 
 			nsName := f.FederationNamespace.Name
-			_, err = createService(fcs, nsName, FederatedServiceName)
+			_, err = createService(fcs, nsName, FederatedServicePrefix)
 			Expect(errors.IsUnauthorized(err)).To(BeTrue())
 		})
 
@@ -94,7 +94,7 @@ var _ = framework.KubeDescribe("[Feature:Federation]", func() {
 			framework.ExpectNoError(err)
 
 			nsName := f.FederationNamespace.Name
-			_, err = createService(fcs, nsName, FederatedServiceName)
+			_, err = createService(fcs, nsName, FederatedServicePrefix)
 			Expect(errors.IsUnauthorized(err)).To(BeTrue())
 		})
 

--- a/test/e2e_federation/ingress.go
+++ b/test/e2e_federation/ingress.go
@@ -47,7 +47,7 @@ const (
 	MaxRetriesOnFederatedApiserver = 3
 	FederatedIngressTimeout        = 10 * time.Minute
 	FederatedIngressName           = "federated-ingress"
-	FederatedIngressServiceName    = "federated-ingress-service"
+	FederatedIngressServicePrefix  = "federated-ingress-service-"
 	FederatedIngressTLSSecretName  = "federated-ingress-tls-secret"
 	FederatedIngressServicePodName = "federated-ingress-service-test-pod"
 	FederatedIngressHost           = "test-f8n.k8s.io."
@@ -129,7 +129,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 			fedframework.SkipUnlessFederated(f.ClientSet)
 			framework.SkipUnlessProviderIs("gce", "gke") // TODO: Federated ingress is not yet supported on non-GCP platforms.
 			nsName := f.FederationNamespace.Name
-			ingress := createIngressOrFail(f.FederationClientset, nsName, FederatedIngressServiceName, FederatedIngressTLSSecretName)
+			ingress := createIngressOrFail(f.FederationClientset, nsName, "federated-ingress-service", FederatedIngressTLSSecretName)
 			By(fmt.Sprintf("Creation of ingress %q in namespace %q succeeded.  Deleting ingress.", ingress.Name, nsName))
 			// Cleanup
 			err := f.FederationClientset.Extensions().Ingresses(nsName).Delete(ingress.Name, &metav1.DeleteOptions{})
@@ -146,6 +146,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 			jig                                    *federationTestJig
 			service                                *v1.Service
 			secret                                 *v1.Secret
+			federatedIngressServiceName            string
 		)
 
 		// register clusters in federation apiserver
@@ -159,7 +160,8 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 			clusters, primaryClusterName = getRegisteredClusters(UserAgentName, f)
 			ns = f.FederationNamespace.Name
 			// create backend service
-			service = createServiceOrFail(f.FederationClientset, ns, FederatedIngressServiceName)
+			service = createServiceOrFail(f.FederationClientset, ns, FederatedIngressServicePrefix)
+			federatedIngressServiceName = service.Name
 			// create the TLS secret
 			secret = createTLSSecretOrFail(f.FederationClientset, ns, FederatedIngressTLSSecretName)
 			// wait for services objects sync
@@ -189,7 +191,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 		})
 
 		It("should create and update matching ingresses in underlying clusters", func() {
-			ingress := createIngressOrFail(f.FederationClientset, ns, FederatedIngressServiceName, FederatedIngressTLSSecretName)
+			ingress := createIngressOrFail(f.FederationClientset, ns, federatedIngressServiceName, FederatedIngressTLSSecretName)
 			// wait for ingress shards being created
 			waitForIngressShardsOrFail(ns, ingress, clusters)
 			ingress = updateIngressOrFail(f.FederationClientset, ns)
@@ -200,7 +202,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 			fedframework.SkipUnlessFederated(f.ClientSet)
 			nsName := f.FederationNamespace.Name
 			orphanDependents := false
-			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, &orphanDependents, nsName)
+			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, &orphanDependents, nsName, federatedIngressServiceName)
 			By(fmt.Sprintf("Verified that ingresses were deleted from underlying clusters"))
 		})
 
@@ -208,14 +210,14 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 			fedframework.SkipUnlessFederated(f.ClientSet)
 			nsName := f.FederationNamespace.Name
 			orphanDependents := true
-			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, &orphanDependents, nsName)
+			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, &orphanDependents, nsName, federatedIngressServiceName)
 			By(fmt.Sprintf("Verified that ingresses were not deleted from underlying clusters"))
 		})
 
 		It("should not be deleted from underlying clusters when OrphanDependents is nil", func() {
 			fedframework.SkipUnlessFederated(f.ClientSet)
 			nsName := f.FederationNamespace.Name
-			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, nil, nsName)
+			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, nil, nsName, federatedIngressServiceName)
 			By(fmt.Sprintf("Verified that ingresses were not deleted from underlying clusters"))
 		})
 
@@ -247,8 +249,8 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 			PIt("should be able to discover a federated ingress service via DNS", func() {
 				// we are about the ingress name
 				svcDNSNames := []string{
-					fmt.Sprintf("%s.%s", FederatedIngressServiceName, ns),
-					fmt.Sprintf("%s.%s.svc.cluster.local.", FederatedIngressServiceName, ns),
+					fmt.Sprintf("%s.%s", federatedIngressServiceName, ns),
+					fmt.Sprintf("%s.%s.svc.cluster.local.", federatedIngressServiceName, ns),
 					// TODO these two entries are not set yet
 					//fmt.Sprintf("%s.%s.%s", FederatedIngressServiceName, ns, federationName),
 					//fmt.Sprintf("%s.%s.%s.svc.cluster.local.", FederatedIngressServiceName, ns, federationName),
@@ -284,8 +286,8 @@ func equivalentIngress(federatedIngress, clusterIngress v1beta1.Ingress) bool {
 // verifyCascadingDeletionForIngress verifies that ingresses are deleted from
 // underlying clusters when orphan dependents is false and they are not deleted
 // when orphan dependents is true.
-func verifyCascadingDeletionForIngress(clientset *fedclientset.Clientset, clusters map[string]*cluster, orphanDependents *bool, nsName string) {
-	ingress := createIngressOrFail(clientset, nsName, FederatedIngressServiceName, FederatedIngressTLSSecretName)
+func verifyCascadingDeletionForIngress(clientset *fedclientset.Clientset, clusters map[string]*cluster, orphanDependents *bool, nsName, serviceName string) {
+	ingress := createIngressOrFail(clientset, nsName, serviceName, FederatedIngressTLSSecretName)
 	ingressName := ingress.Name
 	// Check subclusters if the ingress was created there.
 	By(fmt.Sprintf("Waiting for ingress %s to be created in all underlying clusters", ingressName))

--- a/test/e2e_federation/util.go
+++ b/test/e2e_federation/util.go
@@ -266,16 +266,16 @@ func waitForServiceShardsOrFail(namespace string, service *v1.Service, clusters 
 	}
 }
 
-func createService(clientset *fedclientset.Clientset, namespace, name string) (*v1.Service, error) {
+func createService(clientset *fedclientset.Clientset, namespace, prefix string) (*v1.Service, error) {
 	if clientset == nil || len(namespace) == 0 {
 		return nil, fmt.Errorf("Internal error: invalid parameters passed to createService: clientset: %v, namespace: %v", clientset, namespace)
 	}
-	By(fmt.Sprintf("Creating federated service %q in namespace %q", name, namespace))
+	By(fmt.Sprintf("Creating federated service %q in namespace %q", prefix, namespace))
 
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			GenerateName: prefix,
+			Namespace:    namespace,
 		},
 		Spec: v1.ServiceSpec{
 			Selector: FederatedServiceLabels,
@@ -292,14 +292,14 @@ func createService(clientset *fedclientset.Clientset, namespace, name string) (*
 			SessionAffinity: v1.ServiceAffinityNone,
 		},
 	}
-	By(fmt.Sprintf("Trying to create service %q in namespace %q", service.Name, namespace))
+	By(fmt.Sprintf("Trying to create service with prefix %q in namespace %q", prefix, namespace))
 	return clientset.Services(namespace).Create(service)
 }
 
-func createServiceOrFail(clientset *fedclientset.Clientset, namespace, name string) *v1.Service {
-	service, err := createService(clientset, namespace, name)
+func createServiceOrFail(clientset *fedclientset.Clientset, namespace, prefix string) *v1.Service {
+	service, err := createService(clientset, namespace, prefix)
 	framework.ExpectNoError(err, "Creating service %q in namespace %q", service.Name, namespace)
-	By(fmt.Sprintf("Successfully created federated service %q in namespace %q", name, namespace))
+	By(fmt.Sprintf("Successfully created federated service %q in namespace %q", service.Name, namespace))
 	return service
 }
 


### PR DESCRIPTION
federation e2e tests are being run in parallel now. federation service tests seems to be failing since we are using a fixed name for service. even though each test case is run in separate namespace k8s service controller is rejecting the service creation when done in parallel. This is evident from the k8s api server logs as below, where it is rejecting the POST request by 422 status code
```
I0308 13:59:42.153495       5 wrap.go:75] POST /api/v1/namespaces/e2e-tests-federated-service-zfv4l/services: (53.312589ms) 422 [[hyperkube/v0.0.0 (linux/amd64) kubernetes/$Format/federation-service-controller] 104.154.38.64:47138]
```
So now for each service we will be generating a name instead of fixed name.

cc @kubernetes/sig-federation-bugs @nikhiljindal @madhusudancs 
