### PR TITLE
Only receive hostports on real interface addrs

### DIFF
--- a/pkg/kubelet/network/hostport/BUILD
+++ b/pkg/kubelet/network/hostport/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//pkg/util/iptables:go_default_library",
         "//vendor:github.com/stretchr/testify/assert",
+        "//vendor:k8s.io/apimachinery/pkg/util/sets",
     ],
 )
 

--- a/pkg/kubelet/network/hostport/hostport.go
+++ b/pkg/kubelet/network/hostport/hostport.go
@@ -17,9 +17,11 @@ limitations under the License.
 package hostport
 
 import (
+	"bytes"
 	"fmt"
 	"net"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -30,6 +32,8 @@ import (
 const (
 	// the hostport chain
 	kubeHostportsChain utiliptables.Chain = "KUBE-HOSTPORTS"
+	// the "is a local destination" chain, which pre-filters hostports
+	kubeLocalDestChain utiliptables.Chain = "KUBE-LOCALDEST"
 	// prefix for hostport chains
 	kubeHostportChainPrefix string = "KUBE-HP-"
 )
@@ -144,9 +148,14 @@ func portMappingToHostport(portMapping *PortMapping) hostport {
 // ensureKubeHostportChainLinked ensures the KUBE-HOSTPORTS chain is linked into the root of iptables
 func ensureKubeHostportChainLinked(iptables utiliptables.Interface) error {
 	glog.V(4).Info("Ensuring kubelet hostport chains")
-	// Ensure kubeHostportChain exists
+	// Ensure kubeHostportsChain exists
 	if _, err := iptables.EnsureChain(utiliptables.TableNAT, kubeHostportsChain); err != nil {
 		return fmt.Errorf("Failed to ensure that %s chain %s exists: %v", utiliptables.TableNAT, kubeHostportsChain, err)
+	}
+
+	// Enusure and fill kubeLocalDestChain with current info
+	if err := syncLocaldest(iptables); err != nil {
+		return fmt.Errorf("Failed to populate %s chain %s: %v", utiliptables.TableNAT, kubeLocalDestChain, err)
 	}
 
 	// Ensure it is linked from the root.
@@ -158,18 +167,94 @@ func ensureKubeHostportChainLinked(iptables utiliptables.Interface) error {
 		{utiliptables.TableNAT, utiliptables.ChainPrerouting},
 	}
 	args := []string{
-		"-m", "comment", "--comment", "kube hostport portals",
+		"-m", "comment", "--comment", "maybe kube hostport",
 		"-m", "addrtype", "--dst-type", "LOCAL",
-		"-j", string(kubeHostportsChain),
+		"-j", string(kubeLocalDestChain),
 	}
 	for _, tc := range tableChainsNeedJumpServices {
 		if _, err := iptables.EnsureRule(utiliptables.Prepend, tc.table, tc.chain, args...); err != nil {
 			return fmt.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", tc.table, tc.chain, kubeHostportsChain, err)
 		}
+		removeOldLink(iptables, tc.table, tc.chain) // ignore errors
 	}
-
 	removeOldSNAT(iptables) // ignore errors
 
+	return nil
+}
+
+func syncLocaldest(iptables utiliptables.Interface) error {
+	start := time.Now()
+	defer func() {
+		glog.V(4).Infof("syncLocaldest took %v", time.Since(start))
+	}()
+
+	// Get iptables-save output so we can check for existing chains and rules.
+	// This will be a map of chain name to chain with rules as stored in iptables-save/iptables-restore
+	existingNATChains := make(map[utiliptables.Chain]string)
+	iptablesSaveRaw, err := iptables.Save(utiliptables.TableNAT)
+	if err != nil { // if we failed to get any rules
+		glog.Errorf("Failed to execute iptables-save, syncing all rules: %v", err)
+	} else { // otherwise parse the output
+		existingNATChains = utiliptables.GetChainLines(utiliptables.TableNAT, iptablesSaveRaw)
+	}
+
+	natChains := bytes.NewBuffer(nil)
+	natRules := bytes.NewBuffer(nil)
+	writeLine(natChains, "*nat")
+	// Make sure we keep stats for the top-level chains, if they existed
+	// (which most should have because we created them above).
+	if chain, ok := existingNATChains[kubeLocalDestChain]; ok {
+		writeLine(natChains, chain)
+	} else {
+		writeLine(natChains, utiliptables.MakeChainLine(kubeLocalDestChain))
+	}
+
+	// Populate the LOCALDEST chain.
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return err
+	}
+	// Only consider packets with dest of a real interface addr for hostports.
+	for _, a := range addrs {
+		astr := a.String() // CIDR notation
+		ip, ipnet, err := net.ParseCIDR(astr)
+		if err != nil {
+			return err
+		}
+		if ip.To4() != nil {
+			ipstr := ip.String()
+			if ip.IsLoopback() {
+				// Special case loopback devices.
+				ipstr = ipnet.String()
+			}
+			args := []string{
+				"-A", string(kubeLocalDestChain),
+				"-m", "comment", "--comment", `"maybe kube hostport"`,
+				"-d", ipstr,
+				"-j", string(kubeHostportsChain),
+			}
+			writeLine(natRules, args...)
+		}
+	}
+	writeLine(natRules, "COMMIT")
+
+	natLines := append(natChains.Bytes(), natRules.Bytes()...)
+	glog.V(3).Infof("Restoring iptables rules: %s", natLines)
+	err = iptables.RestoreAll(natLines, utiliptables.NoFlushTables, utiliptables.RestoreCounters)
+	if err != nil {
+		return fmt.Errorf("Failed to execute iptables-restore: %v", err)
+	}
+	return nil
+}
+
+// This can be removed after v1.8.
+func removeOldLink(iptables utiliptables.Interface, table utiliptables.Table, chain utiliptables.Chain) error {
+	if err := iptables.DeleteRule(table, chain,
+		"-m", "comment", "--comment", "kube hostport portals",
+		"-m", "addrtype", "--dst-type", "LOCAL",
+		"-j", string(kubeHostportsChain)); err != nil {
+		return fmt.Errorf("Failed to remove old link from %s chain %s to %s: %v", table, chain, kubeHostportsChain, err)
+	}
 	return nil
 }
 

--- a/pkg/kubelet/network/hostport/hostport_manager.go
+++ b/pkg/kubelet/network/hostport/hostport_manager.go
@@ -37,8 +37,7 @@ type HostPortManager interface {
 	// Add implements port mappings.
 	// id should be a unique identifier for a pod, e.g. podSandboxID.
 	// podPortMapping is the associated port mapping information for the pod.
-	// natInterfaceName is the interface that localhost used to talk to the given pod.
-	Add(id string, podPortMapping *PodPortMapping, natInterfaceName string) error
+	Add(id string, podPortMapping *PodPortMapping) error
 	// Remove cleans up matching port mappings
 	// Remove must be able to clean up port mappings without pod IP
 	Remove(id string, podPortMapping *PodPortMapping) error
@@ -60,7 +59,7 @@ func NewHostportManager() HostPortManager {
 	}
 }
 
-func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping, natInterfaceName string) (err error) {
+func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping) (err error) {
 	if podPortMapping == nil || podPortMapping.HostNetwork {
 		return nil
 	}
@@ -150,7 +149,7 @@ func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping, natInt
 	}
 
 	// Ensure the chain is linked from the root.
-	if err = ensureKubeHostportChainLinked(hm.iptables, natInterfaceName); err != nil {
+	if err = ensureKubeHostportChainLinked(hm.iptables); err != nil {
 		return err
 	}
 

--- a/pkg/kubelet/network/hostport/hostport_manager.go
+++ b/pkg/kubelet/network/hostport/hostport_manager.go
@@ -77,10 +77,6 @@ func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping, natInt
 	}
 	podIP := podPortMapping.IP.String()
 
-	if err = ensureKubeHostportChains(hm.iptables, natInterfaceName); err != nil {
-		return err
-	}
-
 	// Ensure atomicity for port opening and iptables operations
 	hm.mu.Lock()
 	defer hm.mu.Unlock()
@@ -152,6 +148,12 @@ func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping, natInt
 		// clean up opened host port if encounter any error
 		return utilerrors.NewAggregate([]error{err, hm.closeHostports(hostportMappings)})
 	}
