### PR TITLE
Add a juju action to create a docker registry inside the cluster

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/README.md
+++ b/cluster/juju/layers/kubernetes-worker/README.md
@@ -45,6 +45,23 @@ Resuming the workload will [uncordon](http://kubernetes.io/docs/user-guide/kubec
 
 With the "registry" action that is part for the kubernetes-worker charm, you can very easily create a private docker registry, with authentication, and available over TLS. Please note that the registry deployed with the action is not HA, and uses storage tied to the kubernetes node where the pod is running. So if the registry pod changes is migrated from one node to another for whatever reason, you will need to re-publish the images.
 
+### Example usage
+
+Create the relevant authentication files. Let's say you want user `userA` to authenticate with the password `passwordA`. Then you'll do :
+
+    echo "userA:passwordA" > htpasswd-plain
+    htpasswd -b -B htpasswd userA passwordA
+
+(the `htpasswd` program comes with the `apache2-utils` package)
+
+Supposing your registry will be reachable at `myregistry.company.com`, and that you already have your TLS key in the `registry.key` file, and your TLS certificate (with `myregistry.company.com` as Common Name) in the `registry.crt` file, you would then run :
+
+    juju run-action kubernetes-worker/0 registry domain=myregistry.company.com htpasswd="$(base64 -w0 htpasswd)" htpasswd-plain="$(base64 -w0 htpasswd-plain) tlscert="$(base64 -w0 registry.crt)" tlskey="$(base64 -w0 registry.key) ingress=true
+
+If you then decide that you want do delete the registry, just run :
+
+    juju run-action kubernetes-worker/0 registry delete=true ingress=true
+
 ## Known Limitations
 
 Kubernetes workers currently only support 'phaux' HA scenarios. Even when configured with an HA cluster string, they will only ever contact the first unit in the cluster map. To enalbe a proper HA story, kubernetes-worker units are encouraged to proxy through a [kubeapi-load-balancer](https://jujucharms.com/kubeapi-load-balancer)

--- a/cluster/juju/layers/kubernetes-worker/README.md
+++ b/cluster/juju/layers/kubernetes-worker/README.md
@@ -50,13 +50,13 @@ With the "registry" action that is part for the kubernetes-worker charm, you can
 Create the relevant authentication files. Let's say you want user `userA` to authenticate with the password `passwordA`. Then you'll do :
 
     echo "userA:passwordA" > htpasswd-plain
-    htpasswd -b -B htpasswd userA passwordA
+    htpasswd -c -b -B htpasswd userA passwordA
 
 (the `htpasswd` program comes with the `apache2-utils` package)
 
 Supposing your registry will be reachable at `myregistry.company.com`, and that you already have your TLS key in the `registry.key` file, and your TLS certificate (with `myregistry.company.com` as Common Name) in the `registry.crt` file, you would then run :
 
-    juju run-action kubernetes-worker/0 registry domain=myregistry.company.com htpasswd="$(base64 -w0 htpasswd)" htpasswd-plain="$(base64 -w0 htpasswd-plain) tlscert="$(base64 -w0 registry.crt)" tlskey="$(base64 -w0 registry.key) ingress=true
+    juju run-action kubernetes-worker/0 registry domain=myregistry.company.com htpasswd="$(base64 -w0 htpasswd)" htpasswd-plain="$(base64 -w0 htpasswd-plain)" tlscert="$(base64 -w0 registry.crt)" tlskey="$(base64 -w0 registry.key)" ingress=true
 
 If you then decide that you want do delete the registry, just run :
 

--- a/cluster/juju/layers/kubernetes-worker/README.md
+++ b/cluster/juju/layers/kubernetes-worker/README.md
@@ -41,6 +41,10 @@ a unit for maintenance.
 
 Resuming the workload will [uncordon](http://kubernetes.io/docs/user-guide/kubectl/kubectl_uncordon/) a paused unit. Workloads will automatically migrate unless otherwise directed via their application declaration.
 
+## Private registry
+
+With the "registry" action that is part for the kubernetes-worker charm, you can very easily create a private docker registry, with authentication, and available over TLS. Please note that the registry deployed with the action is not HA, and uses storage tied to the kubernetes node where the pod is running. So if the registry pod changes is migrated from one node to another for whatever reason, you will need to re-publish the images.
+
 ## Known Limitations
 
 Kubernetes workers currently only support 'phaux' HA scenarios. Even when configured with an HA cluster string, they will only ever contact the first unit in the cluster map. To enalbe a proper HA story, kubernetes-worker units are encouraged to proxy through a [kubeapi-load-balancer](https://jujucharms.com/kubeapi-load-balancer)
@@ -48,5 +52,4 @@ application. This enables a HA deployment without the need to
 re-render configuration and disrupt the worker services.
 
 External access to pods must be performed through a [Kubernetes
-Ingress Resource](http://kubernetes.io/docs/user-guide/ingress/). More
-information
+Ingress Resource](http://kubernetes.io/docs/user-guide/ingress/).

--- a/cluster/juju/layers/kubernetes-worker/actions.yaml
+++ b/cluster/juju/layers/kubernetes-worker/actions.yaml
@@ -20,13 +20,16 @@ registry:
      params:
       htpasswd:
         type: string
-        description: An htpasswd file used for authentication.
+        description: base64 encoded htpasswd file used for authentication.
+      htpasswd-plain:
+        type: string
+        description: base64 encoded plaintext version of the htpasswd file, needed by docker daemons to authenticate to the registry.
       tlscert:
         type: string
-        description: TLS certificate for the registry.
+        description: base64 encoded TLS certificate for the registry. Common Name must match the domain.
       tlskey:
         type: string
-        description: TLS key for the registry.
+        description: base64 encoded TLS key for the registry.
       domain:
         type: string
         description: The domain name for the registry. Must match the Common Name of the certificate.

--- a/cluster/juju/layers/kubernetes-worker/actions.yaml
+++ b/cluster/juju/layers/kubernetes-worker/actions.yaml
@@ -26,7 +26,7 @@ registry:
         description: base64 encoded plaintext version of the htpasswd file, needed by docker daemons to authenticate to the registry.
       tlscert:
         type: string
-        description: base64 encoded TLS certificate for the registry. Common Name must match the domain.
+        description: base64 encoded TLS certificate for the registry. Common Name must match the domain name of the registry.
       tlskey:
         type: string
         description: base64 encoded TLS key for the registry.
@@ -36,7 +36,7 @@ registry:
       ingress:
         type: boolean
         default: false
-        description: Create an Ingress object for the registry (or delete said object if "delete" is True)
+        description: Create an Ingress resource for the registry (or delete resource object if "delete" is True)
       delete:
         type: boolean
         default: false

--- a/cluster/juju/layers/kubernetes-worker/actions.yaml
+++ b/cluster/juju/layers/kubernetes-worker/actions.yaml
@@ -14,4 +14,27 @@ microbot:
       delete:
         type: boolean
         default: False
-        description: Removes a microbots deployment, service, and ingress if True.
+        description: Remove a microbots deployment, service, and ingress if True.
+registry:
+     description: Create a private Docker registry
+     params:
+      htpasswd:
+        type: string
+        description: An htpasswd file used for authentication.
+      tlscert:
+        type: string
+        description: base64 encoded TLS certificate for the registry.
+      tlskey:
+        type: string
+        description: base64 encoded TLS key for the registry.
+      domain:
+        type: string
+        description: The domain name for the registry. Must match the Common Name of the certificate.
+      ingress:
+        type: boolean
+        default: false
+        description: Create an Ingress object for the registry.
+      delete:
+        type: boolean
+        default: false
+        description: Remove a registry replication controller, service, and ingress if True.

--- a/cluster/juju/layers/kubernetes-worker/actions.yaml
+++ b/cluster/juju/layers/kubernetes-worker/actions.yaml
@@ -23,17 +23,17 @@ registry:
         description: An htpasswd file used for authentication.
       tlscert:
         type: string
-        description: base64 encoded TLS certificate for the registry.
+        description: TLS certificate for the registry.
       tlskey:
         type: string
-        description: base64 encoded TLS key for the registry.
+        description: TLS key for the registry.
       domain:
         type: string
         description: The domain name for the registry. Must match the Common Name of the certificate.
       ingress:
         type: boolean
         default: false
-        description: Create an Ingress object for the registry.
+        description: Create an Ingress object for the registry (or delete said object if "delete" is True)
       delete:
         type: boolean
         default: false

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -43,7 +43,7 @@ for param in ('tlscert', 'tlskey', 'domain', 'htpasswd'):
         param_error = True
 
     if param in b64_params:
-        value = b64encode(value.encode())
+        value = b64encode(value.encode()).decode('ASCII')
 
     context[param] = value
 
@@ -84,5 +84,37 @@ create_response = call(create_command)
 
 if create_response == 0:
     action_set({'registry-create': 'success'})
+
+    # Create a ConfigMap if it doesn't exist yet, else patch it.
+    # A ConfigMap is needed to change the default value for nginx' client_max_body_size.
+    # The default is 1MB, and this is the maximum size of images that can be
+    # pushed on the registry. 1MB images aren't useful, so we bump this value to 1024MB.
+    cm_name = 'nginx-load-balancer-conf'
+    check_cm_command = kubectl + ['get', 'cm', cm_name]
+    check_cm_response = call(check_cm_command)
+
+    if check_cm_response == 0:
+        # There is an existing ConfigMap, patch it
+        patch = '{"data":{"max-body-size":"1024m"}}'
+        patch_cm_command = kubectl + ['patch', 'cm', cm_name, '-p', patch ]
+        patch_cm_response = call(patch_cm_command)
+
+        if patch_cm_response == 0:
+            action_set({'configmap-patch': 'success'})
+        else:
+            action_set({'configmap-patch': 'failure'})
+
+    else:
+        # No existing ConfigMap, create it
+        render('registry-configmap.yaml', '/etc/kubernetes/addons/registry-configmap.yaml',
+               context)
+        create_cm_command = kubectl + ['create', '-f', '/etc/kubernetes/addons/registry-configmap.yaml' ]
+        create_cm_response = call(create_cm_command)
+
+        if create_cm_response == 0:
+            action_set({'configmap-create': 'success'})
+        else:
+            action_set({'configmap-create': 'failure'})
+
 else:
     action_set({'registry-create': 'failure'})

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -44,7 +44,7 @@ for param in ('tlscert', 'tlskey', 'domain', 'htpasswd', 'htpasswd-plain'):
     context[param] = value
 
 # Create the dockercfg template variable
-dockercfg = '{"https://%s/v2/": {"auth": "%s", "email": "root@localhost"}}' % \
+dockercfg = '{"%s:443": {"auth": "%s", "email": "root@localhost"}}' % \
             (context['domain'], context['htpasswd-plain'])
 context['dockercfg'] = b64encode(dockercfg.encode()).decode('ASCII')
 

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -1,25 +1,6 @@
 #!/usr/bin/python3
-
-# Example usage :
 #
-# Registry creation
-#
-# First, setup the needed authentication files
-#
-# $ echo "userA:passwordA" > htpasswd-plain
-# $ htpasswd -b -B htpasswd userA passwordA
-#
-# And then run the action
-#
-# $ juju run-action kubernetes-worker/0 registry domain=myregistry.internal \
-# htpasswd="$(base64 -w0 htpasswd)" htpasswd-plain="$(base64 -w0 htpasswd-plain) \
-# tlscert="$(base64 -w0 registry.crt)" tlskey="$(base64 -w0 registry.key) \
-# ingress=true
-#
-# To delete the registry
-#
-# juju run-action kubernetes-worker/0 registry delete=true ingress=true
-#
+# For a usage examples, see README.md
 #
 # TODO
 #

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+
+# Example usage :
+#
+# Registry creation
+#
+# juju run-action kubernetes-worker/0 registry domain=myregistry.internal \
+# htpasswd="$(cat htpass)" ingress=true \
+# tlscert="$(base64 -w0 registry.crt)" tlskey="$(base64 -w0 registry.key)"
+#
+# Registry deletion
+#
+# juju run-action kubernetes-worker/0 registry delete=true ingress=true
+
+import sys
+import os
+
+from charmhelpers.core.hookenv import action_get
+from charmhelpers.core.hookenv import action_set
+from charmhelpers.core.hookenv import unit_public_ip
+from charms.templating.jinja2 import render
+from subprocess import call
+
+
+deletion = action_get('delete')
+
+context = {}
+
+# These config options must be defined in the case of a creation
+param_error = False
+for param in ('tlscert', 'tlskey', 'domain'):
+    value = action_get(param)
+    if not value and not deletion:
+        key = "registry-create-parameter-{}".format(param)
+        error = "failure, parameter {} is required".format(param)
+        action_set({key: error})
+        param_error = True
+    context[param] = value
+
+if param_error:
+    sys.exit(0)
+
+# This one is either true or false, no need to check if it has a "good" value.
+context['ingress'] = action_get('ingress')
+
+# Declare a kubectl template when invoking kubectl
+kubectl = ['kubectl', '--kubeconfig=/srv/kubernetes/config']
+
+# Remove deployment if requested
+if deletion:
+    resources = ['svc/kube-registry', 'rc/kube-registry-v0', 'secrets/registry-tls-data']
+
+    if action_get('ingress'):
+        resources.append('ing/registry-ing')
+
+    delete_command = kubectl + ['delete'] + resources
+    delete_response = call(delete_command)
+    if delete_response == 0:
+        action_set({'registry-delete': 'success'})
+    else:
+        action_set({'registry-delete': 'failure'})
+
+    sys.exit(0)
+
+# Creation request
+render('registry.yaml', '/etc/kubernetes/addons/registry.yaml',
+       context)
+
+create_command = kubectl + ['create', '-f',
+                            '/etc/kubernetes/addons/registry.yaml']
+
+create_response = call(create_command)
+
+if create_response == 0:
+    action_set({'registry-create': 'success'})
+else:
+    action_set({'registry-create': 'failure'})

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -13,13 +13,11 @@
 # juju run-action kubernetes-worker/0 registry delete=true ingress=true
 
 import sys
-import os
 
 from base64 import b64encode
 
 from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
-from charmhelpers.core.hookenv import unit_public_ip
 from charms.templating.jinja2 import render
 from subprocess import call
 
@@ -46,6 +44,11 @@ for param in ('tlscert', 'tlskey', 'domain', 'htpasswd'):
         value = b64encode(value.encode()).decode('ASCII')
 
     context[param] = value
+
+# Create the dockercfg template variable, using the base64 encoded htpasswd
+dockercfg = '{"https://%s/v2/": {"auth": "%s", "email": "root@localhost"}}' % \
+            (action_get('domain'), context['htpasswd'])
+context['dockercfg'] = b64encode(dockercfg.encode()).decode('ASCII')
 
 if param_error:
     sys.exit(0)
@@ -96,7 +99,7 @@ if create_response == 0:
     if check_cm_response == 0:
         # There is an existing ConfigMap, patch it
         patch = '{"data":{"max-body-size":"1024m"}}'
-        patch_cm_command = kubectl + ['patch', 'cm', cm_name, '-p', patch ]
+        patch_cm_command = kubectl + ['patch', 'cm', cm_name, '-p', patch]
         patch_cm_response = call(patch_cm_command)
 
         if patch_cm_response == 0:
@@ -108,13 +111,26 @@ if create_response == 0:
         # No existing ConfigMap, create it
         render('registry-configmap.yaml', '/etc/kubernetes/addons/registry-configmap.yaml',
                context)
-        create_cm_command = kubectl + ['create', '-f', '/etc/kubernetes/addons/registry-configmap.yaml' ]
+        create_cm_command = kubectl + ['create', '-f', '/etc/kubernetes/addons/registry-configmap.yaml']
         create_cm_response = call(create_cm_command)
 
         if create_cm_response == 0:
             action_set({'configmap-create': 'success'})
         else:
             action_set({'configmap-create': 'failure'})
+
+    # Patch the "default" serviceaccount with an imagePullSecret.
+    # This will allow the docker daemons to authenticate to our private
+    # registry automatically
+    patch = '{"imagePullSecrets":[{"name":"registry-access"}]}'
+    patch_sa_command = kubectl + ['patch', 'sa', 'default', '-p', patch]
+    patch_sa_response = call(patch_sa_command)
+
+    if patch_sa_response == 0:
+        action_set({'serviceaccount-patch': 'success'})
+    else:
+        action_set({'serviceaccount-patch': 'failure'})
+
 
 else:
     action_set({'registry-create': 'failure'})

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -28,7 +28,7 @@ context = {}
 
 # These config options must be defined in the case of a creation
 param_error = False
-for param in ('tlscert', 'tlskey', 'domain'):
+for param in ('tlscert', 'tlskey', 'domain', 'htpasswd'):
     value = action_get(param)
     if not value and not deletion:
         key = "registry-create-parameter-{}".format(param)
@@ -48,7 +48,8 @@ kubectl = ['kubectl', '--kubeconfig=/srv/kubernetes/config']
 
 # Remove deployment if requested
 if deletion:
-    resources = ['svc/kube-registry', 'rc/kube-registry-v0', 'secrets/registry-tls-data']
+    resources = ['svc/kube-registry', 'rc/kube-registry-v0', 'secrets/registry-tls-data',
+                 'secrets/registry-auth-data']
 
     if action_get('ingress'):
         resources.append('ing/registry-ing')

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -4,13 +4,37 @@
 #
 # Registry creation
 #
-# juju run-action kubernetes-worker/0 registry domain=myregistry.internal \
-# htpasswd="$(cat htpasswd)" ingress=true \
-# tlscert="$(cat registry.crt)" tlskey="$(cat registry.key)"
+# First, setup the needed authentication files
 #
-# Registry deletion
+# $ echo "userA:passwordA" > htpasswd-plain
+# $ htpasswd -b -B htpasswd userA passwordA
+#
+# And then run the action
+#
+# $ juju run-action kubernetes-worker/0 registry domain=myregistry.internal \
+# htpasswd="$(base64 -w0 htpasswd)" htpasswd-plain="$(base64 -w0 htpasswd-plain) \
+# tlscert="$(base64 -w0 registry.crt)" tlskey="$(base64 -w0 registry.key) \
+# ingress=true
+#
+# To delete the registry
 #
 # juju run-action kubernetes-worker/0 registry delete=true ingress=true
+#
+#
+# TODO
+#
+# - make the action idempotent (i.e. if you run it multiple times, the first
+# run will create/delete the registry, and the reset will be a no-op and won't
+# error out)
+#
+# - take only a plain authentication file, and create the encrypted version in
+# the action
+#
+# - validate the parameters (make sure tlscert is a certificate, that tlskey is a
+# proper key, etc)
+#
+# - when https://bugs.launchpad.net/juju/+bug/1661015 is fixed, handle the
+# base64 encoding the parameters in the action itself
 
 import sys
 
@@ -26,13 +50,9 @@ deletion = action_get('delete')
 
 context = {}
 
-# List of config options we need to b64encode, as the registry image provided
-# by Google only accepts b64encoded values
-b64_params = ('tlscert', 'tlskey', 'htpasswd')
-
 # These config options must be defined in the case of a creation
 param_error = False
-for param in ('tlscert', 'tlskey', 'domain', 'htpasswd'):
+for param in ('tlscert', 'tlskey', 'domain', 'htpasswd', 'htpasswd-plain'):
     value = action_get(param)
     if not value and not deletion:
         key = "registry-create-parameter-{}".format(param)
@@ -40,14 +60,11 @@ for param in ('tlscert', 'tlskey', 'domain', 'htpasswd'):
         action_set({key: error})
         param_error = True
 
-    if param in b64_params:
-        value = b64encode(value.encode()).decode('ASCII')
-
     context[param] = value
 
-# Create the dockercfg template variable, using the base64 encoded htpasswd
+# Create the dockercfg template variable
 dockercfg = '{"https://%s/v2/": {"auth": "%s", "email": "root@localhost"}}' % \
-            (action_get('domain'), context['htpasswd'])
+            (context['domain'], context['htpasswd-plain'])
 context['dockercfg'] = b64encode(dockercfg.encode()).decode('ASCII')
 
 if param_error:
@@ -62,12 +79,12 @@ kubectl = ['kubectl', '--kubeconfig=/srv/kubernetes/config']
 # Remove deployment if requested
 if deletion:
     resources = ['svc/kube-registry', 'rc/kube-registry-v0', 'secrets/registry-tls-data',
-                 'secrets/registry-auth-data']
+                 'secrets/registry-auth-data', 'secrets/registry-access']
 
     if action_get('ingress'):
         resources.append('ing/registry-ing')
 
-    delete_command = kubectl + ['delete'] + resources
+    delete_command = kubectl + ['delete', '--ignore-not-found=true'] + resources
     delete_response = call(delete_command)
     if delete_response == 0:
         action_set({'registry-delete': 'success'})

--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -5,8 +5,8 @@
 # Registry creation
 #
 # juju run-action kubernetes-worker/0 registry domain=myregistry.internal \
-# htpasswd="$(cat htpass)" ingress=true \
-# tlscert="$(base64 -w0 registry.crt)" tlskey="$(base64 -w0 registry.key)"
+# htpasswd="$(cat htpasswd)" ingress=true \
+# tlscert="$(cat registry.crt)" tlskey="$(cat registry.key)"
 #
 # Registry deletion
 #
@@ -14,6 +14,8 @@
 
 import sys
 import os
+
+from base64 import b64encode
 
 from charmhelpers.core.hookenv import action_get
 from charmhelpers.core.hookenv import action_set
@@ -26,6 +28,10 @@ deletion = action_get('delete')
 
 context = {}
 
+# List of config options we need to b64encode, as the registry image provided
+# by Google only accepts b64encoded values
+b64_params = ('tlscert', 'tlskey', 'htpasswd')
+
 # These config options must be defined in the case of a creation
 param_error = False
 for param in ('tlscert', 'tlskey', 'domain', 'htpasswd'):
@@ -35,6 +41,10 @@ for param in ('tlscert', 'tlskey', 'domain', 'htpasswd'):
         error = "failure, parameter {} is required".format(param)
         action_set({key: error})
         param_error = True
+
+    if param in b64_params:
+        value = b64encode(value.encode())
+
     context[param] = value
 
 if param_error:

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -104,6 +104,11 @@ def install_kubernetes_components():
         hookenv.log(install)
         check_call(install)
 
+    # Used by the "registry" action. The action is run on a single worker, but
+    # the registry pod can end up on any worker, so we need this directory on
+    # all the workers.
+    os.makedirs('/srv/registry', exist_ok=True)
+
     set_state('kubernetes-worker.components.installed')
 
 

--- a/cluster/juju/layers/kubernetes-worker/templates/registry-configmap.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/registry-configmap.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  body-size: 1024m
+kind: ConfigMap
+metadata:
+  name: nginx-load-balancer-conf

--- a/cluster/juju/layers/kubernetes-worker/templates/registry.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/registry.yaml
@@ -88,6 +88,14 @@ spec:
   - name: registry
     port: 5000
     protocol: TCP
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-access
+data:
+  .dockercfg: {{ dockercfg }}
+type: kubernetes.io/dockercfg
 {%- if ingress %}
 ---
 apiVersion: extensions/v1beta1

--- a/cluster/juju/layers/kubernetes-worker/templates/registry.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/registry.yaml
@@ -1,0 +1,93 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-tls-data
+type: Opaque
+data:
+  tls.crt: {{ tlscert }}
+  tls.key: {{ tlskey }}
+---
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: kube-registry-v0
+  labels:
+    k8s-app: kube-registry
+    version: v0
+    kubernetes.io/cluster-service: "true"
+spec:
+  replicas: 1
+  selector:
+    k8s-app: kube-registry
+    version: v0
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-registry
+        version: v0
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+      - name: registry
+        image: registry:2
+        resources:
+          # keep request = limit to keep this container in guaranteed class
+          limits:
+            cpu: 100m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        env:
+        - name: REGISTRY_HTTP_ADDR
+          value: :5000
+        - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
+          value: /var/lib/registry
+        volumeMounts:
+        - name: image-store
+          mountPath: /var/lib/registry
+        ports:
+        - containerPort: 5000
+          name: registry
+          protocol: TCP
+      volumes:
+      - name: image-store
+        hostPath:
+          path: /srv/registry
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-registry
+  labels:
+    k8s-app: kube-registry
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "KubeRegistry"
+spec:
+  selector:
+    k8s-app: kube-registry
+  type: LoadBalancer
+  ports:
+  - name: registry
+    port: 5000
+    protocol: TCP
+{%- if ingress %}
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: registry-ing
+spec:
+  tls:
+  - hosts:
+    - {{ domain }}
+    secretName: registry-tls-data
+  rules:
+  - host: {{ domain }}
+    http:
+      paths:
+      - backend:
+          serviceName: kube-registry
+          servicePort: 5000
+        path: /
+{% endif %}

--- a/cluster/juju/layers/kubernetes-worker/templates/registry.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/registry.yaml
@@ -8,6 +8,14 @@ data:
   tls.key: {{ tlskey }}
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: registry-auth-data
+type: Opaque
+data:
+  htpasswd: {{ htpasswd }}
+---
+apiVersion: v1
 kind: ReplicationController
 metadata:
   name: kube-registry-v0
@@ -43,9 +51,15 @@ spec:
           value: :5000
         - name: REGISTRY_STORAGE_FILESYSTEM_ROOTDIRECTORY
           value: /var/lib/registry
+        - name: REGISTRY_AUTH_HTPASSWD_REALM
+          value: basic_realm
+        - name: REGISTRY_AUTH_HTPASSWD_PATH
+          value: /auth/htpasswd
         volumeMounts:
         - name: image-store
           mountPath: /var/lib/registry
+        - name: auth-dir
+          mountPath: /auth
         ports:
         - containerPort: 5000
           name: registry
@@ -54,6 +68,9 @@ spec:
       - name: image-store
         hostPath:
           path: /srv/registry
+      - name: auth-dir
+        secret:
+          secretName: registry-auth-data
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a "registry" action to the kubernetes-worker juju charm. It allows to easily deploy a private, authenticated, TLS-protected docker registry in your kubernetes cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Original PR at https://github.com/kubernetes/kubernetes/pull/40814

**Release note**:
```
The kubernetes-worker Juju charm now has a "registry" action that greatly simplifies the deployment of a private, authenticated, TLS-protected docker registry in your kubernetes cluster. See the README for usage examples
```