### PR TITLE
Move test to flaky suite while debugging

### DIFF
--- a/test/e2e/deployment.go
+++ b/test/e2e/deployment.go
@@ -69,7 +69,7 @@ var _ = framework.KubeDescribe("Deployment", func() {
 	It("RollingUpdateDeployment should delete old pods and create new ones", func() {
 		testRollingUpdateDeployment(f)
 	})
-	It("RecreateDeployment should delete old pods and create new ones", func() {
+	It("RecreateDeployment should delete old pods and create new ones [Flaky]", func() {
 		testRecreateDeployment(f)
 	})
 	It("deployment should delete old replica sets", func() {


### PR DESCRIPTION
Moves https://github.com/kubernetes/kubernetes/issues/43864 to the flaky suite. We know what caused the flakiness (https://github.com/kubernetes/kubernetes/pull/43508), but I would like to debug this more (https://github.com/kubernetes/kubernetes/pull/43865) because it seems like a race in the deployment controller.