+
+	// Ensure the chain is linked from the root.
+	if err = ensureKubeHostportChainLinked(hm.iptables, natInterfaceName); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/kubelet/network/hostport/hostport_manager_test.go
+++ b/pkg/kubelet/network/hostport/hostport_manager_test.go
@@ -20,10 +20,11 @@ import (
 	"net"
 	"testing"
 
+	"strings"
+
 	"github.com/stretchr/testify/assert"
 	"k8s.io/kubernetes/pkg/api/v1"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
-	"strings"
 )
 
 func NewFakeHostportManager() HostPortManager {

--- a/pkg/kubelet/network/hostport/hostport_manager_test.go
+++ b/pkg/kubelet/network/hostport/hostport_manager_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/api/v1"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
@@ -136,35 +137,33 @@ func TestHostportManager(t *testing.T) {
 	raw, err := iptables.Save(utiliptables.TableNAT)
 	assert.NoError(t, err)
 
-	lines := strings.Split(string(raw), "\n")
-	expectedLines := map[string]bool{
-		`*nat`: true,
-		`:KUBE-HOSTPORTS - [0:0]`:                                                                                                         true,
-		`:OUTPUT - [0:0]`:                                                                                                                 true,
-		`:PREROUTING - [0:0]`:                                                                                                             true,
-		`:POSTROUTING - [0:0]`:                                                                                                            true,
-		`:KUBE-HP-4YVONL46AKYWSKS3 - [0:0]`:                                                                                               true,
-		`:KUBE-HP-7THKRFSEH4GIIXK7 - [0:0]`:                                                                                               true,
-		`:KUBE-HP-5N7UH5JAXCVP5UJR - [0:0]`:                                                                                               true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-5N7UH5JAXCVP5UJR":        true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-7THKRFSEH4GIIXK7":        true,
-		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-4YVONL46AKYWSKS3":        true,
-		"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                         true,
-		"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                     true,
-		"-A POSTROUTING -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s 127.0.0.0/8 -j MASQUERADE":             true,
-		"-A KUBE-HP-4YVONL46AKYWSKS3 -m comment --comment \"pod1_ns1 hostport 8080\" -s 10.1.1.2/32 -j KUBE-MARK-MASQ":                    true,
-		"-A KUBE-HP-4YVONL46AKYWSKS3 -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.2:80":  true,
-		"-A KUBE-HP-7THKRFSEH4GIIXK7 -m comment --comment \"pod1_ns1 hostport 8081\" -s 10.1.1.2/32 -j KUBE-MARK-MASQ":                    true,
-		"-A KUBE-HP-7THKRFSEH4GIIXK7 -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination 10.1.1.2:81":  true,
-		"-A KUBE-HP-5N7UH5JAXCVP5UJR -m comment --comment \"pod3_ns1 hostport 8443\" -s 10.1.1.4/32 -j KUBE-MARK-MASQ":                    true,
-		"-A KUBE-HP-5N7UH5JAXCVP5UJR -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.4:443": true,
-		`COMMIT`: true,
-	}
-	for _, line := range lines {
-		if len(strings.TrimSpace(line)) > 0 {
-			_, ok := expectedLines[strings.TrimSpace(line)]
-			assert.EqualValues(t, true, ok)
-		}
+	lines := splitToLineSet(raw)
+
+	expectedLines := sets.NewString(
+		`*nat`,
+		`:KUBE-HOSTPORTS - [0:0]`,
+		`:KUBE-LOCALDEST - [0:0]`,
+		`:OUTPUT - [0:0]`,
+		`:PREROUTING - [0:0]`,
+		`:KUBE-HP-4YVONL46AKYWSKS3 - [0:0]`,
+		`:KUBE-HP-7THKRFSEH4GIIXK7 - [0:0]`,
+		`:KUBE-HP-5N7UH5JAXCVP5UJR - [0:0]`,
+		"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-5N7UH5JAXCVP5UJR",
+		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-7THKRFSEH4GIIXK7",
+		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-4YVONL46AKYWSKS3",
+		"-A KUBE-LOCALDEST -m comment --comment \"maybe kube hostport\" -d 127.0.0.0/8 -j KUBE-HOSTPORTS",
+		"-A OUTPUT -m comment --comment \"maybe kube hostport\" -m addrtype --dst-type LOCAL -j KUBE-LOCALDEST",
+		"-A PREROUTING -m comment --comment \"maybe kube hostport\" -m addrtype --dst-type LOCAL -j KUBE-LOCALDEST",
+		"-A KUBE-HP-4YVONL46AKYWSKS3 -m comment --comment \"pod1_ns1 hostport 8080\" -s 10.1.1.2/32 -j KUBE-MARK-MASQ",
+		"-A KUBE-HP-4YVONL46AKYWSKS3 -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.2:80",
+		"-A KUBE-HP-7THKRFSEH4GIIXK7 -m comment --comment \"pod1_ns1 hostport 8081\" -s 10.1.1.2/32 -j KUBE-MARK-MASQ",
+		"-A KUBE-HP-7THKRFSEH4GIIXK7 -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination 10.1.1.2:81",
+		"-A KUBE-HP-5N7UH5JAXCVP5UJR -m comment --comment \"pod3_ns1 hostport 8443\" -s 10.1.1.4/32 -j KUBE-MARK-MASQ",
+		"-A KUBE-HP-5N7UH5JAXCVP5UJR -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.4:443",
+		`COMMIT`)
+	for line := range expectedLines {
+		_, ok := lines[line]
+		assert.EqualValues(t, true, ok, "line %q not found in output", line)
 	}
 
 	// Remove all added hostports
@@ -178,11 +177,11 @@ func TestHostportManager(t *testing.T) {
 	// Check Iptables-save result after deleting hostports
 	raw, err = iptables.Save(utiliptables.TableNAT)
 	assert.NoError(t, err)
-	lines = strings.Split(string(raw), "\n")
-	remainingChains := make(map[string]bool)
-	for _, line := range lines {
+	lines = splitToLineSet(raw)
+	remainingChains := sets.NewString()
+	for line := range lines {
 		if strings.HasPrefix(line, ":") {
-			remainingChains[strings.TrimSpace(line)] = true
+			remainingChains.Insert(line)
 		}
 	}
 	expectDeletedChains := []string{"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR"}
@@ -195,4 +194,12 @@ func TestHostportManager(t *testing.T) {
 	for _, port := range portOpener.mem {
 		assert.EqualValues(t, true, port.closed)
 	}
+}
+
+func splitToLineSet(raw []byte) sets.String {
+	linesList := strings.Split(string(raw), "\n")
+	for i, line := range linesList {
+		linesList[i] = strings.TrimSpace(line)
+	}
+	return sets.NewString(linesList...)
 }

--- a/pkg/kubelet/network/hostport/hostport_manager_test.go
+++ b/pkg/kubelet/network/hostport/hostport_manager_test.go
@@ -110,7 +110,7 @@ func TestHostportManager(t *testing.T) {
 
 	// Add Hostports
 	for _, tc := range testCases {
-		err := manager.Add("id", tc.mapping, "cbr0")
+		err := manager.Add("id", tc.mapping)
 		if tc.expectError {
 			assert.Error(t, err)
 			continue

--- a/pkg/kubelet/network/hostport/hostport_syncer.go
+++ b/pkg/kubelet/network/hostport/hostport_syncer.go
@@ -36,11 +36,11 @@ import (
 type HostportSyncer interface {
 	// SyncHostports gathers all hostports on node and setup iptables rules to enable them.
 	// On each invocation existing ports are synced and stale rules are deleted.
-	SyncHostports(natInterfaceName string, activePodPortMappings []*PodPortMapping) error
+	SyncHostports(activePodPortMappings []*PodPortMapping) error
 	// OpenPodHostportsAndSync opens hostports for a new PodPortMapping, gathers all hostports on
 	// node, sets up iptables rules enable them. On each invocation existing ports are synced and stale rules are deleted.
 	// 'newPortMapping' must also be present in 'activePodPortMappings'.
-	OpenPodHostportsAndSync(newPortMapping *PodPortMapping, natInterfaceName string, activePodPortMappings []*PodPortMapping) error
+	OpenPodHostportsAndSync(newPortMapping *PodPortMapping, activePodPortMappings []*PodPortMapping) error
 }
 
 type hostportSyncer struct {
@@ -153,7 +153,7 @@ func hostportChainName(pm *PortMapping, podFullName string) utiliptables.Chain {
 // OpenPodHostportsAndSync opens hostports for a new PodPortMapping, gathers all hostports on
 // node, sets up iptables rules enable them. And finally clean up stale hostports.
 // 'newPortMapping' must also be present in 'activePodPortMappings'.
-func (h *hostportSyncer) OpenPodHostportsAndSync(newPortMapping *PodPortMapping, natInterfaceName string, activePodPortMappings []*PodPortMapping) error {
+func (h *hostportSyncer) OpenPodHostportsAndSync(newPortMapping *PodPortMapping, activePodPortMappings []*PodPortMapping) error {
 	// try to open pod host port if specified
 	if err := h.openHostports(newPortMapping); err != nil {
 		return err
@@ -171,11 +171,11 @@ func (h *hostportSyncer) OpenPodHostportsAndSync(newPortMapping *PodPortMapping,
 		activePodPortMappings = append(activePodPortMappings, newPortMapping)
 	}
 
-	return h.SyncHostports(natInterfaceName, activePodPortMappings)
+	return h.SyncHostports(activePodPortMappings)
 }
 
 // SyncHostports gathers all hostports on node and setup iptables rules enable them. And finally clean up stale hostports
-func (h *hostportSyncer) SyncHostports(natInterfaceName string, activePodPortMappings []*PodPortMapping) error {
+func (h *hostportSyncer) SyncHostports(activePodPortMappings []*PodPortMapping) error {
 	start := time.Now()
 	defer func() {
 		glog.V(4).Infof("syncHostportsRules took %v", time.Since(start))
@@ -276,7 +276,7 @@ func (h *hostportSyncer) SyncHostports(natInterfaceName string, activePodPortMap
 	}
 
 	// Ensure hostport chains are linked into the root
-	ensureKubeHostportChainLinked(h.iptables, natInterfaceName)
+	ensureKubeHostportChainLinked(h.iptables)
 
 	h.cleanupHostportMap(hostportPodMap)
 	return nil

--- a/pkg/kubelet/network/hostport/hostport_syncer.go
+++ b/pkg/kubelet/network/hostport/hostport_syncer.go
@@ -186,9 +186,6 @@ func (h *hostportSyncer) SyncHostports(natInterfaceName string, activePodPortMap
 		return err
 	}
 
-	// Ensure KUBE-HOSTPORTS chains
-	ensureKubeHostportChains(h.iptables, natInterfaceName)
-
 	// Get iptables-save output so we can check for existing chains and rules.
 	// This will be a map of chain name to chain with rules as stored in iptables-save/iptables-restore
 	existingNATChains := make(map[utiliptables.Chain]string)
@@ -277,6 +274,9 @@ func (h *hostportSyncer) SyncHostports(natInterfaceName string, activePodPortMap
 	if err != nil {
 		return fmt.Errorf("Failed to execute iptables-restore: %v", err)
 	}
+
+	// Ensure hostport chains are linked into the root
+	ensureKubeHostportChainLinked(h.iptables, natInterfaceName)
 
 	h.cleanupHostportMap(hostportPodMap)
 	return nil

--- a/pkg/kubelet/network/hostport/hostport_syncer_test.go
+++ b/pkg/kubelet/network/hostport/hostport_syncer_test.go
@@ -175,8 +175,9 @@ func TestOpenPodHostports(t *testing.T) {
 
 	// Generic rules
 	genericRules := []*ruleMatch{
-		{-1, "PREROUTING", "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"},
-		{-1, "OUTPUT", "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"},
+		{-1, "PREROUTING", "-m comment --comment \"maybe kube hostport\" -m addrtype --dst-type LOCAL -j KUBE-LOCALDEST"},
+		{-1, "OUTPUT", "-m comment --comment \"maybe kube hostport\" -m addrtype --dst-type LOCAL -j KUBE-LOCALDEST"},
+		{-1, "KUBE-LOCALDEST", "-m comment --comment \"maybe kube hostport\" -d 127.0.0.0/8 -j KUBE-HOSTPORTS"},
 	}
 
 	for _, rule := range genericRules {
@@ -185,7 +186,7 @@ func TestOpenPodHostports(t *testing.T) {
 			t.Fatalf("Expected NAT chain %s did not exist", rule.chain)
 		}
 		if !matchRule(chain, rule.match) {
-			t.Fatalf("Expected %s chain rule match '%s' not found", rule.chain, rule.match)
+			t.Fatalf("Expected %s chain rule match '%s' not found, got '%s'", rule.chain, rule.match, chain)
 		}
 	}
 

--- a/pkg/kubelet/network/hostport/hostport_syncer_test.go
+++ b/pkg/kubelet/network/hostport/hostport_syncer_test.go
@@ -168,14 +168,13 @@ func TestOpenPodHostports(t *testing.T) {
 		false,
 	}
 
-	err := h.OpenPodHostportsAndSync(tests[0].mapping, "br0", activePodPortMapping)
+	err := h.OpenPodHostportsAndSync(tests[0].mapping, activePodPortMapping)
 	if err != nil {
 		t.Fatalf("Failed to OpenPodHostportsAndSync: %v", err)
 	}
 
 	// Generic rules
 	genericRules := []*ruleMatch{
-		{-1, "POSTROUTING", "-m comment --comment \"SNAT for localhost access to hostports\" -o br0 -s 127.0.0.0/8 -j MASQUERADE"},
 		{-1, "PREROUTING", "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"},
 		{-1, "OUTPUT", "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"},
 	}

--- a/pkg/kubelet/network/hostport/hostport_test.go
+++ b/pkg/kubelet/network/hostport/hostport_test.go
@@ -125,14 +125,14 @@ func TestOpenHostports(t *testing.T) {
 	}
 }
 
-func TestEnsureKubeHostportChains(t *testing.T) {
+func TestEnsureKubeHostportChainLinked(t *testing.T) {
 	interfaceName := "cbr0"
 	builtinChains := []string{"PREROUTING", "OUTPUT"}
 	jumpRule := "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"
 	masqRule := "-m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s 127.0.0.0/8 -j MASQUERADE"
 
 	fakeIPTables := NewFakeIPTables()
-	assert.NoError(t, ensureKubeHostportChains(fakeIPTables, interfaceName))
+	assert.NoError(t, ensureKubeHostportChainLinked(fakeIPTables, interfaceName))
 
 	_, _, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain("KUBE-HOSTPORTS"))
 	assert.NoError(t, err)

--- a/pkg/kubelet/network/hostport/hostport_test.go
+++ b/pkg/kubelet/network/hostport/hostport_test.go
@@ -127,12 +127,15 @@ func TestOpenHostports(t *testing.T) {
 
 func TestEnsureKubeHostportChainLinked(t *testing.T) {
 	builtinChains := []string{"PREROUTING", "OUTPUT"}
-	jumpRule := "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"
+	jumpRule := "-m comment --comment \"maybe kube hostport\" -m addrtype --dst-type LOCAL -j KUBE-LOCALDEST"
 
 	fakeIPTables := NewFakeIPTables()
 	assert.NoError(t, ensureKubeHostportChainLinked(fakeIPTables))
 
-	_, _, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain("KUBE-HOSTPORTS"))
+	_, _, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain("KUBE-LOCALDEST"))
+	assert.NoError(t, err)
+
+	_, _, err = fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain("KUBE-HOSTPORTS"))
 	assert.NoError(t, err)
 
 	for _, chainName := range builtinChains {

--- a/pkg/kubelet/network/hostport/hostport_test.go
+++ b/pkg/kubelet/network/hostport/hostport_test.go
@@ -126,21 +126,14 @@ func TestOpenHostports(t *testing.T) {
 }
 
 func TestEnsureKubeHostportChainLinked(t *testing.T) {
-	interfaceName := "cbr0"
 	builtinChains := []string{"PREROUTING", "OUTPUT"}
 	jumpRule := "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"
-	masqRule := "-m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s 127.0.0.0/8 -j MASQUERADE"
 
 	fakeIPTables := NewFakeIPTables()
-	assert.NoError(t, ensureKubeHostportChainLinked(fakeIPTables, interfaceName))
+	assert.NoError(t, ensureKubeHostportChainLinked(fakeIPTables))
 
 	_, _, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain("KUBE-HOSTPORTS"))
 	assert.NoError(t, err)
-
-	_, chain, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.ChainPostrouting)
-	assert.NoError(t, err)
-	assert.EqualValues(t, len(chain.rules), 1)
-	assert.Contains(t, chain.rules[0], masqRule)
 
 	for _, chainName := range builtinChains {
 		_, chain, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain(chainName))

--- a/pkg/kubelet/network/hostport/testing/fake.go
+++ b/pkg/kubelet/network/hostport/testing/fake.go
@@ -28,11 +28,11 @@ func NewFakeHostportSyncer() hostport.HostportSyncer {
 	return &fakeSyncer{}
 }
 
-func (h *fakeSyncer) OpenPodHostportsAndSync(newPortMapping *hostport.PodPortMapping, natInterfaceName string, activePortMapping []*hostport.PodPortMapping) error {
-	return h.SyncHostports(natInterfaceName, activePortMapping)
+func (h *fakeSyncer) OpenPodHostportsAndSync(newPortMapping *hostport.PodPortMapping, activePortMapping []*hostport.PodPortMapping) error {
+	return h.SyncHostports(activePortMapping)
 }
 
-func (h *fakeSyncer) SyncHostports(natInterfaceName string, activePortMapping []*hostport.PodPortMapping) error {
+func (h *fakeSyncer) SyncHostports(activePortMapping []*hostport.PodPortMapping) error {
 	for _, r := range activePortMapping {
 		if r.IP.To4() == nil {
 			return fmt.Errorf("Invalid or missing pod %s/%s IP", r.Namespace, r.Name)


### PR DESCRIPTION
iptables addrtype LOCAL matches anything in the local routing table,
which is broader than we really want.
    
This change expands the hostport filter to check that destination IP is
actually known on an interface.  Unfortunately, iptables can not express
this, so we have to expand the list manually.  To avoid changing 1 rule
to N rules per packet, we pre-filter for LOCAL, and only if that matches
to we run the list of interface addrs.  This requires a new chain.
   
This should be upgrade-safe with no loss of packets.
