### PR TITLE
don't start controllers against unhealthy master

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -331,6 +331,13 @@ func getAvailableResources(clientBuilder controller.ControllerClientBuilder) (ma
 			return false, nil
 		}
 
+		healthStatus := 0
+		client.Discovery().RESTClient().Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
+		if healthStatus != http.StatusOK {
+			glog.Errorf("Server isn't healthy yet.  Waiting a little while.")
+			return false, nil
+		}
+
 		discoveryClient = client.Discovery()
 		return true, nil
 	})


### PR DESCRIPTION
Operating against an unhealthy apiserver is unpredictable.  Some clients like `kubectl` need to be best effort in this regard so that you can debug broken apiservers.  Controllers shouldn't run against unhealthy masters.

