### PR TITLE
added prompt warning if etcd3 media type isn't set during upgrade

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -447,18 +447,20 @@ if [[ "${master_upgrade}" == "false" ]] && [[ "${node_upgrade}" == "false" ]]; t
   exit 1
 fi
 
-# prompt if etcd storage media type isn't set
-if [[ -z "${STORAGE_MEDIA_TYPE:-}" ]]; then
+# prompt if etcd storage media type isn't set unless using etcd2 when doing master upgrade
+if [[ -z "${STORAGE_MEDIA_TYPE:-}" ]] && [[ "${STORAGE_BACKEND:-}" != "etcd2" ]] && [[ "${master_upgrade}" == "true" ]]; then
+  echo "The default etcd storage media type in 1.6 has changed from application/json to application/vnd.kubernetes.protobuf."
+  echo "Documentation about the change can be found at https://kubernetes.io/docs/admin/etcd_upgrade."
+  echo ""
+  echo "ETCD2 DOES NOT SUPPORT PROTOBUF: If you wish to have to ability to downgrade to etcd2 later application/json must be used."
+  echo ""
+  echo "To enable using json, before running this script set:"
+  echo "export STORAGE_MEDIA_TYPE=application/json"
+  echo ""
+  echo "It's HIGHLY recommended that etcd be backed up before this step!!"
+  echo ""
   if [ -t 0 ] && [ -t 1 ]; then
-    echo "The default etcd storage media type in 1.6 has changed from application/json to application/vnd.kubernetes.protobuf."
-    echo ""
-    echo "ETCD2 DOES NOT SUPPORT PROTOBUF: If you wish to have to ability to downgrade to etcd2 later application/json must be used."
-    echo ""
-    echo "To enable using json, before running this script set:"
-    echo "export STORAGE_MEDIA_TYPE=application/json"
-    echo ""
-    echo "It's HIGHLY recommended that etcd be backed up before this step!!"
-    read -p "Would you like to continue? [y/N] " confirm
+    read -p "Would you like to continue with the new default, and lose the ability to downgrade to etcd2? [y/N] " confirm
     if [[ "${confirm}" != "y" ]]; then
       exit 1
     fi

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -454,10 +454,10 @@ if [[ -z "${STORAGE_MEDIA_TYPE:-}" ]] && [[ "${STORAGE_BACKEND:-}" != "etcd2" ]]
   echo ""
   echo "ETCD2 DOES NOT SUPPORT PROTOBUF: If you wish to have to ability to downgrade to etcd2 later application/json must be used."
   echo ""
+  echo "It's HIGHLY recommended that etcd be backed up before this step!!"
+  echo ""
   echo "To enable using json, before running this script set:"
   echo "export STORAGE_MEDIA_TYPE=application/json"
-  echo ""
-  echo "It's HIGHLY recommended that etcd be backed up before this step!!"
   echo ""
   if [ -t 0 ] && [ -t 1 ]; then
     read -p "Would you like to continue with the new default, and lose the ability to downgrade to etcd2? [y/N] " confirm
@@ -465,6 +465,9 @@ if [[ -z "${STORAGE_MEDIA_TYPE:-}" ]] && [[ "${STORAGE_BACKEND:-}" != "etcd2" ]]
       exit 1
     fi
   else
+    echo "To enable using protobuf, before running this script set:"
+    echo "export STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf"
+    echo ""
     echo "STORAGE_MEDIA_TYPE must be specified when run non-interactively." >&2
     exit 1
   fi

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -447,6 +447,27 @@ if [[ "${master_upgrade}" == "false" ]] && [[ "${node_upgrade}" == "false" ]]; t
   exit 1
 fi
 
+# prompt if etcd storage media type isn't set
+if [[ -z "${STORAGE_MEDIA_TYPE:-}" ]]; then
+  if [ -t 0 ] && [ -t 1 ]; then
+    echo "The default etcd storage media type in 1.6 has changed from application/json to application/vnd.kubernetes.protobuf."
+    echo ""
+    echo "ETCD2 DOES NOT SUPPORT PROTOBUF: If you wish to have to ability to downgrade to etcd2 later application/json must be used."
+    echo ""
+    echo "To enable using json, before running this script set:"
+    echo "export STORAGE_MEDIA_TYPE=application/json"
+    echo ""
+    echo "It's HIGHLY recommended that etcd be backed up before this step!!"
+    read -p "Would you like to continue? [y/N] " confirm
+    if [[ "${confirm}" != "y" ]]; then
+      exit 1
+    fi
+  else
+    echo "STORAGE_MEDIA_TYPE must be specified when run non-interactively." >&2
+    exit 1
+  fi
+fi
+
 print-node-version-info "Pre-Upgrade"
 
 if [[ "${local_binaries}" == "false" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a prompt confirming the upgrade when `STORAGE_MEDIA_TYPE` is not explicitly set. This is to prevent users from accidentally upgrading to protobuf.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
Alongs with docs, addresses #43669

**Special notes for your reviewer**:
Should be cherrypicked onto `release-1.6`

**Release note**:
```release-note
NONE
```
