### PR TITLE
e2e-node: refactor lifecycle test to avoid selinux issues

### DIFF
--- a/test/e2e_node/lifecycle_hook_test.go
+++ b/test/e2e_node/lifecycle_hook_test.go
@@ -17,12 +17,10 @@ limitations under the License.
 package e2e_node
 
 import (
-	"fmt"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -35,179 +33,108 @@ var _ = framework.KubeDescribe("Container Lifecycle Hook", func() {
 	var podClient *framework.PodClient
 	const (
 		podCheckInterval     = 1 * time.Second
-		podWaitTimeout       = 3 * time.Minute
 		postStartWaitTimeout = 2 * time.Minute
 		preStopWaitTimeout   = 30 * time.Second
 	)
 	Context("when create a pod with lifecycle hook", func() {
+		var targetIP string
+		podHandleHookRequest := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "pod-handle-http-request",
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Name:  "pod-handle-http-request",
+						Image: "gcr.io/google_containers/netexec:1.7",
+						Ports: []v1.ContainerPort{
+							{
+								ContainerPort: 8080,
+								Protocol:      v1.ProtocolTCP,
+							},
+						},
+					},
+				},
+			},
+		}
 		BeforeEach(func() {
 			podClient = f.PodClient()
+			By("create the container to handle the HTTPGet hook request.")
+			newPod := podClient.CreateSync(podHandleHookRequest)
+			targetIP = newPod.Status.PodIP
 		})
-
-		Context("when it is exec hook", func() {
-			var file string
-			testPodWithExecHook := func(podWithHook *v1.Pod) {
-				podCheckHook := getExecHookTestPod("pod-check-hook",
-					// Wait until the file is created.
-					[]string{"sh", "-c", fmt.Sprintf("while [ ! -e %s ]; do sleep 1; done", file)},
-				)
-				By("create the pod with lifecycle hook")
-				podClient.CreateSync(podWithHook)
-				if podWithHook.Spec.Containers[0].Lifecycle.PostStart != nil {
-					By("create the hook check pod")
-					podClient.Create(podCheckHook)
-					By("wait for the hook check pod to success")
-					podClient.WaitForSuccess(podCheckHook.Name, postStartWaitTimeout)
-				}
-				By("delete the pod with lifecycle hook")
-				podClient.DeleteSync(podWithHook.Name, metav1.NewDeleteOptions(15), framework.DefaultPodDeletionTimeout)
-				if podWithHook.Spec.Containers[0].Lifecycle.PreStop != nil {
-					By("create the hook check pod")
-					podClient.Create(podCheckHook)
-					By("wait for the prestop check pod to success")
-					podClient.WaitForSuccess(podCheckHook.Name, preStopWaitTimeout)
-				}
+		testPodWithHook := func(podWithHook *v1.Pod) {
+			By("create the pod with lifecycle hook")
+			podClient.CreateSync(podWithHook)
+			if podWithHook.Spec.Containers[0].Lifecycle.PostStart != nil {
+				By("check poststart hook")
+				Eventually(func() error {
+					return podClient.MatchContainerOutput(podHandleHookRequest.Name, podHandleHookRequest.Spec.Containers[0].Name,
+						`GET /echo\?msg=poststart`)
+				}, postStartWaitTimeout, podCheckInterval).Should(BeNil())
 			}
-
-			BeforeEach(func() {
-				file = "/tmp/test-" + string(uuid.NewUUID())
-			})
-
-			AfterEach(func() {
-				By("cleanup the temporary file created in the test.")
-				cleanupPod := getExecHookTestPod("pod-clean-up", []string{"rm", file})
-				podClient.Create(cleanupPod)
-				podClient.WaitForSuccess(cleanupPod.Name, podWaitTimeout)
-			})
-
-			It("should execute poststart exec hook properly [Conformance]", func() {
-				podWithHook := getExecHookTestPod("pod-with-poststart-exec-hook",
-					// Block forever
-					[]string{"tail", "-f", "/dev/null"},
-				)
-				podWithHook.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
-					PostStart: &v1.Handler{
-						Exec: &v1.ExecAction{Command: []string{"touch", file}},
-					},
-				}
-				testPodWithExecHook(podWithHook)
-			})
-
-			It("should execute prestop exec hook properly [Conformance]", func() {
-				podWithHook := getExecHookTestPod("pod-with-prestop-exec-hook",
-					// Block forever
-					[]string{"tail", "-f", "/dev/null"},
-				)
-				podWithHook.Spec.Containers[0].Lifecycle = &v1.Lifecycle{
-					PreStop: &v1.Handler{
-						Exec: &v1.ExecAction{Command: []string{"touch", file}},
-					},
-				}
-				testPodWithExecHook(podWithHook)
-			})
-		})
-
-		Context("when it is http hook", func() {
-			var targetIP string
-			podHandleHookRequest := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pod-handle-http-request",
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:  "pod-handle-http-request",
-							Image: "gcr.io/google_containers/netexec:1.7",
-							Ports: []v1.ContainerPort{
-								{
-									ContainerPort: 8080,
-									Protocol:      v1.ProtocolTCP,
-								},
-							},
-						},
+			By("delete the pod with lifecycle hook")
+			podClient.DeleteSync(podWithHook.Name, metav1.NewDeleteOptions(15), framework.DefaultPodDeletionTimeout)
+			if podWithHook.Spec.Containers[0].Lifecycle.PreStop != nil {
+				By("check prestop hook")
+				Eventually(func() error {
+					return podClient.MatchContainerOutput(podHandleHookRequest.Name, podHandleHookRequest.Spec.Containers[0].Name,
+						`GET /echo\?msg=prestop`)
+				}, preStopWaitTimeout, podCheckInterval).Should(BeNil())
+			}
+		}
+		It("should execute poststart exec hook properly [Conformance]", func() {
+			lifecycle := &v1.Lifecycle{
+				PostStart: &v1.Handler{
+					Exec: &v1.ExecAction{
+						Command: []string{"sh", "-c", "curl http://" + targetIP + ":8080/echo?msg=poststart"},
 					},
 				},
 			}
-			BeforeEach(func() {
-				By("create the container to handle the HTTPGet hook request.")
-				newPod := podClient.CreateSync(podHandleHookRequest)
-				targetIP = newPod.Status.PodIP
-			})
-			testPodWithHttpHook := func(podWithHook *v1.Pod) {
-				By("create the pod with lifecycle hook")
-				podClient.CreateSync(podWithHook)
-				if podWithHook.Spec.Containers[0].Lifecycle.PostStart != nil {
-					By("check poststart hook")
-					Eventually(func() error {
-						return podClient.MatchContainerOutput(podHandleHookRequest.Name, podHandleHookRequest.Spec.Containers[0].Name,
-							`GET /echo\?msg=poststart`)
-					}, postStartWaitTimeout, podCheckInterval).Should(BeNil())
-				}
-				By("delete the pod with lifecycle hook")
-				podClient.DeleteSync(podWithHook.Name, metav1.NewDeleteOptions(15), framework.DefaultPodDeletionTimeout)
-				if podWithHook.Spec.Containers[0].Lifecycle.PreStop != nil {
-					By("check prestop hook")
-					Eventually(func() error {
-						return podClient.MatchContainerOutput(podHandleHookRequest.Name, podHandleHookRequest.Spec.Containers[0].Name,
-							`GET /echo\?msg=prestop`)
-					}, preStopWaitTimeout, podCheckInterval).Should(BeNil())
-				}
+			podWithHook := getPodWithHook("pod-with-poststart-exec-hook", "gcr.io/google_containers/hostexec:1.2", lifecycle)
+			testPodWithHook(podWithHook)
+		})
+		It("should execute prestop exec hook properly [Conformance]", func() {
+			lifecycle := &v1.Lifecycle{
+				PreStop: &v1.Handler{
+					Exec: &v1.ExecAction{
+						Command: []string{"sh", "-c", "curl http://" + targetIP + ":8080/echo?msg=prestop"},
+					},
+				},
 			}
-			It("should execute poststart http hook properly [Conformance]", func() {
-				podWithHook := &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "pod-with-poststart-http-hook",
+			podWithHook := getPodWithHook("pod-with-prestop-exec-hook", "gcr.io/google_containers/hostexec:1.2", lifecycle)
+			testPodWithHook(podWithHook)
+		})
+		It("should execute poststart http hook properly [Conformance]", func() {
+			lifecycle := &v1.Lifecycle{
+				PostStart: &v1.Handler{
+					HTTPGet: &v1.HTTPGetAction{
+						Path: "/echo?msg=poststart",
+						Host: targetIP,
+						Port: intstr.FromInt(8080),
 					},
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
-							{
-								Name:  "pod-with-poststart-http-hook",
-								Image: framework.GetPauseImageNameForHostArch(),
-								Lifecycle: &v1.Lifecycle{
-									PostStart: &v1.Handler{
-										HTTPGet: &v1.HTTPGetAction{
-											Path: "/echo?msg=poststart",
-											Host: targetIP,
-											Port: intstr.FromInt(8080),
-										},
-									},
-								},
-							},
-						},
+				},
+			}
+			podWithHook := getPodWithHook("pod-with-poststart-http-hook", framework.GetPauseImageNameForHostArch(), lifecycle)
+			testPodWithHook(podWithHook)
+		})
+		It("should execute prestop http hook properly [Conformance]", func() {
+			lifecycle := &v1.Lifecycle{
+				PreStop: &v1.Handler{
+					HTTPGet: &v1.HTTPGetAction{
+						Path: "/echo?msg=prestop",
+						Host: targetIP,
+						Port: intstr.FromInt(8080),
 					},
-				}
-				testPodWithHttpHook(podWithHook)
-			})
-			It("should execute prestop http hook properly [Conformance]", func() {
-				podWithHook := &v1.Pod{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "pod-with-prestop-http-hook",
-					},
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
-							{
-								Name:  "pod-with-prestop-http-hook",
-								Image: framework.GetPauseImageNameForHostArch(),
-								Lifecycle: &v1.Lifecycle{
-									PreStop: &v1.Handler{
-										HTTPGet: &v1.HTTPGetAction{
-											Path: "/echo?msg=prestop",
-											Host: targetIP,
-											Port: intstr.FromInt(8080),
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-				testPodWithHttpHook(podWithHook)
-			})
+				},
+			}
+			podWithHook := getPodWithHook("pod-with-prestop-http-hook", framework.GetPauseImageNameForHostArch(), lifecycle)
+			testPodWithHook(podWithHook)
 		})
 	})
 })
 
-func getExecHookTestPod(name string, cmd []string) *v1.Pod {
+func getPodWithHook(name string, image string, lifecycle *v1.Lifecycle) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -215,22 +142,9 @@ func getExecHookTestPod(name string, cmd []string) *v1.Pod {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:  name,
-					Image: "gcr.io/google_containers/busybox:1.24",
-					VolumeMounts: []v1.VolumeMount{
-						{
-							Name:      "tmpfs",
-							MountPath: "/tmp",
-						},
-					},
-					Command: cmd,
-				},
-			},
-			RestartPolicy: v1.RestartPolicyNever,
-			Volumes: []v1.Volume{
-				{
-					Name:         "tmpfs",
-					VolumeSource: v1.VolumeSource{HostPath: &v1.HostPathVolumeSource{Path: "/tmp"}},
+					Name:      name,
+					Image:     image,
+					Lifecycle: lifecycle,
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #42905

Previously, the exec hook tests mounted a HostPath volume from /tmp and touched a file as a indicator that the hook had run.  This is prohibited by selinux policy on Fedora/RHEL/Centos.

This PR refactors the test to avoid filesystem indication and use the same indication that the HTTP hooks use; a GET to a http endpoint.  The exec hooks run `curl` to hit this endpoint and trigger the indication.  This simplifies this test quite a bit as well, removing over 85 lines of code.

REVIEWER NOTE: The diff is a mess on this one.  Probably better to just review the new version of the file.

@derekwaynecarr