### PR TITLE
Update NPD rbac.

### DIFF
--- a/cluster/addons/node-problem-detector/npd.yaml
+++ b/cluster/addons/node-problem-detector/npd.yaml
@@ -7,7 +7,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: npd-binding

--- a/cluster/addons/node-problem-detector/standalone/npd-binding.yaml
+++ b/cluster/addons/node-problem-detector/standalone/npd-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1alpha1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: npd-binding
@@ -10,6 +10,6 @@ roleRef:
   kind: ClusterRole
   name: system:node-problem-detector
 subjects:
-- apiVersion: rbac/v1alpha1
+- apiGroup: rbac.authorization.k8s.io
   kind: User
   name: system:node-problem-detector


### PR DESCRIPTION
I recently enabled NPD in gke.

However, I found that in gke e2e test (https://k8s-testgrid.appspot.com/google-gke#gci-gke), npd on the node could not talk with apiserver, and reported full of following errors:
```
E0324 05:08:26.745545    1328 manager.go:160] failed to update node conditions: the server does not allow access to the requested resource (patch nodes gke-bootstrap-e2e-default-pool-fd91d792-mqh4)
E0324 05:08:37.719423    1328 manager.go:160] failed to update node conditions: the server does not allow access to the requested resource (patch nodes gke-bootstrap-e2e-default-pool-fd91d792-mqh4)
E0324 05:08:47.719694    1328 manager.go:160] failed to update node conditions: the server does not allow access to the requested resource (patch nodes gke-bootstrap-e2e-default-pool-fd91d792-mqh4)
```

I created a GKE cluster (v1.7.0-alpha.0.1483+1e879c69ecf09e) myself, and found that addon manager could not create npd binding with the following error:
```
error: error validating "/etc/kubernetes/addons/node-problem-detector/standalone/npd-binding.yaml": error validating data: couldn't find type: v1alpha1.ClusterRoleBinding; if you choose to ignore these errors, turn validation off with --validate=false
```

I found that rbac was updated to beta, but npd was missed because it was merged after https://github.com/kubernetes/kubernetes/commit/9e6a3496b44e9a5ab9740cb903e46f769d65cde3#diff-b05c70853d9a772b310db71a61297841.

I updated rbac to beta in the master manifest and npd on the node could talk with apiserver immediately.
We must get this in 1.6 to make NPD working. @dchen1107 

@dchen1107 @fabioy @liggitt 