### PR TITLE
Ensure slices are serialized as zero-length, not null

### DIFF
--- a/cmd/libs/go2idl/conversion-gen/generators/conversion.go
+++ b/cmd/libs/go2idl/conversion-gen/generators/conversion.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
 
+	"reflect"
+
 	"github.com/golang/glog"
 )
 
@@ -722,6 +724,15 @@ func (g *genConversion) doStruct(inType, outType *types.Type, sw *generator.Snip
 			outMemberType = &copied
 		}
 
+		// Determine if our destination field is a slice that should be output when empty.
+		// If it is, ensure a nil source slice converts to a zero-length destination slice.
+		// See http://issue.k8s.io/43203
+		persistEmptySlice := false
+		if outMemberType.Kind == types.Slice {
+			jsonTag := reflect.StructTag(outMember.Tags).Get("json")
+			persistEmptySlice = len(jsonTag) > 0 && !strings.Contains(jsonTag, ",omitempty")
+		}
+
 		args := argsFromType(inMemberType, outMemberType).With("name", inMember.Name)
 
 		// try a direct memory copy for any type that has exactly equivalent values
@@ -737,7 +748,15 @@ func (g *genConversion) doStruct(inType, outType *types.Type, sw *generator.Snip
 				sw.Do("out.$.name$ = *(*$.outType|raw$)($.Pointer|raw$(&in.$.name$))\n", args)
 				continue
 			case types.Slice:
-				sw.Do("out.$.name$ = *(*$.outType|raw$)($.Pointer|raw$(&in.$.name$))\n", args)
+				if persistEmptySlice {
+					sw.Do("if in.$.name$ == nil {\n", args)
+					sw.Do("out.$.name$ = make($.outType|raw$, 0)\n", args)
+					sw.Do("} else {\n", nil)
+					sw.Do("out.$.name$ = *(*$.outType|raw$)($.Pointer|raw$(&in.$.name$))\n", args)
+					sw.Do("}\n", nil)
+				} else {
+					sw.Do("out.$.name$ = *(*$.outType|raw$)($.Pointer|raw$(&in.$.name$))\n", args)
+				}
 				continue
 			}
 		}
@@ -787,7 +806,11 @@ func (g *genConversion) doStruct(inType, outType *types.Type, sw *generator.Snip
 			sw.Do("in, out := &in.$.name$, &out.$.name$\n", args)
 			g.generateFor(inMemberType, outMemberType, sw)
 			sw.Do("} else {\n", nil)
-			sw.Do("out.$.name$ = nil\n", args)
+			if persistEmptySlice {
+				sw.Do("out.$.name$ = make($.outType|raw$, 0)\n", args)
+			} else {
+				sw.Do("out.$.name$ = nil\n", args)
+			}
 			sw.Do("}\n", nil)
 		case types.Struct:
 			if g.isDirectlyAssignable(inMemberType, outMemberType) {

--- a/federation/apis/federation/v1beta1/zz_generated.conversion.go
+++ b/federation/apis/federation/v1beta1/zz_generated.conversion.go
@@ -122,7 +122,11 @@ func Convert_v1beta1_ClusterList_To_federation_ClusterList(in *ClusterList, out 
 
 func autoConvert_federation_ClusterList_To_v1beta1_ClusterList(in *federation.ClusterList, out *ClusterList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Cluster)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Cluster, 0)
+	} else {
+		out.Items = *(*[]Cluster)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -141,7 +145,11 @@ func Convert_v1beta1_ClusterSpec_To_federation_ClusterSpec(in *ClusterSpec, out 
 }
 
 func autoConvert_federation_ClusterSpec_To_v1beta1_ClusterSpec(in *federation.ClusterSpec, out *ClusterSpec, s conversion.Scope) error {
-	out.ServerAddressByClientCIDRs = *(*[]ServerAddressByClientCIDR)(unsafe.Pointer(&in.ServerAddressByClientCIDRs))
+	if in.ServerAddressByClientCIDRs == nil {
+		out.ServerAddressByClientCIDRs = make([]ServerAddressByClientCIDR, 0)
+	} else {
+		out.ServerAddressByClientCIDRs = *(*[]ServerAddressByClientCIDR)(unsafe.Pointer(&in.ServerAddressByClientCIDRs))
+	}
 	out.SecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	return nil
 }

--- a/pkg/api/v1/zz_generated.conversion.go
+++ b/pkg/api/v1/zz_generated.conversion.go
@@ -565,7 +565,11 @@ func Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSou
 }
 
 func autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
-	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
+	if in.Monitors == nil {
+		out.Monitors = make([]string, 0)
+	} else {
+		out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
+	}
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
@@ -656,7 +660,11 @@ func Convert_v1_ComponentStatusList_To_api_ComponentStatusList(in *ComponentStat
 
 func autoConvert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.ComponentStatusList, out *ComponentStatusList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ComponentStatus)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ComponentStatus, 0)
+	} else {
+		out.Items = *(*[]ComponentStatus)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -746,7 +754,11 @@ func Convert_v1_ConfigMapList_To_api_ConfigMapList(in *ConfigMapList, out *api.C
 
 func autoConvert_api_ConfigMapList_To_v1_ConfigMapList(in *api.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ConfigMap)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ConfigMap, 0)
+	} else {
+		out.Items = *(*[]ConfigMap)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -879,7 +891,11 @@ func Convert_v1_ContainerImage_To_api_ContainerImage(in *ContainerImage, out *ap
 }
 
 func autoConvert_api_ContainerImage_To_v1_ContainerImage(in *api.ContainerImage, out *ContainerImage, s conversion.Scope) error {
-	out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
+	if in.Names == nil {
+		out.Names = make([]string, 0)
+	} else {
+		out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
+	}
 	out.SizeBytes = in.SizeBytes
 	return nil
 }
@@ -1246,7 +1262,11 @@ func Convert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints, s 
 
 func autoConvert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subsets = *(*[]EndpointSubset)(unsafe.Pointer(&in.Subsets))
+	if in.Subsets == nil {
+		out.Subsets = make([]EndpointSubset, 0)
+	} else {
+		out.Subsets = *(*[]EndpointSubset)(unsafe.Pointer(&in.Subsets))
+	}
 	return nil
 }
 
@@ -1266,7 +1286,11 @@ func Convert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *api.E
 
 func autoConvert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *EndpointsList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Endpoints)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Endpoints, 0)
+	} else {
+		out.Items = *(*[]Endpoints)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1396,7 +1420,11 @@ func Convert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList, s 
 
 func autoConvert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Event, 0)
+	} else {
+		out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1455,7 +1483,11 @@ func Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *ap
 }
 
 func autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
-	out.TargetWWNs = *(*[]string)(unsafe.Pointer(&in.TargetWWNs))
+	if in.TargetWWNs == nil {
+		out.TargetWWNs = make([]string, 0)
+	} else {
+		out.TargetWWNs = *(*[]string)(unsafe.Pointer(&in.TargetWWNs))
+	}
 	out.Lun = (*int32)(unsafe.Pointer(in.Lun))
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
@@ -1802,7 +1834,11 @@ func Convert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out *ap
 
 func autoConvert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out *LimitRangeList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]LimitRange)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]LimitRange, 0)
+	} else {
+		out.Items = *(*[]LimitRange)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1820,7 +1856,11 @@ func Convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *ap
 }
 
 func autoConvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
-	out.Limits = *(*[]LimitRangeItem)(unsafe.Pointer(&in.Limits))
+	if in.Limits == nil {
+		out.Limits = make([]LimitRangeItem, 0)
+	} else {
+		out.Limits = *(*[]LimitRangeItem)(unsafe.Pointer(&in.Limits))
+	}
 	return nil
 }
 
@@ -1859,7 +1899,7 @@ func autoConvert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]runtime.RawExtension, 0)
 	}
 	return nil
 }
