### PR TITLE
Automated cherry pick of #43489

### DIFF
--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -1617,7 +1617,7 @@ func TestGetMatchingPolicies(t *testing.T) {
 			// (ie. a request hitting the unsecure port)
 			expectedPolicies: sets.NewString("policy1", "policy2", "policy3"),
 		},
-		"policies are allowed for nil sa info": {
+		"policies are not allowed for nil sa info": {
 			user: &user.DefaultInfo{Name: "user"},
 			sa:   nil,
 			disallowedPolicies: map[string][]string{
@@ -1629,9 +1629,8 @@ func TestGetMatchingPolicies(t *testing.T) {
 				policyWithName("policy2"),
 				policyWithName("policy3"),
 			},
-			// all policies are allowed regardless of the permissions when sa info is nil
-			// (ie. a request hitting the unsecure port)
-			expectedPolicies: sets.NewString("policy1", "policy2", "policy3"),
+			// only the policies for the user are allowed when sa info is nil
+			expectedPolicies: sets.NewString("policy2"),
 		},
 	}
 	for k, v := range tests {


### PR DESCRIPTION
Cherry pick of #43489 on release-1.5.

#43489: Authorize PSP usage for pods without service accounts

Picks fix made in v1.5.5 into the release-1.5 branch. No release note, since the change was already present in v1.5.5.