### PR TITLE
[GCE] Support legacy-https and generic health checks

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_healthchecks.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks.go
@@ -16,13 +16,9 @@ limitations under the License.
 
 package gce
 
-import (
-	"net/http"
+import compute "google.golang.org/api/compute/v1"
 
-	compute "google.golang.org/api/compute/v1"
-)
-
-// Health Checks
+// Legacy HTTP Health Checks
 
 // GetHttpHealthCheck returns the given HttpHealthCheck by name.
 func (gce *GCECloud) GetHttpHealthCheck(name string) (*compute.HttpHealthCheck, error) {
@@ -42,9 +38,6 @@ func (gce *GCECloud) UpdateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 func (gce *GCECloud) DeleteHttpHealthCheck(name string) error {
 	op, err := gce.service.HttpHealthChecks.Delete(gce.projectID, name).Do()
 	if err != nil {
-		if isHTTPErrorCode(err, http.StatusNotFound) {
-			return nil
-		}
 		return err
 	}
 	return gce.waitForGlobalOp(op)
@@ -59,8 +52,88 @@ func (gce *GCECloud) CreateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 	return gce.waitForGlobalOp(op)
 }
 
-// ListHttpHealthCheck lists all HttpHealthChecks in the project.
+// ListHttpHealthChecks lists all HttpHealthChecks in the project.
 func (gce *GCECloud) ListHttpHealthChecks() (*compute.HttpHealthCheckList, error) {
 	// TODO: use PageToken to list all not just the first 500
 	return gce.service.HttpHealthChecks.List(gce.projectID).Do()
+}
+
+// Legacy HTTPS Health Checks
+
+// GetHttpsHealthCheck returns the given HttpsHealthCheck by name.
+func (gce *GCECloud) GetHttpsHealthCheck(name string) (*compute.HttpsHealthCheck, error) {
+	return gce.service.HttpsHealthChecks.Get(gce.projectID, name).Do()
+}
+
+// UpdateHttpsHealthCheck applies the given HttpsHealthCheck as an update.
+func (gce *GCECloud) UpdateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error {
+	op, err := gce.service.HttpsHealthChecks.Update(gce.projectID, hc.Name, hc).Do()
+	if err != nil {
+		return err
+	}
+	return gce.waitForGlobalOp(op)
+}
+
+// DeleteHttpsHealthCheck deletes the given HttpsHealthCheck by name.
+func (gce *GCECloud) DeleteHttpsHealthCheck(name string) error {
+	op, err := gce.service.HttpsHealthChecks.Delete(gce.projectID, name).Do()
+	if err != nil {
+		return err
+	}
+	return gce.waitForGlobalOp(op)
+}
+
+// CreateHttpsHealthCheck creates the given HttpsHealthCheck.
+func (gce *GCECloud) CreateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error {
+	op, err := gce.service.HttpsHealthChecks.Insert(gce.projectID, hc).Do()
+	if err != nil {
+		return err
+	}
+	return gce.waitForGlobalOp(op)
+}
+
+// ListHttpsHealthChecks lists all HttpsHealthChecks in the project.
+func (gce *GCECloud) ListHttpsHealthChecks() (*compute.HttpsHealthCheckList, error) {
+	// TODO: use PageToken to list all not just the first 500
+	return gce.service.HttpsHealthChecks.List(gce.projectID).Do()
+}
+
+// Generic HealthCheck
+
+// GetHealthCheck returns the given HealthCheck by name.
+func (gce *GCECloud) GetHealthCheck(name string) (*compute.HealthCheck, error) {
+	return gce.service.HealthChecks.Get(gce.projectID, name).Do()
+}
+
+// UpdateHealthCheck applies the given HealthCheck as an update.
+func (gce *GCECloud) UpdateHealthCheck(hc *compute.HealthCheck) error {
+	op, err := gce.service.HealthChecks.Update(gce.projectID, hc.Name, hc).Do()
+	if err != nil {
+		return err
+	}
+	return gce.waitForGlobalOp(op)
+}
+
+// DeleteHealthCheck deletes the given HealthCheck by name.
+func (gce *GCECloud) DeleteHealthCheck(name string) error {
+	op, err := gce.service.HealthChecks.Delete(gce.projectID, name).Do()
+	if err != nil {
+		return err
+	}
+	return gce.waitForGlobalOp(op)
+}
+
+// CreateHealthCheck creates the given HealthCheck.
+func (gce *GCECloud) CreateHealthCheck(hc *compute.HealthCheck) error {
+	op, err := gce.service.HealthChecks.Insert(gce.projectID, hc).Do()
+	if err != nil {
+		return err
+	}
+	return gce.waitForGlobalOp(op)
+}
+
+// ListHealthChecks lists all HealthCheck in the project.
+func (gce *GCECloud) ListHealthChecks() (*compute.HealthCheckList, error) {
+	// TODO: use PageToken to list all not just the first 500
+	return gce.service.HealthChecks.List(gce.projectID).Do()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
- Adds CRUD functions to manage `compute.HttpsHealthChecks` 
The legacy HTTPS healthchecks will be used by the GLBC (GCE Load balancer Controller)

- Adds CRUD functions to manage `compute.HealthChecks`
These are required for the internal load balancer

- Removes the logic that disregards NotFound errors on DeleteHttpHealthChecks as this is useful information for callers. Here are the three known invocations within kubernetes: 
[gce/gce_loadbalancer.go#L457](https://github.com/kubernetes/kubernetes/blob/bc6e77d42fdb40bb82796fd8ee8ba2b04dd9a0ea/pkg/cloudprovider/providers/gce/gce_loadbalancer.go#L457): Only prints warning that HC wasn't deleted  -> acceptable
[gce/gce_loadbalancer.go#L465](https://github.com/kubernetes/kubernetes/blob/bc6e77d42fdb40bb82796fd8ee8ba2b04dd9a0ea/pkg/cloudprovider/providers/gce/gce_loadbalancer.go#L465): Err is ignored if not nil  -> acceptable
[e2e/framework/ingress_utils.go#L530](https://github.com/kubernetes/kubernetes/blob/bc6e77d42fdb40bb82796fd8ee8ba2b04dd9a0ea/test/e2e/framework/ingress_utils.go#L530): Already checks if is NotFound error -> acceptable

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
Step one of https://github.com/kubernetes/ingress/issues/494
Step one of #33483 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
