### PR TITLE
[WIP] Azure Update Domain support with the current failure-domain scheduler logic

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_zones.go
+++ b/pkg/cloudprovider/providers/azure/azure_zones.go
@@ -42,7 +42,7 @@ func (az *Cloud) GetZone() (cloudprovider.Zone, error) {
 	faultMutex.Lock()
 	if faultDomain == nil {
 		var err error
-		faultDomain, err = fetchFaultDomain()
+		faultDomain, err = fetchFaultAndUpdateDomains()
 		if err != nil {
 			return cloudprovider.Zone{}, err
 		}
@@ -55,17 +55,18 @@ func (az *Cloud) GetZone() (cloudprovider.Zone, error) {
 	return zone, nil
 }
 
-func fetchFaultDomain() (*string, error) {
+func fetchFaultAndUpdateDomains() (*string, error) {
 	resp, err := http.Get(instanceInfoURL)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
-	return readFaultDomain(resp.Body)
+	return readFaultAndUpdateDomain(resp.Body)
 }
 
-func readFaultDomain(reader io.Reader) (*string, error) {
+func readFaultAndUpdateDomain(reader io.Reader) (*string, error) {
 	var instanceInfo instanceInfo
+	var faultAndUpdateDomains string
 	body, err := ioutil.ReadAll(reader)
 	if err != nil {
 		return nil, err
@@ -74,5 +75,6 @@ func readFaultDomain(reader io.Reader) (*string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &instanceInfo.FaultDomain, nil
+	faultAndUpdateDomains = "FD" + instanceInfo.FaultDomain + "UP" + instanceInfo.UpdateDomain
+	return &faultAndUpdateDomains, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In the Azure world, when using Availablity Sets, a VM gets assigned two domains: fault and update. 
Currently, the pod Anti-affinity logic of the scheduler will use some default failure-domains labels as part of scheduling logic. 
One of the failure-domain is the zone, which is set by the cloud-provider. For azure, initially, the zone was set to match the FailureDomain. While this covers unplanned VM disruption, Microsoft could still be reboot VMs of the same Update Domain, for this reason, we should try to have Kubernetes aware of those update domain. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #40684

**Special notes for your reviewer**:

This is a first take at supporting Update Domain, I expect that this solution might not be best or aligned with the Kubernetes Vision and I'm o with updating/aligning the PR with the best option. 

We are currently about to deploy a large production cluster in Azure, therefore are requiring this Update Domain to be handled properly. 

**Release Notes**

```release-note
```