### PR TITLE
Remove unpaired '}'

### DIFF
--- a/examples/persistent-volume-provisioning/README.md
+++ b/examples/persistent-volume-provisioning/README.md
@@ -297,7 +297,6 @@ It is required that this value matches the name of a `StorageClass` configured b
   "apiVersion": "v1",
   "metadata": {
     "name": "claim1"
-    }
   },
   "spec": {
     "accessModes": [


### PR DESCRIPTION
**What this PR does / why we need it**:
The sample in examples/persistent-volume-provisioning/README.md had an extra/unpaired '}'.


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
