### PR TITLE
[WIP/RFC] Inject a shared memory backed volume to back /dev/shm

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//plugin/pkg/admission/antiaffinity:go_default_library",
         "//plugin/pkg/admission/defaulttolerationseconds:go_default_library",
         "//plugin/pkg/admission/deny:go_default_library",
+        "//plugin/pkg/admission/devshm:go_default_library",
         "//plugin/pkg/admission/exec:go_default_library",
         "//plugin/pkg/admission/gc:go_default_library",
         "//plugin/pkg/admission/imagepolicy:go_default_library",

--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -29,6 +29,7 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/antiaffinity"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/defaulttolerationseconds"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/deny"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/devshm"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/exec"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/gc"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/imagepolicy"

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -74,6 +74,7 @@ filegroup(
         "//examples/https-nginx:all-srcs",
         "//examples/k8petstore/web-server/src:all-srcs",
         "//examples/sharing-clusters:all-srcs",
+        "//examples/volumes/local_storage/local-discovery-app:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -376,7 +376,7 @@ function start_apiserver {
     fi
 
     # Admission Controllers to invoke prior to persisting objects in cluster
-    ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount${security_admission},ResourceQuota,DefaultStorageClass,DefaultTolerationSeconds
+    ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount${security_admission},ResourceQuota,DefaultStorageClass,DefaultTolerationSeconds,DefaultDevShm
 
     # This is the default dir and filename where the apiserver will generate a self-signed cert
     # which should be able to be used as the CA to verify itself

--- a/pkg/volume/empty_dir/BUILD
+++ b/pkg/volume/empty_dir/BUILD
@@ -18,6 +18,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
+        "//pkg/kubelet/qos:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -260,6 +260,7 @@ func (ed *emptyDir) setupTmpfs(dir string) error {
 		return err
 	}
 	var options []string
+	// Linux system default is 50% of capacity.
 	if memoryLimits > 0 {
 		options = []string{fmt.Sprintf("size=%d", memoryLimits)}
 	}

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
@@ -254,8 +255,36 @@ func (ed *emptyDir) setupTmpfs(dir string) error {
 		return nil
 	}
 
-	glog.V(3).Infof("pod %v: mounting tmpfs for volume %v", ed.pod.UID, ed.volName)
-	return ed.mounter.Mount("tmpfs", dir, "tmpfs", nil /* options */)
+	memoryLimits, err := ed.getMemoryLimits()
+	if err != nil {
+		return err
+	}
+	var options []string
+	if memoryLimits > 0 {
+		options = []string{fmt.Sprintf("size=%d", memoryLimits)}
+	}
+	glog.V(3).Infof("pod %v: mounting tmpfs for volume %v with options %v", ed.pod.UID, ed.volName, options)
+	return ed.mounter.Mount("tmpfs", dir, "tmpfs", options)
+}
+
+func (ed *emptyDir) getMemoryLimits() (int64, error) {
+	if string(qos.GetPodQOS(ed.pod)) == "Guaranteed" {
+		_, limits, err := v1.PodRequestsAndLimits(ed.pod)
+		if err != nil {
+			return 0, err
+		}
+		val := limits[v1.ResourceMemory]
+		return (&val).Value(), nil
+	}
+	// For all other QOS class use allocatable as limit.
+	allocatable, err := ed.plugin.host.GetNodeAllocatable()
+	if err != nil {
+		return 0, err
+	}
+	if val, exists := allocatable[v1.ResourceMemory]; exists {
+		return val.Value(), nil
+	}
+	return 0, nil
 }
 
 // setupDir creates the directory with the specified SELinux context and

--- a/plugin/BUILD
+++ b/plugin/BUILD
@@ -19,6 +19,7 @@ filegroup(
         "//plugin/pkg/admission/antiaffinity:all-srcs",
         "//plugin/pkg/admission/defaulttolerationseconds:all-srcs",
         "//plugin/pkg/admission/deny:all-srcs",
+        "//plugin/pkg/admission/devshm:all-srcs",
         "//plugin/pkg/admission/exec:all-srcs",
         "//plugin/pkg/admission/gc:all-srcs",
         "//plugin/pkg/admission/imagepolicy:all-srcs",

--- a/plugin/pkg/admission/devshm/BUILD
+++ b/plugin/pkg/admission/devshm/BUILD
@@ -13,8 +13,8 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
-        "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
+        "//vendor:k8s.io/apimachinery/pkg/util/uuid",
         "//vendor:k8s.io/apiserver/pkg/admission",
     ],
 )

