### PR TITLE
fix typo in kubeadm join -h

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -122,7 +122,7 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(
 		&skipPreFlight, "skip-preflight-checks", false,
-		"skip preflight checks normally run before modifying the system",
+		"Skip preflight checks normally run before modifying the system",
 	)
 
 	return cmd


### PR DESCRIPTION
```
Flags:
      --config string                Path to kubeadm config file
      --discovery-file string        A file or url from which to load cluster information
      --discovery-token string       A token used to validate cluster information fetched from the master
      --skip-preflight-checks        skip preflight checks normally run before modifying the system
      --tls-bootstrap-token string   A token used for TLS bootstrapping
      --token string                 Use this token for both discovery-token and tls-bootstrap-token
```