### PR TITLE
k8s.io/apiserver: make maxRetryWhenPatchConflicts public

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -104,8 +104,8 @@ func (scope *RequestScope) err(err error, w http.ResponseWriter, req *http.Reque
 // may be used to deserialize an options object to pass to the getter.
 type getterFunc func(ctx request.Context, name string, req *restful.Request) (runtime.Object, error)
 
-// maxRetryWhenPatchConflicts is the maximum number of conflicts retry during a patch operation before returning failure
-const maxRetryWhenPatchConflicts = 5
+// MaxRetryWhenPatchConflicts is the maximum number of conflicts retry during a patch operation before returning failure
+const MaxRetryWhenPatchConflicts = 5
 
 // getResourceHandler is an HTTP handler function for get requests. It delegates to the
 // passed-in getterFunc to perform the actual get.
@@ -742,7 +742,7 @@ func patchResource(
 
 	return finishRequest(timeout, func() (runtime.Object, error) {
 		updateObject, _, updateErr := patcher.Update(ctx, name, updatedObjectInfo)
-		for i := 0; i < maxRetryWhenPatchConflicts && (errors.IsConflict(updateErr)); i++ {
+		for i := 0; i < MaxRetryWhenPatchConflicts && (errors.IsConflict(updateErr)); i++ {
 			lastConflictErr = updateErr
 			updateObject, _, updateErr = patcher.Update(ctx, name, updatedObjectInfo)
 		}


### PR DESCRIPTION
This variable used to be public (before https://github.com/kubernetes/kubernetes/pull/37468). It is pretty use-full to write reliable integration tests that involve resource patching, and it is used in downstream project for that purpose.