### PR TITLE
Increase memory limit for fluentd-gcp

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -41,7 +41,7 @@ spec:
           value: --no-supervisor
         resources:
           limits:
-            memory: 200Mi
+            memory: 300Mi
           requests:
             cpu: 100m
             memory: 200Mi

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -419,7 +419,7 @@ spec:
         </match>
     resources:
       limits:
-        memory: 200Mi
+        memory: 300Mi
       requests:
         # Any change here should be accompanied by a proportional change in CPU
         # requests of other per-node add-ons (e.g. kube-proxy).


### PR DESCRIPTION
This PR increases fluentd memory limit in fluentd-gcp addon to avoid OOMs. Request is left intact