### PR TITLE
[Federation] Remove FEDERATIONS_DOMAIN_MAP references

### DIFF
--- a/cluster/addons/dns/kubedns-controller.yaml.base
+++ b/cluster/addons/dns/kubedns-controller.yaml.base
@@ -89,7 +89,6 @@ spec:
         - --dns-port=10053
         - --config-dir=/kube-dns-config
         - --v=2
-        __PILLAR__FEDERATIONS__DOMAIN__MAP__
         env:
         - name: PROMETHEUS_PORT
           value: "10055"

--- a/cluster/addons/dns/kubedns-controller.yaml.in
+++ b/cluster/addons/dns/kubedns-controller.yaml.in
@@ -89,7 +89,6 @@ spec:
         - --dns-port=10053
         - --config-dir=/kube-dns-config
         - --v=2
-        {{ pillar['federations_domain_map'] }}
         env:
         - name: PROMETHEUS_PORT
           value: "10055"

--- a/cluster/addons/dns/transforms2salt.sed
+++ b/cluster/addons/dns/transforms2salt.sed
@@ -1,4 +1,3 @@
 s/__PILLAR__DNS__SERVER__/{{ pillar['dns_server'] }}/g
 s/__PILLAR__DNS__DOMAIN__/{{ pillar['dns_domain'] }}/g
-s/__PILLAR__FEDERATIONS__DOMAIN__MAP__/{{ pillar['federations_domain_map'] }}/g
 s/__MACHINE_GENERATED_WARNING__/Warning: This is a file generated from the base underscore template file: __SOURCE_FILENAME__/g

--- a/cluster/addons/dns/transforms2sed.sed
+++ b/cluster/addons/dns/transforms2sed.sed
@@ -1,4 +1,3 @@
 s/__PILLAR__DNS__SERVER__/$DNS_SERVER_IP/g
 s/__PILLAR__DNS__DOMAIN__/$DNS_DOMAIN/g
-/__PILLAR__FEDERATIONS__DOMAIN__MAP__/d
 s/__MACHINE_GENERATED_WARNING__/Warning: This is a file generated from the base underscore template file: __SOURCE_FILENAME__/g

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -870,11 +870,6 @@ EOF
 FEDERATION: $(yaml-quote ${FEDERATION})
 EOF
   fi
-  if [ -n "${FEDERATIONS_DOMAIN_MAP:-}" ]; then
-    cat >>$file <<EOF
-FEDERATIONS_DOMAIN_MAP: $(yaml-quote ${FEDERATIONS_DOMAIN_MAP})
-EOF
-  fi
   if [ -n "${FEDERATION_NAME:-}" ]; then
     cat >>$file <<EOF
 FEDERATION_NAME: $(yaml-quote ${FEDERATION_NAME})

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -582,25 +582,6 @@ enable_cluster_autoscaler: '$(echo "${ENABLE_CLUSTER_AUTOSCALER}" | sed -e "s/'/
 autoscaler_mig_config: '$(echo "${AUTOSCALER_MIG_CONFIG}" | sed -e "s/'/''/g")'
 EOF
     fi
-    if [[ "${FEDERATION:-}" == "true" ]]; then
-      local federations_domain_map="${FEDERATIONS_DOMAIN_MAP:-}"
-      if [[ -z "${federations_domain_map}" && -n "${FEDERATION_NAME:-}" && -n "${DNS_ZONE_NAME:-}" ]]; then
-        federations_domain_map="${FEDERATION_NAME}=${DNS_ZONE_NAME}"
-      fi
-      if [[ -n "${federations_domain_map}" ]]; then
-        cat <<EOF >>/srv/salt-overlay/pillar/cluster-params.sls
-federations_domain_map: '$(echo "- --federations=${federations_domain_map}" | sed -e "s/'/''/g")'
-EOF
-      else
-        cat <<EOF >>/srv/salt-overlay/pillar/cluster-params.sls
-federations_domain_map: ''
-EOF
-      fi
-    else
-      cat <<EOF >>/srv/salt-overlay/pillar/cluster-params.sls
-federations_domain_map: ''
-EOF
-    fi
     if [ -n "${SCHEDULING_ALGORITHM_PROVIDER:-}" ]; then
       cat <<EOF >>/srv/salt-overlay/pillar/cluster-params.sls
 scheduling_algorithm_provider: '$(echo "${SCHEDULING_ALGORITHM_PROVIDER}" | sed -e "s/'/''/g")'

