### PR TITLE
Fix selfLink when requesting cluster resouces

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -850,7 +850,7 @@ func (n rootScopeNaming) GenerateLink(req *restful.Request, obj runtime.Object) 
 			return "", err
 		}
 	}
-	return n.pathPrefix + url.QueryEscape(name) + n.pathSuffix, nil
+	return n.pathPrefix + "/" + url.QueryEscape(name) + n.pathSuffix, nil
 }
 
 // GenerateListLink returns the appropriate path and query to locate a list by its canonical path.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer_test.go
@@ -51,9 +51,41 @@ func TestScopeNamingGenerateLink(t *testing.T) {
 			Kind: "Service",
 		},
 	}
-	_, err := s.GenerateLink(&restful.Request{}, service)
+	uri, err := s.GenerateLink(&restful.Request{}, service)
 	if err != nil {
 		t.Errorf("Unexpected error %v", err)
+	}
+	if uri != selfLinker.expectedSet {
+		t.Errorf("Mismatch in expected selflink uri. Expected '%s', got '%s'", selfLinker.expectedSet, uri)
+	}
+}
+
+func TestRootScopeNamingGenerateLink(t *testing.T) {
+	selfLinker := &setTestSelfLinker{
+		t:           t,
+		expectedSet: "/api/v1/nodes/foo/status",
+		name:        "foo",
+	}
+	s := rootScopeNaming{
+		meta.RESTScopeRoot,
+		selfLinker,
+		"/api/v1/nodes",
+		"/status",
+	}
+	service := &api.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Service",
+		},
+	}
+	uri, err := s.GenerateLink(&restful.Request{}, service)
+	if err != nil {
+		t.Errorf("Unexpected error %v", err)
+	}
+	if uri != selfLinker.expectedSet {
+		t.Errorf("Mismatch in expected selflink uri. Expected '%s', got '%s'", selfLinker.expectedSet, uri)
 	}
 }
 


### PR DESCRIPTION
Before this change:
$ curl -s http://172.16.116.128:8080/api/v1/nodes | grep selfLink
    "selfLink": "/api/v1/nodes",
        "selfLink": "/api/v1/nodeskubenet-02",
After this change:
$ curl -s http://172.16.116.128:8080/api/v1/nodes | grep selfLink
    "selfLink": "/api/v1/nodes",
        "selfLink": "/api/v1/nodes/kubenet-02",

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
