### PR TITLE
[Federation] Automate configuring nameserver in cluster-dns for CoreDNS provider

### DIFF
--- a/federation/pkg/dnsprovider/providers/coredns/coredns.go
+++ b/federation/pkg/dnsprovider/providers/coredns/coredns.go
@@ -36,8 +36,9 @@ const (
 // Config to override defaults
 type Config struct {
 	Global struct {
-		EtcdEndpoints string `gcfg:"etcd-endpoints"`
-		DNSZones      string `gcfg:"zones"`
+		EtcdEndpoints    string `gcfg:"etcd-endpoints"`
+		DNSZones         string `gcfg:"zones"`
+		CoreDNSEndpoints string `gcfg:"coredns-endpoints"`
 	}
 }
 

--- a/federation/pkg/kubefed/init/BUILD
+++ b/federation/pkg/kubefed/init/BUILD
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//federation/apis/federation:go_default_library",
+        "//federation/pkg/dnsprovider/providers/coredns:go_default_library",
         "//federation/pkg/kubefed/util:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
@@ -27,6 +28,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
@@ -46,6 +48,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//federation/apis/federation:go_default_library",
+        "//federation/pkg/dnsprovider/providers/coredns:go_default_library",
         "//federation/pkg/kubefed/testing:go_default_library",
         "//federation/pkg/kubefed/util:go_default_library",
         "//pkg/api:go_default_library",
@@ -57,6 +60,7 @@ go_test(
         "//pkg/apis/rbac/v1beta1:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
+        "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/federation/apis/federation"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns"
 	kubefedtesting "k8s.io/kubernetes/federation/pkg/kubefed/testing"
 	"k8s.io/kubernetes/federation/pkg/kubefed/util"
 	"k8s.io/kubernetes/pkg/api"
@@ -55,6 +56,8 @@ import (
 	rbacv1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+
+	"gopkg.in/gcfg.v1"
 )
 
 const (
@@ -74,7 +77,6 @@ const (
 
 func TestInitFederation(t *testing.T) {
 	cmdErrMsg := ""
-	dnsProvider := "google-clouddns"
 	cmdutil.BehaviorOnFatal(func(str string, code int) {
 		cmdErrMsg = str
 	})
@@ -97,6 +99,7 @@ func TestInitFederation(t *testing.T) {
 		etcdPVCapacity               string
 		etcdPersistence              string
 		expectedErr                  string
+		dnsProvider                  string
 		dnsProviderConfig            string
 		dryRun                       string
 		apiserverArgOverrides        string
@@ -116,6 +119,7 @@ func TestInitFederation(t *testing.T) {
 			etcdPVCapacity:        "5Gi",
 			etcdPersistence:       "true",
 			expectedErr:           "",
+			dnsProvider:           util.FedDNSProviderCoreDNS,
 			dnsProviderConfig:     "dns-provider.conf",
 			dryRun:                "",
 			apiserverArgOverrides: "--client-ca-file=override,--log-dir=override",
@@ -210,6 +214,9 @@ func TestInitFederation(t *testing.T) {
 		tmpDirPath := ""
 		buf := bytes.NewBuffer([]byte{})
 
+		if tc.dnsProvider == "" {
+			tc.dnsProvider = "google-clouddns"
+		}
 		if tc.dnsProviderConfig != "" {
 			tmpfile, err := ioutil.TempFile("", tc.dnsProviderConfig)
 			if err != nil {
@@ -227,7 +234,7 @@ func TestInitFederation(t *testing.T) {
 		}
 		defer os.Remove(tmpDirPath)
 
-		hostFactory, err := fakeInitHostFactory(tc.apiserverServiceType, tc.federation, util.DefaultFederationSystemNamespace, tc.advertiseAddress, tc.lbIP, tc.dnsZoneName, tc.image, dnsProvider, tc.dnsProviderConfig, tc.etcdPersistence, tc.etcdPVCapacity, tc.apiserverArgOverrides, tc.cmArgOverrides, tmpDirPath, tc.apiserverEnableHTTPBasicAuth, tc.apiserverEnableTokenAuth, tc.isRBACAPIAvailable)
+		hostFactory, err := fakeInitHostFactory(tc.apiserverServiceType, tc.federation, util.DefaultFederationSystemNamespace, tc.advertiseAddress, tc.lbIP, tc.dnsZoneName, tc.image, tc.dnsProvider, tc.dnsProviderConfig, tc.etcdPersistence, tc.etcdPVCapacity, tc.apiserverArgOverrides, tc.cmArgOverrides, tmpDirPath, tc.apiserverEnableHTTPBasicAuth, tc.apiserverEnableTokenAuth, tc.isRBACAPIAvailable)
 		if err != nil {
 			t.Fatalf("[%d] unexpected error: %v", i, err)
 		}
@@ -243,7 +250,7 @@ func TestInitFederation(t *testing.T) {
 		cmd.Flags().Set("host-cluster-context", "substrate")
 		cmd.Flags().Set("dns-zone-name", tc.dnsZoneName)
 		cmd.Flags().Set("image", tc.image)
-		cmd.Flags().Set("dns-provider", dnsProvider)
+		cmd.Flags().Set("dns-provider", tc.dnsProvider)
 		cmd.Flags().Set("apiserver-arg-overrides", tc.apiserverArgOverrides)
 		cmd.Flags().Set("controllermanager-arg-overrides", tc.cmArgOverrides)
 
@@ -1043,6 +1050,12 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 	}
 	if dnsProviderConfig != "" {
 		cm = addDNSProviderConfigTest(cm, cmDNSProviderSecret.Name)
+		if dnsProvider == util.FedDNSProviderCoreDNS {
+			cm, err = addCoreDNSServerAnnotationTest(cm, dnsZoneName, dnsProviderConfig)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	podList := v1.PodList{}
@@ -1539,4 +1552,17 @@ func addDNSProviderConfigTest(dep *v1beta1.Deployment, secretName string) *v1bet
 	dep.Spec.Template.Spec.Containers[0].Command = append(dep.Spec.Template.Spec.Containers[0].Command, fmt.Sprintf("--dns-provider-config=%s/%s", dnsProviderConfigMountPath, secretName))
 
 	return dep
+}
+
+// TODO: Reuse the function addCoreDNSServerAnnotation once that function is converted to use versioned objects.
+func addCoreDNSServerAnnotationTest(deployment *v1beta1.Deployment, dnsZoneName, dnsProviderConfig string) (*v1beta1.Deployment, error) {
+	var cfg coredns.Config
+	if err := gcfg.ReadFileInto(&cfg, dnsProviderConfig); err != nil {
+		return nil, err
+	}
+
+	deployment.Annotations[util.FedDNSZoneName] = dnsZoneName
+	deployment.Annotations[util.FedNameServer] = cfg.Global.CoreDNSEndpoints
+	deployment.Annotations[util.FedDNSProvider] = util.FedDNSProviderCoreDNS
+	return deployment, nil
 }

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -44,8 +44,13 @@ const (
 	KubeconfigSecretDataKey = "kubeconfig"
 
 	// Used in and to create the kube-dns configmap storing the zone info
-	FedDomainMapKey      = "federations"
-	KubeDnsConfigmapName = "kube-dns"
+	FedDomainMapKey       = "federations"
+	KubeDnsConfigmapName  = "kube-dns"
+	FedDNSZoneName        = "dns-zone-name"
+	FedNameServer         = "nameserver"
+	FedDNSProvider        = "dns-provider"
+	FedDNSProviderCoreDNS = "coredns"
+	KubeDnsStubDomains    = "stubDomains"
 
 	// DefaultFederationSystemNamespace is the namespace in which
 	// federation system components are hosted.


### PR DESCRIPTION
Addresses issue #42894 #42822

**Release note**:
```
[Federation] CoreDNS server will be automatically added to nameserver resolv.conf chain When using CoreDNS as dns provider for federation during federation join.
```
cc @madhusudancs @kubernetes/sig-federation-bugs 