### PR TITLE
[Federation] Deployments unaware of ReadyReplicas

### DIFF
--- a/federation/pkg/federation-controller/deployment/deploymentcontroller.go
+++ b/federation/pkg/federation-controller/deployment/deploymentcontroller.go
@@ -596,11 +596,13 @@ func (fdc *DeploymentController) reconcileDeployment(key string) (reconciliation
 			fedStatus.Replicas += currentLd.Status.Replicas
 			fedStatus.AvailableReplicas += currentLd.Status.AvailableReplicas
 			fedStatus.UnavailableReplicas += currentLd.Status.UnavailableReplicas
+			fedStatus.ReadyReplicas += currentLd.Status.ReadyReplicas
 		}
 	}
 	if fedStatus.Replicas != fd.Status.Replicas ||
 		fedStatus.AvailableReplicas != fd.Status.AvailableReplicas ||
-		fedStatus.UnavailableReplicas != fd.Status.UnavailableReplicas {
+		fedStatus.UnavailableReplicas != fd.Status.UnavailableReplicas ||
+		fedStatus.ReadyReplicas != fd.Status.ReadyReplicas {
 		fd.Status = fedStatus
 		_, err = fdc.fedClient.Extensions().Deployments(fd.Namespace).UpdateStatus(fd)
 		if err != nil {

--- a/test/e2e_federation/deployment.go
+++ b/test/e2e_federation/deployment.go
@@ -245,11 +245,11 @@ func updateDeploymentOrFail(clientset *fedclientset.Clientset, namespace string)
 
 	deployment := newDeploymentForFed(namespace, FederationDeploymentName, 15)
 
-	newRs, err := clientset.Deployments(namespace).Update(deployment)
+	newDeployment, err := clientset.Deployments(namespace).Update(deployment)
 	framework.ExpectNoError(err, "Updating deployment %q in namespace %q", deployment.Name, namespace)
 	By(fmt.Sprintf("Successfully updated federation deployment %q in namespace %q", FederationDeploymentName, namespace))
 
-	return newRs
+	return newDeployment
 }
 
 func deleteDeploymentOrFail(clientset *fedclientset.Clientset, nsName string, deploymentName string, orphanDependents *bool) {


### PR DESCRIPTION
The Deployment controller was not propagating ReadyReplicas to underlying clusters causing these errors:
```
Error syncing cluster controller: Deployment.apps "federation-deployment" is invalid: status.availableReplicas: Invalid value: 5: cannot be greater than readyReplicas
```

This was caught in e2e testing and is a 1.6 regression for support that was added in #37959. Without this fix, users will be unable to scale up their deployments.