### PR TITLE
garbage collector's attemptToOrphanWorker checks for observedGeneration

### DIFF
--- a/pkg/controller/garbagecollector/graph.go
+++ b/pkg/controller/garbagecollector/graph.go
@@ -56,6 +56,18 @@ type node struct {
 	// when processing an Update event, we need to compare the updated
 	// ownerReferences with the owners recorded in the graph.
 	owners []metav1.OwnerReference
+	// deletionGeneration can only be set once, it records the generation of the
+	// object when gc's attemptToOrphanWorker processes the object for the first
+	// time.
+	deletionGeneration     int64
+	deletionGenerationOnce sync.Once
+}
+
+func (n *node) setDeletionGenerationOnce(generation int64) int64 {
+	n.deletionGenerationOnce.Do(func() {
+		n.deletionGeneration = generation
+	})
+	return n.deletionGeneration
 }
 
 // An object is on a one way trip to its final deletion if it starts being

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -434,6 +434,20 @@ func (u *Unstructured) SetClusterName(clusterName string) {
 	u.setNestedField(clusterName, "metadata", "clusterName")
 }
 
+func (u *Unstructured) GetGeneration() int64 {
+	if generation, ok := getNestedField(u.Object, "metadata", "generation").(int64); ok {
+		return generation
+	}
+	return 0
+}
+
+func (u *Unstructured) GetObservedGeneration() int64 {
+	if observedGeneration, ok := getNestedField(u.Object, "status", "observedGeneration").(int64); ok {
+		return observedGeneration
+	}
+	return 0
+}
+
 // UnstructuredList allows lists that do not have Golang structs
 // registered to be manipulated generically. This can be used to deal
 // with the API lists from a plug-in.


### PR DESCRIPTION
Fixes #42639
An alternative to #42938

GC waits until that the responsible controller has observed the deletionTimestamp!=nil before orphaning a controller object's dependents.

Compared to #42938, the change in this pr is more constricted, solely to the GC code. Performance-wise, this is more efficient than #42938, because GC only fetches the latest controller if user deletes it with orphan=true.

However, this fix depends on that all controllers properly set the observedGeneration after they have observed the deletionTimestamp!=nil and have stopped all actions. We need to audit all controllers if they work as we expect. If they don't, the worst case would be that GC stalls at processing one orphan request.
