### PR TITLE
Remove 'beta' from default storage class annotation

### DIFF
--- a/pkg/apis/storage/v1/util/helpers.go
+++ b/pkg/apis/storage/v1/util/helpers.go
@@ -20,8 +20,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // IsDefaultStorageClassAnnotation represents a StorageClass annotation that
 // marks a class as the default StorageClass
-//TODO: Update IsDefaultStorageClassannotation and remove Beta when no longer used
-const IsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
+//TODO: remove Beta when no longer used
+const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
 
 // IsDefaultAnnotationText returns a pretty Yes/No String if

--- a/pkg/apis/storage/v1beta1/util/helpers.go
+++ b/pkg/apis/storage/v1beta1/util/helpers.go
@@ -20,8 +20,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // IsDefaultStorageClassAnnotation represents a StorageClass annotation that
 // marks a class as the default StorageClass
-//TODO: Update IsDefaultStorageClassannotation and remove Beta when no longer used
-const IsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
+//TODO: remove Beta when no longer used
+const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
 
 // IsDefaultAnnotationText returns a pretty Yes/No String if


### PR DESCRIPTION
I forgot to update default storage class annotation in my storage.k8s.io/v1beta1 -> v1 PRs. Let's fix it before 1.6 is released.

I consider it as a bugfix, in #40088 I already updated the release notes to include non-beta annotation  `storageclass.kubernetes.io/is-default-class`

```release-note
NONE
```


@kubernetes/sig-storage-pr-reviews 
@msau42, please help with merging.