### PR TITLE
Handle maxUnavailable larger than spec.replicas

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -415,6 +415,9 @@ func MaxUnavailable(deployment extensions.Deployment) int32 {
 	}
 	// Error caught by validation
 	_, maxUnavailable, _ := ResolveFenceposts(deployment.Spec.Strategy.RollingUpdate.MaxSurge, deployment.Spec.Strategy.RollingUpdate.MaxUnavailable, *(deployment.Spec.Replicas))
+	if maxUnavailable > *deployment.Spec.Replicas {
+		return *deployment.Spec.Replicas
+	}
 	return maxUnavailable
 }
 

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -1150,3 +1150,80 @@ func TestDeploymentTimedOut(t *testing.T) {
 		}
 	}
 }
+
+func TestMaxUnavailable(t *testing.T) {
+	deployment := func(replicas int32, maxUnavailable intstr.IntOrString) extensions.Deployment {
+		return extensions.Deployment{
+			Spec: extensions.DeploymentSpec{
+				Replicas: func(i int32) *int32 { return &i }(replicas),
+				Strategy: extensions.DeploymentStrategy{
+					RollingUpdate: &extensions.RollingUpdateDeployment{
+						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(1)),
+						MaxUnavailable: &maxUnavailable,
+					},
+					Type: extensions.RollingUpdateDeploymentStrategyType,
+				},
+			},
+		}
+	}
+	tests := []struct {
+		name       string
+		deployment extensions.Deployment
+		expected   int32
+	}{
+		{
+			name:       "maxUnavailable less than replicas",
+			deployment: deployment(10, intstr.FromInt(5)),
+			expected:   int32(5),
+		},
+		{
+			name:       "maxUnavailable equal replicas",
+			deployment: deployment(10, intstr.FromInt(10)),
+			expected:   int32(10),
+		},
+		{
+			name:       "maxUnavailable greater than replicas",
+			deployment: deployment(5, intstr.FromInt(10)),
+			expected:   int32(5),
+		},
+		{
+			name:       "maxUnavailable with replicas is 0",
+			deployment: deployment(0, intstr.FromInt(10)),
+			expected:   int32(0),
+		},
+		{
+			name: "maxUnavailable with Recreate deployment strategy",
+			deployment: extensions.Deployment{
+				Spec: extensions.DeploymentSpec{
+					Strategy: extensions.DeploymentStrategy{
+						Type: extensions.RecreateDeploymentStrategyType,
+					},
+				},
+			},
+			expected: int32(0),
+		},
+		{
+			name:       "maxUnavailable less than replicas with percents",
+			deployment: deployment(10, intstr.FromString("50%")),
+			expected:   int32(5),
+		},
+		{
+			name:       "maxUnavailable equal replicas with percents",
+			deployment: deployment(10, intstr.FromString("100%")),
+			expected:   int32(10),
+		},
+		{
+			name:       "maxUnavailable greater than replicas with percents",
+			deployment: deployment(5, intstr.FromString("100%")),
+			expected:   int32(5),
+		},
+	}
+
+	for _, test := range tests {
+		t.Log(test.name)
+		maxUnavailable := MaxUnavailable(test.deployment)
+		if test.expected != maxUnavailable {
+			t.Fatalf("expected:%v, got:%v", test.expected, maxUnavailable)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Handle maxUnavailable larger than spec.replicas
**Which issue this PR fixes** 
fixes #42479

**Special notes for your reviewer**:
None
**Release note**:
```
NONE
```
