### PR TITLE
Add Eviction when EmptyDir exceeds user's requested limit

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -38155,6 +38155,10 @@
      "medium": {
       "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir",
       "type": "string"
+     },
+     "size": {
+      "description": "Size is the limit of EMptyDir volume size",
+      "$ref": "#/definitions/io.k8s.apimachinery.pkg.api.resource.Quantity"
      }
     }
    },

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -2749,6 +2749,9 @@
      "medium": {
       "type": "string",
       "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+     },
+     "size": {
+      "type": "string"
      }
     }
    },

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -1532,6 +1532,9 @@
      "medium": {
       "type": "string",
       "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+     },
+     "size": {
+      "type": "string"
      }
     }
    },

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -6996,6 +6996,9 @@
      "medium": {
       "type": "string",
       "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+     },
+     "size": {
+      "type": "string"
      }
     }
    },

--- a/api/swagger-spec/settings.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/settings.k8s.io_v1alpha1.json
@@ -1404,6 +1404,9 @@
      "medium": {
       "type": "string",
       "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+     },
+     "size": {
+      "type": "string"
      }
     }
    },

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -18877,6 +18877,9 @@
      "medium": {
       "type": "string",
       "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir"
+     },
+     "size": {
+      "type": "string"
      }
     }
    },

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -580,6 +580,8 @@ type EmptyDirVolumeSource struct {
 	// The default is "" which means to use the node's default medium.
 	// +optional
 	Medium StorageMedium
+	// Size is the limit of EMptyDir volume size
+	SizeLimit resource.Quantity
 }
 
 // StorageMedium defines ways that storage can be allocated to a volume.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -667,6 +667,8 @@ type EmptyDirVolumeSource struct {
 	// More info: http://kubernetes.io/docs/user-guide/volumes#emptydir
 	// +optional
 	Medium StorageMedium `json:"medium,omitempty" protobuf:"bytes,1,opt,name=medium,casttype=StorageMedium"`
+	// Size is the limit of EMptyDir volume size
+	SizeLimit resource.Quantity `json:"size,omitempty" protobuf:"bytes,2,opt,name=size"`
 }
 
 // Represents a Glusterfs mount that lasts the lifetime of a pod.

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -286,6 +286,25 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 	m.lastObservations = observations
 	m.Unlock()
 
+	// the only candidates viable for eviction are those pods that had anything running.
+	activePods := podFunc()
+	if len(activePods) == 0 {
+		glog.Errorf("eviction manager: eviction thresholds have been met, but no pods are active to evict")
+		return
+	}
+
+	evictPods := m.localVolumeEviction(activePods)
+
+	for _, pod := range evictPods {
+		gracePeriod := int64(0)
+		m.evictPod(pod, v1.ResourceName("EmptyDir"), gracePeriod)
+		if err != nil {
+			glog.Errorf("eviction manager: pod %s failed to evict %v", format.Pod(pod), err)
+		} else {
+			glog.Infof("eviction manager: pod %s evicted successfully", format.Pod(pod))
+		}
+	}
+
 	// determine the set of resources under starvation
 	starvedResources := getStarvedResources(thresholds)
 	if len(starvedResources) == 0 {
@@ -293,6 +312,11 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 		return
 	}
 
+	activePods = podFunc()
+	if len(activePods) == 0 {
+		glog.Errorf("eviction manager: eviction thresholds have been met, but no pods are active to evict")
+		return
+	}
 	// rank the resources to reclaim by eviction priority
 	sort.Sort(byEvictionPriority(starvedResources))
 	resourceToReclaim := starvedResources[0]
@@ -319,13 +343,6 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 		return
 	}
 
-	// the only candidates viable for eviction are those pods that had anything running.
-	activePods := podFunc()
-	if len(activePods) == 0 {
-		glog.Errorf("eviction manager: eviction thresholds have been met, but no pods are active to evict")
-		return
-	}
-
 	// rank the running pods for eviction for the specified resource
 	rank(activePods, statsFunc)
 
@@ -341,19 +358,12 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 			kubelettypes.IsCriticalPod(pod) && kubepod.IsStaticPod(pod) {
 			continue
 		}
-		status := v1.PodStatus{
-			Phase:   v1.PodFailed,
-			Message: fmt.Sprintf(message, resourceToReclaim),
-			Reason:  reason,
-		}
-		// record that we are evicting the pod
-		m.recorder.Eventf(pod, v1.EventTypeWarning, reason, fmt.Sprintf(message, resourceToReclaim))
 		gracePeriodOverride := int64(0)
 		if softEviction {
 			gracePeriodOverride = m.config.MaxPodGracePeriodSeconds
 		}
 		// this is a blocking call and should only return when the pod and its containers are killed.
