### PR TITLE
[Federation] Create a unique label and label selector for each replica set created by the replica sets E2E test.

### DIFF
--- a/test/e2e_federation/BUILD
+++ b/test/e2e_federation/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/util/intstr",
         "//vendor:k8s.io/apimachinery/pkg/util/net",
         "//vendor:k8s.io/apimachinery/pkg/util/rand",
+        "//vendor:k8s.io/apimachinery/pkg/util/uuid",
         "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/tools/clientcmd",

--- a/test/e2e_federation/replicaset.go
+++ b/test/e2e_federation/replicaset.go
@@ -35,6 +35,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/federation/apis/federation"
 	fedreplicsetcontroller "k8s.io/kubernetes/federation/pkg/federation-controller/replicaset"
 )
@@ -477,6 +478,12 @@ func updateReplicaSetOrFail(clientset *fedclientset.Clientset, replicaset *v1bet
 }
 
 func newReplicaSetObj(namespace string, replicas int32, pref *federation.FederatedReplicaSetPreferences) *v1beta1.ReplicaSet {
+	// When the tests are run in parallel, replicasets from different tests can
+	// collide with each other. Prevent that by creating a unique label and
+	// label selector for each created replica set.
+	uuidString := string(uuid.NewUUID())
+	rsLabel := fmt.Sprintf("myrs-%s", uuidString)
+
 	rs := &v1beta1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:   namespace,
@@ -485,11 +492,11 @@ func newReplicaSetObj(namespace string, replicas int32, pref *federation.Federat
 		Spec: v1beta1.ReplicaSetSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"name": "myrs"},
+				MatchLabels: map[string]string{"name": rsLabel},
 			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"name": "myrs"},
+					Labels: map[string]string{"name": rsLabel},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{


### PR DESCRIPTION
Previously, each replica set created would use the same pod labels and replica set label selectors, so tests run in parallel could conflict with each other. This ensures that each replica set test has its own set of pods to work with.

This should fix the currently-very-flaky E2E test for weighted federated replica set preferences.