### PR TITLE
[Federation][e2e] Ensure kubefed times out in federation-up.sh

### DIFF
--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -82,7 +82,9 @@ function init() {
   kube::log::status "DNS_ZONE_NAME: \"${DNS_ZONE_NAME}\", DNS_PROVIDER: \"${DNS_PROVIDER}\""
   kube::log::status "Image: \"${kube_registry}/hyperkube-amd64:${kube_version}\""
 
-  "${KUBE_ROOT}/federation/develop/kubefed.sh" init \
+  # Send INT after 20m and KILL 1m after that if process is still alive.
+  timeout --signal=INT --kill-after=1m 20m \
+      "${KUBE_ROOT}/federation/develop/kubefed.sh" init \
       "${FEDERATION_NAME}" \
       --host-cluster-context="${HOST_CLUSTER_CONTEXT}" \
       --dns-zone-name="${DNS_ZONE_NAME}" \


### PR DESCRIPTION
Although this should eventually be moved into kubefed itself, monitor kubefed from federation-up.sh and force it to timeout after being unable to initialize. The motivating factor here is to ensure that CI can timeout after a reasonable attempt at trying to initialize the FCP.