### PR TITLE
kubelet: fix the generating the UID for pod manifest files

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -43,13 +43,15 @@ func generatePodName(name string, nodeName types.NodeName) string {
 func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.NodeName) error {
 	if len(pod.UID) == 0 {
 		hasher := md5.New()
+		hash.DeepHashObject(hasher, pod)
+		// DeepHashObject resets the hash, so we should write the pod source
+		// information AFTER it.
 		if isFile {
 			fmt.Fprintf(hasher, "host:%s", nodeName)
 			fmt.Fprintf(hasher, "file:%s", source)
 		} else {
 			fmt.Fprintf(hasher, "url:%s", source)
 		}
-		hash.DeepHashObject(hasher, pod)
 		pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
 		glog.V(5).Infof("Generated UID %q pod %q from %s", pod.UID, pod.Name, source)
 	}


### PR DESCRIPTION
Fix the issue where pod source (e.g., source name and path to the file) are not
included in the hasher when generating the UID for the pod. If there are multiple
pod yaml files with the same content, kubelet will treat them as if they are the
same pod. One issue we have encountered is that editors may create a temporary
file with the same content in the same directory while editing. The removal of this
temporary file at the end of the editing session may cause the pod to be deleted.

This fix changes how kubelet generates hashes for pod manifest files, and will
cause all containers to be killed and recreated after in-place upgrade.