### PR TITLE
Exit if permissions check failed

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -562,6 +562,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.KubeletDeps) (err error) {
 
 	if err := checkPermissions(); err != nil {
 		glog.Error(err)
+		return err
 	}
 
 	utilruntime.ReallyCrash = s.ReallyCrashForTesting


### PR DESCRIPTION
When we run kubelet with non-root user, kubelet prints tons of permission denied logs:

E0327 16:32:09.943241    3891 server.go:428] Kubelet needs to run as uid `0`. It is being run as 1000
W0327 16:32:09.943303    3891 server.go:438] write /proc/self/oom_score_adj: permission denied
I0327 16:32:09.943430    3891 kubelet.go:248] Watching apiserver
W0327 16:32:09.946802    3891 kubelet_network.go:69] Hairpin mode set to "promiscuous-bridge" but kubenet is not enabled, falling back to "hairpin-veth"
I0327 16:32:09.946840    3891 kubelet.go:456] Hairpin mode set to "hairpin-veth"
W0327 16:32:09.948155    3891 plugins.go:173] can't set sysctl net/bridge/bridge-nf-call-iptables: open /proc/sys/net/bridge/bridge-nf-call-iptables: permission denied
E0327 16:32:10.024182    3891 kubelet_network.go:250] Failed to ensure that nat chain KUBE-MARK-DROP exists: error creating chain "KUBE-MARK-DROP": exit status 3: iptables v1.4.21: can't initialize iptables table `nat': Permission denied (you must be root)
I0327 16:32:15.022360    3891 kubelet.go:1542] skipping pod synchronization - [Failed to start ContainerManager [open /proc/sys/vm/overcommit_memory: permission denied, open /proc/sys/kernel/panic: permission denied, open /proc/sys/kernel/panic_on_oops: permission denied]]
I0327 16:32:20.022605    3891 kubelet.go:1542] skipping pod synchronization - [Failed to start ContainerManager [open /proc/sys/vm/overcommit_memory: permission denied, open /proc/sys/kernel/panic: permission denied, open /proc/sys/kernel/panic_on_oops: permission denied]]
...

**Release note**:

```release-note
NONE
```
