### PR TITLE
Bugfix: OpenAPI-gen was not generating extensions correctly

### DIFF
--- a/cmd/libs/go2idl/openapi-gen/generators/openapi.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi.go
@@ -336,7 +336,11 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 		if len(required) > 0 {
 			g.Do("Required: []string{\"$.$\"},\n", strings.Join(required, "\",\""))
 		}
-		g.Do("},\n},\n", nil)
+		g.Do("},\n", nil)
+		if err := g.generateExtensions(t.CommentLines); err != nil {
+			return err
+		}
+		g.Do("},\n", nil)
 		g.Do("Dependencies: []string{\n", args)
 		// Map order is undefined, sort them or we may get a different file generated each time.
 		keys := []string{}
@@ -353,11 +357,7 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 			}
 			g.Do("\"$.$\",", k)
 		}
-		g.Do("},\n", nil)
-		if err := g.generateExtensions(t.CommentLines); err != nil {
-			return err
-		}
-		g.Do("},\n", nil)
+		g.Do("},\n},\n", nil)
 	}
 	return nil
 }
@@ -368,7 +368,7 @@ func (g openAPITypeWriter) generateExtensions(CommentLines []string) error {
 	for _, val := range tagValues {
 		if strings.HasPrefix(val, tagExtensionPrefix) {
 			if !anyExtension {
-				g.Do("spec.VendorExtensible: {\nExtensions: spec.Extensions{\n", nil)
+				g.Do("VendorExtensible: spec.VendorExtensible{\nExtensions: spec.Extensions{\n", nil)
 				anyExtension = true
 			}
 			parts := strings.SplitN(val, ":", 2)

--- a/cmd/libs/go2idl/openapi-gen/generators/openapi_test.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi_test.go
@@ -227,7 +227,7 @@ Format: "byte",
 },
 },
 "WithExtension": {
-spec.VendorExtensible: {
+VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{
 "x-kubernetes-member-tag": "member_test",
 },
@@ -241,13 +241,13 @@ Format: "",
 },
 Required: []string{"String","Int64","Int32","Int16","Int8","Uint","Uint64","Uint32","Uint16","Uint8","Byte","Bool","Float64","Float32","ByteArray","WithExtension"},
 },
-},
-Dependencies: []string{
-},
-spec.VendorExtensible: {
+VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{
 "x-kubernetes-type-tag": "type_test",
 },
+},
+},
+Dependencies: []string{
 },
 },
 `, buffer.String())


### PR DESCRIPTION
Fixes a bug in openapi-gen that generated invalid code if x-kubernetes extensions defined in types.go. The location of VendorExtensions was wrong.