### PR TITLE
local up dns defaults/Privileged defaults so that [Conformance] sets mostly pass on local clusters.

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -52,7 +52,7 @@ EVICTION_PRESSURE_TRANSITION_PERIOD=${EVICTION_PRESSURE_TRANSITION_PERIOD:-"1m"}
 # container bridge docker is currently using) and we don't know the IP of the
 # DNS pod to pass in as --cluster-dns. To set this up by hand, set this flag
 # and change DNS_SERVER_IP to the appropriate IP.
-ENABLE_CLUSTER_DNS=${KUBE_ENABLE_CLUSTER_DNS:-false}
+ENABLE_CLUSTER_DNS=${KUBE_ENABLE_CLUSTER_DNS:-true}
 DNS_SERVER_IP=${KUBE_DNS_SERVER_IP:-10.0.0.10}
 DNS_DOMAIN=${KUBE_DNS_NAME:-"cluster.local"}
 KUBECTL=${KUBECTL:-cluster/kubectl.sh}
@@ -179,9 +179,12 @@ set +e
 
 API_PORT=${API_PORT:-8080}
 API_SECURE_PORT=${API_SECURE_PORT:-6443}
+
+# WARNING: For DNS to work on most setups you should export API_HOST as the docker0 ip address,
 API_HOST=${API_HOST:-localhost}
 API_HOST_IP=${API_HOST_IP:-"127.0.0.1"}
 API_BIND_ADDR=${API_BIND_ADDR:-"0.0.0.0"}
+
 KUBELET_HOST=${KUBELET_HOST:-"127.0.0.1"}
 # By default only allow CORS for requests on localhost
 API_CORS_ALLOWED_ORIGINS=${API_CORS_ALLOWED_ORIGINS:-/127.0.0.1(:[0-9]+)?$,/localhost(:[0-9]+)?$}
@@ -305,7 +308,7 @@ cleanup()
 {
   echo "Cleaning up..."
   # delete running images
-  # if [[ "${ENABLE_CLUSTER_DNS}" = true ]]; then
+  # if [[ "${ENABLE_CLUSTER_DNS}" == true ]]; then
   # Still need to figure why this commands throw an error: Error from server: client: etcd cluster is unavailable or misconfigured
   #     ${KUBECTL} --namespace=kube-system delete service kube-dns
   # And this one hang forever:
@@ -845,5 +848,3 @@ print_success
 if [[ "${ENABLE_DAEMON}" = false ]]; then
   while true; do sleep 1; done
 fi
-
-

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -48,10 +48,10 @@ EVICTION_HARD=${EVICTION_HARD:-"memory.available<100Mi"}
 EVICTION_SOFT=${EVICTION_SOFT:-""}
 EVICTION_PRESSURE_TRANSITION_PERIOD=${EVICTION_PRESSURE_TRANSITION_PERIOD:-"1m"}
 
-# We disable cluster DNS by default because this script uses docker0 (or whatever
-# container bridge docker is currently using) and we don't know the IP of the
-# DNS pod to pass in as --cluster-dns. To set this up by hand, set this flag
-# and change DNS_SERVER_IP to the appropriate IP.
+# This script uses docker0 (or whatever container bridge docker is currently using)
+# and we don't know the IP of the DNS pod to pass in as --cluster-dns.
+# To set this up by hand, set this flag and change DNS_SERVER_IP.
+# Note also that you need API_HOST (defined above) for correct DNS.
 ENABLE_CLUSTER_DNS=${KUBE_ENABLE_CLUSTER_DNS:-true}
 DNS_SERVER_IP=${KUBE_DNS_SERVER_IP:-10.0.0.10}
 DNS_DOMAIN=${KUBE_DNS_NAME:-"cluster.local"}

--- a/test/e2e/portforward.go
+++ b/test/e2e/portforward.go
@@ -157,6 +157,7 @@ func (c *portForwardCommand) Stop() {
 	framework.TryKill(c.cmd)
 }
 
+// runPortForward runs port-forward, warning, this may need root functionality on some systems.
 func runPortForward(ns, podName string, port int) *portForwardCommand {
 	cmd := framework.KubectlCmd("port-forward", fmt.Sprintf("--namespace=%v", ns), podName, fmt.Sprintf(":%d", port))
 	// This is somewhat ugly but is the only way to retrieve the port that was picked
@@ -473,16 +474,16 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 
 	framework.KubeDescribe("With a server listening on 0.0.0.0", func() {
 		framework.KubeDescribe("that expects a client request", func() {
-			It("should support a client that connects, sends no data, and disconnects", func() {
+			It("should support a client that connects, sends NO DATA, and disconnects", func() {
 				doTestMustConnectSendNothing("0.0.0.0", f)
 			})
-			It("should support a client that connects, sends data, and disconnects", func() {
+			It("should support a client that connects, sends DATA, and disconnects", func() {
 				doTestMustConnectSendDisconnect("0.0.0.0", f)
 			})
 		})
 
-		framework.KubeDescribe("that expects no client request", func() {
-			It("should support a client that connects, sends data, and disconnects", func() {
+		framework.KubeDescribe("that expects NO client request", func() {
+			It("should support a client that connects, sends DATA, and disconnects", func() {
 				doTestConnectSendDisconnect("0.0.0.0", f)
 			})
 		})
@@ -492,18 +493,19 @@ var _ = framework.KubeDescribe("Port forwarding", func() {
 		})
 	})
 
+	// kubectl port-forward may need elevated privileges to do its job.
 	framework.KubeDescribe("With a server listening on localhost", func() {
 		framework.KubeDescribe("that expects a client request", func() {
-			It("should support a client that connects, sends no data, and disconnects [Conformance]", func() {
+			It("should support a client that connects, sends NO DATA, and disconnects", func() {
 				doTestMustConnectSendNothing("localhost", f)
 			})
-			It("should support a client that connects, sends data, and disconnects [Conformance]", func() {
+			It("should support a client that connects, sends DATA, and disconnects", func() {
 				doTestMustConnectSendDisconnect("localhost", f)
 			})
 		})
 
-		framework.KubeDescribe("that expects no client request", func() {
-			It("should support a client that connects, sends data, and disconnects [Conformance]", func() {
+		framework.KubeDescribe("that expects NO client request", func() {
+			It("should support a client that connects, sends DATA, and disconnects", func() {
 				doTestConnectSendDisconnect("localhost", f)
 			})
 		})


### PR DESCRIPTION
Fixes #43651 So that only 4 tests fail out of the box.