### PR TITLE
Update ScaleIO volume plugin default readOnly value

### DIFF
--- a/pkg/volume/scaleio/sio_util.go
+++ b/pkg/volume/scaleio/sio_util.go
@@ -125,8 +125,8 @@ func applyConfigDefaults(config map[string]string) {
 	config[confKey.fsType] = defaultString(config[confKey.fsType], "xfs")
 	b, err = strconv.ParseBool(config[confKey.readOnly])
 	if err != nil {
-		glog.Warning(log("failed to parse param readOnly, setting it to true"))
-		b = true
+		glog.Warning(log("failed to parse param readOnly, setting it to false"))
+		b = false
 	}
 	config[confKey.readOnly] = strconv.FormatBool(b)
 }

--- a/pkg/volume/scaleio/sio_util_test.go
+++ b/pkg/volume/scaleio/sio_util_test.go
@@ -136,7 +136,7 @@ func TestUtilApplyConfigDefaults(t *testing.T) {
 	if data[confKey.sslEnabled] != "false" {
 		t.Error("Unexpected sslEnabled value")
 	}
-	if data[confKey.readOnly] != "true" {
+	if data[confKey.readOnly] != "false" {
 		t.Error("Unexpected readOnly value: ", data[confKey.readOnly])
 	}
 }

--- a/pkg/volume/scaleio/sio_volume.go
+++ b/pkg/volume/scaleio/sio_volume.go
@@ -263,8 +263,8 @@ func (v *sioVolume) Provision() (*api.PersistentVolume, error) {
 	}
 	readOnly, err := strconv.ParseBool(v.configData[confKey.readOnly])
 	if err != nil {
-		glog.Warning(log("failed to parse parameter readOnly, setting it to true"))
-		readOnly = true
+		glog.Warning(log("failed to parse parameter readOnly, setting it to false"))
+		readOnly = false
 	}
 
 	// describe created pv


### PR DESCRIPTION
This commit updates the code to set readOnly attribute to be set to false.

**What this PR does / why we need it**:
This PR is a minor fix that updates the default value of `readOnly` attribute to `false`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
