### PR TITLE
Fixes for unprivileged LXD containers

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -337,7 +337,12 @@ func setupKernelTunables(option KernelTunableBehavior) error {
 			glog.V(2).Infof("Updating kernel flag: %v, expected value: %v, actual value: %v", flag, expectedValue, val)
 			err = sysctl.SetSysctl(flag, expectedValue)
 			if err != nil {
-				errList = append(errList, err)
+				// Unprivileged containers cannot write to files in /proc/sys
+				if os.IsPermission(err) {
+					glog.Warningf("Failed to adjust kernel flag, assuming unprivileged system container execution, ignoring: %v", err)
+				} else {
+					errList = append(errList, err)
+				}
 			}
 		}
 	}

--- a/pkg/util/oom/oom_linux.go
+++ b/pkg/util/oom/oom_linux.go
@@ -67,7 +67,10 @@ func applyOOMScoreAdj(pid int, oomScoreAdj int) error {
 	for i := 0; i < maxTries; i++ {
 		err = ioutil.WriteFile(oomScoreAdjPath, []byte(value), 0700)
 		if err != nil {
-			if os.IsNotExist(err) {
+			// User namespaces prohibit write access to this file: https://github.com/lxc/lxd/issues/2994
+			if os.IsPermission(err) {
+				glog.Warningf("Failed to adjust OOM setting, assuming unprivileged system container execution, ignoring: %v", err)
+			} else if os.IsNotExist(err) {
 				glog.V(2).Infof("%q does not exist", oomScoreAdjPath)
 				return os.ErrNotExist
 			}


### PR DESCRIPTION
If there's a permission denied error when trying to modify files in /proc/sys/, kubelet is changed to continue on. The OOM score for processes is not allowed to be changed by unprivileged system containers, so the function has been modified to move on if there's a permission denied error (see https://github.com/lxc/lxd/issues/2994)

Signed-off-by: Carlton-Semple <carlton.semple@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR is intended to bypass a couple of privileged functions that prevent Kubernetes from working within an unprivileged LXD container. Once these are bypassed, Kubernetes does work as intended.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
For more information, see the LXD issue https://github.com/lxc/lxd/issues/2994

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
