### PR TITLE
Validate the serviceName of StatefulSetSpec

### DIFF
--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -86,7 +86,13 @@ func ValidateStatefulSetSpec(spec *apps.StatefulSetSpec, fldPath *field.Path) fi
 	if spec.Template.Spec.RestartPolicy != api.RestartPolicyAlways {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("template", "spec", "restartPolicy"), spec.Template.Spec.RestartPolicy, []string{string(api.RestartPolicyAlways)}))
 	}
-
+	if len(spec.ServiceName) == 0 {
+		return append(allErrs, field.Required(fldPath.Child("serviceName"), ""))
+	} else {
+		for _, msg := range apivalidation.ValidateServiceName(spec.ServiceName, false) {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceName"), spec.ServiceName, msg))
+		}
+	}
 	return allErrs
 }
 

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -27,6 +27,8 @@ import (
 
 func TestValidateStatefulSet(t *testing.T) {
 	validLabels := map[string]string{"a": "b"}
+	validServiceName := "service"
+	invalideServiceName := "Service"
 	validPodTemplate := api.PodTemplate{
 		Template: api.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
@@ -55,15 +57,17 @@ func TestValidateStatefulSet(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: validPodTemplate.Template,
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:    validPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "abc-123", Namespace: metav1.NamespaceDefault},
 			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: validPodTemplate.Template,
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:    validPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 	}
@@ -77,41 +81,47 @@ func TestValidateStatefulSet(t *testing.T) {
 		"zero-length ID": {
 			ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: metav1.NamespaceDefault},
 			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: validPodTemplate.Template,
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:    validPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 		"missing-namespace": {
 			ObjectMeta: metav1.ObjectMeta{Name: "abc-123"},
 			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: validPodTemplate.Template,
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:    validPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 		"empty selector": {
 			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 			Spec: apps.StatefulSetSpec{
-				Template: validPodTemplate.Template,
+				Template:    validPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 		"selector_doesnt_match": {
 			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
-				Template: validPodTemplate.Template,
+				Selector:    &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				Template:    validPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 		"invalid manifest": {
 			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				ServiceName: validServiceName,
 			},
 		},
 		"negative_replicas": {
 			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 			Spec: apps.StatefulSetSpec{
-				Replicas: -1,
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
+				Replicas:    -1,
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				ServiceName: validServiceName,
 			},
 		},
 		"invalid_label": {
@@ -123,8 +133,9 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: validPodTemplate.Template,
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:    validPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 		"invalid_label 2": {
@@ -136,7 +147,8 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			Spec: apps.StatefulSetSpec{
-				Template: invalidPodTemplate.Template,
+				Template:    invalidPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 		"invalid_annotation": {
@@ -148,8 +160,9 @@ func TestValidateStatefulSet(t *testing.T) {
 				},
 			},
 			Spec: apps.StatefulSetSpec{
-				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-				Template: validPodTemplate.Template,
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:    validPodTemplate.Template,
+				ServiceName: validServiceName,
 			},
 		},
 		"invalid restart policy 1": {
@@ -169,6 +182,7 @@ func TestValidateStatefulSet(t *testing.T) {
 						Labels: validLabels,
 					},
 				},
+				ServiceName: validServiceName,
 			},
 		},
 		"invalid restart policy 2": {
@@ -188,6 +202,22 @@ func TestValidateStatefulSet(t *testing.T) {
 						Labels: validLabels,
 					},
 				},
+				ServiceName: validServiceName,
+			},
+		},
+		"invalid serviceName": {
+			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: validLabels},
+				Template: validPodTemplate.Template,
+			},
+		},
+		"invalid serviceName 2": {
+			ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+			Spec: apps.StatefulSetSpec{
+				Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+				Template:    validPodTemplate.Template,
+				ServiceName: invalideServiceName,
 			},
 		},
 	}
@@ -203,6 +233,7 @@ func TestValidateStatefulSet(t *testing.T) {
 				field != "metadata.namespace" &&
 				field != "spec.selector" &&
 				field != "spec.template" &&
+				field != "spec.serviceName" &&
 				field != "GCEPersistentDisk.ReadOnly" &&
 				field != "spec.replicas" &&
 				field != "spec.template.labels" &&
@@ -216,6 +247,8 @@ func TestValidateStatefulSet(t *testing.T) {
 }
 
 func TestValidateStatefulSetUpdate(t *testing.T) {
+	validServiceName := "service"
+	invalideServiceName := "Service"
 	validLabels := map[string]string{"a": "b"}
 	validPodTemplate := api.PodTemplate{
 		Template: api.PodTemplateSpec{
@@ -263,16 +296,18 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 			old: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: validPodTemplate.Template,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 			update: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Replicas: 3,
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: validPodTemplate.Template,
+					Replicas:    3,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 		},
@@ -289,16 +324,18 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 			old: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: validPodTemplate.Template,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 			update: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Replicas: 2,
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: readWriteVolumePodTemplate.Template,
+					Replicas:    2,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    readWriteVolumePodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 		},
@@ -306,16 +343,18 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 			old: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: validPodTemplate.Template,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 			update: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Replicas: 1,
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: readWriteVolumePodTemplate.Template,
+					Replicas:    1,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    readWriteVolumePodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 		},
@@ -323,16 +362,18 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 			old: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: validPodTemplate.Template,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 			update: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Replicas: 2,
-					Selector: &metav1.LabelSelector{MatchLabels: invalidLabels},
-					Template: validPodTemplate.Template,
+					Replicas:    2,
+					Selector:    &metav1.LabelSelector{MatchLabels: invalidLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 		},
@@ -340,16 +381,18 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 			old: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: validPodTemplate.Template,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 			update: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Replicas: 2,
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: invalidPodTemplate.Template,
+					Replicas:    2,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    invalidPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 		},
@@ -357,16 +400,55 @@ func TestValidateStatefulSetUpdate(t *testing.T) {
 			old: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
-					Template: validPodTemplate.Template,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
 				},
 			},
 			update: apps.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 				Spec: apps.StatefulSetSpec{
-					Replicas: -1,
+					Replicas:    -1,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
+				},
+			},
+		},
+		"invalid empty servieName": {
+			old: apps.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: apps.StatefulSetSpec{
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
+				},
+			},
+			update: apps.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: apps.StatefulSetSpec{
+					Replicas: 3,
 					Selector: &metav1.LabelSelector{MatchLabels: validLabels},
 					Template: validPodTemplate.Template,
+				},
+			},
+		},
+		"invalid servieName": {
+			old: apps.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: apps.StatefulSetSpec{
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: validServiceName,
+				},
+			},
+			update: apps.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
+				Spec: apps.StatefulSetSpec{
+					Replicas:    3,
+					Selector:    &metav1.LabelSelector{MatchLabels: validLabels},
+					Template:    validPodTemplate.Template,
+					ServiceName: invalideServiceName,
 				},
 			},
 		},

