### PR TITLE
go-to-protobuf: actually skip - packages

### DIFF
--- a/cmd/libs/go2idl/go-to-protobuf/protobuf/cmd.go
+++ b/cmd/libs/go2idl/go-to-protobuf/protobuf/cmd.go
@@ -137,6 +137,7 @@ func Run(g *Generator) {
 
 	protobufNames := NewProtobufNamer()
 	outputPackages := generator.Packages{}
+	nonOutputPackages := map[string]struct{}{}
 	for _, d := range strings.Split(g.Packages, ",") {
 		generateAllTypes, outputPackage := true, true
 		switch {
@@ -160,6 +161,8 @@ func Run(g *Generator) {
 		protobufNames.Add(p)
 		if outputPackage {
 			outputPackages = append(outputPackages, p)
+		} else {
+			nonOutputPackages[name] = struct{}{}
 		}
 	}
 
@@ -198,6 +201,10 @@ func Run(g *Generator) {
 
 	var vendoredOutputPackages, localOutputPackages generator.Packages
 	for _, p := range protobufNames.packages {
+		if _, ok := nonOutputPackages[p.Name()]; ok {
+			// if we're not outputting the package, don't include it in either package list
+			continue
+		}
 		p.Vendored = strings.Contains(c.Universe[p.PackagePath].SourcePath, "/vendor/")
 		if p.Vendored {
 			vendoredOutputPackages = append(vendoredOutputPackages, p)


### PR DESCRIPTION
If a package is prefixed with -, we are not supposed to be generating
protobuf for it. Make that actually happen :-)

cc @smarterclayton @sttts @deads2k @liggitt @kubernetes/sig-api-machinery-pr-reviews 