### PR TITLE
kubelet: partially revert #42585

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -687,7 +687,7 @@ func (kl *Kubelet) podIsTerminated(pod *v1.Pod) bool {
 		// restarted.
 		status = pod.Status
 	}
-	return status.Phase == v1.PodFailed || status.Phase == v1.PodSucceeded || (pod.DeletionTimestamp != nil && notRunning(status.ContainerStatuses))
+	return status.Phase == v1.PodFailed || status.Phase == v1.PodSucceeded
 }
 
 // OkToDeletePod returns true if all required node-level resources that a pod was consuming have


### PR DESCRIPTION
Even if the deletion timestamp is set and no containers are currently
running, the pod worker may still be in the process of recreating those
pods. Continue dispatch work to the pod worker to make sure deletion of
containers are completed.

