### PR TITLE
Apply taint tolerations for NoExecute for all static pods.

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -73,6 +73,15 @@ func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.Node
 	// The generated UID is the hash of the file.
 	pod.Annotations[kubetypes.ConfigHashAnnotationKey] = string(pod.UID)
 
+	if isFile {
+		// Applying the default Taint tolerations to static pods,
+		// so they are not evicted when there are node problems.
+		api.AddOrUpdateTolerationInPod(pod, &api.Toleration{
+			Operator: "Exists",
+			Effect:   api.TaintEffectNoExecute,
+		})
+	}
+
 	// Set the default status to pending.
 	pod.Status.Phase = api.PodPending
 	return nil

--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -208,6 +208,10 @@ func getTestCases(hostname types.NodeName) []*testCase {
 					RestartPolicy:                 v1.RestartPolicyAlways,
 					DNSPolicy:                     v1.DNSClusterFirst,
 					TerminationGracePeriodSeconds: &grace,
+					Tolerations: []v1.Toleration{{
+						Operator: "Exists",
+						Effect:   "NoExecute",
+					}},
 					Containers: []v1.Container{{
 						Name:  "image",
 						Image: "test/image",


### PR DESCRIPTION
Fixed https://github.com/kubernetes/kubernetes/issues/42753


**Release note**:
```
Apply taint tolerations for NoExecute for all static pods.
```

cc/ @davidopp 