### PR TITLE
Update generator's default value

### DIFF
--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -477,8 +477,8 @@ const (
 	SecretForDockerRegistryV1GeneratorName = "secret-for-docker-registry/v1"
 	SecretForTLSV1GeneratorName            = "secret-for-tls/v1"
 	ConfigMapV1GeneratorName               = "configmap/v1"
-	ClusterRoleBindingV1GeneratorName      = "clusterrolebinding.rbac.authorization.k8s.io/v1alpha1"
-	RoleBindingV1GeneratorName             = "rolebinding.rbac.authorization.k8s.io/v1alpha1"
+	ClusterRoleBindingV1GeneratorName      = "clusterrolebinding.rbac.authorization.k8s.io/v1beta1"
+	RoleBindingV1GeneratorName             = "rolebinding.rbac.authorization.k8s.io/v1beta1"
 	ClusterV1Beta1GeneratorName            = "cluster/v1beta1"
 	PodDisruptionBudgetV1GeneratorName     = "poddisruptionbudget/v1beta1"
 )


### PR DESCRIPTION
Now rbac has upgraded to v1beta1. So "v1beta1" would be a better
default name for users.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
