### PR TITLE
don't wait for first kubelet to be ready and drop dummy deploy

### DIFF
--- a/cmd/kubeadm/app/master/apiclient.go
+++ b/cmd/kubeadm/app/master/apiclient.go
@@ -44,7 +44,7 @@ func CreateClientAndWaitForAPI(file string) (*clientset.Clientset, error) {
 	fmt.Println("[apiclient] Created API client, waiting for the control plane to become ready")
 	WaitForAPI(client)
 
-	fmt.Println("[apiclient] Waiting for at least one node to register and become ready")
+	fmt.Println("[apiclient] Waiting for at least one node to register")
 	start := time.Now()
 	wait.PollInfinite(kubeadmconstants.APICallRetryInterval, func() (bool, error) {
 		nodeList, err := client.Nodes().List(metav1.ListOptions{})
@@ -55,19 +55,10 @@ func CreateClientAndWaitForAPI(file string) (*clientset.Clientset, error) {
 		if len(nodeList.Items) < 1 {
 			return false, nil
 		}
-		n := &nodeList.Items[0]
-		if !v1.IsNodeReady(n) {
-			fmt.Println("[apiclient] First node has registered, but is not ready yet")
-			return false, nil
-		}
 
-		fmt.Printf("[apiclient] First node is ready after %f seconds\n", time.Since(start).Seconds())
+		fmt.Printf("[apiclient] First node has registered after %f seconds\n", time.Since(start).Seconds())
 		return true, nil
 	})
-
-	if err := createAndWaitForADummyDeployment(client); err != nil {
-		return nil, err
-	}
 
 	return client, nil
 }


### PR DESCRIPTION
Per https://github.com/kubernetes/kubernetes/issues/43815#issuecomment-290270198, I suggest that we drop both the node ready and the dummy deployment check altogether for 1.6 and move them to a validation phase for 1.7.

I really think we should drop these checks altogether. CreateClientAndWaitForAPI should create a client and wait for the API, not create dummy deployments and wait for nodes to register and be healthy. These are end to end validations and this is the wrong place to do this stuff. We need an explicit final validation phase for this.

```release-note
Fix a deadlock in kubeadm master initialization.
```

Fixes #43815