--- a/pkg/registry/apps/petset/storage/storage_test.go
+++ b/pkg/registry/apps/petset/storage/storage_test.go
@@ -75,7 +75,8 @@ func validNewStatefulSet() *apps.StatefulSet {
 					DNSPolicy:     api.DNSClusterFirst,
 				},
 			},
-			Replicas: 7,
+			Replicas:    7,
+			ServiceName: "foo",
 		},
 		Status: apps.StatefulSetStatus{},
 	}

--- a/pkg/registry/apps/petset/strategy_test.go
+++ b/pkg/registry/apps/petset/strategy_test.go
@@ -51,8 +51,9 @@ func TestStatefulSetStrategy(t *testing.T) {
 	ps := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "abc", Namespace: metav1.NamespaceDefault},
 		Spec: apps.StatefulSetSpec{
-			Selector: &metav1.LabelSelector{MatchLabels: validSelector},
-			Template: validPodTemplate.Template,
+			Selector:    &metav1.LabelSelector{MatchLabels: validSelector},
+			Template:    validPodTemplate.Template,
+			ServiceName: "abc",
 		},
 		Status: apps.StatefulSetStatus{Replicas: 3},
 	}
@@ -70,8 +71,9 @@ func TestStatefulSetStrategy(t *testing.T) {
 	validPs := &apps.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{Name: ps.Name, Namespace: ps.Namespace, ResourceVersion: "1", Generation: 1},
 		Spec: apps.StatefulSetSpec{
-			Selector: ps.Spec.Selector,
-			Template: validPodTemplate.Template,
+			Selector:    ps.Spec.Selector,
+			Template:    validPodTemplate.Template,
+			ServiceName: "abc",
 		},
 		Status: apps.StatefulSetStatus{Replicas: 4},
 	}


### PR DESCRIPTION
We need validate the serviceName of StatefulSetSpec, if we don't set the serviceName or set with incorrect format, the pod cannot be created with error:
```
oc describe statefulset rd 
Name:			rd
Namespace:		etest
Image(s):		debian:jessie
Selector:		app=redis
Labels:			app=redis
Replicas:		0 current / 3 desired
Annotations:		<none>
CreationTimestamp:	Sat, 11 Mar 2017 01:00:52 +0800
Pods Status:		0 Running / 0 Waiting / 0 Succeeded / 0 Failed
Volumes:
  opt:
    Type:	EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:	
  workdir:
    Type:	EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:	
Events:
  FirstSeen	LastSeen	Count	From		SubObjectPath	Type		Reason			Message
  ---------	--------	-----	----		-------------	--------	------			-------
  1m		1m		1	{statefulset }			Normal		SuccessfulCreate	pvc: datadir-rd-0
  1m		1m		1	{statefulset }			Normal		SuccessfulCreate	pvc: datadir-rd-1
  1m		1m		1	{statefulset }			Normal		SuccessfulCreate	pvc: datadir-rd-2
  1m		12s		17	{statefulset }			Warning		FailedCreate		pet: rd-0, error: Pod "rd-0" is invalid: metadata.annotations[pod.beta.kubernetes.io/subdomain]: Invalid value: "": must match the regex [a-z0-9]([-a-z0-9]*[a-z0-9])? (e.g. 'my-name' or '123-abc')

```
