### PR TITLE
Unit test quota for nodeport associated with loadbalancer

### DIFF
--- a/pkg/quota/evaluator/core/services_test.go
+++ b/pkg/quota/evaluator/core/services_test.go
@@ -67,6 +67,23 @@ func TestServiceEvaluatorUsage(t *testing.T) {
 				api.ResourceServices:              resource.MustParse("1"),
 			},
 		},
+		"loadbalancer_ports": {
+			service: &api.Service{
+				Spec: api.ServiceSpec{
+					Type: api.ServiceTypeLoadBalancer,
+					Ports: []api.ServicePort{
+						{
+							Port: 27443,
+						},
+					},
+				},
+			},
+			usage: api.ResourceList{
+				api.ResourceServicesNodePorts:     resource.MustParse("1"),
+				api.ResourceServicesLoadBalancers: resource.MustParse("1"),
+				api.ResourceServices:              resource.MustParse("1"),
+			},
+		},
 		"clusterip": {
 			service: &api.Service{
 				Spec: api.ServiceSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds unit tests to ensure node ports associated with loadbalancers are charged to quota appropriately.  The original PR that added that feature to quota lacked a unit test (https://github.com/kubernetes/kubernetes/pull/39364)