### PR TITLE
Bumped rescheduler version to 0.3.0

### DIFF
--- a/cluster/saltbase/salt/rescheduler/rescheduler.manifest
+++ b/cluster/saltbase/salt/rescheduler/rescheduler.manifest
@@ -1,17 +1,17 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: rescheduler-v0.2.2
+  name: rescheduler-v0.3.0
   namespace: kube-system
   labels:
     k8s-app: rescheduler
-    version: v0.2.2
+    version: v0.3.0
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Rescheduler"
 spec:
   hostNetwork: true
   containers:
-  - image: gcr.io/google-containers/rescheduler:v0.2.2
+  - image: gcr.io/google-containers/rescheduler:v0.3.0
     name: rescheduler
     volumeMounts:
     - mountPath: /var/log/rescheduler.log


### PR DESCRIPTION
fix #32531

https://github.com/kubernetes/contrib/pull/2474 needs to be merged first

cc @ethernetdan @marun @k82cn @aveshagarwal 

``` release-note
Rescheduler uses taints in v1beta1 and will remove old ones (in version v1alpha1) right after its start.
```