### PR TITLE
Add support for Azure internal load balancer

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -32,37 +32,57 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+// ServiceAnnotationLoadBalancerInternal is the annotation used on the service
+const ServiceAnnotationLoadBalancerInternal = "service.beta.kubernetes.io/azure-load-balancer-internal"
+
 // GetLoadBalancer returns whether the specified load balancer exists, and
 // if so, what its status is.
 func (az *Cloud) GetLoadBalancer(clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
-	lbName := getLoadBalancerName(clusterName)
+	isInternal := isLoadBalancerInternal(service)
+	lbName := getLoadBalancerName(clusterName, isInternal)
 	serviceName := getServiceName(service)
 
-	pipName, err := az.getPublicIPName(clusterName, service)
-	if err != nil {
-		return nil, false, err
-	}
-
-	_, existsLb, err := az.getAzureLoadBalancer(lbName)
+	lb, existsLb, err := az.getAzureLoadBalancer(lbName)
 	if err != nil {
 		return nil, false, err
 	}
 	if !existsLb {
-		glog.V(5).Infof("get(%s): lb(%s) - doesn't exist", serviceName, pipName)
+		glog.V(5).Infof("get(%s): lb(%s) - doesn't exist", serviceName, lbName)
 		return nil, false, nil
 	}
 
-	pip, existsPip, err := az.getPublicIPAddress(pipName)
-	if err != nil {
-		return nil, false, err
+	var lbIP *string
+
+	if isInternal {
+		lbFrontendIPConfigName := getFrontendIPConfigName(service)
+		for _, ipConfiguration := range *lb.FrontendIPConfigurations {
+			if lbFrontendIPConfigName == *ipConfiguration.Name {
+				lbIP = ipConfiguration.PrivateIPAddress
+				break
+			}
+		}
+	} else {
+		// TODO: Consider also read address from lb's FrontendIPConfigurations
+		pipName, err := az.getPublicIPName(clusterName, service)
+		if err != nil {
+			return nil, false, err
+		}
+		pip, existsPip, err := az.getPublicIPAddress(pipName)
+		if err != nil {
+			return nil, false, err
+		}
+		if existsPip {
+			lbIP = pip.IPAddress
+		}
 	}
-	if !existsPip {
-		glog.V(5).Infof("get(%s): pip(%s) - doesn't exist", serviceName, pipName)
+
+	if lbIP == nil {
+		glog.V(5).Infof("get(%s): lb(%s) - IP doesn't exist", serviceName, lbName)
 		return nil, false, nil
 	}
 
 	return &v1.LoadBalancerStatus{
-		Ingress: []v1.LoadBalancerIngress{{IP: *pip.IPAddress}},
+		Ingress: []v1.LoadBalancerIngress{{IP: *lbIP}},
 	}, true, nil
 }
 
@@ -93,10 +113,11 @@ func (az *Cloud) getPublicIPName(clusterName string, service *v1.Service) (strin
 
 // EnsureLoadBalancer creates a new load balancer 'name', or updates the existing one. Returns the status of the balancer
 func (az *Cloud) EnsureLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
-	lbName := getLoadBalancerName(clusterName)
+	isInternal := isLoadBalancerInternal(service)
+	lbName := getLoadBalancerName(clusterName, isInternal)
 	pipName, err := az.getPublicIPName(clusterName, service)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	serviceName := getServiceName(service)
 	glog.V(2).Infof("ensure(%s): START clusterName=%q lbName=%q", serviceName, clusterName, lbName)
@@ -190,7 +211,8 @@ func (az *Cloud) UpdateLoadBalancer(clusterName string, service *v1.Service, nod
 // have multiple underlying components, meaning a Get could say that the LB
 // doesn't exist even if some part of it is still laying around.
 func (az *Cloud) EnsureLoadBalancerDeleted(clusterName string, service *v1.Service) error {
-	lbName := getLoadBalancerName(clusterName)
+	isInternal := isLoadBalancerInternal(service)
+	lbName := getLoadBalancerName(clusterName, isInternal)
 	serviceName := getServiceName(service)
 
 	pipName, err := az.getPublicIPName(clusterName, service)
@@ -307,7 +329,8 @@ func (az *Cloud) ensurePublicIPDeleted(serviceName, pipName string) error {
 // This also reconciles the Service's Ports  with the LoadBalancer config.
 // This entails adding rules/probes for expected Ports and removing stale rules/ports.
 func (az *Cloud) reconcileLoadBalancer(lb network.LoadBalancer, pip *network.PublicIPAddress, clusterName string, service *v1.Service, nodes []*v1.Node) (network.LoadBalancer, bool, error) {
-	lbName := getLoadBalancerName(clusterName)
+	isInternal := isLoadBalancerInternal(service)
+	lbName := getLoadBalancerName(clusterName, isInternal)
 	serviceName := getServiceName(service)
 	lbFrontendIPConfigName := getFrontendIPConfigName(service)
 	lbFrontendIPConfigID := az.getFrontendIPConfigID(lbName, lbFrontendIPConfigName)
@@ -712,4 +735,13 @@ func (az *Cloud) ensureHostInPool(serviceName string, nodeName types.NodeName, b
 		}
 	}
 	return nil
+}
+
+// Check if service requests an internal load balancer.
+func isLoadBalancerInternal(service *v1.Service) bool {
+	if l, ok := service.Annotations[ServiceAnnotationLoadBalancerInternal]; ok {
+		return l == "true"
+	}
+
+	return false
 }

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -133,7 +133,7 @@ func (az *Cloud) EnsureLoadBalancer(clusterName string, service *v1.Service, nod
 	}
 
 	serviceName := getServiceName(service)
-	glog.V(2).Infof("ensure(%s): START clusterName=%q lbName=%q", serviceName, clusterName, lbName)
+	glog.V(5).Infof("ensure(%s): START clusterName=%q lbName=%q", serviceName, clusterName, lbName)
 
 	sg, err := az.SecurityGroupsClient.Get(az.ResourceGroup, az.SecurityGroupName, "")
 	if err != nil {
@@ -281,7 +281,7 @@ func (az *Cloud) EnsureLoadBalancerDeleted(clusterName string, service *v1.Servi
 	lbName := getLoadBalancerName(clusterName, isInternal)
 	serviceName := getServiceName(service)
 
-	glog.V(2).Infof("delete(%s): START clusterName=%q lbName=%q", serviceName, clusterName, lbName)
+	glog.V(5).Infof("delete(%s): START clusterName=%q lbName=%q", serviceName, clusterName, lbName)
 
 	err := az.cleanupLoadBalancer(clusterName, service, isInternal)
 	if err != nil {

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -36,11 +36,11 @@ var testClusterName = "testCluster"
 func TestReconcileLoadBalancerAddPort(t *testing.T) {
 	az := getTestCloud()
 	svc := getTestService("servicea", 80)
-	pip := getTestPublicIP()
+	configProperties := getTestPublicFipConfigurationProperties()
 	lb := getTestLoadBalancer()
 	nodes := []*v1.Node{}
 
-	lb, updated, err := az.reconcileLoadBalancer(lb, &pip, testClusterName, &svc, nodes)
+	lb, updated, err := az.reconcileLoadBalancer(lb, &configProperties, testClusterName, &svc, nodes)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -64,12 +64,12 @@ func TestReconcileLoadBalancerNodeHealth(t *testing.T) {
 		serviceapi.BetaAnnotationExternalTraffic:     serviceapi.AnnotationValueExternalTrafficLocal,
 		serviceapi.BetaAnnotationHealthCheckNodePort: "32456",
 	}
-	pip := getTestPublicIP()
+	configProperties := getTestPublicFipConfigurationProperties()
 	lb := getTestLoadBalancer()
 
 	nodes := []*v1.Node{}
 
-	lb, updated, err := az.reconcileLoadBalancer(lb, &pip, testClusterName, &svc, nodes)
+	lb, updated, err := az.reconcileLoadBalancer(lb, &configProperties, testClusterName, &svc, nodes)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -91,10 +91,10 @@ func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) 
 	az := getTestCloud()
 	svc := getTestService("servicea", 80)
 	lb := getTestLoadBalancer()
-	pip := getTestPublicIP()
+	configProperties := getTestPublicFipConfigurationProperties()
 	nodes := []*v1.Node{}
 
-	lb, updated, err := az.reconcileLoadBalancer(lb, &pip, testClusterName, &svc, nodes)
+	lb, updated, err := az.reconcileLoadBalancer(lb, &configProperties, testClusterName, &svc, nodes)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -121,13 +121,13 @@ func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) 
 func TestReconcileLoadBalancerRemovesPort(t *testing.T) {
 	az := getTestCloud()
 	svc := getTestService("servicea", 80, 443)
-	pip := getTestPublicIP()
+	configProperties := getTestPublicFipConfigurationProperties()
 	nodes := []*v1.Node{}
 
 	existingLoadBalancer := getTestLoadBalancer(svc)
 
 	svcUpdated := getTestService("servicea", 80)
-	updatedLoadBalancer, _, err := az.reconcileLoadBalancer(existingLoadBalancer, &pip, testClusterName, &svcUpdated, nodes)
+	updatedLoadBalancer, _, err := az.reconcileLoadBalancer(existingLoadBalancer, &configProperties, testClusterName, &svcUpdated, nodes)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -140,17 +140,17 @@ func TestReconcileLoadBalancerMultipleServices(t *testing.T) {
 	az := getTestCloud()
 	svc1 := getTestService("servicea", 80, 443)
 	svc2 := getTestService("serviceb", 80)
-	pip := getTestPublicIP()
+	configProperties := getTestPublicFipConfigurationProperties()
 	nodes := []*v1.Node{}
 
 	existingLoadBalancer := getTestLoadBalancer()
 
-	updatedLoadBalancer, _, err := az.reconcileLoadBalancer(existingLoadBalancer, &pip, testClusterName, &svc1, nodes)
+	updatedLoadBalancer, _, err := az.reconcileLoadBalancer(existingLoadBalancer, &configProperties, testClusterName, &svc1, nodes)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
 
-	updatedLoadBalancer, _, err = az.reconcileLoadBalancer(updatedLoadBalancer, &pip, testClusterName, &svc2, nodes)
+	updatedLoadBalancer, _, err = az.reconcileLoadBalancer(updatedLoadBalancer, &configProperties, testClusterName, &svc2, nodes)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -223,10 +223,10 @@ func getBackendPort(port int32) int32 {
 	return port + 10000
 }
 
-func getTestPublicIP() network.PublicIPAddress {
-	pip := network.PublicIPAddress{}
-	pip.ID = to.StringPtr("/this/is/a/public/ip/address/id")
-	return pip
+func getTestPublicFipConfigurationProperties() network.FrontendIPConfigurationPropertiesFormat {
+	return network.FrontendIPConfigurationPropertiesFormat{
+		PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("/this/is/a/public/ip/address/id")},
+	}
 }
 
 func getTestService(identifier string, requestedPorts ...int32) v1.Service {

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -87,6 +87,37 @@ func TestReconcileLoadBalancerNodeHealth(t *testing.T) {
 }
 
 // Test removing all services results in removing the frontend ip configuration
+func TestReconcileLoadBalancerRemoveService(t *testing.T) {
+	az := getTestCloud()
+	svc := getTestService("servicea", 80, 443)
+	lb := getTestLoadBalancer()
+	configProperties := getTestPublicFipConfigurationProperties()
+	nodes := []*v1.Node{}
+
+	lb, updated, err := az.reconcileLoadBalancer(lb, &configProperties, testClusterName, &svc, nodes)
+	if err != nil {
+		t.Errorf("Unexpected error: %q", err)
+	}
+	validateLoadBalancer(t, lb, svc)
+
+	lb, updated, err = az.reconcileLoadBalancer(lb, nil, testClusterName, &svc, nodes)
+	if err != nil {
+		t.Errorf("Unexpected error: %q", err)
+	}
+
+	if !updated {
+		t.Error("Expected the loadbalancer to need an update")
+	}
+
+	// ensure we abandoned the frontend ip configuration
+	if len(*lb.FrontendIPConfigurations) != 0 {
+		t.Error("Expected the loadbalancer to have no frontend ip configuration")
+	}
+
+	validateLoadBalancer(t, lb)
+}
+
+// Test removing all service ports results in removing the frontend ip configuration
 func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) {
 	az := getTestCloud()
 	svc := getTestService("servicea", 80)
@@ -98,6 +129,7 @@ func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) 
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
+	validateLoadBalancer(t, lb, svc)
 
 	svcUpdated := getTestService("servicea")
 	lb, updated, err = az.reconcileLoadBalancer(lb, nil, testClusterName, &svcUpdated, nodes)
@@ -164,12 +196,42 @@ func TestReconcileSecurityGroupNewServiceAddsPort(t *testing.T) {
 
 	sg := getTestSecurityGroup()
 
-	sg, _, err := az.reconcileSecurityGroup(sg, testClusterName, &svc1)
+	sg, _, err := az.reconcileSecurityGroup(sg, testClusterName, &svc1, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
 
 	validateSecurityGroup(t, sg, svc1)
+}
+
+func TestReconcileSecurityGroupNewInternalServiceAddsPort(t *testing.T) {
+	az := getTestCloud()
+	svc1 := getInternalTestService("serviceea", 80)
+
+	sg := getTestSecurityGroup()
+
+	sg, _, err := az.reconcileSecurityGroup(sg, testClusterName, &svc1, true)
+	if err != nil {
+		t.Errorf("Unexpected error: %q", err)
+	}
+
+	validateSecurityGroup(t, sg, svc1)
+}
+
+func TestReconcileSecurityGroupRemoveService(t *testing.T) {
+	service1 := getTestService("servicea", 81)
+	service2 := getTestService("serviceb", 82)
+
+	sg := getTestSecurityGroup(service1, service2)
+
+	validateSecurityGroup(t, sg, service1, service2)
+	az := getTestCloud()
+	sg, _, err := az.reconcileSecurityGroup(sg, testClusterName, &service1, false)
+	if err != nil {
+		t.Errorf("Unexpected error: %q", err)
+	}
+
+	validateSecurityGroup(t, sg, service2)
 }
 
 func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
@@ -179,7 +241,7 @@ func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 	sg := getTestSecurityGroup(svc)
 
 	svcUpdated := getTestService("servicea", 80)
-	sg, _, err := az.reconcileSecurityGroup(sg, testClusterName, &svcUpdated)
+	sg, _, err := az.reconcileSecurityGroup(sg, testClusterName, &svcUpdated, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -196,7 +258,7 @@ func TestReconcileSecurityWithSourceRanges(t *testing.T) {
 	}
 
 	sg := getTestSecurityGroup(svc)
-	sg, _, err := az.reconcileSecurityGroup(sg, testClusterName, &svc)
+	sg, _, err := az.reconcileSecurityGroup(sg, testClusterName, &svc, true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
@@ -249,6 +311,14 @@ func getTestService(identifier string, requestedPorts ...int32) v1.Service {
 	svc.Name = identifier
 	svc.Namespace = "default"
 	svc.UID = types.UID(identifier)
+	svc.Annotations = make(map[string]string)
+
+	return svc
+}
+
+func getInternalTestService(identifier string, requestedPorts ...int32) v1.Service {
+	svc := getTestService(identifier, requestedPorts...)
+	svc.Annotations[ServiceAnnotationLoadBalancerInternal] = "true"
 
 	return svc
 }
@@ -288,8 +358,11 @@ func getTestLoadBalancer(services ...v1.Service) network.LoadBalancer {
 
 func getServiceSourceRanges(service *v1.Service) []string {
 	if len(service.Spec.LoadBalancerSourceRanges) == 0 {
-		return []string{"Internet"}
+		if !requiresInternalLoadBalancer(service) {
+			return []string{"Internet"}
+		}
 	}
+
 	return service.Spec.LoadBalancerSourceRanges
 }
 
@@ -324,7 +397,11 @@ func getTestSecurityGroup(services ...v1.Service) network.SecurityGroup {
 
 func validateLoadBalancer(t *testing.T, loadBalancer network.LoadBalancer, services ...v1.Service) {
 	expectedRuleCount := 0
+	expectedFrontendIPCount := 0
 	for _, svc := range services {
+		if len(svc.Spec.Ports) > 0 {
+			expectedFrontendIPCount++
+		}
 		for _, wantedRule := range svc.Spec.Ports {
 			expectedRuleCount++
 			wantedRuleName := getRuleName(&svc, wantedRule)
@@ -371,6 +448,11 @@ func validateLoadBalancer(t *testing.T, loadBalancer network.LoadBalancer, servi
 		}
 	}
 
+	frontendIPCount := len(*loadBalancer.FrontendIPConfigurations)
+	if frontendIPCount != expectedFrontendIPCount {
+		t.Errorf("Expected the loadbalancer to have %d frontend IPs. Found %d.\n%v", expectedFrontendIPCount, frontendIPCount, loadBalancer.FrontendIPConfigurations)
+	}
+
 	lenRules := len(*loadBalancer.LoadBalancingRules)
 	if lenRules != expectedRuleCount {
 		t.Errorf("Expected the loadbalancer to have %d rules. Found %d.\n%v", expectedRuleCount, lenRules, loadBalancer.LoadBalancingRules)
@@ -386,10 +468,9 @@ func validateSecurityGroup(t *testing.T, securityGroup network.SecurityGroup, se
 	for _, svc := range services {
 		for _, wantedRule := range svc.Spec.Ports {
 			sources := getServiceSourceRanges(&svc)
-
+			wantedRuleName := getRuleName(&svc, wantedRule)
 			for _, source := range sources {
 				expectedRuleCount++
-				wantedRuleName := getRuleName(&svc, wantedRule)
 				foundRule := false
 				for _, actualRule := range *securityGroup.SecurityRules {
 					if strings.EqualFold(*actualRule.Name, wantedRuleName) &&

--- a/pkg/cloudprovider/providers/azure/azure_util.go
+++ b/pkg/cloudprovider/providers/azure/azure_util.go
@@ -160,7 +160,14 @@ func getPrimaryIPConfig(nic network.Interface) (*network.InterfaceIPConfiguratio
 	return nil, fmt.Errorf("failed to determine the determine primary ipconfig. nicname=%q", *nic.Name)
 }
 
-func getLoadBalancerName(clusterName string) string {
+// For a load balancer, all frontend ip should reference either a subnet or publicIpAddress.
+// Thus Azure do not allow mixed type (public and internal) load balancer.
+// So we'd have a separate name for internal load balancer.
+func getLoadBalancerName(clusterName string, isInternal bool) string {
+	if isInternal {
+		return fmt.Sprintf("%s-internal", clusterName)
+	}
+
 	return clusterName
 }
 

--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -124,3 +124,20 @@ func (az *Cloud) getPublicIPAddress(name string) (pip network.PublicIPAddress, e
 
 	return pip, exists, err
 }
+
+func (az *Cloud) getSubnet(virtualNetworkName string, subnetName string) (subnet network.Subnet, exists bool, err error) {
+	var realErr error
+
+	subnet, err = az.SubnetsClient.Get(az.ResourceGroup, virtualNetworkName, subnetName, "")
+
+	exists, realErr = checkResourceExistsFromError(err)
+	if realErr != nil {
+		return subnet, false, realErr
+	}
+
+	if !exists {
+		return subnet, false, nil
+	}
+
+	return subnet, exists, err
+}


### PR DESCRIPTION
**Which issue this PR fixes**
Fixes https://github.com/kubernetes/kubernetes/issues/38901

**What this PR does / why we need it**:
This PR is to add support for Azure internal load balancer

Currently when exposing a serivce with LoadBalancer type, Azure provider would assume that it requires a public load balancer.
Thus it will request a public IP address resource, and expose the service via that public IP.
In this case we're not able to apply private IP addresses (within the cluster virtual network) for the service.

**Special notes for your reviewer**:
1. Clarification:
a. 'LoadBalancer' refers to an option for 'type' field under ServiceSpec. See https://kubernetes.io/docs/resources-reference/v1.5/#servicespec-v1
b. 'Azure LoadBalancer' refers a type of Azure resource. See https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview

2. For a single Azure LoadBalancer, all frontend ip should reference either a subnet or publicIpAddress, which means that it could be either an Internet facing load balancer or an internal one.
For current provider, it would create an Azure LoadBalancer with generated '${loadBalancerName}' for all services with 'LoadBalancer' type.
This PR introduces name '${loadBalancerName}-internal' for a separate Azure Load Balancer resource, used by all the service that requires internal load balancers.

3. This PR introduces a new annotation for the internal load balancer type behaviour:
a. When the annotaion value is set to 'false' or not set, it falls back to the original behaviour, assuming that user is requesting a public load balancer;
b. When the annotaion value is set to 'true', the following rule applies depending on 'loadBalancerIP' field on ServiceSpec:
   - If 'loadBalancerIP' is not set, it will create a load balancer rule with dynamic assigned frontend IP under the cluster subnet;
   - If 'loadBalancerIP' is set, it will create a load balancer rule with the frontend IP set to the given value. If the given value is not valid, that is, it does not falls into the cluster subnet range, then the creation will fail.

4. Users may change the load balancer type by applying the annotation to the service at runtime.
In this case, the load balancer rule would need to be 'switched' between the internal one and external one.
For example, it we have a service with internal load balancer, and then user removes the annotation, making it to a public one. Before we creating rules in the public Azure LoadBalancer, we'll need to clean up rules in the internal Azure LoadBalancer.

**Release note**: