### PR TITLE
Revert #28823 and #30372 in release-1.4 branch

### DIFF
--- a/cluster/addons/addon-manager/README.md
+++ b/cluster/addons/addon-manager/README.md
@@ -3,8 +3,7 @@
 The `addon-manager` periodically checks for Kubernetes manifest changes in the `/etc/kubernetes/addons` directory,
 and when there's a new or changed addon, the `addon-manager` automatically `kubectl create`s it.
 
-It supports `ReplicationControllers`, `Deployments`, `DaemonSets`, `ConfigMaps`, `Services`, `PersistentVolumes` and
-`PersistentVolumeClaims`.
+It supports `ReplicationControllers`, `Deployments`, `DaemonSets`, `Services`, `PersistentVolumes` and `PersistentVolumeClaims`.
 
 The `addon-manager` is built for multiple architectures.
 

--- a/cluster/addons/addon-manager/kube-addon-update.sh
+++ b/cluster/addons/addon-manager/kube-addon-update.sh
@@ -49,7 +49,6 @@ if [[ ! -x ${KUBECTL} ]]; then
     echo "ERROR: kubectl command (${KUBECTL}) not found or is not executable" 1>&2
     exit 1
 fi
-KUBECTL_OPTS=${KUBECTL_OPTS:-}
 
 # If an add-on definition is incorrect, or a definition has just disappeared
 # from the local directory, the script will still keep on retrying.
@@ -197,7 +196,7 @@ function run-until-success() {
 # returns a list of <namespace>/<name> pairs (nsnames)
 function get-addon-nsnames-from-server() {
     local -r obj_type=$1
-    "${KUBECTL}" "${KUBECTL_OPTS}" get "${obj_type}" --all-namespaces -o go-template="{{range.items}}{{.metadata.namespace}}/{{.metadata.name}} {{end}}" -l kubernetes.io/cluster-service=true | sed 's/<no value>//g'
+    "${KUBECTL}" get "${obj_type}" --all-namespaces -o go-template="{{range.items}}{{.metadata.namespace}}/{{.metadata.name}} {{end}}" -l kubernetes.io/cluster-service=true | sed 's/<no value>//g'
 }
 
 # returns the characters after the last separator (including)
@@ -243,7 +242,7 @@ function delete-object() {
     local -r obj_name=$3
     log INFO "Deleting ${obj_type} ${namespace}/${obj_name}"
 
-    run-until-success "${KUBECTL} ${KUBECTL_OPTS} delete --namespace=${namespace} ${obj_type} ${obj_name}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+    run-until-success "${KUBECTL} delete --namespace=${namespace} ${obj_type} ${obj_name}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
 }
 
 function create-object() {
@@ -262,9 +261,9 @@ function create-object() {
     # this will keep on failing if the ${file_path} disappeared in the meantime.
     # Do not use too many retries.
     if [[ -n "${namespace}" ]]; then
-        run-until-success "${KUBECTL} ${KUBECTL_OPTS} create --namespace=${namespace} -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+        run-until-success "${KUBECTL} create --namespace=${namespace} -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
     else
-        run-until-success "${KUBECTL} ${KUBECTL_OPTS} create -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
+        run-until-success "${KUBECTL} create -f ${file_path}" ${NUM_TRIES} ${DELAY_AFTER_ERROR_SEC}
     fi
 }
 

--- a/cluster/addons/addon-manager/kube-addon-update.sh
+++ b/cluster/addons/addon-manager/kube-addon-update.sh
@@ -489,7 +489,6 @@ function update-addons() {
     reconcile-objects ${addon_path} Service "" &
     reconcile-objects ${addon_path} PersistentVolume "" &
     reconcile-objects ${addon_path} PersistentVolumeClaim "" &
-    reconcile-objects ${addon_path} ConfigMap "" &
 
     wait-for-jobs
     if [[ $? -eq 0 ]]; then

--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -18,7 +18,6 @@
 # was already enforced by salt, and /etc/kubernetes/addons is the
 # managed result is of that. Start everything below that directory.
 KUBECTL=${KUBECTL_BIN:-/usr/local/bin/kubectl}
-KUBECTL_OPTS=${KUBECTL_OPTS:-}
 
 ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-60}
 
@@ -50,7 +49,7 @@ function create-resource-from-string() {
   local -r config_name=$4;
   local -r namespace=$5;
   while [ ${tries} -gt 0 ]; do
-    echo "${config_string}" | ${KUBECTL} ${KUBECTL_OPTS} --namespace="${namespace}" apply -f - && \
+    echo "${config_string}" | ${KUBECTL} --namespace="${namespace}" apply -f - && \
         echo "== Successfully started ${config_name} in namespace ${namespace} at $(date -Is)" && \
         return 0;
     let tries=tries-1;
@@ -72,7 +71,7 @@ start_addon /opt/namespace.yaml 100 10 "" &
 token_found=""
 while [ -z "${token_found}" ]; do
   sleep .5
-  token_found=$(${KUBECTL} ${KUBECTL_OPTS} get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default -o go-template="{{with index .secrets 0}}{{.name}}{{end}}" || true)
+  token_found=$(${KUBECTL} get --namespace="${SYSTEM_NAMESPACE}" serviceaccount default -o go-template="{{with index .secrets 0}}{{.name}}{{end}}" || true)
 done
 
 echo "== default service account in the ${SYSTEM_NAMESPACE} namespace has token ${token_found} =="


### PR DESCRIPTION
**What this PR does / why we need it**: these two PRs were added after the kube-addon-manager was bumped to v5.1, but v5.1 is what the Kubernetes 1.4 release uses. We should match the code and functionality so we can easily rebuild the image as needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43587

**Special notes for your reviewer**: I have not yet pushed a new v5.1.1 image.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
(No release note, since this intentionally reverts functionality which doesn't exist in 1.4.)

cc @timstclair @douglas-gibbons @bbreslauer 