### PR TITLE
Updated AddOrUpdateTolerationInPod to return bool only.

### DIFF
--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -467,7 +467,7 @@ const (
 
 // AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
 // Returns true if something was updated, false otherwise.
-func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
+func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) bool {
 	podTolerations := pod.Spec.Tolerations
 
 	var newTolerations []Toleration
@@ -475,7 +475,7 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 	for i := range podTolerations {
 		if toleration.MatchToleration(&podTolerations[i]) {
 			if Semantic.DeepEqual(toleration, podTolerations[i]) {
-				return false, nil
+				return false
 			}
 			newTolerations = append(newTolerations, *toleration)
 			updated = true
@@ -490,7 +490,7 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 	}
 
 	pod.Spec.Tolerations = newTolerations
-	return true, nil
+	return true
 }
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,

--- a/pkg/api/v1/helpers.go
+++ b/pkg/api/v1/helpers.go
@@ -276,9 +276,9 @@ const (
 	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
 )
 
-// Tries to add a toleration to annotations list. Returns true if something was updated
-// false otherwise.
-func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) bool {
 	podTolerations := pod.Spec.Tolerations
 
 	var newTolerations []Toleration
@@ -286,7 +286,7 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 	for i := range podTolerations {
 		if toleration.MatchToleration(&podTolerations[i]) {
 			if api.Semantic.DeepEqual(toleration, podTolerations[i]) {
-				return false, nil
+				return false
 			}
 			newTolerations = append(newTolerations, *toleration)
 			updated = true
@@ -301,7 +301,7 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 	}
 
 	pod.Spec.Tolerations = newTolerations
-	return true, nil
+	return true
 }
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,

--- a/pkg/controller/daemon/daemoncontroller.go
+++ b/pkg/controller/daemon/daemoncontroller.go
@@ -844,27 +844,21 @@ func (dsc *DaemonSetsController) nodeShouldRunDaemonPod(node *v1.Node, ds *exten
 	// Add infinite toleration for taint notReady:NoExecute here
 	// to survive taint-based eviction enforced by NodeController
 	// when node turns not ready.
-	_, err = v1.AddOrUpdateTolerationInPod(newPod, &v1.Toleration{
+	v1.AddOrUpdateTolerationInPod(newPod, &v1.Toleration{
 		Key:      metav1.TaintNodeNotReady,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoExecute,
 	})
-	if err != nil {
-		return false, false, false, err
-	}
 
 	// DaemonSet pods shouldn't be deleted by NodeController in case of node problems.
 	// Add infinite toleration for taint unreachable:NoExecute here
 	// to survive taint-based eviction enforced by NodeController
 	// when node turns unreachable.
-	_, err = v1.AddOrUpdateTolerationInPod(newPod, &v1.Toleration{
+	v1.AddOrUpdateTolerationInPod(newPod, &v1.Toleration{
 		Key:      metav1.TaintNodeUnreachable,
 		Operator: v1.TolerationOpExists,
 		Effect:   v1.TaintEffectNoExecute,
 	})
-	if err != nil {
-		return false, false, false, err
-	}
 
 	pods := []*v1.Pod{}
 

--- a/plugin/pkg/admission/defaulttolerationseconds/admission.go
+++ b/plugin/pkg/admission/defaulttolerationseconds/admission.go
@@ -97,29 +97,21 @@ func (p *plugin) Admit(attributes admission.Attributes) (err error) {
 	}
 
 	if !toleratesNodeNotReady {
-		_, err := api.AddOrUpdateTolerationInPod(pod, &api.Toleration{
+		api.AddOrUpdateTolerationInPod(pod, &api.Toleration{
 			Key:               metav1.TaintNodeNotReady,
 			Operator:          api.TolerationOpExists,
 			Effect:            api.TaintEffectNoExecute,
 			TolerationSeconds: defaultNotReadyTolerationSeconds,
 		})
-		if err != nil {
-			return admission.NewForbidden(attributes,
-				fmt.Errorf("failed to add default tolerations for taints `notReady:NoExecute` and `unreachable:NoExecute`, err: %v", err))
-		}
 	}
 
 	if !toleratesNodeUnreachable {
-		_, err := api.AddOrUpdateTolerationInPod(pod, &api.Toleration{
+		api.AddOrUpdateTolerationInPod(pod, &api.Toleration{
 			Key:               metav1.TaintNodeUnreachable,
 			Operator:          api.TolerationOpExists,
 			Effect:            api.TaintEffectNoExecute,
 			TolerationSeconds: defaultUnreachableTolerationSeconds,
 		})
-		if err != nil {
-			return admission.NewForbidden(attributes,
-				fmt.Errorf("failed to add default tolerations for taints `notReady:NoExecute` and `unreachable:NoExecute`, err: %v", err))
-		}
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/pkg/api/helpers.go
+++ b/staging/src/k8s.io/client-go/pkg/api/helpers.go
@@ -467,7 +467,7 @@ const (
 
 // AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
 // Returns true if something was updated, false otherwise.
-func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
+func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) bool {
 	podTolerations := pod.Spec.Tolerations
 
 	var newTolerations []Toleration
@@ -475,7 +475,7 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 	for i := range podTolerations {
 		if toleration.MatchToleration(&podTolerations[i]) {
 			if Semantic.DeepEqual(toleration, podTolerations[i]) {
-				return false, nil
+				return false
 			}
 			newTolerations = append(newTolerations, *toleration)
 			updated = true
@@ -490,7 +490,7 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 	}
 
 	pod.Spec.Tolerations = newTolerations
-	return true, nil
+	return true
 }
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,

--- a/staging/src/k8s.io/client-go/pkg/api/v1/helpers.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/helpers.go
@@ -276,9 +276,9 @@ const (
 	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
 )
 
-// Tries to add a toleration to annotations list. Returns true if something was updated
-// false otherwise.
-func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) bool {
 	podTolerations := pod.Spec.Tolerations
 
 	var newTolerations []Toleration
@@ -286,7 +286,7 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 	for i := range podTolerations {
 		if toleration.MatchToleration(&podTolerations[i]) {
 			if api.Semantic.DeepEqual(toleration, podTolerations[i]) {
-				return false, nil
+				return false
 			}
 			newTolerations = append(newTolerations, *toleration)
 			updated = true
@@ -301,7 +301,7 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 	}
 
 	pod.Spec.Tolerations = newTolerations
-	return true, nil
+	return true
 }
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,


### PR DESCRIPTION
Updated AddOrUpdateTolerationInPod to return bool only, as there's no case to generate error (the error was used for annotation, it'll not return error after moving to field); and also update admission & daemonset accordingly. 