### PR TITLE
Re-add kube_proxy to the abac file (Match what we had in 1.5).

### DIFF
--- a/cluster/saltbase/salt/kube-apiserver/abac-authz-policy.jsonl
+++ b/cluster/saltbase/salt/kube-apiserver/abac-authz-policy.jsonl
@@ -2,6 +2,7 @@
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"admin", "namespace": "*", "resource": "*", "apiGroup": "*", "nonResourcePath": "*"}}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"{{kube_user}}", "namespace": "*", "resource": "*", "apiGroup": "*", "nonResourcePath": "*"}}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"kubelet", "namespace": "*", "resource": "*", "apiGroup": "*", "nonResourcePath": "*"}}
+{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"kube_proxy", "namespace": "*", "resource": "*", "apiGroup": "*", "nonResourcePath": "*"}}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"kubecfg", "namespace": "*", "resource": "*", "apiGroup": "*", "nonResourcePath": "*"}}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"client", "namespace": "*", "resource": "*", "apiGroup": "*", "nonResourcePath": "*"}}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group":"system:serviceaccounts", "namespace": "*", "resource": "*", "apiGroup": "*", "nonResourcePath": "*"}}


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the ABAC file match what it was in 1.5. GKE rewrites the ABAC file every time, so we were clobbering the kube_proxy entry that used to exist. This would have gone unnoticed, but a separate bug in GKE is causing the token file rewrites to fail on GKE (meaning group used in RBAC aren't there).

**Which issue this PR fixes**
fixes #42746

@liggitt @krousey 