### PR TITLE
[Federation] Rewrite ReplicaSet CRUD and Preferences tests.

### DIFF
--- a/test/e2e_federation/replicaset.go
+++ b/test/e2e_federation/replicaset.go
@@ -41,11 +41,10 @@ import (
 
 const (
 	FederationReplicaSetPrefix = "federation-replicaset-"
-	FederatedReplicaSetTimeout = 2 * time.Minute
 )
 
 // Create/delete replicaset api objects
-var _ = framework.KubeDescribe("Federation replicasets [Feature:Federation]", func() {
+var _ = framework.KubeDescribe("Federated ReplicaSet [Feature:Federation]", func() {
 	f := fedframework.NewDefaultFederatedFramework("federation-replicaset")
 
 	Describe("ReplicaSet objects [NoCluster]", func() {
@@ -72,120 +71,174 @@ var _ = framework.KubeDescribe("Federation replicasets [Feature:Federation]", fu
 	})
 
 	// e2e cases for federated replicaset controller
-	Describe("Federated ReplicaSet", func() {
+	Describe("Features", func() {
 		var (
 			clusters map[string]*cluster
 		)
+
 		BeforeEach(func() {
 			fedframework.SkipUnlessFederated(f.ClientSet)
 			clusters, _ = getRegisteredClusters(UserAgentName, f)
 		})
 
-		AfterEach(func() {
-			// Delete all replicasets.
-			nsName := f.FederationNamespace.Name
-			deleteAllReplicaSetsOrFail(f.FederationClientset, nsName)
-		})
+		// e2e cases for federated replicaset controller
+		Describe("CRUD", func() {
+			var (
+				rs *v1beta1.ReplicaSet
+			)
 
-		It("should create and update matching replicasets in underling clusters", func() {
-			nsName := f.FederationNamespace.Name
-			cleanupFn := func(rs *v1beta1.ReplicaSet) {
-				// cleanup. deletion of replicasets is not supported for underling clusters
-				By(fmt.Sprintf("zero replicas then delete replicaset %q/%q", nsName, rs.Name))
-				zeroReplicas := int32(0)
-				rs.GenerateName = ""
-				rs.ResourceVersion = ""
-				rs.Generation = 0
-				rs.Spec.Replicas = &zeroReplicas
-				updateReplicaSetOrFail(f.FederationClientset, rs)
-				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, nil)
-				f.FederationClientset.ReplicaSets(nsName).Delete(rs.Name, &metav1.DeleteOptions{})
-			}
+			BeforeEach(func() {
+				nsName := f.FederationNamespace.Name
 
-			// general test with default replicaset pref
-			func() {
-				rs := newReplicaSet(nsName, FederationReplicaSetPrefix, 5, nil)
-				rs = createReplicaSetOrFail(f.FederationClientset, rs)
-				defer cleanupFn(rs)
+				By(fmt.Sprintf("Creating a new replicaset in namespace %q", nsName))
+				rs = createAndWaitForReplicasetOrFail(f.FederationClientset, nsName, clusters)
+			})
 
-				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, nil)
-				By(fmt.Sprintf("Successfuly created and synced replicaset %q/%q (%v/%v) to clusters", nsName, rs.Name, *rs.Spec.Replicas, rs.Status.Replicas))
+			AfterEach(func() {
+				// Delete all replicasets.
+				nsName := f.FederationNamespace.Name
 
+				By(fmt.Sprintf("Deleting replicaset \"%s/%s\"", nsName, rs.Name))
+				orphanDependents := false
+				deleteReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, &orphanDependents)
+			})
+
+			It("should create and update matching replicasets in underlying clusters", func() {
+				nsName := f.FederationNamespace.Name
+
+				// As part of the update, we scale the replicaset here.
 				rs = newReplicaSetWithName(nsName, rs.Name, 15, nil)
 				updateReplicaSetOrFail(f.FederationClientset, rs)
 				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, nil)
-				By(fmt.Sprintf("Successfuly updated and synced replicaset %q/%q (%v/%v) to clusters", nsName, rs.Name, *rs.Spec.Replicas, rs.Status.Replicas))
-			}()
+				By(fmt.Sprintf("Successfully updated and synced replicaset \"%s/%s\" (%v/%v) to clusters", nsName, rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
+			})
 
-			// test for replicaset prefs with weight, min and max replicas
-			createAndUpdateFn := func(pref *federation.FederatedReplicaSetPreferences, replicas int32, expect map[string]int32) {
-				rs := newReplicaSet(nsName, FederationReplicaSetPrefix, replicas, pref)
-				rs = createReplicaSetOrFail(f.FederationClientset, rs)
-				defer cleanupFn(rs)
+			It("should be deleted from underlying clusters when OrphanDependents is false", func() {
+				fedframework.SkipUnlessFederated(f.ClientSet)
+				nsName := f.FederationNamespace.Name
+				orphanDependents := false
+				verifyCascadingDeletionForReplicaSet(f.FederationClientset, clusters, &orphanDependents, nsName, rs.Name)
+				By(fmt.Sprintf("Verified that replicasets were deleted from underlying clusters"))
+			})
 
-				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, expect)
-				By(fmt.Sprintf("Successfuly created and synced replicaset %q/%q (%v/%v) to clusters", nsName, rs.Name, *rs.Spec.Replicas, rs.Status.Replicas))
+			It("should not be deleted from underlying clusters when OrphanDependents is true", func() {
+				fedframework.SkipUnlessFederated(f.ClientSet)
+				nsName := f.FederationNamespace.Name
+				orphanDependents := true
+				verifyCascadingDeletionForReplicaSet(f.FederationClientset, clusters, &orphanDependents, nsName, rs.Name)
+				By(fmt.Sprintf("Verified that replicasets were not deleted from underlying clusters"))
+			})
 
-				rs = newReplicaSetWithName(nsName, rs.Name, 0, pref)
-				updateReplicaSetOrFail(f.FederationClientset, rs)
-				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, nil)
-				By(fmt.Sprintf("Successfuly updated and synced replicaset %q/%q (%v/%v) to clusters", nsName, rs.Name, *rs.Spec.Replicas, rs.Status.Replicas))
+			It("should not be deleted from underlying clusters when OrphanDependents is nil", func() {
+				fedframework.SkipUnlessFederated(f.ClientSet)
+				nsName := f.FederationNamespace.Name
+				verifyCascadingDeletionForReplicaSet(f.FederationClientset, clusters, nil, nsName, rs.Name)
+				By(fmt.Sprintf("Verified that replicasets were not deleted from underlying clusters"))
+			})
+		})
 
-				rs = newReplicaSetWithName(nsName, rs.Name, replicas, pref)
-				updateReplicaSetOrFail(f.FederationClientset, rs)
-				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, expect)
-				By(fmt.Sprintf("Successfuly updated and synced replicaset %q/%q (%v/%v) to clusters", nsName, rs.Name, *rs.Spec.Replicas, rs.Status.Replicas))
-			}
-			createAndUpdateFn(generageFedRsPrefsWithWeight(clusters))
-			createAndUpdateFn(generageFedRsPrefsWithMin(clusters))
-			createAndUpdateFn(generageFedRsPrefsWithMax(clusters))
+		// e2e cases for federated replicaset controller
+		Describe("Preferences", func() {
+			var (
+				rs *v1beta1.ReplicaSet
+			)
+
+			AfterEach(func() {
+				// Delete all replicasets.
+				nsName := f.FederationNamespace.Name
+				if rs != nil {
+					orphanDependents := false
+					By(fmt.Sprintf("Deleting replicaset \"%s/%s\"", nsName, rs.Name))
+					deleteReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, &orphanDependents)
+					rs = nil
+				}
+			})
+
+			It("should create replicasets with weight preference", func() {
+				pref, replicas, expect := generateFedRSPrefsWithWeight(clusters)
+				rs = createAndUpdateFedRSWithPref(f.FederationClientset, f.FederationNamespace.Name, clusters, pref, replicas, expect)
+			})
+
+			It("should create replicasets with min replicas preference", func() {
+				pref, replicas, expect := generateFedRSPrefsWithMin(clusters)
+				rs = createAndUpdateFedRSWithPref(f.FederationClientset, f.FederationNamespace.Name, clusters, pref, replicas, expect)
+			})
+
+			It("should create replicasets with max replicas preference", func() {
+				pref, replicas, expect := generateFedRSPrefsWithMax(clusters)
+				rs = createAndUpdateFedRSWithPref(f.FederationClientset, f.FederationNamespace.Name, clusters, pref, replicas, expect)
+			})
 
 			// test for rebalancing
-			func() {
-				pref1, pref2, replicas, expect1, expect2 := generageFedRsPrefsForRebalancing(clusters)
-				rs := newReplicaSet(nsName, FederationReplicaSetPrefix, replicas, pref1)
+			It("should create replicasets and rebalance them", func() {
+				nsName := f.FederationNamespace.Name
+				pref1, pref2, replicas, expect1, expect2 := generateFedRSPrefsForRebalancing(clusters)
+
+				By("Testing replicaset rebalancing")
+				framework.Logf("Replicas: %d", replicas)
+				framework.Logf("Preference 1: %#v", pref1)
+				framework.Logf("Preference 2: %#v", pref2)
+
+				rs = newReplicaSet(nsName, FederationReplicaSetPrefix, replicas, pref1)
 				rs = createReplicaSetOrFail(f.FederationClientset, rs)
-				defer cleanupFn(rs)
 				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, expect1)
-				By(fmt.Sprintf("Successfuly created and synced replicaset %q/%q (%v/%v) to clusters", nsName, rs.Name, *rs.Spec.Replicas, rs.Status.Replicas))
+				By(fmt.Sprintf("Successfully created and synced replicaset \"%s/%s\" (%v/%v) to clusters", nsName, rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
 
 				rs = newReplicaSetWithName(nsName, rs.Name, replicas, pref2)
 				updateReplicaSetOrFail(f.FederationClientset, rs)
 				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, expect1)
-				By(fmt.Sprintf("Successfuly updated and synced replicaset %q/%q (%v/%v) to clusters", nsName, rs.Name, *rs.Spec.Replicas, rs.Status.Replicas))
+				By(fmt.Sprintf("Successfully updated and synced replicaset \"%s/%s\" (%v/%v) to clusters", nsName, rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
 
-				pref2 = updateFedRePrefsRebalance(pref2, true)
+				pref2 = updateFedRSPrefsRebalance(pref2, true)
 				rs = newReplicaSetWithName(nsName, rs.Name, replicas, pref2)
 				updateReplicaSetOrFail(f.FederationClientset, rs)
 				waitForReplicaSetOrFail(f.FederationClientset, nsName, rs.Name, clusters, expect2)
-				By(fmt.Sprintf("Successfuly updated and synced replicaset %q/%q (%v/%v) to clusters", nsName, rs.Name, *rs.Spec.Replicas, rs.Status.Replicas))
-			}()
-		})
-
-		It("should be deleted from underlying clusters when OrphanDependents is false", func() {
-			fedframework.SkipUnlessFederated(f.ClientSet)
-			nsName := f.FederationNamespace.Name
-			orphanDependents := false
-			verifyCascadingDeletionForReplicaSet(f.FederationClientset, clusters, &orphanDependents, nsName)
-			By(fmt.Sprintf("Verified that replica sets were deleted from underlying clusters"))
-		})
-
-		It("should not be deleted from underlying clusters when OrphanDependents is true", func() {
-			fedframework.SkipUnlessFederated(f.ClientSet)
-			nsName := f.FederationNamespace.Name
-			orphanDependents := true
-			verifyCascadingDeletionForReplicaSet(f.FederationClientset, clusters, &orphanDependents, nsName)
-			By(fmt.Sprintf("Verified that replica sets were not deleted from underlying clusters"))
-		})
-
-		It("should not be deleted from underlying clusters when OrphanDependents is nil", func() {
-			fedframework.SkipUnlessFederated(f.ClientSet)
-			nsName := f.FederationNamespace.Name
-			verifyCascadingDeletionForReplicaSet(f.FederationClientset, clusters, nil, nsName)
-			By(fmt.Sprintf("Verified that replica sets were not deleted from underlying clusters"))
+				By(fmt.Sprintf("Successfully updated and synced replicaset \"%s/%s\" (%v/%v) to clusters", nsName, rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
+			})
 		})
 	})
 })
+
+func createAndWaitForReplicasetOrFail(clientset *fedclientset.Clientset, nsName string, clusters map[string]*cluster) *v1beta1.ReplicaSet {
+	rs := createReplicaSetOrFail(clientset, newReplicaSet(nsName, FederationReplicaSetPrefix, 5, nil))
+	// Check subclusters if the replicaSet was created there.
+	By(fmt.Sprintf("Waiting for replica sets %s to be created in all underlying clusters", rs.Name))
+	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
+		for _, cluster := range clusters {
+			_, err := cluster.Extensions().ReplicaSets(nsName).Get(rs.Name, metav1.GetOptions{})
+			if err != nil && errors.IsNotFound(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, err
+			}
+		}
+		return true, nil
+	})
+	framework.ExpectNoError(err, "Not all replica sets created")
+	return rs
+}
+
+func createAndUpdateFedRSWithPref(clientset *fedclientset.Clientset, nsName string, clusters map[string]*cluster, pref *federation.FederatedReplicaSetPreferences, replicas int32, expect map[string]int32) *v1beta1.ReplicaSet {
+	framework.Logf("Replicas: %d, Preference: %#v", replicas, pref)
+	rs := newReplicaSet(nsName, FederationReplicaSetPrefix, replicas, pref)
+	rs = createReplicaSetOrFail(clientset, rs)
+
+	waitForReplicaSetOrFail(clientset, nsName, rs.Name, clusters, expect)
+	By(fmt.Sprintf("Successfully created and synced replicaset \"%s/%s\" (%v/%v) to clusters", nsName, rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
+
+	rs = newReplicaSetWithName(nsName, rs.Name, 0, pref)
+	updateReplicaSetOrFail(clientset, rs)
+	waitForReplicaSetOrFail(clientset, nsName, rs.Name, clusters, nil)
+	By(fmt.Sprintf("Successfully updated and synced replicaset \"%s/%s\" (%v/%v) to clusters", nsName, rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
+
+	rs = newReplicaSetWithName(nsName, rs.Name, replicas, pref)
+	updateReplicaSetOrFail(clientset, rs)
+	waitForReplicaSetOrFail(clientset, nsName, rs.Name, clusters, expect)
+	By(fmt.Sprintf("Successfully updated and synced replicaset \"%s/%s\" (%v/%v) to clusters", nsName, rs.Name, rs.Status.Replicas, *rs.Spec.Replicas))
+
+	return rs
+}
 
 // deleteAllReplicaSetsOrFail deletes all replicasets in the given namespace name.
 func deleteAllReplicaSetsOrFail(clientset *fedclientset.Clientset, nsName string) {
@@ -200,36 +253,18 @@ func deleteAllReplicaSetsOrFail(clientset *fedclientset.Clientset, nsName string
 // verifyCascadingDeletionForReplicaSet verifies that replicaSets are deleted
 // from underlying clusters when orphan dependents is false and they are not
 // deleted when orphan dependents is true.
-func verifyCascadingDeletionForReplicaSet(clientset *fedclientset.Clientset, clusters map[string]*cluster, orphanDependents *bool, nsName string) {
-	replicaSet := createReplicaSetOrFail(clientset, newReplicaSet(nsName, FederationReplicaSetPrefix, 5, nil))
-	replicaSetName := replicaSet.Name
-	// Check subclusters if the replicaSet was created there.
-	By(fmt.Sprintf("Waiting for replica sets %s to be created in all underlying clusters", replicaSetName))
-	err := wait.Poll(5*time.Second, 2*time.Minute, func() (bool, error) {
-		for _, cluster := range clusters {
-			_, err := cluster.Extensions().ReplicaSets(nsName).Get(replicaSetName, metav1.GetOptions{})
-			if err != nil && errors.IsNotFound(err) {
-				return false, nil
-			}
-			if err != nil {
-				return false, err
-			}
-		}
-		return true, nil
-	})
-	framework.ExpectNoError(err, "Not all replica sets created")
+func verifyCascadingDeletionForReplicaSet(clientset *fedclientset.Clientset, clusters map[string]*cluster, orphanDependents *bool, nsName, rsName string) {
+	By(fmt.Sprintf("Deleting replica set %s", rsName))
+	deleteReplicaSetOrFail(clientset, nsName, rsName, orphanDependents)
 
-	By(fmt.Sprintf("Deleting replica set %s", replicaSetName))
-	deleteReplicaSetOrFail(clientset, nsName, replicaSetName, orphanDependents)
-
-	By(fmt.Sprintf("Verifying replica sets %s in underlying clusters", replicaSetName))
+	By(fmt.Sprintf("Verifying replica sets %s in underlying clusters", rsName))
 	errMessages := []string{}
 	for clusterName, clusterClientset := range clusters {
-		_, err := clusterClientset.Extensions().ReplicaSets(nsName).Get(replicaSetName, metav1.GetOptions{})
+		_, err := clusterClientset.Extensions().ReplicaSets(nsName).Get(rsName, metav1.GetOptions{})
 		if (orphanDependents == nil || *orphanDependents == true) && errors.IsNotFound(err) {
-			errMessages = append(errMessages, fmt.Sprintf("unexpected NotFound error for replica set %s in cluster %s, expected replica set to exist", replicaSetName, clusterName))
+			errMessages = append(errMessages, fmt.Sprintf("unexpected NotFound error for replica set %s in cluster %s, expected replica set to exist", rsName, clusterName))
 		} else if (orphanDependents != nil && *orphanDependents == false) && (err == nil || !errors.IsNotFound(err)) {
-			errMessages = append(errMessages, fmt.Sprintf("expected NotFound error for replica set %s in cluster %s, got error: %v", replicaSetName, clusterName, err))
+			errMessages = append(errMessages, fmt.Sprintf("expected NotFound error for replica set %s in cluster %s, got error: %v", rsName, clusterName, err))
 		}
 	}
 	if len(errMessages) != 0 {
@@ -237,7 +272,8 @@ func verifyCascadingDeletionForReplicaSet(clientset *fedclientset.Clientset, clu
 	}
 }
 
-func generageFedRsPrefsWithWeight(clusters map[string]*cluster) (pref *federation.FederatedReplicaSetPreferences, replicas int32, expect map[string]int32) {
+func generateFedRSPrefsWithWeight(clusters map[string]*cluster) (pref *federation.FederatedReplicaSetPreferences, replicas int32, expect map[string]int32) {
+	By("Generating replicaset preferences with weights")
 	clusterNames := extraceClusterNames(clusters)
 	pref = &federation.FederatedReplicaSetPreferences{
 		Clusters: map[string]federation.ClusterReplicaSetPreferences{},
@@ -247,8 +283,9 @@ func generageFedRsPrefsWithWeight(clusters map[string]*cluster) (pref *federatio
 
 	for i, clusterName := range clusterNames {
 		if i != 0 { // do not set weight for cluster[0] thus it should have no replicas scheduled
-			clusterRsPref := pref.Clusters[clusterName]
-			clusterRsPref.Weight = int64(i)
+			pref.Clusters[clusterName] = federation.ClusterReplicaSetPreferences{
+				Weight: int64(i),
+			}
 			replicas += int32(i)
 			expect[clusterName] = int32(i)
 		}
@@ -256,7 +293,8 @@ func generageFedRsPrefsWithWeight(clusters map[string]*cluster) (pref *federatio
 	return
 }
 
-func generageFedRsPrefsWithMin(clusters map[string]*cluster) (pref *federation.FederatedReplicaSetPreferences, replicas int32, expect map[string]int32) {
+func generateFedRSPrefsWithMin(clusters map[string]*cluster) (pref *federation.FederatedReplicaSetPreferences, replicas int32, expect map[string]int32) {
+	By("Generating replicaset preferences with min replicas")
 	clusterNames := extraceClusterNames(clusters)
 	pref = &federation.FederatedReplicaSetPreferences{
 		Clusters: map[string]federation.ClusterReplicaSetPreferences{
@@ -268,9 +306,10 @@ func generageFedRsPrefsWithMin(clusters map[string]*cluster) (pref *federation.F
 
 	for i, clusterName := range clusterNames {
 		if i != 0 { // do not set weight and minReplicas for cluster[0] thus it should have no replicas scheduled
-			clusterRsPref := pref.Clusters[clusterName]
-			clusterRsPref.Weight = int64(1)
-			clusterRsPref.MinReplicas = int64(i + 2)
+			pref.Clusters[clusterName] = federation.ClusterReplicaSetPreferences{
+				Weight:      int64(1),
+				MinReplicas: int64(i + 2),
+			}
 			replicas += int32(i + 2)
 			expect[clusterName] = int32(i + 2)
 		}
@@ -281,7 +320,8 @@ func generageFedRsPrefsWithMin(clusters map[string]*cluster) (pref *federation.F
 	return
 }
 
-func generageFedRsPrefsWithMax(clusters map[string]*cluster) (pref *federation.FederatedReplicaSetPreferences, replicas int32, expect map[string]int32) {
+func generateFedRSPrefsWithMax(clusters map[string]*cluster) (pref *federation.FederatedReplicaSetPreferences, replicas int32, expect map[string]int32) {
+	By("Generating replicaset preferences with max replicas")
 	clusterNames := extraceClusterNames(clusters)
 	pref = &federation.FederatedReplicaSetPreferences{
 		Clusters: map[string]federation.ClusterReplicaSetPreferences{
@@ -293,10 +333,11 @@ func generageFedRsPrefsWithMax(clusters map[string]*cluster) (pref *federation.F
 
 	for i, clusterName := range clusterNames {
 		if i != 0 { // do not set maxReplicas for cluster[0] thus replicas exceeds the total maxReplicas turned to cluster[0]
-			clusterRsPref := pref.Clusters[clusterName]
-			clusterRsPref.Weight = int64(100)
 			maxReplicas := int64(i)
-			clusterRsPref.MaxReplicas = &maxReplicas
+			pref.Clusters[clusterName] = federation.ClusterReplicaSetPreferences{
+				Weight:      int64(100),
+				MaxReplicas: &maxReplicas,
+			}
 			replicas += int32(i)
 			expect[clusterName] = int32(i)
 		}
@@ -307,12 +348,13 @@ func generageFedRsPrefsWithMax(clusters map[string]*cluster) (pref *federation.F
 	return
 }
 
-func updateFedRePrefsRebalance(pref *federation.FederatedReplicaSetPreferences, rebalance bool) *federation.FederatedReplicaSetPreferences {
+func updateFedRSPrefsRebalance(pref *federation.FederatedReplicaSetPreferences, rebalance bool) *federation.FederatedReplicaSetPreferences {
 	pref.Rebalance = rebalance
 	return pref
 }
 
-func generageFedRsPrefsForRebalancing(clusters map[string]*cluster) (pref1, pref2 *federation.FederatedReplicaSetPreferences, replicas int32, expect1, expect2 map[string]int32) {
+func generateFedRSPrefsForRebalancing(clusters map[string]*cluster) (pref1, pref2 *federation.FederatedReplicaSetPreferences, replicas int32, expect1, expect2 map[string]int32) {
+	By("Generating replicaset for rebalancing")
 	clusterNames := extraceClusterNames(clusters)
 	replicas = 3
 
@@ -341,11 +383,12 @@ func generageFedRsPrefsForRebalancing(clusters map[string]*cluster) (pref1, pref
 
 func waitForReplicaSetOrFail(c *fedclientset.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster, expect map[string]int32) {
 	err := waitForReplicaSet(c, namespace, replicaSetName, clusters, expect)
-	framework.ExpectNoError(err, "Failed to verify replica set %q/%q, err: %v", namespace, replicaSetName, err)
+	framework.ExpectNoError(err, "Failed to verify replica set \"%s/%s\", err: %v", namespace, replicaSetName, err)
 }
 
 func waitForReplicaSet(c *fedclientset.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster, expect map[string]int32) error {
-	err := wait.Poll(10*time.Second, FederatedReplicaSetTimeout, func() (bool, error) {
+	framework.Logf("waitForReplicaSet: %s/%s; clusters: %v; expect: %v", namespace, replicaSetName, clusters, expect)
+	err := wait.Poll(10*time.Second, federatedReplicasetTimeout, func() (bool, error) {
 		frs, err := c.ReplicaSets(namespace).Get(replicaSetName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -354,21 +397,21 @@ func waitForReplicaSet(c *fedclientset.Clientset, namespace string, replicaSetNa
 		for _, cluster := range clusters {
 			rs, err := cluster.ReplicaSets(namespace).Get(replicaSetName, metav1.GetOptions{})
 			if err != nil && !errors.IsNotFound(err) {
-				By(fmt.Sprintf("Failed getting replicaset: %q/%q/%q, err: %v", cluster.name, namespace, replicaSetName, err))
+				framework.Logf("Failed getting replicaset: \"%s/%s/%s\", err: %v", cluster.name, namespace, replicaSetName, err)
 				return false, err
 			}
 			if errors.IsNotFound(err) {
 				if expect != nil && expect[cluster.name] > 0 {
-					By(fmt.Sprintf("Replicaset %q/%q/%q not created replicas: %v", cluster.name, namespace, replicaSetName, expect[cluster.name]))
+					framework.Logf("Replicaset \"%s/%s/%s\" with replica count %d does not exist", cluster.name, namespace, replicaSetName, expect[cluster.name])
 					return false, nil
 				}
 			} else {
 				if !equivalentReplicaSet(frs, rs) {
-					By(fmt.Sprintf("Replicaset meta or spec not match for cluster %q:\n    federation: %v\n    cluster: %v", cluster.name, frs, rs))
+					framework.Logf("Replicaset meta or spec does not match for cluster %q:\n    federation: %v\n    cluster: %v", cluster.name, frs, rs)
 					return false, nil
 				}
 				if expect != nil && *rs.Spec.Replicas < expect[cluster.name] {
-					By(fmt.Sprintf("Replicas not match for %q/%q/%q: expect: >= %v, actual: %v", cluster.name, namespace, replicaSetName, expect[cluster.name], *rs.Spec.Replicas))
+					framework.Logf("Replicas do not match for \"%s/%s/%s\": expected: >= %v, actual: %v", cluster.name, namespace, replicaSetName, expect[cluster.name], *rs.Spec.Replicas)
 					return false, nil
 				}
 				specReplicas += *rs.Spec.Replicas
@@ -376,13 +419,13 @@ func waitForReplicaSet(c *fedclientset.Clientset, namespace string, replicaSetNa
 			}
 		}
 		if *frs.Spec.Replicas == 0 && frs.Status.Replicas != 0 {
-			By(fmt.Sprintf("ReplicaSet %q/%q with zero replicas should match the status as no overflow happens: expected: 0, actual: %v", namespace, replicaSetName, frs.Status.Replicas))
+			framework.Logf("ReplicaSet \"%s/%s\" with zero replicas should match the status as no overflow happens: expected: 0, actual: %v", namespace, replicaSetName, frs.Status.Replicas)
 			return false, nil
 		}
 		if statusReplicas == frs.Status.Replicas && specReplicas >= *frs.Spec.Replicas {
 			return true, nil
 		}
-		By(fmt.Sprintf("Replicas not match, federation replicas: %v/%v, clusters replicas: %v/%v\n", *frs.Spec.Replicas, frs.Status.Replicas, specReplicas, statusReplicas))
+		framework.Logf("Replicas do not match, federation replicas: %v/%v, cluster replicas: %v/%v", frs.Status.Replicas, *frs.Spec.Replicas, statusReplicas, specReplicas)
 		return false, nil
 	})
 
@@ -426,19 +469,7 @@ func updateReplicaSetOrFail(clientset *fedclientset.Clientset, replicaset *v1bet
 	}
 	By(fmt.Sprintf("Updating federation replicaset %q in namespace %q", replicaset.Name, namespace))
 
-	var newRS *v1beta1.ReplicaSet
-	err := wait.Poll(5*time.Second, FederatedReplicaSetTimeout, func() (bool, error) {
-		var err error
-		newRS, err = clientset.ReplicaSets(namespace).Update(replicaset)
-		if !errors.IsConflict(err) {
-			if err != nil {
-				return false, err
-			}
-			return true, nil
-		}
-		framework.Logf("Retrying due to an update failure: %v", err)
-		return false, nil
-	})
+	newRS, err := clientset.ReplicaSets(namespace).Update(replicaset)
 	framework.ExpectNoError(err, "Updating replicaset %q in namespace %q", replicaset.Name, namespace)
 	By(fmt.Sprintf("Successfully updated federation replicaset %q in namespace %q", replicaset.Name, namespace))
 

--- a/test/e2e_federation/util.go
+++ b/test/e2e_federation/util.go
@@ -52,6 +52,7 @@ var (
 
 const (
 	federatedNamespaceTimeout    = 5 * time.Minute
+	federatedReplicasetTimeout   = 5 * time.Minute
 	federatedServiceTimeout      = 5 * time.Minute
 	federatedClustersWaitTimeout = 1 * time.Minute
 
@@ -551,7 +552,7 @@ func deleteBackendPodsOrFail(clusters map[string]*cluster, namespace string) {
 // waitForReplicatSetToBeDeletedOrFail waits for the named ReplicaSet in namespace to be deleted.
 // If the deletion fails, the enclosing test fails.
 func waitForReplicaSetToBeDeletedOrFail(clientset *fedclientset.Clientset, namespace string, replicaSet string) {
-	err := wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	err := wait.Poll(5*time.Second, federatedReplicasetTimeout, func() (bool, error) {
 		_, err := clientset.Extensions().ReplicaSets(namespace).Get(replicaSet, metav1.GetOptions{})
 		if err != nil && errors.IsNotFound(err) {
 			return true, nil


### PR DESCRIPTION
I think `should create replicasets and rebalance them` test is still flaky. I still don't know the source of this flakiness. I will continue hunting. But it is a lot less flaky than before (or perhaps it even never passed before?). This PR could be merged now and flake hunting can happen in parallel.

```release-note
NONE
```
