### PR TITLE
Disable readyReplicas validation for Deployments

### DIFF
--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -352,7 +352,9 @@ func ValidateDeploymentStatus(status *extensions.DeploymentStatus, fldPath *fiel
 	if status.AvailableReplicas > status.Replicas {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("availableReplicas"), status.AvailableReplicas, msg))
 	}
-	if status.AvailableReplicas > status.ReadyReplicas {
+	// TODO: ReadyReplicas is introduced in 1.6 and this check breaks the Deployment controller when pre-1.6 clusters get upgraded.
+	// 		 Remove the comparison to zero once we stop supporting upgrades from 1.5.
+	if status.ReadyReplicas > 0 && status.AvailableReplicas > status.ReadyReplicas {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("availableReplicas"), status.AvailableReplicas, "cannot be greater than readyReplicas"))
 	}
 	return allErrs

--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -1290,6 +1290,15 @@ func TestValidateDeploymentStatus(t *testing.T) {
 			observedGeneration: 1,
 			expectedErr:        true,
 		},
+		// TODO: Remove the following test case once we stop supporting upgrades from 1.5.
+		{
+			name:               "don't validate readyReplicas when it's zero",
+			replicas:           3,
+			readyReplicas:      0,
+			availableReplicas:  3,
+			observedGeneration: 1,
+			expectedErr:        false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Because there is no field in 1.5, when we update to 1.6 and the
controller tries to update the Deployment, it will be denied by
validation because the pre-existing availableReplicas field is greater
than readyReplicas (normally readyReplicas should always be greater or
equal).

Fixes https://github.com/kubernetes/kubernetes/issues/43392

@kubernetes/sig-apps-bugs 