### PR TITLE
Loosen requirements of cluster logging e2e tests, make them more stable

### DIFF
--- a/test/e2e/cluster_logging_es.go
+++ b/test/e2e/cluster_logging_es.go
@@ -45,10 +45,10 @@ var _ = framework.KubeDescribe("Cluster level logging using Elasticsearch [Featu
 		framework.ExpectNoError(err, "Elasticsearch is not working")
 
 		By("Running synthetic logger")
-		pod := createLoggingPod(f, podName, 100, 1*time.Second)
+		pod := createLoggingPod(f, podName, 10*60, 10*time.Minute)
 		defer f.PodClient().Delete(podName, &meta_v1.DeleteOptions{})
-		err = framework.WaitForPodSuccessInNamespace(f.ClientSet, podName, f.Namespace.Name)
-		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to succeed", podName))
+		err = framework.WaitForPodNameRunningInNamespace(f.ClientSet, podName, f.Namespace.Name)
+		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to be running", podName))
 
 		By("Waiting for logs to ingest")
 		config := &loggingTestConfig{
@@ -58,7 +58,6 @@ var _ = framework.KubeDescribe("Cluster level logging using Elasticsearch [Featu
 			MaxAllowedLostFraction:    0,
 			MaxAllowedFluentdRestarts: 0,
 		}
-		err = waitForLogsIngestion(f, config)
-		framework.ExpectNoError(err, "Failed to ingest logs")
+		framework.ExpectNoError(waitForSomeLogs(f, config), "Failed to ingest logs")
 	})
 })

--- a/test/e2e/cluster_logging_gcl.go
+++ b/test/e2e/cluster_logging_gcl.go
@@ -26,8 +26,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-// TODO(crassirostris): Remove Flaky once test is stable
-var _ = framework.KubeDescribe("Cluster level logging using GCL [Flaky]", func() {
+var _ = framework.KubeDescribe("Cluster level logging using GCL", func() {
 	f := framework.NewDefaultFramework("gcl-logging")
 
 	BeforeEach(func() {
@@ -44,10 +43,10 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Flaky]", func()
 		framework.ExpectNoError(err, "GCL is not working")
 
 		By("Running synthetic logger")
-		pod := createLoggingPod(f, podName, 100, 1*time.Second)
+		pod := createLoggingPod(f, podName, 10*60, 10*time.Minute)
 		defer f.PodClient().Delete(podName, &meta_v1.DeleteOptions{})
-		err = framework.WaitForPodSuccessInNamespace(f.ClientSet, podName, f.Namespace.Name)
-		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to succeed", podName))
+		err = framework.WaitForPodNameRunningInNamespace(f.ClientSet, podName, f.Namespace.Name)
+		framework.ExpectNoError(err, fmt.Sprintf("Should've successfully waited for pod %s to be running", podName))
 
 		By("Waiting for logs to ingest")
 		config := &loggingTestConfig{
@@ -57,7 +56,6 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Flaky]", func()
 			MaxAllowedLostFraction:    0,
 			MaxAllowedFluentdRestarts: 0,
 		}
-		err = waitForLogsIngestion(f, config)
-		framework.ExpectNoError(err, "Failed to ingest logs")
+		framework.ExpectNoError(waitForSomeLogs(f, config), "Failed to ingest logs")
 	})
 })

--- a/test/e2e/cluster_logging_gcl_load.go
+++ b/test/e2e/cluster_logging_gcl_load.go
@@ -67,7 +67,7 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Slow] [Flaky]",
 			MaxAllowedLostFraction:    loadTestMaxAllowedLostFraction,
 			MaxAllowedFluentdRestarts: loadTestMaxAllowedFluentdRestarts,
 		}
-		err = waitForLogsIngestion(f, config)
+		err = waitForFullLogsIngestion(f, config)
 		if err != nil {
 			framework.Failf("Failed to ingest logs: %v", err)
 		} else {
@@ -113,7 +113,7 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL [Slow] [Flaky]",
 			MaxAllowedLostFraction:    loadTestMaxAllowedLostFraction,
 			MaxAllowedFluentdRestarts: loadTestMaxAllowedFluentdRestarts,
 		}
-		err = waitForLogsIngestion(f, config)
+		err = waitForFullLogsIngestion(f, config)
 		if err != nil {
 			framework.Failf("Failed to ingest logs: %v", err)
 		} else {


### PR DESCRIPTION
There should be an e2e test for cloud logging in the main test suite, because this is the important part of functionality and it can be broken by different components.

However, existing cluster logging e2e tests were too strict for the current solution, which may loose some log entries, which results in flakes. There's no way to fix this problem in 1.6, so this PR makes basic cluster logging e2e tests less strict.