### PR TITLE
[WIP] Empty or nil Namespaces in PodAffinityTerm means "my namespace." Singleton list with entry "*" for Namespaces in PodAffinityTerm means "all namespaces."

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1885,10 +1885,9 @@ type PodAffinityTerm struct {
 	// A label query over a set of resources, in this case pods.
 	// +optional
 	LabelSelector *metav1.LabelSelector
-	// namespaces specifies which namespaces the labelSelector applies to (matches against);
-	// nil list means "this pod's namespace," empty list means "all namespaces"
-	// The json tag here is not "omitempty" since we need to distinguish nil and empty.
-	// See https://golang.org/pkg/encoding/json/#Marshal for more details.
+	// namespaces specifies which namespaces the labelSelector applies to (matches against).
+	// As a special case, a singleton list containing "*" means "all namespaces."
+	// As a special case, a nil or empty list means "this pod's namespace." 
 	Namespaces []string
 	// This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
 	// the labelSelector in the specified namespaces, where co-located is defined as running on a node

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2101,10 +2101,9 @@ type PodAffinityTerm struct {
 	// A label query over a set of resources, in this case pods.
 	// +optional
 	LabelSelector *metav1.LabelSelector `json:"labelSelector,omitempty" protobuf:"bytes,1,opt,name=labelSelector"`
-	// namespaces specifies which namespaces the labelSelector applies to (matches against);
-	// nil list means "this pod's namespace," empty list means "all namespaces"
-	// The json tag here is not "omitempty" since we need to distinguish nil and empty.
-	// See https://golang.org/pkg/encoding/json/#Marshal for more details.
+	// namespaces specifies which namespaces the labelSelector applies to (matches against).
+	// As a special case, a singleton list containing "*" means "all namespaces."
+	// As a special case, a nil or empty list means "this pod's namespace." 
 	Namespaces []string `json:"namespaces" protobuf:"bytes,2,rep,name=namespaces"`
 	// This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
 	// the labelSelector in the specified namespaces, where co-located is defined as running on a node

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2169,9 +2169,11 @@ func ValidatePreferredSchedulingTerms(terms []api.PreferredSchedulingTerm, fldPa
 func validatePodAffinityTerm(podAffinityTerm api.PodAffinityTerm, allowEmptyTopologyKey bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(podAffinityTerm.LabelSelector, fldPath.Child("matchExpressions"))...)
-	for _, name := range podAffinityTerm.Namespaces {
-		for _, msg := range ValidateNamespaceName(name, false) {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), name, msg))
+	if !(len(podAffinityTerm.Namespaces) == 1 && podAffinityTerm.Namespaces[0] == "*") {
+		for _, name := range podAffinityTerm.Namespaces {
+			for _, msg := range ValidateNamespaceName(name, false) {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("namespace"), name, msg))
+			}
 		}
 	}
 	if !allowEmptyTopologyKey && len(podAffinityTerm.TopologyKey) == 0 {

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -2389,6 +2389,103 @@ func TestInterPodAffinity(t *testing.T) {
 		{
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabel2,
+					Namespace: "foo",
+				},
+				Spec: v1.PodSpec{
+					Affinity: &v1.Affinity{
+						PodAffinity: &v1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "service",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"securityscan", "value2"},
+											},
+										},
+									},
+									TopologyKey: "region",
+								},
+							},
+						},
+						PodAntiAffinity: &v1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "service",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"securityscan", "value2"},
+											},
+										},
+									},
+									Namespaces: []string{"*"},
+									TopologyKey: "zone",
+								},
+							},
+						},
+					},
+				},
+			},
+			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel, Namespace:"bar"}}},
+			node: &node1,
+			fits: false,
+			test: "satisfies the PodAffinity but doesn't satisfy the PodAntiAffinity with the existing pod; PodAntiAffinity pods are in different namespaces but pod to be scheduled specifies * Namespace in PodAntiAffinity which matches all namespaces and thus there is a conflict XXX",
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabel2,
+					Namespace: "foo",
+				},
+				Spec: v1.PodSpec{
+					Affinity: &v1.Affinity{
+						PodAffinity: &v1.PodAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "service",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"securityscan", "value2"},
+											},
+										},
+									},
+									TopologyKey: "region",
+								},
+							},
+						},
+						PodAntiAffinity: &v1.PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+								{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											{
+												Key:      "service",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"securityscan", "value2"},
+											},
+										},
+									},
+									TopologyKey: "zone",
+								},
+							},
+						},
+					},
+				},
+			},
+			pods: []*v1.Pod{{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabel, Namespace:"bar"}}},
+			node: &node1,
+			fits: true,
+			test: "like previous but pod to be scheduled specifies no Namespace which means its own namespace which does not match the running pod hence the anti-affinity rule does not prevent the pod from scheduling XXX",
+		},
+		{
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
 					Labels: podLabel,
 				},
 				Spec: v1.PodSpec{

--- a/plugin/pkg/scheduler/algorithm/priorities/util/topologies.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/util/topologies.go
@@ -26,13 +26,13 @@ import (
 
 // GetNamespacesFromPodAffinityTerm returns a set of names
 // according to the namespaces indicated in podAffinityTerm.
-// 1. If the namespaces is nil considers the given pod's namespace
-// 2. If the namespaces is empty list then considers all the namespaces
+// 1. If the namespaces is nil or empty list then considers the given pod's namespace
+// 2. If the namespaces is singleton list containing "*" then considers all the namespaces
 func GetNamespacesFromPodAffinityTerm(pod *v1.Pod, podAffinityTerm *v1.PodAffinityTerm) sets.String {
 	names := sets.String{}
-	if podAffinityTerm.Namespaces == nil {
+	if podAffinityTerm.Namespaces == nil || len(podAffinityTerm.Namespaces) == 0 {
 		names.Insert(pod.Namespace)
-	} else if len(podAffinityTerm.Namespaces) != 0 {
+	} else if !(len(podAffinityTerm.Namespaces == 1 && podAffinityTerm.Namespaces[0] == "*")) {
 		names.Insert(podAffinityTerm.Namespaces...)
 	}
 	return names


### PR DESCRIPTION
I think this would fix #43203, but it has been a while since I've built the Kubernetes code and when I run hack/update-all.sh I get random unrelated errors, so maybe someone could pick this up?

cc/ @kevin-wangzefeng @wojtek-t @kubernetes/sig-scheduling-pr-reviews @liggitt @derekwaynecarr @smarterclayton @aveshagarwal 

