### PR TITLE
Unify test timeouts under a common name.

### DIFF
--- a/test/e2e_federation/deployment.go
+++ b/test/e2e_federation/deployment.go
@@ -185,7 +185,7 @@ func waitForDeploymentOrFail(c *fedclientset.Clientset, namespace string, deploy
 }
 
 func waitForDeployment(c *fedclientset.Clientset, namespace string, deploymentName string, clusters map[string]*cluster) error {
-	err := wait.Poll(10*time.Second, federatedDeploymentTimeout, func() (bool, error) {
+	err := wait.Poll(10*time.Second, federatedDefaultTestTimeout, func() (bool, error) {
 		fdep, err := c.Deployments(namespace).Get(deploymentName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
@@ -259,7 +259,7 @@ func deleteDeploymentOrFail(clientset *fedclientset.Clientset, nsName string, de
 	}
 
 	// Wait for the deployment to be deleted.
-	err = wait.Poll(10*time.Second, federatedDeploymentTimeout, func() (bool, error) {
+	err = wait.Poll(10*time.Second, federatedDefaultTestTimeout, func() (bool, error) {
 		_, err := clientset.Extensions().Deployments(nsName).Get(deploymentName, metav1.GetOptions{})
 		if err != nil && errors.IsNotFound(err) {
 			return true, nil

--- a/test/e2e_federation/ingress.go
+++ b/test/e2e_federation/ingress.go
@@ -171,8 +171,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 
 		AfterEach(func() {
 			// Delete all ingresses.
-			nsName := f.FederationNamespace.Name
-			deleteAllIngressesOrFail(f.FederationClientset, nsName)
+			deleteAllIngressesOrFail(f.FederationClientset, ns)
 			if secret != nil {
 				By("Deleting secret")
 				orphanDependents := false
@@ -202,24 +201,21 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 
 		It("should be deleted from underlying clusters when OrphanDependents is false", func() {
 			fedframework.SkipUnlessFederated(f.ClientSet)
-			nsName := f.FederationNamespace.Name
 			orphanDependents := false
-			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, &orphanDependents, nsName)
+			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, &orphanDependents, ns)
 			By(fmt.Sprintf("Verified that ingresses were deleted from underlying clusters"))
 		})
 
 		It("should not be deleted from underlying clusters when OrphanDependents is true", func() {
 			fedframework.SkipUnlessFederated(f.ClientSet)
-			nsName := f.FederationNamespace.Name
 			orphanDependents := true
-			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, &orphanDependents, nsName)
+			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, &orphanDependents, ns)
 			By(fmt.Sprintf("Verified that ingresses were not deleted from underlying clusters"))
 		})
 
 		It("should not be deleted from underlying clusters when OrphanDependents is nil", func() {
 			fedframework.SkipUnlessFederated(f.ClientSet)
-			nsName := f.FederationNamespace.Name
-			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, nil, nsName)
+			verifyCascadingDeletionForIngress(f.FederationClientset, clusters, nil, ns)
 			By(fmt.Sprintf("Verified that ingresses were not deleted from underlying clusters"))
 		})
 
@@ -240,10 +236,8 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 				deleteBackendPodsOrFail(clusters, ns)
 				if jig.ing != nil {
 					By(fmt.Sprintf("Deleting ingress %v on all clusters", jig.ing.Name))
-					deleteIngressOrFail(f.FederationClientset, ns, jig.ing.Name, nil)
-					for clusterName, cluster := range clusters {
-						deleteClusterIngressOrFail(clusterName, cluster.Clientset, ns, jig.ing.Name)
-					}
+					orphanDependents := false
+					deleteIngressOrFail(f.FederationClientset, ns, jig.ing.Name, &orphanDependents)
 					jig.ing = nil
 				} else {
 					By("No ingress to delete. Ingress is nil")

--- a/test/e2e_federation/replicaset.go
+++ b/test/e2e_federation/replicaset.go
@@ -388,7 +388,7 @@ func waitForReplicaSetOrFail(c *fedclientset.Clientset, namespace string, replic
 
 func waitForReplicaSet(c *fedclientset.Clientset, namespace string, replicaSetName string, clusters map[string]*cluster, expect map[string]int32) error {
 	framework.Logf("waitForReplicaSet: %s/%s; clusters: %v; expect: %v", namespace, replicaSetName, clusters, expect)
-	err := wait.Poll(10*time.Second, federatedReplicasetTimeout, func() (bool, error) {
+	err := wait.Poll(10*time.Second, federatedDefaultTestTimeout, func() (bool, error) {
 		frs, err := c.ReplicaSets(namespace).Get(replicaSetName, metav1.GetOptions{})
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Some timeouts were too aggressive and since we've slowly been moving every controller to 5 minutes, consolidate everyone under ``federatedDefaultTestTimeout``. To aid in debugging some service-related issues, if a service cannot be deleted, we issue a kubectl describe on it prior to failing.