### PR TITLE
Convert PrefixWriter to an interface

### DIFF
--- a/pkg/kubectl/history.go
+++ b/pkg/kubectl/history.go
@@ -105,7 +105,8 @@ func (h *DeploymentHistoryViewer) ViewHistory(namespace, name string, revision i
 		if err := v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(template, internalTemplate, nil); err != nil {
 			return "", fmt.Errorf("failed to convert podtemplate, %v", err)
 		}
-		printersinternal.DescribePodTemplate(internalTemplate, buf)
+		w := printersinternal.NewPrefixWriter(buf)
+		printersinternal.DescribePodTemplate(internalTemplate, w)
 		return buf.String(), nil
 	}
 

--- a/pkg/kubectl/rollback.go
+++ b/pkg/kubectl/rollback.go
@@ -172,7 +172,8 @@ func simpleDryRun(deployment *extensions.Deployment, c clientset.Interface, toRe
 		if err := v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(template, internalTemplate, nil); err != nil {
 			return "", fmt.Errorf("failed to convert podtemplate, %v", err)
 		}
-		printersinternal.DescribePodTemplate(internalTemplate, buf)
+		w := printersinternal.NewPrefixWriter(buf)
+		printersinternal.DescribePodTemplate(internalTemplate, w)
 		return buf.String(), nil
 	}
 
@@ -190,6 +191,7 @@ func simpleDryRun(deployment *extensions.Deployment, c clientset.Interface, toRe
 	if err := v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(template, internalTemplate, nil); err != nil {
 		return "", fmt.Errorf("failed to convert podtemplate, %v", err)
 	}
-	printersinternal.DescribePodTemplate(internalTemplate, buf)
+	w := printersinternal.NewPrefixWriter(buf)
+	printersinternal.DescribePodTemplate(internalTemplate, w)
 	return buf.String(), nil
 }

--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -76,11 +76,27 @@ const (
 	LEVEL_3
 )
 
