### PR TITLE
Fix empty RBAC Forbidden message

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go
@@ -52,6 +52,10 @@ func forbiddenMessage(attributes authorizer.Attributes) string {
 		username = user.GetName()
 	}
 
+	if !attributes.IsResourceRequest() {
+		return fmt.Sprintf("User %q cannot %s path %q.", username, attributes.GetVerb(), attributes.GetPath())
+	}
+
 	resource := attributes.GetResource()
 	if group := attributes.GetAPIGroup(); len(group) > 0 {
 		resource = resource + "." + group


### PR DESCRIPTION
Fix empty RBAC Forbidden message when accessing cluster scope resources.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
