### PR TITLE
skip taint tests for 1.5-1.6 skew tests

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1657,6 +1657,16 @@ func SkipUnlessKubectlVersionGTE(v semver.Version) {
 	}
 }
 
+func SkipUnlessKubectlVersionLTE(v semver.Version) {
+	gte, err := KubectlVersionGTE(v)
+	if err != nil {
+		Failf("Failed to get kubectl version: %v", err)
+	}
+	if gte {
+		Skipf("Not supported for kubectl versions after %q", v)
+	}
+}
+
 // KubectlVersionGTE returns true if the kubectl version is greater than or
 // equal to v.
 func KubectlVersionGTE(v semver.Version) (bool, error) {

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -1333,6 +1333,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 
 	framework.KubeDescribe("Kubectl taint", func() {
 		It("should update the taint on a node", func() {
+			framework.SkipUnlessKubectlVersionLTE(version.MustParse("v1.6.0-alpha.3"))
 			testTaint := api.Taint{
 				Key:    fmt.Sprintf("kubernetes.io/e2e-taint-key-001-%s", string(uuid.NewUUID())),
 				Value:  "testing-taint-value",
@@ -1364,6 +1365,7 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 		})
 
 		It("should remove all the taints with the same key off a node", func() {
+			framework.SkipUnlessKubectlVersionLTE(version.MustParse("v1.6.0-alpha.3"))
 			testTaint := api.Taint{
 				Key:    fmt.Sprintf("kubernetes.io/e2e-taint-key-002-%s", string(uuid.NewUUID())),
 				Value:  "testing-taint-value",


### PR DESCRIPTION
In 1.5 branch, skip kubectl taint tests unless kubectl is 1.6.0-alpha.3 or earlier to make skew passing.
Based on discussion https://github.com/kubernetes/kubernetes/issues/42918#issuecomment-286019730
```release-note
NONE
```

cc: @pwittrock @davidopp 