### PR TITLE
[Federation] Disable the E2E test for federated replica set rebalancing

### DIFF
--- a/test/e2e_federation/replicaset.go
+++ b/test/e2e_federation/replicaset.go
@@ -170,7 +170,7 @@ var _ = framework.KubeDescribe("Federated ReplicaSet [Feature:Federation]", func
 			})
 
 			// test for rebalancing
-			It("should create replicasets and rebalance them", func() {
+			PIt("should create replicasets and rebalance them", func() {
 				nsName := f.FederationNamespace.Name
 				pref1, pref2, replicas, expect1, expect2 := generateFedRSPrefsForRebalancing(clusters)
 


### PR DESCRIPTION
We are able to reproduce the flaky failure locally, and can debug without running this on the CI.