### PR TITLE
Patch CVE-2016-8859 in alpine based images

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,7 +15,7 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v6.1
+VERSION=v6.1.1
 KUBECTL_VERSION?=v1.5.0-beta.2
 
 ifeq ($(ARCH),amd64)

--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.0.0
+        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0-r2
         resources:
             requests:
                 cpu: "20m"
@@ -40,7 +40,6 @@ spec:
           - /cluster-proportional-autoscaler
           - --namespace=kube-system
           - --configmap=kube-dns-autoscaler
-          - --mode=linear
           # Should keep target in sync with cluster/addons/dns/skydns-rc.yaml.base
           - --target=Deployment/kube-dns
           # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.

--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -99,7 +99,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -127,7 +127,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: dnsmasq-metrics
-        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
+        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0.1
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -99,7 +99,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -127,7 +127,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: dnsmasq-metrics
-        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
+        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0.1
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -98,7 +98,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -126,7 +126,7 @@ spec:
             cpu: 150m
             memory: 10Mi
       - name: dnsmasq-metrics
-        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
+        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0.1
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
@@ -10,4 +10,4 @@ spec:
   dnsPolicy: Default
   containers:
   - name: etcd-empty-dir-cleanup
-    image: gcr.io/google_containers/etcd-empty-dir-cleanup:0.0.1
+    image: gcr.io/google_containers/etcd-empty-dir-cleanup:0.0.2

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -77,7 +77,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -100,7 +100,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: dnsmasq-metrics
-        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
+        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0.1
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -16,7 +16,7 @@
 
 ETCD_VERSION = 2.2.1
 IMAGE = gcr.io/google_containers/etcd-empty-dir-cleanup
-TAG = 0.0.1
+TAG = 0.0.2
 
 clean:
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz

--- a/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
+++ b/cluster/juju/layers/kubernetes/templates/kubedns-rc.yaml
@@ -95,7 +95,7 @@ spec:
           name: metrics
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-{{ arch }}:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-{{ arch }}:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq
@@ -118,7 +118,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: dnsmasq-metrics
-        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
+        image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0.1
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -10,7 +10,7 @@ spec:
   containers:
   - name: kube-addon-manager
     # When updating version also bump it in cluster/images/hyperkube/static-pods/addon-manager.json
-    image: gcr.io/google-containers/kube-addon-manager:v6.1
+    image: gcr.io/google-containers/kube-addon-manager:v6.1.1
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
```release-note
Patch CVE-2016-8859 in alpine based images:
- gcr.io/google-containers/cluster-proportional-autoscaler-amd64
- gcr.io/google-containers/dnsmasq-metrics-amd64
- gcr.io/google-containers/etcd-empty-dir-cleanup
- gcr.io/google-containers/kube-addon-manager
- gcr.io/google-containers/kube-dnsmasq-amd64
```

/cc @ixdy @bowei @MrHohn 