### PR TITLE
Fix Deployment upgrade test.

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3139,6 +3139,16 @@ func NewDeployment(deploymentName string, replicas int32, podLabels map[string]s
 // Note that the status should stay valid at all times unless shortly after a scaling event or the deployment is just created.
 // To verify that the deployment status is valid and wait for the rollout to finish, use WaitForDeploymentStatus instead.
 func WaitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deployment) error {
+	return waitForDeploymentStatusValid(c, d, false)
+}
+
+// WaitForDeploymentStatusValidV15 is a compatibility function that behaves the
+// way WaitForDeploymentStatusValid() did in v1.5.x.
+func WaitForDeploymentStatusValidV15(c clientset.Interface, d *extensions.Deployment) error {
+	return waitForDeploymentStatusValid(c, d, true)
+}
+
+func waitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deployment, v15Compatible bool) error {
 	var (
 		oldRSs, allOldRSs, allRSs []*extensions.ReplicaSet
 		newRS                     *extensions.ReplicaSet
@@ -3152,7 +3162,11 @@ func WaitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deploymen
 		if err != nil {
 			return false, err
 		}
-		oldRSs, allOldRSs, newRS, err = deploymentutil.GetAllReplicaSets(deployment, c)
+		if v15Compatible {
+			oldRSs, allOldRSs, newRS, err = deploymentutil.GetAllReplicaSetsV15(deployment, c)
+		} else {
+			oldRSs, allOldRSs, newRS, err = deploymentutil.GetAllReplicaSets(deployment, c)
+		}
 		if err != nil {
 			return false, err
 		}
@@ -3198,7 +3212,7 @@ func WaitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deploymen
 
 	if err == wait.ErrWaitTimeout {
 		logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
-		logPodsOfDeployment(c, deployment)
+		logPodsOfDeployment(c, deployment, allRSs, v15Compatible)
 		err = fmt.Errorf("%s", reason)
 	}
 	if err != nil {
@@ -3210,6 +3224,16 @@ func WaitForDeploymentStatusValid(c clientset.Interface, d *extensions.Deploymen
 // Waits for the deployment to reach desired state.
 // Returns an error if the deployment's rolling update strategy (max unavailable or max surge) is broken at any times.
 func WaitForDeploymentStatus(c clientset.Interface, d *extensions.Deployment) error {
+	return waitForDeploymentStatus(c, d, false)
+}
+
+// WaitForDeploymentStatusV15 is a compatibility function that behaves the way
+// WaitForDeploymentStatus() did in v1.5.x.
+func WaitForDeploymentStatusV15(c clientset.Interface, d *extensions.Deployment) error {
+	return waitForDeploymentStatus(c, d, true)
+}
+
+func waitForDeploymentStatus(c clientset.Interface, d *extensions.Deployment, v15Compatible bool) error {
 	var (
 		oldRSs, allOldRSs, allRSs []*extensions.ReplicaSet
 		newRS                     *extensions.ReplicaSet
@@ -3222,7 +3246,11 @@ func WaitForDeploymentStatus(c clientset.Interface, d *extensions.Deployment) er
 		if err != nil {
 			return false, err
 		}
-		oldRSs, allOldRSs, newRS, err = deploymentutil.GetAllReplicaSets(deployment, c)
+		if v15Compatible {
+			oldRSs, allOldRSs, newRS, err = deploymentutil.GetAllReplicaSetsV15(deployment, c)
+		} else {
+			oldRSs, allOldRSs, newRS, err = deploymentutil.GetAllReplicaSets(deployment, c)
+		}
 		if err != nil {
 			return false, err
 		}
@@ -3241,13 +3269,13 @@ func WaitForDeploymentStatus(c clientset.Interface, d *extensions.Deployment) er
 		maxCreated := *(deployment.Spec.Replicas) + deploymentutil.MaxSurge(*deployment)
 		if totalCreated > maxCreated {
 			logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
-			logPodsOfDeployment(c, deployment)
+			logPodsOfDeployment(c, deployment, allRSs, v15Compatible)
 			return false, fmt.Errorf("total pods created: %d, more than the max allowed: %d", totalCreated, maxCreated)
 		}
 		minAvailable := deploymentutil.MinAvailable(deployment)
 		if deployment.Status.AvailableReplicas < minAvailable {
 			logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
-			logPodsOfDeployment(c, deployment)
+			logPodsOfDeployment(c, deployment, allRSs, v15Compatible)
 			return false, fmt.Errorf("total pods available: %d, less than the min required: %d", deployment.Status.AvailableReplicas, minAvailable)
 		}
 
@@ -3257,7 +3285,7 @@ func WaitForDeploymentStatus(c clientset.Interface, d *extensions.Deployment) er
 
 	if err == wait.ErrWaitTimeout {
 		logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
-		logPodsOfDeployment(c, deployment)
+		logPodsOfDeployment(c, deployment, allRSs, v15Compatible)
 	}
 	if err != nil {
 		return fmt.Errorf("error waiting for deployment %q status to match expectation: %v", d.Name, err)
@@ -3340,6 +3368,16 @@ func WatchRecreateDeployment(c clientset.Interface, d *extensions.Deployment) er
 // WaitForDeploymentRevisionAndImage waits for the deployment's and its new RS's revision and container image to match the given revision and image.
 // Note that deployment revision and its new RS revision should be updated shortly, so we only wait for 1 minute here to fail early.
 func WaitForDeploymentRevisionAndImage(c clientset.Interface, ns, deploymentName string, revision, image string) error {
+	return waitForDeploymentRevisionAndImage(c, ns, deploymentName, revision, image, false)
+}
+
+// WaitForDeploymentRevisionAndImageV15 is a compatibility function that behaves
+// the way WaitForDeploymentRevisionAndImage() did in v1.5.x.
+func WaitForDeploymentRevisionAndImageV15(c clientset.Interface, ns, deploymentName string, revision, image string) error {
+	return waitForDeploymentRevisionAndImage(c, ns, deploymentName, revision, image, true)
+}
+
+func waitForDeploymentRevisionAndImage(c clientset.Interface, ns, deploymentName string, revision, image string, v15Compatible bool) error {
 	var deployment *extensions.Deployment
 	var newRS *extensions.ReplicaSet
 	var reason string
@@ -3350,7 +3388,11 @@ func WaitForDeploymentRevisionAndImage(c clientset.Interface, ns, deploymentName
 			return false, err
 		}
 		// The new ReplicaSet needs to be non-nil and contain the pod-template-hash label
-		newRS, err = deploymentutil.GetNewReplicaSet(deployment, c)
+		if v15Compatible {
+			newRS, err = deploymentutil.GetNewReplicaSetV15(deployment, c)
+		} else {
+			newRS, err = deploymentutil.GetNewReplicaSet(deployment, c)
+		}
 		if err != nil {
 			return false, err
 		}
@@ -3497,33 +3539,24 @@ func WaitForDeploymentWithCondition(c clientset.Interface, ns, deploymentName, r
 		_, allOldRSs, newRS, err := deploymentutil.GetAllReplicaSets(deployment, c)
 		if err == nil {
 			logReplicaSetsOfDeployment(deployment, allOldRSs, newRS)
+			logPodsOfDeployment(c, deployment, append(allOldRSs, newRS), false)
 		}
-		logPodsOfDeployment(c, deployment)
 	}
 	return pollErr
 }
 
-func logPodsOfDeployment(c clientset.Interface, deployment *extensions.Deployment) {
+func logPodsOfDeployment(c clientset.Interface, deployment *extensions.Deployment, rsList []*extensions.ReplicaSet, v15Compatible bool) {
 	minReadySeconds := deployment.Spec.MinReadySeconds
-	rsList, err := deploymentutil.ListReplicaSets(deployment,
-		func(namespace string, options metav1.ListOptions) ([]*extensions.ReplicaSet, error) {
-			rsList, err := c.Extensions().ReplicaSets(namespace).List(options)
-			if err != nil {
-				return nil, err
-			}
-			ret := make([]*extensions.ReplicaSet, 0, len(rsList.Items))
-			for i := range rsList.Items {
-				ret = append(ret, &rsList.Items[i])
-			}
-			return ret, nil
-		})
-	if err != nil {
-		Logf("Failed to list ReplicaSets of Deployment %s: %v", deployment.Name, err)
+	podListFunc := func(namespace string, options metav1.ListOptions) (*v1.PodList, error) {
+		return c.Core().Pods(namespace).List(options)
 	}
-	podList, err := deploymentutil.ListPods(deployment, rsList,
-		func(namespace string, options metav1.ListOptions) (*v1.PodList, error) {
-			return c.Core().Pods(namespace).List(options)
-		})
+	var podList *v1.PodList
+	var err error
+	if v15Compatible {
+		podList, err = deploymentutil.ListPodsV15(deployment, podListFunc)
+	} else {
+		podList, err = deploymentutil.ListPods(deployment, rsList, podListFunc)
+	}
 	if err != nil {
 		Logf("Failed to list Pods of Deployment %s: %v", deployment.Name, err)
 		return

--- a/test/e2e/upgrades/deployments.go
+++ b/test/e2e/upgrades/deployments.go
@@ -56,13 +56,13 @@ func (t *DeploymentUpgradeTest) Setup(f *framework.Framework) {
 
 	// Wait for it to be updated to revision 1
 	By(fmt.Sprintf("Waiting deployment %q to be updated to revision 1", deploymentName))
-	err = framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "1", nginxImage)
+	err = framework.WaitForDeploymentRevisionAndImageV15(c, ns, deploymentName, "1", nginxImage)
 	framework.ExpectNoError(err)
 
 	By(fmt.Sprintf("Waiting deployment %q to complete", deploymentName))
-	framework.ExpectNoError(framework.WaitForDeploymentStatusValid(c, deployment))
+	framework.ExpectNoError(framework.WaitForDeploymentStatusValidV15(c, deployment))
 
-	rs, err := deploymentutil.GetNewReplicaSet(deployment, c)
+	rs, err := deploymentutil.GetNewReplicaSetV15(deployment, c)
 	framework.ExpectNoError(err)
 	if rs == nil {
 		framework.ExpectNoError(fmt.Errorf("expected a new replica set for deployment %q, found none", deployment.Name))
@@ -84,12 +84,12 @@ func (t *DeploymentUpgradeTest) Setup(f *framework.Framework) {
 
 	// Wait for it to be updated to revision 2
 	By(fmt.Sprintf("Waiting deployment %q to be updated to revision 2", deploymentName))
-	framework.ExpectNoError(framework.WaitForDeploymentRevisionAndImage(c, ns, deploymentName, "2", nginxImage))
+	framework.ExpectNoError(framework.WaitForDeploymentRevisionAndImageV15(c, ns, deploymentName, "2", nginxImage))
 
 	By(fmt.Sprintf("Waiting deployment %q to complete", deploymentName))
-	framework.ExpectNoError(framework.WaitForDeploymentStatus(c, deployment))
+	framework.ExpectNoError(framework.WaitForDeploymentStatusV15(c, deployment))
 
-	rs, err = deploymentutil.GetNewReplicaSet(deployment, c)
+	rs, err = deploymentutil.GetNewReplicaSetV15(deployment, c)
 	framework.ExpectNoError(err)
 	if rs == nil {
 		framework.ExpectNoError(fmt.Errorf("expected a new replica set for deployment %q", deployment.Name))
@@ -117,6 +117,9 @@ func (t *DeploymentUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 	deployment, err := c.Extensions().Deployments(t.oldD.Namespace).Get(t.oldD.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	t.updatedD = deployment
+
+	By(fmt.Sprintf("Waiting for deployment %q to complete adoption", deployment.Name))
+	framework.ExpectNoError(framework.WaitForDeploymentStatus(c, deployment))
 
 	By(fmt.Sprintf("Checking that replica sets for deployment %q are the same as prior to the upgrade", t.updatedD.Name))
 	_, allOldRSs, newRS, err := deploymentutil.GetAllReplicaSets(t.updatedD, c)


### PR DESCRIPTION
**What this PR does / why we need it**:

When the upgrade test operates on Deployments in a pre-1.6 cluster (i.e. during the Setup phase), it needs to use the v1.5 deployment/util logic. In particular, the v1.5 logic does not filter children to only those with a matching ControllerRef.

**Which issue this PR fixes**:

Fixes #42738

**Special notes for your reviewer**:

**Release note**:
```release-note
```
cc @kubernetes/sig-apps-pr-reviews 