### PR TITLE
Fixed incorrect result of getMinTolerationTime.

### DIFF
--- a/pkg/controller/node/taint_controller.go
+++ b/pkg/controller/node/taint_controller.go
@@ -59,7 +59,7 @@ type podUpdateItem struct {
 	newTolerations []v1.Toleration
 }
 
-// NoExecuteTaint manager listens to Taint/Toleration changes and is resposible for removing Pods
+// NoExecuteTaintManager listens to Taint/Toleration changes and is resposible for removing Pods
 // from Nodes tainted with NoExecute Taints.
 type NoExecuteTaintManager struct {
 	client   clientset.Interface
@@ -126,30 +126,24 @@ func getPodsAssignedToNode(c clientset.Interface, nodeName string) ([]v1.Pod, er
 	return pods.Items, nil
 }
 
-// Returns minimal toleration time from the given slice, or -1 if it's infinite.
+// getMinTolerationTime returns minimal toleration time from the given slice, or -1 if it's infinite.
 func getMinTolerationTime(tolerations []v1.Toleration) time.Duration {
 	minTolerationTime := int64(-1)
 	if len(tolerations) == 0 {
 		return 0
 	}
-	if tolerations[0].TolerationSeconds != nil {
-		tolerationSeconds := *(tolerations[0].TolerationSeconds)
-		if tolerationSeconds <= 0 {
-			return 0
-		} else {
-			minTolerationTime = tolerationSeconds
-		}
-	}
+
 	for i := range tolerations {
 		if tolerations[i].TolerationSeconds != nil {
 			tolerationSeconds := *(tolerations[i].TolerationSeconds)
 			if tolerationSeconds <= 0 {
 				return 0
-			} else if tolerationSeconds < minTolerationTime {
+			} else if tolerationSeconds < minTolerationTime || minTolerationTime == -1 {
 				minTolerationTime = tolerationSeconds
 			}
 		}
 	}
+
 	return time.Duration(minTolerationTime) * time.Second
 }
 

--- a/pkg/controller/node/taint_controller_test.go
+++ b/pkg/controller/node/taint_controller_test.go
@@ -549,3 +549,47 @@ func TestUpdateNodeWithMultiplePods(t *testing.T) {
 		close(stopCh)
 	}
 }
+
+func TestGetMinTolerationTime(t *testing.T) {
+	one := int64(1)
+	oneSec := 1 * time.Second
+
+	tests := []struct {
+		tolerations []v1.Toleration
+		expected    time.Duration
+	}{
+		{
+			tolerations: []v1.Toleration{},
+			expected:    0,
+		},
+		{
+			tolerations: []v1.Toleration{
+				{
+					TolerationSeconds: &one,
+				},
+				{
+					TolerationSeconds: nil,
+				},
+			},
+			expected: oneSec,
+		},
+		{
+			tolerations: []v1.Toleration{
+				{
+					TolerationSeconds: nil,
+				},
+				{
+					TolerationSeconds: &one,
+				},
+			},
+			expected: oneSec,
+		},
+	}
+
+	for _, test := range tests {
+		got := getMinTolerationTime(test.tolerations)
+		if got != test.expected {
+			t.Errorf("Incorrect min toleration time: got %v, expected %v", got, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
For the following case, `getMinTolerationTime` should return one; but  it returned -1 ：
1. for tolerations[0], TolerationSeconds is nil, minTolerationTime is not set 
2. for tolerations[1], it's TolerationSeconds (1) is bigger than `minTolerationTime`, so minTolerationTime is still -1 which means infinite.

```
+		{
+			tolerations: []v1.Toleration{
+				{
+					TolerationSeconds: nil,
+				},
+				{
+					TolerationSeconds: &one,
+				},
+			},
+		},
```