@@ -2022,7 +2062,11 @@ func Convert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *api.N
 
 func autoConvert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *NamespaceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Namespace)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Namespace, 0)
+	} else {
+		out.Items = *(*[]Namespace)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2198,7 +2242,11 @@ func Convert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conv
 
 func autoConvert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Node)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Node, 0)
+	} else {
+		out.Items = *(*[]Node)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2252,7 +2300,11 @@ func Convert_v1_NodeSelector_To_api_NodeSelector(in *NodeSelector, out *api.Node
 }
 
 func autoConvert_api_NodeSelector_To_v1_NodeSelector(in *api.NodeSelector, out *NodeSelector, s conversion.Scope) error {
-	out.NodeSelectorTerms = *(*[]NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
+	if in.NodeSelectorTerms == nil {
+		out.NodeSelectorTerms = make([]NodeSelectorTerm, 0)
+	} else {
+		out.NodeSelectorTerms = *(*[]NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
+	}
 	return nil
 }
 
@@ -2292,7 +2344,11 @@ func Convert_v1_NodeSelectorTerm_To_api_NodeSelectorTerm(in *NodeSelectorTerm, o
 }
 
 func autoConvert_api_NodeSelectorTerm_To_v1_NodeSelectorTerm(in *api.NodeSelectorTerm, out *NodeSelectorTerm, s conversion.Scope) error {
-	out.MatchExpressions = *(*[]NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	if in.MatchExpressions == nil {
+		out.MatchExpressions = make([]NodeSelectorRequirement, 0)
+	} else {
+		out.MatchExpressions = *(*[]NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	}
 	return nil
 }
 
@@ -2574,7 +2630,11 @@ func Convert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *P
 
 func autoConvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *api.PersistentVolumeClaimList, out *PersistentVolumeClaimList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]PersistentVolumeClaim)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]PersistentVolumeClaim, 0)
+	} else {
+		out.Items = *(*[]PersistentVolumeClaim)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2685,7 +2745,7 @@ func autoConvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.Per
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PersistentVolume, 0)
 	}
 	return nil
 }
@@ -2980,7 +3040,11 @@ func autoConvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions,
 	out.Stderr = in.Stderr
 	out.TTY = in.TTY
 	out.Container = in.Container
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
+	if in.Command == nil {
+		out.Command = make([]string, 0)
+	} else {
+		out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
+	}
 	return nil
 }
 
@@ -3019,7 +3083,7 @@ func autoConvert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conv
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Pod, 0)
 	}
 	return nil
 }
@@ -3192,7 +3256,11 @@ func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 		out.Volumes = nil
 	}
 	out.InitContainers = *(*[]Container)(unsafe.Pointer(&in.InitContainers))
-	out.Containers = *(*[]Container)(unsafe.Pointer(&in.Containers))
+	if in.Containers == nil {
+		out.Containers = make([]Container, 0)
+	} else {
+		out.Containers = *(*[]Container)(unsafe.Pointer(&in.Containers))
+	}
 	out.RestartPolicy = RestartPolicy(in.RestartPolicy)
 	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
 	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
@@ -3326,7 +3394,7 @@ func autoConvert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateLi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodTemplate, 0)
 	}
 	return nil
 }
@@ -3486,7 +3554,11 @@ func Convert_v1_ProjectedVolumeSource_To_api_ProjectedVolumeSource(in *Projected
 }
 
 func autoConvert_api_ProjectedVolumeSource_To_v1_ProjectedVolumeSource(in *api.ProjectedVolumeSource, out *ProjectedVolumeSource, s conversion.Scope) error {
-	out.Sources = *(*[]VolumeProjection)(unsafe.Pointer(&in.Sources))
+	if in.Sources == nil {
+		out.Sources = make([]VolumeProjection, 0)
+	} else {
+		out.Sources = *(*[]VolumeProjection)(unsafe.Pointer(&in.Sources))
+	}
 	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
 	return nil
 }
@@ -3538,7 +3610,11 @@ func Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out 
 }
 
 func autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
-	out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
+	if in.CephMonitors == nil {
+		out.CephMonitors = make([]string, 0)
+	} else {
+		out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
+	}
 	out.RBDImage = in.RBDImage
 	out.FSType = in.FSType
 	out.RBDPool = in.RBDPool
@@ -3567,7 +3643,11 @@ func Convert_v1_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation, out 
 func autoConvert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, out *RangeAllocation, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Range = in.Range
-	out.Data = *(*[]byte)(unsafe.Pointer(&in.Data))
+	if in.Data == nil {
+		out.Data = make([]byte, 0)
+	} else {
+		out.Data = *(*[]byte)(unsafe.Pointer(&in.Data))
+	}
 	return nil
 }
 
@@ -3662,7 +3742,7 @@ func autoConvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(i
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ReplicationController, 0)
 	}
 	return nil
 }
@@ -3799,7 +3879,11 @@ func Convert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuotaList
 
 func autoConvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuotaList, out *ResourceQuotaList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ResourceQuota)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ResourceQuota, 0)
+	} else {
+		out.Items = *(*[]ResourceQuota)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -4027,7 +4111,7 @@ func autoConvert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *Secret
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Secret, 0)
 	}
 	return nil
 }
@@ -4202,7 +4286,11 @@ func Convert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountL
 
 func autoConvert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAccountList, out *ServiceAccountList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ServiceAccount)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ServiceAccount, 0)
+	} else {
+		out.Items = *(*[]ServiceAccount)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -4241,7 +4329,7 @@ func autoConvert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *Ser
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Service, 0)
 	}
 	return nil
 }

--- a/pkg/apis/apps/v1beta1/BUILD
+++ b/pkg/apis/apps/v1beta1/BUILD
@@ -65,6 +65,7 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/apps/install:go_default_library",
         "//pkg/apis/apps/v1beta1:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/api/equality",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/util/intstr",
     ],

--- a/pkg/apis/apps/v1beta1/defaults_test.go
+++ b/pkg/apis/apps/v1beta1/defaults_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/api"
@@ -173,7 +174,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			t.Errorf("unexpected object: %v", got)
 			t.FailNow()
 		}
-		if !reflect.DeepEqual(got.Spec, expected.Spec) {
+		if !apiequality.Semantic.DeepEqual(got.Spec, expected.Spec) {
 			t.Errorf("object mismatch!\nexpected:\n\t%+v\ngot:\n\t%+v", got.Spec, expected.Spec)
 		}
 	}

--- a/pkg/apis/apps/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.conversion.go
@@ -110,7 +110,7 @@ func autoConvert_apps_StatefulSetList_To_v1beta1_StatefulSetList(in *apps.Statef
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]StatefulSet, 0)
 	}
 	return nil
 }

--- a/pkg/apis/autoscaling/v1/zz_generated.conversion.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.conversion.go
@@ -149,7 +149,7 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v1_HorizontalPodAuto
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]HorizontalPodAutoscaler, 0)
 	}
 	return nil
 }

--- a/pkg/apis/autoscaling/v2alpha1/zz_generated.conversion.go
+++ b/pkg/apis/autoscaling/v2alpha1/zz_generated.conversion.go
@@ -132,7 +132,11 @@ func Convert_v2alpha1_HorizontalPodAutoscalerList_To_autoscaling_HorizontalPodAu
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v2alpha1_HorizontalPodAutoscalerList(in *autoscaling.HorizontalPodAutoscalerList, out *HorizontalPodAutoscalerList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]HorizontalPodAutoscaler)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]HorizontalPodAutoscaler, 0)
+	} else {
+		out.Items = *(*[]HorizontalPodAutoscaler)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -186,7 +190,11 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerStatus_To_v2alpha1_Horizonta
 	out.LastScaleTime = (*v1.Time)(unsafe.Pointer(in.LastScaleTime))
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	out.CurrentMetrics = *(*[]MetricStatus)(unsafe.Pointer(&in.CurrentMetrics))
+	if in.CurrentMetrics == nil {
+		out.CurrentMetrics = make([]MetricStatus, 0)
+	} else {
+		out.CurrentMetrics = *(*[]MetricStatus)(unsafe.Pointer(&in.CurrentMetrics))
+	}
 	return nil
 }
 

