### PR TITLE
WIP: Speed up pod watch by not create map

### DIFF
--- a/federation/registry/cluster/strategy.go
+++ b/federation/registry/cluster/strategy.go
@@ -56,7 +56,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	return labels.Set(cluster.ObjectMeta.Labels), ClusterToSelectableFields(cluster), nil
 }
 
-func MatchCluster(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func MatchCluster(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/apps/petset/strategy.go
+++ b/pkg/registry/apps/petset/strategy.go
@@ -122,7 +122,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 // MatchStatefulSet is the filter used by the generic etcd backend to watch events
 // from etcd to clients of the apiserver only interested in specific labels/fields.
-func MatchStatefulSet(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchStatefulSet(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/strategy.go
@@ -99,7 +99,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	return labels.Set(hpa.ObjectMeta.Labels), AutoscalerToSelectableFields(hpa), nil
 }
 
-func MatchAutoscaler(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchAutoscaler(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -116,7 +116,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 // MatchCronJob is the filter used by the generic etcd backend to route
 // watch events from etcd to clients of the apiserver only interested in specific
 // labels/fields.
-func MatchCronJob(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchCronJob(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -178,7 +178,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 // MatchJob is the filter used by the generic etcd backend to route
 // watch events from etcd to clients of the apiserver only interested in specific
 // labels/fields.
-func MatchJob(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchJob(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/certificates/certificates/strategy.go
+++ b/pkg/registry/certificates/certificates/strategy.go
@@ -187,7 +187,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/configmap/strategy.go
+++ b/pkg/registry/core/configmap/strategy.go
@@ -100,7 +100,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchConfigMap returns a generic matcher for a given label and field selector.
-func MatchConfigMap(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func MatchConfigMap(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/endpoint/strategy.go
+++ b/pkg/registry/core/endpoint/strategy.go
@@ -91,7 +91,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchEndpoints returns a generic matcher for a given label and field selector.
-func MatchEndpoints(label labels.Selector, field fields.Selector) pkgstorage.SelectionPredicate {
+func MatchEndpoints(label labels.Selector, field fields.Selector) pkgstorage.SelectionMatcher {
 	return pkgstorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/event/strategy.go
+++ b/pkg/registry/core/event/strategy.go
@@ -81,7 +81,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	return labels.Set(event.Labels), EventToSelectableFields(event), nil
 }
 
-func MatchEvent(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchEvent(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/limitrange/strategy.go
+++ b/pkg/registry/core/limitrange/strategy.go
@@ -96,7 +96,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	return labels.Set(lr.ObjectMeta.Labels), LimitRangeToSelectableFields(lr), nil
 }
 
-func MatchLimitRange(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchLimitRange(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/namespace/strategy.go
+++ b/pkg/registry/core/namespace/strategy.go
@@ -147,7 +147,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchNamespace returns a generic matcher for a given label and field selector.
-func MatchNamespace(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func MatchNamespace(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -157,7 +157,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchNode returns a generic matcher for a given label and field selector.
-func MatchNode(label labels.Selector, field fields.Selector) pkgstorage.SelectionPredicate {
+func MatchNode(label labels.Selector, field fields.Selector) pkgstorage.SelectionMatcher {
 	return pkgstorage.SelectionPredicate{
 		Label:       label,
 		Field:       field,

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -111,7 +111,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchPersistentVolume returns a generic matcher for a given label and field selector.
-func MatchPersistentVolumes(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchPersistentVolumes(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -107,7 +107,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchPersistentVolumeClaim returns a generic matcher for a given label and field selector.
-func MatchPersistentVolumeClaim(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchPersistentVolumeClaim(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/pod/BUILD
+++ b/pkg/registry/core/pod/BUILD
@@ -52,6 +52,7 @@ go_test(
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/apiserver/pkg/endpoints/request",
+        "//vendor:k8s.io/apiserver/pkg/storage",
     ],
 )
 

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -160,6 +160,23 @@ func (podStatusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old 
 	return validation.ValidatePodStatusUpdate(obj.(*api.Pod), old.(*api.Pod))
 }
 
+type PodFastPredicate struct {
+	storage.SelectionPredicate
+}
+
+func (p *PodFastPredicate) Matches(obj runtime.Object) (bool, error) {
+	if p.Label.Empty() && p.Field.Len() == 1 {
+		if name, ok := p.Field.RequiresExactMatch("spec.NodeName"); ok {
+			pod, ok := obj.(*api.Pod)
+			if !ok {
+				return false, fmt.Errorf("not a pod")
+			}
+			return name == pod.Spec.NodeName, nil
+		}
+	}
+	return p.SelectionPredicate.Matches(obj)
+}
+
 // GetAttrs returns labels and fields of a given object for filtering purposes.
 func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	pod, ok := obj.(*api.Pod)
@@ -171,11 +188,13 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 // MatchPod returns a generic matcher for a given label and field selector.
 func MatchPod(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
-	return storage.SelectionPredicate{
-		Label:       label,
-		Field:       field,
-		GetAttrs:    GetAttrs,
-		IndexFields: []string{"spec.nodeName"},
+	return &PodFastPredicate{
+		SelectionPredicate: storage.SelectionPredicate{
+			Label:       label,
+			Field:       field,
+			GetAttrs:    GetAttrs,
+			IndexFields: []string{"spec.nodeName"},
+		},
 	}
 }
 

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -187,8 +187,8 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchPod returns a generic matcher for a given label and field selector.
-func MatchPod(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
-	return &PodFastPredicate{
+func MatchPod(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
+	return PodFastPredicate{
 		SelectionPredicate: storage.SelectionPredicate{
 			Label:       label,
 			Field:       field,

--- a/pkg/registry/core/podtemplate/strategy.go
+++ b/pkg/registry/core/podtemplate/strategy.go
@@ -97,7 +97,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	return labels.Set(pt.ObjectMeta.Labels), PodTemplateToSelectableFields(pt), nil
 }
 
-func MatchPodTemplate(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchPodTemplate(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -155,7 +155,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 // MatchController is the filter used by the generic etcd backend to route
 // watch events from etcd to clients of the apiserver only interested in specific
 // labels/fields.
-func MatchController(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func MatchController(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/resourcequota/strategy.go
+++ b/pkg/registry/core/resourcequota/strategy.go
@@ -110,7 +110,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchResourceQuota returns a generic matcher for a given label and field selector.
-func MatchResourceQuota(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchResourceQuota(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/secret/strategy.go
+++ b/pkg/registry/core/secret/strategy.go
@@ -106,7 +106,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/service/strategy.go
+++ b/pkg/registry/core/service/strategy.go
@@ -112,7 +112,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 	return labels.Set(service.ObjectMeta.Labels), ServiceToSelectableFields(service), nil
 }
 
-func MatchServices(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func MatchServices(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/core/serviceaccount/strategy.go
+++ b/pkg/registry/core/serviceaccount/strategy.go
@@ -89,7 +89,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/extensions/daemonset/strategy.go
+++ b/pkg/registry/extensions/daemonset/strategy.go
@@ -142,7 +142,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 // MatchSetDaemon is the filter used by the generic etcd backend to route
 // watch events from etcd to clients of the apiserver only interested in specific
 // labels/fields.
-func MatchDaemonSet(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchDaemonSet(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/extensions/deployment/strategy.go
+++ b/pkg/registry/extensions/deployment/strategy.go
@@ -137,7 +137,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 // MatchDeployment is the filter used by the generic etcd backend to route
 // watch events from etcd to clients of the apiserver only interested in specific
 // labels/fields.
-func MatchDeployment(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func MatchDeployment(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/extensions/ingress/strategy.go
+++ b/pkg/registry/extensions/ingress/strategy.go
@@ -117,7 +117,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 // MatchIngress is the filter used by the generic etcd backend to ingress
 // watch events from etcd to clients of the apiserver only interested in specific
 // labels/fields.
-func MatchIngress(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchIngress(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/extensions/networkpolicy/strategy.go
+++ b/pkg/registry/extensions/networkpolicy/strategy.go
@@ -109,7 +109,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 // MatchNetworkPolicy is the filter used by the generic etcd backend to watch events
 // from etcd to clients of the apiserver only interested in specific labels/fields.
-func MatchNetworkPolicy(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchNetworkPolicy(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/extensions/podsecuritypolicy/strategy.go
+++ b/pkg/registry/extensions/podsecuritypolicy/strategy.go
@@ -86,7 +86,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func MatchPodSecurityPolicy(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchPodSecurityPolicy(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/extensions/replicaset/strategy.go
+++ b/pkg/registry/extensions/replicaset/strategy.go
@@ -133,7 +133,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 // MatchReplicaSet is the filter used by the generic etcd backend to route
 // watch events from etcd to clients of the apiserver only interested in specific
 // labels/fields.
-func MatchReplicaSet(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func MatchReplicaSet(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/extensions/thirdpartyresource/strategy.go
+++ b/pkg/registry/extensions/thirdpartyresource/strategy.go
@@ -88,7 +88,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/extensions/thirdpartyresourcedata/strategy.go
+++ b/pkg/registry/extensions/thirdpartyresourcedata/strategy.go
@@ -86,7 +86,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/policy/poddisruptionbudget/strategy.go
+++ b/pkg/registry/policy/poddisruptionbudget/strategy.go
@@ -115,7 +115,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 // MatchPodDisruptionBudget is the filter used by the generic etcd backend to watch events
 // from etcd to clients of the apiserver only interested in specific labels/fields.
-func MatchPodDisruptionBudget(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchPodDisruptionBudget(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/rbac/clusterrole/strategy.go
+++ b/pkg/registry/rbac/clusterrole/strategy.go
@@ -113,7 +113,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/rbac/clusterrolebinding/strategy.go
+++ b/pkg/registry/rbac/clusterrolebinding/strategy.go
@@ -113,7 +113,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/rbac/role/strategy.go
+++ b/pkg/registry/rbac/role/strategy.go
@@ -113,7 +113,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/rbac/rolebinding/strategy.go
+++ b/pkg/registry/rbac/rolebinding/strategy.go
@@ -113,7 +113,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // Matcher returns a generic matcher for a given label and field selector.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/settings/podpreset/strategy.go
+++ b/pkg/registry/settings/podpreset/strategy.go
@@ -103,7 +103,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 // Matcher is the filter used by the generic etcd backend to watch events
 // from etcd to clients of the apiserver only interested in specific labels/fields.
-func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func Matcher(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/pkg/registry/storage/storageclass/strategy.go
+++ b/pkg/registry/storage/storageclass/strategy.go
@@ -89,7 +89,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 }
 
 // MatchStorageClass returns a generic matcher for a given label and field selector.
-func MatchStorageClasses(label labels.Selector, field fields.Selector) apistorage.SelectionPredicate {
+func MatchStorageClasses(label labels.Selector, field fields.Selector) apistorage.SelectionMatcher {
 	return apistorage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/fields/selector.go
@@ -48,6 +48,9 @@ type Selector interface {
 
 	// String returns a human readable string that represents this selector.
 	String() string
+
+	// Len returns how much item this seletor has
+	Len() int
 }
 
 // Everything returns a selector that matches all fields.
@@ -94,6 +97,10 @@ func (t *hasTerm) String() string {
 	return fmt.Sprintf("%v=%v", t.field, EscapeValue(t.value))
 }
 
+func (t *hasTerm) Len() int {
+	return 1
+}
+
 type notHasTerm struct {
 	field, value string
 }
@@ -128,6 +135,10 @@ func (t *notHasTerm) Requirements() Requirements {
 
 func (t *notHasTerm) String() string {
 	return fmt.Sprintf("%v!=%v", t.field, EscapeValue(t.value))
+}
+
+func (t *notHasTerm) Len() int {
+	return 1
 }
 
 type andTerm []Selector
@@ -195,6 +206,10 @@ func (t andTerm) String() string {
 		terms = append(terms, q.String())
 	}
 	return strings.Join(terms, ",")
+}
+
+func (t andTerm) Len() int {
+	return len([]Selector(t))
 }
 
 // SelectorFromSet returns a Selector which will match exactly the given Set. A

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -114,7 +114,7 @@ type Store struct {
 	// PredicateFunc returns a matcher corresponding to the provided labels
 	// and fields. The SelectionPredicate returned should return true if the
 	// object matches the given field and label selectors.
-	PredicateFunc func(label labels.Selector, field fields.Selector) storage.SelectionPredicate
+	PredicateFunc func(label labels.Selector, field fields.Selector) storage.SelectionMatcher
 
 	// EnableGarbageCollection affects the handling of Update and Delete
 	// requests. Enabling garbage collection allows finalizers to do work to
@@ -253,7 +253,7 @@ func (e *Store) List(ctx genericapirequest.Context, options *metainternalversion
 
 // ListPredicate returns a list of all the items matching the given
 // SelectionPredicate.
-func (e *Store) ListPredicate(ctx genericapirequest.Context, p storage.SelectionPredicate, options *metainternalversion.ListOptions) (runtime.Object, error) {
+func (e *Store) ListPredicate(ctx genericapirequest.Context, p storage.SelectionMatcher, options *metainternalversion.ListOptions) (runtime.Object, error) {
 	if options == nil {
 		// By default we should serve the request from etcd.
 		options = &metainternalversion.ListOptions{ResourceVersion: ""}
@@ -1019,7 +1019,7 @@ func (e *Store) Watch(ctx genericapirequest.Context, options *metainternalversio
 }
 
 // WatchPredicate starts a watch for the items that m matches.
-func (e *Store) WatchPredicate(ctx genericapirequest.Context, p storage.SelectionPredicate, resourceVersion string) (watch.Interface, error) {
+func (e *Store) WatchPredicate(ctx genericapirequest.Context, p storage.SelectionMatcher, resourceVersion string) (watch.Interface, error) {
 	if name, ok := p.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
 			w, err := e.Storage.Watch(ctx, key, resourceVersion, p)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -1526,7 +1526,7 @@ func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheE
 			return path.Join(podPrefix, id), nil
 		},
 		ObjectNameFunc: func(obj runtime.Object) (string, error) { return obj.(*example.Pod).Name, nil },
-		PredicateFunc: func(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+		PredicateFunc: func(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 			return storage.SelectionPredicate{
 				Label: label,
 				Field: field,

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
@@ -291,7 +291,7 @@ func (c *Cacher) Delete(ctx context.Context, key string, out runtime.Object, pre
 }
 
 // Implements storage.Interface.
-func (c *Cacher) Watch(ctx context.Context, key string, resourceVersion string, pred SelectionPredicate) (watch.Interface, error) {
+func (c *Cacher) Watch(ctx context.Context, key string, resourceVersion string, pred SelectionMatcher) (watch.Interface, error) {
 	watchRV, err := ParseWatchResourceVersion(resourceVersion)
 	if err != nil {
 		return nil, err
@@ -348,7 +348,7 @@ func (c *Cacher) Watch(ctx context.Context, key string, resourceVersion string, 
 }
 
 // Implements storage.Interface.
-func (c *Cacher) WatchList(ctx context.Context, key string, resourceVersion string, pred SelectionPredicate) (watch.Interface, error) {
+func (c *Cacher) WatchList(ctx context.Context, key string, resourceVersion string, pred SelectionMatcher) (watch.Interface, error) {
 	return c.Watch(ctx, key, resourceVersion, pred)
 }
 
@@ -398,7 +398,7 @@ func (c *Cacher) Get(ctx context.Context, key string, resourceVersion string, ob
 }
 
 // Implements storage.Interface.
-func (c *Cacher) GetToList(ctx context.Context, key string, resourceVersion string, pred SelectionPredicate, listObj runtime.Object) error {
+func (c *Cacher) GetToList(ctx context.Context, key string, resourceVersion string, pred SelectionMatcher, listObj runtime.Object) error {
 	if resourceVersion == "" {
 		// If resourceVersion is not specified, serve it from underlying
 		// storage (for backward compatibility).
@@ -454,7 +454,7 @@ func (c *Cacher) GetToList(ctx context.Context, key string, resourceVersion stri
 }
 
 // Implements storage.Interface.
-func (c *Cacher) List(ctx context.Context, key string, resourceVersion string, pred SelectionPredicate, listObj runtime.Object) error {
+func (c *Cacher) List(ctx context.Context, key string, resourceVersion string, pred SelectionMatcher, listObj runtime.Object) error {
 	if resourceVersion == "" {
 		// If resourceVersion is not specified, serve it from underlying
 		// storage (for backward compatibility).
@@ -646,7 +646,7 @@ func forgetWatcher(c *Cacher, index int, triggerValue string, triggerSupported b
 	}
 }
 
-func filterFunction(key string, p SelectionPredicate) func(string, runtime.Object) bool {
+func filterFunction(key string, p SelectionMatcher) func(string, runtime.Object) bool {
 	f := SimpleFilter(p)
 	filterFunc := func(objKey string, obj runtime.Object) bool {
 		if !hasPathPrefix(objKey, key) {
@@ -657,7 +657,7 @@ func filterFunction(key string, p SelectionPredicate) func(string, runtime.Objec
 	return filterFunc
 }
 
-func watchFilterFunction(key string, p SelectionPredicate) watchFilterFunc {
+func watchFilterFunction(key string, p SelectionMatcher) watchFilterFunc {
 	filterFunc := func(objKey string, label labels.Set, field fields.Set) bool {
 		if !hasPathPrefix(objKey, key) {
 			return false

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -231,7 +231,7 @@ func (h *etcdHelper) Delete(ctx context.Context, key string, out runtime.Object,
 }
 
 // Implements storage.Interface.
-func (h *etcdHelper) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (h *etcdHelper) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionMatcher) (watch.Interface, error) {
 	if ctx == nil {
 		glog.Errorf("Context is nil")
 	}
@@ -246,7 +246,7 @@ func (h *etcdHelper) Watch(ctx context.Context, key string, resourceVersion stri
 }
 
 // Implements storage.Interface.
-func (h *etcdHelper) WatchList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (h *etcdHelper) WatchList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionMatcher) (watch.Interface, error) {
 	if ctx == nil {
 		glog.Errorf("Context is nil")
 	}
@@ -330,7 +330,7 @@ func (h *etcdHelper) extractObj(response *etcd.Response, inErr error, objPtr run
 }
 
 // Implements storage.Interface.
-func (h *etcdHelper) GetToList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate, listObj runtime.Object) error {
+func (h *etcdHelper) GetToList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionMatcher, listObj runtime.Object) error {
 	if ctx == nil {
 		glog.Errorf("Context is nil")
 	}
@@ -420,7 +420,7 @@ func (h *etcdHelper) decodeNodeList(nodes []*etcd.Node, filter storage.FilterFun
 }
 
 // Implements storage.Interface.
-func (h *etcdHelper) List(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate, listObj runtime.Object) error {
+func (h *etcdHelper) List(ctx context.Context, key string, resourceVersion string, pred storage.SelectionMatcher, listObj runtime.Object) error {
 	if ctx == nil {
 		glog.Errorf("Context is nil")
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -341,7 +341,7 @@ func (s *store) GuaranteedUpdate(
 }
 
 // GetToList implements storage.Interface.GetToList.
-func (s *store) GetToList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate, listObj runtime.Object) error {
+func (s *store) GetToList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionMatcher, listObj runtime.Object) error {
 	listPtr, err := meta.GetItemsPtr(listObj)
 	if err != nil {
 		return err
@@ -371,7 +371,7 @@ func (s *store) GetToList(ctx context.Context, key string, resourceVersion strin
 }
 
 // List implements storage.Interface.List.
-func (s *store) List(ctx context.Context, key, resourceVersion string, pred storage.SelectionPredicate, listObj runtime.Object) error {
+func (s *store) List(ctx context.Context, key, resourceVersion string, pred storage.SelectionMatcher, listObj runtime.Object) error {
 	listPtr, err := meta.GetItemsPtr(listObj)
 	if err != nil {
 		return err
@@ -409,16 +409,16 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, pred stor
 }
 
 // Watch implements storage.Interface.Watch.
-func (s *store) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (s *store) Watch(ctx context.Context, key string, resourceVersion string, pred storage.SelectionMatcher) (watch.Interface, error) {
 	return s.watch(ctx, key, resourceVersion, pred, false)
 }
 
 // WatchList implements storage.Interface.WatchList.
-func (s *store) WatchList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (s *store) WatchList(ctx context.Context, key string, resourceVersion string, pred storage.SelectionMatcher) (watch.Interface, error) {
 	return s.watch(ctx, key, resourceVersion, pred, true)
 }
 
-func (s *store) watch(ctx context.Context, key string, rv string, pred storage.SelectionPredicate, recursive bool) (watch.Interface, error) {
+func (s *store) watch(ctx context.Context, key string, rv string, pred storage.SelectionMatcher, recursive bool) (watch.Interface, error) {
 	rev, err := storage.ParseWatchResourceVersion(rv)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store_test.go
@@ -263,7 +263,7 @@ func TestGetToList(t *testing.T) {
 
 	tests := []struct {
 		key         string
-		pred        storage.SelectionPredicate
+		pred        storage.SelectionMatcher
 		expectedOut []*example.Pod
 	}{{ // test GetToList on existing key
 		key:         key,
@@ -622,7 +622,7 @@ func TestList(t *testing.T) {
 
 	tests := []struct {
 		prefix      string
-		pred        storage.SelectionPredicate
+		pred        storage.SelectionMatcher
 		expectedOut []*example.Pod
 	}{{ // test List on existing key
 		prefix:      "/one-level/",

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher.go
@@ -76,7 +76,7 @@ func newWatcher(client *clientv3.Client, codec runtime.Codec, versioner storage.
 // If recursive is false, it watches on given key.
 // If recursive is true, it watches any children and directories under the key, excluding the root key itself.
 // pred must be non-nil. Only if pred matches the change, it will be returned.
-func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bool, pred storage.SelectionPredicate) (watch.Interface, error) {
+func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bool, pred storage.SelectionMatcher) (watch.Interface, error) {
 	if recursive && !strings.HasSuffix(key, "/") {
 		key += "/"
 	}
@@ -85,7 +85,7 @@ func (w *watcher) Watch(ctx context.Context, key string, rev int64, recursive bo
 	return wc, nil
 }
 
-func (w *watcher) createWatchChan(ctx context.Context, key string, rev int64, recursive bool, pred storage.SelectionPredicate) *watchChan {
+func (w *watcher) createWatchChan(ctx context.Context, key string, rev int64, recursive bool, pred storage.SelectionMatcher) *watchChan {
 	wc := &watchChan{
 		watcher:           w,
 		key:               key,

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/watcher_test.go
@@ -62,7 +62,7 @@ func testWatch(t *testing.T, recursive bool) {
 
 	tests := []struct {
 		key        string
-		pred       storage.SelectionPredicate
+		pred       storage.SelectionMatcher
 		watchTests []*testWatchStruct
 	}{{ // create a key
 		key:        "/somekey-1",

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -114,7 +114,7 @@ type Interface interface {
 	// (e.g. reconnecting without missing any updates).
 	// If resource version is "0", this interface will get current object at given key
 	// and send it in an "ADDED" event, before watch starts.
-	Watch(ctx context.Context, key string, resourceVersion string, p SelectionPredicate) (watch.Interface, error)
+	Watch(ctx context.Context, key string, resourceVersion string, p SelectionMatcher) (watch.Interface, error)
 
 	// WatchList begins watching the specified key's items. Items are decoded into API
 	// objects and any item selected by 'p' are sent down to returned watch.Interface.
@@ -123,7 +123,7 @@ type Interface interface {
 	// (e.g. reconnecting without missing any updates).
 	// If resource version is "0", this interface will list current objects directory defined by key
 	// and send them in "ADDED" events, before watch starts.
-	WatchList(ctx context.Context, key string, resourceVersion string, p SelectionPredicate) (watch.Interface, error)
+	WatchList(ctx context.Context, key string, resourceVersion string, p SelectionMatcher) (watch.Interface, error)
 
 	// Get unmarshals json found at key into objPtr. On a not found error, will either
 	// return a zero object of the requested type, or an error, depending on ignoreNotFound.
@@ -136,13 +136,13 @@ type Interface interface {
 	// (an object that satisfies the runtime.IsList definition).
 	// The returned contents may be delayed, but it is guaranteed that they will
 	// be have at least 'resourceVersion'.
-	GetToList(ctx context.Context, key string, resourceVersion string, p SelectionPredicate, listObj runtime.Object) error
+	GetToList(ctx context.Context, key string, resourceVersion string, p SelectionMatcher, listObj runtime.Object) error
 
 	// List unmarshalls jsons found at directory defined by key and opaque them
 	// into *List api object (an object that satisfies runtime.IsList definition).
 	// The returned contents may be delayed, but it is guaranteed that they will
 	// be have at least 'resourceVersion'.
-	List(ctx context.Context, key string, resourceVersion string, p SelectionPredicate, listObj runtime.Object) error
+	List(ctx context.Context, key string, resourceVersion string, p SelectionMatcher, listObj runtime.Object) error
 
 	// GuaranteedUpdate keeps calling 'tryUpdate()' to update key 'key' (of type 'ptrToType')
 	// retrying the update until success if there is index conflict.

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
@@ -26,6 +26,13 @@ import (
 // In any failure to parse given object, it returns error.
 type AttrFunc func(obj runtime.Object) (labels.Set, fields.Set, error)
 
+type SelectionMatcher interface {
+	Matches(obj runtime.Object) (bool, error)
+	MatchesLabelsAndFields(l labels.Set, f fields.Set) bool
+	MatchesSingle() (string, bool)
+	MatcherIndex() []MatchValue
+}
+
 // SelectionPredicate is used to represent the way to select objects from api storage.
 type SelectionPredicate struct {
 	Label       labels.Selector

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -300,7 +300,7 @@ type injectListError struct {
 	storage.Interface
 }
 
-func (self *injectListError) List(ctx context.Context, key string, resourceVersion string, p storage.SelectionPredicate, listObj runtime.Object) error {
+func (self *injectListError) List(ctx context.Context, key string, resourceVersion string, p storage.SelectionMatcher, listObj runtime.Object) error {
 	if self.errors > 0 {
 		self.errors--
 		return fmt.Errorf("injected error")

--- a/staging/src/k8s.io/apiserver/pkg/storage/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/util.go
@@ -42,7 +42,7 @@ func SimpleUpdate(fn SimpleUpdateFunc) UpdateFunc {
 
 // SimpleFilter converts a selection predicate into a FilterFunc.
 // It ignores any error from Matches().
-func SimpleFilter(p SelectionPredicate) FilterFunc {
+func SimpleFilter(p SelectionMatcher) FilterFunc {
 	return func(obj runtime.Object) bool {
 		matches, err := p.Matches(obj)
 		if err != nil {

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
@@ -84,7 +84,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 // MatchAPIService is the filter used by the generic etcd backend to watch events
 // from etcd to clients of the apiserver only interested in specific labels/fields.
-func MatchAPIService(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchAPIService(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/strategy.go
@@ -81,7 +81,7 @@ func GetAttrs(obj runtime.Object) (labels.Set, fields.Set, error) {
 
 // MatchFlunder is the filter used by the generic etcd backend to watch events
 // from etcd to clients of the apiserver only interested in specific labels/fields.
-func MatchFlunder(label labels.Selector, field fields.Selector) storage.SelectionPredicate {
+func MatchFlunder(label labels.Selector, field fields.Selector) storage.SelectionMatcher {
 	return storage.SelectionPredicate{
 		Label:    label,
 		Field:    field,


### PR DESCRIPTION
**Help reduce the watch CPU cost**:

Most CPU cost in apiserver's watch is on this [code](https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/pod/strategy.go#L190) with pprof test result

```
func PodToSelectableFields(pod *api.Pod) fields.Set {
	// The purpose of allocation with a given number of elements is to reduce
	// amount of allocations needed to create the fields.Set. If you add any
	// field here or the number of object-meta related fields changes, this should
	// be adjusted.
	podSpecificFieldsSet := make(fields.Set, 5)
	podSpecificFieldsSet["spec.nodeName"] = pod.Spec.NodeName
	podSpecificFieldsSet["spec.restartPolicy"] = string(pod.Spec.RestartPolicy)
	podSpecificFieldsSet["status.phase"] = string(pod.Status.Phase)
	return generic.AddObjectMetaFieldsSet(podSpecificFieldsSet, &pod.ObjectMeta, true)
}

```

As `make(fields.Set, 5)` is actually make a map, which is quite slow because there is memory allocation in it. And every time when pod had status change, it will go through this code and make watch slow.

The main way of avoid this cost is focus on the nodeName, if there is only a NodeName selector, don't call PodToSelectableFields and simply compare the pod's nodeName.

we have test that it could save about 20% CPU apiserver cost on over 2000 node in density test.

**Special notes for your reviewer**:

**Release note**:

```
none
```
