### PR TITLE
Add guards for StatefulSet and AppArmor upgrade testing

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -200,6 +200,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/watch",
         "//vendor:k8s.io/apiserver/pkg/authentication/serviceaccount",
         "//vendor:k8s.io/apiserver/pkg/registry/generic/registry",
+        "//vendor:k8s.io/client-go/discovery",
         "//vendor:k8s.io/client-go/kubernetes",
         "//vendor:k8s.io/client-go/pkg/api/v1",
         "//vendor:k8s.io/client-go/pkg/apis/extensions/v1beta1",

--- a/test/e2e/common/apparmor.go
+++ b/test/e2e/common/apparmor.go
@@ -32,8 +32,11 @@ const (
 	appArmorDeniedPath    = "/expect_permission_denied"
 )
 
+// AppArmorDistros are distros with AppArmor support
+var AppArmorDistros = []string{"gci", "ubuntu"}
+
 func SkipIfAppArmorNotSupported() {
-	framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu")
+	framework.SkipUnlessNodeOSDistroIs(AppArmorDistros...)
 }
 
 func LoadAppArmorProfiles(f *framework.Framework) {

--- a/test/e2e/upgrades/BUILD
+++ b/test/e2e/upgrades/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/controller/deployment/util:go_default_library",
         "//pkg/kubelet/sysctl:go_default_library",
+        "//pkg/util/version:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//vendor:github.com/onsi/ginkgo",

--- a/test/e2e/upgrades/apparmor.go
+++ b/test/e2e/upgrades/apparmor.go
@@ -34,9 +34,22 @@ type AppArmorUpgradeTest struct {
 
 func (AppArmorUpgradeTest) Name() string { return "apparmor-upgrade" }
 
+func (AppArmorUpgradeTest) Skip(upgCtx UpgradeContext) bool {
+	var supportedImages map[string]bool
+	for _, d := range common.AppArmorDistros {
+		supportedImages[d] = true
+	}
+
+	for _, vCtx := range upgCtx.Versions {
+		if !supportedImages[vCtx.NodeImage] {
+			return true
+		}
+	}
+	return false
+}
+
 // Setup creates a secret and then verifies that a pod can consume it.
 func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
-	common.SkipIfAppArmorNotSupported()
 	By("Loading AppArmor profiles to nodes")
 	common.LoadAppArmorProfiles(f)
 

--- a/test/e2e/upgrades/statefulset.go
+++ b/test/e2e/upgrades/statefulset.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/kubernetes/pkg/api/v1"
 	apps "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
+	"k8s.io/kubernetes/pkg/util/version"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -34,6 +35,17 @@ type StatefulSetUpgradeTest struct {
 }
 
 func (StatefulSetUpgradeTest) Name() string { return "statefulset-upgrade" }
+
+func (StatefulSetUpgradeTest) SkipVersions(versions ...version.Version) bool {
+	minVersion := version.MustParseSemantic("1.5.0")
+
+	for _, v := range versions {
+		if v.LessThan(minVersion) {
+			return true
+		}
+	}
+	return false
+}
 
 // Setup creates a StatefulSet and a HeadlessService. It verifies the basic SatefulSet properties
 func (t *StatefulSetUpgradeTest) Setup(f *framework.Framework) {

--- a/test/e2e/upgrades/statefulset.go
+++ b/test/e2e/upgrades/statefulset.go
@@ -36,11 +36,11 @@ type StatefulSetUpgradeTest struct {
 
 func (StatefulSetUpgradeTest) Name() string { return "statefulset-upgrade" }
 
-func (StatefulSetUpgradeTest) SkipVersions(versions ...version.Version) bool {
+func (StatefulSetUpgradeTest) Skip(upgCtx UpgradeContext) bool {
 	minVersion := version.MustParseSemantic("1.5.0")
 
-	for _, v := range versions {
-		if v.LessThan(minVersion) {
+	for _, vCtx := range upgCtx.Versions {
+		if vCtx.Version.LessThan(minVersion) {
 			return true
 		}
 	}

--- a/test/e2e/upgrades/upgrade.go
+++ b/test/e2e/upgrades/upgrade.go
@@ -61,10 +61,23 @@ type Test interface {
 	Teardown(f *framework.Framework)
 }
 
-// VersionSkippable is an interface that an upgrade test can implement
-// to be able to indicate that it should be skipped.
-type VersionSkippable interface {
-	// SkipVersions should return true if test should be skipped
-	// for any of provided versions.
-	SkipVersions(versions ...version.Version) bool
+// Skippable is an interface that an upgrade test can implement to be
+// able to indicate that it should be skipped.
+type Skippable interface {
+	// Skip should return true if test should be skipped. upgCtx
+	// provides information about the upgrade that is going to
+	// occur.
+	Skip(upgCtx UpgradeContext) bool
+}
+
+// UpgradeContext contains information about all the stages of the
+// upgrade that is going to occur.
+type UpgradeContext struct {
+	Versions []VersionContext
+}
+
+// VersionContext represents a stage of the upgrade.
+type VersionContext struct {
+	Version   version.Version
+	NodeImage string
 }

--- a/test/e2e/upgrades/upgrade.go
+++ b/test/e2e/upgrades/upgrade.go
@@ -18,7 +18,10 @@ limitations under the License.
 // features before, during, and after different types of upgrades.
 package upgrades
 
-import "k8s.io/kubernetes/test/e2e/framework"
+import (
+	"k8s.io/kubernetes/pkg/util/version"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
 
 // UpgradeType represents different types of upgrades.
 type UpgradeType int
@@ -56,4 +59,12 @@ type Test interface {
 	// TearDown should clean up any objects that are created that
 	// aren't already cleaned up by the framework.
 	Teardown(f *framework.Framework)
+}
+
+// VersionSkippable is an interface that an upgrade test can implement
+// to be able to indicate that it should be skipped.
+type VersionSkippable interface {
+	// SkipVersions should return true if test should be skipped
+	// for any of provided versions.
+	SkipVersions(versions ...version.Version) bool
 }


### PR DESCRIPTION
This PR adds automated upgrade infrastructure to allow test suites to know what versions and node images are going to be testing and whether or not they should be skipped. It also adds a guard to prevent StatefulSets from being tested with versions prior to 1.5.0, and a guard to prevent AppArmor from running on distros other than gci and ubuntu.

