### PR TITLE
Use constant time compare for bootstrap tokens

### DIFF
--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
@@ -20,6 +20,7 @@ Package bootstrap provides a token authenticator for TLS bootstrap secrets.
 package bootstrap
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"regexp"
 	"time"
@@ -95,7 +96,7 @@ func (t *TokenAuthenticator) AuthenticateToken(token string) (user.Info, bool, e
 	}
 
 	ts := getSecretString(secret, bootstrapapi.BootstrapTokenSecretKey)
-	if ts != tokenSecret {
+	if subtle.ConstantTimeCompare([]byte(ts), []byte(tokenSecret)) != 1 {
 		return nil, false, nil
 	}
 


### PR DESCRIPTION
This is a subtle security issue that should go in for 1.6 on a new feature (bootstrap tokens).

```release-note
NONE
```
