### PR TITLE
tests: e2e-node: skip logpath test when not using json-file logging driver

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -108,6 +108,8 @@ go_test(
         "//test/utils:go_default_library",
         "//vendor:github.com/coreos/go-systemd/util",
         "//vendor:github.com/davecgh/go-spew/spew",
+        "//vendor:github.com/docker/engine-api/client",
+        "//vendor:github.com/docker/engine-api/types",
         "//vendor:github.com/golang/glog",
         "//vendor:github.com/kardianos/osext",
         "//vendor:github.com/onsi/ginkgo",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/43479

The container logs are only on the path the test expects if the docker logging driver is set to `json-file`.

This PR skips the test if it can be determined that is not that case.

NOTE: this test still fails on selinux systems when using the `json-file` driver due to the checker pod using a HostPathVolume to /var/log/containers, which is prohibited by selinux policy.

@derekwaynecarr 