### PR TITLE
kubeadm: only print stderr/stdout if failed test

### DIFF
--- a/cmd/kubeadm/test/cmd/util.go
+++ b/cmd/kubeadm/test/cmd/util.go
@@ -19,8 +19,6 @@ package kubeadm
 import (
 	"bytes"
 	"fmt"
-	"io"
-	"os"
 	"os/exec"
 )
 
@@ -29,12 +27,12 @@ import (
 func RunCmd(command string, args ...string) (string, string, error) {
 	var bout, berr bytes.Buffer
 	cmd := exec.Command(command, args...)
-	cmd.Stdout = io.MultiWriter(os.Stdout, &bout)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &berr)
+	cmd.Stdout = &bout
+	cmd.Stderr = &berr
 	err := cmd.Run()
 	stdout, stderr := bout.String(), berr.String()
 	if err != nil {
-		return "", "", fmt.Errorf("error running %s %v; got error %v, stdout %q, stderr %q",
+		return "", "", fmt.Errorf("error running %s %v; \ngot error %v, \nstdout %q, \nstderr %q",
 			command, args, err, stdout, stderr)
 	}
 	return stdout, stderr, nil


### PR DESCRIPTION
**What this PR does / why we need it**: This PR changes when stdout/stderr will be logged during a kubeadm test-cmd test. It's useful when a real failure occurs to only see the failure rather than output that looks like it might be a failure

**Special notes for your reviewer**: /cc @luxas @marun 

**Release note**:
```release-note
NONE
```
