### PR TITLE
Adding IPv6 to cidr_set and cidr_set_test

### DIFF
--- a/pkg/controller/node/cidr_set_test.go
+++ b/pkg/controller/node/cidr_set_test.go
@@ -26,124 +26,244 @@ import (
 )
 
 func TestCIDRSetFullyAllocated(t *testing.T) {
-	_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/30")
-	a := newCIDRSet(clusterCIDR, 30)
+	cases := []struct {
+		clusterCIDRStr string
+		subNetMaskSize int
+		expectedCIDR   string
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.123.234.0/30",
+			subNetMaskSize: 30,
+			expectedCIDR:   "127.123.234.0/30",
+			description:    "Fully allocated CIDR with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/30",
+			subNetMaskSize: 30,
+			expectedCIDR:   "beef:1234::/30",
+			description:    "Fully allocated CIDR with IPv6",
+		},
+	}
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a := newCIDRSet(clusterCIDR, tc.subNetMaskSize)
 
-	p, err := a.allocateNext()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if p.String() != "127.123.234.0/30" {
-		t.Fatalf("unexpected allocated cidr: %s", p.String())
-	}
+		p, err := a.allocateNext()
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+		if p.String() != tc.expectedCIDR {
+			t.Fatalf("unexpected allocated cidr: %v, expecting %v for %v",
+				p.String(), tc.expectedCIDR, tc.description)
+		}
 
-	_, err = a.allocateNext()
-	if err == nil {
-		t.Fatalf("expected error because of fully-allocated range")
-	}
+		_, err = a.allocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
 
-	a.release(p)
-	p, err = a.allocateNext()
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		a.release(p)
+
+		p, err = a.allocateNext()
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+		if p.String() != tc.expectedCIDR {
+			t.Fatalf("unexpected allocated cidr: %v, expecting %v for %v",
+				p.String(), tc.expectedCIDR, tc.description)
+		}
+		_, err = a.allocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
 	}
-	if p.String() != "127.123.234.0/30" {
-		t.Fatalf("unexpected allocated cidr: %s", p.String())
+}
+
+func TestIndexToCIDRBlock(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		subnetMaskSize int
+		index          int
+		CIDRBlock      string
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.123.3.0/16",
+			subnetMaskSize: 24,
+			index:          0,
+			CIDRBlock:      "127.123.0.0/24",
+			description:    "Index with IPv4",
+		},
+		{
+			clusterCIDRStr: "127.123.0.0/16",
+			subnetMaskSize: 24,
+			index:          15,
+			CIDRBlock:      "127.123.15.0/24",
+			description:    "Index with IPv4",
+		},
+		{
+			clusterCIDRStr: "192.168.5.219/28",
+			subnetMaskSize: 32,
+			index:          5,
+			CIDRBlock:      "192.168.5.213/32",
+			description:    "Index with IPv4",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234:3::/48",
+			subnetMaskSize: 64,
+			index:          0,
+			CIDRBlock:      "2001:db8:1234::/64",
+			description:    "Index with IPv6",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234::/48",
+			subnetMaskSize: 64,
+			index:          15,
+			CIDRBlock:      "2001:db8:1234:f::/64",
+			description:    "Index with IPv6",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:85a3::8a2e:0370:7334/50",
+			subnetMaskSize: 63,
+			index:          6425,
+			CIDRBlock:      "2001:db8:85a3:3232::/63",
+			description:    "Index with IPv6",
+		},
 	}
-	_, err = a.allocateNext()
-	if err == nil {
-		t.Fatalf("expected error because of fully-allocated range")
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a := newCIDRSet(clusterCIDR, tc.subnetMaskSize)
+		cidr := a.indexToCIDRBlock(tc.index)
+		if cidr.String() != tc.CIDRBlock {
+			t.Fatalf("error for %v index %d %s", tc.description, tc.index, cidr.String())
+		}
 	}
 }
 
 func TestCIDRSet_RandomishAllocation(t *testing.T) {
-	_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/16")
-	a := newCIDRSet(clusterCIDR, 24)
-	// allocate all the CIDRs
-	var err error
-	cidrs := make([]*net.IPNet, 256)
+	cases := []struct {
+		clusterCIDRStr string
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.123.234.0/16",
+			description:    "RandomishAllocation with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/16",
+			description:    "RandomishAllocation with IPv6",
+		},
+	}
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a := newCIDRSet(clusterCIDR, 24)
+		// allocate all the CIDRs
+		var cidrs []*net.IPNet
 
