### PR TITLE
Add the support of volumes in Kubelet runonce

### DIFF
--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -139,7 +139,12 @@ func (m *qosContainerManagerImpl) Start(getNodeAllocatable func() v1.ResourceLis
 }
 
 func (m *qosContainerManagerImpl) setCPUCgroupConfig(configs map[v1.PodQOSClass]*CgroupConfig) error {
-	pods := m.activePods()
+	var pods []*v1.Pod
+	if m.activePods != nil {
+		pods = m.activePods()
+	} else {
+		glog.Warning("ActivePodsFunc is nil")
+	}
 	burstablePodCPURequest := int64(0)
 	for i := range pods {
 		pod := pods[i]

--- a/pkg/kubelet/runonce.go
+++ b/pkg/kubelet/runonce.go
@@ -54,6 +54,11 @@ func (kl *Kubelet) RunOnce(updates <-chan kubetypes.PodUpdate) ([]RunPodResult, 
 		}
 	}
 
+	// Start volume manager
+	stopCh := make(chan struct{})
+	go kl.volumeManager.Run(kl.sourcesReady, stopCh)
+	defer func(stopCh chan struct{}) { stopCh <- struct{}{} }(stopCh)
+
 	select {
 	case u := <-updates:
 		glog.Infof("processing manifest with %d pods", len(u.Pods))
@@ -125,6 +130,7 @@ func (kl *Kubelet) runPod(pod *v1.Pod, retryDelay time.Duration) error {
 			glog.Errorf("Failed creating a mirror pod %q: %v", format.Pod(pod), err)
 		}
 		mirrorPod, _ := kl.podManager.GetMirrorPodByPod(pod)
+		kl.podManager.UpdatePod(pod)
 		if err = kl.syncPod(syncPodOptions{
 			pod:        pod,
 			mirrorPod:  mirrorPod,


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows to create and mount volumes when the kubelet is started with `--runonce` flag.


**Which issue this PR fixes** 

Fix #42909

**Special notes for your reviewer**:

During the `--runonce` process, the volumeManager have to be started and triggered by the `podManager.UpdatePod`

I plan to cherry-pick this feature to a Kubernetes => 1.5.5 

**On Master**:
Outside of the scope of my feature, I had to check if a pointer to function is not nil to avoid a [panic](https://github.com/kubernetes/kubernetes/pull/43675/commits/5205c9db40de7d09820548cddf2b84777e870496#diff-11a0ce137adf1398fb48471cbe346d9aR141)

Without my PR kubelet `--runonce` panics anyway.

**Release note**:

 `NONE`
