### PR TITLE
Remove credentials on worker nodes for vSphere cloud provider.

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -40,6 +40,7 @@ func configFromEnv() (cfg VSphereConfig, ok bool) {
 	cfg.Global.Datastore = os.Getenv("VSPHERE_DATASTORE")
 	cfg.Disk.SCSIControllerType = os.Getenv("VSPHERE_SCSICONTROLLER_TYPE")
 	cfg.Global.WorkingDir = os.Getenv("VSPHERE_WORKING_DIR")
+	cfg.Global.VMName = os.Getenv("VSPHERE_VM_NAME")
 	if os.Getenv("VSPHERE_INSECURE") != "" {
 		InsecureFlag, err = strconv.ParseBool(os.Getenv("VSPHERE_INSECURE"))
 	} else {
@@ -71,6 +72,7 @@ password = password
 insecure-flag = true
 datacenter = us-west
 vm-uuid = 1234
+vm-name = vmname
 `))
 	if err != nil {
 		t.Fatalf("Should succeed when a valid config is provided: %s", err)
@@ -86,6 +88,10 @@ vm-uuid = 1234
 
 	if cfg.Global.VMUUID != "1234" {
 		t.Errorf("incorrect vm-uuid: %s", cfg.Global.VMUUID)
+	}
+
+	if cfg.Global.VMName != "vmname" {
+		t.Errorf("incorrect vm-name: %s", cfg.Global.VMName)
 	}
 }
 
@@ -156,21 +162,16 @@ func TestInstances(t *testing.T) {
 		t.Fatalf("Instances() returned false")
 	}
 
-	srvs, err := vs.list("*")
+	nodeName, err := vs.CurrentNodeName("")
 	if err != nil {
-		t.Fatalf("list() failed: %s", err)
+		t.Fatalf("CurrentNodeName() failed: %s", err)
 	}
 
-	if len(srvs) == 0 {
-		t.Fatalf("list() returned zero servers")
-	}
-	t.Logf("Found servers (%d): %s\n", len(srvs), srvs)
-
-	externalId, err := i.ExternalID(srvs[0])
+	externalId, err := i.ExternalID(nodeName)
 	if err != nil {
-		t.Fatalf("Instances.ExternalID(%s) failed: %s", srvs[0], err)
+		t.Fatalf("Instances.ExternalID(%s) failed: %s", nodeName, err)
 	}
-	t.Logf("Found ExternalID(%s) = %s\n", srvs[0], externalId)
+	t.Logf("Found ExternalID(%s) = %s\n", nodeName, externalId)
 
 	nonExistingVM := types.NodeName(rand.String(15))
 	externalId, err = i.ExternalID(nonExistingVM)
@@ -182,11 +183,11 @@ func TestInstances(t *testing.T) {
 		t.Fatalf("Instances.ExternalID did not fail as expected, err: %v", err)
 	}
 
-	instanceId, err := i.InstanceID(srvs[0])
+	instanceId, err := i.InstanceID(nodeName)
 	if err != nil {
-		t.Fatalf("Instances.InstanceID(%s) failed: %s", srvs[0], err)
+		t.Fatalf("Instances.InstanceID(%s) failed: %s", nodeName, err)
 	}
-	t.Logf("Found InstanceID(%s) = %s\n", srvs[0], instanceId)
+	t.Logf("Found InstanceID(%s) = %s\n", nodeName, instanceId)
 
 	instanceId, err = i.InstanceID(nonExistingVM)
 	if err == cloudprovider.InstanceNotFound {
@@ -197,11 +198,11 @@ func TestInstances(t *testing.T) {
 		t.Fatalf("Instances.InstanceID did not fail as expected, err: %v", err)
 	}
 
-	addrs, err := i.NodeAddresses(srvs[0])
+	addrs, err := i.NodeAddresses(nodeName)
 	if err != nil {
-		t.Fatalf("Instances.NodeAddresses(%s) failed: %s", srvs[0], err)
+		t.Fatalf("Instances.NodeAddresses(%s) failed: %s", nodeName, err)
 	}
-	t.Logf("Found NodeAddresses(%s) = %s\n", srvs[0], addrs)
+	t.Logf("Found NodeAddresses(%s) = %s\n", nodeName, addrs)
 }
 
 func TestVolumes(t *testing.T) {
@@ -215,12 +216,9 @@ func TestVolumes(t *testing.T) {
 		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
 	}
 
-	srvs, err := vs.list("*")
+	nodeName, err := vs.CurrentNodeName("")
 	if err != nil {
-		t.Fatalf("list() failed: %s", err)
-	}
-	if len(srvs) == 0 {
-		t.Fatalf("list() returned zero servers")
+		t.Fatalf("CurrentNodeName() failed: %s", err)
 	}
 
 	volumeOptions := &VolumeOptions{
@@ -236,12 +234,12 @@ func TestVolumes(t *testing.T) {
 
 	_, _, err = vs.AttachDisk(volPath, "")
 	if err != nil {
-		t.Fatalf("Cannot attach volume(%s) to VM(%s): %v", volPath, srvs[0], err)
+		t.Fatalf("Cannot attach volume(%s) to VM(%s): %v", volPath, nodeName, err)
 	}
 
 	err = vs.DetachDisk(volPath, "")
 	if err != nil {
-		t.Fatalf("Cannot detach disk(%s) from VM(%s): %v", volPath, srvs[0], err)
+		t.Fatalf("Cannot detach disk(%s) from VM(%s): %v", volPath, nodeName, err)
 	}
 
 	// todo: Deleting a volume after detach currently not working through API or UI (vSphere)

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -48,6 +48,7 @@ func getVSphereConfig() *VSphereConfig {
 	cfg.Global.Datacenter = os.Getenv("VSPHERE_DATACENTER")
 	cfg.Global.Datastore = os.Getenv("VSPHERE_DATASTORE")
 	cfg.Global.WorkingDir = os.Getenv("VSPHERE_WORKING_DIR")
+	cfg.Global.VMName = os.Getenv("VSPHERE_VM_NAME")
 	cfg.Global.InsecureFlag = false
 	if strings.ToLower(os.Getenv("VSPHERE_INSECURE")) == "true" {
 		cfg.Global.InsecureFlag = true


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove the dependency of login information on worker nodes for vsphere cloud provider:
1. VM Name is required to be set in the cloud provider configuration file.
2. Remove the requirement of login for Instance functions when querying local node information.

**Which issue this PR fixes** : fixes #https://github.com/kubernetes/kubernetes/issues/35339

**Release note**:

```release-note
vSphere cloud provider: Remove the dependency of login information on worker nodes for vsphere cloud provider.
```