### PR TITLE
Ignore error of file not found when deleting a cni network

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -271,6 +272,12 @@ func (network *cniNetwork) deleteFromNetwork(podName string, podNamespace string
 	err = cninet.DelNetwork(netconf, rt)
 	if err != nil {
 		glog.Errorf("Error deleting network: %v", err)
+		if network.NetworkConfig.Network.Type == "flannel" {
+			subStr := "no such file or directory"
+			if strings.Contains(err.Error(), subStr) {
+				return nil
+			}
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
We can safely ignore this errors according to cni spec #43014
This is a temporal workaround, while PR containernetworking/cni#406 merges and we can check for better error codes (will also need to update the cni vendor)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43014

**Special notes for your reviewer**:

**Release note**:

```NONE
```
