### PR TITLE
Adding more proxy options and header to nginx load-balancer.

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/templates/apilb.conf
+++ b/cluster/juju/layers/kubeapi-load-balancer/templates/apilb.conf
@@ -8,7 +8,7 @@ upstream target_service {
 
 
 server {
-    listen 443;
+    listen 443 ssl http2;
     server_name {{ server_name }};
 
     access_log /var/log/nginx.access.log;
@@ -28,9 +28,17 @@ server {
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
-      proxy_ssl_certificate {{ server_certificate }};
+      proxy_set_header        X-Forwarded-Proto-Version $http2;
+      proxy_set_header        Upgrade $http_upgrade;
+      proxy_set_header        Connection $http_connection;
+      proxy_set_header        X-Stream-Protocol-Version $http_x_stream_protocol_version;
+
+      proxy_ssl_certificate   {{ server_certificate }};
       proxy_ssl_certificate_key {{ server_key }};
-      proxy_pass https://target_service;
-      proxy_read_timeout  90;
+
+      add_header              X-Stream-Protocol-Version $upstream_http_x_stream_protocol_version;
+
+      proxy_pass              https://target_service;
+      proxy_read_timeout      90;
     }
 }


### PR DESCRIPTION
**What this PR does / why we need it**: The kubeapi-load-balancer uses nginx to proxy commands to the kube-apiserver. It currently does not support SPDY and therefore the `kubectl exec` command is broken.

**Which issue this PR fixes** : 
fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/226
fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/201

**Special notes for your reviewer**: This only changes the nginx configuration no code change was required.

**Release note**:
```release-note
Using http2 in kubeapi-load-balancer to fix kubectl exec uses
```
