### PR TITLE
Remove an accidentally duplicated line when adding a defer in #42157.

### DIFF
--- a/test/e2e/volume_provisioning.go
+++ b/test/e2e/volume_provisioning.go
@@ -199,7 +199,6 @@ var _ = framework.KubeDescribe("Dynamic provisioning", func() {
 			// Set an unmanaged zone.
 			sc.Parameters = map[string]string{"zone": unmanagedZone}
 			sc, err = c.StorageV1().StorageClasses().Create(sc)
-			defer Expect(c.StorageV1().StorageClasses().Delete(sc.Name, nil)).To(Succeed())
 			Expect(err).NotTo(HaveOccurred())
 			defer func() {
 				Expect(c.StorageV1().StorageClasses().Delete(sc.Name, nil)).To(Succeed())


### PR DESCRIPTION
**What this PR does / why we need it**: the submit queue is broken currently on 
[k8s.io] Dynamic provisioning [k8s.io] DynamicProvisioner Beta should not provision a volume in an unmanaged GCE zone. [Slow] [Volume] 5m19s

#42157 tries to delete the same resource twice.

**Release note**:
```release-note
NONE
```
