### PR TITLE
discriminate more when parsing kube-env :(

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -1052,7 +1052,7 @@ function generate-certs {
 # $1 master env (kube-env of master; result of calling get-master-env)
 # $2 env key to use
 function get-env-val() {
-  local match=`(echo "${1}" | grep ${2}) || echo ""`
+  local match=`(echo "${1}" | grep -E "^${2}:") || echo ""`
   if [[ -z ${match} ]]; then
     echo ""
   fi


### PR DESCRIPTION
Exactly match the key. Right now CA_KEY matches ETCD_CA_KEY and we just pick the first because fml.

I HATE BASH

more fixes for kubelet rbac enablement upgrades.