### PR TITLE
initial subsets before compare

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -459,6 +459,7 @@ func (e *EndpointController) syncService(key string) error {
 					Name:   service.Name,
 					Labels: service.Labels,
 				},
+				Subsets:	[]v1.EndpointSubset{},
 			}
 		} else {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
issue:[#42798](https://github.com/kubernetes/kubernetes/issues/42798)  endpointscontroller calls reflect.DeepEqual(currentEndpoints.Subsets , subsets) always return false because they're one initialized and another not.  
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
issue:[#42798](https://github.com/kubernetes/kubernetes/issues/42798)
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
