### PR TITLE
kubeadm: fixed warning nil logging

### DIFF
--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//test/e2e_node/system:go_default_library",
         "//vendor:github.com/PuerkitoBio/purell",
         "//vendor:github.com/blang/semver",
-        "//vendor:k8s.io/apimachinery/pkg/util/errors",
     ],
 )
 

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -38,7 +38,6 @@ import (
 
 	"net/url"
 
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/pkg/api/validation"
@@ -343,12 +342,11 @@ func (sysver SystemVerificationCheck) Check() (warnings, errors []error) {
 		}
 	}
 
-	err := utilerrors.NewAggregate(errs)
-	if err != nil {
+	if len(errs) != 0 {
 		// Only print the output from the system verification check if the check failed
 		fmt.Println("[preflight] The system verification failed. Printing the output from the verification:")
 		bufw.Flush()
-		return warns, []error{err}
+		return warns, errs
 	}
 	return warns, nil
 }

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -335,8 +335,12 @@ func (sysver SystemVerificationCheck) Check() (warnings, errors []error) {
 	// Run all validators
 	for _, v := range validators {
 		warn, err := v.Validate(system.DefaultSysSpec)
-		errs = append(errs, err)
-		warns = append(warns, warn)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		if warn != nil {
+			warns = append(warns, warn)
+		}
 	}
 
 	err := utilerrors.NewAggregate(errs)
@@ -575,7 +579,7 @@ func RunChecks(checks []Checker, ww io.Writer) error {
 	for _, c := range checks {
 		warnings, errs := c.Check()
 		for _, w := range warnings {
-			io.WriteString(ww, fmt.Sprintf("[preflight] WARNING: %s\n", w))
+			io.WriteString(ww, fmt.Sprintf("[preflight] WARNING: %v\n", w))
 		}
 		found = append(found, errs...)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Fix bug in warning aggregation for preflight checks. Would cause logging like this:

`[preflight] WARNING: %!s(<nil>)`

Will now only append non-nil cases to warning.

**Special notes for your reviewer**: /cc @jbeda 

**Release note**:
```release-note
NONE
```
