### PR TITLE
Authorize PSP usage for pods without service accounts

### DIFF
--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -1610,7 +1610,7 @@ func TestGetMatchingPolicies(t *testing.T) {
 			// (ie. a request hitting the unsecure port)
 			expectedPolicies: sets.NewString("policy1", "policy2", "policy3"),
 		},
-		"policies are allowed for nil sa info": {
+		"policies are not allowed for nil sa info": {
 			user: &user.DefaultInfo{Name: "user"},
 			sa:   nil,
 			disallowedPolicies: map[string][]string{
@@ -1622,9 +1622,8 @@ func TestGetMatchingPolicies(t *testing.T) {
 				policyWithName("policy2"),
 				policyWithName("policy3"),
 			},
-			// all policies are allowed regardless of the permissions when sa info is nil
-			// (ie. a request hitting the unsecure port)
-			expectedPolicies: sets.NewString("policy1", "policy2", "policy3"),
+			// only the policies for the user are allowed when sa info is nil
+			expectedPolicies: sets.NewString("policy2"),
 		},
 	}
 	for k, v := range tests {


### PR DESCRIPTION
Fixes #43459

```release-note
PodSecurityPolicy authorization is correctly enforced by the PodSecurityPolicy admission plugin.
```