### PR TITLE
Bump cluster autoscaler to 0.5.0-beta2

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.5.0-beta1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.5.0-beta2",
                 "command": [
                     "./run.sh",
                     "--kubernetes=http://127.0.0.1:8080?inClusterConfig=f",


### PR DESCRIPTION
**What this PR does / why we need it**:

This part is a part of Cluster Autoscaler release process for 1.6.0. It contains couple of bugfixes on top of 0.5.0-beta1. Hopefully this will be the last beta before final bump to 0.5.0

cc: @MaciekPytel @jszczepkowski @fgrzadkowski