### PR TITLE
Better logging for PVC flakes

### DIFF
--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -536,7 +536,7 @@ func MakePod(ns string, pvcName string, isPrivileged bool, command string) *v1.P
 			APIVersion: api.Registry.GroupOrDie(v1.GroupName).GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "client-",
+			GenerateName: "pvc-tester-",
 			Namespace:    ns,
 		},
 		Spec: v1.PodSpec{

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2236,7 +2236,7 @@ func (f *Framework) MatchContainerOutput(
 			}
 			Logf("Output of node %q pod %q container %q: %s", podStatus.Spec.NodeName, podStatus.Name, container.Name, logs)
 		}
-		return fmt.Errorf("expected pod %q success: %v", pod.Name, err)
+		return fmt.Errorf("expected pod %q success: %v", createdPod.Name, err)
 	}
 
 	Logf("Trying to get logs from node %s pod %s container %s: %v",


### PR DESCRIPTION
Addresses some logging ambiguities in https://github.com/kubernetes/kubernetes/issues/43610, but does not fix it.