### PR TITLE
Replaced syscall with sys/unix.

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/opencontainers/runc/libcontainer/cgroups:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"syscall"
 	"time"
+
+	"golang.org/x/sys/unix"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -387,8 +388,8 @@ func getNodeTime() (time.Time, time.Time, error) {
 	nodeTime := time.Now()
 
 	// Get system uptime.
-	var info syscall.Sysinfo_t
-	if err := syscall.Sysinfo(&info); err != nil {
+	var info unix.Sysinfo_t
+	if err := unix.Sysinfo(&info); err != nil {
 		return time.Time{}, time.Time{}, err
 	}
 	// Get node boot time. NOTE that because we get node current time before uptime, the boot time


### PR DESCRIPTION
**What this PR does / why we need it**:
`syscall` was not supported after go 1.4.

>NOTE: This package is locked down. Code outside the standard Go repository should be migrated to use the corresponding package in the golang.org/x/sys repository. That is also where updates required by new systems or versions should be applied. See https://golang.org/s/go1.4-syscall for more information.

**Special notes for your reviewer**:
This was triggered when building failed in Mac; it did not resolve the build error in Mac :(.

```release-note
None
```
