### PR TITLE
start informers as a post-start-hook

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -106,8 +106,11 @@ func RunServer(config *master.Config, sharedInformers informers.SharedInformerFa
 	if err != nil {
 		return err
 	}
+	m.GenericAPIServer.AddPostStartHook("start-kube-apiserver-informers", func(context genericapiserver.PostStartHookContext) error {
+		sharedInformers.Start(stopCh)
+		return nil
+	})
 
-	sharedInformers.Start(stopCh)
 	return m.GenericAPIServer.PrepareRun().Run(stopCh)
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -152,7 +152,7 @@ func (c completedConfig) New(stopCh <-chan struct{}) (*APIAggregator, error) {
 
 	apiserviceRegistrationController := NewAPIServiceRegistrationController(informerFactory.Apiregistration().InternalVersion().APIServices(), s)
 
-	s.GenericAPIServer.AddPostStartHook("start-informers", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHook("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {
 		informerFactory.Start(stopCh)
 		kubeInformers.Start(stopCh)
 		return nil


### PR DESCRIPTION
Switches the shared informer start to a post start hook to make future API server composition easier.  PostStartHooks will have to be unioned for server composition and this ensures that we don't accidentally skip starting them.