--- a/pkg/apis/batch/v1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v1/zz_generated.conversion.go
@@ -140,7 +140,7 @@ func autoConvert_batch_JobList_To_v1_JobList(in *batch.JobList, out *JobList, s 
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Job, 0)
 	}
 	return nil
 }

--- a/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
@@ -115,7 +115,7 @@ func autoConvert_batch_CronJobList_To_v2alpha1_CronJobList(in *batch.CronJobList
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]CronJob, 0)
 	}
 	return nil
 }

--- a/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
@@ -114,7 +114,11 @@ func Convert_v1beta1_CertificateSigningRequestList_To_certificates_CertificateSi
 
 func autoConvert_certificates_CertificateSigningRequestList_To_v1beta1_CertificateSigningRequestList(in *certificates.CertificateSigningRequestList, out *CertificateSigningRequestList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]CertificateSigningRequest)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CertificateSigningRequest, 0)
+	} else {
+		out.Items = *(*[]CertificateSigningRequest)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -137,7 +141,11 @@ func Convert_v1beta1_CertificateSigningRequestSpec_To_certificates_CertificateSi
 }
 
 func autoConvert_certificates_CertificateSigningRequestSpec_To_v1beta1_CertificateSigningRequestSpec(in *certificates.CertificateSigningRequestSpec, out *CertificateSigningRequestSpec, s conversion.Scope) error {
-	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
+	if in.Request == nil {
+		out.Request = make([]byte, 0)
+	} else {
+		out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
+	}
 	out.Usages = *(*[]KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -458,9 +458,21 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 	if err := v1.Convert_bool_To_Pointer_bool(&in.AllowPrivileged, &out.AllowPrivileged, s); err != nil {
 		return err
 	}
-	out.HostNetworkSources = *(*[]string)(unsafe.Pointer(&in.HostNetworkSources))
-	out.HostPIDSources = *(*[]string)(unsafe.Pointer(&in.HostPIDSources))
-	out.HostIPCSources = *(*[]string)(unsafe.Pointer(&in.HostIPCSources))
+	if in.HostNetworkSources == nil {
+		out.HostNetworkSources = make([]string, 0)
+	} else {
+		out.HostNetworkSources = *(*[]string)(unsafe.Pointer(&in.HostNetworkSources))
+	}
+	if in.HostPIDSources == nil {
+		out.HostPIDSources = make([]string, 0)
+	} else {
+		out.HostPIDSources = *(*[]string)(unsafe.Pointer(&in.HostPIDSources))
+	}
+	if in.HostIPCSources == nil {
+		out.HostIPCSources = make([]string, 0)
+	} else {
+		out.HostIPCSources = *(*[]string)(unsafe.Pointer(&in.HostIPCSources))
+	}
 	if err := v1.Convert_int32_To_Pointer_int32(&in.RegistryPullQPS, &out.RegistryPullQPS, s); err != nil {
 		return err
 	}
@@ -489,7 +501,11 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 	}
 	out.ClusterDomain = in.ClusterDomain
 	out.MasterServiceNamespace = in.MasterServiceNamespace
-	out.ClusterDNS = *(*[]string)(unsafe.Pointer(&in.ClusterDNS))
+	if in.ClusterDNS == nil {
+		out.ClusterDNS = make([]string, 0)
+	} else {
+		out.ClusterDNS = *(*[]string)(unsafe.Pointer(&in.ClusterDNS))
+	}
 	out.StreamingConnectionIdleTimeout = in.StreamingConnectionIdleTimeout
 	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	out.ImageMinimumGCAge = in.ImageMinimumGCAge
@@ -546,7 +562,11 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 	if err := v1.Convert_bool_To_Pointer_bool(&in.RegisterSchedulable, &out.RegisterSchedulable, s); err != nil {
 		return err
 	}
-	out.RegisterWithTaints = *(*[]api_v1.Taint)(unsafe.Pointer(&in.RegisterWithTaints))
+	if in.RegisterWithTaints == nil {
+		out.RegisterWithTaints = make([]api_v1.Taint, 0)
+	} else {
+		out.RegisterWithTaints = *(*[]api_v1.Taint)(unsafe.Pointer(&in.RegisterWithTaints))
+	}
 	out.ContentType = in.ContentType
 	if err := v1.Convert_int32_To_Pointer_int32(&in.KubeAPIQPS, &out.KubeAPIQPS, s); err != nil {
 		return err

--- a/pkg/apis/extensions/v1beta1/BUILD
+++ b/pkg/apis/extensions/v1beta1/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/extensions/install:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//vendor:k8s.io/apimachinery/pkg/api/equality",
         "//vendor:k8s.io/apimachinery/pkg/api/resource",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",

--- a/pkg/apis/extensions/v1beta1/defaults_test.go
+++ b/pkg/apis/extensions/v1beta1/defaults_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -156,7 +157,7 @@ func TestSetDefaultDaemonSet(t *testing.T) {
 			t.Errorf("(%d) unexpected object: %v", i, got)
 			t.FailNow()
 		}
-		if !reflect.DeepEqual(got.Spec, expected.Spec) {
+		if !apiequality.Semantic.DeepEqual(got.Spec, expected.Spec) {
 			t.Errorf("(%d) got different than expected\ngot:\n\t%+v\nexpected:\n\t%+v", i, got.Spec, expected.Spec)
 		}
 	}
@@ -295,7 +296,7 @@ func TestSetDefaultDeployment(t *testing.T) {
 			t.Errorf("unexpected object: %v", got)
 			t.FailNow()
 		}
-		if !reflect.DeepEqual(got.Spec, expected.Spec) {
+		if !apiequality.Semantic.DeepEqual(got.Spec, expected.Spec) {
 			t.Errorf("object mismatch!\nexpected:\n\t%+v\ngot:\n\t%+v", got.Spec, expected.Spec)
 		}
 	}

--- a/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
@@ -206,7 +206,11 @@ func Convert_v1beta1_CustomMetricCurrentStatusList_To_extensions_CustomMetricCur
 }
 
 func autoConvert_extensions_CustomMetricCurrentStatusList_To_v1beta1_CustomMetricCurrentStatusList(in *extensions.CustomMetricCurrentStatusList, out *CustomMetricCurrentStatusList, s conversion.Scope) error {
-	out.Items = *(*[]CustomMetricCurrentStatus)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CustomMetricCurrentStatus, 0)
+	} else {
+		out.Items = *(*[]CustomMetricCurrentStatus)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -244,7 +248,11 @@ func Convert_v1beta1_CustomMetricTargetList_To_extensions_CustomMetricTargetList
 }
 
 func autoConvert_extensions_CustomMetricTargetList_To_v1beta1_CustomMetricTargetList(in *extensions.CustomMetricTargetList, out *CustomMetricTargetList, s conversion.Scope) error {
-	out.Items = *(*[]CustomMetricTarget)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CustomMetricTarget, 0)
+	} else {
+		out.Items = *(*[]CustomMetricTarget)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -313,7 +321,7 @@ func autoConvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extension
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]DaemonSet, 0)
 	}
 	return nil
 }
@@ -513,7 +521,7 @@ func autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Deployment, 0)
 	}
 	return nil
 }
@@ -698,7 +706,11 @@ func Convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in 
 }
 
 func autoConvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
