### PR TITLE
Should not set struct pointer directly to interface which may cause potential panic

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -159,6 +159,7 @@ func UnsecuredDependencies(s *options.KubeletServer) (*kubelet.Dependencies, err
 		DockerClient:       dockerClient,
 		KubeClient:         nil,
 		ExternalKubeClient: nil,
+		EventClient:        nil,
 		Mounter:            mounter,
 		NetworkPlugins:     ProbeNetworkPlugins(s.NetworkPluginDir, s.CNIConfDir, s.CNIBinDir),
 		OOMAdjuster:        oom.NewOOMAdjuster(),
@@ -502,7 +503,9 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies) (err error) {
 
 		kubeDeps.KubeClient = kubeClient
 		kubeDeps.ExternalKubeClient = externalKubeClient
-		kubeDeps.EventClient = eventClient
+		if eventClient != nil {
+			kubeDeps.EventClient = eventClient
+		}
 	}
 
 	if kubeDeps.Auth == nil {


### PR DESCRIPTION
fix https://github.com/kubernetes/kubernetes/issues/43127 to avoid potential kubelet panic.

In our old implemention, interface `kubeDeps.EventClient ` (interface) will never equals to `nil` even if `eventClient `(struct pointer )was set to `nil`.  `kubeDeps.ExternalKubeClient` and `kubeDeps.KubeClient` also have same potential risk.
