### PR TITLE
Use beta default class annotation for default storageclass tests.

### DIFF
--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -361,12 +361,12 @@ func updateDefaultStorageClass(c clientset.Interface, defaultStr string) {
 	Expect(err).NotTo(HaveOccurred())
 
 	if defaultStr == "" {
-		delete(sc.Annotations, storageutil.IsDefaultStorageClassAnnotation)
+		delete(sc.Annotations, storageutil.BetaIsDefaultStorageClassAnnotation)
 	} else {
 		if sc.Annotations == nil {
 			sc.Annotations = make(map[string]string)
 		}
-		sc.Annotations[storageutil.IsDefaultStorageClassAnnotation] = defaultStr
+		sc.Annotations[storageutil.BetaIsDefaultStorageClassAnnotation] = defaultStr
 	}
 
 	sc, err = c.StorageV1().StorageClasses().Update(sc)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
The default storageclasses are still installed with the beta annotation, so the test should explicitly use the beta annotation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43150

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
