### PR TITLE
[Federation] Fix flakey ingress unit test

### DIFF
--- a/federation/pkg/federation-controller/ingress/ingress_controller_test.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller_test.go
@@ -252,14 +252,10 @@ func TestIngressController(t *testing.T) {
 	assert.True(t, reflect.DeepEqual(updatedIngress2.Spec, fedIngress.Spec), "Spec of updated ingress is not equal")
 	assert.Equal(t, updatedIngress2.ObjectMeta.Annotations["A"], fedIngress.ObjectMeta.Annotations["A"], "Updated annotation not transferred from federated to cluster ingress.")
 
-	// Test add cluster
-	t.Log("Adding a second cluster")
-
 	fedIngress.Annotations[staticIPNameKeyWritable] = "foo" // Make sure that the base object has a static IP name first.
 	fedIngressWatch.Modify(&fedIngress)
-	clusterWatch.Add(cluster2)
 
-	t.Log("Checking that the ingress got created in cluster 2")
+	t.Log("Checking that the ingress got created in cluster 2 after a global ip was assigned")
 	createdIngress2 := GetIngressFromChan(t, cluster2IngressCreateChan)
 	assert.NotNil(t, createdIngress2)
 	assert.True(t, reflect.DeepEqual(fedIngress.Spec, createdIngress2.Spec), "Spec of created ingress is not equal")

--- a/federation/pkg/federation-controller/util/federated_informer.go
+++ b/federation/pkg/federation-controller/util/federated_informer.go
@@ -281,6 +281,10 @@ func (f *federatedInformerImpl) Stop() {
 	for key, informer := range f.targetInformers {
 		glog.V(4).Infof("... Closing informer channel for %q.", key)
 		close(informer.stopChan)
+		// Remove each informer after it has been stopped to prevent
+		// subsequent cluster deletion from attempting to double close
+		// an informer's stop channel.
+		delete(f.targetInformers, key)
 	}
 }
 


### PR DESCRIPTION
The unit test for the ingress controller was previously adding a cluster twice, which resulted in a cluster being deleted and added back.  The deletion was racing the controller shutdown to close
informer channels, sometimes resulting in closing an already closed channel.  This change ensures that the federated informer clears its map of informers when ``Stop()`` is called to insure against a double close, and fixes the test to no longer add the cluster twice.

Targets #43009

cc: @csbell @kubernetes/sig-federation-bugs 