--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -1143,20 +1143,6 @@ function start-kube-addons {
     if [[ "${ENABLE_DNS_HORIZONTAL_AUTOSCALER:-}" == "true" ]]; then
       setup-addon-manifests "addons" "dns-horizontal-autoscaler"
     fi
-
-    if [[ "${FEDERATION:-}" == "true" ]]; then
-      local federations_domain_map="${FEDERATIONS_DOMAIN_MAP:-}"
-      if [[ -z "${federations_domain_map}" && -n "${FEDERATION_NAME:-}" && -n "${DNS_ZONE_NAME:-}" ]]; then
-        federations_domain_map="${FEDERATION_NAME}=${DNS_ZONE_NAME}"
-      fi
-      if [[ -n "${federations_domain_map}" ]]; then
-        sed -i -e "s@{{ *pillar\['federations_domain_map'\] *}}@- --federations=${federations_domain_map}@g" "${dns_controller_file}"
-      else
-        sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_controller_file}"
-      fi
-    else
-      sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_controller_file}"
-    fi
   fi
   if [[ "${ENABLE_CLUSTER_REGISTRY:-}" == "true" ]]; then
     setup-addon-manifests "addons" "registry"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1370,20 +1370,6 @@ function start-kube-addons {
     if [[ "${ENABLE_DNS_HORIZONTAL_AUTOSCALER:-}" == "true" ]]; then
       setup-addon-manifests "addons" "dns-horizontal-autoscaler"
     fi
-
-    if [[ "${FEDERATION:-}" == "true" ]]; then
-      local federations_domain_map="${FEDERATIONS_DOMAIN_MAP:-}"
-      if [[ -z "${federations_domain_map}" && -n "${FEDERATION_NAME:-}" && -n "${DNS_ZONE_NAME:-}" ]]; then
-        federations_domain_map="${FEDERATION_NAME}=${DNS_ZONE_NAME}"
-      fi
-      if [[ -n "${federations_domain_map}" ]]; then
-        sed -i -e "s@{{ *pillar\['federations_domain_map'\] *}}@- --federations=${federations_domain_map}@g" "${dns_controller_file}"
-      else
-        sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_controller_file}"
-      fi
-    else
-      sed -i -e "/{{ *pillar\['federations_domain_map'\] *}}/d" "${dns_controller_file}"
-    fi
   fi
   if [[ "${ENABLE_CLUSTER_REGISTRY:-}" == "true" ]]; then
     setup-addon-manifests "addons" "registry"

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -87,7 +87,7 @@ ifeq ($(CACHEBUST),1)
 endif
 	cd ${TEMP_DIR} && sed -i.back "s|-amd64|-${ARCH}|g" addons/singlenode/*.yaml addons/multinode/*.yaml
 	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__SERVER__|10.0.0.10|g" addons/singlenode/kubedns*.yaml addons/multinode/kubedns*.yaml
-	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__DOMAIN__|cluster.local|g;s|__PILLAR__FEDERATIONS__DOMAIN__MAP__||g;" addons/singlenode/kubedns*.yaml addons/multinode/kubedns*.yaml
+	cd ${TEMP_DIR} && sed -i.back "s|__PILLAR__DNS__DOMAIN__|cluster.local|g" addons/singlenode/kubedns*.yaml addons/multinode/kubedns*.yaml
 	cd ${TEMP_DIR} && rm -f addons/singlenode/*.back addons/multinode/*.back static-pods/*.back
 
 	# Make scripts executable before they are copied into the Docker image. If we make them executable later, in another layer

--- a/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/fragments/configure-salt.yaml
@@ -56,7 +56,6 @@ write_files:
       dns_server: 10.246.0.10
       dns_domain: cluster.local
       enable_dns_horizontal_autoscaler: "false"
-      federations_domain_map: ''
       instance_prefix: kubernetes
       admission_control: NamespaceLifecycle,LimitRanger,SecurityContextDeny,ServiceAccount,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds
       enable_cpu_cfs_quota: "true"

--- a/cluster/photon-controller/templates/create-dynamic-salt-files.sh
+++ b/cluster/photon-controller/templates/create-dynamic-salt-files.sh
@@ -119,7 +119,6 @@ elasticsearch_replicas: $ELASTICSEARCH_LOGGING_REPLICAS
 enable_cluster_dns: "${ENABLE_CLUSTER_DNS:-false}"
 dns_server: $DNS_SERVER_IP
 dns_domain: $DNS_DOMAIN
-federations_domain_map: ''
 e2e_storage_test_environment: "${E2E_STORAGE_TEST_ENVIRONMENT:-false}"
 cluster_cidr: "$NODE_IP_RANGES"
 allocate_node_cidrs: "${ALLOCATE_NODE_CIDRS:-true}"

--- a/cluster/vagrant/provision-utils.sh
+++ b/cluster/vagrant/provision-utils.sh
@@ -65,7 +65,6 @@ elasticsearch_replicas: '$(echo "$ELASTICSEARCH_LOGGING_REPLICAS" | sed -e "s/'/
 enable_cluster_dns: '$(echo "$ENABLE_CLUSTER_DNS" | sed -e "s/'/''/g")'
 dns_server: '$(echo "$DNS_SERVER_IP" | sed -e "s/'/''/g")'
 dns_domain: '$(echo "$DNS_DOMAIN" | sed -e "s/'/''/g")'
-federations_domain_map: ''
 instance_prefix: '$(echo "$INSTANCE_PREFIX" | sed -e "s/'/''/g")'
 admission_control: '$(echo "$ADMISSION_CONTROL" | sed -e "s/'/''/g")'
 enable_cpu_cfs_quota: '$(echo "$ENABLE_CPU_CFS_QUOTA" | sed -e "s/'/''/g")'

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -161,7 +161,6 @@ spec:
         - --dns-port=10053
         - --config-dir=/kube-dns-config
         - --v=2
-        # Do we need to set __PILLAR__FEDERATIONS__DOMAIN__MAP__ here?
         env:
         - name: PROMETHEUS_PORT
           value: "10055"

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -36,7 +36,6 @@ source "${KUBE_ROOT}/federation/cluster/common.sh"
 
 DNS_ZONE_NAME="${FEDERATION_DNS_ZONE_NAME:-}"
 DNS_PROVIDER="${FEDERATION_DNS_PROVIDER:-google-clouddns}"
-FEDERATIONS_DOMAIN_MAP="${FEDERATIONS_DOMAIN_MAP:-}"
 
 # get_version returns the version in KUBERNETES_RELEASE or defaults to the
 # value in the federation `versions` file.

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -674,19 +674,6 @@ function start_kubedns {
     if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
         echo "Creating kube-system namespace"
         sed -e "s/{{ pillar\['dns_domain'\] }}/${DNS_DOMAIN}/g" "${KUBE_ROOT}/cluster/addons/dns/kubedns-controller.yaml.in" >| kubedns-deployment.yaml
-        if [[ "${FEDERATION:-}" == "true" ]]; then
-          FEDERATIONS_DOMAIN_MAP="${FEDERATIONS_DOMAIN_MAP:-}"
-          if [[ -z "${FEDERATIONS_DOMAIN_MAP}" && -n "${FEDERATION_NAME:-}" && -n "${DNS_ZONE_NAME:-}" ]]; then
-            FEDERATIONS_DOMAIN_MAP="${FEDERATION_NAME}=${DNS_ZONE_NAME}"
-          fi
-          if [[ -n "${FEDERATIONS_DOMAIN_MAP}" ]]; then
-            sed -i -e "s/{{ pillar\['federations_domain_map'\] }}/- --federations=${FEDERATIONS_DOMAIN_MAP}/g" kubedns-deployment.yaml
-          else
-            sed -i -e "/{{ pillar\['federations_domain_map'\] }}/d" kubedns-deployment.yaml
-          fi
-        else
-          sed -i -e "/{{ pillar\['federations_domain_map'\] }}/d" kubedns-deployment.yaml
-        fi
         sed -e "s/{{ pillar\['dns_server'\] }}/${DNS_SERVER_IP}/g" "${KUBE_ROOT}/cluster/addons/dns/kubedns-svc.yaml.in" >| kubedns-svc.yaml
         
         # TODO update to dns role once we have one.


### PR DESCRIPTION
Remove all references to FEDERATIONS_DOMAIN_MAP as this method is no longer is used and is replaced by adding federation domain map to kube-dns configmap.

cc @madhusudancs @kubernetes/sig-federation-pr-reviews 

**Release note**:
```
[Federation] Mechanism of adding `federation domain maps` to kube-dns deployment via `--federations` flag is superseded by adding/updating `federations` key in `kube-system/kube-dns` configmap. If user is using kubefed tool to join cluster federation, adding federation domain maps to kube-dns is already taken care by `kubefed join` and does not need further action.
```