### PR TITLE
Enable upgrade test on distros without AppArmor

### DIFF
--- a/test/e2e/common/apparmor.go
+++ b/test/e2e/common/apparmor.go
@@ -33,19 +33,19 @@ const (
 )
 
 var (
-	// AppArmorPlatforms are platforms with AppArmor support.
-	AppArmorPlatforms = []string{"gci", "ubuntu"}
+	// AppArmorDistros are distributions with AppArmor support.
+	AppArmorDistros = []string{"gci", "ubuntu"}
 )
 
 func SkipIfAppArmorNotSupported() {
 	if !IsAppArmorSupported() {
-		framework.Skipf("Only supported for distros with AppArmor %v (not %s)", AppArmorPlatforms, framework.TestContext.NodeOSDistro)
+		framework.Skipf("Only supported for distros with AppArmor %v (not %s)", AppArmorDistros, framework.TestContext.NodeOSDistro)
 	}
 }
 
 // IsAppArmorSupported returns true if the current OS distro supports AppArmor.
 func IsAppArmorSupported() bool {
-	return framework.NodeOSDistroIs(AppArmorPlatforms...)
+	return framework.NodeOSDistroIs(AppArmorDistros...)
 }
 
 func LoadAppArmorProfiles(f *framework.Framework) {

--- a/test/e2e/common/apparmor.go
+++ b/test/e2e/common/apparmor.go
@@ -32,8 +32,20 @@ const (
 	appArmorDeniedPath    = "/expect_permission_denied"
 )
 
+var (
+	// AppArmorPlatforms are platforms with AppArmor support.
+	AppArmorPlatforms = []string{"gci", "ubuntu"}
+)
+
 func SkipIfAppArmorNotSupported() {
-	framework.SkipUnlessNodeOSDistroIs("gci", "ubuntu")
+	if !IsAppArmorSupported() {
+		framework.Skipf("Only supported for distros with AppArmor %v (not %s)", AppArmorPlatforms, framework.TestContext.NodeOSDistro)
+	}
+}
+
+// IsAppArmorSupported returns true if the current OS distro supports AppArmor.
+func IsAppArmorSupported() bool {
+	return framework.NodeOSDistroIs(AppArmorPlatforms...)
 }
 
 func LoadAppArmorProfiles(f *framework.Framework) {

--- a/test/e2e/upgrades/apparmor.go
+++ b/test/e2e/upgrades/apparmor.go
@@ -36,7 +36,7 @@ func (AppArmorUpgradeTest) Name() string { return "apparmor-upgrade" }
 
 // Setup creates a secret and then verifies that a pod can consume it.
 func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
-	// only setup on platforms that support app armor
+	// only setup on distros that support AppArmor
 	if !common.IsAppArmorSupported() {
 		return
 	}
@@ -55,7 +55,10 @@ func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
 // Test waits for the upgrade to complete, and then verifies that a
 // pod can still consume the secret.
 func (t *AppArmorUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
-	common.SkipIfAppArmorNotSupported()
+	// Disable on distros without AppArmor
+	if !common.IsAppArmorSupported() {
+		return
+	}
 	<-done
 	if upgrade == MasterUpgrade {
 		t.verifyPodStillUp(f)

--- a/test/e2e/upgrades/apparmor.go
+++ b/test/e2e/upgrades/apparmor.go
@@ -36,7 +36,10 @@ func (AppArmorUpgradeTest) Name() string { return "apparmor-upgrade" }
 
 // Setup creates a secret and then verifies that a pod can consume it.
 func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
-	common.SkipIfAppArmorNotSupported()
+	// only setup on platforms that support app armor
+	if !common.IsAppArmorSupported() {
+		return
+	}
 	By("Loading AppArmor profiles to nodes")
 	common.LoadAppArmorProfiles(f)
 
@@ -52,6 +55,7 @@ func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
 // Test waits for the upgrade to complete, and then verifies that a
 // pod can still consume the secret.
 func (t *AppArmorUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
+	common.SkipIfAppArmorNotSupported()
 	<-done
 	if upgrade == MasterUpgrade {
 		t.verifyPodStillUp(f)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently the AppArmor test disables upgrades if AppArmor is not supported on the current OS distro. This moves that Skip out of setup and into the test. It also does not run AppArmor test setup if on an unsupported platform.


**Which issue this PR fixes**
Fixes #43102

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
