### PR TITLE
Only display error message when appropriate

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -175,7 +175,7 @@ func newServiceInfo(serviceName proxy.ServicePortName, port *api.ServicePort, se
 
 	if info.onlyNodeLocalEndpoints {
 		p := apiservice.GetServiceHealthCheckNodePort(service)
-		if p == 0 {
+		if p == 0 && service.Spec.Type == api.ServiceTypeLoadBalancer {
 			glog.Errorf("Service does not contain necessary annotation %v",
 				apiservice.BetaAnnotationHealthCheckNodePort)
 		} else {


### PR DESCRIPTION
The health-check-node-port is only used when the service is type LoadBalancer

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/kubernetes/blob/master/CONTRIBUTING.md and developer guide https://github.com/kubernetes/kubernetes/blob/master/docs/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/kubernetes/blob/master/docs/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes**: fixes #42888

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
