### PR TITLE
[Federation] Add type-agnostic e2e crud test

### DIFF
--- a/test/e2e_federation/BUILD
+++ b/test/e2e_federation/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = [
         "apiserver.go",
         "authn.go",
+        "crud.go",
         "daemonset.go",
         "deployment.go",
         "event.go",
@@ -29,6 +30,7 @@ go_library(
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset:go_default_library",
         "//federation/client/clientset_generated/federation_clientset/typed/core/v1:go_default_library",
+        "//federation/pkg/federatedtypes:go_default_library",
         "//federation/pkg/federation-controller/replicaset:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
         "//pkg/api:go_default_library",

--- a/test/e2e_federation/crud.go
+++ b/test/e2e_federation/crud.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_federation
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+
+	"k8s.io/kubernetes/federation/pkg/federatedtypes"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	"k8s.io/kubernetes/test/e2e/framework"
+	fedframework "k8s.io/kubernetes/test/e2e_federation/framework"
+)
+
+var _ = framework.KubeDescribe("Federated types [Feature:Federation][Experimental] ", func() {
+	var clusterClients []kubeclientset.Interface
+
+	f := fedframework.NewDefaultFederatedFramework("federated-types")
+
+	for name, fedType := range federatedtypes.FederatedTypes() {
+		Describe(fmt.Sprintf("Federated %q resources", name), func() {
+			It("should be created, read, updated and deleted successfully", func() {
+				fedframework.SkipUnlessFederated(f.ClientSet)
+
+				// Load clients only if not skipping to avoid doing
+				// unnecessary work.  Assume clients can be shared
+				// across tests.
+				if clusterClients == nil {
+					clusterClients = f.GetClusterClients()
+				}
+				adapter := fedType.AdapterFactory(f.FederationClientset)
+				crudTester := fedframework.NewFederatedTypeCRUDTester(adapter, clusterClients)
+				obj := adapter.NewTestObject(f.FederationNamespace.Name)
+				crudTester.CheckLifecycle(obj)
+			})
+		})
+	}
+})

--- a/test/e2e_federation/framework/BUILD
+++ b/test/e2e_federation/framework/BUILD
@@ -11,6 +11,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cluster.go",
+        "crudtester.go",
         "framework.go",
         "util.go",
     ],
@@ -18,6 +19,8 @@ go_library(
     deps = [
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset:go_default_library",
+        "//federation/pkg/federatedtypes:go_default_library",
+        "//federation/pkg/federatedtypes/crudtester:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/api/validation:go_default_library",

--- a/test/e2e_federation/framework/crudtester.go
+++ b/test/e2e_federation/framework/crudtester.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	. "github.com/onsi/ginkgo"
+	"k8s.io/kubernetes/federation/pkg/federatedtypes"
+	"k8s.io/kubernetes/federation/pkg/federatedtypes/crudtester"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// Adapt the methods to log/fail in e2e to the interface expected by CRUDHelper
+type e2eTestLogger struct{}
+
+func (e2eTestLogger) Fatal(msg string) {
+	Fail(msg)
+}
+
+func (e2eTestLogger) Fatalf(format string, args ...interface{}) {
+	framework.Failf(format, args...)
+}
+
+func (e2eTestLogger) Logf(format string, args ...interface{}) {
+	framework.Logf(format, args...)
+}
+
+func NewFederatedTypeCRUDTester(adapter federatedtypes.FederatedTypeAdapter, clusterClients []kubeclientset.Interface) *crudtester.FederatedTypeCRUDTester {
+	return crudtester.NewFederatedTypeCRUDTester(&e2eTestLogger{}, adapter, clusterClients, framework.Poll, FederatedDefaultTestTimeout)
+}

--- a/test/e2e_federation/framework/framework.go
+++ b/test/e2e_federation/framework/framework.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
 	"k8s.io/kubernetes/pkg/api/v1"
+	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
@@ -228,4 +229,13 @@ func (f *Framework) GetUnderlyingFederatedContexts() []E2EContext {
 
 func (f *Framework) GetRegisteredClusters() ClusterSlice {
 	return getRegisteredClusters(f)
+}
+
+func (f *Framework) GetClusterClients() []kubeclientset.Interface {
+	clusters := getRegisteredClusters(f)
+	var clusterClients []kubeclientset.Interface
+	for _, c := range clusters {
+		clusterClients = append(clusterClients, c.Clientset)
+	}
+	return clusterClients
 }


### PR DESCRIPTION
This PR proposes an e2e test that reuses the type-agnostic crudtester already used for integration testing to validate crud against a deployed cluster. It is intended to to eventually replace the existing e2e tests for simple types like secrets, but for now will run in addition to the existing testing to gain confidence in the coverage it provides.

The deletion corner cases - when orphanDependents is nil or true - do not involve operations in the member clusters and are already well-tested in integration testing and so are not reimplemented here.

Where it can be applied, this approach of abstracting a test from its execution environment - making the test 'retargetable' - can reduce the cost of test development since the bulk of the work can be iterated on as an integration test.  It can also serve as a check on assumptions made in the integration test about how a deployed environment will behave.

cc: @kubernetes/sig-federation-pr-reviews @kubernetes/sig-testing-misc @smarterclayton @derekwaynecarr 