### PR TITLE
Make func modifySandboxNamespaceOptions() more robust

### DIFF
--- a/pkg/kubelet/dockershim/security_context.go
+++ b/pkg/kubelet/dockershim/security_context.go
@@ -109,8 +109,12 @@ func modifyHostConfig(sc *runtimeapi.LinuxContainerSecurityContext, hostConfig *
 
 // modifySandboxNamespaceOptions apply namespace options for sandbox
 func modifySandboxNamespaceOptions(nsOpts *runtimeapi.NamespaceOption, hostConfig *dockercontainer.HostConfig, network *knetwork.PluginManager) {
+	hostNetwork := false
+	if nsOpts != nil {
+		hostNetwork = nsOpts.HostNetwork
+	}
 	modifyCommonNamespaceOptions(nsOpts, hostConfig)
-	modifyHostNetworkOptionForSandbox(nsOpts.HostNetwork, network, hostConfig)
+	modifyHostNetworkOptionForSandbox(hostNetwork, network, hostConfig)
 }
 
 // modifyContainerNamespaceOptions apply namespace options for container


### PR DESCRIPTION
Make func `modifySandboxNamespaceOptions()` more robust, just like what we do in func [`modifyContainerNamespaceOptions`](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/security_context.go#L117).

/cc @feiskyer 

Signed-off-by: Xianglin Gao <xlgao@zju.edu.cn>
