### PR TITLE
Rename default storageclasses

### DIFF
--- a/cluster/addons/storage-class/aws/default.yaml
+++ b/cluster/addons/storage-class/aws/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-  name: default
+  name: gp2
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:

--- a/cluster/addons/storage-class/azure/default.yaml
+++ b/cluster/addons/storage-class/azure/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-  name: default
+  name: standard
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:

--- a/cluster/addons/storage-class/gce/default.yaml
+++ b/cluster/addons/storage-class/gce/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-  name: default
+  name: standard
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:

--- a/cluster/addons/storage-class/openstack/default.yaml
+++ b/cluster/addons/storage-class/openstack/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-  name: default
+  name: standard
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:

--- a/cluster/addons/storage-class/vsphere/default.yaml
+++ b/cluster/addons/storage-class/vsphere/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-  name: default
+  name: thin
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:


### PR DESCRIPTION
From UX perspective, 'default' is a bad name for the default storage class:

```
$ kubectl get storageclass
NAME                TYPE
default (default)   kubernetes.io/aws-ebs
```

This is sort of OK, it gets more confusing when user is not happy with the
preinstalled default storage class and creates its own and makes it default:

```
NAME             TYPE
default          kubernetes.io/aws-ebs
iops (default)   kubernetes.io/aws-ebs
```

This PR uses name of the underlying storage as name of the default storage class:

```
NAME            TYPE
gp2 (default)   kubernetes.io/aws-ebs
```

On GCE (and many others):
```
NAME                 TYPE
standard (default)   kubernetes.io/gce-pd
```

Detailed list of names of new default storage classes:

* AWS: `gp2`
* GCE: `standard` (from pd-standard)
* vSphere: `thin`

* Cinder does not have a default - it's up to OpenStack admin to set some default and it can change at any time, using `standard` as the class name.
* I was not able to find details about Azure, using `standard` too.

@justinsb @jingxu97 @kerneltime @colemickens, PTAL quickly so we can catch 1.6.

```release-note
NONE
```

For 1.6 release manager, this PR just renames objects in addon manager.