### PR TITLE
Fix typo in storage-layer section of release notes for v1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -617,7 +617,7 @@ Anyway, the cluster should get back to the proper size after 10 min.
 * Cluster federation servers have changed the location in etcd where federated services are stored, so existing federated services must be deleted and recreated. Before upgrading, export all federated services from the federation server and delete the services. After upgrading the cluster, recreate the federated services from the exported data. ([[#37770](https://github.com/kubernetes/kubernetes/pull/37770)](https://github.com/kubernetes/kubernetes/pull/37770), [[@enj](https://github.com/enj)](https://github.com/enj))
 
 ### Internal Storage Layer
-* upgrade to etcd3 prior to upgrading to 1.6 **OR** explicitly specify `--storage-type=etcd2 --storage-media-type=application/json` when starting the apiserver
+* upgrade to etcd3 prior to upgrading to 1.6 **OR** explicitly specify `--storage-backend=etcd2 --storage-media-type=application/json` when starting the apiserver
 
 ### Node Components
 * **Kubelet with the Docker-CRI implementation**


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

* Fixes typo in v1.6 release notes: apiserver flag should be `--storage-backend` instead of `--storage-type` as per the docs: https://kubernetes.io/docs/admin/kube-apiserver/

**Special notes for your reviewer**:

I guess this should be cherry picked to 1.6 branch

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
None
```
