### PR TITLE
hack/godep-restore.sh: use godep v79 which works

### DIFF
--- a/hack/godep-restore.sh
+++ b/hack/godep-restore.sh
@@ -22,7 +22,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
-kube::util::ensure_godep_version v74
+kube::util::ensure_godep_version v79
 
 echo "Starting to download all kubernetes godeps. This takes a while"
 GOPATH=${GOPATH}:${KUBE_ROOT}/staging godep restore "$@"


### PR DESCRIPTION
Godep v74 gives me:

```shell
godep: Checking dependency: k8s.io/metrics/pkg/apis/custom_metrics
godep: Dep (k8s.io/metrics/pkg/apis/custom_metrics) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/api/resource) not found
godep: Checking dependency: k8s.io/metrics/pkg/apis/custom_metrics/install
godep: Dep (k8s.io/metrics/pkg/apis/custom_metrics/install) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/apimachinery/announced) not found
godep: Checking dependency: k8s.io/metrics/pkg/apis/custom_metrics/v1alpha1
godep: Dep (k8s.io/metrics/pkg/apis/custom_metrics/v1alpha1) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/api/resource) not found
godep: Checking dependency: k8s.io/metrics/pkg/apis/metrics
godep: Dep (k8s.io/metrics/pkg/apis/metrics) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/apis/meta/v1) not found
godep: Checking dependency: k8s.io/metrics/pkg/apis/metrics/install
godep: Dep (k8s.io/metrics/pkg/apis/metrics/install) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/apimachinery/announced) not found
godep: Checking dependency: k8s.io/metrics/pkg/apis/metrics/v1alpha1
godep: Dep (k8s.io/metrics/pkg/apis/metrics/v1alpha1) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/api/resource) not found
godep: Checking dependency: k8s.io/metrics/pkg/client/clientset_generated/clientset
godep: Dep (k8s.io/metrics/pkg/client/clientset_generated/clientset) restored, but was unable to load it with error:
	Package (k8s.io/client-go/discovery) not found
godep: Checking dependency: k8s.io/metrics/pkg/client/clientset_generated/clientset/fake
godep: Dep (k8s.io/metrics/pkg/client/clientset_generated/clientset/fake) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/runtime) not found
godep: Checking dependency: k8s.io/metrics/pkg/client/clientset_generated/clientset/scheme
godep: Dep (k8s.io/metrics/pkg/client/clientset_generated/clientset/scheme) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/apis/meta/v1) not found
godep: Checking dependency: k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1
godep: Dep (k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/apis/meta/v1) not found
godep: Checking dependency: k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1/fake
godep: Dep (k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1/fake) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/apis/meta/v1) not found
godep: Checking dependency: k8s.io/metrics/pkg/client/custom_metrics
godep: Dep (k8s.io/metrics/pkg/client/custom_metrics) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/api/meta) not found
godep: Checking dependency: k8s.io/metrics/pkg/client/custom_metrics/fake
godep: Dep (k8s.io/metrics/pkg/client/custom_metrics/fake) restored, but was unable to load it with error:
	Package (k8s.io/apimachinery/pkg/labels) not found
godep: Checking dependency: vbom.ml/util/sortorder
godep: Error checking some deps.
2,64s user 2,75s system 11% cpu 47,395s total
```

v79 works.