### PR TITLE
Update hack scripts to use godep v79 and ensure_godep_version

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "k8s.io/kubernetes",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"github.com/ugorji/go/codec/codecgen",
 		"github.com/onsi/ginkgo/ginkgo",
@@ -16,7 +16,7 @@
 		{
 			"ImportPath": "bitbucket.org/ww/goautoneg",
 			"Comment": "null-5",
-			"Rev": "'75cd24fc2f2c2a2088577d12123ddee5f54e0675'"
+			"Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 		},
 		{
 			"ImportPath": "cloud.google.com/go/compute/metadata",

--- a/hack/godep-save.sh
+++ b/hack/godep-save.sh
@@ -22,7 +22,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
-kube::util::ensure_godep_version v74
+kube::util::ensure_godep_version v79
 
 # Some things we want in godeps aren't code dependencies, so ./...
 # won't pick them up.

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -38,7 +38,7 @@ kube::golang::server_targets() {
 readonly KUBE_SERVER_TARGETS=($(kube::golang::server_targets))
 readonly KUBE_SERVER_BINARIES=("${KUBE_SERVER_TARGETS[@]##*/}")
 
-# The set of server targets that we are only building for Kubernetes nodes 
+# The set of server targets that we are only building for Kubernetes nodes
 # If you update this list, please also update build/release-tars/BUILD.
 kube::golang::node_targets() {
   local targets=(
@@ -311,33 +311,6 @@ kube::golang::create_gopath_tree() {
 # infinite loop created by the symlink at
 # ${go_pkg_dir}
 EOF
-}
-
-# Ensure the godep tool exists and is a viable version.
-kube::golang::verify_godep_version() {
-  local -a godep_version_string
-  local godep_version
-  local godep_min_version="63"
-
-  if ! which godep &>/dev/null; then
-    kube::log::usage_from_stdin <<EOF
-Can't find 'godep' in PATH, please fix and retry.
-See https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md#godep-and-dependency-management for installation instructions.
-EOF
-    return 2
-  fi
-
-  godep_version_string=($(godep version))
-  godep_version=${godep_version_string[1]/v/}
-  if ((godep_version<$godep_min_version)); then
-    kube::log::usage_from_stdin <<EOF
-Detected godep version: ${godep_version_string[*]}.
-Kubernetes requires godep v$godep_min_version or greater.
-Please update:
-go get -u github.com/tools/godep
-EOF
-    return 2
-  fi
 }
 
 # Ensure the go tool exists and is a viable version.

--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -469,7 +469,8 @@ kube::util::ensure_clean_working_dir() {
 
 # Ensure that the given godep version is installed and in the path
 kube::util::ensure_godep_version() {
-  if [[ "$(godep version)" == *"godep ${1}"* ]]; then
+  GODEP_VERSION=${1:-"v79"}
+  if [[ "$(godep version)" == *"godep ${GODEP_VERSION}"* ]]; then
     return
   fi
 
@@ -478,7 +479,7 @@ kube::util::ensure_godep_version() {
 
   GOPATH="${KUBE_TEMP}/go" go get -d -u github.com/tools/godep 2>/dev/null
   pushd "${KUBE_TEMP}/go/src/github.com/tools/godep" >/dev/null
-    git checkout "${1:-v74}"
+    git checkout "${GODEP_VERSION}"
     GOPATH="${KUBE_TEMP}/go" go install .
   popd >/dev/null
 

--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -54,7 +54,7 @@ if ! $ALL ; then
 	echo "Running in short-circuit mode; run with -a to force all scripts to run."
 fi
 
-kube::util::ensure_godep_version v74
+kube::util::ensure_godep_version v79
 
 if ! kube::util::godep_restored 2>&1 | sed 's/^/  /'; then
 	echo "Running godep restore"
@@ -95,4 +95,3 @@ for t in $BASH_TARGETS; do
 done
 
 echo -e "${color_green}Update scripts completed successfully${color_norm}"
-

--- a/hack/update-staging-client-go.sh
+++ b/hack/update-staging-client-go.sh
@@ -22,7 +22,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/util.sh"
 
 kube::util::ensure_clean_working_dir
-kube::util::ensure_godep_version v74
+kube::util::ensure_godep_version v79
 
 cd ${KUBE_ROOT}
 

--- a/hack/update-staging-godeps.sh
+++ b/hack/update-staging-godeps.sh
@@ -56,7 +56,7 @@ if ! kube::util::godep_restored 2>&1 | sed 's/^/  /'; then
 fi
 
 kube::util::ensure-temp-dir
-kube::util::ensure_godep_version v74
+kube::util::ensure_godep_version v79
 
 TMP_GOPATH="${KUBE_TEMP}/go"
 

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -44,7 +44,6 @@ preload-dep() {
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
-kube::golang::verify_godep_version
 
 readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
 if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
@@ -86,23 +85,12 @@ _kubetmp="${_kubetmp}/kubernetes"
 export GOPATH="${_tmpdir}"
 
 pushd "${_kubetmp}" 2>&1 > /dev/null
-  # Build the godep tool
-  go get -u github.com/tools/godep 2>/dev/null
-  export GODEP="${GOPATH}/bin/godep"
-  pin-godep() {
-    pushd "${GOPATH}/src/github.com/tools/godep" > /dev/null
-      git checkout "$1"
-      "${GODEP}" go install
-    popd > /dev/null
-  }
-  # Use to following if we ever need to pin godep to a specific version again
-  pin-godep 'v74'
-  "${GODEP}" version
+  kube::util::ensure_godep_version v79
 
   export GOPATH="${GOPATH}:${_kubetmp}/staging"
   # Fill out that nice clean place with the kube godeps
   echo "Starting to download all kubernetes godeps. This takes a while"
-  "${GODEP}" restore
+  godep restore
   echo "Download finished"
 
   # Destroy deps in the copy of the kube tree
@@ -132,7 +120,7 @@ pushd "${KUBE_ROOT}" 2>&1 > /dev/null
     ret=1
   fi
 
-  if ! _out="$(diff -Naupr -x 'BUILD' vendor ${_kubetmp}/vendor)"; then
+  if ! _out="$(diff -Naupr -x "BUILD" -x "AUTHORS*" -x "CONTRIBUTORS*" vendor ${_kubetmp}/vendor)"; then
     echo "Your vendored results are different:"
     echo "${_out}"
     echo "Godeps Verify failed."

--- a/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apimachinery/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "k8s.io/apimachinery",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1,14 +1,14 @@
 {
 	"ImportPath": "k8s.io/apiserver",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
 	"Deps": [
 		{
 			"ImportPath": "bitbucket.org/ww/goautoneg",
-			"Rev": "'75cd24fc2f2c2a2088577d12123ddee5f54e0675'"
+			"Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 		},
 		{
 			"ImportPath": "github.com/PuerkitoBio/purell",

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "k8s.io/client-go",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -1,14 +1,14 @@
 {
 	"ImportPath": "k8s.io/kube-aggregator",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
 	"Deps": [
 		{
 			"ImportPath": "bitbucket.org/ww/goautoneg",
-			"Rev": "'75cd24fc2f2c2a2088577d12123ddee5f54e0675'"
+			"Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 		},
 		{
 			"ImportPath": "github.com/PuerkitoBio/purell",

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -1,14 +1,14 @@
 {
 	"ImportPath": "k8s.io/sample-apiserver",
 	"GoVersion": "go1.7",
-	"GodepVersion": "v74",
+	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
 	],
 	"Deps": [
 		{
 			"ImportPath": "bitbucket.org/ww/goautoneg",
-			"Rev": "'75cd24fc2f2c2a2088577d12123ddee5f54e0675'"
+			"Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 		},
 		{
 			"ImportPath": "github.com/PuerkitoBio/purell",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Based on #42965 and https://github.com/kubernetes/kubernetes/pull/42958#discussion_r105568318, this pins the godep version at v79, which should fix some issues when running godep in go1.8 local environments.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #42817

**Special notes for your reviewer**:
This should likely get the v1.6 milestone so that it can be merged into master. While I'm setting a default godep version, I'm continuing to use the local pins per this comment: https://github.com/kubernetes/kubernetes/pull/42965#issuecomment-285962723 .

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

cc: @sttts 