### PR TITLE
kubelet: check and enforce minimum docker api version

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -47,6 +47,10 @@ const (
 	dockerRuntimeName = "docker"
 	kubeAPIVersion    = "0.1.0"
 
+	// https://docs.docker.com/engine/reference/api/docker_remote_api/
+	// docker version should be at least 1.10.x
+	minimumDockerAPIVersion = "1.22.0"
+
 	// String used to detect docker host mode for various namespaces (e.g.
 	// networking). Must match the value returned by docker inspect -f
 	// '{{.HostConfig.NetworkMode}}'.
@@ -164,6 +168,13 @@ func NewDockerService(client dockertools.DockerInterface, seccompProfileRoot str
 		containerManager:  cm.NewContainerManager(cgroupsName, client),
 		checkpointHandler: checkpointHandler,
 	}
+
+	// check docker version compatibility.
+	if err = ds.checkVersionCompatibility(); err != nil {
+		return nil, err
+	}
+
+	// create streaming server if configured.
 	if streamingConfig != nil {
 		var err error
 		ds.streamingServer, err = streaming.NewServer(*streamingConfig, ds.streamingRuntime)
@@ -377,6 +388,27 @@ func (ds *dockerService) GenerateExpectedCgroupParent(cgroupParent string) (stri
 	}
 	glog.V(3).Infof("Setting cgroup parent to: %q", cgroupParent)
 	return cgroupParent, nil
+}
+
+// checkVersionCompatibility verifies whether docker is in a compatible version.
+func (ds *dockerService) checkVersionCompatibility() error {
+	apiVersion, err := ds.getDockerAPIVersion()
+	if err != nil {
+		return err
+	}
+
+	minAPIVersion, err := semver.Parse(minimumDockerAPIVersion)
+	if err != nil {
+		return err
+	}
+
+	// Verify the docker version.
+	result := apiVersion.Compare(minAPIVersion)
+	if result < 0 {
+		return fmt.Errorf("docker API version is older than %s", minimumDockerAPIVersion)
+	}
+
+	return nil
 }
 
 // getDockerAPIVersion gets the semver-compatible docker api version.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds enforcing a minimum docker api version (same with what we have do for dockertools).

**Which issue this PR fixes** 

Fixes #42696.

**Release note**:

```release-note
NONE
```
