### PR TITLE
Don't fail if the grep fails to match any resources

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -49,7 +49,7 @@ function gcloud-compute-list() {
   while true; do
     if result=$(gcloud compute ${resource} list --project=${PROJECT} ${@:2}); then
       if [[ ! -z "${GREP_REGEX}" ]]; then
-        result=$(echo "${result}" | grep "${GREP_REGEX}")
+        result=$(echo "${result}" | grep "${GREP_REGEX}" || true)
       fi
       echo "${result}"
       return


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/42208 #41917

/assign @jessfraz @ixdy 
/release-note-none

We have a variety of upgrade jobs that intentionally run test code from 1.3, so merge this back into there as well

https://k8s-testgrid.appspot.com/release-1.5-all#Summary
https://k8s-testgrid.appspot.com/release-1.5-all#gke-1.3-1.5-upgrade-master

Source of this failure group: https://storage.googleapis.com/k8s-gubernator/triage/index.html#69095700b0b2b3dc3c46