### PR TITLE
bump Kubernetes packaged CNI to v0.5.1

### DIFF
--- a/build/cni/Makefile
+++ b/build/cni/Makefile
@@ -18,7 +18,7 @@
 #	[ARCH=amd64] [CNI_RELEASE=v0.3.0] make (build|push)
 
 ARCH?=amd64
-CNI_RELEASE?=07a8a28637e97b22eb8dfe710eeae1344f69d16e
+CNI_RELEASE?=0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff
 CNI_TARBALL=cni-$(ARCH)-$(CNI_RELEASE).tar.gz
 CUR_DIR=$(shell pwd)
 OUTPUT_DIR=$(CUR_DIR)/output


### PR DESCRIPTION
Update version of packaged CNI to v0.5.1 in order as part of a fix for #43488.

Next steps compiling these versions and updating references to artifacts.

/cc @ixdy 