### PR TITLE
Fix vsphere selinux support

### DIFF
--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -188,6 +188,7 @@ type vsphereVolumeMounter struct {
 func (b *vsphereVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
 		SupportsSELinux: true,
+		Managed:         true,
 	}
 }
 


### PR DESCRIPTION
Managed flag must be true for SELinux relabelling to work
for vsphere.

Fixes #42972 

```release-note
Fix [vSphere volumes in SELinux environment](https://github.com/kubernetes/kubernetes/issues/42972).
```