### PR TITLE
remove ListMetaFor

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
@@ -36,20 +36,6 @@ func ObjectMetaFor(obj runtime.Object) (*ObjectMeta, error) {
 	return meta, err
 }
 
-// ListMetaFor returns a pointer to a provided object's ListMeta,
-// or an error if the object does not have that pointer.
-// TODO: allow runtime.Unknown to extract this object
-// TODO: Remove this function and use meta.ObjectMetaAccessor() instead.
-func ListMetaFor(obj runtime.Object) (*ListMeta, error) {
-	v, err := conversion.EnforcePtr(obj)
-	if err != nil {
-		return nil, err
-	}
-	var meta *ListMeta
-	err = runtime.FieldPtr(v, "ListMeta", &meta)
-	return meta, err
-}
-
 // TODO: move this, Object, List, and Type to a different package
 type ObjectMetaAccessor interface {
 	GetObjectMeta() Object

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/api_object_versioner.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/api_object_versioner.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/storage"
 )
@@ -45,15 +44,15 @@ func (a APIObjectVersioner) UpdateObject(obj runtime.Object, resourceVersion uin
 
 // UpdateList implements Versioner
 func (a APIObjectVersioner) UpdateList(obj runtime.Object, resourceVersion uint64) error {
-	listMeta, err := metav1.ListMetaFor(obj)
-	if err != nil || listMeta == nil {
+	listAccessor, err := meta.ListAccessor(obj)
+	if err != nil || listAccessor == nil {
 		return err
 	}
 	versionString := ""
 	if resourceVersion != 0 {
 		versionString = strconv.FormatUint(resourceVersion, 10)
 	}
-	listMeta.ResourceVersion = versionString
+	listAccessor.SetResourceVersion(versionString)
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/tools/cache/testing/fake_controller_source.go
+++ b/staging/src/k8s.io/client-go/tools/cache/testing/fake_controller_source.go
@@ -174,12 +174,12 @@ func (f *FakeControllerSource) List(options metav1.ListOptions) (runtime.Object,
 	if err := meta.SetList(listObj, list); err != nil {
 		return nil, err
 	}
-	objMeta, err := metav1.ListMetaFor(listObj)
+	listAccessor, err := meta.ListAccessor(listObj)
 	if err != nil {
 		return nil, err
 	}
 	resourceVersion := len(f.changes)
-	objMeta.ResourceVersion = strconv.Itoa(resourceVersion)
+	listAccessor.SetResourceVersion(strconv.Itoa(resourceVersion))
 	return listObj, nil
 }
 
@@ -195,12 +195,12 @@ func (f *FakePVControllerSource) List(options metav1.ListOptions) (runtime.Objec
 	if err := meta.SetList(listObj, list); err != nil {
 		return nil, err
 	}
-	objMeta, err := metav1.ListMetaFor(listObj)
+	listAccessor, err := meta.ListAccessor(listObj)
 	if err != nil {
 		return nil, err
 	}
 	resourceVersion := len(f.changes)
-	objMeta.ResourceVersion = strconv.Itoa(resourceVersion)
+	listAccessor.SetResourceVersion(strconv.Itoa(resourceVersion))
 	return listObj, nil
 }
 
@@ -216,12 +216,12 @@ func (f *FakePVCControllerSource) List(options metav1.ListOptions) (runtime.Obje
 	if err := meta.SetList(listObj, list); err != nil {
 		return nil, err
 	}
-	objMeta, err := metav1.ListMetaFor(listObj)
+	listAccessor, err := meta.ListAccessor(listObj)
 	if err != nil {
 		return nil, err
 	}
 	resourceVersion := len(f.changes)
-	objMeta.ResourceVersion = strconv.Itoa(resourceVersion)
+	listAccessor.SetResourceVersion(strconv.Itoa(resourceVersion))
 	return listObj, nil
 }
 


### PR DESCRIPTION
Finish replacing `ListMetaFor` with `ListAccessor`.  This gives more flexibility for list handling as intended.  `UnstructuredList` matches now.

@kubernetes/sig-api-machinery-pr-reviews 