### PR TITLE
kubeadm: test-cmds for kubeadm completion

### DIFF
--- a/cmd/kubeadm/test/cmd/BUILD
+++ b/cmd/kubeadm/test/cmd/BUILD
@@ -17,6 +17,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "completion_test.go",
         "init_test.go",
         "join_test.go",
         "token_test.go",

--- a/cmd/kubeadm/test/cmd/completion_test.go
+++ b/cmd/kubeadm/test/cmd/completion_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+import "testing"
+
+func TestCmdCompletion(t *testing.T) {
+	if *kubeadmCmdSkip {
+		t.Log("kubeadm cmd tests being skipped")
+		t.Skip()
+	}
+
+	var tests = []struct {
+		args     string
+		expected bool
+	}{
+		{"", false},    // shell not specified
+		{"foo", false}, // unsupported shell type
+	}
+
+	for _, rt := range tests {
+		_, _, actual := RunCmd(*kubeadmPath, "completion", rt.args)
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed CmdCompletion running 'kubeadm completion %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+				rt.args,
+				actual,
+				rt.expected,
+				(actual == nil),
+			)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**: Adding test-cmds for kubeadm completion. 

Adding tests is a WIP from #34136

**Special notes for your reviewer**: /cc @luxas

**Release note**:
```release-note
NONE
```