### PR TITLE
A new implementation of RenameDirectory for Go 1.8

### DIFF
--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -329,7 +329,7 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 }
 
 func (ed *emptyDir) teardownDefault(dir string) error {
-	tmpDir, err := volume.RenameDirectory(dir, ed.volName+".deleting~")
+	tmpDir, err := volume.RenameDirectory(dir, ed.volName+".deleting~", true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Since Go 1.8, os.Rename call fails when the destination exists even under Linux and the old implementation of RenameDirectory does not handle such situation. This PR fixes such bug and introduces a more efficient way for implementation.

**Release note**:
```release-note
NONE
```
updates #38228, #38345
solves #43534