### PR TITLE
Cherrypick #42745

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.8.0
+  name: l7-lb-controller-v0.9.2
   namespace: kube-system
   labels:
     k8s-app: glbc
-    version: v0.8.0
+    version: v0.9.2
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/glbc:0.8.0
+  - image: gcr.io/google_containers/glbc:0.9.2
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Cherry-pick https://github.com/kubernetes/kubernetes/pull/42745 into 1.4 branch.

Version 0.9.2 rebases glbc on alpine (from ubuntu:14.04), closing many open CVEs in the process, and greatly reducing the maintenance version due to the smaller package footprint.

@csbell @nicksardo - please confirm you're comfortable with the glbc minor version bump in a patch release. Is there any extra testing we should put this through?

/cc @ixdy 

```release-note
Bump gcr.io/google_containers/glbc from 0.8.0 to 0.9.2. Release notes: [0.9.0](https://github.com/kubernetes/ingress/releases/tag/0.9.0), [0.9.1](https://github.com/kubernetes/ingress/releases/tag/0.9.1), [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2)
```