### PR TITLE
[Federation] Generate a random nodePort for each service object in e2e tests.

### DIFF
--- a/test/e2e_federation/BUILD
+++ b/test/e2e_federation/BUILD
@@ -43,6 +43,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/util/intstr",
         "//vendor:k8s.io/apimachinery/pkg/util/net",
+        "//vendor:k8s.io/apimachinery/pkg/util/rand",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/tools/clientcmd",

--- a/test/e2e_federation/util.go
+++ b/test/e2e_federation/util.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/wait"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -48,16 +48,17 @@ var (
 	UserAgentName                 = "federation-e2e"
 	// We use this to decide how long to wait for our DNS probes to succeed.
 	DNSTTL = 180 * time.Second // TODO: make k8s.io/kubernetes/federation/pkg/federation-controller/service.minDnsTtl exported, and import it here.
-
-	// FederatedSvcNodePort is the node port on which the federated
-	// service shards are exposed in the underlying cluster.
-	FederatedSvcNodePort = int32(32256)
 )
 
 const (
 	federatedNamespaceTimeout    = 5 * time.Minute
 	federatedServiceTimeout      = 5 * time.Minute
 	federatedClustersWaitTimeout = 1 * time.Minute
+
+	// [30000, 32767] is the allowed default service nodeport range and our
+	// tests just use the defaults.
+	FederatedSvcNodePortFirst = 30000
+	FederatedSvcNodePortLast  = 32767
 )
 
 var FederationSuite common.Suite
@@ -272,6 +273,12 @@ func createService(clientset *fedclientset.Clientset, namespace, name string) (*
 	}
 	By(fmt.Sprintf("Creating federated service %q in namespace %q", name, namespace))
 
+	// Tests can be run in parallel, so we need a different nodePort for
+	// each test.
+	// We add 1 to FederatedSvcNodePortLast because IntnRange's range end
+	// is not inclusive.
+	nodePort := int32(rand.IntnRange(FederatedSvcNodePortFirst, FederatedSvcNodePortLast+1))
+
 	service := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -286,7 +293,7 @@ func createService(clientset *fedclientset.Clientset, namespace, name string) (*
 					Protocol:   v1.ProtocolTCP,
 					Port:       80,
 					TargetPort: intstr.FromInt(8080),
-					NodePort:   FederatedSvcNodePort,
+					NodePort:   nodePort,
 				},
 			},
 			SessionAffinity: v1.ServiceAffinityNone,


### PR DESCRIPTION
We now run e2e tests in parallel in the CI environment and nodeports are a single available range of numbers for all the service objects, so they have to be unique for each service object.

```release-note
NONE
```
