### PR TITLE
Enhance message in cluster-info dump

### DIFF
--- a/pkg/kubectl/cmd/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump.go
@@ -205,10 +205,10 @@ func dumpClusterInfo(f cmdutil.Factory, cmd *cobra.Command, args []string, out i
 	}
 	dir := cmdutil.GetFlagString(cmd, "output-directory")
 	if len(dir) == 0 {
-		dir = "."
+		dir = "standard output"
 	}
 	if dir != "-" {
-		fmt.Fprintf(out, "Cluster info dumped to %s", dir)
+		fmt.Fprintf(out, "Cluster info dumped to %s\n", dir)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR fixes the information message prints in the end after the cluster-info dump command.
- Added newline in the end
- Enhanced the message for dumping information to standard out

**Which issue this PR fixes** *

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
