### PR TITLE
Darwin won't build: syscall.Sysinfo issue.

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -16,7 +16,7 @@ go_library(
         "doc.go",
         "gpus.go",
         "image_list.go",
-        "node_problem_detector.go",
+        "node_problem_detector_linux.go",
         "resource_collector.go",
         "simple_mount.go",
         "util.go",

--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -1,3 +1,5 @@
+// +build cgo,linux
+
 /*
 Copyright 2016 The Kubernetes Authors.
 


### PR DESCRIPTION
**What this PR does / why we need it**: On darwin had problems building and testing because of syscall.Sysinfo_t etc which is a linux specific command. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**: Definitely would like another set of eyes on the bootTime function, it will have to be inaccurate but open to suggestions about improving this for darwin.


**Release note**:
```
NONE
```
