### PR TITLE
Automated cherry pick of #43458

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.5.0-beta2",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.5.0",
                 "command": [
                     "./run.sh",
                     "--kubernetes=http://127.0.0.1:8080?inClusterConfig=f",


### PR DESCRIPTION
Cherry pick of #43458 on release-1.6.

#43458: Bump cluster autoscaler version to 0.5.0