### PR TITLE
require codecfactory

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -249,7 +249,7 @@ func BuildMasterConfig(s *options.ServerRunOptions) (*master.Config, informers.S
 
 // BuildGenericConfig takes the master server options and produces the genericapiserver.Config associated with it
 func BuildGenericConfig(s *options.ServerRunOptions) (*genericapiserver.Config, informers.SharedInformerFactory, error) {
-	genericConfig := genericapiserver.NewConfig().WithSerializer(api.Codecs)
+	genericConfig := genericapiserver.NewConfig(api.Codecs)
 	if err := s.GenericServerRunOptions.ApplyTo(genericConfig); err != nil {
 		return nil, nil, err
 	}

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -98,9 +98,7 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 		return utilerrors.NewAggregate(errs)
 	}
 
-	genericConfig := genericapiserver.NewConfig().
-		WithSerializer(api.Codecs)
-
+	genericConfig := genericapiserver.NewConfig(api.Codecs)
 	if err := s.GenericServerRunOptions.ApplyTo(genericConfig); err != nil {
 		return err
 	}

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -64,7 +64,7 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	server, storageConfig := etcdtesting.NewUnsecuredEtcd3TestClientServer(t, api.Scheme)
 
 	config := &Config{
-		GenericConfig:           genericapiserver.NewConfig().WithSerializer(api.Codecs),
+		GenericConfig:           genericapiserver.NewConfig(api.Codecs),
 		APIResourceConfigSource: DefaultAPIResourceConfigSource(),
 		APIServerServicePort:    443,
 		MasterCount:             1,

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -195,8 +195,9 @@ type SecureServingInfo struct {
 }
 
 // NewConfig returns a Config struct with the default values
-func NewConfig() *Config {
+func NewConfig(codecs serializer.CodecFactory) *Config {
 	return &Config{
+		Serializer:                  codecs,
 		ReadWritePort:               443,
 		RequestContextMapper:        apirequest.NewRequestContextMapper(),
 		BuildHandlerChainsFunc:      DefaultBuildHandlerChain,
@@ -212,11 +213,6 @@ func NewConfig() *Config {
 		// Generic API servers have no inherent long-running subresources
 		LongRunningFunc: genericfilters.BasicLongRunningRequestCheck(sets.NewString("watch"), sets.NewString()),
 	}
-}
-
-func (c *Config) WithSerializer(codecs serializer.CodecFactory) *Config {
-	c.Serializer = codecs
-	return c
 }
 
 func DefaultOpenAPIConfig(getDefinitions openapicommon.GetOpenAPIDefinitions, scheme *runtime.Scheme) *openapicommon.Config {

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -33,7 +33,7 @@ import (
 )
 
 func TestNewWithDelegate(t *testing.T) {
-	delegateConfig := NewConfig().WithSerializer(codecs)
+	delegateConfig := NewConfig(codecs)
 	delegateConfig.PublicAddress = net.ParseIP("192.168.10.4")
 	delegateConfig.RequestContextMapper = genericapirequest.NewRequestContextMapper()
 	delegateConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
@@ -63,7 +63,7 @@ func TestNewWithDelegate(t *testing.T) {
 	// this wires up swagger
 	delegateServer.PrepareRun()
 
-	wrappingConfig := NewConfig().WithSerializer(codecs)
+	wrappingConfig := NewConfig(codecs)
 	wrappingConfig.PublicAddress = net.ParseIP("192.168.10.4")
 	wrappingConfig.RequestContextMapper = genericapirequest.NewRequestContextMapper()
 	wrappingConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -86,7 +86,7 @@ func testGetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi
 func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
 	etcdServer, _ := etcdtesting.NewUnsecuredEtcd3TestClientServer(t, scheme)
 
-	config := NewConfig().WithSerializer(codecs)
+	config := NewConfig(codecs)
 	config.PublicAddress = net.ParseIP("192.168.10.4")
 	config.RequestContextMapper = genericapirequest.NewRequestContextMapper()
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")

--- a/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
@@ -19,6 +19,7 @@ package options
 import (
 	"github.com/spf13/pflag"
 
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/server"
 )
 
@@ -29,7 +30,7 @@ type FeatureOptions struct {
 }
 
 func NewFeatureOptions() *FeatureOptions {
-	defaults := server.NewConfig()
+	defaults := server.NewConfig(serializer.CodecFactory{})
 
 	return &FeatureOptions{
 		EnableProfiling:           defaults.EnableProfiling,

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/server"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -48,7 +49,7 @@ type ServerRunOptions struct {
 }
 
 func NewServerRunOptions() *ServerRunOptions {
-	defaults := server.NewConfig()
+	defaults := server.NewConfig(serializer.CodecFactory{})
 
 	return &ServerRunOptions{
 		AdmissionControl:            "AlwaysAdmit",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -46,7 +46,7 @@ func setUp(t *testing.T) Config {
 	scheme := runtime.NewScheme()
 	codecs := serializer.NewCodecFactory(scheme)
 
-	config := NewConfig().WithSerializer(codecs)
+	config := NewConfig(codecs)
 	config.RequestContextMapper = genericapirequest.NewRequestContextMapper()
 
 	return *config

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -114,8 +114,7 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 
-	serverConfig := genericapiserver.NewConfig().
-		WithSerializer(apiserver.Codecs)
+	serverConfig := genericapiserver.NewConfig(apiserver.Codecs)
 
 	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
 		return err

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -90,7 +90,7 @@ func (o WardleServerOptions) Config() (*apiserver.Config, error) {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 
-	serverConfig := genericapiserver.NewConfig().WithSerializer(apiserver.Codecs)
+	serverConfig := genericapiserver.NewConfig(apiserver.Codecs)
 	if err := o.RecommendedOptions.ApplyTo(serverConfig); err != nil {
 		return nil, err
 	}

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -358,7 +358,7 @@ func NewMasterConfig() *master.Config {
 		"",
 		ns)
 
-	genericConfig := genericapiserver.NewConfig().WithSerializer(api.Codecs)
+	genericConfig := genericapiserver.NewConfig(api.Codecs)
 	kubeVersion := version.Get()
 	genericConfig.Version = &kubeVersion
 	genericConfig.Authorizer = authorizerfactory.NewAlwaysAllowAuthorizer()

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -10742,6 +10742,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/apimachinery/pkg/runtime/serializer",
         "//vendor:k8s.io/apimachinery/pkg/util/net",
         "//vendor:k8s.io/apiserver/pkg/admission",
         "//vendor:k8s.io/apiserver/pkg/authentication/authenticatorfactory",


### PR DESCRIPTION
The genericapiserver requires a codec to start.  Help new comers to the API by forcing them to set it when they create a new config.

