### PR TITLE
Check fluentd deployment befure running cluster logging e2e tests

### DIFF
--- a/test/e2e/cluster_logging_es.go
+++ b/test/e2e/cluster_logging_es.go
@@ -44,6 +44,9 @@ var _ = framework.KubeDescribe("Cluster level logging using Elasticsearch [Featu
 		err = esLogsProvider.EnsureWorking()
 		framework.ExpectNoError(err, "Elasticsearch is not working")
 
+		err = ensureSingleFluentdOnEachNode(f, esLogsProvider.FluentdApplicationName())
+		framework.ExpectNoError(err, "Fluentd deployed incorrectly")
+
 		By("Running synthetic logger")
 		pod := createLoggingPod(f, podName, 10*60, 10*time.Minute)
 		defer f.PodClient().Delete(podName, &meta_v1.DeleteOptions{})

--- a/test/e2e/cluster_logging_gcl.go
+++ b/test/e2e/cluster_logging_gcl.go
@@ -42,6 +42,9 @@ var _ = framework.KubeDescribe("Cluster level logging using GCL", func() {
 		err = gclLogsProvider.EnsureWorking()
 		framework.ExpectNoError(err, "GCL is not working")
 
+		err = ensureSingleFluentdOnEachNode(f, gclLogsProvider.FluentdApplicationName())
+		framework.ExpectNoError(err, "Fluentd deployed incorrectly")
+
 		By("Running synthetic logger")
 		pod := createLoggingPod(f, podName, 10*60, 10*time.Minute)
 		defer f.PodClient().Delete(podName, &meta_v1.DeleteOptions{})


### PR DESCRIPTION
There were changes to the way cluster logging is deployed to the cluster.

PR adds logic to the cluster logging e2e tests to check that cluster has fluentd and that there's only one fluentd instance on the node. This will verify the correctness of the deployment method.