### PR TITLE
Reorganize the output of "kubectl get -o json"

### DIFF
--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -362,8 +362,10 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 				},
 			}
 			if listMeta, err := meta.ListAccessor(obj); err == nil {
-				list.Object["selfLink"] = listMeta.GetSelfLink()
-				list.Object["resourceVersion"] = listMeta.GetResourceVersion()
+				list.Object["metadata"] = map[string]interface{}{
+					"selfLink":        listMeta.GetSelfLink(),
+					"resourceVersion": listMeta.GetResourceVersion(),
+				}
 			}
 
 			for _, item := range items {

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -603,7 +603,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 	}
 
 	expected := &unstructured.UnstructuredList{
-		Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{}, "selfLink": "", "resourceVersion": ""},
+		Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{"selfLink": "", "resourceVersion": ""}},
 		Items: []unstructured.Unstructured{
 			fn(&pods.Items[0]),
 			fn(&pods.Items[1]),


### PR DESCRIPTION
"resourceVersion" and "selfLink" are members of "metadata" rather than
the list. This change reorganize the struct to provide consistency with
other places.

Before this change:
```json
    "kind": "List",
    "metadata": {},
    "resourceVersion": "",
    "selfLink": ""
```
After this change:
```json
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
```

Reference:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L57

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
