### PR TITLE
dns_autoscaling test: Don't expect configMap to be re-created with previous params

### DIFF
--- a/test/e2e/dns_autoscaling.go
+++ b/test/e2e/dns_autoscaling.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"fmt"
 	"math"
-	"reflect"
 	"strings"
 	"time"
 
@@ -185,11 +184,8 @@ var _ = framework.KubeDescribe("DNS horizontal autoscaling", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Wait for the ConfigMap got re-created")
-		configMap, err := waitForDNSConfigMapCreated(c, DNSdefaultTimeout)
+		_, err = waitForDNSConfigMapCreated(c, DNSdefaultTimeout)
 		Expect(err).NotTo(HaveOccurred())
-
-		By("Check the new created ConfigMap got the same data as we have")
-		Expect(reflect.DeepEqual(previousParams, configMap.Data)).To(Equal(true))
 
 		By("Replace the dns autoscaling parameters with another testing parameters")
 		err = updateDNSScalingConfigMap(c, packDNSScalingConfigMap(packLinearParams(&DNSParams_2)))


### PR DESCRIPTION
Fix #42766.

In dns_autoscaling e2e test, there is a test case that we delete the kube-dns-autoscaler configMap first and wait for it to be recreated with previous params. This is not necessarily true, because we will preserve the kube-dns-autoscaler configMap during upgrade but we may update the default params in kube-dns-autoscale binary, which means a configMap with new params will be created in the upgrade case.

One of the test failures could be found on: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gke-gci-1.5-gci-1.6-upgrade-cluster-new/18#k8sio-dns-horizontal-autoscaling-kube-dns-autoscaler-should-scale-kube-dns-pods-in-both-nonfaulty-and-faulty-scenarios

This PR removes the codes that make above assertion. 

@bowei @skriss

```release-note
NONE
```
