### PR TITLE
client-go: add doc.go file pointing to samples in root package

### DIFF
--- a/staging/src/k8s.io/client-go/doc.go
+++ b/staging/src/k8s.io/client-go/doc.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package clientgo contains a collection of subpackages for Go client for
+// Kubernetes.
+//
+// Examples
+//
+// See https://github.com/kubernetes/client-go/tree/master/examples for sample
+// programs written using client-go.
+package clientgo // import "k8s.io/client-go"


### PR DESCRIPTION
Context: https://groups.google.com/forum/#!topic/kubernetes-users/_HnGSuPmDoc

I do not know if making the package root an actual go package by
adding a doc.go file would have bad implications. Because now
`go get k8s.io/client-go` will work and not require the trailing `/...`.

I am not sure about the package name declared either, but I guess it does not
matter as we do not expect people to import this package.
