### PR TITLE
Increase delays between calling Stackdriver Logging API in e2e tests

### DIFF
--- a/test/e2e/cluster_logging_gcl_utils.go
+++ b/test/e2e/cluster_logging_gcl_utils.go
@@ -35,8 +35,8 @@ const (
 	// quota limit exceeded. So we retry for some time in case the problem will go away.
 	// Quota is enforced every 100 seconds, so we have to wait for more than
 	// that to reliably get the next portion.
-	queryGclRetryDelay   = 10 * time.Second
-	queryGclRetryTimeout = 200 * time.Second
+	queryGclRetryDelay   = 100 * time.Second
+	queryGclRetryTimeout = 250 * time.Second
 )
 
 type gclLogsProvider struct {

--- a/test/e2e/cluster_logging_utils.go
+++ b/test/e2e/cluster_logging_utils.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	// Duration of delay between any two attempts to check if all logs are ingested
-	ingestionRetryDelay = 10 * time.Second
+	ingestionRetryDelay = 100 * time.Second
 
 	// Amount of requested cores for logging container in millicores
 	loggingContainerCpuRequest = 10


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/43442

This is a temporary hack, proper solution will be implemented soon