### PR TITLE
Handle NPD during cluster upgrade.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -148,7 +148,6 @@ ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 #   standalone     - Run node problem detector as standalone system daemon.
 if [[ "${NODE_OS_DISTRIBUTION}" == "gci" ]]; then
   # Enable standalone mode by default for gci.
-  # TODO: Consider upgrade test.
   ENABLE_NODE_PROBLEM_DETECTOR="${KUBE_ENABLE_NODE_PROBLEM_DETECTOR:-standalone}"
 else
   ENABLE_NODE_PROBLEM_DETECTOR="${KUBE_ENABLE_NODE_PROBLEM_DETECTOR:-daemonset}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -173,7 +173,6 @@ ENABLE_CLUSTER_UI="${KUBE_ENABLE_CLUSTER_UI:-true}"
 #   standalone     - Run node problem detector as standalone system daemon.
 if [[ "${NODE_OS_DISTRIBUTION}" == "gci" ]]; then
   # Enable standalone mode by default for gci.
-  # TODO: Consider upgrade test.
   ENABLE_NODE_PROBLEM_DETECTOR="${KUBE_ENABLE_NODE_PROBLEM_DETECTOR:-standalone}"
 else
   ENABLE_NODE_PROBLEM_DETECTOR="${KUBE_ENABLE_NODE_PROBLEM_DETECTOR:-daemonset}"


### PR DESCRIPTION
Generate NPD token during upgrade.

I could not fully verify this change because of https://github.com/kubernetes/kubernetes/issues/42199. However, at least I tried upgrade master, and the corresponding environment variables are correctly generated.
```
...
ENABLE_NODE_PROBLEM_DETECTOR: 'standalone'
...
KUBELET_TOKEN: 'PKNgAaVXeL3VojND2s0KMleELjzGK0oW'
```

@maisem @dchen1107 