### PR TITLE
dockershim: process protocol correctly for port mapping

### DIFF
--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -96,6 +96,7 @@ go_test(
         "//vendor:github.com/blang/semver",
         "//vendor:github.com/docker/engine-api/types",
         "//vendor:github.com/docker/engine-api/types/container",
+        "//vendor:github.com/docker/go-connections/nat",
         "//vendor:github.com/golang/mock/gomock",
         "//vendor:github.com/stretchr/testify/assert",
         "//vendor:github.com/stretchr/testify/require",

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -149,10 +149,10 @@ func makePortsAndBindings(pm []*runtimeapi.PortMapping) (map[dockernat.Port]stru
 		// Some of this port stuff is under-documented voodoo.
 		// See http://stackoverflow.com/questions/20428302/binding-a-port-to-a-host-interface-using-the-rest-api
 		var protocol string
-		switch strings.ToUpper(string(port.Protocol)) {
-		case "UDP":
+		switch port.Protocol {
+		case runtimeapi.Protocol_UDP:
 			protocol = "/udp"
-		case "TCP":
+		case runtimeapi.Protocol_TCP:
 			protocol = "/tcp"
 		default:
 			glog.Warningf("Unknown protocol %q: defaulting to TCP", port.Protocol)


### PR DESCRIPTION
**What this PR does / why we need it**:

dockershim: process protocol correctly for port mapping.

**Which issue this PR fixes** 

Fixes #43365.

**Special notes for your reviewer**:

Should be included in v1.6.

**Release note**:

```release-note
NONE
```

cc/ @Random-Liu @justinsb @kubernetes/sig-node-pr-reviews 