-	out.Paths = *(*[]HTTPIngressPath)(unsafe.Pointer(&in.Paths))
+	if in.Paths == nil {
+		out.Paths = make([]HTTPIngressPath, 0)
+	} else {
+		out.Paths = *(*[]HTTPIngressPath)(unsafe.Pointer(&in.Paths))
+	}
 	return nil
 }
 
@@ -808,7 +820,11 @@ func Convert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, out 
 
 func autoConvert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.IngressList, out *IngressList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Ingress)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Ingress, 0)
+	} else {
+		out.Items = *(*[]Ingress)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -980,7 +996,11 @@ func Convert_v1beta1_NetworkPolicyList_To_extensions_NetworkPolicyList(in *Netwo
 
 func autoConvert_extensions_NetworkPolicyList_To_v1beta1_NetworkPolicyList(in *extensions.NetworkPolicyList, out *NetworkPolicyList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]NetworkPolicy)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]NetworkPolicy, 0)
+	} else {
+		out.Items = *(*[]NetworkPolicy)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1103,7 +1123,7 @@ func autoConvert_extensions_PodSecurityPolicyList_To_v1beta1_PodSecurityPolicyLi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodSecurityPolicy, 0)
 	}
 	return nil
 }
@@ -1279,7 +1299,7 @@ func autoConvert_extensions_ReplicaSetList_To_v1beta1_ReplicaSetList(in *extensi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ReplicaSet, 0)
 	}
 	return nil
 }
@@ -1571,7 +1591,11 @@ func Convert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResource
 
 func autoConvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in *extensions.ThirdPartyResourceDataList, out *ThirdPartyResourceDataList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ThirdPartyResourceData)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ThirdPartyResourceData, 0)
+	} else {
+		out.Items = *(*[]ThirdPartyResourceData)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1591,7 +1615,11 @@ func Convert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList
 
 func autoConvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in *extensions.ThirdPartyResourceList, out *ThirdPartyResourceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ThirdPartyResource)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ThirdPartyResource, 0)
+	} else {
+		out.Items = *(*[]ThirdPartyResource)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/pkg/apis/policy/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.conversion.go
@@ -111,7 +111,11 @@ func Convert_v1beta1_PodDisruptionBudgetList_To_policy_PodDisruptionBudgetList(i
 
 func autoConvert_policy_PodDisruptionBudgetList_To_v1beta1_PodDisruptionBudgetList(in *policy.PodDisruptionBudgetList, out *PodDisruptionBudgetList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]PodDisruptionBudget)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]PodDisruptionBudget, 0)
+	} else {
+		out.Items = *(*[]PodDisruptionBudget)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1alpha1_ClusterRole_To_rbac_ClusterRole(in *ClusterRole, out *rbac
 
 func autoConvert_rbac_ClusterRole_To_v1alpha1_ClusterRole(in *rbac.ClusterRole, out *ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -118,7 +122,7 @@ func autoConvert_rbac_ClusterRoleBinding_To_v1alpha1_ClusterRoleBinding(in *rbac
 			}
 		}
 	} else {
-		out.Subjects = nil
+		out.Subjects = make([]Subject, 0)
 	}
 	if err := Convert_rbac_RoleRef_To_v1alpha1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
@@ -183,7 +187,7 @@ func autoConvert_rbac_ClusterRoleBindingList_To_v1alpha1_ClusterRoleBindingList(
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ClusterRoleBinding, 0)
 	}
 	return nil
 }
@@ -204,7 +208,11 @@ func Convert_v1alpha1_ClusterRoleList_To_rbac_ClusterRoleList(in *ClusterRoleLis
 
 func autoConvert_rbac_ClusterRoleList_To_v1alpha1_ClusterRoleList(in *rbac.ClusterRoleList, out *ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRole, 0)
+	} else {
+		out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -226,7 +234,11 @@ func Convert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.Po
 }
 
 func autoConvert_rbac_PolicyRule_To_v1alpha1_PolicyRule(in *rbac.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	if in.Verbs == nil {
+		out.Verbs = make([]string, 0)
+	} else {
+		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	}
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -272,7 +284,11 @@ func Convert_v1alpha1_Role_To_rbac_Role(in *Role, out *rbac.Role, s conversion.S
 
 func autoConvert_rbac_Role_To_v1alpha1_Role(in *rbac.Role, out *Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -314,7 +330,7 @@ func autoConvert_rbac_RoleBinding_To_v1alpha1_RoleBinding(in *rbac.RoleBinding, 
 			}
 		}
 	} else {
-		out.Subjects = nil
+		out.Subjects = make([]Subject, 0)
 	}
 	if err := Convert_rbac_RoleRef_To_v1alpha1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
@@ -357,7 +373,7 @@ func autoConvert_rbac_RoleBindingList_To_v1alpha1_RoleBindingList(in *rbac.RoleB
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]RoleBinding, 0)
 	}
 	return nil
 }
