### PR TITLE
Use DNS for client InClusterConfig()

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -275,11 +275,6 @@ func DefaultKubernetesUserAgent() string {
 // running inside a pod running on kubernetes. It will return an error if
 // called from a process not running in a kubernetes environment.
 func InClusterConfig() (*Config, error) {
-	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
-	if len(host) == 0 || len(port) == 0 {
-		return nil, fmt.Errorf("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
-	}
-
 	token, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/" + api.ServiceAccountTokenKey)
 	if err != nil {
 		return nil, err
@@ -292,12 +287,24 @@ func InClusterConfig() (*Config, error) {
 		tlsClientConfig.CAFile = rootCAFile
 	}
 
-	return &Config{
-		// TODO: switch to using cluster DNS.
-		Host:            "https://" + net.JoinHostPort(host, port),
+	config := &Config{
 		BearerToken:     string(token),
 		TLSClientConfig: tlsClientConfig,
-	}, nil
+	}
+
+	// Get the kubernetes service port using the SRV record. If that fails, fallback to use
+	// the environment variables.
+	if _, addresses, err := net.LookupSRV("https", "tcp", "kubernetes.default.svc"); err == nil && len(addresses) > 0 {
+		config.Host = fmt.Sprintf("https://kubernetes.default.svc:%d", addresses[0].Port)
+	} else {
+		host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+		if len(host) == 0 || len(port) == 0 {
+			return nil, fmt.Errorf("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
+		}
+		config.Host = "https://" + net.JoinHostPort(host, port)
+	}
+
+	return config, nil
 }
 
 // IsConfigTransportTLS returns true if and only if the provided

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -602,8 +602,8 @@ var _ = framework.KubeDescribe("Kubectl client", func() {
 			framework.ExpectNoError(err)
 			kubectlPath = strings.TrimSpace(string(kubectlPathNormalized))
 
-			inClusterHost := strings.TrimSpace(framework.RunHostCmdOrDie(ns, simplePodName, "printenv KUBERNETES_SERVICE_HOST"))
-			inClusterPort := strings.TrimSpace(framework.RunHostCmdOrDie(ns, simplePodName, "printenv KUBERNETES_SERVICE_PORT"))
+			inClusterHost := "kubernetes.default.svc"
+			inClusterPort := "443"
 
 			framework.Logf("copying %s to the %s pod", kubectlPath, simplePodName)
 			framework.RunKubectlOrDie("cp", kubectlPath, ns+"/"+simplePodName+":/tmp/")


### PR DESCRIPTION
This PR will switch `InClusterConfig()` to use DNS (`kubernetes.default.svc:443`) over the environment variables.

The reason for this is that you can have namespace B where you create service with name "kubernetes", which in that case the in-cluster client will see and use that service IP:PORT instead of real kubernetes api url.

Another reason why we might need this: https://github.com/kubernetes/kubernetes/issues/40973

Note that this will break users without kube-dns, but if that turns to be an issue, I think we can do a check if the DNS is resolvable and fallback to env var.

@smarterclayton @ncdc FYI