### PR TITLE
Fix comments typo in rkt.

### DIFF
--- a/pkg/kubelet/rkt/systemd.go
+++ b/pkg/kubelet/rkt/systemd.go
@@ -57,7 +57,7 @@ type systemdInterface interface {
 	ListUnits() ([]dbus.UnitStatus, error)
 	// StopUnits stops the unit with the given name.
 	StopUnit(name string, mode string, ch chan<- string) (int, error)
-	// StopUnits restarts the unit with the given name.
+	// RestartUnit restarts the unit with the given name.
 	RestartUnit(name string, mode string, ch chan<- string) (int, error)
 	// ResetFailedUnit resets the "failed" state of a specific unit.
 	ResetFailedUnit(name string) error


### PR DESCRIPTION
fixes comments typo of rkt runtime.

```release-note
None
```
