### PR TITLE
Support generating Open API extensions for strategic merge patch tags in go struct tags

### DIFF
--- a/cmd/libs/go2idl/openapi-gen/generators/openapi_test.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi_test.go
@@ -111,6 +111,10 @@ type Blah struct {
 	// a member with an extension
 	// +k8s:openapi-gen=x-kubernetes-member-tag:member_test
 	WithExtension string
+	// a member with struct tag as extension
+	// +patch-strategy=ps
+	// +patch-merge-key=pmk
+	WithStructTagExtension string `+"`"+`patchStrategy:"ps" patchMergeKey:"pmk"`+"`"+`
 }
 		`)
 	if err != nil {
@@ -238,8 +242,21 @@ Type: []string{"string"},
 Format: "",
 },
 },
+"WithStructTagExtension": {
+VendorExtensible: spec.VendorExtensible{
+Extensions: spec.Extensions{
+"patch-strategy": "ps",
+"patch-merge-key": "pmk",
 },
-Required: []string{"String","Int64","Int32","Int16","Int8","Uint","Uint64","Uint32","Uint16","Uint8","Byte","Bool","Float64","Float32","ByteArray","WithExtension"},
+},
+SchemaProps: spec.SchemaProps{
+Description: "a member with struct tag as extension",
+Type: []string{"string"},
+Format: "",
+},
+},
+},
+Required: []string{"String","Int64","Int32","Int16","Int8","Uint","Uint64","Uint32","Uint16","Uint8","Byte","Bool","Float64","Float32","ByteArray","WithExtension","WithStructTagExtension"},
 },
 VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{

--- a/federation/apis/federation/v1beta1/generated.proto
+++ b/federation/apis/federation/v1beta1/generated.proto
@@ -89,6 +89,8 @@ message ClusterSpec {
   // This is to help clients reach servers in the most network-efficient way possible.
   // Clients can use the appropriate server address as per the CIDR that they match.
   // In case of multiple matches, clients should use the longest matching CIDR.
+  // +patch-strategy=merge
+  // +patch-merge-key=clientCIDR
   repeated ServerAddressByClientCIDR serverAddressByClientCIDRs = 1;
 
   // Name of the secret containing kubeconfig to access this cluster.

--- a/federation/apis/federation/v1beta1/types.go
+++ b/federation/apis/federation/v1beta1/types.go
@@ -36,6 +36,8 @@ type ClusterSpec struct {
 	// This is to help clients reach servers in the most network-efficient way possible.
 	// Clients can use the appropriate server address as per the CIDR that they match.
 	// In case of multiple matches, clients should use the longest matching CIDR.
+	// +patch-strategy=merge
+	// +patch-merge-key=clientCIDR
 	ServerAddressByClientCIDRs []ServerAddressByClientCIDR `json:"serverAddressByClientCIDRs" patchStrategy:"merge" patchMergeKey:"clientCIDR" protobuf:"bytes,1,rep,name=serverAddressByClientCIDRs"`
 	// Name of the secret containing kubeconfig to access this cluster.
 	// The secret is read from the kubernetes cluster that is hosting federation control plane.

--- a/federation/apis/swagger-spec/extensions_v1beta1.json
+++ b/federation/apis/swagger-spec/extensions_v1beta1.json
@@ -5871,7 +5871,7 @@
     "properties": {
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.podIP."
+      "description": "Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",

--- a/federation/apis/swagger-spec/v1.json
+++ b/federation/apis/swagger-spec/v1.json
@@ -4287,7 +4287,7 @@
      },
      "data": {
       "type": "object",
-      "description": "Data contains the configuration data. Each key must be a valid DNS_SUBDOMAIN with an optional leading dot."
+      "description": "Data contains the configuration data. Each key must consist of alphanumeric characters, '-', '_' or '.'."
      }
     }
    },
@@ -4815,7 +4815,7 @@
      },
      "data": {
       "type": "object",
-      "description": "Data contains the secret data. Each key must be a valid DNS_SUBDOMAIN or leading dot followed by valid DNS_SUBDOMAIN. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4"
+      "description": "Data contains the secret data. Each key must consist of alphanumeric characters, '-', '_' or '.'. The serialized form of the secret data is a base64 encoded string, representing the arbitrary (possibly non-string) data value here. Described in https://tools.ietf.org/html/rfc4648#section-4"
      },
      "stringData": {
       "type": "object",

--- a/pkg/api/v1/generated.proto
+++ b/pkg/api/v1/generated.proto
@@ -245,6 +245,8 @@ message ComponentStatus {
 
   // List of component conditions observed
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated ComponentCondition conditions = 2;
 }
 
@@ -415,6 +417,8 @@ message Container {
   // accessible from the network.
   // Cannot be updated.
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=containerPort
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.
@@ -429,6 +433,8 @@ message Container {
   // List of environment variables to set in the container.
   // Cannot be updated.
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=name
   repeated EnvVar env = 7;
 
   // Compute Resources required by this container.
@@ -440,6 +446,8 @@ message Container {
   // Pod volumes to mount into the container's filesystem.
   // Cannot be updated.
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=mountPath
   repeated VolumeMount volumeMounts = 9;
 
   // Periodic probe of container liveness.
@@ -1591,6 +1599,8 @@ message NodeSelector {
 // that relates the key and values.
 message NodeSelectorRequirement {
   // The label key that the selector applies to.
+  // +patch-strategy=merge
+  // +patch-merge-key=key
   optional string key = 1;
 
   // Represents a key's relationship to a set of values.
@@ -1658,12 +1668,16 @@ message NodeStatus {
   // Conditions is an array of current observed node conditions.
   // More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated NodeCondition conditions = 4;
 
   // List of addresses reachable to the node.
   // Queried from cloud provider, if available.
   // More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated NodeAddress addresses = 5;
 
   // Endpoints of daemons running on the Node.
@@ -1869,6 +1883,8 @@ message ObjectMeta {
   // then an entry in this list will point to this controller, with the controller field set to true.
   // There cannot be more than one managing controller.
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=uid
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.OwnerReference ownerReferences = 13;
 
   // Must be empty before the object is deleted from the registry. Each entry
@@ -1876,6 +1892,7 @@ message ObjectMeta {
   // from the list. If the deletionTimestamp of the object is non-nil, entries
   // in this list can only be removed.
   // +optional
+  // +patch-strategy=merge
   repeated string finalizers = 14;
 
   // The name of the cluster which the object belongs to.
@@ -2562,6 +2579,8 @@ message PodSpec {
   // List of volumes that can be mounted by containers belonging to the pod.
   // More info: http://kubernetes.io/docs/user-guide/volumes
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=name
   repeated Volume volumes = 1;
 
   // List of initialization containers belonging to the pod.
@@ -2577,6 +2596,8 @@ message PodSpec {
   // Init containers cannot currently be added or removed.
   // Cannot be updated.
   // More info: http://kubernetes.io/docs/user-guide/containers
+  // +patch-strategy=merge
+  // +patch-merge-key=name
   repeated Container initContainers = 20;
 
   // List of containers belonging to the pod.
@@ -2584,6 +2605,8 @@ message PodSpec {
   // There must be at least one container in a Pod.
   // Cannot be updated.
   // More info: http://kubernetes.io/docs/user-guide/containers
+  // +patch-strategy=merge
+  // +patch-merge-key=name
   repeated Container containers = 2;
 
   // Restart policy for all containers within the pod.
@@ -2672,6 +2695,8 @@ message PodSpec {
   // in the case of docker, only DockerConfig type secrets are honored.
   // More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=name
   repeated LocalObjectReference imagePullSecrets = 15;
 
   // Specifies the hostname of the Pod
@@ -2709,6 +2734,8 @@ message PodStatus {
   // Current service state of pod.
   // More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated PodCondition conditions = 2;
 
   // A human readable message indicating details about why the pod is in this condition.
@@ -3107,6 +3134,8 @@ message ReplicationControllerStatus {
 
   // Represents the latest available observations of a replication controller's current state.
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated ReplicationControllerCondition conditions = 6;
 }
 
@@ -3468,6 +3497,8 @@ message ServiceAccount {
   // Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount.
   // More info: http://kubernetes.io/docs/user-guide/secrets
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=name
   repeated ObjectReference secrets = 2;
 
   // ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
@@ -3558,6 +3589,8 @@ message ServiceProxyOptions {
 message ServiceSpec {
   // The list of ports that are exposed by this service.
   // More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+  // +patch-strategy=merge
+  // +patch-merge-key=port
   repeated ServicePort ports = 1;
 
   // Route service traffic to pods with label keys and values matching this
@@ -3677,6 +3710,8 @@ message TCPSocketAction {
 // any pod that that does not tolerate the Taint.
 message Taint {
   // Required. The taint key to be applied to a node.
+  // +patch-strategy=merge
+  // +patch-merge-key=key
   optional string key = 1;
 
   // Required. The taint value corresponding to the taint key.
@@ -3700,6 +3735,8 @@ message Toleration {
   // Key is the taint key that the toleration applies to. Empty means match all taint keys.
   // If the key is empty, operator must be Exists; this combination means to match all values and all keys.
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=key
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -197,6 +197,8 @@ type ObjectMeta struct {
 	// then an entry in this list will point to this controller, with the controller field set to true.
 	// There cannot be more than one managing controller.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=uid
 	OwnerReferences []metav1.OwnerReference `json:"ownerReferences,omitempty" patchStrategy:"merge" patchMergeKey:"uid" protobuf:"bytes,13,rep,name=ownerReferences"`
 
 	// Must be empty before the object is deleted from the registry. Each entry
@@ -204,6 +206,7 @@ type ObjectMeta struct {
 	// from the list. If the deletionTimestamp of the object is non-nil, entries
 	// in this list can only be removed.
 	// +optional
+	// +patch-strategy=merge
 	Finalizers []string `json:"finalizers,omitempty" patchStrategy:"merge" protobuf:"bytes,14,rep,name=finalizers"`
 
 	// The name of the cluster which the object belongs to.
@@ -1637,6 +1640,8 @@ type Container struct {
 	// accessible from the network.
 	// Cannot be updated.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=containerPort
 	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
@@ -1649,6 +1654,8 @@ type Container struct {
 	// List of environment variables to set in the container.
 	// Cannot be updated.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,7,rep,name=env"`
 	// Compute Resources required by this container.
 	// Cannot be updated.
