### PR TITLE
Speed up pod watch by not create map

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
@@ -48,6 +48,9 @@ type Selector interface {
 
 	// String returns a human readable string that represents this selector.
 	String() string
+
+	// Len returns how much item this seletor has
+	Len() int
 }
 
 // Everything returns a selector that matches all fields.
@@ -66,6 +69,7 @@ func (t *hasTerm) Matches(ls Fields) bool {
 func (t *hasTerm) Empty() bool {
 	return false
 }
+
 
 func (t *hasTerm) RequiresExactMatch(field string) (value string, found bool) {
 	if t.field == field {
@@ -92,6 +96,10 @@ func (t *hasTerm) Requirements() Requirements {
 
 func (t *hasTerm) String() string {
 	return fmt.Sprintf("%v=%v", t.field, EscapeValue(t.value))
+}
+
+func (t *hasTerm) Len() int {
+	return 1
 }
 
 type notHasTerm struct {
@@ -128,6 +136,10 @@ func (t *notHasTerm) Requirements() Requirements {
 
 func (t *notHasTerm) String() string {
 	return fmt.Sprintf("%v!=%v", t.field, EscapeValue(t.value))
+}
+
+func (t *notHasTerm) Len() int {
+	return 1
 }
 
 type andTerm []Selector
@@ -197,6 +209,9 @@ func (t andTerm) String() string {
 	return strings.Join(terms, ",")
 }
 
+func (t andTerm) Len() int {
+	return len([]Selector(t))
+}
 // SelectorFromSet returns a Selector which will match exactly the given Set. A
 // nil Set is considered equivalent to Everything().
 func SelectorFromSet(ls Set) Selector {


### PR DESCRIPTION
**Help reduce the watch CPU cost**:

Most CPU cost in apiserver's watch is on this [code](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/pod/strategy.go#L190) with pprof test result

```
func PodToSelectableFields(pod *api.Pod) fields.Set {
	// The purpose of allocation with a given number of elements is to reduce
	// amount of allocations needed to create the fields.Set. If you add any
	// field here or the number of object-meta related fields changes, this should
	// be adjusted.
	podSpecificFieldsSet := make(fields.Set, 5)
	podSpecificFieldsSet["spec.nodeName"] = pod.Spec.NodeName
	podSpecificFieldsSet["spec.restartPolicy"] = string(pod.Spec.RestartPolicy)
	podSpecificFieldsSet["status.phase"] = string(pod.Status.Phase)
	return generic.AddObjectMetaFieldsSet(podSpecificFieldsSet, &pod.ObjectMeta, true)
}

```

As `make(fields.Set, 5)` is actually make a map, which is quite slow because there is memory allocation in it. And every time when pod had status change, it will go through this code and make watch slow.

The main way of avoid this cost is focus on the nodeName, if there is only a NodeName selector, don't call PodToSelectableFields and simply compare the pod's nodeName.

we have test that it could save about 20% CPU apiserver cost on 2000 node in density test.

**Special notes for your reviewer**:

**Release note**:

```
none
```
