### PR TITLE
Fix bug in dockershim when log dir does not exist

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -225,6 +225,14 @@ func (ds *dockerService) createContainerLogSymlink(containerID string) error {
 	if path == "" {
 		glog.V(5).Infof("Container %s log path isn't specified, will not create the symlink", containerID)
 		return nil
+	} else {
+		logDir := filepath.Dir(path)
+		if _, err := os.Stat(logDir); os.IsNotExist(err) {
+			if err = os.MkdirAll(logDir, os.FileMode(0755)); err != nil {
+				return fmt.Errorf("cannot create container log directory %q: %v", logDir, err)
+			}
+			glog.V(5).Infof("Create log directory %q", logDir)
+		}
 	}
 
 	if realPath != "" {


### PR DESCRIPTION
When we wrote logs test case for cri-tools, we found out that dockershim will not create the log dir. So file this PR to fix this bug.

/cc @Random-Liu 

Signed-off-by: Xianglin Gao <xlgao@zju.edu.cn>