-type PrefixWriter struct {
+// PrefixWriter can write text at various indentation levels.
+type PrefixWriter interface {
+	// Write writes text with the specified indentation level.
+	Write(level int, format string, a ...interface{})
+	// WriteLine writes an entire line with no indentation level.
+	WriteLine(a ...interface{})
+}
+
+// prefixWriter implements PrefixWriter
+type prefixWriter struct {
 	out io.Writer
 }
 
-func (pw *PrefixWriter) Write(level int, format string, a ...interface{}) {
+var _ PrefixWriter = &prefixWriter{}
+
+// NewPrefixWriter creates a new PrefixWriter.
+func NewPrefixWriter(out io.Writer) PrefixWriter {
+	return &prefixWriter{out: out}
+}
+
+func (pw *prefixWriter) Write(level int, format string, a ...interface{}) {
 	levelSpace := "  "
 	prefix := ""
 	for i := 0; i < level; i++ {
@@ -89,7 +105,7 @@ func (pw *PrefixWriter) Write(level int, format string, a ...interface{}) {
 	fmt.Fprintf(pw.out, prefix+format, a...)
 }
 
-func (pw *PrefixWriter) WriteLine(a ...interface{}) {
+func (pw *prefixWriter) WriteLine(a ...interface{}) {
 	fmt.Fprintln(pw.out, a...)
 }
 
@@ -174,7 +190,7 @@ func (g *genericDescriber) Describe(namespace, name string, describerSettings pr
 	}
 
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", obj.GetName())
 		w.Write(LEVEL_0, "Namespace:\t%s\n", obj.GetNamespace())
 		printLabelsMultiline(w, "Labels", obj.GetLabels())
@@ -241,7 +257,7 @@ func (d *NamespaceDescriber) Describe(namespace, name string, describerSettings 
 
 func describeNamespace(namespace *api.Namespace, resourceQuotaList *api.ResourceQuotaList, limitRangeList *api.LimitRangeList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", namespace.Name)
 		printLabelsMultiline(w, "Labels", namespace.Labels)
 		printAnnotationsMultiline(w, "Annotations", namespace.Annotations)
@@ -258,7 +274,7 @@ func describeNamespace(namespace *api.Namespace, resourceQuotaList *api.Resource
 	})
 }
 
-func describeLimitRangeSpec(spec api.LimitRangeSpec, prefix string, w *PrefixWriter) {
+func describeLimitRangeSpec(spec api.LimitRangeSpec, prefix string, w PrefixWriter) {
 	for i := range spec.Limits {
 		item := spec.Limits[i]
 		maxResources := item.Max
@@ -324,7 +340,7 @@ func describeLimitRangeSpec(spec api.LimitRangeSpec, prefix string, w *PrefixWri
 }
 
 // DescribeLimitRanges merges a set of limit range items into a single tabular description
-func DescribeLimitRanges(limitRanges *api.LimitRangeList, w *PrefixWriter) {
+func DescribeLimitRanges(limitRanges *api.LimitRangeList, w PrefixWriter) {
 	if len(limitRanges.Items) == 0 {
 		w.Write(LEVEL_0, "No resource limits.\n")
 		return
@@ -337,7 +353,7 @@ func DescribeLimitRanges(limitRanges *api.LimitRangeList, w *PrefixWriter) {
 }
 
 // DescribeResourceQuotas merges a set of quota items into a single tabular description of all quotas
-func DescribeResourceQuotas(quotas *api.ResourceQuotaList, w *PrefixWriter) {
+func DescribeResourceQuotas(quotas *api.ResourceQuotaList, w PrefixWriter) {
 	if len(quotas.Items) == 0 {
 		w.Write(LEVEL_0, "No resource quota.\n")
 		return
@@ -396,7 +412,7 @@ func (d *LimitRangeDescriber) Describe(namespace, name string, describerSettings
 
 func describeLimitRange(limitRange *api.LimitRange) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", limitRange.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", limitRange.Namespace)
 		w.Write(LEVEL_0, "Type\tResource\tMin\tMax\tDefault Request\tDefault Limit\tMax Limit/Request Ratio\n")
@@ -438,7 +454,7 @@ func helpTextForResourceQuotaScope(scope api.ResourceQuotaScope) string {
 }
 func describeQuota(resourceQuota *api.ResourceQuota) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", resourceQuota.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", resourceQuota.Namespace)
 		if len(resourceQuota.Spec.Scopes) > 0 {
@@ -491,7 +507,7 @@ func (d *PodDescriber) Describe(namespace, name string, describerSettings printe
 			events, err2 := eventsInterface.List(options)
 			if describerSettings.ShowEvents && err2 == nil && len(events.Items) > 0 {
 				return tabbedString(func(out io.Writer) error {
-					w := &PrefixWriter{out}
+					w := NewPrefixWriter(out)
 					w.Write(LEVEL_0, "Pod '%v': error '%v', but found events.\n", name, err)
 					DescribeEvents(events, w)
 					return nil
@@ -516,7 +532,7 @@ func (d *PodDescriber) Describe(namespace, name string, describerSettings printe
 
 func describePod(pod *api.Pod, events *api.EventList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", pod.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", pod.Namespace)
 		w.Write(LEVEL_0, "Node:\t%s\n", pod.Spec.NodeName+"/"+pod.Status.HostIP)
@@ -575,7 +591,7 @@ func printControllers(annotation map[string]string) string {
 	return "<none>"
 }
 
-func describeVolumes(volumes []api.Volume, w *PrefixWriter, space string) {
+func describeVolumes(volumes []api.Volume, w PrefixWriter, space string) {
 	if volumes == nil || len(volumes) == 0 {
 		w.Write(LEVEL_0, "%sVolumes:\t<none>\n", space)
 		return
@@ -634,17 +650,17 @@ func describeVolumes(volumes []api.Volume, w *PrefixWriter, space string) {
 	}
 }
 
-func printHostPathVolumeSource(hostPath *api.HostPathVolumeSource, w *PrefixWriter) {
+func printHostPathVolumeSource(hostPath *api.HostPathVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tHostPath (bare host directory volume)\n"+
 		"    Path:\t%v\n", hostPath.Path)
 }
 
-func printEmptyDirVolumeSource(emptyDir *api.EmptyDirVolumeSource, w *PrefixWriter) {
+func printEmptyDirVolumeSource(emptyDir *api.EmptyDirVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tEmptyDir (a temporary directory that shares a pod's lifetime)\n"+
 		"    Medium:\t%v\n", emptyDir.Medium)
 }
 
-func printGCEPersistentDiskVolumeSource(gce *api.GCEPersistentDiskVolumeSource, w *PrefixWriter) {
+func printGCEPersistentDiskVolumeSource(gce *api.GCEPersistentDiskVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tGCEPersistentDisk (a Persistent Disk resource in Google Compute Engine)\n"+
 		"    PDName:\t%v\n"+
 		"    FSType:\t%v\n"+
@@ -653,7 +669,7 @@ func printGCEPersistentDiskVolumeSource(gce *api.GCEPersistentDiskVolumeSource, 
 		gce.PDName, gce.FSType, gce.Partition, gce.ReadOnly)
 }
 
-func printAWSElasticBlockStoreVolumeSource(aws *api.AWSElasticBlockStoreVolumeSource, w *PrefixWriter) {
+func printAWSElasticBlockStoreVolumeSource(aws *api.AWSElasticBlockStoreVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tAWSElasticBlockStore (a Persistent Disk resource in AWS)\n"+
 		"    VolumeID:\t%v\n"+
 		"    FSType:\t%v\n"+
@@ -662,14 +678,14 @@ func printAWSElasticBlockStoreVolumeSource(aws *api.AWSElasticBlockStoreVolumeSo
 		aws.VolumeID, aws.FSType, aws.Partition, aws.ReadOnly)
 }
 
-func printGitRepoVolumeSource(git *api.GitRepoVolumeSource, w *PrefixWriter) {
+func printGitRepoVolumeSource(git *api.GitRepoVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tGitRepo (a volume that is pulled from git when the pod is created)\n"+
 		"    Repository:\t%v\n"+
 		"    Revision:\t%v\n",
 		git.Repository, git.Revision)
 }
 
-func printSecretVolumeSource(secret *api.SecretVolumeSource, w *PrefixWriter) {
+func printSecretVolumeSource(secret *api.SecretVolumeSource, w PrefixWriter) {
 	optional := secret.Optional != nil && *secret.Optional
 	w.Write(LEVEL_2, "Type:\tSecret (a volume populated by a Secret)\n"+
 		"    SecretName:\t%v\n"+
@@ -677,7 +693,7 @@ func printSecretVolumeSource(secret *api.SecretVolumeSource, w *PrefixWriter) {
 		secret.SecretName, optional)
 }
 
-func printConfigMapVolumeSource(configMap *api.ConfigMapVolumeSource, w *PrefixWriter) {
+func printConfigMapVolumeSource(configMap *api.ConfigMapVolumeSource, w PrefixWriter) {
 	optional := configMap.Optional != nil && *configMap.Optional
 	w.Write(LEVEL_2, "Type:\tConfigMap (a volume populated by a ConfigMap)\n"+
 		"    Name:\t%v\n"+
@@ -685,7 +701,7 @@ func printConfigMapVolumeSource(configMap *api.ConfigMapVolumeSource, w *PrefixW
 		configMap.Name, optional)
 }
 
-func printNFSVolumeSource(nfs *api.NFSVolumeSource, w *PrefixWriter) {
+func printNFSVolumeSource(nfs *api.NFSVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tNFS (an NFS mount that lasts the lifetime of a pod)\n"+
 		"    Server:\t%v\n"+
 		"    Path:\t%v\n"+
@@ -693,7 +709,7 @@ func printNFSVolumeSource(nfs *api.NFSVolumeSource, w *PrefixWriter) {
 		nfs.Server, nfs.Path, nfs.ReadOnly)
 }
 
-func printQuobyteVolumeSource(quobyte *api.QuobyteVolumeSource, w *PrefixWriter) {
+func printQuobyteVolumeSource(quobyte *api.QuobyteVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tQuobyte (a Quobyte mount on the host that shares a pod's lifetime)\n"+
 		"    Registry:\t%v\n"+
 		"    Volume:\t%v\n"+
@@ -701,13 +717,13 @@ func printQuobyteVolumeSource(quobyte *api.QuobyteVolumeSource, w *PrefixWriter)
 		quobyte.Registry, quobyte.Volume, quobyte.ReadOnly)
 }
 
-func printPortworxVolumeSource(pwxVolume *api.PortworxVolumeSource, w *PrefixWriter) {
+func printPortworxVolumeSource(pwxVolume *api.PortworxVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tPortworxVolume (a Portworx Volume resource)\n"+
 		"    VolumeID:\t%v\n",
 		pwxVolume.VolumeID)
 }
 
-func printISCSIVolumeSource(iscsi *api.ISCSIVolumeSource, w *PrefixWriter) {
+func printISCSIVolumeSource(iscsi *api.ISCSIVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tISCSI (an ISCSI Disk resource that is attached to a kubelet's host machine and then exposed to the pod)\n"+
 		"    TargetPortal:\t%v\n"+
 		"    IQN:\t%v\n"+
@@ -718,7 +734,7 @@ func printISCSIVolumeSource(iscsi *api.ISCSIVolumeSource, w *PrefixWriter) {
 		iscsi.TargetPortal, iscsi.IQN, iscsi.Lun, iscsi.ISCSIInterface, iscsi.FSType, iscsi.ReadOnly)
 }
 
-func printGlusterfsVolumeSource(glusterfs *api.GlusterfsVolumeSource, w *PrefixWriter) {
+func printGlusterfsVolumeSource(glusterfs *api.GlusterfsVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tGlusterfs (a Glusterfs mount on the host that shares a pod's lifetime)\n"+
 		"    EndpointsName:\t%v\n"+
 		"    Path:\t%v\n"+
@@ -726,14 +742,14 @@ func printGlusterfsVolumeSource(glusterfs *api.GlusterfsVolumeSource, w *PrefixW
 		glusterfs.EndpointsName, glusterfs.Path, glusterfs.ReadOnly)
 }
 
-func printPersistentVolumeClaimVolumeSource(claim *api.PersistentVolumeClaimVolumeSource, w *PrefixWriter) {
+func printPersistentVolumeClaimVolumeSource(claim *api.PersistentVolumeClaimVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tPersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)\n"+
 		"    ClaimName:\t%v\n"+
 		"    ReadOnly:\t%v\n",
 		claim.ClaimName, claim.ReadOnly)
 }
 
-func printRBDVolumeSource(rbd *api.RBDVolumeSource, w *PrefixWriter) {
+func printRBDVolumeSource(rbd *api.RBDVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tRBD (a Rados Block Device mount on the host that shares a pod's lifetime)\n"+
 		"    CephMonitors:\t%v\n"+
 		"    RBDImage:\t%v\n"+
@@ -746,7 +762,7 @@ func printRBDVolumeSource(rbd *api.RBDVolumeSource, w *PrefixWriter) {
 		rbd.CephMonitors, rbd.RBDImage, rbd.FSType, rbd.RBDPool, rbd.RadosUser, rbd.Keyring, rbd.SecretRef, rbd.ReadOnly)
 }
 
-func printDownwardAPIVolumeSource(d *api.DownwardAPIVolumeSource, w *PrefixWriter) {
+func printDownwardAPIVolumeSource(d *api.DownwardAPIVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tDownwardAPI (a volume populated by information about the pod)\n    Items:\n")
 	for _, mapping := range d.Items {
 		if mapping.FieldRef != nil {
@@ -758,7 +774,7 @@ func printDownwardAPIVolumeSource(d *api.DownwardAPIVolumeSource, w *PrefixWrite
 	}
 }
 
-func printAzureDiskVolumeSource(d *api.AzureDiskVolumeSource, w *PrefixWriter) {
+func printAzureDiskVolumeSource(d *api.AzureDiskVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tAzureDisk (an Azure Data Disk mount on the host and bind mount to the pod)\n"+
 		"    DiskName:\t%v\n"+
 		"    DiskURI:\t%v\n"+
@@ -768,21 +784,21 @@ func printAzureDiskVolumeSource(d *api.AzureDiskVolumeSource, w *PrefixWriter) {
 		d.DiskName, d.DataDiskURI, *d.FSType, *d.CachingMode, *d.ReadOnly)
 }
 
-func printVsphereVolumeSource(vsphere *api.VsphereVirtualDiskVolumeSource, w *PrefixWriter) {
+func printVsphereVolumeSource(vsphere *api.VsphereVirtualDiskVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tvSphereVolume (a Persistent Disk resource in vSphere)\n"+
 		"    VolumePath:\t%v\n"+
 		"    FSType:\t%v\n",
 		vsphere.VolumePath, vsphere.FSType)
 }
 
-func printPhotonPersistentDiskVolumeSource(photon *api.PhotonPersistentDiskVolumeSource, w *PrefixWriter) {
+func printPhotonPersistentDiskVolumeSource(photon *api.PhotonPersistentDiskVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tPhotonPersistentDisk (a Persistent Disk resource in photon platform)\n"+
 		"    PdID:\t%v\n"+
 		"    FSType:\t%v\n",
 		photon.PdID, photon.FSType)
 }
 
-func printCinderVolumeSource(cinder *api.CinderVolumeSource, w *PrefixWriter) {
+func printCinderVolumeSource(cinder *api.CinderVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tCinder (a Persistent Disk resource in OpenStack)\n"+
 		"    VolumeID:\t%v\n"+
 		"    FSType:\t%v\n"+
@@ -790,7 +806,7 @@ func printCinderVolumeSource(cinder *api.CinderVolumeSource, w *PrefixWriter) {
 		cinder.VolumeID, cinder.FSType, cinder.ReadOnly)
 }
 
-func printScaleIOVolumeSource(sio *api.ScaleIOVolumeSource, w *PrefixWriter) {
+func printScaleIOVolumeSource(sio *api.ScaleIOVolumeSource, w PrefixWriter) {
 	w.Write(LEVEL_2, "Type:\tScaleIO (a persistent volume backed by a block device in ScaleIO)\n"+
 		"    Gateway:\t%v\n"+
 		"    System:\t%v\n"+
@@ -823,7 +839,7 @@ func (d *PersistentVolumeDescriber) Describe(namespace, name string, describerSe
 	}
 
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", pv.Name)
 		printLabelsMultiline(w, "Labels", pv.Labels)
 		printAnnotationsMultiline(w, "Annotations", pv.Annotations)
@@ -903,7 +919,7 @@ func (d *PersistentVolumeClaimDescriber) Describe(namespace, name string, descri
 	events, _ := d.Core().Events(namespace).Search(api.Scheme, pvc)
 
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", pvc.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", pvc.Namespace)
 		w.Write(LEVEL_0, "StorageClass:\t%s\n", api.GetPersistentVolumeClaimClass(pvc))
@@ -922,7 +938,7 @@ func (d *PersistentVolumeClaimDescriber) Describe(namespace, name string, descri
 }
 
 func describeContainers(label string, containers []api.Container, containerStatuses []api.ContainerStatus,
-	resolverFn EnvVarResolverFunc, w *PrefixWriter, space string) {
+	resolverFn EnvVarResolverFunc, w PrefixWriter, space string) {
 	statuses := map[string]api.ContainerStatus{}
 	for _, status := range containerStatuses {
 		statuses[status.Name] = status
@@ -947,7 +963,7 @@ func describeContainers(label string, containers []api.Container, containerStatu
 	}
 }
 
-func describeContainersLabel(containers []api.Container, label, space string, w *PrefixWriter) {
+func describeContainersLabel(containers []api.Container, label, space string, w PrefixWriter) {
 	none := ""
 	if len(containers) == 0 {
 		none = " <none>"
@@ -955,7 +971,7 @@ func describeContainersLabel(containers []api.Container, label, space string, w 
 	w.Write(LEVEL_0, "%s%s:%s\n", space, label, none)
 }
 
-func describeContainerBasicInfo(container api.Container, status api.ContainerStatus, ok bool, space string, w *PrefixWriter) {
+func describeContainerBasicInfo(container api.Container, status api.ContainerStatus, ok bool, space string, w PrefixWriter) {
 	nameIndent := ""
 	if len(space) > 0 {
 		nameIndent = " "
@@ -984,7 +1000,7 @@ func describeContainerPorts(cPorts []api.ContainerPort) string {
 	return strings.Join(ports, ", ")
 }
 
-func describeContainerCommand(container api.Container, w *PrefixWriter) {
+func describeContainerCommand(container api.Container, w PrefixWriter) {
 	if len(container.Command) > 0 {
 		w.Write(LEVEL_2, "Command:\n")
 		for _, c := range container.Command {
@@ -999,7 +1015,7 @@ func describeContainerCommand(container api.Container, w *PrefixWriter) {
 	}
 }
 
-func describeContainerResource(container api.Container, w *PrefixWriter) {
+func describeContainerResource(container api.Container, w PrefixWriter) {
 	resources := container.Resources
 	if len(resources.Limits) > 0 {
 		w.Write(LEVEL_2, "Limits:\n")
@@ -1018,7 +1034,7 @@ func describeContainerResource(container api.Container, w *PrefixWriter) {
 	}
 }
 
-func describeContainerState(status api.ContainerStatus, w *PrefixWriter) {
+func describeContainerState(status api.ContainerStatus, w PrefixWriter) {
 	describeStatus("State", status.State, w)
 	if status.LastTerminationState.Terminated != nil {
 		describeStatus("Last State", status.LastTerminationState, w)
@@ -1027,7 +1043,7 @@ func describeContainerState(status api.ContainerStatus, w *PrefixWriter) {
 	w.Write(LEVEL_2, "Restart Count:\t%d\n", status.RestartCount)
 }
 
-func describeContainerProbe(container api.Container, w *PrefixWriter) {
+func describeContainerProbe(container api.Container, w PrefixWriter) {
 	if container.LivenessProbe != nil {
 		probe := DescribeProbe(container.LivenessProbe)
 		w.Write(LEVEL_2, "Liveness:\t%s\n", probe)
@@ -1038,7 +1054,7 @@ func describeContainerProbe(container api.Container, w *PrefixWriter) {
 	}
 }
 
-func describeContainerVolumes(container api.Container, w *PrefixWriter) {
+func describeContainerVolumes(container api.Container, w PrefixWriter) {
 	none := ""
 	if len(container.VolumeMounts) == 0 {
 		none = "\t<none>"
@@ -1059,7 +1075,7 @@ func describeContainerVolumes(container api.Container, w *PrefixWriter) {
 	}
 }
 
-func describeContainerEnvVars(container api.Container, resolverFn EnvVarResolverFunc, w *PrefixWriter) {
+func describeContainerEnvVars(container api.Container, resolverFn EnvVarResolverFunc, w PrefixWriter) {
 	none := ""
 	if len(container.Env) == 0 {
 		none = "\t<none>"
@@ -1099,7 +1115,7 @@ func describeContainerEnvVars(container api.Container, resolverFn EnvVarResolver
 	}
 }
 
-func describeContainerEnvFrom(container api.Container, resolverFn EnvVarResolverFunc, w *PrefixWriter) {
+func describeContainerEnvFrom(container api.Container, resolverFn EnvVarResolverFunc, w PrefixWriter) {
 	none := ""
 	if len(container.EnvFrom) == 0 {
 		none = "\t<none>"
@@ -1168,7 +1184,7 @@ func EnvValueRetriever(pod *api.Pod) EnvVarResolverFunc {
 	}
 }
 
-func describeStatus(stateName string, state api.ContainerState, w *PrefixWriter) {
+func describeStatus(stateName string, state api.ContainerState, w PrefixWriter) {
 	switch {
 	case state.Running != nil:
 		w.Write(LEVEL_2, "%s:\tRunning\n", stateName)
@@ -1197,7 +1213,7 @@ func describeStatus(stateName string, state api.ContainerState, w *PrefixWriter)
 	}
 }
 
-func describeVolumeClaimTemplates(templates []api.PersistentVolumeClaim, w *PrefixWriter) {
+func describeVolumeClaimTemplates(templates []api.PersistentVolumeClaim, w PrefixWriter) {
 	if len(templates) == 0 {
 		w.Write(LEVEL_0, "Volume Claims:\t<none>\n")
 		return
@@ -1263,7 +1279,7 @@ func (d *ReplicationControllerDescriber) Describe(namespace, name string, descri
 
 func describeReplicationController(controller *api.ReplicationController, events *api.EventList, running, waiting, succeeded, failed int) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", controller.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", controller.Namespace)
 		w.Write(LEVEL_0, "Selector:\t%s\n", labels.FormatLabels(controller.Spec.Selector))
@@ -1272,7 +1288,7 @@ func describeReplicationController(controller *api.ReplicationController, events
 		w.Write(LEVEL_0, "Replicas:\t%d current / %d desired\n", controller.Status.Replicas, controller.Spec.Replicas)
 		w.Write(LEVEL_0, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
 
-		DescribePodTemplate(controller.Spec.Template, out)
+		DescribePodTemplate(controller.Spec.Template, w)
 		if events != nil {
 			DescribeEvents(events, w)
 		}
@@ -1280,8 +1296,7 @@ func describeReplicationController(controller *api.ReplicationController, events
 	})
 }
 
-func DescribePodTemplate(template *api.PodTemplateSpec, out io.Writer) {
-	w := &PrefixWriter{out}
+func DescribePodTemplate(template *api.PodTemplateSpec, w PrefixWriter) {
 	w.Write(LEVEL_0, "Pod Template:\n")
 	if template == nil {
 		w.Write(LEVEL_1, "<unset>")
@@ -1332,7 +1347,7 @@ func (d *ReplicaSetDescriber) Describe(namespace, name string, describerSettings
 
 func describeReplicaSet(rs *extensions.ReplicaSet, events *api.EventList, running, waiting, succeeded, failed int, getPodErr error) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", rs.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", rs.Namespace)
 		w.Write(LEVEL_0, "Selector:\t%s\n", metav1.FormatLabelSelector(rs.Spec.Selector))
@@ -1345,7 +1360,7 @@ func describeReplicaSet(rs *extensions.ReplicaSet, events *api.EventList, runnin
 		} else {
 			w.Write(LEVEL_0, "%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
 		}
-		DescribePodTemplate(&rs.Spec.Template, out)
+		DescribePodTemplate(&rs.Spec.Template, w)
 		if events != nil {
 			DescribeEvents(events, w)
 		}
@@ -1374,7 +1389,7 @@ func (d *JobDescriber) Describe(namespace, name string, describerSettings printe
 
 func describeJob(job *batch.Job, events *api.EventList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", job.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", job.Namespace)
 		selector, _ := metav1.LabelSelectorAsSelector(job.Spec.Selector)
@@ -1394,7 +1409,7 @@ func describeJob(job *batch.Job, events *api.EventList) (string, error) {
 			w.Write(LEVEL_0, "Active Deadline Seconds:\t%ds\n", *job.Spec.ActiveDeadlineSeconds)
 		}
 		w.Write(LEVEL_0, "Pods Statuses:\t%d Running / %d Succeeded / %d Failed\n", job.Status.Active, job.Status.Succeeded, job.Status.Failed)
-		DescribePodTemplate(&job.Spec.Template, out)
+		DescribePodTemplate(&job.Spec.Template, w)
 		if events != nil {
 			DescribeEvents(events, w)
 		}
@@ -1423,7 +1438,7 @@ func (d *CronJobDescriber) Describe(namespace, name string, describerSettings pr
 
 func describeCronJob(scheduledJob *batch.CronJob, events *api.EventList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", scheduledJob.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", scheduledJob.Namespace)
 		printLabelsMultiline(w, "Labels", scheduledJob.Labels)
@@ -1450,7 +1465,7 @@ func describeCronJob(scheduledJob *batch.CronJob, events *api.EventList) (string
 	})
 }
 
-func describeJobTemplate(jobTemplate batch.JobTemplateSpec, w *PrefixWriter) {
+func describeJobTemplate(jobTemplate batch.JobTemplateSpec, w PrefixWriter) {
 	if jobTemplate.Spec.Selector != nil {
 		selector, _ := metav1.LabelSelectorAsSelector(jobTemplate.Spec.Selector)
 		w.Write(LEVEL_0, "Selector:\t%s\n", selector)
@@ -1470,10 +1485,10 @@ func describeJobTemplate(jobTemplate batch.JobTemplateSpec, w *PrefixWriter) {
 	if jobTemplate.Spec.ActiveDeadlineSeconds != nil {
 		w.Write(LEVEL_0, "Active Deadline Seconds:\t%ds\n", *jobTemplate.Spec.ActiveDeadlineSeconds)
 	}
-	DescribePodTemplate(&jobTemplate.Spec.Template, w.out)
+	DescribePodTemplate(&jobTemplate.Spec.Template, w)
 }
 
-func printActiveJobs(w *PrefixWriter, title string, jobs []api.ObjectReference) {
+func printActiveJobs(w PrefixWriter, title string, jobs []api.ObjectReference) {
 	w.Write(LEVEL_0, "%s:\t", title)
 	if len(jobs) == 0 {
 		w.WriteLine("<none>")
@@ -1522,7 +1537,7 @@ func (d *DaemonSetDescriber) Describe(namespace, name string, describerSettings 
 
 func describeDaemonSet(daemon *extensions.DaemonSet, events *api.EventList, running, waiting, succeeded, failed int) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", daemon.Name)
 		selector, err := metav1.LabelSelectorAsSelector(daemon.Spec.Selector)
 		if err != nil {
@@ -1539,7 +1554,7 @@ func describeDaemonSet(daemon *extensions.DaemonSet, events *api.EventList, runn
 		w.Write(LEVEL_0, "Number of Nodes Scheduled with Available Pods: %d\n", daemon.Status.NumberAvailable)
 		w.Write(LEVEL_0, "Number of Nodes Misscheduled: %d\n", daemon.Status.NumberMisscheduled)
 		w.Write(LEVEL_0, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
-		DescribePodTemplate(&daemon.Spec.Template, out)
+		DescribePodTemplate(&daemon.Spec.Template, w)
 		if events != nil {
 			DescribeEvents(events, w)
 		}
@@ -1565,7 +1580,7 @@ func (d *SecretDescriber) Describe(namespace, name string, describerSettings pri
 
 func describeSecret(secret *api.Secret) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", secret.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", secret.Namespace)
 		printLabelsMultiline(w, "Labels", secret.Labels)
@@ -1623,7 +1638,7 @@ func (i *IngressDescriber) describeBackend(ns string, backend *extensions.Ingres
 
 func (i *IngressDescriber) describeIngress(ing *extensions.Ingress, describerSettings printers.DescriberSettings) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%v\n", ing.Name)
 		w.Write(LEVEL_0, "Namespace:\t%v\n", ing.Namespace)
 		w.Write(LEVEL_0, "Address:\t%v\n", loadBalancerStatusStringer(ing.Status.LoadBalancer, true))
@@ -1674,7 +1689,7 @@ func (i *IngressDescriber) describeIngress(ing *extensions.Ingress, describerSet
 	})
 }
 
-func describeIngressTLS(w *PrefixWriter, ingTLS []extensions.IngressTLS) {
+func describeIngressTLS(w PrefixWriter, ingTLS []extensions.IngressTLS) {
 	w.Write(LEVEL_0, "TLS:\n")
 	for _, t := range ingTLS {
 		if t.SecretName == "" {
@@ -1687,7 +1702,7 @@ func describeIngressTLS(w *PrefixWriter, ingTLS []extensions.IngressTLS) {
 }
 
 // TODO: Move from annotations into Ingress status.
-func describeIngressAnnotations(w *PrefixWriter, annotations map[string]string) {
+func describeIngressAnnotations(w PrefixWriter, annotations map[string]string) {
 	w.Write(LEVEL_0, "Annotations:\n")
 	for k, v := range annotations {
 		if !strings.HasPrefix(k, "ingress") {
@@ -1742,7 +1757,7 @@ func describeService(service *api.Service, endpoints *api.Endpoints, events *api
 		endpoints = &api.Endpoints{}
 	}
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", service.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", service.Namespace)
 		printLabelsMultiline(w, "Labels", service.Labels)
@@ -1804,7 +1819,7 @@ func (d *EndpointsDescriber) Describe(namespace, name string, describerSettings 
 
 func describeEndpoints(ep *api.Endpoints, events *api.EventList) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", ep.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", ep.Namespace)
 		printLabelsMultiline(w, "Labels", ep.Labels)
@@ -1911,7 +1926,7 @@ func (d *ServiceAccountDescriber) Describe(namespace, name string, describerSett
 
 func describeServiceAccount(serviceAccount *api.ServiceAccount, tokens []api.Secret, missingSecrets sets.String) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", serviceAccount.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", serviceAccount.Namespace)
 		printLabelsMultiline(w, "Labels", serviceAccount.Labels)
@@ -2008,7 +2023,7 @@ func (d *NodeDescriber) Describe(namespace, name string, describerSettings print
 
 func describeNode(node *api.Node, nodeNonTerminatedPodsList *api.PodList, events *api.EventList, canViewPods bool) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", node.Name)
 		w.Write(LEVEL_0, "Role:\t%s\n", findNodeRole(node))
 		printLabelsMultiline(w, "Labels", node.Labels)
@@ -2110,7 +2125,7 @@ func (p *StatefulSetDescriber) Describe(namespace, name string, describerSetting
 	}
 
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", ps.ObjectMeta.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", ps.ObjectMeta.Namespace)
 		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", ps.CreationTimestamp.Time.Format(time.RFC1123Z))
@@ -2119,7 +2134,7 @@ func (p *StatefulSetDescriber) Describe(namespace, name string, describerSetting
 		printAnnotationsMultiline(w, "Annotations", ps.Annotations)
 		w.Write(LEVEL_0, "Replicas:\t%d desired | %d total\n", ps.Spec.Replicas, ps.Status.Replicas)
 		w.Write(LEVEL_0, "Pods Status:\t%d Running / %d Waiting / %d Succeeded / %d Failed\n", running, waiting, succeeded, failed)
-		DescribePodTemplate(&ps.Spec.Template, out)
+		DescribePodTemplate(&ps.Spec.Template, w)
 		describeVolumeClaimTemplates(ps.Spec.VolumeClaimTemplates, w)
 		if describerSettings.ShowEvents {
 			events, _ := p.client.Core().Events(namespace).Search(api.Scheme, ps)
@@ -2150,7 +2165,7 @@ func (p *CertificateSigningRequestDescriber) Describe(namespace, name string, de
 		return "", err
 	}
 
-	printListHelper := func(w *PrefixWriter, prefix, name string, values []string) {
+	printListHelper := func(w PrefixWriter, prefix, name string, values []string) {
 		if len(values) == 0 {
 			return
 		}
@@ -2160,7 +2175,7 @@ func (p *CertificateSigningRequestDescriber) Describe(namespace, name string, de
 	}
 
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", csr.Name)
 		w.Write(LEVEL_0, "Labels:\t%s\n", labels.FormatLabels(csr.Labels))
 		w.Write(LEVEL_0, "Annotations:\t%s\n", labels.FormatLabels(csr.Annotations))
@@ -2211,7 +2226,7 @@ func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string, desc
 		return "", err
 	}
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", hpa.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", hpa.Namespace)
 		printLabelsMultiline(w, "Labels", hpa.Labels)
@@ -2287,7 +2302,7 @@ func (d *HorizontalPodAutoscalerDescriber) Describe(namespace, name string, desc
 	})
 }
 
-func describeNodeResource(nodeNonTerminatedPodsList *api.PodList, node *api.Node, w *PrefixWriter) error {
+func describeNodeResource(nodeNonTerminatedPodsList *api.PodList, node *api.Node, w PrefixWriter) error {
 	w.Write(LEVEL_0, "Non-terminated Pods:\t(%d in total)\n", len(nodeNonTerminatedPodsList.Items))
 	w.Write(LEVEL_1, "Namespace\tName\t\tCPU Requests\tCPU Limits\tMemory Requests\tMemory Limits\n")
 	w.Write(LEVEL_1, "---------\t----\t\t------------\t----------\t---------------\t-------------\n")
@@ -2369,7 +2384,7 @@ func getPodsTotalRequestsAndLimits(podList *api.PodList) (reqs map[api.ResourceN
 	return
 }
 
-func DescribeEvents(el *api.EventList, w *PrefixWriter) {
+func DescribeEvents(el *api.EventList, w PrefixWriter) {
 	if len(el.Items) == 0 {
 		w.Write(LEVEL_0, "Events:\t<none>\n")
 		return
@@ -2410,7 +2425,7 @@ func (dd *DeploymentDescriber) Describe(namespace, name string, describerSetting
 		return "", err
 	}
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", d.ObjectMeta.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", d.ObjectMeta.Namespace)
 		w.Write(LEVEL_0, "CreationTimestamp:\t%s\n", d.CreationTimestamp.Time.Format(time.RFC1123Z))
@@ -2424,7 +2439,7 @@ func (dd *DeploymentDescriber) Describe(namespace, name string, describerSetting
 			ru := d.Spec.Strategy.RollingUpdate
 			w.Write(LEVEL_0, "RollingUpdateStrategy:\t%s max unavailable, %s max surge\n", ru.MaxUnavailable.String(), ru.MaxSurge.String())
 		}
-		DescribePodTemplate(&internalDeployment.Spec.Template, out)
+		DescribePodTemplate(&internalDeployment.Spec.Template, w)
 		if len(d.Status.Conditions) > 0 {
 			w.Write(LEVEL_0, "Conditions:\n  Type\tStatus\tReason\n")
 			w.Write(LEVEL_1, "----\t------\t------\n")
@@ -2546,7 +2561,7 @@ func (d *ConfigMapDescriber) Describe(namespace, name string, describerSettings 
 
 func describeConfigMap(configMap *api.ConfigMap) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", configMap.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", configMap.Namespace)
 		printLabelsMultiline(w, "Labels", configMap.Labels)
@@ -2576,7 +2591,7 @@ func (d *ClusterDescriber) Describe(namespace, name string, describerSettings pr
 
 func describeCluster(cluster *federation.Cluster) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", cluster.Name)
 		w.Write(LEVEL_0, "Labels:\t%s\n", labels.FormatLabels(cluster.Labels))
 
@@ -2621,7 +2636,7 @@ func (d *NetworkPolicyDescriber) Describe(namespace, name string, describerSetti
 
 func describeNetworkPolicy(networkPolicy *extensions.NetworkPolicy) (string, error) {
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", networkPolicy.Name)
 		w.Write(LEVEL_0, "Namespace:\t%s\n", networkPolicy.Namespace)
 		printLabelsMultiline(w, "Labels", networkPolicy.Labels)
@@ -2641,7 +2656,7 @@ func (s *StorageClassDescriber) Describe(namespace, name string, describerSettin
 		return "", err
 	}
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", sc.Name)
 		w.Write(LEVEL_0, "IsDefaultClass:\t%s\n", storageutil.IsDefaultAnnotationText(sc.ObjectMeta))
 		w.Write(LEVEL_0, "Annotations:\t%s\n", labels.FormatLabels(sc.Annotations))
@@ -2670,7 +2685,7 @@ func (p *PodDisruptionBudgetDescriber) Describe(namespace, name string, describe
 		return "", err
 	}
 	return tabbedString(func(out io.Writer) error {
-		w := &PrefixWriter{out}
+		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", pdb.Name)
 		w.Write(LEVEL_0, "Min available:\t%s\n", pdb.Spec.MinAvailable.String())
 		if pdb.Spec.Selector != nil {
@@ -2838,17 +2853,17 @@ func (fn typeFunc) Describe(exact interface{}, extra ...interface{}) (string, er
 }
 
 // printLabelsMultilineWithFilter prints filtered multiple labels with a proper alignment.
-func printLabelsMultilineWithFilter(w *PrefixWriter, title string, labels map[string]string, skip sets.String) {
+func printLabelsMultilineWithFilter(w PrefixWriter, title string, labels map[string]string, skip sets.String) {
 	printLabelsMultilineWithIndent(w, "", title, "\t", labels, skip)
 }
 
 // printLabelsMultiline prints multiple labels with a proper alignment.
-func printLabelsMultiline(w *PrefixWriter, title string, labels map[string]string) {
+func printLabelsMultiline(w PrefixWriter, title string, labels map[string]string) {
 	printLabelsMultilineWithIndent(w, "", title, "\t", labels, sets.NewString())
 }
 
 // printLabelsMultiline prints multiple labels with a user-defined alignment.
-func printLabelsMultilineWithIndent(w *PrefixWriter, initialIndent, title, innerIndent string, labels map[string]string, skip sets.String) {
+func printLabelsMultilineWithIndent(w PrefixWriter, initialIndent, title, innerIndent string, labels map[string]string, skip sets.String) {
 
 	w.Write(LEVEL_0, "%s%s:%s", initialIndent, title, innerIndent)
 
@@ -2882,12 +2897,12 @@ func printLabelsMultilineWithIndent(w *PrefixWriter, initialIndent, title, inner
 }
 
 // printTaintsMultiline prints multiple taints with a proper alignment.
-func printNodeTaintsMultiline(w *PrefixWriter, title string, taints []api.Taint) {
+func printNodeTaintsMultiline(w PrefixWriter, title string, taints []api.Taint) {
 	printTaintsMultilineWithIndent(w, "", title, "\t", taints)
 }
 
 // printTaintsMultilineWithIndent prints multiple taints with a user-defined alignment.
-func printTaintsMultilineWithIndent(w *PrefixWriter, initialIndent, title, innerIndent string, taints []api.Taint) {
+func printTaintsMultilineWithIndent(w PrefixWriter, initialIndent, title, innerIndent string, taints []api.Taint) {
 	w.Write(LEVEL_0, "%s%s:%s", initialIndent, title, innerIndent)
 
 	if taints == nil || len(taints) == 0 {
@@ -2917,12 +2932,12 @@ func printTaintsMultilineWithIndent(w *PrefixWriter, initialIndent, title, inner
 }
 
 // printPodTolerationsMultiline prints multiple tolerations with a proper alignment.
-func printPodTolerationsMultiline(w *PrefixWriter, title string, tolerations []api.Toleration) {
+func printPodTolerationsMultiline(w PrefixWriter, title string, tolerations []api.Toleration) {
 	printTolerationsMultilineWithIndent(w, "", title, "\t", tolerations)
 }
 
 // printTolerationsMultilineWithIndent prints multiple tolerations with a user-defined alignment.
-func printTolerationsMultilineWithIndent(w *PrefixWriter, initialIndent, title, innerIndent string, tolerations []api.Toleration) {
+func printTolerationsMultilineWithIndent(w PrefixWriter, initialIndent, title, innerIndent string, tolerations []api.Toleration) {
 	w.Write(LEVEL_0, "%s%s:%s", initialIndent, title, innerIndent)
 
 	if tolerations == nil || len(tolerations) == 0 {
@@ -3051,18 +3066,18 @@ func versionedClientsetForDeployment(internalClient clientset.Interface) version
 var maxAnnotationLen = 200
 
 // printAnnotationsMultilineWithFilter prints filtered multiple annotations with a proper alignment.
-func printAnnotationsMultilineWithFilter(w *PrefixWriter, title string, annotations map[string]string, skip sets.String) {
+func printAnnotationsMultilineWithFilter(w PrefixWriter, title string, annotations map[string]string, skip sets.String) {
 	printAnnotationsMultilineWithIndent(w, "", title, "\t", annotations, skip)
 }
 
 // printAnnotationsMultiline prints multiple annotations with a proper alignment.
-func printAnnotationsMultiline(w *PrefixWriter, title string, annotations map[string]string) {
+func printAnnotationsMultiline(w PrefixWriter, title string, annotations map[string]string) {
 	printAnnotationsMultilineWithIndent(w, "", title, "\t", annotations, sets.NewString())
 }
 
 // printAnnotationsMultilineWithIndent prints multiple annotations with a user-defined alignment.
 // If annotation string is too long, we omit chars more than 200 length.
-func printAnnotationsMultilineWithIndent(w *PrefixWriter, initialIndent, title, innerIndent string, annotations map[string]string, skip sets.String) {
+func printAnnotationsMultilineWithIndent(w PrefixWriter, initialIndent, title, innerIndent string, annotations map[string]string, skip sets.String) {
 
 	w.Write(LEVEL_0, "%s%s:%s", initialIndent, title, innerIndent)
 

--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -402,7 +402,7 @@ func TestDescribeContainers(t *testing.T) {
 				ContainerStatuses: []api.ContainerStatus{testCase.status},
 			},
 		}
-		writer := &PrefixWriter{out}
+		writer := NewPrefixWriter(out)
 		describeContainers("Containers", pod.Spec.Containers, pod.Status.ContainerStatuses, EnvValueRetriever(&pod), writer, "")
 		output := out.String()
 		for _, expected := range testCase.expectedElements {
@@ -1297,7 +1297,7 @@ func TestPrintLabelsMultiline(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		out := new(bytes.Buffer)
-		writer := &PrefixWriter{out}
+		writer := NewPrefixWriter(out)
 		printAnnotationsMultiline(writer, "Annotations", testCase.annotations)
 		output := out.String()
 		if output != testCase.expectPrint {


### PR DESCRIPTION
Convert PrefixWriter to an interface to allow other packages to create instances. This is needed for downstream projects such as OpenShift.

cc @sttts @smarterclayton @oulinbao @deads2k @liggitt @kargakis @soltysh @kubernetes/sig-cli-pr-reviews 