### PR TITLE
Improve pause-container warning message

### DIFF
--- a/build/pause/pause.c
+++ b/build/pause/pause.c
@@ -27,8 +27,7 @@ static void sigdown(int signo) {
 }
 
 static void sigreap(int signo) {
-  while (waitpid(-1, NULL, WNOHANG) > 0)
-    ;
+  while (waitpid(-1, NULL, WNOHANG) > 0);
 }
 
 int main() {

--- a/build/pause/pause.c
+++ b/build/pause/pause.c
@@ -34,7 +34,7 @@ static void sigreap(int signo) {
 int main() {
   if (getpid() != 1)
     /* Not an error because pause sees use outside of infra containers. */
-    fprintf(stderr, "Warning: pause should be the first process in a pod\n");
+    fprintf(stderr, "Warning: pause should be the first process\n");
 
   if (sigaction(SIGINT, &(struct sigaction){.sa_handler = sigdown}, NULL) < 0)
     return 1;


### PR DESCRIPTION
Signed-off-by: Vinothkumar Siddharth <sidvin@amazon.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This just improves the warning message currently emitted by pause

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
