### PR TITLE
Remove E2E_UPGRADE_TEST check in config-test.sh

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -242,15 +242,9 @@ SCHEDULING_ALGORITHM_PROVIDER="${SCHEDULING_ALGORITHM_PROVIDER:-}"
 ENABLE_DEFAULT_STORAGE_CLASS="${ENABLE_DEFAULT_STORAGE_CLASS:-true}"
 
 # Optional: Enable legacy ABAC policy that makes all service accounts superusers.
-if [[ "${E2E_UPGRADE_TEST:-}" == "true" ]]; then
-  # Enable (match the regular default) when running upgrade tests (E2E_UPGRADE_TEST=true is set by upgrade CI jobs).
-  # This ensures the combination of legacy ABAC and default RBAC policies work properly for upgrade scenarios.
-  ENABLE_LEGACY_ABAC="${ENABLE_LEGACY_ABAC:-true}" # true, false
-else
-  # Disable by default when running regular e2e tests.
-  # This ensures default RBAC policies alone are sufficient for e2e tests from 1.6+
-  ENABLE_LEGACY_ABAC="${ENABLE_LEGACY_ABAC:-false}" # true, false
-fi
+# Disabling this by default in tests ensures default RBAC policies are sufficient from 1.6+
+# Upgrade test jobs that go from a version < 1.6 to a version >= 1.6 should override this to be true.
+ENABLE_LEGACY_ABAC="${ENABLE_LEGACY_ABAC:-false}" # true, false
 
 # TODO(dawn1107): Remove this once the flag is built into CVM image.
 # Kernel panic upon soft lockup issue


### PR DESCRIPTION
Once https://github.com/kubernetes/test-infra/pull/2330 merges, the upgrade tests will drive the exact behavior they want, and we can remove the check for envvars leaked from the job env