### PR TITLE
Bump CNI consumers to v0.5.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -62,6 +62,6 @@ debs = (
 
 http_file(
     name = "kubernetes_cni",
-    sha256 = "ddcb7a429f82b284a13bdb36313eeffd997753b6fa5191205f1e978dcfeb0792",
-    url = " https://storage.googleapis.com/kubernetes-release/network-plugins/cni-amd64-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz",
+    sha256 = "05ab3937bc68562e989dc143362ec4d4275262ba9f359338aed720fc914457a5",
+    url = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-amd64-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz",
 )

--- a/cluster/gce/container-linux/configure.sh
+++ b/cluster/gce/container-linux/configure.sh
@@ -111,8 +111,8 @@ function install-kube-binary-config {
   if [[ "${NETWORK_PROVIDER:-}" == "kubenet" ]] || \
      [[ "${NETWORK_PROVIDER:-}" == "cni" ]]; then
     #TODO(andyzheng0831): We should make the cni version number as a k8s env variable.
-    local -r cni_tar="cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
-    local -r cni_sha1="19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
+    local -r cni_tar="cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
+    local -r cni_sha1="1d9788b0f5420e1a219aad2cb8681823fc515e7c"
     download-or-bust "${cni_sha1}" "https://storage.googleapis.com/kubernetes-release/network-plugins/${cni_tar}"
     local -r cni_dir="${KUBE_HOME}/cni"
     mkdir -p "${cni_dir}"

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -184,8 +184,8 @@ function install-kube-binary-config {
   if [[ "${NETWORK_PROVIDER:-}" == "kubenet" ]] || \
      [[ "${NETWORK_PROVIDER:-}" == "cni" ]]; then
     #TODO(andyzheng0831): We should make the cni version number as a k8s env variable.
-    local -r cni_tar="cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz"
-    local -r cni_sha1="19d49f7b2b99cd2493d5ae0ace896c64e289ccbb"
+    local -r cni_tar="cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz"
+    local -r cni_sha1="1d9788b0f5420e1a219aad2cb8681823fc515e7c"
     download-or-bust "${cni_sha1}" "https://storage.googleapis.com/kubernetes-release/network-plugins/${cni_tar}"
     local -r cni_dir="${KUBE_HOME}/cni"
     mkdir -p "${cni_dir}"

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -20,7 +20,7 @@
 REGISTRY?=gcr.io/google_containers
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
-CNI_RELEASE=07a8a28637e97b22eb8dfe710eeae1344f69d16e
+CNI_RELEASE=0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff
 CACHEBUST?=1
 QEMUVERSION=v2.7.0
 

--- a/cluster/saltbase/salt/cni/init.sls
+++ b/cluster/saltbase/salt/cni/init.sls
@@ -19,9 +19,9 @@ cni-tar:
     - user: root
     - name: /opt/cni
     - makedirs: True
-    - source: https://storage.googleapis.com/kubernetes-release/network-plugins/cni-07a8a28637e97b22eb8dfe710eeae1344f69d16e.tar.gz
+    - source: https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
     - tar_options: v
-    - source_hash: md5=dd11b04dcb0b9aca00b5287ba18dcfaa
+    - source_hash: md5=afbb526e7d976f98353ac96f73043031
     - archive_format: tar
     - if_missing: /opt/cni/bin
 

--- a/test/e2e_node/remote/utils.go
+++ b/test/e2e_node/remote/utils.go
@@ -27,7 +27,7 @@ import (
 // utils.go contains functions used accross test suites.
 
 const (
-	cniRelease   = "07a8a28637e97b22eb8dfe710eeae1344f69d16e"
+	cniRelease   = "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"
 	cniDirectory = "cni"
 	cniURL       = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-" + cniRelease + ".tar.gz"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
- vendored CNI plugins properly handle `DEL` on missing resources
- update CNI version refs

**Which issue this PR fixes**

fixes #43488

**Release note**:

`bumps CNI to version v0.5.1 where plugins properly handle DEL on non existent resources`
