### PR TITLE
[Federation] Fix missing coredns-endpoints in CoreDNS provider config

### DIFF
--- a/federation/pkg/dnsprovider/providers/coredns/coredns.go
+++ b/federation/pkg/dnsprovider/providers/coredns/coredns.go
@@ -36,8 +36,9 @@ const (
 // Config to override defaults
 type Config struct {
 	Global struct {
-		EtcdEndpoints string `gcfg:"etcd-endpoints"`
-		DNSZones      string `gcfg:"zones"`
+		EtcdEndpoints    string `gcfg:"etcd-endpoints"`
+		DNSZones         string `gcfg:"zones"`
+		CoreDNSEndpoints string `gcfg:"coredns-endpoints"`
 	}
 }
 


### PR DESCRIPTION
Adding a new config field `coredns-endpoints` to CoreDNS provider config. 
without this config user has to manually configure the cluster-dns to add the private nameserver in federated cluster in order to do cross-cluster service discovery. with this field, now we can add the private nameserver to cluster-dns when cluster joins federation.

Request to accept this as a bug-fix, which needs to go in 1.6
Fixes: #42822

cc @kubernetes/sig-federation-bugs, @madhusudancs @nikhiljindal 

P.S: I am also documenting using the CoreDNS dns provider for federation, where i will document the format of the dns-provider config file. This will be for 1.6 release