### PR TITLE
protobuf generation modifies types.go, which needs to be copied out

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -704,6 +704,7 @@ function kube::build::copy_output() {
     --filter='+ zz_generated.*' \
     --filter='+ generated.proto' \
     --filter='+ *.pb.go' \
+    --filter='+ types.go' \
     --filter='+ */' \
     --filter='- /**' \
     "rsync://k8s@${KUBE_RSYNC_ADDR}/k8s/" "${KUBE_ROOT}"

--- a/pkg/api/serialization_proto_test.go
+++ b/pkg/api/serialization_proto_test.go
@@ -19,7 +19,9 @@ package api_test
 import (
 	"bytes"
 	"encoding/hex"
+	"fmt"
 	"math/rand"
+	"reflect"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -57,6 +59,41 @@ func TestUniversalDeserializer(t *testing.T) {
 			t.Fatalf("%s: %#v", mediaType, obj)
 		}
 	}
+}
+
+func TestAllFieldsHaveTags(t *testing.T) {
+	for gvk, obj := range api.Scheme.AllKnownTypes() {
+		if gvk.Version == runtime.APIVersionInternal {
+			// internal versions are not serialized to protobuf
+			continue
+		}
+		if gvk.Group == "componentconfig" {
+			// component config is not serialized to protobuf
+			continue
+		}
+		if err := fieldsHaveProtobufTags(obj); err != nil {
+			t.Errorf("type %s as gvk %v is missing tags: %v", obj, gvk, err)
+		}
+	}
+}
+
+func fieldsHaveProtobufTags(obj reflect.Type) error {
+	switch obj.Kind() {
+	case reflect.Slice, reflect.Map, reflect.Ptr, reflect.Array:
+		return fieldsHaveProtobufTags(obj.Elem())
+	case reflect.Struct:
+		for i := 0; i < obj.NumField(); i++ {
+			f := obj.Field(i)
+			if f.Name == "TypeMeta" && f.Type.Name() == "TypeMeta" {
+				// TypeMeta is not included in external protobuf because we use an envelope type with TypeMeta
+				continue
+			}
+			if len(f.Tag.Get("json")) > 0 && len(f.Tag.Get("protobuf")) == 0 {
+				return fmt.Errorf("field %s in %s has a 'json' tag but no protobuf tag", f.Name, obj)
+			}
+		}
+	}
+	return nil
 }
 
 func TestProtobufRoundTrip(t *testing.T) {


### PR DESCRIPTION
This was broken when we moved to the build container, but no one
noticed. Made it so that we get a test error if a field in a registered type has a json tag with no protobuf tag.

Fixes #35486