### PR TITLE
Rename default storageclass to standard in all clouds

### DIFF
--- a/cluster/addons/storage-class/aws/default.yaml
+++ b/cluster/addons/storage-class/aws/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-  name: gp2
+  name: standard
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:

--- a/cluster/addons/storage-class/vsphere/default.yaml
+++ b/cluster/addons/storage-class/vsphere/default.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: StorageClass
 metadata:
-  name: thin
+  name: standard
   annotations:
     storageclass.beta.kubernetes.io/is-default-class: "true"
   labels:


### PR DESCRIPTION
Rename default storageclass to `standard`  in all cloudproviders.

Keeping same name across all cloudproviders is easier on user. The earlier default of using - `default` was problematic but `standard` should work well. `standard` was the name being used on `cinder`, `GCE`, `azure` 

