### PR TITLE
Add fabianofranz as approver for test/e2e/kubectl.go

### DIFF
--- a/test/OWNERS
+++ b/test/OWNERS
@@ -30,3 +30,4 @@ approvers:
   - gmarek
   - soltysh
   - pwittrock # for test/e2e/kubectl.go
+  - fabianofranz # for test/e2e/kubectl.go


### PR DESCRIPTION
Adding myself as approver for `kubectl` end-to-end tests.

```release-note
NONE
```
