### PR TITLE
Bump cluster-proportional-autoscaler to 1.1.1-r2

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1
+        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1-r2
         resources:
             requests:
                 cpu: "20m"


### PR DESCRIPTION
```release-note
Patch CVE-2016-8859 in gcr.io/google-containers/cluster-proportional-autoscaler-amd64
```

/cc @ixdy 