### PR TITLE
Fix revision when SetDeploymentRevision

### DIFF
--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -287,9 +287,7 @@ func TestReentrantRollback(t *testing.T) {
 	d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
 
 	d.Spec.RollbackTo = &extensions.RollbackConfig{Revision: 0}
-	// TODO: This is 1 for now until FindOldReplicaSets gets fixed.
-	// See https://github.com/kubernetes/kubernetes/issues/42570.
-	d.Annotations = map[string]string{util.RevisionAnnotation: "1"}
+	d.Annotations = map[string]string{util.RevisionAnnotation: "2"}
 	f.dLister = append(f.dLister, d)
 
 	rs1 := newReplicaSet(d, "deploymentrs-old", 0)

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -259,7 +259,8 @@ func (dc *DeploymentController) getNewReplicaSet(deployment *extensions.Deployme
 			return dc.client.Extensions().ReplicaSets(rsCopy.ObjectMeta.Namespace).Update(rsCopy)
 		}
 
-		updateConditions := deploymentutil.SetDeploymentRevision(deployment, newRevision)
+		// Should use the revision in existingNewRS's annotation, since it set by before
+		updateConditions := deploymentutil.SetDeploymentRevision(deployment, rsCopy.Annotations[deploymentutil.RevisionAnnotation])
 		// If no other Progressing condition has been recorded and we need to estimate the progress
 		// of this deployment then it is likely that old users started caring about progress. In that
 		// case we need to take into account the first time we noticed their new replica set.


### PR DESCRIPTION
When some oldRSs be deleted or cleared(eg. revisionHistoryLimit set 0), the revision for  SetDeploymentRevision is incorrect