### PR TITLE
Disable Horizontal Pod Autoscaler upgrade tests

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -33,7 +33,8 @@ var upgradeTests = []upgrades.Test{
 	&upgrades.DeploymentUpgradeTest{},
 	&upgrades.JobUpgradeTest{},
 	&upgrades.ConfigMapUpgradeTest{},
-	&upgrades.HPAUpgradeTest{},
+	// Disabling until can be debugged, causing upgrade jobs to timeout
+	// &upgrades.HPAUpgradeTest{},
 	&upgrades.PersistentVolumeUpgradeTest{},
 	&upgrades.DaemonSetUpgradeTest{},
 	&upgrades.IngressUpgradeTest{},


### PR DESCRIPTION
This PR disables HPA upgrade tests until they can be debugged as part of #43187.

/cc @skriss @krousey 

```release-note
NONE
```