-	for i := 0; i < 256; i++ {
-		cidrs[i], err = a.allocateNext()
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		for i := 0; i < 256; i++ {
+			if c, err := a.allocateNext(); err == nil {
+				cidrs = append(cidrs, c)
+			} else {
+				t.Fatalf("unexpected error: %v for %v", err, tc.description)
+			}
 		}
-	}
 
-	_, err = a.allocateNext()
-	if err == nil {
-		t.Fatalf("expected error because of fully-allocated range")
-	}
-	// release them all
-	for i := 0; i < 256; i++ {
-		a.release(cidrs[i])
-	}
-
-	// allocate the CIDRs again
-	rcidrs := make([]*net.IPNet, 256)
-	for i := 0; i < 256; i++ {
-		rcidrs[i], err = a.allocateNext()
-		if err != nil {
-			t.Fatalf("unexpected error: %d, %v", i, err)
+		var err error
+		_, err = a.allocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
 		}
-	}
-	_, err = a.allocateNext()
-	if err == nil {
-		t.Fatalf("expected error because of fully-allocated range")
-	}
+		// release them all
+		for i := 0; i < len(cidrs); i++ {
+			a.release(cidrs[i])
+		}
 
-	if !reflect.DeepEqual(cidrs, rcidrs) {
-		t.Fatalf("expected re-allocated cidrs are the same collection")
+		// allocate the CIDRs again
+		var rcidrs []*net.IPNet
+		for i := 0; i < 256; i++ {
+			if c, err := a.allocateNext(); err == nil {
+				rcidrs = append(rcidrs, c)
+			} else {
+				t.Fatalf("unexpected error: %d, %v for %v", i, err, tc.description)
+			}
+		}
+		_, err = a.allocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
+
+		if !reflect.DeepEqual(cidrs, rcidrs) {
+			t.Fatalf("expected re-allocated cidrs are the same collection for %v", tc.description)
+		}
 	}
 }
 
 func TestCIDRSet_AllocationOccupied(t *testing.T) {
-	_, clusterCIDR, _ := net.ParseCIDR("127.123.234.0/16")
-	a := newCIDRSet(clusterCIDR, 24)
+	cases := []struct {
+		clusterCIDRStr string
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.123.234.0/16",
+			description:    "AllocationOccupied with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/16",
+			description:    "AllocationOccupied with IPv6",
+		},
+	}
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a := newCIDRSet(clusterCIDR, 24)
 
-	// allocate all the CIDRs
-	var err error
-	cidrs := make([]*net.IPNet, 256)
+		// allocate all the CIDRs
+		var cidrs []*net.IPNet
+		var num_cidrs = 256
 
-	for i := 0; i < 256; i++ {
-		cidrs[i], err = a.allocateNext()
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		for i := 0; i < num_cidrs; i++ {
+			if c, err := a.allocateNext(); err == nil {
+				cidrs = append(cidrs, c)
+			} else {
+				t.Fatalf("unexpected error: %v for %v", err, tc.description)
+			}
 		}
-	}
 
-	_, err = a.allocateNext()
-	if err == nil {
-		t.Fatalf("expected error because of fully-allocated range")
-	}
-	// release them all
-	for i := 0; i < 256; i++ {
-		a.release(cidrs[i])
-	}
-	// occupy the last 128 CIDRs
-	for i := 128; i < 256; i++ {
-		a.occupy(cidrs[i])
-	}
-
-	// allocate the first 128 CIDRs again
-	rcidrs := make([]*net.IPNet, 128)
-	for i := 0; i < 128; i++ {
-		rcidrs[i], err = a.allocateNext()
-		if err != nil {
-			t.Fatalf("unexpected error: %d, %v", i, err)
+		var err error
+		_, err = a.allocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
 		}
-	}
-	_, err = a.allocateNext()
-	if err == nil {
-		t.Fatalf("expected error because of fully-allocated range")
-	}
+		// release them all
+		for i := 0; i < len(cidrs); i++ {
+			a.release(cidrs[i])
+		}
+		// occupy the last 128 CIDRs
+		for i := num_cidrs / 2; i < num_cidrs; i++ {
+			a.occupy(cidrs[i])
+		}
 
