### PR TITLE
delete etcd socket file for unit tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -692,6 +692,7 @@ func testPropogateStore(ctx context.Context, t *testing.T, store *store, obj *ex
 func TestPrefix(t *testing.T) {
 	codec := apitesting.TestCodec(codecs, examplev1.SchemeGroupVersion)
 	cluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
+	defer cluster.Terminate(t)
 	transformer := prefixTransformer{prefix: []byte("test!")}
 	testcases := map[string]string{
 		"custom/prefix":     "/custom/prefix",


### PR DESCRIPTION
This change clean up the environment for etcd3 unit test.
Without this change, "make test" will leave some socket files in
workspace. And these socket files make hack/verify-generated-protobuf.sh
fails.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