@@ -378,7 +394,11 @@ func Convert_v1alpha1_RoleList_To_rbac_RoleList(in *RoleList, out *rbac.RoleList
 
 func autoConvert_rbac_RoleList_To_v1alpha1_RoleList(in *rbac.RoleList, out *RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Role, 0)
+	} else {
+		out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1beta1_ClusterRole_To_rbac_ClusterRole(in *ClusterRole, out *rbac.
 
 func autoConvert_rbac_ClusterRole_To_v1beta1_ClusterRole(in *rbac.ClusterRole, out *ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -99,7 +103,11 @@ func Convert_v1beta1_ClusterRoleBinding_To_rbac_ClusterRoleBinding(in *ClusterRo
 
 func autoConvert_rbac_ClusterRoleBinding_To_v1beta1_ClusterRoleBinding(in *rbac.ClusterRoleBinding, out *ClusterRoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	if in.Subjects == nil {
+		out.Subjects = make([]Subject, 0)
+	} else {
+		out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	}
 	if err := Convert_rbac_RoleRef_To_v1beta1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -144,7 +152,11 @@ func Convert_v1beta1_ClusterRoleBindingList_To_rbac_ClusterRoleBindingList(in *C
 
 func autoConvert_rbac_ClusterRoleBindingList_To_v1beta1_ClusterRoleBindingList(in *rbac.ClusterRoleBindingList, out *ClusterRoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRoleBinding)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRoleBinding, 0)
+	} else {
+		out.Items = *(*[]ClusterRoleBinding)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -164,7 +176,11 @@ func Convert_v1beta1_ClusterRoleList_To_rbac_ClusterRoleList(in *ClusterRoleList
 
 func autoConvert_rbac_ClusterRoleList_To_v1beta1_ClusterRoleList(in *rbac.ClusterRoleList, out *ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRole, 0)
+	} else {
+		out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -186,7 +202,11 @@ func Convert_v1beta1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.Pol
 }
 
 func autoConvert_rbac_PolicyRule_To_v1beta1_PolicyRule(in *rbac.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	if in.Verbs == nil {
+		out.Verbs = make([]string, 0)
+	} else {
+		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	}
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -232,7 +252,11 @@ func Convert_v1beta1_Role_To_rbac_Role(in *Role, out *rbac.Role, s conversion.Sc
 
 func autoConvert_rbac_Role_To_v1beta1_Role(in *rbac.Role, out *Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -255,7 +279,11 @@ func Convert_v1beta1_RoleBinding_To_rbac_RoleBinding(in *RoleBinding, out *rbac.
 
 func autoConvert_rbac_RoleBinding_To_v1beta1_RoleBinding(in *rbac.RoleBinding, out *RoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	if in.Subjects == nil {
+		out.Subjects = make([]Subject, 0)
+	} else {
+		out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	}
 	if err := Convert_rbac_RoleRef_To_v1beta1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -278,7 +306,11 @@ func Convert_v1beta1_RoleBindingList_To_rbac_RoleBindingList(in *RoleBindingList
 
 func autoConvert_rbac_RoleBindingList_To_v1beta1_RoleBindingList(in *rbac.RoleBindingList, out *RoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]RoleBinding)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]RoleBinding, 0)
+	} else {
+		out.Items = *(*[]RoleBinding)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -298,7 +330,11 @@ func Convert_v1beta1_RoleList_To_rbac_RoleList(in *RoleList, out *rbac.RoleList,
 
 func autoConvert_rbac_RoleList_To_v1beta1_RoleList(in *rbac.RoleList, out *RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Role, 0)
+	} else {
+		out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/pkg/apis/settings/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/settings/v1alpha1/zz_generated.conversion.go
@@ -101,7 +101,7 @@ func autoConvert_settings_PodPresetList_To_v1alpha1_PodPresetList(in *settings.P
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodPreset, 0)
 	}
 	return nil
 }

--- a/pkg/apis/storage/v1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1_StorageClassList_To_storage_StorageClassList(in *StorageClassLis
 
 func autoConvert_storage_StorageClassList_To_v1_StorageClassList(in *storage.StorageClassList, out *StorageClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]StorageClass, 0)
+	} else {
+		out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/pkg/apis/storage/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1beta1_StorageClassList_To_storage_StorageClassList(in *StorageCla
 
 func autoConvert_storage_StorageClassList_To_v1beta1_StorageClassList(in *storage.StorageClassList, out *StorageClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]StorageClass, 0)
+	} else {
+		out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -152,6 +152,7 @@ go_test(
         "//pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion:go_default_library",
         "//pkg/controller/deployment/util:go_default_library",
         "//vendor:github.com/spf13/cobra",
+        "//vendor:k8s.io/apimachinery/pkg/api/equality",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/api/resource",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -102,6 +102,7 @@ go_test(
         "//pkg/util/exec:go_default_library",
         "//vendor:github.com/emicklei/go-restful/swagger",
         "//vendor:github.com/stretchr/testify/assert",
+        "//vendor:k8s.io/apimachinery/pkg/api/equality",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/api/meta",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -25,12 +25,12 @@ import (
 	"os"
 	"os/user"
 	"path"
-	"reflect"
 	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -623,7 +623,7 @@ func TestGetFirstPod(t *testing.T) {
 			t.Errorf("%s: expected %d pods, got %d", test.name, test.expectedNum, numPods)
 			continue
 		}
-		if !reflect.DeepEqual(test.expected, pod) {
+		if !apiequality.Semantic.DeepEqual(test.expected, pod) {
 			t.Errorf("%s:\nexpected pod:\n%#v\ngot:\n%#v\n\n", test.name, test.expected, pod)
 		}
 	}

--- a/pkg/kubectl/cmd/util/helpers_test.go
+++ b/pkg/kubectl/cmd/util/helpers_test.go
@@ -21,11 +21,11 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"reflect"
 	"strings"
 	"syscall"
 	"testing"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,7 +194,7 @@ func TestMerge(t *testing.T) {
 		if !test.expectErr {
 			if err != nil {
 				t.Errorf("testcase[%d], unexpected error: %v", i, err)
-			} else if !reflect.DeepEqual(out, test.expected) {
+			} else if !apiequality.Semantic.DeepEqual(out, test.expected) {
 				t.Errorf("\n\ntestcase[%d]\nexpected:\n%+v\nsaw:\n%+v", i, test.expected, out)
 			}
 		}
@@ -374,7 +374,7 @@ func TestMaybeConvert(t *testing.T) {
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
-		if !reflect.DeepEqual(test.expected, obj) {
+		if !apiequality.Semantic.DeepEqual(test.expected, obj) {
 			t.Errorf("expected:\n%#v\nsaw:\n%#v\n", test.expected, obj)
 		}
 	}

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -556,7 +556,7 @@ func TestResourceByName(t *testing.T) {
 	if err != nil || !singleItemImplied || len(test.Infos) != 1 {
 		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, test.Infos)
 	}
-	if !reflect.DeepEqual(&pods.Items[0], test.Objects()[0]) {
+	if !apiequality.Semantic.DeepEqual(&pods.Items[0], test.Objects()[0]) {
 		t.Errorf("unexpected object: %#v", test.Objects()[0])
 	}
 
@@ -621,10 +621,10 @@ func TestResourceNames(t *testing.T) {
 	if err != nil || len(test.Infos) != 2 {
 		t.Fatalf("unexpected response: %v %#v", err, test.Infos)
 	}
-	if !reflect.DeepEqual(&pods.Items[0], test.Objects()[0]) {
+	if !apiequality.Semantic.DeepEqual(&pods.Items[0], test.Objects()[0]) {
 		t.Errorf("unexpected object: \n%#v, expected: \n%#v", test.Objects()[0], &pods.Items[0])
 	}
-	if !reflect.DeepEqual(&svc.Items[0], test.Objects()[1]) {
+	if !apiequality.Semantic.DeepEqual(&svc.Items[0], test.Objects()[1]) {
 		t.Errorf("unexpected object: \n%#v, expected: \n%#v", test.Objects()[1], &svc.Items[0])
 	}
 }
@@ -698,7 +698,7 @@ func TestResourceByNameAndEmptySelector(t *testing.T) {
 	if err != nil || !singleItemImplied || len(infos) != 1 {
 		t.Fatalf("unexpected response: %v %t %#v", err, singleItemImplied, infos)
 	}
-	if !reflect.DeepEqual(&pods.Items[0], infos[0].Object) {
+	if !apiequality.Semantic.DeepEqual(&pods.Items[0], infos[0].Object) {
 		t.Errorf("unexpected object: %#v", infos[0])
 	}
 

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1475,7 +1476,7 @@ func TestUpdateRcWithRetries(t *testing.T) {
 				updates = updates[1:]
 				// We should always get an update with a valid rc even when the get fails. The rc should always
 				// contain the update.
-				if c, ok := readOrDie(t, req, codec).(*api.ReplicationController); !ok || !reflect.DeepEqual(rc, c) {
+				if c, ok := readOrDie(t, req, codec).(*api.ReplicationController); !ok || !apiequality.Semantic.DeepEqual(rc, c) {
 					t.Errorf("Unexpected update body, got %+v expected %+v", c, rc)
 				} else if sel, ok := c.Spec.Selector["baz"]; !ok || sel != "foobar" {
 					t.Errorf("Expected selector label update, got %+v", c.Spec.Selector)

--- a/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1/zz_generated.conversion.go
+++ b/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1/zz_generated.conversion.go
@@ -52,7 +52,11 @@ func Convert_v1alpha1_Configuration_To_resourcequota_Configuration(in *Configura
 }
 
 func autoConvert_resourcequota_Configuration_To_v1alpha1_Configuration(in *resourcequota.Configuration, out *Configuration, s conversion.Scope) error {
-	out.LimitedResources = *(*[]LimitedResource)(unsafe.Pointer(&in.LimitedResources))
+	if in.LimitedResources == nil {
+		out.LimitedResources = make([]LimitedResource, 0)
+	} else {
+		out.LimitedResources = *(*[]LimitedResource)(unsafe.Pointer(&in.LimitedResources))
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -70,7 +70,7 @@ func autoConvert_apiserver_AdmissionConfiguration_To_v1alpha1_AdmissionConfigura
 			}
 		}
 	} else {
-		out.Plugins = nil
+		out.Plugins = make([]AdmissionPluginConfiguration, 0)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.conversion.go
@@ -138,7 +138,7 @@ func autoConvert_example_PodList_To_v1_PodList(in *example.PodList, out *PodList
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Pod, 0)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/pkg/api/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/zz_generated.conversion.go
@@ -565,7 +565,11 @@ func Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSou
 }
 
 func autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
-	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
+	if in.Monitors == nil {
+		out.Monitors = make([]string, 0)
+	} else {
+		out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
+	}
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
@@ -656,7 +660,11 @@ func Convert_v1_ComponentStatusList_To_api_ComponentStatusList(in *ComponentStat
 
 func autoConvert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.ComponentStatusList, out *ComponentStatusList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ComponentStatus)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ComponentStatus, 0)
+	} else {
+		out.Items = *(*[]ComponentStatus)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -746,7 +754,11 @@ func Convert_v1_ConfigMapList_To_api_ConfigMapList(in *ConfigMapList, out *api.C
 
 func autoConvert_api_ConfigMapList_To_v1_ConfigMapList(in *api.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ConfigMap)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ConfigMap, 0)
+	} else {
+		out.Items = *(*[]ConfigMap)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -879,7 +891,11 @@ func Convert_v1_ContainerImage_To_api_ContainerImage(in *ContainerImage, out *ap
 }
 
 func autoConvert_api_ContainerImage_To_v1_ContainerImage(in *api.ContainerImage, out *ContainerImage, s conversion.Scope) error {
-	out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
+	if in.Names == nil {
+		out.Names = make([]string, 0)
+	} else {
+		out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
+	}
 	out.SizeBytes = in.SizeBytes
 	return nil
 }
@@ -1246,7 +1262,11 @@ func Convert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints, s 
 
 func autoConvert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subsets = *(*[]EndpointSubset)(unsafe.Pointer(&in.Subsets))
+	if in.Subsets == nil {
+		out.Subsets = make([]EndpointSubset, 0)
+	} else {
+		out.Subsets = *(*[]EndpointSubset)(unsafe.Pointer(&in.Subsets))
+	}
 	return nil
 }
 
@@ -1266,7 +1286,11 @@ func Convert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *api.E
 
 func autoConvert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *EndpointsList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Endpoints)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Endpoints, 0)
+	} else {
+		out.Items = *(*[]Endpoints)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1396,7 +1420,11 @@ func Convert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList, s 
 
 func autoConvert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Event, 0)
+	} else {
+		out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1455,7 +1483,11 @@ func Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *ap
 }
 
 func autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
-	out.TargetWWNs = *(*[]string)(unsafe.Pointer(&in.TargetWWNs))
+	if in.TargetWWNs == nil {
+		out.TargetWWNs = make([]string, 0)
+	} else {
+		out.TargetWWNs = *(*[]string)(unsafe.Pointer(&in.TargetWWNs))
+	}
 	out.Lun = (*int32)(unsafe.Pointer(in.Lun))
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
@@ -1802,7 +1834,11 @@ func Convert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out *ap
 
 func autoConvert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out *LimitRangeList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]LimitRange)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]LimitRange, 0)
+	} else {
+		out.Items = *(*[]LimitRange)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1820,7 +1856,11 @@ func Convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *ap
 }
 
 func autoConvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
-	out.Limits = *(*[]LimitRangeItem)(unsafe.Pointer(&in.Limits))
+	if in.Limits == nil {
+		out.Limits = make([]LimitRangeItem, 0)
+	} else {
+		out.Limits = *(*[]LimitRangeItem)(unsafe.Pointer(&in.Limits))
+	}
 	return nil
 }
 
@@ -1859,7 +1899,7 @@ func autoConvert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]runtime.RawExtension, 0)
 	}
 	return nil
 }
@@ -2022,7 +2062,11 @@ func Convert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *api.N
 
 func autoConvert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *NamespaceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Namespace)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Namespace, 0)
