### PR TITLE
fix return value of "kubectl auth cani --quiet"

### DIFF
--- a/pkg/kubectl/cmd/auth/cani.go
+++ b/pkg/kubectl/cmd/auth/cani.go
@@ -90,11 +90,9 @@ func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 
 			allowed, err := o.RunAccessCheck()
 			if err == nil {
-				return
-			}
-
-			if o.Quiet && !allowed {
-				os.Exit(1)
+				if o.Quiet && !allowed {
+					os.Exit(1)
+				}
 			}
 
 			cmdutil.CheckErr(err)


### PR DESCRIPTION
Before this change:
$ kubectl auth can-i get pod
no
$ kubectl auth can-i get pod --quiet
$ echo $?
0

After this change:
$ kubectl auth can-i get pod
no
$ kubectl auth can-i get pod --quiet
$ echo $?
1

@deads2k 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
