### PR TITLE
Attach/detach controller: fix potential race in constructor

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -103,20 +103,6 @@ func NewAttachDetachController(
 		cloud:      cloud,
 	}
 
-	podInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
-		AddFunc:    adc.podAdd,
-		UpdateFunc: adc.podUpdate,
-		DeleteFunc: adc.podDelete,
-	})
-	adc.podsSynced = podInformer.Informer().HasSynced
-
-	nodeInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
-		AddFunc:    adc.nodeAdd,
-		UpdateFunc: adc.nodeUpdate,
-		DeleteFunc: adc.nodeDelete,
-	})
-	adc.nodesSynced = nodeInformer.Informer().HasSynced
-
 	if err := adc.volumePluginMgr.InitPlugins(plugins, adc); err != nil {
 		return nil, fmt.Errorf("Could not initialize volume plugins for Attach/Detach Controller: %+v", err)
 	}
@@ -152,6 +138,20 @@ func NewAttachDetachController(
 		desiredStateOfWorldPopulatorLoopSleepPeriod,
 		podInformer.Lister(),
 		adc.desiredStateOfWorld)
+
+	podInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
+		AddFunc:    adc.podAdd,
+		UpdateFunc: adc.podUpdate,
+		DeleteFunc: adc.podDelete,
+	})
+	adc.podsSynced = podInformer.Informer().HasSynced
+
+	nodeInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
+		AddFunc:    adc.nodeAdd,
+		UpdateFunc: adc.nodeUpdate,
+		DeleteFunc: adc.nodeDelete,
+	})
+	adc.nodesSynced = nodeInformer.Informer().HasSynced
 
 	return adc, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
There is a potential race condition in the Attach/detach controller: The "constructor" first installs informer event handlers and then creates and initializes the other data structures. However there is no guarantee an event cannot arrive before the data structures required by the event handlers are ready. This may result in nil pointer derefernces and potential crashes (e.g. the nodeAdd method calls adc.actualStateOfWorld.SetNodeStatusUpdateNeeded even though the actualStateOfWorld might be still nil).

It should be enough just to move the event handlers installation at the end of the constructor function.

**Release note**:

```release-note
NONE
```
