### PR TITLE
remove go-restful from namer for rest handling

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/namer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/namer.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+// ContextFunc returns a Context given a request - a context must be returned
+type ContextFunc func(req *http.Request) request.Context
+
+// ScopeNamer handles accessing names from requests and objects
+type ScopeNamer interface {
+	// Namespace returns the appropriate namespace value from the request (may be empty) or an
+	// error.
+	Namespace(req *http.Request) (namespace string, err error)
+	// Name returns the name from the request, and an optional namespace value if this is a namespace
+	// scoped call. An error is returned if the name is not available.
+	Name(req *http.Request) (namespace, name string, err error)
+	// ObjectName returns the namespace and name from an object if they exist, or an error if the object
+	// does not support names.
+	ObjectName(obj runtime.Object) (namespace, name string, err error)
+	// SetSelfLink sets the provided URL onto the object. The method should return nil if the object
+	// does not support selfLinks.
+	SetSelfLink(obj runtime.Object, url string) error
+	// GenerateLink creates an encoded URI for a given runtime object that represents the canonical path
+	// and query.
+	GenerateLink(req *http.Request, obj runtime.Object) (uri string, err error)
+	// GenerateLink creates an encoded URI for a list that represents the canonical path and query.
+	GenerateListLink(req *http.Request) (uri string, err error)
+}
+
+type ContextBasedNaming struct {
+	GetContext    ContextFunc
+	SelfLinker    runtime.SelfLinker
+	ClusterScoped bool
+
+	SelfLinkPathPrefix string
+	SelfLinkPathSuffix string
+}
+
+// ContextBasedNaming implements ScopeNamer
+var _ ScopeNamer = ContextBasedNaming{}
+
+func (n ContextBasedNaming) SetSelfLink(obj runtime.Object, url string) error {
+	return n.SelfLinker.SetSelfLink(obj, url)
+}
+
+func (n ContextBasedNaming) Namespace(req *http.Request) (namespace string, err error) {
+	requestInfo, ok := request.RequestInfoFrom(n.GetContext(req))
+	if !ok {
+		return "", fmt.Errorf("missing requestInfo")
+	}
+	return requestInfo.Namespace, nil
+}
+
+func (n ContextBasedNaming) Name(req *http.Request) (namespace, name string, err error) {
+	requestInfo, ok := request.RequestInfoFrom(n.GetContext(req))
+	if !ok {
+		return "", "", fmt.Errorf("missing requestInfo")
+	}
+	ns, err := n.Namespace(req)
+	if err != nil {
+		return "", "", err
+	}
+
+	if len(requestInfo.Name) == 0 {
+		return "", "", errEmptyName
+	}
+	return ns, requestInfo.Name, nil
+}
+
+func (n ContextBasedNaming) GenerateLink(req *http.Request, obj runtime.Object) (uri string, err error) {
+	namespace, name, err := n.ObjectName(obj)
+	if err != nil {
+		return "", err
+	}
+	requestInfo, ok := request.RequestInfoFrom(n.GetContext(req))
+	if !ok {
+		return "", fmt.Errorf("missing requestInfo")
+	}
+
+	if len(namespace) == 0 && len(name) == 0 {
+		if len(requestInfo.Name) == 0 {
+			return "", errEmptyName
+		}
+
+		namespace = requestInfo.Namespace
+		name = requestInfo.Name
+	}
+
+	if n.ClusterScoped {
+		return n.SelfLinkPathPrefix + url.QueryEscape(name) + n.SelfLinkPathSuffix, nil
+	}
+
+	return n.SelfLinkPathPrefix +
+			url.QueryEscape(namespace) +
+			"/" + url.QueryEscape(requestInfo.Resource) + "/" +
+			url.QueryEscape(name) +
+			n.SelfLinkPathSuffix,
+		nil
+}
+
+func (n ContextBasedNaming) GenerateListLink(req *http.Request) (uri string, err error) {
+	if len(req.URL.RawPath) > 0 {
+		return req.URL.RawPath, nil
+	}
+	return req.URL.EscapedPath(), nil
+}
+
+func (n ContextBasedNaming) ObjectName(obj runtime.Object) (namespace, name string, err error) {
+	name, err = n.SelfLinker.Name(obj)
+	if err != nil {
+		return "", "", err
+	}
+	if len(name) == 0 {
+		return "", "", errEmptyName
+	}
+	namespace, err = n.SelfLinker.Namespace(obj)
+	if err != nil {
+		return "", "", err
+	}
+	return namespace, name, err
+}
+
+// errEmptyName is returned when API requests do not fill the name section of the path.
+var errEmptyName = errors.NewBadRequest("name must be provided")

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -19,11 +19,11 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
 
