### PR TITLE
Give apiserver full access to kubelet API

### DIFF
--- a/cluster/addons/rbac/kube-apiserver-kubelet-api-admin-binding.yaml
+++ b/cluster/addons/rbac/kube-apiserver-kubelet-api-admin-binding.yaml
@@ -1,14 +1,15 @@
+# This binding gives the kube-apiserver user full access to the kubelet API
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: apiserver-node-proxy
+  name: kube-apiserver-kubelet-api-admin
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: node-proxy
+  name: kubelet-api-admin
 subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User

--- a/cluster/addons/rbac/kubelet-api-admin-role.yaml
+++ b/cluster/addons/rbac/kubelet-api-admin-role.yaml
@@ -1,7 +1,8 @@
+# This role allows full access to the kubelet API
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: node-proxy
+  name: kubelet-api-admin
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -10,15 +11,9 @@ rules:
   - ""
   resources:
   - nodes/proxy
-  verbs:
-  - create
-  - get
-- apiGroups:
-  - ""
-  resources:
   - nodes/log
   - nodes/stats
   - nodes/metrics
   - nodes/spec
   verbs:
-  - get
+  - "*"


### PR DESCRIPTION
the kubelet stats API calls use both GET and POST. POST calls proxied through the API server were getting forbidden because only `get` was allowed.

more broadly, the apiserver is responsible for proxying authorized API calls to the kubelet API... I think this means the apiserver should have access to all verbs on the kubelet subresources.

Fixes #42045