@@ -1658,6 +1665,8 @@ type Container struct {
 	// Pod volumes to mount into the container's filesystem.
 	// Cannot be updated.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=mountPath
 	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"mountPath" protobuf:"bytes,9,rep,name=volumeMounts"`
 	// Periodic probe of container liveness.
 	// Container will be restarted if the probe fails.
@@ -1978,6 +1987,8 @@ type NodeSelectorTerm struct {
 // that relates the key and values.
 type NodeSelectorRequirement struct {
 	// The label key that the selector applies to.
+	// +patch-strategy=merge
+	// +patch-merge-key=key
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -2162,6 +2173,8 @@ type PreferredSchedulingTerm struct {
 // any pod that that does not tolerate the Taint.
 type Taint struct {
 	// Required. The taint key to be applied to a node.
+	// +patch-strategy=merge
+	// +patch-merge-key=key
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Required. The taint value corresponding to the taint key.
 	// +optional
@@ -2204,6 +2217,8 @@ type Toleration struct {
 	// Key is the taint key that the toleration applies to. Empty means match all taint keys.
 	// If the key is empty, operator must be Exists; this combination means to match all values and all keys.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=key
 	Key string `json:"key,omitempty" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Operator represents a key's relationship to the value.
 	// Valid operators are Exists and Equal. Defaults to Equal.
@@ -2261,6 +2276,8 @@ type PodSpec struct {
 	// List of volumes that can be mounted by containers belonging to the pod.
 	// More info: http://kubernetes.io/docs/user-guide/volumes
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Volumes []Volume `json:"volumes,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
 	// List of initialization containers belonging to the pod.
 	// Init containers are executed in order prior to containers being started. If any
@@ -2275,12 +2292,16 @@ type PodSpec struct {
 	// Init containers cannot currently be added or removed.
 	// Cannot be updated.
 	// More info: http://kubernetes.io/docs/user-guide/containers
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	InitContainers []Container `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.
 	// There must be at least one container in a Pod.
 	// Cannot be updated.
 	// More info: http://kubernetes.io/docs/user-guide/containers
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
 	// Restart policy for all containers within the pod.
 	// One of Always, OnFailure, Never.
@@ -2357,6 +2378,8 @@ type PodSpec struct {
 	// in the case of docker, only DockerConfig type secrets are honored.
 	// More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 	// Specifies the hostname of the Pod
 	// If not specified, the pod's hostname will be set to a system-defined value.
@@ -2444,6 +2467,8 @@ type PodStatus struct {
 	// Current service state of pod.
 	// More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []PodCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
 	// A human readable message indicating details about why the pod is in this condition.
 	// +optional
@@ -2640,6 +2665,8 @@ type ReplicationControllerStatus struct {
 
 	// Represents the latest available observations of a replication controller's current state.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []ReplicationControllerCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 
@@ -2777,6 +2804,8 @@ type LoadBalancerIngress struct {
 type ServiceSpec struct {
 	// The list of ports that are exposed by this service.
 	// More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+	// +patch-strategy=merge
+	// +patch-merge-key=port
 	Ports []ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
 
 	// Route service traffic to pods with label keys and values matching this
@@ -2962,6 +2991,8 @@ type ServiceAccount struct {
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount.
 	// More info: http://kubernetes.io/docs/user-guide/secrets
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Secrets []ObjectReference `json:"secrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=secrets"`
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
@@ -3182,11 +3213,15 @@ type NodeStatus struct {
 	// Conditions is an array of current observed node conditions.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []NodeCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,4,rep,name=conditions"`
 	// List of addresses reachable to the node.
 	// Queried from cloud provider, if available.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Addresses []NodeAddress `json:"addresses,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,5,rep,name=addresses"`
 	// Endpoints of daemons running on the Node.
 	// +optional
@@ -4235,6 +4270,8 @@ type ComponentStatus struct {
 
 	// List of component conditions observed
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []ComponentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
 }
 

--- a/pkg/apis/apps/v1beta1/generated.proto
+++ b/pkg/apis/apps/v1beta1/generated.proto
@@ -167,6 +167,8 @@ message DeploymentStatus {
   optional int32 unavailableReplicas = 5;
 
   // Represents the latest available observations of a deployment's current state.
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated DeploymentCondition conditions = 6;
 }
 

--- a/pkg/apis/apps/v1beta1/types.go
+++ b/pkg/apis/apps/v1beta1/types.go
@@ -327,6 +327,8 @@ type DeploymentStatus struct {
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 

--- a/pkg/apis/batch/v1/generated.proto
+++ b/pkg/apis/batch/v1/generated.proto
@@ -139,6 +139,8 @@ message JobStatus {
   // Conditions represent the latest available observations of an object's current state.
   // More info: http://kubernetes.io/docs/user-guide/jobs
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated JobCondition conditions = 1;
 
   // StartTime represents time when the job was acknowledged by the Job Manager.

--- a/pkg/apis/batch/v1/types.go
+++ b/pkg/apis/batch/v1/types.go
@@ -110,6 +110,8 @@ type JobStatus struct {
 	// Conditions represent the latest available observations of an object's current state.
 	// More info: http://kubernetes.io/docs/user-guide/jobs
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []JobCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
 	// StartTime represents time when the job was acknowledged by the Job Manager.

--- a/pkg/apis/extensions/v1beta1/generated.proto
+++ b/pkg/apis/extensions/v1beta1/generated.proto
@@ -321,6 +321,8 @@ message DeploymentStatus {
   optional int32 unavailableReplicas = 5;
 
   // Represents the latest available observations of a deployment's current state.
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated DeploymentCondition conditions = 6;
 }
 
@@ -818,6 +820,8 @@ message ReplicaSetStatus {
 
   // Represents the latest available observations of a replica set's current state.
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=type
   repeated ReplicaSetCondition conditions = 6;
 }
 

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -322,6 +322,8 @@ type DeploymentStatus struct {
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 
@@ -802,6 +804,8 @@ type ReplicaSetStatus struct {
 
 	// Represents the latest available observations of a replica set's current state.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []ReplicaSetCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -683,6 +683,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
 					Properties: map[string]spec.Schema{
 						"key": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "key",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "key is the label key that the selector applies to.",
 								Type:        []string{"string"},
@@ -901,6 +907,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"ownerReferences": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-merge-key": "uid",
+									"patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
 								Type:        []string{"array"},
@@ -914,6 +926,11 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"finalizers": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy": "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
 								Type:        []string{"array"},
@@ -1674,6 +1691,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "ClusterSpec describes the attributes of a kubernetes cluster.",
 					Properties: map[string]spec.Schema{
 						"serverAddressByClientCIDRs": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "clientCIDR",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "A map of client CIDR to server address. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR.",
 								Type:        []string{"array"},
@@ -2197,6 +2220,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-merge-key": "type",
+									"patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of component conditions observed",
 								Type:        []string{"array"},
@@ -2544,6 +2573,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"ports": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "containerPort",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
 								Type:        []string{"array"},
@@ -2570,6 +2605,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"env": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "name",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of environment variables to set in the container. Cannot be updated.",
 								Type:        []string{"array"},
@@ -2589,6 +2630,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"volumeMounts": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "mountPath",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Pod volumes to mount into the container's filesystem. Cannot be updated.",
 								Type:        []string{"array"},
@@ -4792,6 +4839,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
 					Properties: map[string]spec.Schema{
 						"key": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "key",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "The label key that the selector applies to.",
 								Type:        []string{"string"},
@@ -4941,6 +4994,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "type",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition",
 								Type:        []string{"array"},
@@ -4954,6 +5013,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"addresses": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "type",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses",
 								Type:        []string{"array"},
@@ -6448,6 +6513,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "PodSpec is a description of a pod.",
 					Properties: map[string]spec.Schema{
 						"volumes": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-merge-key": "name",
+									"patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes",
 								Type:        []string{"array"},
@@ -6461,6 +6532,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"initContainers": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-merge-key": "name",
+									"patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers",
 								Type:        []string{"array"},
@@ -6474,6 +6551,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"containers": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "name",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers",
 								Type:        []string{"array"},
@@ -6584,6 +6667,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"imagePullSecrets": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "name",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod",
 								Type:        []string{"array"},
@@ -6656,6 +6745,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "type",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Current service state of pod. More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions",
 								Type:        []string{"array"},
@@ -7460,6 +7555,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "type",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Represents the latest available observations of a replication controller's current state.",
 								Type:        []string{"array"},
@@ -8231,6 +8332,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"secrets": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "name",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: http://kubernetes.io/docs/user-guide/secrets",
 								Type:        []string{"array"},
@@ -8442,6 +8549,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "ServiceSpec describes the attributes that a user creates on a service.",
 					Properties: map[string]spec.Schema{
 						"ports": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "port",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "The list of ports that are exposed by this service. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
 								Type:        []string{"array"},
@@ -8621,6 +8734,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "The node this Taint is attached to has the effect \"effect\" on any pod that that does not tolerate the Taint.",
 					Properties: map[string]spec.Schema{
 						"key": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "key",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Required. The taint key to be applied to a node.",
 								Type:        []string{"string"},
@@ -8660,6 +8779,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
 					Properties: map[string]spec.Schema{
 						"key": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "key",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
 								Type:        []string{"string"},
@@ -9571,6 +9696,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "type",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Represents the latest available observations of a deployment's current state.",
 								Type:        []string{"array"},
@@ -12081,6 +12212,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "JobStatus represents the current state of a Job.",
 					Properties: map[string]spec.Schema{
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "type",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
 								Type:        []string{"array"},
@@ -14609,6 +14746,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "type",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Represents the latest available observations of a deployment's current state.",
 								Type:        []string{"array"},
@@ -15652,6 +15795,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"patch-strategy":  "merge",
+									"patch-merge-key": "type",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Represents the latest available observations of a replica set's current state.",
 								Type:        []string{"array"},

--- a/pkg/kubelet/api/v1alpha1/stats/types.go
+++ b/pkg/kubelet/api/v1alpha1/stats/types.go
@@ -35,6 +35,8 @@ type NodeStats struct {
 	// Stats of system daemons tracked as raw containers.
 	// The system containers are named according to the SystemContainer* constants.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	SystemContainers []ContainerStats `json:"systemContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// The time at which data collection for the node-scoped (i.e. aggregate) stats was (re)started.
 	StartTime metav1.Time `json:"startTime"`
@@ -81,6 +83,8 @@ type PodStats struct {
 	// The time at which data collection for the pod-scoped (e.g. network) stats was (re)started.
 	StartTime metav1.Time `json:"startTime"`
 	// Stats of containers in the measured pod.
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Containers []ContainerStats `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Stats pertaining to network resources.
 	// +optional
@@ -88,6 +92,8 @@ type PodStats struct {
 	// Stats pertaining to volume usage of filesystem resources.
 	// VolumeStats.UsedBytes is the number of bytes used by the Volume
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	VolumeStats []VolumeStats `json:"volume,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
@@ -112,6 +118,8 @@ type ContainerStats struct {
 	// +optional
 	Logs *FsStats `json:"logs,omitempty"`
 	// User defined metrics that are exposed by containers in the pod. Typically, we expect only one container in the pod to be exposing user defined metrics. In the event of multiple containers exposing metrics, they will be combined here.
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	UserDefinedMetrics []UserDefinedMetric `json:"userDefinedMetrics,omitmepty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -249,6 +249,8 @@ message LabelSelector {
 // relates the key and values.
 message LabelSelectorRequirement {
   // key is the label key that the selector applies to.
+  // +patch-strategy=merge
+  // +patch-merge-key=key
   optional string key = 1;
 
   // operator represents a key's relationship to a set of values.
@@ -445,6 +447,8 @@ message ObjectMeta {
   // then an entry in this list will point to this controller, with the controller field set to true.
   // There cannot be more than one managing controller.
   // +optional
+  // +patch-strategy=merge
+  // +patch-merge-key=uid
   repeated OwnerReference ownerReferences = 13;
 
   // Must be empty before the object is deleted from the registry. Each entry
@@ -452,6 +456,7 @@ message ObjectMeta {
   // from the list. If the deletionTimestamp of the object is non-nil, entries
   // in this list can only be removed.
   // +optional
+  // +patch-strategy=merge
   repeated string finalizers = 14;
 
   // The name of the cluster which the object belongs to.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -209,6 +209,8 @@ type ObjectMeta struct {
 	// then an entry in this list will point to this controller, with the controller field set to true.
 	// There cannot be more than one managing controller.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=uid
 	OwnerReferences []OwnerReference `json:"ownerReferences,omitempty" patchStrategy:"merge" patchMergeKey:"uid" protobuf:"bytes,13,rep,name=ownerReferences"`
 
 	// Must be empty before the object is deleted from the registry. Each entry
@@ -216,6 +218,7 @@ type ObjectMeta struct {
 	// from the list. If the deletionTimestamp of the object is non-nil, entries
 	// in this list can only be removed.
 	// +optional
+	// +patch-strategy=merge
 	Finalizers []string `json:"finalizers,omitempty" patchStrategy:"merge" protobuf:"bytes,14,rep,name=finalizers"`
 
 	// The name of the cluster which the object belongs to.
@@ -773,6 +776,8 @@ type LabelSelector struct {
 // relates the key and values.
 type LabelSelectorRequirement struct {
 	// key is the label key that the selector applies to.
+	// +patch-strategy=merge
+	// +patch-merge-key=key
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// operator represents a key's relationship to a set of values.
 	// Valid operators ard In, NotIn, Exists and DoesNotExist.

--- a/staging/src/k8s.io/client-go/pkg/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/types.go
@@ -197,6 +197,8 @@ type ObjectMeta struct {
 	// then an entry in this list will point to this controller, with the controller field set to true.
 	// There cannot be more than one managing controller.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=uid
 	OwnerReferences []metav1.OwnerReference `json:"ownerReferences,omitempty" patchStrategy:"merge" patchMergeKey:"uid" protobuf:"bytes,13,rep,name=ownerReferences"`
 
 	// Must be empty before the object is deleted from the registry. Each entry
@@ -204,6 +206,7 @@ type ObjectMeta struct {
 	// from the list. If the deletionTimestamp of the object is non-nil, entries
 	// in this list can only be removed.
 	// +optional
+	// +patch-strategy=merge
 	Finalizers []string `json:"finalizers,omitempty" patchStrategy:"merge" protobuf:"bytes,14,rep,name=finalizers"`
 
 	// The name of the cluster which the object belongs to.
@@ -1637,6 +1640,8 @@ type Container struct {
 	// accessible from the network.
 	// Cannot be updated.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=containerPort
 	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
@@ -1649,6 +1654,8 @@ type Container struct {
 	// List of environment variables to set in the container.
 	// Cannot be updated.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,7,rep,name=env"`
 	// Compute Resources required by this container.
 	// Cannot be updated.
@@ -1658,6 +1665,8 @@ type Container struct {
 	// Pod volumes to mount into the container's filesystem.
 	// Cannot be updated.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=mountPath
 	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"mountPath" protobuf:"bytes,9,rep,name=volumeMounts"`
 	// Periodic probe of container liveness.
 	// Container will be restarted if the probe fails.
@@ -1978,6 +1987,8 @@ type NodeSelectorTerm struct {
 // that relates the key and values.
 type NodeSelectorRequirement struct {
 	// The label key that the selector applies to.
+	// +patch-strategy=merge
+	// +patch-merge-key=key
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -2162,6 +2173,8 @@ type PreferredSchedulingTerm struct {
 // any pod that that does not tolerate the Taint.
 type Taint struct {
 	// Required. The taint key to be applied to a node.
+	// +patch-strategy=merge
+	// +patch-merge-key=key
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Required. The taint value corresponding to the taint key.
 	// +optional
@@ -2204,6 +2217,8 @@ type Toleration struct {
 	// Key is the taint key that the toleration applies to. Empty means match all taint keys.
 	// If the key is empty, operator must be Exists; this combination means to match all values and all keys.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=key
 	Key string `json:"key,omitempty" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Operator represents a key's relationship to the value.
 	// Valid operators are Exists and Equal. Defaults to Equal.
@@ -2261,6 +2276,8 @@ type PodSpec struct {
 	// List of volumes that can be mounted by containers belonging to the pod.
 	// More info: http://kubernetes.io/docs/user-guide/volumes
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Volumes []Volume `json:"volumes,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
 	// List of initialization containers belonging to the pod.
 	// Init containers are executed in order prior to containers being started. If any
@@ -2275,12 +2292,16 @@ type PodSpec struct {
 	// Init containers cannot currently be added or removed.
 	// Cannot be updated.
 	// More info: http://kubernetes.io/docs/user-guide/containers
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	InitContainers []Container `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.
 	// There must be at least one container in a Pod.
 	// Cannot be updated.
 	// More info: http://kubernetes.io/docs/user-guide/containers
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
 	// Restart policy for all containers within the pod.
 	// One of Always, OnFailure, Never.
@@ -2357,6 +2378,8 @@ type PodSpec struct {
 	// in the case of docker, only DockerConfig type secrets are honored.
 	// More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 	// Specifies the hostname of the Pod
 	// If not specified, the pod's hostname will be set to a system-defined value.
@@ -2444,6 +2467,8 @@ type PodStatus struct {
 	// Current service state of pod.
 	// More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []PodCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
 	// A human readable message indicating details about why the pod is in this condition.
 	// +optional
@@ -2640,6 +2665,8 @@ type ReplicationControllerStatus struct {
 
 	// Represents the latest available observations of a replication controller's current state.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []ReplicationControllerCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 
@@ -2777,6 +2804,8 @@ type LoadBalancerIngress struct {
 type ServiceSpec struct {
 	// The list of ports that are exposed by this service.
 	// More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+	// +patch-strategy=merge
+	// +patch-merge-key=port
 	Ports []ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
 
 	// Route service traffic to pods with label keys and values matching this
@@ -2962,6 +2991,8 @@ type ServiceAccount struct {
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount.
 	// More info: http://kubernetes.io/docs/user-guide/secrets
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=name
 	Secrets []ObjectReference `json:"secrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=secrets"`
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
@@ -3182,11 +3213,15 @@ type NodeStatus struct {
 	// Conditions is an array of current observed node conditions.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []NodeCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,4,rep,name=conditions"`
 	// List of addresses reachable to the node.
 	// Queried from cloud provider, if available.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Addresses []NodeAddress `json:"addresses,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,5,rep,name=addresses"`
 	// Endpoints of daemons running on the Node.
 	// +optional
@@ -4235,6 +4270,8 @@ type ComponentStatus struct {
 
 	// List of component conditions observed
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []ComponentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/apps/v1beta1/types.go
@@ -327,6 +327,8 @@ type DeploymentStatus struct {
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/batch/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/batch/v1/types.go
@@ -110,6 +110,8 @@ type JobStatus struct {
 	// Conditions represent the latest available observations of an object's current state.
 	// More info: http://kubernetes.io/docs/user-guide/jobs
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []JobCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
 	// StartTime represents time when the job was acknowledged by the Job Manager.

--- a/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/types.go
@@ -322,6 +322,8 @@ type DeploymentStatus struct {
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 
@@ -802,6 +804,8 @@ type ReplicaSetStatus struct {
 
 	// Represents the latest available observations of a replica set's current state.
 	// +optional
+	// +patch-strategy=merge
+	// +patch-merge-key=type
 	Conditions []ReplicaSetCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 


### PR DESCRIPTION
Support generating Open API extensions for strategic merge patch tags in go struct tags
Support `patchStrategy` and `patchMergeKey`.
Don't support checking if the Open API extension and struct tags match.

```release-note
Support generating Open API extensions for strategic merge patch tags in go struct tags
```

cc: @pwittrock @mbohlool 
