### PR TITLE
Use "hack/godep-restore.sh" instead of "godep restore"

### DIFF
--- a/hack/update-staging-client-go.sh
+++ b/hack/update-staging-client-go.sh
@@ -28,7 +28,7 @@ cd ${KUBE_ROOT}
 
 echo "Checking whether godeps are restored"
 if ! kube::util::godep_restored 2>&1 | sed 's/^/  /'; then
-  echo -e '\nRun 'godep restore' to download dependencies.' 1>&2
+  echo -e '\nExecute script 'hack/godep-restore.sh' to download dependencies.' 1>&2
   exit 1
 fi
 

--- a/hack/update-staging-godeps.sh
+++ b/hack/update-staging-godeps.sh
@@ -51,7 +51,7 @@ source "${KUBE_ROOT}/hack/lib/util.sh"
 
 echo "Checking whether godeps are restored"
 if ! kube::util::godep_restored 2>&1 | sed 's/^/  /'; then
-  echo -e '\nRun 'godep restore' to download dependencies.' 1>&2
+  echo -e '\nExecute script 'hack/godep-restore.sh' to download dependencies.' 1>&2
   exit 1
 fi
 


### PR DESCRIPTION
Now we get errors when run "godep restore".
So we need to update the help message.
@derekwaynecarr 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
