### PR TITLE
Automated cherry pick of #38330

### DIFF
--- a/pkg/runtime/serializer/codec_factory.go
+++ b/pkg/runtime/serializer/codec_factory.go
@@ -220,9 +220,10 @@ type DirectCodecFactory struct {
 	CodecFactory
 }
 
-// EncoderForVersion returns an encoder that does not do conversion. gv is ignored.
-func (f DirectCodecFactory) EncoderForVersion(serializer runtime.Encoder, _ runtime.GroupVersioner) runtime.Encoder {
+// EncoderForVersion returns an encoder that does not do conversion.
+func (f DirectCodecFactory) EncoderForVersion(serializer runtime.Encoder, version runtime.GroupVersioner) runtime.Encoder {
 	return versioning.DirectEncoder{
+		Version:     version,
 		Encoder:     serializer,
 		ObjectTyper: f.CodecFactory.scheme,
 	}

--- a/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/pkg/runtime/serializer/versioning/versioning_test.go
@@ -329,8 +329,9 @@ func (c *checkConvertor) ConvertFieldLabel(version, kind, label, value string) (
 }
 
 type mockSerializer struct {
-	err error
-	obj runtime.Object
+	err            error
+	obj            runtime.Object
+	encodingObjGVK unversioned.GroupVersionKind
 
 	defaults, actual *unversioned.GroupVersionKind
 	into             runtime.Object
@@ -344,6 +345,7 @@ func (s *mockSerializer) Decode(data []byte, defaults *unversioned.GroupVersionK
 
 func (s *mockSerializer) Encode(obj runtime.Object, w io.Writer) error {
 	s.obj = obj
+	s.encodingObjGVK = obj.GetObjectKind().GroupVersionKind()
 	return s.err
 }
 
@@ -368,4 +370,30 @@ func (t *mockTyper) ObjectKinds(obj runtime.Object) ([]unversioned.GroupVersionK
 
 func (t *mockTyper) Recognizes(_ unversioned.GroupVersionKind) bool {
 	return true
+}
+
+func TestDirectCodecEncode(t *testing.T) {
+	serializer := mockSerializer{}
+	typer := mockTyper{
+		gvks: []unversioned.GroupVersionKind{
+			{
+				Group: "wrong_group",
+				Kind:  "some_kind",
+			},
+			{
+				Group: "expected_group",
+				Kind:  "some_kind",
+			},
+		},
+	}
+
+	c := DirectEncoder{
+		Version:     unversioned.GroupVersion{Group: "expected_group"},
+		Encoder:     &serializer,
+		ObjectTyper: &typer,
+	}
+	c.Encode(&testDecodable{}, ioutil.Discard)
+	if e, a := "expected_group", serializer.encodingObjGVK.Group; e != a {
+		t.Errorf("expected group to be %v, got %v", e, a)
+	}
 }


### PR DESCRIPTION
Cherry pick of #38330 on release-1.5.

#38330: let DirectEncoder take a hint of what gvk to set during its