### PR TITLE
Adds default kube-dns configmap

### DIFF
--- a/cluster/addons/dns/kubedns-cm.yaml
+++ b/cluster/addons/dns/kubedns-cm.yaml
@@ -1,0 +1,21 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists


### PR DESCRIPTION
From #42746.

Using 1.4 kubelet with 1.6 master is causing upgrade test failures. Because kubelet doesn't understand optional configmaps and there is no kube-dns configmap exist, kubelet will crash.

This PR adds an empty kube-dns configmap as an "EnsureExists" class addon for fixing that.

Note: The addon-manager creates "Reconcile" class addons before creates "EnsureExists" class addons, which is not the order we want. I will soon have another PR to reverse this order.

@bowei @krousey @skriss 

```release-note
none
```