-		err := m.killPodFunc(pod, status, &gracePeriodOverride)
+		err := m.evictPod(pod, resourceToReclaim, gracePeriodOverride)
 		if err != nil {
 			glog.Infof("eviction manager: pod %s failed to evict %v", format.Pod(pod), err)
 			continue
@@ -363,6 +373,57 @@ func (m *managerImpl) synchronize(diskInfoProvider DiskInfoProvider, podFunc Act
 		return
 	}
 	glog.Infof("eviction manager: unable to evict any pods from the node")
+
+}
+
+func (m *managerImpl) evictPod(pod *v1.Pod, resourceName v1.ResourceName, gracePeriod int64) error {
+	status := v1.PodStatus{
+		Phase:   v1.PodFailed,
+		Message: fmt.Sprintf(message, resourceName),
+		Reason:  reason,
+	}
+	// record that we are evicting the pod
+	m.recorder.Eventf(pod, v1.EventTypeWarning, reason, fmt.Sprintf(message, resourceName))
+	return m.killPodFunc(pod, status, &gracePeriod)
+}
+
+// localVolumeEviction checks the EmptyDir volume usage and determine whether it exceeds the limit and needs
+// to be evicted
+func (m *managerImpl) localVolumeEviction(pods []*v1.Pod) []*v1.Pod {
+	evictPods := []*v1.Pod{}
+	summary, err := m.summaryProvider.Get()
+	if err != nil {
+		glog.Errorf("Could not get summary provider")
+		return evictPods
+	}
+
+	podVolumeUsed := make(map[string]*resource.Quantity)
+	// get Pod volume usage from summary object
+	for _, podStats := range summary.Pods {
+		for _, volume := range podStats.VolumeStats {
+			podVolumeName := getPodVolumeName(podStats.PodRef.Name, volume.Name)
+			podVolumeUsed[podVolumeName] = resource.NewQuantity(int64(*volume.UsedBytes), resource.BinarySI)
+		}
+	}
+	for _, pod := range pods {
+		for i := range pod.Spec.Volumes {
+			source := &pod.Spec.Volumes[i].VolumeSource
+			if source.EmptyDir != nil {
+				size := source.EmptyDir.SizeLimit
+				used := podVolumeUsed[getPodVolumeName(pod.Name, pod.Spec.Volumes[i].Name)]
+				zero := resource.NewQuantity(int64(0), resource.BinarySI)
+				if used != nil && size.Cmp(*zero) > 0 && used.Cmp(size) > 0 {
+					evictPods = append(evictPods, pod)
+				}
+			}
+		}
+	}
+
+	return evictPods
+}
+
+func getPodVolumeName(podUID, volumeName string) string {
+	return fmt.Sprintf("pod_%s_volume_%s", podUID, volumeName)
 }
 
 // reclaimNodeLevelResources attempts to reclaim node level resources.  returns true if thresholds were satisfied and no pod eviction is required.

--- a/staging/src/k8s.io/client-go/pkg/api/types.go
+++ b/staging/src/k8s.io/client-go/pkg/api/types.go
@@ -580,6 +580,8 @@ type EmptyDirVolumeSource struct {
 	// The default is "" which means to use the node's default medium.
 	// +optional
 	Medium StorageMedium
+	// Size is the limit of EMptyDir volume size
+	Size resource.Quantity
 }
 
 // StorageMedium defines ways that storage can be allocated to a volume.

--- a/staging/src/k8s.io/client-go/pkg/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/types.go
@@ -667,6 +667,8 @@ type EmptyDirVolumeSource struct {
 	// More info: http://kubernetes.io/docs/user-guide/volumes#emptydir
 	// +optional
 	Medium StorageMedium `json:"medium,omitempty" protobuf:"bytes,1,opt,name=medium,casttype=StorageMedium"`
+	// Size is the limit of EMptyDir volume size
+	SizeLimit resource.Quantity `json:"size,omitempty" protobuf:"bytes,2,opt,name=size"`
 }
 
 // Represents a Glusterfs mount that lasts the lifetime of a pod.


### PR DESCRIPTION
User can specify a size limit for emptyDir volume. Eviction manager will
evict the pod if the usage of EmptyDIr volume exceeds the limit.

