### PR TITLE
Juju: Enable GPU mode if GPU hardware detected

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -11,3 +11,13 @@ options:
     type: string
     default: 10.152.183.0/24
     description: CIDR to user for Kubernetes services. Cannot be changed after deployment.
+  allow-privileged:
+    type: string
+    default: "auto"
+    description: |
+      Allow kube-apiserver to run in privileged mode. Supported values are
+      "true", "false", and "auto". If "true", kube-apiserver will run in
+      privileged mode by default. If "false", kube-apiserver will never run in
+      privileged mode. If "auto", kube-apiserver will not run in privileged
+      mode by default, but will switch to privileged mode if gpu hardware is
+      detected on a worker node.

--- a/cluster/juju/layers/kubernetes-master/layer.yaml
+++ b/cluster/juju/layers/kubernetes-master/layer.yaml
@@ -10,6 +10,7 @@ includes:
   - 'interface:http'
   - 'interface:kubernetes-cni'
   - 'interface:kube-dns'
+  - 'interface:kube-control'
   - 'interface:public-address'
 options:
   basic:

--- a/cluster/juju/layers/kubernetes-master/lib/charms/kubernetes/common.py
+++ b/cluster/juju/layers/kubernetes-master/lib/charms/kubernetes/common.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import subprocess
+
+from charmhelpers.core import unitdata
+
+BIN_VERSIONS = 'bin_versions'
+
+
+def get_version(bin_name):
+    """Get the version of an installed Kubernetes binary.
+
+    :param str bin_name: Name of binary
+    :return: 3-tuple version (maj, min, patch)
+
+    Example::
+
+        >>> `get_version('kubelet')
+        (1, 6, 0)
+
+    """
+    db = unitdata.kv()
+    bin_versions = db.get(BIN_VERSIONS, {})
+
+    cached_version = bin_versions.get(bin_name)
+    if cached_version:
+        return tuple(cached_version)
+
+    version = _get_bin_version(bin_name)
+    bin_versions[bin_name] = list(version)
+    db.set(BIN_VERSIONS, bin_versions)
+    return version
+
+
+def reset_versions():
+    """Reset the cache of bin versions.
+
+    """
+    db = unitdata.kv()
+    db.unset(BIN_VERSIONS)
+
+
+def _get_bin_version(bin_name):
+    """Get a binary version by calling it with --version and parsing output.
+
+    """
+    cmd = '{} --version'.format(bin_name).split()
+    version_string = subprocess.check_output(cmd).decode('utf-8')
+    return tuple(int(q) for q in re.findall("[0-9]+", version_string)[:3])

--- a/cluster/juju/layers/kubernetes-master/lib/charms/kubernetes/flagmanager.py
+++ b/cluster/juju/layers/kubernetes-master/lib/charms/kubernetes/flagmanager.py
@@ -107,9 +107,16 @@ class FlagManager:
             if strict:
                 self.data.pop('{}-strict'.format(key))
             else:
-                self.data.pop('key')
+                self.data.pop(key)
+            self.__save()
         except KeyError:
             pass
