### PR TITLE
enable generation

### DIFF
--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -39,7 +39,7 @@ function kfind() {
     # include the "special" vendor directories which are actually part
     # of the Kubernetes source tree - generators will use these for
     # including certain core API concepts.
-    find -H . ./vendor/k8s.io/apimachinery ./vendor/k8s.io/apiserver \
+    find -H . ./vendor/k8s.io/apimachinery ./vendor/k8s.io/apiserver ./vendor/k8s.io/kube-aggregator ./vendor/k8s.io/sample-apiserver \
         \(                         \
         -not \(                    \
             \(                     \

--- a/hack/update-codecgen.sh
+++ b/hack/update-codecgen.sh
@@ -31,15 +31,27 @@ generated_files=($(
       \( \
         -wholename './output' \
         -o -wholename './_output' \
-        -o -wholename './staging/src/k8s.io/client-go' \
-        -o -wholename './staging/src/k8s.io/apiserver' \
+        -o -wholename './staging' \
         -o -wholename './release' \
         -o -wholename './target' \
         -o -wholename '*/third_party/*' \
         -o -wholename '*/vendor/*' \
         -o -wholename '*/codecgen-*-1234.generated.go' \
       \) -prune \
-    \) -name '*.generated.go' | LC_ALL=C sort -r))
+    \) -name '*.generated.go' | LC_ALL=C sort -r
+
+  find ./vendor/k8s.io/kube-aggregator/ -not \( \
+      \( \
+        -wholename './output' \
+        -o -wholename './_output' \
+        -o -wholename './staging' \
+        -o -wholename './release' \
+        -o -wholename './target' \
+        -o -wholename '*/third_party/*' \
+        -o -wholename '*/codecgen-*-1234.generated.go' \
+      \) -prune \
+    \) -name '*.generated.go' | LC_ALL=C sort -r
+))
 
 # We only work for deps within this prefix.
 my_prefix="k8s.io/kubernetes"

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/doc.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/doc.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 // Package api is the internal version of the API.
 // +groupName=apiregistration.k8s.io
-package apiregistration
+package apiregistration // import "k8s.io/kube-aggregator/pkg/apis/apiregistration"

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1/doc.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1/doc.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kube-aggregator/pkg/apis/apiregistration
+// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 // +groupName=apiregistration.k8s.io
-package v1alpha1
+package v1alpha1 // import "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1"

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1/zz_generated.conversion.go
@@ -90,7 +90,11 @@ func Convert_v1alpha1_APIServiceList_To_apiregistration_APIServiceList(in *APISe
 
 func autoConvert_apiregistration_APIServiceList_To_v1alpha1_APIServiceList(in *apiregistration.APIServiceList, out *APIServiceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]APIService)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]APIService, 0)
+	} else {
+		out.Items = *(*[]APIService)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -117,7 +121,11 @@ func autoConvert_apiregistration_APIServiceSpec_To_v1alpha1_APIServiceSpec(in *a
 	out.Group = in.Group
 	out.Version = in.Version
 	out.InsecureSkipTLSVerify = in.InsecureSkipTLSVerify
-	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
+	if in.CABundle == nil {
+		out.CABundle = make([]byte, 0)
+	} else {
+		out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
+	}
 	out.Priority = in.Priority
 	return nil
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1/zz_generated.deepcopy.go
@@ -53,8 +53,10 @@ func DeepCopy_v1alpha1_APIService(in interface{}, out interface{}, c *conversion
 		} else {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
 		}
-		if err := DeepCopy_v1alpha1_APIServiceSpec(&in.Spec, &out.Spec, c); err != nil {
+		if newVal, err := c.DeepCopy(&in.Spec); err != nil {
 			return err
+		} else {
+			out.Spec = *newVal.(*APIServiceSpec)
 		}
 		return nil
 	}
@@ -69,8 +71,10 @@ func DeepCopy_v1alpha1_APIServiceList(in interface{}, out interface{}, c *conver
 			in, out := &in.Items, &out.Items
 			*out = make([]APIService, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_APIService(&(*in)[i], &(*out)[i], c); err != nil {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
 					return err
+				} else {
+					(*out)[i] = *newVal.(*APIService)
 				}
 			}
 		}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/zz_generated.deepcopy.go
@@ -53,8 +53,10 @@ func DeepCopy_apiregistration_APIService(in interface{}, out interface{}, c *con
 		} else {
 			out.ObjectMeta = *newVal.(*v1.ObjectMeta)
 		}
-		if err := DeepCopy_apiregistration_APIServiceSpec(&in.Spec, &out.Spec, c); err != nil {
+		if newVal, err := c.DeepCopy(&in.Spec); err != nil {
 			return err
+		} else {
+			out.Spec = *newVal.(*APIServiceSpec)
 		}
 		return nil
 	}
@@ -69,8 +71,10 @@ func DeepCopy_apiregistration_APIServiceList(in interface{}, out interface{}, c 
 			in, out := &in.Items, &out.Items
 			*out = make([]APIService, len(*in))
 			for i := range *in {
-				if err := DeepCopy_apiregistration_APIService(&(*in)[i], &(*out)[i], c); err != nil {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
 					return err
+				} else {
+					(*out)[i] = *newVal.(*APIService)
 				}
 			}
 		}

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/doc.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/sample-apiserver/pkg/apis/wardle
+// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/sample-apiserver/pkg/apis/wardle
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 // +groupName=wardle.k8s.io

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.conversion.go
@@ -88,7 +88,11 @@ func Convert_v1alpha1_FlunderList_To_wardle_FlunderList(in *FlunderList, out *wa
 
 func autoConvert_wardle_FlunderList_To_v1alpha1_FlunderList(in *wardle.FlunderList, out *FlunderList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Flunder)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Flunder, 0)
+	} else {
+		out.Items = *(*[]Flunder)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.deepcopy.go
@@ -65,8 +65,10 @@ func DeepCopy_v1alpha1_FlunderList(in interface{}, out interface{}, c *conversio
 			in, out := &in.Items, &out.Items
 			*out = make([]Flunder, len(*in))
 			for i := range *in {
-				if err := DeepCopy_v1alpha1_Flunder(&(*in)[i], &(*out)[i], c); err != nil {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
 					return err
+				} else {
+					(*out)[i] = *newVal.(*Flunder)
 				}
 			}
 		}

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/zz_generated.deepcopy.go
@@ -65,8 +65,10 @@ func DeepCopy_wardle_FlunderList(in interface{}, out interface{}, c *conversion.
 			in, out := &in.Items, &out.Items
 			*out = make([]Flunder, len(*in))
 			for i := range *in {
-				if err := DeepCopy_wardle_Flunder(&(*in)[i], &(*out)[i], c); err != nil {
+				if newVal, err := c.DeepCopy(&(*in)[i]); err != nil {
 					return err
+				} else {
+					(*out)[i] = *newVal.(*Flunder)
 				}
 			}
 		}


### PR DESCRIPTION
Looks like the deep equals and conversion generation were turned off for sample-apiserver and kube-aggregator.  This turns them back on.

@kubernetes/sig-api-machinery-misc 