### PR TITLE
remove default kubeconfig from kubeadm token

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -85,7 +85,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 	}
 
 	tokenCmd.PersistentFlags().StringVar(&kubeConfigFile,
-		"kubeconfig", "/etc/kubernetes/admin.conf", "The KubeConfig file to use for talking to the cluster")
+		"kubeconfig", "", "The KubeConfig file to use for talking to the cluster")
 
 	var usages []string
 	var tokenDuration time.Duration

--- a/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/util/kubeconfig/kubeconfig.go
@@ -18,6 +18,7 @@ package kubeconfig
 
 import (
 	"fmt"
+	"os"
 
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -68,6 +69,12 @@ func CreateWithToken(serverURL, clusterName, userName string, caCert []byte, tok
 
 // ClientSetFromFile returns a ready-to-use client from a KubeConfig file
 func ClientSetFromFile(path string) (*clientset.Clientset, error) {
+	if len(path) == 0 {
+		// get the default kubeconfig from env
+		if path = os.Getenv("KUBECONFIG"); len(path) == 0 {
+			return nil, fmt.Errorf("failed to load admin kubeconfig [the value of KUBECONFIG is \"\"]")
+		}
+	}
 	config, err := clientcmd.LoadFromFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load admin kubeconfig [%v]", err)


### PR DESCRIPTION
The problem is similar to https://github.com/kubernetes/kubernetes/pull/42970
fixes https://github.com/kubernetes/kubeadm/issues/198
