### PR TITLE
Revert "Mark failing PersistentVolumes:GCEPD tests flaky"

### DIFF
--- a/test/e2e/persistent_volumes.go
+++ b/test/e2e/persistent_volumes.go
@@ -294,7 +294,7 @@ var _ = framework.KubeDescribe("PersistentVolumes [Volume][Serial]", func() {
 	//				GCE PD
 	///////////////////////////////////////////////////////////////////////
 	// Testing configurations of single a PV/PVC pair attached to a GCE PD
-	framework.KubeDescribe("PersistentVolumes:GCEPD[Flaky]", func() {
+	framework.KubeDescribe("PersistentVolumes:GCEPD", func() {
 
 		var (
 			diskName  string


### PR DESCRIPTION
Reverts kubernetes/kubernetes#43336

As detailed in https://github.com/kubernetes/kubernetes/issues/43200#issuecomment-287815986, this test is not actually flaky on `gke-serial`. In normal execution the test is executed on GCE but skipped on GKE. The failures on GKE are failures of the common pre-test setup steps (creating namespace), likely caused by infrastructure issues. Therefore, we can move these tests out of flaky.

CC @copejon @jeffvance 