+
+    def get(self, key, default=None):
+        """Return the value for ``key``, or the default if ``key`` doesn't exist.
+
+        """
+        return self.data.get(key, default)
 
     def to_s(self):
         '''

--- a/cluster/juju/layers/kubernetes-master/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-master/metadata.yaml
@@ -20,7 +20,12 @@ provides:
   kube-api-endpoint:
     interface: http
   cluster-dns:
+    # kube-dns is deprecated. Its functionality has been rolled into the
+    # kube-control interface. The cluster-dns relation will be removed in
+    # a future release.
     interface: kube-dns
+  kube-control:
+    interface: kube-control
   cni:
     interface: kubernetes-cni
     scope: container

--- a/cluster/juju/layers/kubernetes-master/templates/kube-apiserver.defaults
+++ b/cluster/juju/layers/kubernetes-master/templates/kube-apiserver.defaults
@@ -11,7 +11,7 @@ KUBE_API_ADDRESS="--insecure-bind-address=127.0.0.1"
 KUBE_API_PORT="--insecure-port=8080"
 
 # default admission control policies
-KUBE_ADMISSION_CONTROL="--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultTolerationSeconds,ResourceQuota"
+KUBE_ADMISSION_CONTROL=""
 
 # Add your own!
 KUBE_API_ARGS="{{ kube_apiserver_flags }}"

--- a/cluster/juju/layers/kubernetes-master/templates/kube-defaults.defaults
+++ b/cluster/juju/layers/kubernetes-master/templates/kube-defaults.defaults
@@ -16,7 +16,7 @@ KUBE_LOGTOSTDERR="--logtostderr=true"
 KUBE_LOG_LEVEL="--v=0"
 
 # Should this cluster be allowed to run privileged docker containers
-KUBE_ALLOW_PRIV="--allow-privileged=false"
+KUBE_ALLOW_PRIV="{{ kube_allow_priv }}"
 
 # How the controller-manager, scheduler, and proxy find the apiserver
 KUBE_MASTER="--master=http://127.0.0.1:8080"

--- a/cluster/juju/layers/kubernetes-worker/config.yaml
+++ b/cluster/juju/layers/kubernetes-worker/config.yaml
@@ -11,3 +11,12 @@ options:
     description: |
       Labels can be used to organize and to select subsets of nodes in the
       cluster. Declare node labels in key=value format, separated by spaces.
+  allow-privileged:
+    type: string
+    default: "auto"
+    description: |
+      Allow privileged containers to run on worker nodes. Supported values are
+      "true", "false", and "auto". If "true", kubelet will run in privileged
+      mode by default. If "false", kubelet will never run in privileged mode.
+      If "auto", kubelet will not run in privileged mode by default, but will
+      switch to privileged mode if gpu hardware is detected.

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -5,9 +5,11 @@ includes:
   - 'layer:docker'
   - 'layer:nagios'
   - 'layer:tls-client'
+  - 'layer:nvidia-cuda'
   - 'interface:http'
   - 'interface:kubernetes-cni'
   - 'interface:kube-dns'
+  - 'interface:kube-control'
 options:
   basic:
     packages:

--- a/cluster/juju/layers/kubernetes-worker/lib/charms/kubernetes/common.py
+++ b/cluster/juju/layers/kubernetes-worker/lib/charms/kubernetes/common.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+import subprocess
+
+from charmhelpers.core import unitdata
+
+BIN_VERSIONS = 'bin_versions'
+
+
+def get_version(bin_name):
+    """Get the version of an installed Kubernetes binary.
+
+    :param str bin_name: Name of binary
+    :return: 3-tuple version (maj, min, patch)
+
+    Example::
+
+        >>> `get_version('kubelet')
+        (1, 6, 0)
+
+    """
+    db = unitdata.kv()
+    bin_versions = db.get(BIN_VERSIONS, {})
+
+    cached_version = bin_versions.get(bin_name)
+    if cached_version:
+        return tuple(cached_version)
+
+    version = _get_bin_version(bin_name)
+    bin_versions[bin_name] = list(version)
+    db.set(BIN_VERSIONS, bin_versions)
+    return version
+
+
+def reset_versions():
+    """Reset the cache of bin versions.
+
+    """
+    db = unitdata.kv()
+    db.unset(BIN_VERSIONS)
+
+
+def _get_bin_version(bin_name):
+    """Get a binary version by calling it with --version and parsing output.
+
+    """
+    cmd = '{} --version'.format(bin_name).split()
+    version_string = subprocess.check_output(cmd).decode('utf-8')
+    return tuple(int(q) for q in re.findall("[0-9]+", version_string)[:3])

--- a/cluster/juju/layers/kubernetes-worker/lib/charms/kubernetes/flagmanager.py
+++ b/cluster/juju/layers/kubernetes-worker/lib/charms/kubernetes/flagmanager.py
@@ -107,9 +107,16 @@ class FlagManager:
             if strict:
                 self.data.pop('{}-strict'.format(key))
             else:
-                self.data.pop('key')
+                self.data.pop(key)
+            self.__save()
         except KeyError:
             pass
+
+    def get(self, key, default=None):
+        """Return the value for ``key``, or the default if ``key`` doesn't exist.
+
+        """
+        return self.data.get(key, default)
 
     def to_s(self):
         '''