-	"github.com/emicklei/go-restful"
 	"github.com/evanphx/json-patch"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -128,13 +128,13 @@ type testNamer struct {
 	name      string
 }
 
-func (p *testNamer) Namespace(req *restful.Request) (namespace string, err error) {
+func (p *testNamer) Namespace(req *http.Request) (namespace string, err error) {
 	return p.namespace, nil
 }
 
 // Name returns the name from the request, and an optional namespace value if this is a namespace
 // scoped call. An error is returned if the name is not available.
-func (p *testNamer) Name(req *restful.Request) (namespace, name string, err error) {
+func (p *testNamer) Name(req *http.Request) (namespace, name string, err error) {
 	return p.namespace, p.name, nil
 }
 
@@ -151,12 +151,12 @@ func (p *testNamer) SetSelfLink(obj runtime.Object, url string) error {
 }
 
 // GenerateLink creates a path and query for a given runtime object that represents the canonical path.
-func (p *testNamer) GenerateLink(req *restful.Request, obj runtime.Object) (uri string, err error) {
+func (p *testNamer) GenerateLink(req *http.Request, obj runtime.Object) (uri string, err error) {
 	return "", errors.New("not implemented")
 }
 
 // GenerateLink creates a path and query for a list that represents the canonical path.
-func (p *testNamer) GenerateListLink(req *restful.Request) (uri string, err error) {
+func (p *testNamer) GenerateListLink(req *http.Request) (uri string, err error) {
 	return "", errors.New("not implemented")
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer_test.go
@@ -17,45 +17,8 @@ limitations under the License.
 package endpoints
 
 import (
-	"bytes"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/api"
-
-	"github.com/emicklei/go-restful"
 )
-
-func TestScopeNamingGenerateLink(t *testing.T) {
-	selfLinker := &setTestSelfLinker{
-		t:           t,
-		expectedSet: "/api/v1/namespaces/other/services/foo",
-		name:        "foo",
-		namespace:   "other",
-	}
-	s := scopeNaming{
-		meta.RESTScopeNamespace,
-		selfLinker,
-		func(name, namespace string) bytes.Buffer {
-			return *bytes.NewBufferString("/api/v1/namespaces/" + namespace + "/services/" + name)
-		},
-		true,
-	}
-	service := &api.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foo",
-			Namespace: "other",
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind: "Service",
-		},
-	}
-	_, err := s.GenerateLink(&restful.Request{}, service)
-	if err != nil {
-		t.Errorf("Unexpected error %v", err)
-	}
-}
 
 func TestIsVowel(t *testing.T) {
 	tests := []struct {

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -9950,7 +9950,6 @@ go_test(
         "//vendor:k8s.io/apiserver/pkg/endpoints/request",
         "//vendor:k8s.io/apiserver/pkg/endpoints/testing",
         "//vendor:k8s.io/apiserver/pkg/registry/rest",
-        "//vendor:k8s.io/client-go/pkg/api",
     ],
 )
 
@@ -10041,7 +10040,6 @@ go_test(
     library = ":k8s.io/apiserver/pkg/endpoints/handlers",
     tags = ["automanaged"],
     deps = [
-        "//vendor:github.com/emicklei/go-restful",
         "//vendor:github.com/evanphx/json-patch",
         "//vendor:k8s.io/apimachinery/pkg/api/equality",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
@@ -10064,6 +10062,7 @@ go_library(
     srcs = [
         "k8s.io/apiserver/pkg/endpoints/handlers/discovery.go",
         "k8s.io/apiserver/pkg/endpoints/handlers/doc.go",
+        "k8s.io/apiserver/pkg/endpoints/handlers/namer.go",
         "k8s.io/apiserver/pkg/endpoints/handlers/patch.go",
         "k8s.io/apiserver/pkg/endpoints/handlers/proxy.go",
         "k8s.io/apiserver/pkg/endpoints/handlers/rest.go",


### PR DESCRIPTION
Our RESTHandler code is currently tightly coupled to go-restful, but there's no reason for this coupling.  It makes integrations that want API handling (decode, sanity check, admission, verb handling), but don't need the REST installer flow impractical.  I know of two layers now: metrics and TPR.

This starts the process of unwinding by switching the `ScopeNamer` (used for request identification and selflinks) to use the standard http library along with the `RequestInfo` we place in the context for authorization and any other interested layer.

@kubernetes/sig-api-machinery-misc @smarterclayton @ncdc @sttts 