### PR TITLE
Force true on git add in update-staging-godeps.sh

### DIFF
--- a/hack/update-staging-godeps.sh
+++ b/hack/update-staging-godeps.sh
@@ -71,7 +71,9 @@ function updateGodepManifest() {
     go run "${KUBE_ROOT}/staging/godeps-json-updater.go" --godeps-file="${TMP_GOPATH}/src/k8s.io/${repo}/Godeps/Godeps.json" --client-go-import-path="k8s.io/${repo}"
 
     # commit so that following repos do not see this repo as dirty
-    git add vendor >/dev/null
+    # pipe through true so that command script won't error if there are no
+    # files to add
+    git add vendor/ >/dev/null || true
     git commit -a -m "Updated Godeps.json" >/dev/null
   popd >/dev/null
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
When running hack/update-staging-godeps.sh, if there is nothing in the vendor/ folder to update, git add would return a non-zero error code. This uses `true` if non-zero, so the command succeeds no matter what. This should fix #42817.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #42817

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