--- a/cluster/juju/layers/kubernetes-worker/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-worker/metadata.yaml
@@ -18,7 +18,12 @@ requires:
   kube-api-endpoint:
     interface: http
   kube-dns:
+    # kube-dns is deprecated. Its functionality has been rolled into the
+    # kube-control interface. The kube-dns relation will be removed in
+    # a future release.
     interface: kube-dns
+  kube-control:
+    interface: kube-control
 provides:
   cni:
     interface: kubernetes-cni

--- a/cluster/juju/layers/kubernetes-worker/templates/kube-default
+++ b/cluster/juju/layers/kubernetes-worker/templates/kube-default
@@ -16,7 +16,7 @@ KUBE_LOGTOSTDERR="--logtostderr=true"
 KUBE_LOG_LEVEL="--v=0"
 
 # Should this cluster be allowed to run privileged docker containers
-KUBE_ALLOW_PRIV="--allow-privileged=false"
+KUBE_ALLOW_PRIV="{{ kube_allow_priv }}"
 
 # How the controller-manager, scheduler, and proxy find the apiserver
-KUBE_MASTER="--master={{ kube_api_endpoint }}"
+KUBE_MASTER="{{ kube_api_endpoint }}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Automatically configures kubernetes-worker node to utilize GPU hardware when such hardware is detected.

layer-nvidia-cuda does the hardware detection, installs CUDA and Nvidia
drivers, and sets a state that the k8s-worker can react to.

When gpu is available, worker updates config and restarts kubelet to
enable gpu mode. Worker then notifies master that it's in gpu mode via
the kube-control relation.

When master sees that a worker is in gpu mode, it updates to privileged
mode and restarts kube-apiserver.

The kube-control interface has subsumed the kube-dns interface
functionality.

An 'allow-privileged' config option has been added to both worker and
master charms. The gpu enablement respects the value of this option;
i.e., we can't enable gpu mode if the operator has set
allow-privileged="false".

**Special notes for your reviewer**:

Quickest test setup is as follows:
```bash
# Bootstrap. If your aws account doesn't have a default vpc, you'll need to
# specify one at bootstrap time so that juju can provision a p2.xlarge.
# Otherwise you can leave out the --config "vpc-id=vpc-xxxxxxxx" bit.
juju bootstrap --config "vpc-id=vpc-xxxxxxxx" --constraints "cores=4 mem=16G root-disk=64G" aws/us-east-1 k8s

# Deploy the bundle containing master and worker charms built from
# https://github.com/tvansteenburgh/kubernetes/tree/gpu-support/cluster/juju/layers
juju deploy cs:~tvansteenburgh/bundle/kubernetes-gpu-support-3

# Setup kubectl locally
mkdir -p ~/.kube
juju scp kubernetes-master/0:config ~/.kube/config
juju scp kubernetes-master/0:kubectl ./kubectl

# Download a gpu-dependent job spec
wget -O /tmp/nvidia-smi.yaml https://raw.githubusercontent.com/madeden/blogposts/master/k8s-gpu-cloud/src/nvidia-smi.yaml

# Create the job
kubectl create -f /tmp/nvidia-smi.yaml

# You should see a new nvidia-smi-xxxxx pod created
kubectl get pods

# Wait a bit for the job to run, then view logs; you should see the
# nvidia-smi table output
kubectl logs $(kubectl get pods -l name=nvidia-smi -o=name -a)
```

kube-control interface: https://github.com/juju-solutions/interface-kube-control
nvidia-cuda layer: https://github.com/juju-solutions/layer-nvidia-cuda
(Both are registered on http://interfaces.juju.solutions/)

**Release note**:
```release-note
Juju: Enable GPU mode if GPU hardware detected
```