### PR TITLE
Fix command exec -- COMMAND can not contain spaces

### DIFF
--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -47,7 +47,15 @@ var (
 
 		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890
 		# and sends stdout/stderr from 'bash' back to the client
-		kubectl exec 123456-7890 -c ruby-container -i -t -- bash -il`))
+		kubectl exec 123456-7890 -c ruby-container -i -t -- bash -il
+
+		# List contents of /usr from the first container of pod 123456-7890 and sort by modification time.
+		# If the command you want to execute in the pod has any flags in common (e.g. -i),
+		# you must use two dashes (--) to separate your command's flags/arguments.
+		# Also note, do not surround your command and its flags/arguments with quotes
+		# unless that is how you would execute it normally (i.e., do ls -t /usr, not "ls -t /usr").
+		kubectl exec 123456-7890 -i -t -- ls -t /usr
+		`))
 )
 
 const (


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/7688
the problem is when you execute command:
 `cluster/kubectl.sh exec -p client-blue-8yw37 -c client -i -t -- 'ls -t /usr'`
the args is 
[`client-blue-8yw37` , `ls -t /usr`] 
**instead of** 
[`client-blue-8yw37`, `ls`, `-t`, `/usr`]
@kubernetes/sig-cli-pr-reviews, so I add a warning, wdyt ?
cc @ymqytw @adohe @fabianofranz 