### PR TITLE
Change the junit file name format to `junit_image-name_id.xml`,

### DIFF
--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -114,7 +114,7 @@ func TestE2eNode(t *testing.T) {
 			glog.Errorf("Failed creating report directory: %v", err)
 		} else {
 			// Configure a junit reporter to write to the directory
-			junitFile := fmt.Sprintf("junit_%s%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode)
+			junitFile := fmt.Sprintf("junit_%s_%02d.xml", framework.TestContext.ReportPrefix, config.GinkgoConfig.ParallelNode)
 			junitPath := path.Join(reportDir, junitFile)
 			reporters = append(reporters, morereporters.NewJUnitReporter(junitPath))
 		}

--- a/test/e2e_node/jenkins/cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/cri_validation/image-config.yaml
@@ -2,7 +2,7 @@ images:
   containervm:
     image: e2e-node-containervm-v20161208-image # docker 1.11.2
     project: kubernetes-node-e2e-images
-  gci-family:
+  gci:
     image_regex: gci-stable-56-9000-84-2 # docker 1.11.2
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -15,7 +15,7 @@ images:
   containervm:
     image: e2e-node-containervm-v20161208-image # docker 1.11.2
     project: kubernetes-node-e2e-images
-  gci-family:
+  gci:
     image_regex: gci-stable-56-9000-84-2 # docker 1.11.2
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"

--- a/test/e2e_node/jenkins/non-cri_validation/image-config.yaml
+++ b/test/e2e_node/jenkins/non-cri_validation/image-config.yaml
@@ -2,7 +2,7 @@ images:
   containervm:
     image: e2e-node-containervm-v20161208-image # docker 1.11.2
     project: kubernetes-node-e2e-images
-  gci-family:
+  gci:
     image_regex: gci-beta-56-9000-80-0 # docker 1.11.2
     project: google-containers
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -198,8 +198,9 @@ func main() {
 					machine:  imageConfig.Machine,
 					tests:    imageConfig.Tests,
 				}
-				if isRegex {
-					name = shortName + "-" + image
+				if isRegex && len(images) > 1 {
+					// Use image name when shortName is not unique.
+					name = image
 				}
 				gceImages.images[name] = gceImage
 			}


### PR DESCRIPTION
With this, the junit file name will be `junit_image-name_id.xml:
```
junit_containervm_id.xml
junit_coreos-alpha_id.xml
junit_gci_id.xml
junit_ubuntu-docker10_id.xml
junit_ubuntu-docker12_id.xml
```

The test infra team will use the `image-name` inside the junit file name and replace the original `[1] [2] [3] ..` with the actual image name.

This will make it a little bit easier for debugging.

/cc @dchen1107 @krzyzacy @kubernetes/sig-node-pr-reviews 
/cc @kubernetes/release-maintainers This is a minor test only change to make it easier to debug issues.