### PR TITLE
[Do Not Merge] Add kubelet deletion prometheus metrics

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -30,6 +30,7 @@ const (
 	PodWorkerLatencyKey           = "pod_worker_latency_microseconds"
 	SyncPodsLatencyKey            = "sync_pods_latency_microseconds"
 	PodStartLatencyKey            = "pod_start_latency_microseconds"
+	PodDeletionLatencyKey         = "pod_deletion_latency_microseconds"
 	PodStatusLatencyKey           = "generate_pod_status_latency_microseconds"
 	ContainerManagerOperationsKey = "container_manager_latency_microseconds"
 	CgroupManagerOperationsKey    = "cgroup_manager_latency_microseconds"
@@ -74,6 +75,13 @@ var (
 			Subsystem: KubeletSubsystem,
 			Name:      PodStartLatencyKey,
 			Help:      "Latency in microseconds for a single pod to go from pending to running. Broken down by podname.",
+		},
+	)
+	PodDeletionLatency = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Subsystem: KubeletSubsystem,
+			Name:      PodDeletionLatencyKey,
+			Help:      "Latency in microseconds between when a single pod's deletion timestamp is set, and the pod is removed from etcd",
 		},
 	)
 	PodStatusLatency = prometheus.NewSummary(
@@ -188,6 +196,7 @@ func Register(containerCache kubecontainer.RuntimeCache) {
 	registerMetrics.Do(func() {
 		prometheus.MustRegister(PodWorkerLatency)
 		prometheus.MustRegister(PodStartLatency)
+		prometheus.MustRegister(PodDeletionLatency)
 		prometheus.MustRegister(PodStatusLatency)
 		prometheus.MustRegister(DockerOperationsLatency)
 		prometheus.MustRegister(ContainerManagerLatency)

--- a/pkg/kubelet/status/BUILD
+++ b/pkg/kubelet/status/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/kubelet/container:go_default_library",
+        "//pkg/kubelet/metrics:go_default_library",
         "//pkg/kubelet/pod:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",

--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/metrics"
 	kubepod "k8s.io/kubernetes/pkg/kubelet/pod"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
@@ -455,6 +456,7 @@ func (m *manager) syncPod(uid types.UID, status versionedPodStatus) {
 			deleteOptions.Preconditions = metav1.NewUIDPreconditions(string(pod.UID))
 			if err = m.kubeClient.Core().Pods(pod.Namespace).Delete(pod.Name, deleteOptions); err == nil {
 				glog.V(3).Infof("Pod %q fully terminated and removed from etcd", format.Pod(pod))
+				metrics.PodDeletionLatency.Observe(metrics.SinceInMicroseconds(pod.DeletionTimestamp.Time))
 				m.deletePodStatus(uid)
 				return
 			}


### PR DESCRIPTION
Completes #42673.

One thing to note: This measures deletion from when the timestamp is set by the API server.  This is simpler to add, but may be less useful, since it can be affected by network outages, for example.

cc @kubernetes/sig-node-pr-reviews 