### PR TITLE
add missing clusterRole

### DIFF
--- a/cluster/addons/node-problem-detector/npd.yaml
+++ b/cluster/addons/node-problem-detector/npd.yaml
@@ -8,6 +8,36 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:node-problem-detector
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
   name: npd-binding


### PR DESCRIPTION
**What this PR does / why we need it**: Add missing cluster role ```system:node-problem-detector``` to node-problem-detector RBAC rules

@Random-Liu 
