### PR TITLE
Bump kube-addon-manager to v5.1.1

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,26 +15,26 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v5.1
+VERSION=v5.1.1
 
 # amd64 and arm has "stable" binaries pushed for v1.2, arm64 and ppc64le hasn't so they have to fetch the latest alpha
 # however, arm64 and ppc64le are very experimental right now, so it's okay
 ifeq ($(ARCH),amd64)
-	KUBECTL_VERSION?=v1.3.0-beta.2
+	KUBECTL_VERSION?=v1.3.10
 	BASEIMAGE?=python:2.7-slim
 endif
 ifeq ($(ARCH),arm)
-	KUBECTL_VERSION?=v1.3.0-beta.2
+	KUBECTL_VERSION?=v1.3.10
 	BASEIMAGE?=hypriot/rpi-python:2.7
 	QEMUARCH=arm
 endif
 ifeq ($(ARCH),arm64)
-	KUBECTL_VERSION?=v1.3.0-beta.2
+	KUBECTL_VERSION?=v1.3.10
 	BASEIMAGE?=aarch64/python:2.7-slim
 	QEMUARCH=aarch64
 endif
 ifeq ($(ARCH),ppc64le)
-	KUBECTL_VERSION?=v1.3.0-beta.2
+	KUBECTL_VERSION?=v1.3.10
 	BASEIMAGE?=ppc64le/python:2.7-slim
 	QEMUARCH=ppc64le
 endif

--- a/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-multinode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v5.1",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v5.1.1",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
+++ b/cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
@@ -11,7 +11,7 @@
     "containers": [
       {
         "name": "kube-addon-manager",
-        "image": "REGISTRY/kube-addon-manager-ARCH:v5.1",
+        "image": "REGISTRY/kube-addon-manager-ARCH:v5.1.1",
         "resources": {
           "requests": {
             "cpu": "5m",

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -11,7 +11,7 @@ spec:
   containers:
   - name: kube-addon-manager
     # When updating version also bump it in cluster/images/hyperkube/static-pods/addon-manager.json
-    image: gcr.io/google-containers/kube-addon-manager:v5.1
+    image: gcr.io/google-containers/kube-addon-manager:v5.1.1
     resources:
       requests:
         cpu: 5m


### PR DESCRIPTION
**What this PR does / why we need it**: the `kube-addon-manager:v5.1` image is pretty old (July 4 2016) and should be rebased on a newer version of its base image, `python:2.7-slim`. This PR just bumps the tag with no other code changes; pushing this image should rebase it on the latest `python:2.7-slim` image with no other changes.

**Special notes for your reviewer**:
Alternately, we could look into upgrading the 1.4 branch to a newer version of `kube-addon-manager`, ideally one which doesn't depend on python. That's probably a bit riskier of a change, though. cc @MrHohn to comment.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Updates base image used for `kube-addon-manager` to latest `python:2.7-slim` and embedded `kubectl` to `v1.3.10`. No functionality changes expected.
```

cc @timstclair 