### PR TITLE
[Federation][e2e] Use correct default dns name in e2e-testing

### DIFF
--- a/test/e2e_federation/util.go
+++ b/test/e2e_federation/util.go
@@ -44,7 +44,7 @@ import (
 var (
 	KubeAPIQPS            float32 = 20.0
 	KubeAPIBurst                  = 30
-	DefaultFederationName         = "federation"
+	DefaultFederationName         = "e2e-federation"
 	UserAgentName                 = "federation-e2e"
 	// We use this to decide how long to wait for our DNS probes to succeed.
 	DNSTTL = 180 * time.Second // TODO: make k8s.io/kubernetes/federation/pkg/federation-controller/service.minDnsTtl exported, and import it here.


### PR DESCRIPTION
After some kubefed changes, the environment variable did not get propagated and we defaulted back to 'federation' instead of 'e2e-federation'. This fixes ongoing service test issues in e2e.