### PR TITLE
Fix version.go after relase 1.5.5

### DIFF
--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -51,7 +51,7 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v1.5.5-beta.0+$Format:%h$"
+	gitVersion   string = "v1.5.6-beta.0+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 


### PR DESCRIPTION
The security release 1.5.5 was done in a separate branch. PodSecurityPolicy fix has been added to 1.5 release branch. However the update of version.go didn't go through. This PR fixes it. 

The commit history on release-1.5 will NOT be altered to reflect where (and with what commits) 1.5.5 was made. Changing history in published repos is strongly discouraged by all git docs/tutorials.  

cc: @saad-ali @liggitt 