### PR TITLE
Patch CVE-2016-8859 in alpine based images

### DIFF
--- a/cluster/addons/dns/skydns-rc.yaml.base
+++ b/cluster/addons/dns/skydns-rc.yaml.base
@@ -83,7 +83,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq

--- a/cluster/addons/dns/skydns-rc.yaml.in
+++ b/cluster/addons/dns/skydns-rc.yaml.in
@@ -83,7 +83,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq

--- a/cluster/addons/dns/skydns-rc.yaml.sed
+++ b/cluster/addons/dns/skydns-rc.yaml.sed
@@ -82,7 +82,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq

--- a/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
@@ -10,4 +10,4 @@ spec:
   dnsPolicy: Default
   containers:
   - name: etcd-empty-dir-cleanup
-    image: gcr.io/google_containers/etcd-empty-dir-cleanup:0.0.1
+    image: gcr.io/google_containers/etcd-empty-dir-cleanup:0.0.2

--- a/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
+++ b/cluster/gce/coreos/kube-manifests/addons/dns/skydns-rc.yaml
@@ -64,7 +64,7 @@ spec:
           name: dns-tcp-local
           protocol: TCP
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         livenessProbe:
           httpGet:
             path: /healthz-dnsmasq

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -16,7 +16,7 @@
 
 ETCD_VERSION = 2.2.1
 IMAGE = gcr.io/google_containers/etcd-empty-dir-cleanup
-TAG = 0.0.1
+TAG = 0.0.2
 
 clean:
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz


### PR DESCRIPTION
```release-note
Patch CVE-2016-8859 in alpine based images:
- gcr.io/google-containers/etcd-empty-dir-cleanup
- gcr.io/google-containers/kube-dnsmasq-amd64
```

/cc @ixdy @bowei @MrHohn 