### PR TITLE
StatefulSet supports all kinds of RestartPolicy

### DIFF
--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -83,10 +83,6 @@ func ValidateStatefulSetSpec(spec *apps.StatefulSetSpec, fldPath *field.Path) fi
 		allErrs = append(allErrs, ValidatePodTemplateSpecForStatefulSet(&spec.Template, selector, fldPath.Child("template"))...)
 	}
 
-	if spec.Template.Spec.RestartPolicy != api.RestartPolicyAlways {
-		allErrs = append(allErrs, field.NotSupported(fldPath.Child("template", "spec", "restartPolicy"), spec.Template.Spec.RestartPolicy, []string{string(api.RestartPolicyAlways)}))
-	}
-
 	return allErrs
 }
 

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -152,44 +152,6 @@ func TestValidateStatefulSet(t *testing.T) {
 				Template: validPodTemplate.Template,
 			},
 		},
-		"invalid restart policy 1": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: metav1.NamespaceDefault,
-			},
-			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: api.PodTemplateSpec{
-					Spec: api.PodSpec{
-						RestartPolicy: api.RestartPolicyOnFailure,
-						DNSPolicy:     api.DNSClusterFirst,
-						Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: validLabels,
-					},
-				},
-			},
-		},
-		"invalid restart policy 2": {
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "abc-123",
-				Namespace: metav1.NamespaceDefault,
-			},
-			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: api.PodTemplateSpec{
-					Spec: api.PodSpec{
-						RestartPolicy: api.RestartPolicyNever,
-						DNSPolicy:     api.DNSClusterFirst,
-						Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: validLabels,
-					},
-				},
-			},
-		},
 	}
 	for k, v := range errorCases {
 		errs := ValidateStatefulSet(&v)

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -62,7 +62,7 @@ func (ssc *defaultStatefulSetControl) UpdateStatefulSet(set *apps.StatefulSet, p
 	// First we partition pods into two lists valid replicas and condemned Pods
 	for i := range pods {
 		//count the number of running and ready replicas
-		if isRunningAndReady(pods[i]) {
+		if isAlive(pods[i]) {
 			ready++
 		}
 		if ord := getOrdinal(pods[i]); 0 <= ord && ord < replicaCount {
@@ -135,7 +135,7 @@ func (ssc *defaultStatefulSetControl) UpdateStatefulSet(set *apps.StatefulSet, p
 		// If we have a Pod that has been created but is not running and ready we can not make progress.
 		// We must ensure that all for each Pod, when we create it, all of its predecessors, with respect to its
 		// ordinal, are Running and Ready.
-		if !isRunningAndReady(replicas[i]) {
+		if !isAlive(replicas[i]) {
 			glog.V(2).Infof("StatefulSet %s is waiting for Pod %s to be Running and Ready",
 				set.Name, replicas[i].Name)
 			return nil

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -857,7 +857,7 @@ func assertInvariants(set *apps.StatefulSet, spc *fakeStatefulPodControl) error 
 	}
 	sort.Sort(ascendingOrdinal(pods))
 	for ord := 0; ord < len(pods); ord++ {
-		if ord > 0 && isRunningAndReady(pods[ord]) && !isRunningAndReady(pods[ord-1]) {
+		if ord > 0 && isAlive(pods[ord]) && !isAlive(pods[ord-1]) {
 			return fmt.Errorf("Predecessor %s is Running and Ready while %s is not",
 				pods[ord-1].Name,
 				pods[ord].Name)


### PR DESCRIPTION
**What this PR does / why we need it**:

Make StatefulSet to support all kinds of PodSpec.RestartPolicy, instead of allowing "Always" only.
We can allow the Pods in StatefulSet to use "OnFailure" and "Never" to exit when their work is done, instead of restarting over and over again.
In the meantime, it still follows the definition of StatefulSet, which is ordered and stateful.
To implement this, we only need to change the way how we determine a Pod is alive for different RestartPolicy.

**Special notes for your reviewer**:

A simple use-case:

In machine learning, for training a model in distributed way, we define a bunch of ordered stateful container workers, e.g. "worker-0" "worker-1" ... "worker-n". (They use numbers as their suffix. StatefulSet can manage these continuous numbers for us.)
When training begins, these containers talk to each other by their DNS records. (StatefulSet can help us to make their DNS records.)
When the training is done, all the workers save the result into their persistent volumes and `exit 0`. (StatefulSet helps us to manage their PVs.)
Then, all the stateful Pods stop there in success state, and we still can check their logs.

You see, this is a suitable scene to use StatefulSet, and it is really helpful to allow to use "OnFailure" and "Never" RestartPolicy in StatefulSet.



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
StatefulSet supports pod restart policy: "OnFailure" and "Never"
```
