### PR TITLE
[Federation] Prevent trailing periods in kube-dns federations domains

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -829,7 +829,9 @@ func createControllerManager(clientset client.Interface, namespace, name, svcNam
 				// TODO: the name/domain name pair should ideally be checked for naming convention
 				// as done in kube-dns federation flags check.
 				// https://github.com/kubernetes/dns/blob/master/pkg/dns/federation/federation.go
-				util.FedDomainMapKey: fmt.Sprintf("%s=%s", name, dnsZoneName),
+				// TODO v2: Until kube-dns can handle trailing periods we strip them all.
+				//          See https://github.com/kubernetes/dns/issues/67
+				util.FedDomainMapKey: fmt.Sprintf("%s=%s", name, strings.TrimRight(dnsZoneName, ".")),
 			},
 		},
 		Spec: extensions.DeploymentSpec{

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -936,7 +936,7 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 			Namespace: namespaceName,
 			Labels:    componentLabel,
 			Annotations: map[string]string{
-				util.FedDomainMapKey: fmt.Sprintf("%s=%s", federationName, dnsZoneName),
+				util.FedDomainMapKey: fmt.Sprintf("%s=%s", federationName, strings.TrimRight(dnsZoneName, ".")),
 			},
 		},
 		Spec: v1beta1.DeploymentSpec{


### PR DESCRIPTION
kubefed-level fix to catch cases where FEDERATIONS_DOMAIN_MAP is not set in the environment (i.e. CI).

Addresses https://github.com/kubernetes/kubernetes/issues/42809