### PR TITLE
noticed typo in known-flags.txt

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -64,7 +64,6 @@ bench-pods
 bench-quiet
 bench-tasks
 bench-workers
-bind-addrsse
 bind-address
 bind-pods-burst
 bind-pods-qps


### PR DESCRIPTION
**What this PR does / why we need it**: looks like this was a typo that wasn't cleaned up

**Release note**:
```release-note
NONE
```
