### PR TITLE
Fixed potential OutOfSync of nodeInfo.

### DIFF
--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -82,6 +82,19 @@ func (r *Resource) ResourceList() v1.ResourceList {
 	return result
 }
 
+func (r *Resource) Clone() *Resource {
+	res := &Resource{
+		MilliCPU:  r.MilliCPU,
+		Memory:    r.Memory,
+		NvidiaGPU: r.NvidiaGPU,
+	}
+	res.OpaqueIntResources = make(map[v1.ResourceName]int64)
+	for k, v := range r.OpaqueIntResources {
+		res.OpaqueIntResources[k] = v
+	}
+	return res
+}
+
 func (r *Resource) AddOpaque(name v1.ResourceName, quantity int64) {
 	// Lazily allocate opaque integer resource map.
 	if r.OpaqueIntResources == nil {
@@ -186,9 +199,9 @@ func (n *NodeInfo) AllocatableResource() Resource {
 func (n *NodeInfo) Clone() *NodeInfo {
 	clone := &NodeInfo{
 		node:                    n.node,
-		requestedResource:       &(*n.requestedResource),
-		nonzeroRequest:          &(*n.nonzeroRequest),
-		allocatableResource:     &(*n.allocatableResource),
+		requestedResource:       n.requestedResource.Clone(),
+		nonzeroRequest:          n.nonzeroRequest.Clone(),
+		allocatableResource:     n.allocatableResource.Clone(),
 		allowedPodNumber:        n.allowedPodNumber,
 		taintsErr:               n.taintsErr,
 		memoryPressureCondition: n.memoryPressureCondition,


### PR DESCRIPTION
The cloned NodeInfo still share the same resource objects in cache; it may make `requestedResource` and Pods OutOfSync, for example, if the pod was deleted, the `requestedResource` is updated by Pods are not in cloned info. Found this when investigating #32531 , but seems not the root cause, as nodeInfo are readonly in predicts & priorities.

Sample codes for `&(*)`:

```
package main

import (
	"fmt"
)

type Resource struct {
	A int
}

type Node struct {
	Res *Resource
}

func main() {
	r1 := &Resource { A:10 }
	n1 := &Node{Res: r1}
	r2 := &(*n1.Res)
	r2.A = 11

	fmt.Printf("%t, %d %d\n", r1==r2, r1, r2)
}
```

Output:

```
true, &{11} &{11}
```
