### PR TITLE
kubectl: fall back to computing QoS class if server does not populate

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -553,7 +553,11 @@ func describePod(pod *api.Pod, events *api.EventList) (string, error) {
 			}
 		}
 		describeVolumes(pod.Spec.Volumes, w, "")
-		w.Write(LEVEL_0, "QoS Class:\t%s\n", pod.Status.QOSClass)
+		if pod.Status.QOSClass != "" {
+			w.Write(LEVEL_0, "QoS Class:\t%s\n", pod.Status.QOSClass)
+		} else {
+			w.Write(LEVEL_0, "QoS Class:\t%s\n", qos.InternalGetPodQOS(pod))
+		}
 		printLabelsMultiline(w, "Node-Selectors", pod.Spec.NodeSelector)
 		printPodTolerationsMultiline(w, "Tolerations", pod.Spec.Tolerations)
 		if events != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/42831

https://github.com/kubernetes/kubernetes/pull/38989 changed how kubectl determines the the QoS Class field.  In order to prevent reimplementation of the QoS class logic in each client, the API server was modified to set the QoS Class in a new status field.  However API servers 1.5 and older do not set this field.  This results in a kubectl 1.6 client talking to a 1.5 API server to not print the QoS class field, which is a regression.

This PR causes kubectl to fall back to the old method of evaluting the QoS class when the status field from the API server is not set.

@vishh @derekwaynecarr @ymqytw @pwittrock @skriss