### PR TITLE
Renamed fluentd-ds-ready annotation

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -41,7 +41,7 @@ spec:
           mountPath: /var/lib/docker/containers
           readOnly: true
       nodeSelector:
-        alpha.kubernetes.io/fluentd-ds-ready: "true"
+        beta.kubernetes.io/fluentd-ds-ready: "true"
       tolerations:
       - key : "node.alpha.kubernetes.io/ismaster"
         effect: "NoSchedule"

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -89,7 +89,7 @@ spec:
                 exit 1;
               fi;
       nodeSelector:
-        alpha.kubernetes.io/fluentd-ds-ready: "true"
+        beta.kubernetes.io/fluentd-ds-ready: "true"
       tolerations:
       - key: "node.alpha.kubernetes.io/ismaster"
         effect: "NoSchedule"

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -111,7 +111,7 @@ ENABLE_CLUSTER_MONITORING="${KUBE_ENABLE_CLUSTER_MONITORING:-influxdb}"
 # of fluentd running on a node, kubelet need to mark node on which
 # fluentd is not running as a manifest pod with appropriate label.
 # TODO(piosz): remove this in 1.8
-NODE_LABELS="${KUBE_NODE_LABELS:-alpha.kubernetes.io/fluentd-ds-ready=true}"
+NODE_LABELS="${KUBE_NODE_LABELS:-beta.kubernetes.io/fluentd-ds-ready=true}"
 
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING="${KUBE_ENABLE_NODE_LOGGING:-true}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -142,7 +142,7 @@ KUBEPROXY_TEST_ARGS="${KUBEPROXY_TEST_ARGS:-} ${TEST_CLUSTER_API_CONTENT_TYPE}"
 # of fluentd running on a node, kubelet need to mark node on which
 # fluentd is not running as a manifest pod with appropriate label.
 # TODO(piosz): remove this in 1.8
-NODE_LABELS="${KUBE_NODE_LABELS:-alpha.kubernetes.io/fluentd-ds-ready=true}"
+NODE_LABELS="${KUBE_NODE_LABELS:-beta.kubernetes.io/fluentd-ds-ready=true}"
 
 # Optional: Enable node logging.
 ENABLE_NODE_LOGGING="${KUBE_ENABLE_NODE_LOGGING:-true}"


### PR DESCRIPTION
We don't want to have alpha annotation as production ready solution.

Low risk change, only rename.