### PR TITLE
Move & export ConstructPodPortMapping

### DIFF
--- a/pkg/kubelet/network/hostport/hostport.go
+++ b/pkg/kubelet/network/hostport/hostport.go
@@ -18,9 +18,10 @@ package hostport
 
 import (
 	"fmt"
-	"github.com/golang/glog"
 	"net"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"k8s.io/kubernetes/pkg/api/v1"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
@@ -49,6 +50,31 @@ type PodPortMapping struct {
 	PortMappings []*PortMapping
 	HostNetwork  bool
 	IP           net.IP
+}
+
+// ConstructPodPortMapping creates a PodPortMapping from the ports specified in the pod's
+// containers.
+func ConstructPodPortMapping(pod *v1.Pod, podIP net.IP) *PodPortMapping {
+	portMappings := make([]*PortMapping, 0)
+	for _, c := range pod.Spec.Containers {
+		for _, port := range c.Ports {
+			portMappings = append(portMappings, &PortMapping{
+				Name:          port.Name,
+				HostPort:      port.HostPort,
+				ContainerPort: port.ContainerPort,
+				Protocol:      port.Protocol,
+				HostIP:        port.HostIP,
+			})
+		}
+	}
+
+	return &PodPortMapping{
+		Namespace:    pod.Namespace,
+		Name:         pod.Name,
+		PortMappings: portMappings,
+		HostNetwork:  pod.Spec.HostNetwork,
+		IP:           podIP,
+	}
 }
 
 type hostport struct {


### PR DESCRIPTION
ConstructPodPortMapping: move & export

Move ConstructPodPortMapping to pkg/kubelet/network/hostport and export
it so downstream projects (such as OpenShift) can use it.

cc @sttts @kubernetes/sig-node-pr-reviews @kubernetes/sig-network-pr-reviews 