### PR TITLE
node e2e: improve the validate OOM score test for infra containers

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -125,6 +125,7 @@ go_test(
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/apimachinery/pkg/util/intstr",
+        "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/apimachinery/pkg/util/uuid",
         "//vendor:k8s.io/apimachinery/pkg/watch",
         "//vendor:k8s.io/client-go/pkg/api",

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -28,6 +28,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -93,7 +94,13 @@ var _ = framework.KubeDescribe("Container Manager Misc [Serial]", func() {
 			})
 			Context("", func() {
 				It("pod infra containers oom-score-adj should be -998 and best effort container's should be 1000", func() {
-					var err error
+					// Take a snapshot of existing pause processes. These were
+					// created before this test, and may not be infra
+					// containers. They should be excluded from the test.
+					existingPausePIDs, err := getPidsForProcess("pause", "")
+					Expect(err).To(BeNil(), "failed to list all pause processes on the node")
+					existingPausePIDSet := sets.NewInt(existingPausePIDs...)
+
 					podClient := f.PodClient()
 					podName := "besteffort" + string(uuid.NewUUID())
 					podClient.Create(&v1.Pod{
@@ -117,6 +124,10 @@ var _ = framework.KubeDescribe("Container Manager Misc [Serial]", func() {
 							return fmt.Errorf("failed to get list of pause pids: %v", err)
 						}
 						for _, pid := range pausePids {
+							if existingPausePIDSet.Has(pid) {
+								// Not created by this test. Ignore it.
+								continue
+							}
 							if err := validateOOMScoreAdjSetting(pid, -998); err != nil {
 								return err
 							}


### PR DESCRIPTION
The test blindly checked all "pause" processes on the node, assuming
they were all infra containers. This change takes a snapshot of all
existing "pause" processes on the node, and exclude them in the
validation. The test still relies on the fact that it runs exclusively
on the node. If that assumption changes, we will need other methods to
locate the PIDs of the infra containers.

This fixes #37580
