### PR TITLE
Update startup scripts for kube-dns ConfigMap and ServiceAccount

### DIFF
--- a/cluster/centos/deployAddons.sh
+++ b/cluster/centos/deployAddons.sh
@@ -34,6 +34,7 @@ function deploy_dns {
   if [ ! "$KUBEDNS" ]; then
     # use kubectl to create kube-dns deployment and service
     ${KUBECTL} --namespace=kube-system create -f kubedns-sa.yaml
+    ${KUBECTL} --namespace=kube-system create -f kubedns-cm.yaml
     ${KUBECTL} --namespace=kube-system create -f kubedns-controller.yaml
     ${KUBECTL} --namespace=kube-system create -f kubedns-svc.yaml
 

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -66,6 +66,8 @@ endif
 	# Singlenode addons
 	cp ../../addons/dns/kubedns-controller.yaml.base ${TEMP_DIR}/addons/singlenode/kubedns-controller.yaml
 	cp ../../addons/dns/kubedns-svc.yaml.base ${TEMP_DIR}/addons/singlenode/kubedns-svc.yaml
+	cp ../../addons/dns/kubedns-sa.yaml ${TEMP_DIR}/addons/singlenode/kubedns-sa.yaml
+	cp ../../addons/dns/kubedns-cm.yaml ${TEMP_DIR}/addons/singlenode/kubedns-cm.yaml
 	cp ../../addons/dashboard/dashboard-controller.yaml ${TEMP_DIR}/addons/singlenode/
 	cp ../../addons/dashboard/dashboard-service.yaml ${TEMP_DIR}/addons/singlenode/
 

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -372,6 +372,8 @@ def start_kube_dns():
     }
 
     try:
+        create_addon('kubedns-sa.yaml', context)
+        create_addon('kubedns-cm.yaml', context)
         create_addon('kubedns-controller.yaml', context)
         create_addon('kubedns-svc.yaml', context)
     except CalledProcessError:

--- a/cluster/juju/layers/kubernetes-master/tactics/update_addons.py
+++ b/cluster/juju/layers/kubernetes-master/tactics/update_addons.py
@@ -104,6 +104,10 @@ def update_addons(dest):
         add_addon(repo, "dashboard/dashboard-controller.yaml", dest)
         add_addon(repo, "dashboard/dashboard-service.yaml", dest)
         try:
+            add_addon(repo, "dns/kubedns-sa.yaml",
+                      dest + "/kubedns-sa.yaml")
+            add_addon(repo, "dns/kubedns-cm.yaml",
+                      dest + "/kubedns-cm.yaml")
             add_addon(repo, "dns/kubedns-controller.yaml.in",
                       dest + "/kubedns-controller.yaml")
             add_addon(repo, "dns/kubedns-svc.yaml.in",

--- a/cluster/libvirt-coreos/config-default.sh
+++ b/cluster/libvirt-coreos/config-default.sh
@@ -68,6 +68,7 @@ ENABLE_DNS_HORIZONTAL_AUTOSCALER="${KUBE_ENABLE_DNS_HORIZONTAL_AUTOSCALER:-false
 sed -f "${KUBE_ROOT}/cluster/addons/dns/transforms2sed.sed" < "${KUBE_ROOT}/cluster/addons/dns/kubedns-controller.yaml.base" | sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  > "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-controller.yaml"
 sed -f "${KUBE_ROOT}/cluster/addons/dns/transforms2sed.sed" < "${KUBE_ROOT}/cluster/addons/dns/kubedns-svc.yaml.base" | sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  > "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-svc.yaml"
 cp "${KUBE_ROOT}/cluster/addons/dns/kubedns-sa.yaml" "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-sa.yaml"
+cp "${KUBE_ROOT}/cluster/addons/dns/kubedns-cm.yaml" "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-cm.yaml"
 
 
 #Generate registry files

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -188,6 +188,7 @@ function initialize-pool {
       render-template "$ROOT/kubedns-svc.yaml" > "$POOL_PATH/kubernetes/addons/kubedns-svc.yaml"
       render-template "$ROOT/kubedns-controller.yaml"  > "$POOL_PATH/kubernetes/addons/kubedns-controller.yaml"
       render-template "$ROOT/kubedns-sa.yaml"  > "$POOL_PATH/kubernetes/addons/kubedns-sa.yaml"
+      render-template "$ROOT/kubedns-cm.yaml"  > "$POOL_PATH/kubernetes/addons/kubedns-cm.yaml"
   fi
 
   virsh pool-refresh $POOL

--- a/cluster/saltbase/salt/kube-addons/init.sls
+++ b/cluster/saltbase/salt/kube-addons/init.sls
@@ -88,6 +88,22 @@ addon-dir-create:
     - group: root
     - dir_mode: 755
     - makedirs: True
+
+/etc/kubernetes/addons/dns/kubedns-sa.yaml:
+  file.managed:
+    - source: salt://kube-addons/dns/kubedns-sa.yaml
+    - user: root
+    - group: root
+    - file_mode: 644
+    - makedirs: True
+
+/etc/kubernetes/addons/dns/kubedns-cm.yaml:
+  file.managed:
+    - source: salt://kube-addons/dns/kubedns-cm.yaml
+    - user: root
+    - group: root
+    - file_mode: 644
+    - makedirs: True
 {% endif %}
 
 {% if pillar.get('enable_dns_horizontal_autoscaler', '').lower() == 'true'

--- a/cluster/ubuntu/deployAddons.sh
+++ b/cluster/ubuntu/deployAddons.sh
@@ -44,12 +44,14 @@ function deploy_dns {
   sed -e "s/\\\$DNS_DOMAIN/${DNS_DOMAIN}/g" "${KUBE_ROOT}/cluster/addons/dns/kubedns-controller.yaml.sed" > kubedns-controller.yaml
   sed -e "s/\\\$DNS_SERVER_IP/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/addons/dns/kubedns-svc.yaml.sed" > kubedns-svc.yaml
   cp "${KUBE_ROOT}/cluster/addons/dns/kubedns-sa.yaml" kubedns-sa.yaml
+  cp "${KUBE_ROOT}/cluster/addons/dns/kubedns-cm.yaml" kubedns-cm.yaml
 
   KUBEDNS=`eval "${KUBECTL} get services --namespace=kube-system | grep kube-dns | cat"`
 
   if [ ! "$KUBEDNS" ]; then
     # use kubectl to create kubedns controller and service
     ${KUBECTL} --namespace=kube-system create -f kubedns-sa.yaml
+    ${KUBECTL} --namespace=kube-system create -f kubedns-cm.yaml
     ${KUBECTL} --namespace=kube-system create -f kubedns-controller.yaml 
     ${KUBECTL} --namespace=kube-system create -f kubedns-svc.yaml
 

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -693,6 +693,7 @@ function start_kubedns {
         ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" create clusterrolebinding system:kube-dns --clusterrole=cluster-admin --serviceaccount=kube-system:default
         # use kubectl to create kubedns deployment and service
         ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system create -f ${KUBE_ROOT}/cluster/addons/dns/kubedns-sa.yaml
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system create -f ${KUBE_ROOT}/cluster/addons/dns/kubedns-cm.yaml
         ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system create -f kubedns-deployment.yaml
         ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" --namespace=kube-system create -f kubedns-svc.yaml
         echo "Kube-dns deployment and service successfully deployed."


### PR DESCRIPTION
Follow up PR of #42757. This PR changes all existing startup scripts to support default kube-dns ConfigMap and ServiceAccount.

@bowei 

cc @liggitt 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
