### PR TITLE
Ignore volume directories that have been renamed for deletion

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -648,6 +648,12 @@ func getVolumesFromPodDir(podDir string) ([]podVolume, error) {
 
 			unescapePluginName := strings.UnescapeQualifiedNameForDisk(pluginName)
 			for _, volumeName := range volumePluginDirs {
+				if volumehelper.IsVolumeDeleting(volumeName) {
+					// Ignore volumes that are being deleted
+					glog.V(4).Infof("Ignoring volume at %q", path.Join(volumePluginPath, volumeName))
+					continue
+				}
+
 				mountPath := path.Join(volumePluginPath, volumeName)
 				volumes = append(volumes, podVolume{
 					podName:        volumetypes.UniquePodName(podName),

--- a/pkg/volume/empty_dir/BUILD
+++ b/pkg/volume/empty_dir/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
+        "//pkg/volume/util/volumehelper:go_default_library",
         "//vendor:github.com/golang/glog",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/types",

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
 )
 
 // TODO: in the near future, this will be changed to be more restrictive
@@ -329,7 +330,7 @@ func (ed *emptyDir) TearDownAt(dir string) error {
 }
 
 func (ed *emptyDir) teardownDefault(dir string) error {
-	tmpDir, err := volume.RenameDirectory(dir, ed.volName+".deleting~")
+	tmpDir, err := volume.RenameDirectory(dir, ed.volName+volumehelper.VolumeDeletingSuffix)
 	if err != nil {
 		return err
 	}

--- a/pkg/volume/util/volumehelper/BUILD
+++ b/pkg/volume/util/volumehelper/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -16,6 +17,13 @@ go_library(
         "//pkg/volume:go_default_library",
         "//pkg/volume/util/types:go_default_library",
     ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["volumehelper_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
 )
 
 filegroup(

--- a/pkg/volume/util/volumehelper/volumehelper.go
+++ b/pkg/volume/util/volumehelper/volumehelper.go
@@ -20,6 +20,7 @@ package volumehelper
 
 import (
 	"fmt"
+	"strings"
 
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/volume"
@@ -35,6 +36,10 @@ const (
 	// VolumeGidAnnotationKey is the of the annotation on the PersistentVolume
 	// object that specifies a supplemental GID.
 	VolumeGidAnnotationKey = "pv.beta.kubernetes.io/gid"
+
+	// VolumeDeletingSuffix is used by EmptyDir-based volume plugins to rename the volume directory during
+	// deletion so that the volume manager will not detect it as a valid volume
+	VolumeDeletingSuffix = ".deleting~"
 )
 
 // GetUniquePodName returns a unique identifier to reference a pod by
@@ -86,4 +91,10 @@ func GetUniqueVolumeNameFromSpec(
 			volumePlugin.GetPluginName(),
 			volumeName),
 		nil
+}
+
+// IsVolumeDeleting checks if the volume name matches the deletion format used
+// by EmptyDir-based volumes
+func IsVolumeDeleting(volumeName string) bool {
+	return strings.Contains(volumeName, VolumeDeletingSuffix)
 }

--- a/pkg/volume/util/volumehelper/volumehelper_test.go
+++ b/pkg/volume/util/volumehelper/volumehelper_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package volumehelper contains consts and helper methods used by various
+// volume components (attach/detach controller, kubelet, etc.).
+package volumehelper
+
+import (
+	"testing"
+)
+
+func TestDeletingVolumeDetection(t *testing.T) {
+	cases := []struct {
+		volumeName       string
+		expectedDeleting bool
+	}{
+		{
+			volumeName:       ".deleting~",
+			expectedDeleting: true,
+		},
+		{
+			volumeName:       ".deleting~1234",
+			expectedDeleting: true,
+		},
+		{
+			volumeName:       "myvol.deleting~",
+			expectedDeleting: true,
+		},
+		{
+			volumeName:       "myvol.deleting~1234",
+			expectedDeleting: true,
+		},
+		{
+			volumeName:       "deleting~",
+			expectedDeleting: false,
+		},
+		{
+			volumeName:       ".deleting",
+			expectedDeleting: false,
+		},
+		{
+			volumeName:       "deleting",
+			expectedDeleting: false,
+		},
+		{
+			volumeName:       ".Deleting~",
+			expectedDeleting: false,
+		},
+		{
+			volumeName:       "myvol.deleting",
+			expectedDeleting: false,
+		},
+		{
+			volumeName:       "myvol",
+			expectedDeleting: false,
+		},
+	}
+
+	for _, tc := range cases {
+		isDeleting := IsVolumeDeleting(tc.volumeName)
+		if isDeleting != tc.expectedDeleting {
+			t.Errorf("Result for volumeName %v: %v does not match expected %v", tc.volumeName, isDeleting, tc.expectedDeleting)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
As part of EmptyDir cleanup, the volume directory gets renamed before the contents get deleted so that the volume manager does not detect it as a valid volume if there are a lot of contents to delete.  However, the volume manager doesn't actually ignore the renamed volume, and treats it as a valid EmptyDir volume.  If the deletion fails for some reason, then the directory remains and kubelet will discover it as a new volume.  This causes an exponential increase in number of detected volumes, which can cause system resource starvation as kubelet is handling the cleanup for more and more volumes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Partial fix #43534.  The remaining part is to fix the EmptyDir renaming error.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
NONE.  So far, this bug has only been hit in unsupported configurations.
