### PR TITLE
conversion-gen: make duplicate func error message readable

### DIFF
--- a/cmd/libs/go2idl/conversion-gen/generators/conversion.go
+++ b/cmd/libs/go2idl/conversion-gen/generators/conversion.go
@@ -160,7 +160,7 @@ func getManualConversionFunctions(context *generator.Context, pkg *types.Package
 			key := conversionPair{inType.Elem, outType.Elem}
 			// We might scan the same package twice, and that's OK.
 			if v, ok := manualMap[key]; ok && v != nil && v.Name.Package != pkg.Path {
-				panic(fmt.Sprintf("duplicate static conversion defined: %#v", key))
+				panic(fmt.Sprintf("duplicate static conversion defined: %s -> %s", key.inType, key.outType))
 			}
 			manualMap[key] = f
 		}


### PR DESCRIPTION
Before you only got two hex pointer values.