### PR TITLE
[Federation][e2e] Provide less strict timeouts on destruction paths

### DIFF
--- a/test/e2e_federation/deployment.go
+++ b/test/e2e_federation/deployment.go
@@ -36,8 +36,7 @@ import (
 )
 
 const (
-	FederationDeploymentName   = "federation-deployment"
-	FederatedDeploymentTimeout = 120 * time.Second
+	FederationDeploymentName = "federation-deployment"
 )
 
 // Create/delete deployment api objects
@@ -186,7 +185,7 @@ func waitForDeploymentOrFail(c *fedclientset.Clientset, namespace string, deploy
 }
 
 func waitForDeployment(c *fedclientset.Clientset, namespace string, deploymentName string, clusters map[string]*cluster) error {
-	err := wait.Poll(10*time.Second, FederatedDeploymentTimeout, func() (bool, error) {
+	err := wait.Poll(10*time.Second, federatedDeploymentTimeout, func() (bool, error) {
 		fdep, err := c.Deployments(namespace).Get(deploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -260,7 +259,7 @@ func deleteDeploymentOrFail(clientset *fedclientset.Clientset, nsName string, de
 	}
 
 	// Wait for the deployment to be deleted.
-	err = wait.Poll(5*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+	err = wait.Poll(10*time.Second, federatedDeploymentTimeout, func() (bool, error) {
 		_, err := clientset.Extensions().Deployments(nsName).Get(deploymentName, metav1.GetOptions{})
 		if err != nil && errors.IsNotFound(err) {
 			return true, nil


### PR DESCRIPTION
The CI tests show that some timeouts are too strict. This PR harmonizes some of the "ForeverWaitTimeouts" in one place. The goal is to reduce the e2e flakiness.