+	} else {
+		out.Items = *(*[]Namespace)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2198,7 +2242,11 @@ func Convert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conv
 
 func autoConvert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Node)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Node, 0)
+	} else {
+		out.Items = *(*[]Node)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2252,7 +2300,11 @@ func Convert_v1_NodeSelector_To_api_NodeSelector(in *NodeSelector, out *api.Node
 }
 
 func autoConvert_api_NodeSelector_To_v1_NodeSelector(in *api.NodeSelector, out *NodeSelector, s conversion.Scope) error {
-	out.NodeSelectorTerms = *(*[]NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
+	if in.NodeSelectorTerms == nil {
+		out.NodeSelectorTerms = make([]NodeSelectorTerm, 0)
+	} else {
+		out.NodeSelectorTerms = *(*[]NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
+	}
 	return nil
 }
 
@@ -2292,7 +2344,11 @@ func Convert_v1_NodeSelectorTerm_To_api_NodeSelectorTerm(in *NodeSelectorTerm, o
 }
 
 func autoConvert_api_NodeSelectorTerm_To_v1_NodeSelectorTerm(in *api.NodeSelectorTerm, out *NodeSelectorTerm, s conversion.Scope) error {
-	out.MatchExpressions = *(*[]NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	if in.MatchExpressions == nil {
+		out.MatchExpressions = make([]NodeSelectorRequirement, 0)
+	} else {
+		out.MatchExpressions = *(*[]NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	}
 	return nil
 }
 
@@ -2574,7 +2630,11 @@ func Convert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *P
 
 func autoConvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *api.PersistentVolumeClaimList, out *PersistentVolumeClaimList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]PersistentVolumeClaim)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]PersistentVolumeClaim, 0)
+	} else {
+		out.Items = *(*[]PersistentVolumeClaim)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2685,7 +2745,7 @@ func autoConvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.Per
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PersistentVolume, 0)
 	}
 	return nil
 }
@@ -2980,7 +3040,11 @@ func autoConvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions,
 	out.Stderr = in.Stderr
 	out.TTY = in.TTY
 	out.Container = in.Container
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
+	if in.Command == nil {
+		out.Command = make([]string, 0)
+	} else {
+		out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
+	}
 	return nil
 }
 
@@ -3019,7 +3083,7 @@ func autoConvert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conv
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Pod, 0)
 	}
 	return nil
 }
@@ -3192,7 +3256,11 @@ func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 		out.Volumes = nil
 	}
 	out.InitContainers = *(*[]Container)(unsafe.Pointer(&in.InitContainers))
-	out.Containers = *(*[]Container)(unsafe.Pointer(&in.Containers))
+	if in.Containers == nil {
+		out.Containers = make([]Container, 0)
+	} else {
+		out.Containers = *(*[]Container)(unsafe.Pointer(&in.Containers))
+	}
 	out.RestartPolicy = RestartPolicy(in.RestartPolicy)
 	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
 	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
@@ -3326,7 +3394,7 @@ func autoConvert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateLi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodTemplate, 0)
 	}
 	return nil
 }
@@ -3486,7 +3554,11 @@ func Convert_v1_ProjectedVolumeSource_To_api_ProjectedVolumeSource(in *Projected
 }
 
 func autoConvert_api_ProjectedVolumeSource_To_v1_ProjectedVolumeSource(in *api.ProjectedVolumeSource, out *ProjectedVolumeSource, s conversion.Scope) error {
-	out.Sources = *(*[]VolumeProjection)(unsafe.Pointer(&in.Sources))
+	if in.Sources == nil {
+		out.Sources = make([]VolumeProjection, 0)
+	} else {
+		out.Sources = *(*[]VolumeProjection)(unsafe.Pointer(&in.Sources))
+	}
 	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
 	return nil
 }
@@ -3538,7 +3610,11 @@ func Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out 
 }
 
 func autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
-	out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
+	if in.CephMonitors == nil {
+		out.CephMonitors = make([]string, 0)
+	} else {
+		out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
+	}
 	out.RBDImage = in.RBDImage
 	out.FSType = in.FSType
 	out.RBDPool = in.RBDPool
@@ -3567,7 +3643,11 @@ func Convert_v1_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation, out 
 func autoConvert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, out *RangeAllocation, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Range = in.Range
