### PR TITLE
kubectl/cmd: remove a bunch of unused parameters

### DIFF
--- a/federation/pkg/kubefed/kubefed.go
+++ b/federation/pkg/kubefed/kubefed.go
@@ -67,7 +67,7 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 	templates.ActsAsRootCommand(cmds, filters, groups...)
 
 	cmds.AddCommand(kubectl.NewCmdVersion(f, out))
-	cmds.AddCommand(kubectl.NewCmdOptions(out))
+	cmds.AddCommand(kubectl.NewCmdOptions())
 
 	return cmds
 }

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -117,7 +117,7 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    annotate_long,
 		Example: annotate_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.Complete(f, out, cmd, args); err != nil {
+			if err := options.Complete(out, cmd, args); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
 			}
 			if err := options.Validate(); err != nil {
@@ -144,7 +144,7 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 // Complete adapts from the command line args and factory to the data required.
-func (o *AnnotateOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) (err error) {
+func (o *AnnotateOptions) Complete(out io.Writer, cmd *cobra.Command, args []string) (err error) {
 	o.out = out
 	o.local = cmdutil.GetFlagBool(cmd, "local")
 	o.overwrite = cmdutil.GetFlagBool(cmd, "overwrite")

--- a/pkg/kubectl/cmd/annotate_test.go
+++ b/pkg/kubectl/cmd/annotate_test.go
@@ -404,7 +404,7 @@ func TestAnnotateErrors(t *testing.T) {
 			cmd.Flags().Set(k, v)
 		}
 		options := &AnnotateOptions{}
-		err := options.Complete(f, buf, cmd, testCase.args)
+		err := options.Complete(buf, cmd, testCase.args)
 		if err == nil {
 			err = options.Validate()
 		}
@@ -461,7 +461,7 @@ func TestAnnotateObject(t *testing.T) {
 	cmd.SetOutput(buf)
 	options := &AnnotateOptions{}
 	args := []string{"pods/foo", "a=b", "c-"}
-	if err := options.Complete(f, buf, cmd, args); err != nil {
+	if err := options.Complete(buf, cmd, args); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if err := options.Validate(); err != nil {
@@ -513,7 +513,7 @@ func TestAnnotateObjectFromFile(t *testing.T) {
 	options := &AnnotateOptions{}
 	options.Filenames = []string{"../../../examples/storage/cassandra/cassandra-controller.yaml"}
 	args := []string{"a=b", "c-"}
-	if err := options.Complete(f, buf, cmd, args); err != nil {
+	if err := options.Complete(buf, cmd, args); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if err := options.Validate(); err != nil {
@@ -543,7 +543,7 @@ func TestAnnotateLocal(t *testing.T) {
 	options := &AnnotateOptions{}
 	options.Filenames = []string{"../../../examples/storage/cassandra/cassandra-controller.yaml"}
 	args := []string{"a=b"}
-	if err := options.Complete(f, buf, cmd, args); err != nil {
+	if err := options.Complete(buf, cmd, args); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if err := options.Validate(); err != nil {
@@ -597,7 +597,7 @@ func TestAnnotateMultipleObjects(t *testing.T) {
 	cmd.Flags().Set("all", "true")
 	options := &AnnotateOptions{}
 	args := []string{"pods", "a=b", "c-"}
-	if err := options.Complete(f, buf, cmd, args); err != nil {
+	if err := options.Complete(buf, cmd, args); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if err := options.Validate(); err != nil {

--- a/pkg/kubectl/cmd/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump.go
@@ -40,7 +40,7 @@ func NewCmdClusterInfoDump(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 		Long:    dumpLong,
 		Example: dumpExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(dumpClusterInfo(f, cmd, args, cmdOut))
+			cmdutil.CheckErr(dumpClusterInfo(f, cmd, cmdOut))
 		},
 	}
 	cmd.Flags().String("output-directory", "", i18n.T("Where to output the files.  If empty or '-' uses stdout, otherwise creates a directory hierarchy in that directory"))
@@ -88,7 +88,7 @@ func setupOutputWriter(cmd *cobra.Command, defaultWriter io.Writer, filename str
 	return file
 }
 
-func dumpClusterInfo(f cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func dumpClusterInfo(f cmdutil.Factory, cmd *cobra.Command, out io.Writer) error {
 	timeout, err := cmdutil.GetPodRunningTimeoutFlag(cmd)
 	if err != nil {
 		return cmdutil.UsageError(cmd, err.Error())

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -296,7 +296,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 				NewCmdExec(f, in, out, err),
 				NewCmdPortForward(f, out, err),
 				NewCmdProxy(f, out),
-				NewCmdCp(f, in, out, err),
+				NewCmdCp(f, out, err),
 				auth.NewCmdAuth(f, out, err),
 			},
 		},
@@ -314,7 +314,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 			Commands: []*cobra.Command{
 				NewCmdLabel(f, out),
 				NewCmdAnnotate(f, out),
-				NewCmdCompletion(f, out, ""),
+				NewCmdCompletion(out, ""),
 			},
 		},
 	}
@@ -349,7 +349,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 	cmds.AddCommand(cmdconfig.NewCmdConfig(clientcmd.NewDefaultPathOptions(), out, err))
 	cmds.AddCommand(NewCmdVersion(f, out))
 	cmds.AddCommand(NewCmdApiVersions(f, out))
-	cmds.AddCommand(NewCmdOptions(out))
+	cmds.AddCommand(NewCmdOptions())
 
 	return cmds
 }

--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -87,7 +87,7 @@ var (
 	}
 )
 
-func NewCmdCompletion(f cmdutil.Factory, out io.Writer, boilerPlate string) *cobra.Command {
+func NewCmdCompletion(out io.Writer, boilerPlate string) *cobra.Command {
 	shells := []string{}
 	for s := range completion_shells {
 		shells = append(shells, s)

--- a/pkg/kubectl/cmd/config/current_context.go
+++ b/pkg/kubectl/cmd/config/current_context.go
@@ -50,7 +50,7 @@ func NewCmdConfigCurrentContext(out io.Writer, configAccess clientcmd.ConfigAcce
 		Long:    current_context_long,
 		Example: current_context_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := RunCurrentContext(out, args, options)
+			err := RunCurrentContext(out, options)
 			cmdutil.CheckErr(err)
 		},
 	}
@@ -58,7 +58,7 @@ func NewCmdConfigCurrentContext(out io.Writer, configAccess clientcmd.ConfigAcce
 	return cmd
 }
 
-func RunCurrentContext(out io.Writer, args []string, options *CurrentContextOptions) error {
+func RunCurrentContext(out io.Writer, options *CurrentContextOptions) error {
 	config, err := options.ConfigAccess.GetStartingConfig()
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/config/current_context_test.go
+++ b/pkg/kubectl/cmd/config/current_context_test.go
@@ -72,7 +72,7 @@ func (test currentContextTest) run(t *testing.T) {
 	}
 
 	buf := bytes.NewBuffer([]byte{})
-	err = RunCurrentContext(buf, []string{}, &options)
+	err = RunCurrentContext(buf, &options)
 	if len(test.expectedError) != 0 {
 		if err == nil {
 			t.Errorf("Did not get %v", test.expectedError)

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -69,7 +69,7 @@ func NewCmdConvert(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    convert_long,
 		Example: convert_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := options.Complete(f, out, cmd, args)
+			err := options.Complete(f, out, cmd)
 			cmdutil.CheckErr(err)
 			err = options.RunConvert()
 			cmdutil.CheckErr(err)
@@ -117,7 +117,7 @@ func outputVersion(cmd *cobra.Command, defaultVersion *schema.GroupVersion) (sch
 }
 
 // Complete collects information required to run Convert command from command line.
-func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) (err error) {
+func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) (err error) {
 	o.outputVersion, err = outputVersion(cmd, &api.Registry.EnabledVersionsForGroup(api.GroupName)[0])
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -59,7 +59,7 @@ var (
 )
 
 // NewCmdCp creates a new Copy command.
-func NewCmdCp(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *cobra.Command {
+func NewCmdCp(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "cp <file-spec-src> <file-spec-dest>",
 		Short:   i18n.T("Copy files and directories to and from containers."),
@@ -121,7 +121,7 @@ func runCopy(f cmdutil.Factory, cmd *cobra.Command, out, cmderr io.Writer, args 
 		return err
 	}
 	if len(srcSpec.PodName) != 0 {
-		return copyFromPod(f, cmd, out, cmderr, srcSpec, destSpec)
+		return copyFromPod(f, cmd, cmderr, srcSpec, destSpec)
 	}
 	if len(destSpec.PodName) != 0 {
 		return copyToPod(f, cmd, out, cmderr, srcSpec, destSpec)
@@ -161,7 +161,7 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 	return execute(f, cmd, options)
 }
 
-func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, out, cmderr io.Writer, src, dest fileSpec) error {
+func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, dest fileSpec) error {
 	reader, outStream := io.Pipe()
 	options := &ExecOptions{
 		StreamOptions: StreamOptions{

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -137,7 +137,7 @@ func NewCmdDelete(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 			if err := options.Complete(f, out, errOut, args); err != nil {
 				cmdutil.CheckErr(err)
 			}
-			if err := options.Validate(f, cmd); err != nil {
+			if err := options.Validate(cmd); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
 			}
 			if err := options.RunDelete(); err != nil {
@@ -198,7 +198,7 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args 
 	return nil
 }
 
-func (o *DeleteOptions) Validate(f cmdutil.Factory, cmd *cobra.Command) error {
+func (o *DeleteOptions) Validate(cmd *cobra.Command) error {
 	if o.DeleteAll {
 		f := cmd.Flags().Lookup("ignore-not-found")
 		// The flag should never be missing

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -24,9 +24,7 @@ import (
 	"github.com/spf13/cobra"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/kubectl"
@@ -138,7 +136,7 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 	infos, err := r.Infos()
 	if err != nil {
 		if apierrors.IsNotFound(err) && len(args) == 2 {
-			return DescribeMatchingResources(mapper, typer, f, cmdNamespace, args[0], args[1], describerSettings, out, err)
+			return DescribeMatchingResources(f, cmdNamespace, args[0], args[1], describerSettings, out, err)
 		}
 		allErrs = append(allErrs, err)
 	}
@@ -176,7 +174,7 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 	return utilerrors.NewAggregate(allErrs)
 }
 
-func DescribeMatchingResources(mapper meta.RESTMapper, typer runtime.ObjectTyper, f cmdutil.Factory, namespace, rsrc, prefix string, describerSettings *printers.DescriberSettings, out io.Writer, originalError error) error {
+func DescribeMatchingResources(f cmdutil.Factory, namespace, rsrc, prefix string, describerSettings *printers.DescriberSettings, out io.Writer, originalError error) error {
 	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -286,9 +286,9 @@ func runEdit(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args 
 
 			switch editMode {
 			case NormalEditMode:
-				err = visitToPatch(infos, updatedVisitor, mapper, encoder, out, errOut, &results, file)
+				err = visitToPatch(infos, updatedVisitor, mapper, encoder, out, errOut, &results)
 			case EditBeforeCreateMode:
-				err = visitToCreate(updatedVisitor, mapper, out, errOut, &results, file)
+				err = visitToCreate(updatedVisitor, mapper, out)
 			default:
 				err = fmt.Errorf("Unsupported edit mode %q", editMode)
 			}
@@ -420,7 +420,6 @@ func visitToPatch(
 	encoder runtime.Encoder,
 	out, errOut io.Writer,
 	results *editResults,
-	file string,
 ) error {
 	err := patchVisitor.Visit(func(info *resource.Info, incomingErr error) error {
 		editObjUID, err := meta.NewAccessor().UID(info.Object)
@@ -521,7 +520,7 @@ func visitToPatch(
 	return err
 }
 
-func visitToCreate(createVisitor resource.Visitor, mapper meta.RESTMapper, out, errOut io.Writer, results *editResults, file string) error {
+func visitToCreate(createVisitor resource.Visitor, mapper meta.RESTMapper, out io.Writer) error {
 	err := createVisitor.Visit(func(info *resource.Info, incomingErr error) error {
 		if err := createAndRefresh(info); err != nil {
 			return err

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -231,7 +231,7 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 
 		if inline := cmdutil.GetFlagString(cmd, "overrides"); len(inline) > 0 {
 			codec := runtime.NewCodec(f.JSONEncoder(), f.Decoder(true))
-			object, err = cmdutil.Merge(codec, object, inline, mapping.GroupVersionKind.Kind)
+			object, err = cmdutil.Merge(codec, object, inline)
 			if err != nil {
 				return err
 			}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -504,6 +504,6 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 		}
 	}
 	w.Flush()
-	cmdutil.PrintFilterCount(errOut, len(objs), filteredResourceCount, len(allErrs), "", filterOpts, options.IgnoreNotFound)
+	cmdutil.PrintFilterCount(errOut, len(objs), filteredResourceCount, len(allErrs), filterOpts, options.IgnoreNotFound)
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/help.go
+++ b/pkg/kubectl/cmd/help.go
@@ -17,13 +17,11 @@ limitations under the License.
 package cmd
 
 import (
-	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
-	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/util/i18n"
 )
 
@@ -31,7 +29,7 @@ var help_long = templates.LongDesc(`
 	Help provides help for any command in the application.
 	Simply type kubectl help [path to command] for full details.`)
 
-func NewCmdHelp(f cmdutil.Factory, out io.Writer) *cobra.Command {
+func NewCmdHelp() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "help [command] | STRING_TO_SEARCH",
 		Short: i18n.T("Help about any command"),

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -115,7 +115,7 @@ func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    fmt.Sprintf(label_long, validation.LabelValueMaxLength),
 		Example: label_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := options.Complete(f, out, cmd, args); err != nil {
+			if err := options.Complete(out, cmd, args); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
 			}
 			if err := options.Validate(); err != nil {
@@ -142,7 +142,7 @@ func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 // Complete adapts from the command line args and factory to the data required.
-func (o *LabelOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []string) (err error) {
+func (o *LabelOptions) Complete(out io.Writer, cmd *cobra.Command, args []string) (err error) {
 	o.out = out
 	o.local = cmdutil.GetFlagBool(cmd, "local")
 	o.overwrite = cmdutil.GetFlagBool(cmd, "overwrite")

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -325,7 +325,7 @@ func TestLabelErrors(t *testing.T) {
 			cmd.Flags().Set(k, v)
 		}
 		opts := LabelOptions{}
-		err := opts.Complete(f, buf, cmd, testCase.args)
+		err := opts.Complete(buf, cmd, testCase.args)
 		if err == nil {
 			err = opts.Validate()
 		}
@@ -382,7 +382,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 	cmd := NewCmdLabel(f, buf)
 	opts := LabelOptions{FilenameOptions: resource.FilenameOptions{
 		Filenames: []string{"../../../examples/storage/cassandra/cassandra-controller.yaml"}}}
-	err := opts.Complete(f, buf, cmd, []string{"a=b"})
+	err := opts.Complete(buf, cmd, []string{"a=b"})
 	if err == nil {
 		err = opts.Validate()
 	}
@@ -415,7 +415,7 @@ func TestLabelLocal(t *testing.T) {
 	cmd.Flags().Set("local", "true")
 	opts := LabelOptions{FilenameOptions: resource.FilenameOptions{
 		Filenames: []string{"../../../examples/storage/cassandra/cassandra-controller.yaml"}}}
-	err := opts.Complete(f, buf, cmd, []string{"a=b"})
+	err := opts.Complete(buf, cmd, []string{"a=b"})
 	if err == nil {
 		err = opts.Validate()
 	}
@@ -470,7 +470,7 @@ func TestLabelMultipleObjects(t *testing.T) {
 	cmd.Flags().Set("all", "true")
 
 	opts := LabelOptions{}
-	err := opts.Complete(f, buf, cmd, []string{"pods", "a=b"})
+	err := opts.Complete(buf, cmd, []string{"pods", "a=b"})
 	if err == nil {
 		err = opts.Validate()
 	}

--- a/pkg/kubectl/cmd/options.go
+++ b/pkg/kubectl/cmd/options.go
@@ -17,8 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"io"
-
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	"k8s.io/kubernetes/pkg/util/i18n"
 
@@ -32,7 +30,7 @@ var (
 )
 
 // NewCmdOptions implements the options command
-func NewCmdOptions(out io.Writer) *cobra.Command {
+func NewCmdOptions() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "options",
 		Short:   i18n.T("Print the list of flags inherited by all commands"),

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -77,7 +77,7 @@ func NewCmdPortForward(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.Comma
 		Long:    "Forward one or more local ports to a pod.",
 		Example: portforward_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := opts.Complete(f, cmd, args, cmdOut, cmdErr); err != nil {
+			if err := opts.Complete(f, cmd, args); err != nil {
 				cmdutil.CheckErr(err)
 			}
 			if err := opts.Validate(); err != nil {
@@ -114,7 +114,7 @@ func (f *defaultPortForwarder) ForwardPorts(method string, url *url.URL, opts Po
 }
 
 // Complete completes all the required options for port-forward cmd.
-func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string, cmdOut io.Writer, cmdErr io.Writer) error {
+func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
 	o.PodName = cmdutil.GetFlagString(cmd, "pod")
 	if len(o.PodName) == 0 && len(args) == 0 {

--- a/pkg/kubectl/cmd/portforward_test.go
+++ b/pkg/kubectl/cmd/portforward_test.go
@@ -93,7 +93,7 @@ func testPortForward(t *testing.T, flags map[string]string, args []string) {
 		opts := &PortForwardOptions{}
 		cmd := NewCmdPortForward(f, os.Stdout, os.Stderr)
 		cmd.Run = func(cmd *cobra.Command, args []string) {
-			if err = opts.Complete(f, cmd, args, os.Stdout, os.Stderr); err != nil {
+			if err = opts.Complete(f, cmd, args); err != nil {
 				return
 			}
 			opts.PortForwarder = ff

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -313,7 +313,7 @@ func Run(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cobr
 		if err != nil {
 			return err
 		}
-		err = handleAttachPod(f, clientset.Core(), attachablePod.Namespace, attachablePod.Name, opts, quiet)
+		err = handleAttachPod(f, clientset.Core(), attachablePod.Namespace, attachablePod.Name, opts)
 		if err != nil {
 			return err
 		}
@@ -322,7 +322,7 @@ func Run(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cobr
 		leaveStdinOpen := cmdutil.GetFlagBool(cmd, "leave-stdin-open")
 		waitForExitCode := !leaveStdinOpen && restartPolicy == api.RestartPolicyNever
 		if waitForExitCode {
-			pod, err = waitForPodTerminated(clientset.Core(), attachablePod.Namespace, attachablePod.Name, opts.Out, quiet)
+			pod, err = waitForPodTerminated(clientset.Core(), attachablePod.Namespace, attachablePod.Name)
 			if err != nil {
 				return err
 			}
@@ -419,7 +419,7 @@ func waitForPod(podClient coreclient.PodsGetter, ns, name string, exitCondition 
 	return result, err
 }
 
-func waitForPodRunning(podClient coreclient.PodsGetter, ns, name string, out io.Writer, quiet bool) (*api.Pod, error) {
+func waitForPodRunning(podClient coreclient.PodsGetter, ns, name string) (*api.Pod, error) {
 	pod, err := waitForPod(podClient, ns, name, conditions.PodRunningAndReady)
 
 	// fix generic not found error with empty name in PodRunningAndReady
@@ -430,7 +430,7 @@ func waitForPodRunning(podClient coreclient.PodsGetter, ns, name string, out io.
 	return pod, err
 }
 
-func waitForPodTerminated(podClient coreclient.PodsGetter, ns, name string, out io.Writer, quiet bool) (*api.Pod, error) {
+func waitForPodTerminated(podClient coreclient.PodsGetter, ns, name string) (*api.Pod, error) {
 	pod, err := waitForPod(podClient, ns, name, conditions.PodCompleted)
 
 	// fix generic not found error with empty name in PodCompleted
@@ -441,8 +441,8 @@ func waitForPodTerminated(podClient coreclient.PodsGetter, ns, name string, out 
 	return pod, err
 }
 
-func handleAttachPod(f cmdutil.Factory, podClient coreclient.PodsGetter, ns, name string, opts *AttachOptions, quiet bool) error {
-	pod, err := waitForPodRunning(podClient, ns, name, opts.Out, quiet)
+func handleAttachPod(f cmdutil.Factory, podClient coreclient.PodsGetter, ns, name string, opts *AttachOptions) error {
+	pod, err := waitForPodRunning(podClient, ns, name)
 	if err != nil && err != conditions.ErrPodCompleted {
 		return err
 	}
@@ -589,7 +589,7 @@ func createGeneratedObject(f cmdutil.Factory, cmd *cobra.Command, generator kube
 
 	if len(overrides) > 0 {
 		codec := runtime.NewCodec(f.JSONEncoder(), f.Decoder(true))
-		obj, err = cmdutil.Merge(codec, obj, overrides, groupVersionKind.Kind)
+		obj, err = cmdutil.Merge(codec, obj, overrides)
 		if err != nil {
 			return nil, "", nil, nil, err
 		}

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -83,7 +83,7 @@ func NewCmdSelector(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    fmt.Sprintf(selectorLong, validation.LabelValueMaxLength),
 		Example: selectorExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(options.Complete(f, cmd, args, out))
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
 			cmdutil.CheckErr(options.Validate())
 			cmdutil.CheckErr(options.RunSelector())
 		},
@@ -101,7 +101,7 @@ func NewCmdSelector(f cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 // Complete assigns the SelectorOptions from args.
-func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
+func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.local = cmdutil.GetFlagBool(cmd, "local")
 	o.all = cmdutil.GetFlagBool(cmd, "all")
 	o.record = cmdutil.GetRecordFlag(cmd)

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -91,7 +91,7 @@ func NewCmdTaint(f cmdutil.Factory, out io.Writer) *cobra.Command {
 			if err := options.Complete(f, out, cmd, args); err != nil {
 				cmdutil.CheckErr(err)
 			}
-			if err := options.Validate(args); err != nil {
+			if err := options.Validate(); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageError(cmd, err.Error()))
 			}
 			if err := options.RunTaint(); err != nil {
@@ -249,7 +249,7 @@ func (o *TaintOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Com
 }
 
 // Validate checks to the TaintOptions to see if there is sufficient information run the command.
-func (o TaintOptions) Validate(args []string) error {
+func (o TaintOptions) Validate() error {
 	resourceType := strings.ToLower(o.resources[0])
 	validResources, isValidResource := append(kubectl.ResourceAliases([]string{"node"}), "node"), false
 	for _, validResource := range validResources {

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -441,7 +441,7 @@ func ReadConfigDataFromReader(reader io.Reader, source string) ([]byte, error) {
 
 // Merge requires JSON serialization
 // TODO: merge assumes JSON serialization, and does not properly abstract API retrieval
-func Merge(codec runtime.Codec, dst runtime.Object, fragment, kind string) (runtime.Object, error) {
+func Merge(codec runtime.Codec, dst runtime.Object, fragment string) (runtime.Object, error) {
 	// encode dst into versioned json and apply fragment directly too it
 	target, err := runtime.Encode(codec, dst)
 	if err != nil {
@@ -712,7 +712,7 @@ func FilterResourceList(obj runtime.Object, filterFuncs kubectl.Filters, filterO
 
 // PrintFilterCount displays informational messages based on the number of resources found, hidden, or
 // config flags shown.
-func PrintFilterCount(out io.Writer, found, hidden, errors int, resource string, options *printers.PrintOptions, ignoreNotFound bool) {
+func PrintFilterCount(out io.Writer, found, hidden, errors int, options *printers.PrintOptions, ignoreNotFound bool) {
 	switch {
 	case errors > 0 || ignoreNotFound:
 		// print nothing

--- a/pkg/kubectl/cmd/util/helpers_test.go
+++ b/pkg/kubectl/cmd/util/helpers_test.go
@@ -47,10 +47,8 @@ func TestMerge(t *testing.T) {
 		fragment  string
 		expected  runtime.Object
 		expectErr bool
-		kind      string
 	}{
 		{
-			kind: "Pod",
 			obj: &api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -67,7 +65,6 @@ func TestMerge(t *testing.T) {
 		/* TODO: uncomment this test once Merge is updated to use
 		strategic-merge-patch. See #8449.
 		{
-			kind: "Pod",
 			obj: &api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -105,7 +102,6 @@ func TestMerge(t *testing.T) {
 			},
 		}, */
 		{
-			kind: "Pod",
 			obj: &api.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
@@ -136,20 +132,17 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
-			kind:      "Pod",
 			obj:       &api.Pod{},
 			fragment:  "invalid json",
 			expected:  &api.Pod{},
 			expectErr: true,
 		},
 		{
-			kind:      "Service",
 			obj:       &api.Service{},
 			fragment:  `{ "apiVersion": "badVersion" }`,
 			expectErr: true,
 		},
 		{
-			kind: "Service",
 			obj: &api.Service{
 				Spec: api.ServiceSpec{},
 			},
@@ -168,7 +161,6 @@ func TestMerge(t *testing.T) {
 			},
 		},
 		{
-			kind: "Service",
 			obj: &api.Service{
 				Spec: api.ServiceSpec{
 					Selector: map[string]string{
@@ -190,7 +182,7 @@ func TestMerge(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		out, err := Merge(testapi.Default.Codec(), test.obj, test.fragment, test.kind)
+		out, err := Merge(testapi.Default.Codec(), test.obj, test.fragment)
 		if !test.expectErr {
 			if err != nil {
 				t.Errorf("testcase[%d], unexpected error: %v", i, err)


### PR DESCRIPTION
Found with github.com/mvdan/unparam.

**Release note**: NONE