### PR TITLE
ThirdPartyResource example: added watcher example, code cleanup

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
@@ -48,6 +48,7 @@ func AddToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 		&ExportOptions{},
 		&GetOptions{},
 		&DeleteOptions{},
+		&Status{},
 	)
 	scheme.AddConversionFuncs(
 		Convert_versioned_Event_to_watch_Event,

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/README.md
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/README.md
@@ -4,6 +4,7 @@ This particular example demonstrates how to perform basic operations such as:
 
 * How to register a new ThirdPartyResource (custom Resource type)
 * How to create/get/list instances of your new Resource type (update/delete/etc work as well but are not demonstrated) 
+* How to setup a watcher on Resource create/update/delete events
 
 ## Running
 

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/client.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/client.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+)
+
+func NewClient(cfg *rest.Config) (*rest.RESTClient, *runtime.Scheme, error) {
+	groupVersion := schema.GroupVersion{
+		Group:   ExampleResourceGroup,
+		Version: ExampleResourceVersion,
+	}
+
+	schemeBuilder := runtime.NewSchemeBuilder(func(scheme *runtime.Scheme) error {
+		scheme.AddKnownTypes(
+			groupVersion,
+			&Example{},
+			&ExampleList{},
+		)
+		metav1.AddToGroupVersion(scheme, groupVersion)
+		return nil
+	})
+
+	scheme := runtime.NewScheme()
+	if err := schemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, nil, err
+	}
+
+	config := *cfg
+	config.GroupVersion = &groupVersion
+	config.APIPath = "/apis"
+	config.ContentType = runtime.ContentTypeJSON
+	config.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)}
+
+	client, err := rest.RESTClientFor(&config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return client, scheme, nil
+}

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/types.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/types.go
@@ -23,6 +23,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const (
+	ExampleDomain              = "tpr.client-go.k8s.io"
+	ExampleResourceDescription = "An Example ThirdPartyResource"
+	ExampleResourceGroup       = ExampleDomain
+
+	ExampleResourcePath         = "examples"
+	ExampleResourceName         = "example." + ExampleDomain
+	ExampleResourceVersion      = "v1"
+	ExampleResourceKind         = "Example"
+	ExampleResourceGroupVersion = ExampleResourceGroup + "/" + ExampleResourceVersion
+)
+
 type ExampleSpec struct {
 	Foo string `json:"foo"`
 	Bar bool   `json:"bar"`

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/watcher.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/watcher.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+// Watcher is an example of watching on resource create/update/delete events
+type Watcher struct {
+	clientset     *kubernetes.Clientset
+	exampleClient *rest.RESTClient
+	exampleScheme *runtime.Scheme
+}
+
+// Run starts an Example resource watcher
+func (w *Watcher) Run(ctx context.Context) error {
+	fmt.Printf("Watch Example objects\n")
+
+	// Watch Example objects
+	handler := ExampleEventHandler{}
+	_, err := watchExamples(ctx, w.exampleClient, w.exampleScheme, &handler)
+	if err != nil {
+		fmt.Printf("Failed to register watch for Example resource: %v\n", err)
+		return err
+	}
+
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func watchExamples(ctx context.Context, exampleClient cache.Getter, exampleScheme *runtime.Scheme, handler cache.ResourceEventHandler) (cache.Controller, error) {
+	parameterCodec := runtime.NewParameterCodec(exampleScheme)
+
+	source := newListWatchFromClient(
+		exampleClient,
+		ExampleResourcePath,
+		api.NamespaceAll,
+		fields.Everything(),
+		parameterCodec)
+
+	store, controller := cache.NewInformer(
+		source,
+
+		// The object type.
+		&Example{},
+
+		// resyncPeriod
+		// Every resyncPeriod, all resources in the cache will retrigger events.
+		// Set to 0 to disable the resync.
+		0,
+
+		// Your custom resource event handlers.
+		handler)
+
+	// store can be used to List and Get
+	// NEVER modify objects from the store. It's a read-only, local cache.
+	// You can use exampleScheme.Copy() to make a deep copy of original object and modify this copy
+	for _, obj := range store.List() {
+		example := obj.(*Example)
+		exampleScheme.Copy(example)
+
+		// This will likely be empty the first run, but may not
+		fmt.Printf("Existing example: %#v\n", example)
+	}
+
+	go controller.Run(ctx.Done())
+
+	return controller, nil
+}
+
+// See the issue comment: https://github.com/kubernetes/kubernetes/issues/16376#issuecomment-272167794
+// newListWatchFromClient is a copy of cache.NewListWatchFromClient() method with custom codec
+// Cannot use cache.NewListWatchFromClient() because it uses global api.ParameterCodec which uses global
+// api.Scheme which does not know about custom types (Example in our case) group/version.
+func newListWatchFromClient(c cache.Getter, resource string, namespace string, fieldSelector fields.Selector, paramCodec runtime.ParameterCodec) *cache.ListWatch {
+	listFunc := func(options metav1.ListOptions) (runtime.Object, error) {
+		return c.Get().
+			Namespace(namespace).
+			Resource(resource).
+			VersionedParams(&options, paramCodec).
+			FieldsSelectorParam(fieldSelector).
+			Do().
+			Get()
+	}
+	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
+		return c.Get().
+			Prefix("watch").
+			Namespace(namespace).
+			Resource(resource).
+			VersionedParams(&options, paramCodec).
+			FieldsSelectorParam(fieldSelector).
+			Watch()
+	}
+	return &cache.ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
+}
+
+// ExampleEventHandler can handle events for Example resource
+type ExampleEventHandler struct {
+}
+
+func (h *ExampleEventHandler) OnAdd(obj interface{}) {
+	example := obj.(*Example)
+	fmt.Printf("[WATCH] OnAdd %s\n", example.Metadata.SelfLink)
+}
+
+func (h *ExampleEventHandler) OnUpdate(oldObj, newObj interface{}) {
+	oldExample := oldObj.(*Example)
+	newExample := newObj.(*Example)
+	fmt.Printf("[WATCH] OnUpdate oldObj: %s\n", oldExample.Metadata.SelfLink)
+	fmt.Printf("[WATCH] OnUpdate newObj: %s\n", newExample.Metadata.SelfLink)
+}
+
+func (h *ExampleEventHandler) OnDelete(obj interface{}) {
+	example := obj.(*Example)
+	fmt.Printf("[WATCH] OnDelete %s\n", example.Metadata.SelfLink)
+}

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -11757,21 +11757,26 @@ go_test(
 go_library(
     name = "k8s.io/client-go/examples/third-party-resources",
     srcs = [
+        "k8s.io/client-go/examples/third-party-resources/client.go",
         "k8s.io/client-go/examples/third-party-resources/main.go",
         "k8s.io/client-go/examples/third-party-resources/types.go",
+        "k8s.io/client-go/examples/third-party-resources/watcher.go",
     ],
     tags = ["automanaged"],
     deps = [
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
+        "//vendor:k8s.io/apimachinery/pkg/fields",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apimachinery/pkg/runtime/serializer",
+        "//vendor:k8s.io/apimachinery/pkg/watch",
         "//vendor:k8s.io/client-go/kubernetes",
         "//vendor:k8s.io/client-go/pkg/api",
         "//vendor:k8s.io/client-go/pkg/apis/extensions/v1beta1",
         "//vendor:k8s.io/client-go/plugin/pkg/client/auth/gcp",
         "//vendor:k8s.io/client-go/rest",
+        "//vendor:k8s.io/client-go/tools/cache",
         "//vendor:k8s.io/client-go/tools/clientcmd",
     ],
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Added an example of using go-client for watching on ThirdPartyResource events (create/update/delete).
Watching TPRs is a very common case, but a rather complicated process (especially due to many non-trivial details like [client-go#8](https://github.com/kubernetes/client-go/issues/8#issuecomment-285333502) and [kubernetes#16376](https://github.com/kubernetes/kubernetes/issues/16376#issuecomment-272167794))

Also, made minor code cleanup to avoid too many hardcoded strings copy-paste.

**Which issue this PR fixes**:
This PR gives an example of workarounds for [kubernetes#16376](https://github.com/kubernetes/kubernetes/issues/16376#issuecomment-272167794) and [kubernetes#26003](https://github.com/kubernetes/kubernetes/issues/26003#issuecomment-285674832)
