### PR TITLE
Partial Fix 43015

### DIFF
--- a/examples/storage/cassandra/cassandra-statefulset.yaml
+++ b/examples/storage/cassandra/cassandra-statefulset.yaml
@@ -82,17 +82,10 @@ spec:
   - metadata:
       name: cassandra-data
       annotations:
-        volume.beta.kubernetes.io/storage-class: fast
+        volume.alpha.kubernetes.io/storage-class: default
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
           storage: 1Gi
 ---
-kind: StorageClass
-apiVersion: storage.k8s.io/v1beta1
-metadata:
-  name: fast
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-ssd

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -221,56 +221,16 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 			master()
 		})
 	})
-
-	framework.KubeDescribe("Cassandra", func() {
-		It("should create and scale cassandra", func() {
-			mkpath := func(file string) string {
-				return filepath.Join(framework.TestContext.RepoRoot, "examples/storage/cassandra", file)
-			}
-			serviceYaml := mkpath("cassandra-service.yaml")
-			controllerYaml := mkpath("cassandra-controller.yaml")
-			nsFlag := fmt.Sprintf("--namespace=%v", ns)
-
-			By("Starting the cassandra service")
-			framework.RunKubectlOrDie("create", "-f", serviceYaml, nsFlag)
-			framework.Logf("wait for service")
-			err := framework.WaitForService(c, ns, "cassandra", true, framework.Poll, framework.ServiceRespondingTimeout)
-			Expect(err).NotTo(HaveOccurred())
-
-			// Create an RC with n nodes in it.  Each node will then be verified.
-			By("Creating a Cassandra RC")
-			framework.RunKubectlOrDie("create", "-f", controllerYaml, nsFlag)
-			label := labels.SelectorFromSet(labels.Set(map[string]string{"app": "cassandra"}))
-			err = testutils.WaitForPodsWithLabelRunning(c, ns, label)
-			Expect(err).NotTo(HaveOccurred())
-			forEachPod("app", "cassandra", func(pod v1.Pod) {
-				framework.Logf("Verifying pod %v ", pod.Name)
-				// TODO how do we do this better?  Ready Probe?
-				_, err = framework.LookForStringInLog(ns, pod.Name, "cassandra", "Starting listening for CQL clients", serverStartTimeout)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			By("Finding each node in the nodetool status lines")
-			forEachPod("app", "cassandra", func(pod v1.Pod) {
-				output := framework.RunKubectlOrDie("exec", pod.Name, nsFlag, "--", "nodetool", "status")
-				matched, _ := regexp.MatchString("UN.*"+pod.Status.PodIP, output)
-				if matched != true {
-					framework.Failf("Cassandra pod ip %s is not reporting Up and Normal 'UN' via nodetool status", pod.Status.PodIP)
-				}
-			})
-		})
-	})
-
 	framework.KubeDescribe("CassandraStatefulSet", func() {
 		It("should create statefulset", func() {
 			mkpath := func(file string) string {
-				return filepath.Join("examples/storage/cassandra", file)
+				return filepath.Join(framework.TestContext.RepoRoot, "examples/storage/cassandra", file)
 			}
 			serviceYaml := mkpath("cassandra-service.yaml")
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			// have to change dns prefix because of the dynamic namespace
-			input := generated.ReadOrDie(mkpath("cassandra-statefulset.yaml"))
+			input := generated.ReadOrDie("examples/storage/cassandra/cassandra-statefulset.yaml")
 
 			output := strings.Replace(string(input), "cassandra-0.cassandra.default.svc.cluster.local", "cassandra-0.cassandra."+ns+".svc.cluster.local", -1)
 


### PR DESCRIPTION
**What this PR does / why we need it**: Partial mitigation of #43015. Fixes Cassandra example issues. Does not fix Hazelcast. The Hazlecast StatefulSet is using a K8s integration plugin that is not part of the standard Hazlecast application, and specific expertise is needed to fix this.
```release-note
NONE
```