-	out.Data = *(*[]byte)(unsafe.Pointer(&in.Data))
+	if in.Data == nil {
+		out.Data = make([]byte, 0)
+	} else {
+		out.Data = *(*[]byte)(unsafe.Pointer(&in.Data))
+	}
 	return nil
 }
 
@@ -3662,7 +3742,7 @@ func autoConvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(i
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ReplicationController, 0)
 	}
 	return nil
 }
@@ -3799,7 +3879,11 @@ func Convert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuotaList
 
 func autoConvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuotaList, out *ResourceQuotaList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ResourceQuota)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ResourceQuota, 0)
+	} else {
+		out.Items = *(*[]ResourceQuota)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -4027,7 +4111,7 @@ func autoConvert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *Secret
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Secret, 0)
 	}
 	return nil
 }
@@ -4202,7 +4286,11 @@ func Convert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountL
 
 func autoConvert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAccountList, out *ServiceAccountList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ServiceAccount)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ServiceAccount, 0)
+	} else {
+		out.Items = *(*[]ServiceAccount)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -4241,7 +4329,7 @@ func autoConvert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *Ser
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Service, 0)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/apps/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/apps/v1beta1/zz_generated.conversion.go
@@ -110,7 +110,7 @@ func autoConvert_apps_StatefulSetList_To_v1beta1_StatefulSetList(in *apps.Statef
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]StatefulSet, 0)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/autoscaling/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/autoscaling/v1/zz_generated.conversion.go
@@ -149,7 +149,7 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v1_HorizontalPodAuto
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]HorizontalPodAutoscaler, 0)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/autoscaling/v2alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/autoscaling/v2alpha1/zz_generated.conversion.go
@@ -132,7 +132,11 @@ func Convert_v2alpha1_HorizontalPodAutoscalerList_To_autoscaling_HorizontalPodAu
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v2alpha1_HorizontalPodAutoscalerList(in *autoscaling.HorizontalPodAutoscalerList, out *HorizontalPodAutoscalerList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]HorizontalPodAutoscaler)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]HorizontalPodAutoscaler, 0)
+	} else {
+		out.Items = *(*[]HorizontalPodAutoscaler)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -186,7 +190,11 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerStatus_To_v2alpha1_Horizonta
 	out.LastScaleTime = (*v1.Time)(unsafe.Pointer(in.LastScaleTime))
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	out.CurrentMetrics = *(*[]MetricStatus)(unsafe.Pointer(&in.CurrentMetrics))
+	if in.CurrentMetrics == nil {
+		out.CurrentMetrics = make([]MetricStatus, 0)
+	} else {
+		out.CurrentMetrics = *(*[]MetricStatus)(unsafe.Pointer(&in.CurrentMetrics))
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/batch/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/batch/v1/zz_generated.conversion.go
@@ -140,7 +140,7 @@ func autoConvert_batch_JobList_To_v1_JobList(in *batch.JobList, out *JobList, s 
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Job, 0)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
@@ -115,7 +115,7 @@ func autoConvert_batch_CronJobList_To_v2alpha1_CronJobList(in *batch.CronJobList
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]CronJob, 0)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
@@ -114,7 +114,11 @@ func Convert_v1beta1_CertificateSigningRequestList_To_certificates_CertificateSi
 
 func autoConvert_certificates_CertificateSigningRequestList_To_v1beta1_CertificateSigningRequestList(in *certificates.CertificateSigningRequestList, out *CertificateSigningRequestList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]CertificateSigningRequest)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CertificateSigningRequest, 0)
+	} else {
+		out.Items = *(*[]CertificateSigningRequest)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -137,7 +141,11 @@ func Convert_v1beta1_CertificateSigningRequestSpec_To_certificates_CertificateSi
 }
 
 func autoConvert_certificates_CertificateSigningRequestSpec_To_v1beta1_CertificateSigningRequestSpec(in *certificates.CertificateSigningRequestSpec, out *CertificateSigningRequestSpec, s conversion.Scope) error {
-	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
+	if in.Request == nil {
+		out.Request = make([]byte, 0)
+	} else {
+		out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
+	}
 	out.Usages = *(*[]KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID

--- a/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
@@ -206,7 +206,11 @@ func Convert_v1beta1_CustomMetricCurrentStatusList_To_extensions_CustomMetricCur
 }
 
 func autoConvert_extensions_CustomMetricCurrentStatusList_To_v1beta1_CustomMetricCurrentStatusList(in *extensions.CustomMetricCurrentStatusList, out *CustomMetricCurrentStatusList, s conversion.Scope) error {
-	out.Items = *(*[]CustomMetricCurrentStatus)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CustomMetricCurrentStatus, 0)
+	} else {
+		out.Items = *(*[]CustomMetricCurrentStatus)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -244,7 +248,11 @@ func Convert_v1beta1_CustomMetricTargetList_To_extensions_CustomMetricTargetList
 }
 
 func autoConvert_extensions_CustomMetricTargetList_To_v1beta1_CustomMetricTargetList(in *extensions.CustomMetricTargetList, out *CustomMetricTargetList, s conversion.Scope) error {
-	out.Items = *(*[]CustomMetricTarget)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CustomMetricTarget, 0)
+	} else {
+		out.Items = *(*[]CustomMetricTarget)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -313,7 +321,7 @@ func autoConvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extension
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]DaemonSet, 0)
 	}
 	return nil
 }
@@ -513,7 +521,7 @@ func autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Deployment, 0)
 	}
 	return nil
 }
@@ -698,7 +706,11 @@ func Convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in 
 }
 
 func autoConvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
-	out.Paths = *(*[]HTTPIngressPath)(unsafe.Pointer(&in.Paths))
+	if in.Paths == nil {
+		out.Paths = make([]HTTPIngressPath, 0)
+	} else {
+		out.Paths = *(*[]HTTPIngressPath)(unsafe.Pointer(&in.Paths))
+	}
 	return nil
 }
 
@@ -808,7 +820,11 @@ func Convert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, out 
 
 func autoConvert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.IngressList, out *IngressList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Ingress)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Ingress, 0)
+	} else {
+		out.Items = *(*[]Ingress)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -980,7 +996,11 @@ func Convert_v1beta1_NetworkPolicyList_To_extensions_NetworkPolicyList(in *Netwo
 
 func autoConvert_extensions_NetworkPolicyList_To_v1beta1_NetworkPolicyList(in *extensions.NetworkPolicyList, out *NetworkPolicyList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]NetworkPolicy)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]NetworkPolicy, 0)
+	} else {
+		out.Items = *(*[]NetworkPolicy)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1103,7 +1123,7 @@ func autoConvert_extensions_PodSecurityPolicyList_To_v1beta1_PodSecurityPolicyLi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodSecurityPolicy, 0)
 	}
 	return nil
 }
@@ -1279,7 +1299,7 @@ func autoConvert_extensions_ReplicaSetList_To_v1beta1_ReplicaSetList(in *extensi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ReplicaSet, 0)
 	}
 	return nil
 }
@@ -1571,7 +1591,11 @@ func Convert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResource
 
 func autoConvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in *extensions.ThirdPartyResourceDataList, out *ThirdPartyResourceDataList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ThirdPartyResourceData)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ThirdPartyResourceData, 0)
+	} else {
+		out.Items = *(*[]ThirdPartyResourceData)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1591,7 +1615,11 @@ func Convert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList
 
 func autoConvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in *extensions.ThirdPartyResourceList, out *ThirdPartyResourceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ThirdPartyResource)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ThirdPartyResource, 0)
+	} else {
+		out.Items = *(*[]ThirdPartyResource)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/policy/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/policy/v1beta1/zz_generated.conversion.go
@@ -111,7 +111,11 @@ func Convert_v1beta1_PodDisruptionBudgetList_To_policy_PodDisruptionBudgetList(i
 
 func autoConvert_policy_PodDisruptionBudgetList_To_v1beta1_PodDisruptionBudgetList(in *policy.PodDisruptionBudgetList, out *PodDisruptionBudgetList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]PodDisruptionBudget)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]PodDisruptionBudget, 0)
