### PR TITLE
Remove unused DockerManager daemon version

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -1876,8 +1876,7 @@ func (dm *DockerManager) calculateOomScoreAdj(pod *v1.Pod, container *v1.Contain
 
 // versionInfo wraps api version and daemon version.
 type versionInfo struct {
-	apiVersion    kubecontainer.Version
-	daemonVersion kubecontainer.Version
+	apiVersion kubecontainer.Version
 }
 
 // checkDockerAPIVersion checks current docker API version against expected version.
@@ -2751,19 +2750,14 @@ func (dm *DockerManager) GetPodStatus(uid kubetypes.UID, name, namespace string)
 	return podStatus, nil
 }
 
-// getVersionInfo returns apiVersion & daemonVersion of docker runtime
+// getVersionInfo returns apiVersion of docker runtime
 func (dm *DockerManager) getVersionInfo() (versionInfo, error) {
 	apiVersion, err := dm.APIVersion()
 	if err != nil {
 		return versionInfo{}, err
 	}
-	daemonVersion, err := dm.Version()
-	if err != nil {
-		return versionInfo{}, err
-	}
 	return versionInfo{
-		apiVersion:    apiVersion,
-		daemonVersion: daemonVersion,
+		apiVersion: apiVersion,
 	}, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the unused daemonVersion field from the versionInfo struct in DockerManager. Because the daemon version is no longer parsed, pods can run on the newer Docker CE.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Remove parsing of Docker daemon version in DockerManager. Allows Kubelet to run pods on the latest Docker CE version.
```
