### PR TITLE
[cli] fix Generator's error messages

### DIFF
--- a/pkg/kubectl/clusterrolebinding.go
+++ b/pkg/kubectl/clusterrolebinding.go
@@ -52,29 +52,29 @@ func (s ClusterRoleBindingGeneratorV1) Generate(genericParams map[string]interfa
 		return nil, err
 	}
 	delegate := &ClusterRoleBindingGeneratorV1{}
-	fromFileStrings, found := genericParams["user"]
+	userStrings, found := genericParams["user"]
 	if found {
-		fromFileArray, isArray := fromFileStrings.([]string)
+		fromFileArray, isArray := userStrings.([]string)
 		if !isArray {
-			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+			return nil, fmt.Errorf("expected []string, found :%v", userStrings)
 		}
 		delegate.Users = fromFileArray
 		delete(genericParams, "user")
 	}
-	fromLiteralStrings, found := genericParams["group"]
+	groupStrings, found := genericParams["group"]
 	if found {
-		fromLiteralArray, isArray := fromLiteralStrings.([]string)
+		fromLiteralArray, isArray := groupStrings.([]string)
 		if !isArray {
-			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+			return nil, fmt.Errorf("expected []string, found :%v", groupStrings)
 		}
 		delegate.Groups = fromLiteralArray
 		delete(genericParams, "group")
 	}
-	fromSAStrings, found := genericParams["serviceaccount"]
+	saStrings, found := genericParams["serviceaccount"]
 	if found {
-		fromLiteralArray, isArray := fromSAStrings.([]string)
+		fromLiteralArray, isArray := saStrings.([]string)
 		if !isArray {
-			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+			return nil, fmt.Errorf("expected []string, found :%v", saStrings)
 		}
 		delegate.ServiceAccounts = fromLiteralArray
 		delete(genericParams, "serviceaccount")

--- a/pkg/kubectl/configmap.go
+++ b/pkg/kubectl/configmap.go
@@ -66,7 +66,7 @@ func (s ConfigMapGeneratorV1) Generate(genericParams map[string]interface{}) (ru
 	if found {
 		fromLiteralArray, isArray := fromLiteralStrings.([]string)
 		if !isArray {
-			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+			return nil, fmt.Errorf("expected []string, found :%v", fromLiteralStrings)
 		}
 		delegate.LiteralSources = fromLiteralArray
 		delete(genericParams, "from-literal")

--- a/pkg/kubectl/rolebinding.go
+++ b/pkg/kubectl/rolebinding.go
@@ -54,29 +54,29 @@ func (s RoleBindingGeneratorV1) Generate(genericParams map[string]interface{}) (
 		return nil, err
 	}
 	delegate := &RoleBindingGeneratorV1{}
-	fromFileStrings, found := genericParams["user"]
+	userStrings, found := genericParams["user"]
 	if found {
-		fromFileArray, isArray := fromFileStrings.([]string)
+		fromFileArray, isArray := userStrings.([]string)
 		if !isArray {
-			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+			return nil, fmt.Errorf("expected []string, found :%v", userStrings)
 		}
 		delegate.Users = fromFileArray
 		delete(genericParams, "user")
 	}
-	fromLiteralStrings, found := genericParams["group"]
+	groupStrings, found := genericParams["group"]
 	if found {
-		fromLiteralArray, isArray := fromLiteralStrings.([]string)
+		fromLiteralArray, isArray := groupStrings.([]string)
 		if !isArray {
-			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+			return nil, fmt.Errorf("expected []string, found :%v", groupStrings)
 		}
 		delegate.Groups = fromLiteralArray
 		delete(genericParams, "group")
 	}
-	fromSAStrings, found := genericParams["serviceaccount"]
+	saStrings, found := genericParams["serviceaccount"]
 	if found {
-		fromLiteralArray, isArray := fromSAStrings.([]string)
+		fromLiteralArray, isArray := saStrings.([]string)
 		if !isArray {
-			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+			return nil, fmt.Errorf("expected []string, found :%v", saStrings)
 		}
 		delegate.ServiceAccounts = fromLiteralArray
 		delete(genericParams, "serviceaccount")

--- a/pkg/kubectl/secret.go
+++ b/pkg/kubectl/secret.go
@@ -66,7 +66,7 @@ func (s SecretGeneratorV1) Generate(genericParams map[string]interface{}) (runti
 	if found {
 		fromLiteralArray, isArray := fromLiteralStrings.([]string)
 		if !isArray {
-			return nil, fmt.Errorf("expected []string, found :%v", fromFileStrings)
+			return nil, fmt.Errorf("expected []string, found :%v", fromLiteralStrings)
 		}
 		delegate.LiteralSources = fromLiteralArray
 		delete(genericParams, "from-literal")


### PR DESCRIPTION
Invalid variables are used when format error messages. This change
fixes them.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
