### PR TITLE
Use docker API version - 1.23 API is 1.11.0

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -67,7 +67,7 @@ const (
 
 var (
 	// The docker version in which containerd was introduced.
-	containerdVersion = utilversion.MustParseSemantic("1.11.0")
+	containerdVersion = utilversion.MustParseSemantic("1.23")
 )
 
 // A non-user container tracked by the Kubelet.
@@ -816,9 +816,9 @@ func getDockerVersion(cadvisor cadvisor.Interface) *utilversion.Version {
 		glog.Errorf("Error requesting cAdvisor VersionInfo: %v", err)
 		return utilversion.MustParseSemantic("0.0.0")
 	}
-	dockerVersion, err := utilversion.ParseSemantic(versions.DockerVersion)
+	dockerVersion, err := utilversion.ParseSemantic(versions.DockerAPIVersion)
 	if err != nil {
-		glog.Errorf("Error parsing docker version %q: %v", versions.DockerVersion, err)
+		glog.Errorf("Error parsing docker version %q: %v", versions.DockerAPIVersion, err)
 		return utilversion.MustParseSemantic("0.0.0")
 	}
 	return dockerVersion

--- a/pkg/kubelet/dockershim/cm/container_manager_linux.go
+++ b/pkg/kubelet/dockershim/cm/container_manager_linux.go
@@ -85,9 +85,9 @@ func (m *containerManager) doWork() {
 		glog.Errorf("Unable to get docker version: %v", err)
 		return
 	}
-	version, err := utilversion.ParseSemantic(v.Version)
+	version, err := utilversion.ParseSemantic(v.APIVersion)
 	if err != nil {
-		glog.Errorf("Unable to parse docker version %q: %v", v.Version, err)
+		glog.Errorf("Unable to parse docker version %q: %v", v.APIVersion, err)
 		return
 	}
 	// EnsureDockerInConatiner does two things.


### PR DESCRIPTION
**What this PR does / why we need it**:

Docker version was previously used to check compatibility but was broken due to the version format changed by Docker. API version is really what we want and should be using.

API v1.23 corresponds to Docker v1.11.0, which was the previous min-req
https://docs.docker.com/engine/api/v1.23/#show-the-docker-version-information

**Which issue this PR fixes** 
Fixes #42492

/cc @mikebrow @yujuhong @yongtang


ps: this PR depends on the CAdvisor update made by @mkumatag:
https://github.com/google/cadvisor/pull/1623