### PR TITLE
allow combining API servers

### DIFF
--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -223,7 +223,7 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 		return err
 	}
 
-	routes.UIRedirect{}.Install(m.HandlerContainer)
+	routes.UIRedirect{}.Install(m.FallThroughHandler)
 	routes.Logs{}.Install(m.HandlerContainer)
 
 	installFederationAPIs(m, genericConfig.RESTOptionsGetter)

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -216,7 +216,7 @@ func (c completedConfig) New() (*Master, error) {
 	}
 
 	if c.EnableUISupport {
-		routes.UIRedirect{}.Install(s.HandlerContainer)
+		routes.UIRedirect{}.Install(s.FallThroughHandler)
 	}
 	if c.EnableLogsSupport {
 		routes.Logs{}.Install(s.HandlerContainer)

--- a/pkg/master/master_openapi_test.go
+++ b/pkg/master/master_openapi_test.go
@@ -40,7 +40,7 @@ import (
 // TestValidOpenAPISpec verifies that the open api is added
 // at the proper endpoint and the spec is valid.
 func TestValidOpenAPISpec(t *testing.T) {
-	_, etcdserver, config, assert := setUp(t)
+	etcdserver, config, assert := setUp(t)
 	defer etcdserver.Terminate(t)
 
 	config.GenericConfig.EnableIndex = true

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -60,7 +60,7 @@ import (
 )
 
 // setUp is a convience function for setting up for (most) tests.
-func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
+func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
 	server, storageConfig := etcdtesting.NewUnsecuredEtcd3TestClientServer(t, api.Scheme)
 
 	config := &Config{
@@ -101,16 +101,11 @@ func setUp(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.
 		TLSClientConfig: &tls.Config{},
 	})
 
-	master, err := config.Complete().New()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	return master, server, *config, assert.New(t)
+	return server, *config, assert.New(t)
 }
 
 func newMaster(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
-	_, etcdserver, config, assert := setUp(t)
+	etcdserver, config, assert := setUp(t)
 
 	master, err := config.Complete().New()
 	if err != nil {
@@ -136,7 +131,7 @@ func limitedAPIResourceConfigSource() *serverstorage.ResourceConfig {
 
 // newLimitedMaster only enables the core group, the extensions group, the batch group, and the autoscaling group.
 func newLimitedMaster(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
-	_, etcdserver, config, assert := setUp(t)
+	etcdserver, config, assert := setUp(t)
 	config.APIResourceConfigSource = limitedAPIResourceConfigSource()
 	master, err := config.Complete().New()
 	if err != nil {

--- a/pkg/routes/ui.go
+++ b/pkg/routes/ui.go
@@ -27,8 +27,8 @@ const dashboardPath = "/api/v1/namespaces/kube-system/services/kubernetes-dashbo
 // UIRediect redirects /ui to the kube-ui proxy path.
 type UIRedirect struct{}
 
-func (r UIRedirect) Install(c *mux.APIContainer) {
-	c.NonSwaggerRoutes.HandleFunc("/ui/", func(w http.ResponseWriter, r *http.Request) {
+func (r UIRedirect) Install(c *mux.PathRecorderMux) {
+	c.HandleFunc("/ui/", func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, dashboardPath, http.StatusTemporaryRedirect)
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/apiserver/pkg/server/mux"
+	"k8s.io/client-go/rest"
+)
+
+func TestNewWithDelegate(t *testing.T) {
+	delegateConfig := NewConfig().WithSerializer(codecs)
+	delegateConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	delegateConfig.RequestContextMapper = genericapirequest.NewRequestContextMapper()
+	delegateConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
+	delegateConfig.LoopbackClientConfig = &rest.Config{}
+	delegateConfig.FallThroughHandler = mux.NewPathRecorderMux()
+	delegateConfig.SwaggerConfig = DefaultSwaggerConfig()
+
+	delegateHealthzCalled := false
+	delegateConfig.HealthzChecks = append(delegateConfig.HealthzChecks, healthz.NamedCheck("delegate-health", func(r *http.Request) error {
+		delegateHealthzCalled = true
+		return fmt.Errorf("delegate failed healthcheck")
+	}))
+
+	delegateConfig.FallThroughHandler.HandleFunc("/foo", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	})
+
+	delegateServer, err := delegateConfig.SkipComplete().New()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	delegateServer.AddPostStartHook("delegate-post-start-hook", func(context PostStartHookContext) error {
+		return nil
+	})
+
+	// this wires up swagger
+	delegateServer.PrepareRun()
+
+	wrappingConfig := NewConfig().WithSerializer(codecs)
+	wrappingConfig.PublicAddress = net.ParseIP("192.168.10.4")
+	wrappingConfig.RequestContextMapper = genericapirequest.NewRequestContextMapper()
+	wrappingConfig.LegacyAPIGroupPrefixes = sets.NewString("/api")
+	wrappingConfig.LoopbackClientConfig = &rest.Config{}
+	wrappingConfig.FallThroughHandler = mux.NewPathRecorderMux()
+	wrappingConfig.SwaggerConfig = DefaultSwaggerConfig()
+
+	wrappingHealthzCalled := false
+	wrappingConfig.HealthzChecks = append(wrappingConfig.HealthzChecks, healthz.NamedCheck("wrapping-health", func(r *http.Request) error {
+		wrappingHealthzCalled = true
+		return fmt.Errorf("wrapping failed healthcheck")
+	}))
+
+	wrappingConfig.FallThroughHandler.HandleFunc("/bar", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	})
+
+	wrappingServer, err := wrappingConfig.Complete().NewWithDelegate(delegateServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wrappingServer.AddPostStartHook("wrapping-post-start-hook", func(context PostStartHookContext) error {
+		return nil
+	})
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	wrappingServer.PrepareRun()
+	wrappingServer.RunPostStartHooks()
+
+	server := httptest.NewServer(wrappingServer.Handler)
+	defer server.Close()
+
+	checkPath(server.URL, http.StatusOK, `{
+  "paths": [
+    "/apis",
+    "/bar",
+    "/foo",
+    "/healthz",
+    "/healthz/delegate-health",
+    "/healthz/ping",
+    "/healthz/poststarthook/delegate-post-start-hook",
+    "/healthz/poststarthook/wrapping-post-start-hook",
+    "/healthz/wrapping-health",
+    "/swaggerapi/"
+  ]
+}`, t)
+	checkPath(server.URL+"/healthz", http.StatusInternalServerError, `[+]ping ok
+[-]wrapping-health failed: reason withheld
+[-]delegate-health failed: reason withheld
+[+]poststarthook/delegate-post-start-hook ok
+[+]poststarthook/wrapping-post-start-hook ok
+healthz check failed
+`, t)
+
+	checkPath(server.URL+"/healthz/delegate-health", http.StatusInternalServerError, `internal server error: delegate failed healthcheck
+`, t)
+	checkPath(server.URL+"/healthz/wrapping-health", http.StatusInternalServerError, `internal server error: wrapping failed healthcheck
+`, t)
+	checkPath(server.URL+"/healthz/poststarthook/delegate-post-start-hook", http.StatusOK, `ok`, t)
+	checkPath(server.URL+"/healthz/poststarthook/wrapping-post-start-hook", http.StatusOK, `ok`, t)
+	checkPath(server.URL+"/foo", http.StatusForbidden, ``, t)
+	checkPath(server.URL+"/bar", http.StatusUnauthorized, ``, t)
+}
+
+func checkPath(url string, expectedStatusCode int, expectedBody string, t *testing.T) {
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dump, _ := httputil.DumpResponse(resp, true)
+	t.Log(string(dump))
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if e, a := expectedBody, string(body); e != a {
+		t.Errorf("%q expected %v, got %v", url, e, a)
+	}
+	if e, a := expectedStatusCode, resp.StatusCode; e != a {
+		t.Errorf("%q expected %v, got %v", url, e, a)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -44,6 +44,7 @@ import (
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/apiserver/pkg/server/mux"
 	genericmux "k8s.io/apiserver/pkg/server/mux"
 	"k8s.io/apiserver/pkg/server/routes"
 	restclient "k8s.io/client-go/rest"
@@ -125,6 +126,9 @@ type GenericAPIServer struct {
 	// "Outputs"
 	Handler         http.Handler
 	InsecureHandler http.Handler
+	// FallThroughHandler is the final HTTP handler in the chain.
+	// It comes after all filters and the API handling
+	FallThroughHandler *mux.PathRecorderMux
 
 	// Map storing information about all groups to be exposed in discovery response.
 	// The map is from name to the group.
@@ -179,7 +183,7 @@ func (s *GenericAPIServer) PrepareRun() preparedGenericAPIServer {
 	if s.openAPIConfig != nil {
 		routes.OpenAPI{
 			Config: s.openAPIConfig,
-		}.Install(s.HandlerContainer)
+		}.Install(s.HandlerContainer, s.FallThroughHandler)
 	}
 
 	s.installHealthz()

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/server/mux"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	restclient "k8s.io/client-go/rest"
 )
@@ -90,6 +91,7 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	config.RequestContextMapper = genericapirequest.NewRequestContextMapper()
 	config.LegacyAPIGroupPrefixes = sets.NewString("/api")
 	config.LoopbackClientConfig = &restclient.Config{}
+	config.FallThroughHandler = mux.NewPathRecorderMux()
 
 	// TODO restore this test, but right now, eliminate our cycle
 	// config.OpenAPIConfig = DefaultOpenAPIConfig(testGetOpenAPIDefinitions, runtime.NewScheme())
@@ -352,8 +354,8 @@ func TestCustomHandlerChain(t *testing.T) {
 		t.Fatalf("Error in bringing up the server: %v", err)
 	}
 
-	s.HandlerContainer.NonSwaggerRoutes.Handle("/nonswagger", handler)
-	s.HandlerContainer.UnlistedRoutes.Handle("/secret", handler)
+	s.FallThroughHandler.Handle("/nonswagger", handler)
+	s.FallThroughHandler.Handle("/secret", handler)
 
 	type Test struct {
 		handler   http.Handler

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz.go
@@ -41,5 +41,5 @@ func (s *GenericAPIServer) installHealthz() {
 	defer s.healthzLock.Unlock()
 	s.healthzCreated = true
 
-	healthz.InstallHandler(&s.HandlerContainer.NonSwaggerRoutes, s.healthzChecks...)
+	healthz.InstallHandler(s.FallThroughHandler, s.healthzChecks...)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/container.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/container.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	rt "runtime"
+	"sort"
 
 	"github.com/emicklei/go-restful"
 	"github.com/golang/glog"
@@ -56,6 +57,18 @@ func NewAPIContainer(mux *http.ServeMux, s runtime.NegotiatedSerializer, default
 	c.Container.Handle("/", defaultMux)
 
 	return &c
+}
+
+// ListedPaths returns the paths of the webservices for listing on /.
+func (c *APIContainer) ListedPaths() []string {
+	var handledPaths []string
+	// Extract the paths handled using restful.WebService
+	for _, ws := range c.RegisteredWebServices() {
+		handledPaths = append(handledPaths, ws.RootPath())
+	}
+	sort.Strings(handledPaths)
+
+	return handledPaths
 }
 
 //TODO: Unify with RecoverPanics?

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"sort"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
@@ -42,9 +43,12 @@ func NewPathRecorderMux() *PathRecorderMux {
 	}
 }
 
-// HandledPaths returns the registered handler exposedPaths.
-func (m *PathRecorderMux) HandledPaths() []string {
-	return append([]string{}, m.exposedPaths...)
+// ListedPaths returns the registered handler exposedPaths.
+func (m *PathRecorderMux) ListedPaths() []string {
+	handledPaths := append([]string{}, m.exposedPaths...)
+	sort.Strings(handledPaths)
+
+	return handledPaths
 }
 
 // Handle registers the handler for the given pattern.

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -17,47 +17,83 @@ limitations under the License.
 package mux
 
 import (
+	"fmt"
 	"net/http"
+	"runtime/debug"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
-// Mux is an object that can register http handlers.
-type Mux interface {
-	Handle(pattern string, handler http.Handler)
-	HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request))
-}
-
-// PathRecorderMux wraps a mux object and records the registered paths. It is _not_ go routine safe.
+// PathRecorderMux wraps a mux object and records the registered exposedPaths. It is _not_ go routine safe.
 type PathRecorderMux struct {
-	mux   Mux
-	paths []string
+	mux          *http.ServeMux
+	exposedPaths []string
+
+	// pathStacks holds the stacks of all registered paths.  This allows us to show a more helpful message
+	// before the "http: multiple registrations for %s" panic.
+	pathStacks map[string]string
 }
 
 // NewPathRecorderMux creates a new PathRecorderMux with the given mux as the base mux.
-func NewPathRecorderMux(mux Mux) *PathRecorderMux {
+func NewPathRecorderMux() *PathRecorderMux {
 	return &PathRecorderMux{
-		mux: mux,
+		mux:        http.NewServeMux(),
+		pathStacks: map[string]string{},
 	}
 }
 
-// BaseMux returns the underlying mux.
-func (m *PathRecorderMux) BaseMux() Mux {
-	return m.mux
-}
-
-// HandledPaths returns the registered handler paths.
+// HandledPaths returns the registered handler exposedPaths.
 func (m *PathRecorderMux) HandledPaths() []string {
-	return append([]string{}, m.paths...)
+	return append([]string{}, m.exposedPaths...)
 }
 
 // Handle registers the handler for the given pattern.
 // If a handler already exists for pattern, Handle panics.
 func (m *PathRecorderMux) Handle(path string, handler http.Handler) {
-	m.paths = append(m.paths, path)
+	if existingStack, ok := m.pathStacks[path]; ok {
+		utilruntime.HandleError(fmt.Errorf("registered %q from %v", path, existingStack))
+	}
+	m.pathStacks[path] = string(debug.Stack())
+
+	m.exposedPaths = append(m.exposedPaths, path)
 	m.mux.Handle(path, handler)
 }
 
 // HandleFunc registers the handler function for the given pattern.
+// If a handler already exists for pattern, Handle panics.
 func (m *PathRecorderMux) HandleFunc(path string, handler func(http.ResponseWriter, *http.Request)) {
-	m.paths = append(m.paths, path)
+	if existingStack, ok := m.pathStacks[path]; ok {
+		utilruntime.HandleError(fmt.Errorf("registered %q from %v", path, existingStack))
+	}
+	m.pathStacks[path] = string(debug.Stack())
+
+	m.exposedPaths = append(m.exposedPaths, path)
 	m.mux.HandleFunc(path, handler)
+}
+
+// UnlistedHandle registers the handler for the given pattern, but doesn't list it.
+// If a handler already exists for pattern, Handle panics.
+func (m *PathRecorderMux) UnlistedHandle(path string, handler http.Handler) {
+	if existingStack, ok := m.pathStacks[path]; ok {
+		utilruntime.HandleError(fmt.Errorf("registered %q from %v", path, existingStack))
+	}
+	m.pathStacks[path] = string(debug.Stack())
+	m.mux.Handle(path, handler)
+
+}
+
+// UnlistedHandleFunc registers the handler function for the given pattern, but doesn't list it.
+// If a handler already exists for pattern, Handle panics.
+func (m *PathRecorderMux) UnlistedHandleFunc(path string, handler func(http.ResponseWriter, *http.Request)) {
+	if existingStack, ok := m.pathStacks[path]; ok {
+		utilruntime.HandleError(fmt.Errorf("registered %q from %v", path, existingStack))
+	}
+	m.pathStacks[path] = string(debug.Stack())
+
+	m.mux.HandleFunc(path, handler)
+}
+
+// ServeHTTP makes it an http.Handler
+func (m *PathRecorderMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	m.mux.ServeHTTP(w, r)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder_test.go
@@ -23,18 +23,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewAPIContainer(t *testing.T) {
-	mux := http.NewServeMux()
-	c := NewAPIContainer(mux, nil)
-	assert.Equal(t, mux, c.UnlistedRoutes, "UnlistedRoutes ServeMux's do not match")
-	assert.Equal(t, mux, c.Container.ServeMux, "Container ServeMux's do not match")
-}
-
 func TestSecretHandlers(t *testing.T) {
-	mux := http.NewServeMux()
-	c := NewAPIContainer(mux, nil)
-	c.UnlistedRoutes.HandleFunc("/secret", func(http.ResponseWriter, *http.Request) {})
-	c.NonSwaggerRoutes.HandleFunc("/nonswagger", func(http.ResponseWriter, *http.Request) {})
-	assert.NotContains(t, c.NonSwaggerRoutes.HandledPaths(), "/secret")
-	assert.Contains(t, c.NonSwaggerRoutes.HandledPaths(), "/nonswagger")
+	c := NewPathRecorderMux()
+	c.UnlistedHandleFunc("/secret", func(http.ResponseWriter, *http.Request) {})
+	c.HandleFunc("/nonswagger", func(http.ResponseWriter, *http.Request) {})
+	assert.NotContains(t, c.HandledPaths(), "/secret")
+	assert.Contains(t, c.HandledPaths(), "/nonswagger")
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder_test.go
@@ -27,6 +27,6 @@ func TestSecretHandlers(t *testing.T) {
 	c := NewPathRecorderMux()
 	c.UnlistedHandleFunc("/secret", func(http.ResponseWriter, *http.Request) {})
 	c.HandleFunc("/nonswagger", func(http.ResponseWriter, *http.Request) {})
-	assert.NotContains(t, c.HandledPaths(), "/secret")
-	assert.Contains(t, c.HandledPaths(), "/nonswagger")
+	assert.NotContains(t, c.ListedPaths(), "/secret")
+	assert.Contains(t, c.ListedPaths(), "/nonswagger")
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi.go
@@ -44,7 +44,7 @@ type openAPI struct {
 }
 
 // RegisterOpenAPIService registers a handler to provides standard OpenAPI specification.
-func RegisterOpenAPIService(servePath string, webServices []*restful.WebService, config *openapi.Config, container *genericmux.APIContainer) (err error) {
+func RegisterOpenAPIService(servePath string, webServices []*restful.WebService, config *openapi.Config, mux *genericmux.PathRecorderMux) (err error) {
 	o := openAPI{
 		config:    config,
 		servePath: servePath,
@@ -63,7 +63,7 @@ func RegisterOpenAPIService(servePath string, webServices []*restful.WebService,
 		return err
 	}
 
-	container.UnlistedRoutes.HandleFunc(servePath, func(w http.ResponseWriter, r *http.Request) {
+	mux.UnlistedHandleFunc(servePath, func(w http.ResponseWriter, r *http.Request) {
 		resp := restful.NewResponse(w)
 		if r.URL.Path != servePath {
 			resp.WriteErrorString(http.StatusNotFound, "Path not found!")

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
@@ -29,8 +29,8 @@ import (
 type Index struct{}
 
 // Install adds the Index webservice to the given mux.
-func (i Index) Install(c *mux.APIContainer) {
-	c.UnlistedRoutes.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+func (i Index) Install(c *mux.APIContainer, mux *mux.PathRecorderMux) {
+	mux.UnlistedHandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		status := http.StatusOK
 		if r.URL.Path != "/" && r.URL.Path != "/index.html" {
 			// Since "/" matches all paths, handleIndex is called for all paths for which there is no handler api.Registry.
@@ -43,7 +43,7 @@ func (i Index) Install(c *mux.APIContainer) {
 			handledPaths = append(handledPaths, ws.RootPath())
 		}
 		// Extract the paths handled using mux handler.
-		handledPaths = append(handledPaths, c.NonSwaggerRoutes.HandledPaths()...)
+		handledPaths = append(handledPaths, mux.HandledPaths()...)
 		sort.Strings(handledPaths)
 		responsewriters.WriteRawJSON(status, metav1.RootPaths{Paths: handledPaths}, w)
 	})

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/index.go
@@ -18,33 +18,52 @@ package routes
 
 import (
 	"net/http"
-	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/handlers/responsewriters"
 	"k8s.io/apiserver/pkg/server/mux"
 )
+
+// ListedPathProvider is an interface for providing paths that should be reported at /.
+type ListedPathProvider interface {
+	// ListedPaths is an alphabetically sorted list of paths to be reported at /.
+	ListedPaths() []string
+}
+
+// ListedPathProviders is a convenient way to combine multiple ListedPathProviders
+type ListedPathProviders []ListedPathProvider
+
+// ListedPaths unions and sorts the included paths.
+func (p ListedPathProviders) ListedPaths() []string {
+	ret := sets.String{}
+	for _, provider := range p {
+		for _, path := range provider.ListedPaths() {
+			ret.Insert(path)
+		}
+	}
+
+	return ret.List()
+}
 
 // Index provides a webservice for the http root / listing all known paths.
 type Index struct{}
 
 // Install adds the Index webservice to the given mux.
-func (i Index) Install(c *mux.APIContainer, mux *mux.PathRecorderMux) {
+func (i Index) Install(pathProvider ListedPathProvider, mux *mux.PathRecorderMux, delegate http.Handler) {
 	mux.UnlistedHandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		status := http.StatusOK
 		if r.URL.Path != "/" && r.URL.Path != "/index.html" {
 			// Since "/" matches all paths, handleIndex is called for all paths for which there is no handler api.Registry.
-			// We want to return a 404 status with a list of all valid paths, incase of an invalid URL request.
+			// if we have a delegate, we should call to it and simply return
+			if delegate != nil {
+				delegate.ServeHTTP(w, r)
+				return
+			}
+
+			// If we have no delegate, we want to return a 404 status with a list of all valid paths, incase of an invalid URL request.
 			status = http.StatusNotFound
 		}
-		var handledPaths []string
-		// Extract the paths handled using restful.WebService
-		for _, ws := range c.RegisteredWebServices() {
-			handledPaths = append(handledPaths, ws.RootPath())
-		}
-		// Extract the paths handled using mux handler.
-		handledPaths = append(handledPaths, mux.HandledPaths()...)
-		sort.Strings(handledPaths)
-		responsewriters.WriteRawJSON(status, metav1.RootPaths{Paths: handledPaths}, w)
+		responsewriters.WriteRawJSON(status, metav1.RootPaths{Paths: pathProvider.ListedPaths()}, w)
 	})
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/metrics.go
@@ -31,8 +31,8 @@ import (
 type DefaultMetrics struct{}
 
 // Install adds the DefaultMetrics handler
-func (m DefaultMetrics) Install(c *mux.APIContainer) {
-	c.NonSwaggerRoutes.Handle("/metrics", prometheus.Handler())
+func (m DefaultMetrics) Install(c *mux.PathRecorderMux) {
+	c.Handle("/metrics", prometheus.Handler())
 }
 
 // MetricsWithReset install the prometheus metrics handler extended with support for the DELETE method
@@ -40,9 +40,9 @@ func (m DefaultMetrics) Install(c *mux.APIContainer) {
 type MetricsWithReset struct{}
 
 // Install adds the MetricsWithReset handler
-func (m MetricsWithReset) Install(c *mux.APIContainer) {
+func (m MetricsWithReset) Install(c *mux.PathRecorderMux) {
 	defaultMetricsHandler := prometheus.Handler().ServeHTTP
-	c.NonSwaggerRoutes.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
+	c.HandleFunc("/metrics", func(w http.ResponseWriter, req *http.Request) {
 		if req.Method == "DELETE" {
 			apimetrics.Reset()
 			etcdmetrics.Reset()

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/openapi.go
@@ -30,8 +30,8 @@ type OpenAPI struct {
 }
 
 // Install adds the SwaggerUI webservice to the given mux.
-func (oa OpenAPI) Install(c *mux.APIContainer) {
-	err := apiserveropenapi.RegisterOpenAPIService("/swagger.json", c.RegisteredWebServices(), oa.Config, c)
+func (oa OpenAPI) Install(c *mux.APIContainer, mux *mux.PathRecorderMux) {
+	err := apiserveropenapi.RegisterOpenAPIService("/swagger.json", c.RegisteredWebServices(), oa.Config, mux)
 	if err != nil {
 		glog.Fatalf("Failed to register open api spec for root: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/profiling.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/profiling.go
@@ -26,9 +26,9 @@ import (
 type Profiling struct{}
 
 // Install adds the Profiling webservice to the given mux.
-func (d Profiling) Install(c *mux.APIContainer) {
-	c.UnlistedRoutes.HandleFunc("/debug/pprof/", pprof.Index)
-	c.UnlistedRoutes.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	c.UnlistedRoutes.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	c.UnlistedRoutes.HandleFunc("/debug/pprof/trace", pprof.Trace)
+func (d Profiling) Install(c *mux.PathRecorderMux) {
+	c.UnlistedHandleFunc("/debug/pprof/", pprof.Index)
+	c.UnlistedHandleFunc("/debug/pprof/profile", pprof.Profile)
+	c.UnlistedHandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	c.UnlistedHandleFunc("/debug/pprof/trace", pprof.Trace)
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/swaggerui.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/swaggerui.go
@@ -29,12 +29,12 @@ import (
 type SwaggerUI struct{}
 
 // Install adds the SwaggerUI webservice to the given mux.
-func (l SwaggerUI) Install(c *mux.APIContainer) {
+func (l SwaggerUI) Install(c *mux.PathRecorderMux) {
 	fileServer := http.FileServer(&assetfs.AssetFS{
 		Asset:    swagger.Asset,
 		AssetDir: swagger.AssetDir,
 		Prefix:   "third_party/swagger-ui",
 	})
 	prefix := "/swagger-ui/"
-	c.NonSwaggerRoutes.Handle(prefix, http.StripPrefix(prefix, fileServer))
+	c.Handle(prefix, http.StripPrefix(prefix, fileServer))
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -250,8 +250,8 @@ func (s *APIAggregator) AddAPIService(apiService *apiregistration.APIService) {
 		endpointsLister: s.endpointsLister,
 	}
 	// aggregation is protected
-	s.GenericAPIServer.HandlerContainer.UnlistedRoutes.Handle(groupPath, groupDiscoveryHandler)
-	s.GenericAPIServer.HandlerContainer.UnlistedRoutes.Handle(groupPath+"/", groupDiscoveryHandler)
+	s.GenericAPIServer.FallThroughHandler.UnlistedHandle(groupPath, groupDiscoveryHandler)
+	s.GenericAPIServer.FallThroughHandler.UnlistedHandle(groupPath+"/", groupDiscoveryHandler)
 	s.handledGroups.Insert(apiService.Spec.Group)
 }
 

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -10467,7 +10467,10 @@ go_library(
 
 go_test(
     name = "k8s.io/apiserver/pkg/server_test",
-    srcs = ["k8s.io/apiserver/pkg/server/genericapiserver_test.go"],
+    srcs = [
+        "k8s.io/apiserver/pkg/server/config_test.go",
+        "k8s.io/apiserver/pkg/server/genericapiserver_test.go",
+    ],
     library = ":k8s.io/apiserver/pkg/server",
     tags = ["automanaged"],
     deps = [
@@ -10488,6 +10491,7 @@ go_test(
         "//vendor:k8s.io/apiserver/pkg/authorization/authorizer",
         "//vendor:k8s.io/apiserver/pkg/endpoints/request",
         "//vendor:k8s.io/apiserver/pkg/registry/rest",
+        "//vendor:k8s.io/apiserver/pkg/server/healthz",
         "//vendor:k8s.io/apiserver/pkg/server/mux",
         "//vendor:k8s.io/apiserver/pkg/storage/etcd/testing",
         "//vendor:k8s.io/client-go/rest",
@@ -10767,6 +10771,7 @@ go_library(
         "//vendor:github.com/prometheus/client_golang/prometheus",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/openapi",
+        "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/apimachinery/pkg/version",
         "//vendor:k8s.io/apiserver/pkg/endpoints/handlers/responsewriters",
         "//vendor:k8s.io/apiserver/pkg/endpoints/metrics",

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -10488,6 +10488,7 @@ go_test(
         "//vendor:k8s.io/apiserver/pkg/authorization/authorizer",
         "//vendor:k8s.io/apiserver/pkg/endpoints/request",
         "//vendor:k8s.io/apiserver/pkg/registry/rest",
+        "//vendor:k8s.io/apiserver/pkg/server/mux",
         "//vendor:k8s.io/apiserver/pkg/storage/etcd/testing",
         "//vendor:k8s.io/client-go/rest",
     ],
@@ -10627,7 +10628,7 @@ go_library(
 
 go_test(
     name = "k8s.io/apiserver/pkg/server/mux_test",
-    srcs = ["k8s.io/apiserver/pkg/server/mux/container_test.go"],
+    srcs = ["k8s.io/apiserver/pkg/server/mux/pathrecorder_test.go"],
     library = ":k8s.io/apiserver/pkg/server/mux",
     tags = ["automanaged"],
     deps = ["//vendor:github.com/stretchr/testify/assert"],
@@ -10647,6 +10648,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/apimachinery/pkg/util/runtime",
         "//vendor:k8s.io/apiserver/pkg/endpoints/handlers/responsewriters",
     ],
 )


### PR DESCRIPTION
Builds on https://github.com/kubernetes/kubernetes/pull/42886 (already lgtm'ed)

We need to be able to chain multiple API servers together so that a fallthrough case from to another results in delegated handling without double wrapping. We also need to be able to combine shared lists like healthz and poststarthooks so that a single API server start will run all the poststarthooks and present a unified view of health.  This creates an interface and methods to provide that wiring.

@kubernetes/sig-api-machinery-misc @ncdc 