### PR TITLE
Update `kubectl help` descriptions and examples

### DIFF
--- a/docs/user-guide/kubectl/kubectl_stop.md
+++ b/docs/user-guide/kubectl/kubectl_stop.md
@@ -26,8 +26,8 @@ $ kubectl stop replicationcontroller foo
 # Stop pods and services with label name=myLabel.
 $ kubectl stop pods,services -l name=myLabel
 
-# Shut down the service defined in service.json
-$ kubectl stop -f service.json
+# Shut down the service defined in service.yaml
+$ kubectl stop -f service.yaml
 
 # Shut down all resources in the path/to/resources directory
 $ kubectl stop -f path/to/resources

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -113,7 +113,7 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]",
-		Short:   i18n.T("Update the annotations on a resource"),
+		Short:   i18n.T("Add or update the annotations of one or more resources"),
 		Long:    annotate_long,
 		Example: annotate_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -40,7 +40,7 @@ func NewCmdApiVersions(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Use: "api-versions",
 		// apiversions is deprecated.
 		Aliases: []string{"apiversions"},
-		Short:   "Print the supported API versions on the server, in the form of \"group/version\"",
+		Short:   "List the API versions that are available",
 		Long:    "Print the supported API versions on the server, in the form of \"group/version\"",
 		Example: apiversions_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -101,7 +101,7 @@ func NewCmdApply(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "apply -f FILENAME",
-		Short:   i18n.T("Apply a configuration to a resource by filename or stdin"),
+		Short:   i18n.T("Apply a configuration change to a resource from a file or stdin"),
 		Long:    apply_long,
 		Example: apply_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -67,7 +67,7 @@ func NewCmdAttach(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) 
 	}
 	cmd := &cobra.Command{
 		Use:     "attach (POD | TYPE/NAME) -c CONTAINER",
-		Short:   i18n.T("Attach to a running container"),
+		Short:   i18n.T("Attach to a running container either to view the output stream or interact with the container (stdin)"),
 		Long:    "Attach to a process that is already running inside an existing container.",
 		Example: attach_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -53,7 +53,7 @@ func NewCmdAutoscale(f cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --max=MAXPODS [--cpu-percent=CPU] [flags]",
-		Short:   i18n.T("Auto-scale a Deployment, ReplicaSet, or ReplicationController"),
+		Short:   i18n.T("Automatically scale the set of pods that are managed by a replication controller"),
 		Long:    autoscaleLong,
 		Example: autoscaleExample,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -48,7 +48,7 @@ func NewCmdClusterInfo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Use: "cluster-info",
 		// clusterinfo is deprecated.
 		Aliases: []string{"clusterinfo"},
-		Short:   i18n.T("Display cluster info"),
+		Short:   i18n.T("Display endpoint information about the master and services in the cluster"),
 		Long:    longDescr,
 		Example: clusterinfo_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -52,7 +52,16 @@ var (
 		cat pod.json | kubectl create -f -
 
 		# Edit the data in docker-registry.yaml in JSON using the v1 API format then create the resource using the edited data.
-		kubectl create -f docker-registry.yaml --edit --output-version=v1 -o json`)
+		kubectl create -f docker-registry.yaml --edit --output-version=v1 -o json
+
+		# Create a service using the definition in example-service.yaml.
+		kubectl create -f example-service.yaml
+
+		# Create a replication controller using the definition in example-controller.yaml.
+		kubectl create -f example-controller.yaml
+
+		# Create the objects that are defined in any .yaml, .yml, or .json file within the <directory> directory.
+		kubectl create -f <directory>`)
 )
 
 func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
@@ -60,7 +69,7 @@ func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "create -f FILENAME",
-		Short:   i18n.T("Create a resource by filename or stdin"),
+		Short:   i18n.T("Create one or more resources from a file or stdin"),
 		Long:    create_long,
 		Example: create_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -129,7 +129,7 @@ func NewCmdDelete(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "delete ([-f FILENAME] | TYPE [(NAME | -l label | --all)])",
-		Short:   i18n.T("Delete resources by filenames, stdin, resources and names, or by resources and label selector"),
+		Short:   i18n.T("Delete resources either from a file, stdin, or specifying label selectors, names, resource selectors, or resources"),
 		Long:    delete_long,
 		Example: delete_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -52,11 +52,11 @@ var (
 		` + valid_resources)
 
 	describe_example = templates.Examples(`
-		# Describe a node
-		kubectl describe nodes kubernetes-node-emt8.c.myproject.internal
+		# Display the details of the node with name <node-name>.
+		kubectl describe nodes <node-name>
 
-		# Describe a pod
-		kubectl describe pods/nginx
+		# Display the details of the pod with name <pod-name>.
+		kubectl describe pods/<pod-name>
 
 		# Describe a pod identified by type and name in "pod.json"
 		kubectl describe -f pod.json
@@ -67,9 +67,9 @@ var (
 		# Describe pods by label name=myLabel
 		kubectl describe po -l name=myLabel
 
-		# Describe all pods managed by the 'frontend' replication controller (rc-created pods
-		# get the name of the rc as a prefix in the pod the name).
-		kubectl describe pods frontend`)
+		# Display the details of all the pods that are managed by the replication controller named <rc-name>.
+		# Remember: Any pods that are created by the replication controller get prefixed with the name of the replication controller.
+		kubectl describe pods <rc-name>`)
 )
 
 func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
@@ -83,7 +83,7 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",
-		Short:   i18n.T("Show details of a specific resource or group of resources"),
+		Short:   i18n.T("Display the detailed state of one or more resources"),
 		Long:    describe_long,
 		Example: describe_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -107,7 +107,7 @@ func NewCmdEdit(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "edit (RESOURCE/NAME | -f FILENAME)",
-		Short:   i18n.T("Edit a resource on the server"),
+		Short:   i18n.T("Edit and update the definition of one or more resources on the server by using the default editor"),
 		Long:    editLong,
 		Example: fmt.Sprintf(editExample),
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -39,15 +39,18 @@ import (
 
 var (
 	exec_example = templates.Examples(`
-		# Get output from running 'date' from pod 123456-7890, using the first container by default
-		kubectl exec 123456-7890 date
+		# Get output from running 'date' from pod <pod-name>. By default, output is from the first container.
+		kubectl exec <pod-name> date
 
-		# Get output from running 'date' in ruby-container from pod 123456-7890
-		kubectl exec 123456-7890 -c ruby-container date
+		# Get output from running 'date' in container <container-name> of pod <pod-name>.
+		kubectl exec <pod-name> -c <container-name> date
 
-		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890
+		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod <pod-name>
 		# and sends stdout/stderr from 'bash' back to the client
-		kubectl exec 123456-7890 -c ruby-container -i -t -- bash -il`)
+		kubectl exec <pod-name> -c ruby-container -i -t -- bash -il
+
+		# Get an interactive TTY and run /bin/bash from pod <pod-name>. By default, output is from the first container.
+		kubectl exec -ti <pod-name> /bin/bash`)
 )
 
 const (
@@ -67,7 +70,7 @@ func NewCmdExec(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *c
 	cmd := &cobra.Command{
 		Use:     "exec POD [-c CONTAINER] -- COMMAND [args...]",
 		Short:   i18n.T("Execute a command in a container"),
-		Long:    "Execute a command in a container.",
+		Long:    "Execute a command against a container in a pod",
 		Example: exec_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			argsLenAtDash := cmd.ArgsLenAtDash()

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -48,7 +48,7 @@ var (
 func NewCmdExplain(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "explain RESOURCE",
-		Short:   i18n.T("Documentation of resources"),
+		Short:   i18n.T("Get documentation of various resources. For instance pods, nodes, services, etc"),
 		Long:    explainLong,
 		Example: explainExamples,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -85,7 +85,7 @@ func NewCmdExposeService(f cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "expose (-f FILENAME | TYPE NAME) [--port=port] [--protocol=TCP|UDP] [--target-port=number-or-name] [--name=name] [--external-ip=external-ip-of-service] [--type=type]",
-		Short:   i18n.T("Take a replication controller, service, deployment or pod and expose it as a new Kubernetes Service"),
+		Short:   i18n.T("Expose a replication controller, service, or pod as a new Kubernetes service"),
 		Long:    expose_long,
 		Example: expose_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -68,8 +68,8 @@ var (
 		# List all pods in ps output format with more information (such as node name).
 		kubectl get pods -o wide
 
-		# List a single replication controller with specified NAME in ps output format.
-		kubectl get replicationcontroller web
+		# List a single replication controller with specified NAME in ps output format. Tip: You can shorten and replace the 'replicationcontroller' resource type with the alias 'rc'.
+		kubectl get replicationcontroller <rc-name>
 
 		# List a single pod in JSON output format.
 		kubectl get -o json pod web-pod-13je7
@@ -108,7 +108,7 @@ func NewCmdGet(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comman
 
 	cmd := &cobra.Command{
 		Use:     "get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE [NAME | -l label] | TYPE/NAME ...) [flags]",
-		Short:   i18n.T("Display one or many resources"),
+		Short:   i18n.T("List one or more resources"),
 		Long:    get_long,
 		Example: get_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -111,7 +111,7 @@ func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "label [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]",
-		Short:   i18n.T("Update the labels on a resource"),
+		Short:   i18n.T("Add or update the labels of one or more resources"),
 		Long:    fmt.Sprintf(label_long, validation.LabelValueMaxLength),
 		Example: label_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -93,7 +93,7 @@ func NewCmdPatch(f cmdutil.Factory, out io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "patch (-f FILENAME | TYPE NAME) -p PATCH",
-		Short:   i18n.T("Update field(s) of a resource using strategic merge patch"),
+		Short:   i18n.T("Update one or more fields of a resource by using the strategic merge patch process"),
 		Long:    patch_long,
 		Example: patch_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -68,7 +68,7 @@ func NewCmdReplace(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Use: "replace -f FILENAME",
 		// update is deprecated.
 		Aliases: []string{"update"},
-		Short:   i18n.T("Replace a resource by filename or stdin"),
+		Short:   i18n.T("Replace a resource from a file or stdin"),
 		Long:    replace_long,
 		Example: replace_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -82,7 +82,7 @@ func NewCmdRollingUpdate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Use: "rolling-update OLD_CONTROLLER_NAME ([NEW_CONTROLLER_NAME] --image=NEW_CONTAINER_IMAGE | -f NEW_CONTROLLER_SPEC)",
 		// rollingupdate is deprecated.
 		Aliases: []string{"rollingupdate"},
-		Short:   i18n.T("Perform a rolling update of the given ReplicationController"),
+		Short:   i18n.T("Perform a rolling update by gradually replacing the specified replication controller and its pods"),
 		Long:    rollingUpdate_long,
 		Example: rollingUpdate_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -94,7 +94,7 @@ func NewCmdRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *co
 		Use: "run NAME --image=image [--env=\"key=value\"] [--port=port] [--replicas=replicas] [--dry-run=bool] [--overrides=inline-json] [--command] -- [COMMAND] [args...]",
 		// run-container is deprecated
 		Aliases: []string{"run-container"},
-		Short:   i18n.T("Run a particular image on the cluster"),
+		Short:   i18n.T("Run a specified image on the cluster"),
 		Long:    run_long,
 		Example: run_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -68,7 +68,7 @@ func NewCmdScale(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Use: "scale [--resource-version=version] [--current-replicas=count] --replicas=COUNT (-f FILENAME | TYPE NAME)",
 		// resize is deprecated
 		Aliases: []string{"resize"},
-		Short:   i18n.T("Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job"),
+		Short:   i18n.T("Update the size of the specified replication controller"),
 		Long:    scale_long,
 		Example: scale_example,
 		Run: func(cmd *cobra.Command, args []string) {

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -37,7 +37,7 @@ var (
 func NewCmdVersion(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
-		Short:   i18n.T("Print the client and server version information"),
+		Short:   i18n.T("Display the Kubernetes version running on the client and server"),
 		Long:    "Print the client and server version information for the current context",
 		Example: version_example,
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

The kubectl overview document contains edits of kubectl descriptions.
(https://kubernetes.io/docs/user-guide/kubectl-overview/)

- [x] Updated kubectl commands descriptions to align with descriptions in [kubectl operations table](https://kubernetes.io/docs/user-guide/kubectl-overview/#operations)
- [x] Added/Updated appropriate examples to kubectl commands from [kubectl overview examples](https://kubernetes.io/docs/user-guide/kubectl-overview/#examples-common-operations) and [kubectl cheatsheet](https://kubernetes.io/docs/user-guide/kubectl-cheatsheet/)
- [x] Changed use of .json to .yaml (see [best practice](https://kubernetes.io/docs/concepts/configuration/overview/))

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #25290
See also: #16089

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
NONE
```
