### PR TITLE
Retry kubectl test replace on conflict

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -666,16 +666,15 @@ run_pod_tests() {
   }
 }
 __EOF__
-  kubectl replace -f - "${kube_flags[@]}" << __EOF__
-{
+  kubectl-with-retry replace "${kube_flags[@]}" -f <(echo '{
   "kind": "Node",
   "apiVersion": "v1",
   "metadata": {
     "name": "node-v1-test",
     "annotations": {"a":"b"}
   }
-}
-__EOF__
+}')
+
   # Post-condition: the node command succeeds
   kube::test::get_object_assert "node node-v1-test" "{{.metadata.annotations.a}}" 'b'
   kubectl delete node node-v1-test "${kube_flags[@]}"


### PR DESCRIPTION
Since kubectl is doing a resource-version-constrained replace, it is subject to conflicts on a contentious resource (like a node managed by the node controller)

Fixes #41892 (the specific flake, not the watch cache issue)