### PR TITLE
allow etcd2/3 choice when bringing up a local cluster, default to etcd3

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -62,7 +62,7 @@ HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-"127.0.0.1"}
 CLOUD_PROVIDER=${CLOUD_PROVIDER:-""}
 CLOUD_CONFIG=${CLOUD_CONFIG:-""}
 FEATURE_GATES=${FEATURE_GATES:-"AllAlpha=true"}
-
+STORAGE_BACKEND=${STORAGE_BACKEND:-"etcd3"}
 # enable swagger ui
 ENABLE_SWAGGER_UI=${ENABLE_SWAGGER_UI:-false}
 
@@ -449,6 +449,7 @@ function start_apiserver {
       --tls-ca-file="${CERT_DIR}/server-ca.crt" \
       --insecure-bind-address="${API_HOST_IP}" \
       --insecure-port="${API_PORT}" \
+      --storage-backend=${STORAGE_BACKEND} \
       --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
       --service-cluster-ip-range="${SERVICE_CLUSTER_IP_RANGE}" \
       --feature-gates="${FEATURE_GATES}" \


### PR DESCRIPTION
**What this PR does / why we need it**: local-up-cluster currently doesn't allow you to select which etcd version to use, here we allow you to select one, since k8s is moving towards etcd3 we suggest it to be the default.

**Special notes for your reviewer**: Note, i didnt realize this until i had used https://github.com/kubernetes/kubernetes/pull/42656 which made it immediately clear.

**Release note**:
```
NONE
```
