### PR TITLE
Use TabWriter to keep output of "kubectl get xx -w" aligned.

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -245,16 +245,19 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 		// print the current object
 		if !isWatchOnly {
 			var objsToPrint []runtime.Object
+			writer := printers.GetNewTabWriter(out)
+
 			if isList {
 				objsToPrint, _ = meta.ExtractList(obj)
 			} else {
 				objsToPrint = append(objsToPrint, obj)
 			}
 			for _, objToPrint := range objsToPrint {
-				if err := printer.PrintObj(objToPrint, out); err != nil {
+				if err := printer.PrintObj(objToPrint, writer); err != nil {
 					return fmt.Errorf("unable to output the provided object: %v", err)
 				}
 			}
+			writer.Flush()
 		}
 
 		// print watched changes


### PR DESCRIPTION
Use TabWriter to keep output of "kubectl get xx -w" aligned.

fixed #43126