### PR TITLE
Automatic cherry-pick of #43700: added failing upgrade if there are many master replicas.

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -74,6 +74,13 @@ function print-node-version-info() {
 }
 
 function upgrade-master() {
+  local num_masters
+  num_masters=$(get-master-replicas-count)
+  if [[ "${num_masters}" -gt 1 ]]; then
+    echo "Upgrade of master not supported if more than one master replica present. The current number of master replicas: ${num_masters}"
+    exit 1
+  fi
+
   echo "== Upgrading master to '${SERVER_BINARY_TAR_URL}'. Do not interrupt, deleting master instance. =="
 
   # Tries to figure out KUBE_USER/KUBE_PASSWORD by first looking under


### PR DESCRIPTION
Automatic cherry-pick of #43700: Added failing upgrade (GCE) if there are many master replicas. Related to #43688.

```release-note
None
```
