### PR TITLE
Wait for garbagecollector to be synced in test

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -125,6 +125,10 @@ func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 	glog.Infof("Garbage Collector: Shutting down")
 }
 
+func (gc *GarbageCollector) HasSynced() bool {
+	return gc.dependencyGraphBuilder.HasSynced()
+}
+
 func (gc *GarbageCollector) runAttemptToDeleteWorker() {
 	for gc.attemptToDeleteWorker() {
 	}


### PR DESCRIPTION
Fix #42952

Without the `cache.WaitForCacheSync` in the test, it's possible for the GC to get a merged event of RC's creation and its update (update to deletionTimestamp != 0), before GC gets the creation event of the pod, so it's possible the GC will handle the foreground deletion of the RC before it adds the Pod to the dependency graph, thus the race.

With the `cache.WaitForCacheSync` in the test, because GC runs a single thread to process graph changes, it's guaranteed the Pod will be added to the dependency graph before GC handles the foreground deletion of the RC.

Note that this pull fixes the race in the test. The race described in the first point of #26120 still exists.
