### PR TITLE
kubeadm: add api validation exit code

### DIFF
--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -16,7 +16,10 @@ go_library(
         "version.go",
     ],
     tags = ["automanaged"],
-    deps = ["//cmd/kubeadm/app/preflight:go_default_library"],
+    deps = [
+        "//cmd/kubeadm/app/preflight:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/util/errors",
+    ],
 )
 
 go_test(

--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -21,12 +21,14 @@ import (
 	"os"
 	"strings"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
 )
 
 const (
 	DefaultErrorExitCode = 1
 	PreFlightExitCode    = 2
+	ValidationExitCode   = 3
 )
 
 type debugError interface {
@@ -63,6 +65,9 @@ func checkErr(prefix string, err error, handleErr func(string, int)) {
 		return
 	case *preflight.Error:
 		handleErr(err.Error(), PreFlightExitCode)
+	case utilerrors.Aggregate:
+		handleErr(err.Error(), ValidationExitCode)
+
 	default:
 		handleErr(err.Error(), DefaultErrorExitCode)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: This will help with automation and provide more meaningful exit code for api validation. 

WIP to add more meaningful exit codes https://github.com/kubernetes/kubeadm/issues/61

**Special notes for your reviewer**: /cc @luxas 

**Release note**:
```release-note
NONE
```