-	// check Occupy() work properly
-	for i := 128; i < 256; i++ {
-		rcidrs = append(rcidrs, cidrs[i])
-	}
-	if !reflect.DeepEqual(cidrs, rcidrs) {
-		t.Fatalf("expected re-allocated cidrs are the same collection")
+		// allocate the first 128 CIDRs again
+		var rcidrs []*net.IPNet
+		for i := 0; i < num_cidrs/2; i++ {
+			if c, err := a.allocateNext(); err == nil {
+				rcidrs = append(rcidrs, c)
+			} else {
+				t.Fatalf("unexpected error: %d, %v for %v", i, err, tc.description)
+			}
+		}
+		_, err = a.allocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
+
+		// check Occupy() work properly
+		for i := num_cidrs / 2; i < num_cidrs; i++ {
+			rcidrs = append(rcidrs, cidrs[i])
+		}
+		if !reflect.DeepEqual(cidrs, rcidrs) {
+			t.Fatalf("expected re-allocated cidrs are the same collection for %v", tc.description)
+		}
 	}
 }
 
@@ -154,6 +274,7 @@ func TestGetBitforCIDR(t *testing.T) {
 		subNetCIDRStr  string
 		expectedBit    int
 		expectErr      bool
+		description    string
 	}{
 		{
 			clusterCIDRStr: "127.0.0.0/8",
@@ -161,6 +282,15 @@ func TestGetBitforCIDR(t *testing.T) {
 			subNetCIDRStr:  "127.0.0.0/16",
 			expectedBit:    0,
 			expectErr:      false,
+			description:    "Get 0 Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "be00::/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "be00::/16",
+			expectedBit:    0,
+			expectErr:      false,
+			description:    "Get 0 Bit with IPv6",
 		},
 		{
 			clusterCIDRStr: "127.0.0.0/8",
@@ -168,6 +298,15 @@ func TestGetBitforCIDR(t *testing.T) {
 			subNetCIDRStr:  "127.123.0.0/16",
 			expectedBit:    123,
 			expectErr:      false,
+			description:    "Get 123rd Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "be00::/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "beef::/16",
+			expectedBit:    0xef,
+			expectErr:      false,
+			description:    "Get xef Bit with IPv6",
 		},
 		{
 			clusterCIDRStr: "127.0.0.0/8",
@@ -175,6 +314,15 @@ func TestGetBitforCIDR(t *testing.T) {
 			subNetCIDRStr:  "127.168.0.0/16",
 			expectedBit:    168,
 			expectErr:      false,
+			description:    "Get 168th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "be00::/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "be68::/16",
+			expectedBit:    0x68,
+			expectErr:      false,
+			description:    "Get x68th Bit with IPv6",
 		},
 		{
 			clusterCIDRStr: "127.0.0.0/8",
@@ -182,6 +330,15 @@ func TestGetBitforCIDR(t *testing.T) {
 			subNetCIDRStr:  "127.224.0.0/16",
 			expectedBit:    224,
 			expectErr:      false,
+			description:    "Get 224th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "be00::/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "be24::/16",
+			expectedBit:    0x24,
+			expectErr:      false,
+			description:    "Get x24th Bit with IPv6",
 		},
 		{
 			clusterCIDRStr: "192.168.0.0/16",
@@ -189,6 +346,15 @@ func TestGetBitforCIDR(t *testing.T) {
 			subNetCIDRStr:  "192.168.12.0/24",
 			expectedBit:    12,
 			expectErr:      false,
+			description:    "Get 12th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef::/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "beef:1200::/24",
+			expectedBit:    0x12,
+			expectErr:      false,
+			description:    "Get x12th Bit with IPv6",
 		},
 		{
 			clusterCIDRStr: "192.168.0.0/16",
@@ -196,41 +362,58 @@ func TestGetBitforCIDR(t *testing.T) {
 			subNetCIDRStr:  "192.168.151.0/24",
 			expectedBit:    151,
 			expectErr:      false,
+			description:    "Get 151st Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef::/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "beef:9700::/24",
+			expectedBit:    0x97,
+			expectErr:      false,
+			description:    "Get x97st Bit with IPv6",
 		},
 		{
 			clusterCIDRStr: "192.168.0.0/16",
 			subNetMaskSize: 24,
 			subNetCIDRStr:  "127.168.224.0/24",
 			expectErr:      true,
+			description:    "Get error with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef::/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "2001:db00::/24",
+			expectErr:      true,
+			description:    "Get error with IPv6",
 		},
 	}
 
 	for _, tc := range cases {
 		_, clusterCIDR, err := net.ParseCIDR(tc.clusterCIDRStr)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
 		cs := newCIDRSet(clusterCIDR, tc.subNetMaskSize)
 
 		_, subnetCIDR, err := net.ParseCIDR(tc.subNetCIDRStr)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
 		got, err := cs.getIndexForCIDR(subnetCIDR)
 		if err == nil && tc.expectErr {
-			glog.Errorf("expected error but got null")
+			glog.Errorf("expected error but got null for %v", tc.description)
 			continue
 		}
 
 		if err != nil && !tc.expectErr {
-			glog.Errorf("unexpected error: %v", err)
+			glog.Errorf("unexpected error: %v for %v", err, tc.description)
 			continue
 		}
 
 		if got != tc.expectedBit {
-			glog.Errorf("expected %v, but got %v", tc.expectedBit, got)
+			glog.Errorf("expected %v, but got %v for %v", tc.expectedBit, got, tc.description)
 		}
 	}
 }
@@ -243,6 +426,7 @@ func TestOccupy(t *testing.T) {
 		expectedUsedBegin int
 		expectedUsedEnd   int
 		expectErr         bool
+		description       string
 	}{
 		{
 			clusterCIDRStr:    "127.0.0.0/8",
@@ -251,6 +435,16 @@ func TestOccupy(t *testing.T) {
 			expectedUsedBegin: 0,
 			expectedUsedEnd:   255,
 			expectErr:         false,
+			description:       "Occupy all Bits with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:1200::/40",
+			subNetMaskSize:    48,
+			subNetCIDRStr:     "2001:beef:1200::/40",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   255,
+			expectErr:         false,
+			description:       "Occupy all Bits with IPv6",
 		},
 		{
 			clusterCIDRStr:    "127.0.0.0/8",
@@ -259,6 +453,16 @@ func TestOccupy(t *testing.T) {
 			expectedUsedBegin: 0,
 			expectedUsedEnd:   255,
 			expectErr:         false,
+			description:       "Occupy every Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:1200::/40",
+			subNetMaskSize:    48,
+			subNetCIDRStr:     "2001:beef:1234::/34",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   255,
+			expectErr:         false,
+			description:       "Occupy every Bit with IPv6",
 		},
 		{
 			clusterCIDRStr:    "127.0.0.0/8",
@@ -267,6 +471,16 @@ func TestOccupy(t *testing.T) {
 			expectedUsedBegin: 0,
 			expectedUsedEnd:   0,
 			expectErr:         false,
+			description:       "Occupy 1st Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:1200::/40",
+			subNetMaskSize:    48,
+			subNetCIDRStr:     "2001:beef:1200::/48",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   0,
+			expectErr:         false,
+			description:       "Occupy 1st Bit with IPv6",
 		},
 		{
 			clusterCIDRStr:    "127.0.0.0/8",
@@ -275,6 +489,16 @@ func TestOccupy(t *testing.T) {
 			expectedUsedBegin: 0,
 			expectedUsedEnd:   65535,
 			expectErr:         false,
+			description:       "Occupy 65535 Bits with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:1200::/48",
+			subNetMaskSize:    64,
+			subNetCIDRStr:     "2001:beef:1200::/48",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   65535,
+			expectErr:         false,
+			description:       "Occupy 65535 Bits with IPv6",
 		},
 		{
 			clusterCIDRStr:    "127.0.0.0/7",
@@ -283,6 +507,16 @@ func TestOccupy(t *testing.T) {
 			expectedUsedBegin: 256,
 			expectedUsedEnd:   257,
 			expectErr:         false,
+			description:       "Occupy 257th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:7f00::/39",
+			subNetMaskSize:    48,
+			subNetCIDRStr:     "2001:beef:7f00::/47",
+			expectedUsedBegin: 256,
+			expectedUsedEnd:   257,
+			expectErr:         false,
+			description:       "Occupy 257th Bit with IPv6",
 		},
 		{
 			clusterCIDRStr:    "127.0.0.0/7",
@@ -291,6 +525,16 @@ func TestOccupy(t *testing.T) {
 			expectedUsedBegin: 128,
 			expectedUsedEnd:   128,
 			expectErr:         false,
+			description:       "Occupy 128th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:7f00::/39",
+			subNetMaskSize:    47,
+			subNetCIDRStr:     "2001:beef:7f00::/47",
+			expectedUsedBegin: 128,
+			expectedUsedEnd:   128,
+			expectErr:         false,
+			description:       "Occupy 128th Bit with IPv6",
 		},
 		{
 			clusterCIDRStr:    "127.0.0.0/7",
@@ -299,29 +543,39 @@ func TestOccupy(t *testing.T) {
 			expectedUsedBegin: 1024,
 			expectedUsedEnd:   1031,
 			expectErr:         false,
+			description:       "Occupy 1031st Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:7f00::/39",
+			subNetMaskSize:    50,
+			subNetCIDRStr:     "2001:beef:7f00::/47",
+			expectedUsedBegin: 1024,
+			expectedUsedEnd:   1031,
+			expectErr:         false,
+			description:       "Occupy 1031st Bit with IPv6",
 		},
 	}
 
 	for _, tc := range cases {
 		_, clusterCIDR, err := net.ParseCIDR(tc.clusterCIDRStr)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
 		cs := newCIDRSet(clusterCIDR, tc.subNetMaskSize)
 
 		_, subnetCIDR, err := net.ParseCIDR(tc.subNetCIDRStr)
 		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
 		}
 
 		err = cs.occupy(subnetCIDR)
 		if err == nil && tc.expectErr {
-			t.Errorf("expected error but got none")
+			t.Errorf("expected error but got none for %v", tc.description)
 			continue
 		}
 		if err != nil && !tc.expectErr {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("unexpected error: %v for %v", err, tc.description)
 			continue
 		}
 
@@ -330,7 +584,72 @@ func TestOccupy(t *testing.T) {
 			expectedUsed.SetBit(&expectedUsed, i, 1)
 		}
 		if expectedUsed.Cmp(&cs.used) != 0 {
-			t.Errorf("error")
+			t.Errorf("error for %v", tc.description)
+		}
+	}
+}
+
+func TestCIDRSetv6(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		subNetMaskSize int
+		expectedCIDR   string
+		expectedCIDR2  string
+		expectErr      bool
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.0.0.0/8",
+			subNetMaskSize: 32,
+			expectErr:      false,
+			expectedCIDR:   "127.0.0.0/32",
+			expectedCIDR2:  "127.0.0.1/32",
+			description:    "Max cluster subnet size with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/32",
+			subNetMaskSize: 49,
+			expectErr:      true,
+			description:    "Max cluster subnet size with IPv6",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/60",
+			subNetMaskSize: 65,
+			expectErr:      true,
+			description:    "Max prefix length with IPv6",
+		},
+		{
+			clusterCIDRStr: "2001:beef:1234:369b::/60",
+			subNetMaskSize: 64,
+			expectedCIDR:   "2001:beef:1234:3690::/64",
+			expectedCIDR2:  "2001:beef:1234:3691::/64",
+			expectErr:      false,
+			description:    "Allocate a few IPv6",
+		},
+	}
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a := newCIDRSet(clusterCIDR, tc.subNetMaskSize)
+
+		p, err := a.allocateNext()
+		if err == nil && tc.expectErr {
+			t.Errorf("expected error but got none for %v", tc.description)
+			continue
+		}
+		if err != nil && !tc.expectErr {
+			t.Errorf("unexpected error: %v for %v", err, tc.description)
+			continue
+		}
+		if !tc.expectErr {
+			if p.String() != tc.expectedCIDR {
+				t.Fatalf("unexpected allocated cidr: %s for %v", p.String(), tc.description)
+			}
+		}
+		p2, err := a.allocateNext()
+		if !tc.expectErr {
+			if p2.String() != tc.expectedCIDR2 {
+				t.Fatalf("unexpected allocated cidr: %s for %v", p2.String(), tc.description)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This allows IPv6 in cidr_set

Currently cidr_set only supports IPv4. This adds IPv6 compatibility and adds
IPv6 unit tests.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43588

**Special notes for your reviewer**:
The IPv6 code here makes some assumptions.
The subnets should be at least /64. (maximum 64 bits of prefix)
The subnet mask size cannot be greater than 30 more than the cluster mask size.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
