### PR TITLE
Do not set container state to be Unknown when determineContainerIP fails

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -439,12 +439,7 @@ func (dm *DockerManager) inspectContainer(id string, podName, podNamespace strin
 		status.State = kubecontainer.ContainerStateRunning
 		status.StartedAt = startedAt
 		if containerProvidesPodIP(dockerName.ContainerName) {
-			ip, err = dm.determineContainerIP(podNamespace, podName, iResult)
-			// Kubelet doesn't handle the network error scenario
-			if err != nil {
-				status.State = kubecontainer.ContainerStateUnknown
-				status.Message = fmt.Sprintf("Network error: %#v", err)
-			}
+			ip, _ = dm.determineContainerIP(podNamespace, podName, iResult)
 		}
 		return &status, ip, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #43851 

**Special notes for your reviewer**:
Fix the issue as is written in Dan's closed PR #30147  (https://github.com/kubernetes/kubernetes/pull/30147/files#diff-e2eefa11d78ba95197ce406772c18c30R408)
Though we will deprecate dockertools, I think it's OK to fix the issue currently.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
