### PR TITLE
If we already have the right version of gazel installed, use it

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -20,18 +20,17 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-git config http.https://gopkg.in.followRedirects true
-
-go get -u gopkg.in/mikedanese/gazel.v14/gazel
+go get gopkg.in/mikedanese/gazel.v14/gazel
 
 for path in ${GOPATH//:/ }; do
-    if [[ -e "${path}/bin/gazel" ]]; then
-      gazel="${path}/bin/gazel"
-      break
-    fi
+  if [[ -e "${path}/bin/gazel" ]]; then
+    gazel="${path}/bin/gazel"
+    break
+  fi
 done
 if [[ -z "${gazel:-}" ]]; then
   echo "Couldn't find gazel on the GOPATH."
   exit 1
 fi
+
 "${gazel}" -root="$(kube::realpath ${KUBE_ROOT})"

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -20,10 +20,20 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-git config http.https://gopkg.in.followRedirects true
+go get gopkg.in/mikedanese/gazel.v14/gazel
 
-go get -u gopkg.in/mikedanese/gazel.v14/gazel
-if ! "${GOPATH}/bin/gazel" -validate -print-diff -root="$(kube::realpath ${KUBE_ROOT})" ; then
+for path in ${GOPATH//:/ }; do
+  if [[ -e "${path}/bin/gazel" ]]; then
+    gazel="${path}/bin/gazel"
+    break
+  fi
+done
+if [[ -z "${gazel:-}" ]]; then
+  echo "Couldn't find gazel on the GOPATH."
+  exit 1
+fi
+
+if ! "${gazel}" -validate -print-diff -root="$(kube::realpath ${KUBE_ROOT})" ; then
   echo
   echo "Run ./hack/update-bazel.sh"
   exit 1


### PR DESCRIPTION
**What this PR does / why we need it**: makes the bazel scripts marginally faster by only downloading/building gazel when necessary. Also removes the `followRedirects` config setting for gopkg.in which is no longer needed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
