### PR TITLE
Enable RollingUpdates for the fluentd daemonset addon

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -9,6 +9,8 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
     version: v2.0
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
In anticipation of needing to rev fluentd-gcp image versions in patch releases, we should enable rolling update so the new versions get rolled out in a timely manner.

/cc @ixdy 