### PR TITLE
kubelet/cni: hook network plugin Status() up to CNI network discovery

### DIFF
--- a/pkg/kubelet/network/cni/BUILD
+++ b/pkg/kubelet/network/cni/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//vendor:github.com/containernetworking/cni/libcni",
         "//vendor:github.com/containernetworking/cni/pkg/types",
         "//vendor:github.com/golang/glog",
-        "//vendor:k8s.io/apimachinery/pkg/util/wait",
     ],
 )
 

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -21,12 +21,10 @@ import (
 	"fmt"
 	"sort"
 	"sync"
-	"time"
 
 	"github.com/containernetworking/cni/libcni"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/golang/glog"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/network"
@@ -147,13 +145,9 @@ func (plugin *cniNetworkPlugin) Init(host network.Host, hairpinMode componentcon
 	if err != nil {
 		return err
 	}
-
 	plugin.host = host
 
-	// sync network config from pluginDir periodically to detect network config updates
-	go wait.Forever(func() {
-		plugin.syncNetworkConfig()
-	}, 10*time.Second)
+	plugin.syncNetworkConfig()
 	return nil
 }
 
@@ -187,6 +181,14 @@ func (plugin *cniNetworkPlugin) checkInitialized() error {
 
 func (plugin *cniNetworkPlugin) Name() string {
 	return CNIPluginName
+}
+
+func (plugin *cniNetworkPlugin) Status() error {
+	// sync network config from pluginDir periodically to detect network config updates
+	plugin.syncNetworkConfig()
+
+	// Can't set up pods if we don't have any CNI network configs yet
+	return plugin.checkInitialized()
 }
 
 func (plugin *cniNetworkPlugin) SetUpPod(namespace string, name string, id kubecontainer.ContainerID, annotations map[string]string) error {


### PR DESCRIPTION
Ensure that the plugin returns NotReady status until there is a
CNI network available which can be used to set up pods.

Fixes: https://github.com/kubernetes/kubernetes/issues/43014

I think the only reason it wasn't done like this in the first place was that the dynamic "reread /etc/cni/net.d every 10s forever" was added long after the Status() hook was.  What do you think?

@freehan @caseydavenport @luxas @jbeda 