+	} else {
+		out.Items = *(*[]PodDisruptionBudget)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1alpha1_ClusterRole_To_rbac_ClusterRole(in *ClusterRole, out *rbac
 
 func autoConvert_rbac_ClusterRole_To_v1alpha1_ClusterRole(in *rbac.ClusterRole, out *ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -118,7 +122,7 @@ func autoConvert_rbac_ClusterRoleBinding_To_v1alpha1_ClusterRoleBinding(in *rbac
 			}
 		}
 	} else {
-		out.Subjects = nil
+		out.Subjects = make([]Subject, 0)
 	}
 	if err := Convert_rbac_RoleRef_To_v1alpha1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
@@ -183,7 +187,7 @@ func autoConvert_rbac_ClusterRoleBindingList_To_v1alpha1_ClusterRoleBindingList(
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ClusterRoleBinding, 0)
 	}
 	return nil
 }
@@ -204,7 +208,11 @@ func Convert_v1alpha1_ClusterRoleList_To_rbac_ClusterRoleList(in *ClusterRoleLis
 
 func autoConvert_rbac_ClusterRoleList_To_v1alpha1_ClusterRoleList(in *rbac.ClusterRoleList, out *ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRole, 0)
+	} else {
+		out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -226,7 +234,11 @@ func Convert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.Po
 }
 
 func autoConvert_rbac_PolicyRule_To_v1alpha1_PolicyRule(in *rbac.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	if in.Verbs == nil {
+		out.Verbs = make([]string, 0)
+	} else {
+		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	}
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -272,7 +284,11 @@ func Convert_v1alpha1_Role_To_rbac_Role(in *Role, out *rbac.Role, s conversion.S
 
 func autoConvert_rbac_Role_To_v1alpha1_Role(in *rbac.Role, out *Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -314,7 +330,7 @@ func autoConvert_rbac_RoleBinding_To_v1alpha1_RoleBinding(in *rbac.RoleBinding, 
 			}
 		}
 	} else {
-		out.Subjects = nil
+		out.Subjects = make([]Subject, 0)
 	}
 	if err := Convert_rbac_RoleRef_To_v1alpha1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
@@ -357,7 +373,7 @@ func autoConvert_rbac_RoleBindingList_To_v1alpha1_RoleBindingList(in *rbac.RoleB
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]RoleBinding, 0)
 	}
 	return nil
 }
@@ -378,7 +394,11 @@ func Convert_v1alpha1_RoleList_To_rbac_RoleList(in *RoleList, out *rbac.RoleList
 
 func autoConvert_rbac_RoleList_To_v1alpha1_RoleList(in *rbac.RoleList, out *RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Role, 0)
+	} else {
+		out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1beta1_ClusterRole_To_rbac_ClusterRole(in *ClusterRole, out *rbac.
 
 func autoConvert_rbac_ClusterRole_To_v1beta1_ClusterRole(in *rbac.ClusterRole, out *ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -99,7 +103,11 @@ func Convert_v1beta1_ClusterRoleBinding_To_rbac_ClusterRoleBinding(in *ClusterRo
 
 func autoConvert_rbac_ClusterRoleBinding_To_v1beta1_ClusterRoleBinding(in *rbac.ClusterRoleBinding, out *ClusterRoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	if in.Subjects == nil {
+		out.Subjects = make([]Subject, 0)
+	} else {
+		out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	}
 	if err := Convert_rbac_RoleRef_To_v1beta1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -144,7 +152,11 @@ func Convert_v1beta1_ClusterRoleBindingList_To_rbac_ClusterRoleBindingList(in *C
 
 func autoConvert_rbac_ClusterRoleBindingList_To_v1beta1_ClusterRoleBindingList(in *rbac.ClusterRoleBindingList, out *ClusterRoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRoleBinding)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRoleBinding, 0)
+	} else {
+		out.Items = *(*[]ClusterRoleBinding)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -164,7 +176,11 @@ func Convert_v1beta1_ClusterRoleList_To_rbac_ClusterRoleList(in *ClusterRoleList
 
 func autoConvert_rbac_ClusterRoleList_To_v1beta1_ClusterRoleList(in *rbac.ClusterRoleList, out *ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRole, 0)
+	} else {
+		out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -186,7 +202,11 @@ func Convert_v1beta1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.Pol
 }
 
 func autoConvert_rbac_PolicyRule_To_v1beta1_PolicyRule(in *rbac.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	if in.Verbs == nil {
+		out.Verbs = make([]string, 0)
+	} else {
+		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	}
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -232,7 +252,11 @@ func Convert_v1beta1_Role_To_rbac_Role(in *Role, out *rbac.Role, s conversion.Sc
 
 func autoConvert_rbac_Role_To_v1beta1_Role(in *rbac.Role, out *Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -255,7 +279,11 @@ func Convert_v1beta1_RoleBinding_To_rbac_RoleBinding(in *RoleBinding, out *rbac.
 
 func autoConvert_rbac_RoleBinding_To_v1beta1_RoleBinding(in *rbac.RoleBinding, out *RoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	if in.Subjects == nil {
+		out.Subjects = make([]Subject, 0)
+	} else {
+		out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	}
 	if err := Convert_rbac_RoleRef_To_v1beta1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -278,7 +306,11 @@ func Convert_v1beta1_RoleBindingList_To_rbac_RoleBindingList(in *RoleBindingList
 
 func autoConvert_rbac_RoleBindingList_To_v1beta1_RoleBindingList(in *rbac.RoleBindingList, out *RoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]RoleBinding)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]RoleBinding, 0)
+	} else {
+		out.Items = *(*[]RoleBinding)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -298,7 +330,11 @@ func Convert_v1beta1_RoleList_To_rbac_RoleList(in *RoleList, out *rbac.RoleList,
 
 func autoConvert_rbac_RoleList_To_v1beta1_RoleList(in *rbac.RoleList, out *RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Role, 0)
+	} else {
+		out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/settings/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/settings/v1alpha1/zz_generated.conversion.go
@@ -101,7 +101,7 @@ func autoConvert_settings_PodPresetList_To_v1alpha1_PodPresetList(in *settings.P
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodPreset, 0)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/storage/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/storage/v1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1_StorageClassList_To_storage_StorageClassList(in *StorageClassLis
 
 func autoConvert_storage_StorageClassList_To_v1_StorageClassList(in *storage.StorageClassList, out *StorageClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]StorageClass, 0)
+	} else {
+		out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/storage/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/storage/v1beta1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1beta1_StorageClassList_To_storage_StorageClassList(in *StorageCla
 
 func autoConvert_storage_StorageClassList_To_v1beta1_StorageClassList(in *storage.StorageClassList, out *StorageClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]StorageClass, 0)
+	} else {
+		out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/43203 null serialization of slices to prevent NPE errors in clients that store and expect to receive non-null JSON values in these fields.

Ensures when we are converting to an external slice field that will be serialized even if empty (has `json` tag that does not include `omitempty`), we populate it with `[]`, not `nil`

Other places I considered putting this logic instead:

* When unmarshaling
  * Would have to be done for both protobuf and ugorji
  * Would still have to be done here (or on marshal) to handle cases where we construct objects to return
* When marshaling
  * Would have to switch to use custom json marshaler (currently we use stdlib) (or alias all field types and write per-field json marshalers)
* When defaulting
  * Defaulting isn't run on some fields, notably, pod template in rc/deployment spec
  * Would still have to be done here (or on marshal) to handle cases where we construct objects to return

```release-note
API fields that previously serialized null arrays as `null` and empty arrays as `[]` no longer distinguish between those values and always output `[]` when serializing to JSON.
```