### PR TITLE
Update cadvisor godeps to v0.25.0

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "k8s.io/kubernetes",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v79",
+	"GodepVersion": "v74",
 	"Packages": [
 		"github.com/ugorji/go/codec/codecgen",
 		"github.com/onsi/ginkgo/ginkgo",
@@ -1186,203 +1186,203 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/tail",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.24.0-alpha1-82-gc30a9e7",
-			"Rev": "c30a9e7d3642fffb422f08be34a7bbc15d69cdbf"
+			"Comment": "v0.25.0",
+			"Rev": "17543becf9053e7e80806a57b05002a88c79ec8a"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",
@@ -2057,6 +2057,7 @@
 		},
 		{
 			"ImportPath": "github.com/pelletier/go-buffruneio",
+			"Comment": "v0.1.0",
 			"Rev": "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d"
 		},
 		{

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -1108,6 +1108,35 @@ go_library(
 )
 
 go_library(
+    name = "github.com/codedellemc/goscaleio",
+    srcs = [
+        "github.com/codedellemc/goscaleio/api.go",
+        "github.com/codedellemc/goscaleio/certs.go",
+        "github.com/codedellemc/goscaleio/device.go",
+        "github.com/codedellemc/goscaleio/instance.go",
+        "github.com/codedellemc/goscaleio/protectiondomain.go",
+        "github.com/codedellemc/goscaleio/scsiinitiator.go",
+        "github.com/codedellemc/goscaleio/sdc.go",
+        "github.com/codedellemc/goscaleio/sds.go",
+        "github.com/codedellemc/goscaleio/storagepool.go",
+        "github.com/codedellemc/goscaleio/system.go",
+        "github.com/codedellemc/goscaleio/user.go",
+        "github.com/codedellemc/goscaleio/volume.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:github.com/Sirupsen/logrus",
+        "//vendor:github.com/codedellemc/goscaleio/types/v1",
+    ],
+)
+
+go_library(
+    name = "github.com/codedellemc/goscaleio/types/v1",
+    srcs = ["github.com/codedellemc/goscaleio/types/v1/types.go"],
+    tags = ["automanaged"],
+)
+
+go_library(
     name = "github.com/codegangsta/negroni",
     srcs = [
         "github.com/codegangsta/negroni/doc.go",
@@ -10107,6 +10136,13 @@ go_library(
     ],
 )
 
+go_test(
+    name = "k8s.io/apiserver/pkg/endpoints/metrics_test",
+    srcs = ["k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go"],
+    library = ":k8s.io/apiserver/pkg/endpoints/metrics",
+    tags = ["automanaged"],
+)
+
 go_library(
     name = "k8s.io/apiserver/pkg/endpoints/metrics",
     srcs = ["k8s.io/apiserver/pkg/endpoints/metrics/metrics.go"],
@@ -16251,13 +16287,6 @@ go_library(
     tags = ["automanaged"],
 )
 
-go_test(
-    name = "k8s.io/apiserver/pkg/endpoints/metrics_test",
-    srcs = ["k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go"],
-    library = ":k8s.io/apiserver/pkg/endpoints/metrics",
-    tags = ["automanaged"],
-)
-
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -16268,34 +16297,5 @@ filegroup(
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
-    tags = ["automanaged"],
-)
-
-go_library(
-    name = "github.com/codedellemc/goscaleio",
-    srcs = [
-        "github.com/codedellemc/goscaleio/api.go",
-        "github.com/codedellemc/goscaleio/certs.go",
-        "github.com/codedellemc/goscaleio/device.go",
-        "github.com/codedellemc/goscaleio/instance.go",
-        "github.com/codedellemc/goscaleio/protectiondomain.go",
-        "github.com/codedellemc/goscaleio/scsiinitiator.go",
-        "github.com/codedellemc/goscaleio/sdc.go",
-        "github.com/codedellemc/goscaleio/sds.go",
-        "github.com/codedellemc/goscaleio/storagepool.go",
-        "github.com/codedellemc/goscaleio/system.go",
-        "github.com/codedellemc/goscaleio/user.go",
-        "github.com/codedellemc/goscaleio/volume.go",
-    ],
-    tags = ["automanaged"],
-    deps = [
-        "//vendor:github.com/Sirupsen/logrus",
-        "//vendor:github.com/codedellemc/goscaleio/types/v1",
-    ],
-)
-
-go_library(
-    name = "github.com/codedellemc/goscaleio/types/v1",
-    srcs = ["github.com/codedellemc/goscaleio/types/v1/types.go"],
     tags = ["automanaged"],
 )

--- a/vendor/github.com/google/cadvisor/container/docker/handler.go
+++ b/vendor/github.com/google/cadvisor/container/docker/handler.go
@@ -252,9 +252,11 @@ func newDockerContainerHandler(
 	// split env vars to get metadata map.
 	for _, exposedEnv := range metadataEnvs {
 		for _, envVar := range ctnr.Config.Env {
-			splits := strings.SplitN(envVar, "=", 2)
-			if splits[0] == exposedEnv {
-				handler.envs[strings.ToLower(exposedEnv)] = splits[1]
+			if envVar != "" {
+				splits := strings.SplitN(envVar, "=", 2)
+				if len(splits) == 2 && splits[0] == exposedEnv {
+					handler.envs[strings.ToLower(exposedEnv)] = splits[1]
+				}
 			}
 		}
 	}

--- a/vendor/github.com/google/cadvisor/devicemapper/util.go
+++ b/vendor/github.com/google/cadvisor/devicemapper/util.go
@@ -22,14 +22,10 @@ import (
 // ThinLsBinaryPresent returns the location of the thin_ls binary in the mount
 // namespace cadvisor is running in or an error.  The locations checked are:
 //
+// - /sbin/
 // - /bin/
 // - /usr/sbin/
 // - /usr/bin/
-//
-// ThinLsBinaryPresent checks these paths relative to:
-//
-// 1. For non-containerized operation - `/`
-// 2. For containerized operation - `/rootfs`
 //
 // The thin_ls binary is provided by the device-mapper-persistent-data
 // package.
@@ -39,17 +35,10 @@ func ThinLsBinaryPresent() (string, error) {
 		err        error
 	)
 
-	for _, path := range []string{"/bin", "/usr/sbin/", "/usr/bin"} {
+	for _, path := range []string{"/sbin", "/bin", "/usr/sbin/", "/usr/bin"} {
 		// try paths for non-containerized operation
 		// note: thin_ls is most likely a symlink to pdata_tools
 		thinLsPath = filepath.Join(path, "thin_ls")
-		_, err = os.Stat(thinLsPath)
-		if err == nil {
-			return thinLsPath, nil
-		}
-
-		// try paths for containerized operation
-		thinLsPath = filepath.Join("/rootfs", thinLsPath)
 		_, err = os.Stat(thinLsPath)
 		if err == nil {
 			return thinLsPath, nil


### PR DESCRIPTION
Completes #42008, a 1.6 issue.

The cadvisor changes include only a couple minor bug fixes, mainly for the devicemapper storage driver.

cc @dchen1107 

```release-note
Disable devicemapper thin_ls due to excessive iops
```