### PR TITLE
i42983: scheduler.alpha.kubernetes.io/tolerations is an annotation

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -20,6 +20,14 @@ spec:
       # Note that this does not guarantee admission on the nodes (#40573).
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [
+            {
+              "key": "role",
+              "value": "master",
+              "effect": "NoSchedule"
+            }
+          ]
     spec:
       containers:
       - name: fluentd-es
@@ -42,9 +50,6 @@ spec:
           readOnly: true
       nodeSelector:
         alpha.kubernetes.io/fluentd-ds-ready: "true"
-      tolerations:
-      - key : "node.alpha.kubernetes.io/ismaster"
-        effect: "NoSchedule"
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
Fix #42983 