### PR TITLE
Prefer extensions group over apps group in Kubernetes 1.6.

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1151,7 +1151,7 @@ run_kubectl_get_tests() {
   kube::test::if_has_string "${output_message}" "/apis/apps/v1beta1/namespaces/default/statefulsets 200 OK"
   kube::test::if_has_string "${output_message}" "/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers 200"
   kube::test::if_has_string "${output_message}" "/apis/batch/v1/namespaces/default/jobs 200 OK"
-  kube::test::if_has_string "${output_message}" "/apis/apps/v1beta1/namespaces/default/deployments 200 OK"
+  kube::test::if_has_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/deployments 200 OK"
   kube::test::if_has_string "${output_message}" "/apis/extensions/v1beta1/namespaces/default/replicasets 200 OK"
 
   ### Test --allow-missing-template-keys


### PR DESCRIPTION
Fixes #42392

Kubectl 1.5 still uses compiled in types in kubectl edit and apply.
Because kubectl 1.5 does not have the apps/v1beta1/deployment resource
compiled in, the preferred group order must have extensions come
before apps.  The preference order is determined by the order
that the groups are listed by the discovery service, with
the first elements preferred over the last elements.

The quick fix is to manually ensure that the apps group
is listed after the extensions group in 1.6.