--- a/plugin/pkg/admission/devshm/BUILD
+++ b/plugin/pkg/admission/devshm/BUILD
@@ -1,0 +1,33 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["admission.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//vendor:github.com/golang/glog",
+        "//vendor:k8s.io/apimachinery/pkg/api/errors",
+        "//vendor:k8s.io/apiserver/pkg/admission",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/plugin/pkg/admission/devshm/admission.go
+++ b/plugin/pkg/admission/devshm/admission.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package devshm
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+const (
+	// Default name for the devShm volume.
+	defaultDevShmVolumeName string = "dev-shm"
+	// Default mount directory for the shm volume.
+	defaultDevShmMountPath string = "/dev/shm"
+)
+
+func init() {
+	admission.RegisterPlugin("DefaultDevShm", func(config io.Reader) (admission.Interface, error) {
+		return NewDefaultDevShm(), nil
+	})
+}
+
+// plugin contains the client used by the admission controller
+// It will add default /dev/shm volume to all pods.
+type plugin struct {
+	*admission.Handler
+}
+
+// NewDefaultTolerationSeconds creates a new instance of the DefaultTolerationSeconds admission controller
+func NewDefaultDevShm() admission.Interface {
+	return &plugin{
+		Handler: admission.NewHandler(admission.Create, admission.Update),
+	}
+}
+
+func (p *plugin) Admit(attributes admission.Attributes) (err error) {
+	if attributes.GetResource().GroupResource() != api.Resource("pods") {
+		return nil
+	}
+	if len(attributes.GetSubresource()) > 0 {
+		// only run the checks below on pods proper and not subresources
+		return nil
+	}
+	pod, ok := attributes.GetObject().(*api.Pod)
+	if !ok {
+		return errors.NewBadRequest(fmt.Sprintf("expected *api.Pod but got %T", attributes.GetObject()))
+	}
+
+	// Find the volume and volume name for the ServiceAccountTokenSecret if it already exists
+	hasDevShmVolume := false
+	glog.Errorf("%+v", pod.Spec.Volumes)
+	for _, volume := range pod.Spec.Volumes {
+		if volume.EmptyDir != nil && volume.EmptyDir.Medium == api.StorageMediumMemory && volume.Name == defaultDevShmVolumeName {
+			hasDevShmVolume = true
+			break
+		}
+	}
+	// Create the prototypical VolumeMount
+	volumeMount := api.VolumeMount{
+		Name:      defaultDevShmVolumeName,
+		MountPath: defaultDevShmMountPath,
+	}
+	// Ensure every container mounts the shm volume
+	needsDevShmVolume := false
+	for i, container := range pod.Spec.InitContainers {
+		existingContainerMount := false
+		for _, volumeMount := range container.VolumeMounts {
+			// Existing mounts at the default mount path prevent mounting of the API token
+			if volumeMount.MountPath == defaultDevShmMountPath {
+				existingContainerMount = true
+				break
+			}
+		}
+		if !existingContainerMount {
+			pod.Spec.InitContainers[i].VolumeMounts = append(pod.Spec.InitContainers[i].VolumeMounts, volumeMount)
+			needsDevShmVolume = true
+			glog.Errorf("%+v", pod.Spec.InitContainers[i].VolumeMounts)
+		}
+	}
+	for i, container := range pod.Spec.Containers {
+		existingContainerMount := false
+		for _, volumeMount := range container.VolumeMounts {
+			// Existing mounts at the default mount path prevent mounting of the API token
+			if volumeMount.MountPath == defaultDevShmMountPath {
+				existingContainerMount = true
+				break
+			}
+		}
+		if !existingContainerMount {
+			pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, volumeMount)
+			glog.Errorf("%+v", pod.Spec.Containers[i].VolumeMounts)
+			needsDevShmVolume = true
+		}
+	}
+	// Add the volume if a container needs it
+	if !hasDevShmVolume && needsDevShmVolume {
+		volume := api.Volume{
+			Name: defaultDevShmVolumeName,
+			VolumeSource: api.VolumeSource{
+				EmptyDir: &api.EmptyDirVolumeSource{
+					Medium: api.StorageMediumMemory,
+				},
+			},
+		}
+		pod.Spec.Volumes = append(pod.Spec.Volumes, volume)
+	}
+	return nil
+}


### PR DESCRIPTION
Inject a memory back volume during admission to provide a shared memory space for containers in a pod.

Memory backed volumes are restricted to the pod's memory limit or node allocatable which ever is the lowest.

For #28272

cc @thockin @derekwaynecarr thoughts/opinions?

I'm looking for feedback on handling shared memory for pods. 