### PR TITLE
Fix strategic merge patch input mutation leading to broken PATCH retry logic

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -82,23 +82,18 @@ func patchObjectJSON(
 func strategicPatchObjectInPlace(
 	codec runtime.Codec,
 	defaulter runtime.ObjectDefaulter,
-	originalObject runtime.Object,
+	originalObjMap map[string]interface{},
 	patchJS []byte,
 	objToUpdate runtime.Object,
 	versionedObj runtime.Object,
-) (originalObjMap map[string]interface{}, patchMap map[string]interface{}, retErr error) {
-	originalObjMap = make(map[string]interface{})
-	if err := unstructured.DefaultConverter.ToUnstructured(originalObject, &originalObjMap); err != nil {
-		return nil, nil, err
-	}
-
+) (patchMap map[string]interface{}, retErr error) {
 	patchMap = make(map[string]interface{})
 	if err := json.Unmarshal(patchJS, &patchMap); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if err := applyPatchToObjectInPlace(codec, defaulter, originalObjMap, patchMap, objToUpdate, versionedObj); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	return
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -74,12 +74,12 @@ func patchObjectJSON(
 	return
 }
 
-// strategicPatchObject applies a strategic merge patch of <patchJS> to
+// strategicPatchObjectInPlace applies a strategic merge patch of <patchJS> to
 // <originalObject> and stores the result in <objToUpdate>.
 // It additionally returns the map[string]interface{} representation of the
 // <originalObject> and <patchJS>.
 // NOTE: Both <originalObject> and <objToUpdate> are supposed to be versioned.
-func strategicPatchObject(
+func strategicPatchObjectInPlace(
 	codec runtime.Codec,
 	defaulter runtime.ObjectDefaulter,
 	originalObject runtime.Object,
@@ -97,7 +97,7 @@ func strategicPatchObject(
 		return nil, nil, err
 	}
 
-	if err := applyPatchToObject(codec, defaulter, originalObjMap, patchMap, objToUpdate, versionedObj); err != nil {
+	if err := applyPatchToObjectInPlace(codec, defaulter, originalObjMap, patchMap, objToUpdate, versionedObj); err != nil {
 		return nil, nil, err
 	}
 	return
@@ -106,7 +106,7 @@ func strategicPatchObject(
 // applyPatchToObject applies a strategic merge patch of <patchMap> to
 // <originalMap> and stores the result in <objToUpdate>.
 // NOTE: <objToUpdate> must be a versioned object.
-func applyPatchToObject(
+func applyPatchToObjectInPlace(
 	codec runtime.Codec,
 	defaulter runtime.ObjectDefaulter,
 	originalMap map[string]interface{},
@@ -114,7 +114,7 @@ func applyPatchToObject(
 	objToUpdate runtime.Object,
 	versionedObj runtime.Object,
 ) error {
-	patchedObjMap, err := strategicpatch.StrategicMergeMapPatch(originalMap, patchMap, versionedObj)
+	patchedObjMap, err := strategicpatch.StrategicMergeMapPatchInPlace(originalMap, patchMap, versionedObj)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -621,7 +621,7 @@ func patchResource(
 				if err != nil {
 					return nil, err
 				}
-				originalMap, patchMap, err := strategicPatchObject(codec, defaulter, currentVersionedObject, patchJS, versionedObjToUpdate, versionedObj)
+				originalMap, patchMap, err := strategicPatchObjectInPlace(codec, defaulter, currentVersionedObject, patchJS, versionedObjToUpdate, versionedObj)
 				if err != nil {
 					return nil, err
 				}
@@ -718,7 +718,7 @@ func patchResource(
 			if err != nil {
 				return nil, err
 			}
-			if err := applyPatchToObject(codec, defaulter, currentObjMap, originalPatchMap, versionedObjToUpdate, versionedObj); err != nil {
+			if err := applyPatchToObjectInPlace(codec, defaulter, currentObjMap, originalPatchMap, versionedObjToUpdate, versionedObj); err != nil {
 				return nil, err
 			}
 			// Convert the object back to unversioned.

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -567,6 +567,7 @@ func patchResource(
 	namespace := request.NamespaceValue(ctx)
 
 	var (
+		originalObj             runtime.Object
 		originalObjJS           []byte
 		originalPatchedObjJS    []byte
 		originalObjMap          map[string]interface{}
@@ -591,7 +592,7 @@ func patchResource(
 		}
 
 		switch {
-		case originalObjJS == nil && originalObjMap == nil:
+		case originalObj == nil && originalObjJS == nil && originalObjMap == nil:
 			// first time through,
 			// 1. apply the patch
 			// 2. save the original and patched to detect whether there were conflicting changes on retries
@@ -613,7 +614,8 @@ func patchResource(
 			case types.StrategicMergePatchType:
 				// Since the patch is applied on versioned objects, we need to convert the
 				// current object to versioned representation first.
-				currentVersionedObject, err := unsafeConvertor.ConvertToVersion(currentObject, kind.GroupVersion())
+				var err error
+				originalObj, err = unsafeConvertor.ConvertToVersion(currentObject, kind.GroupVersion())
 				if err != nil {
 					return nil, err
 				}
@@ -621,7 +623,14 @@ func patchResource(
 				if err != nil {
 					return nil, err
 				}
-				originalMap, patchMap, err := strategicPatchObjectInPlace(codec, defaulter, currentVersionedObject, patchJS, versionedObjToUpdate, versionedObj)
+				temporaryOriginalObjMap := make(map[string]interface{})
+				if err := unstructured.DefaultConverter.ToUnstructured(originalObj, &temporaryOriginalObjMap); err != nil {
+					return nil, err
+				}
+				// this call mutates temporaryOriginalObjMap. Because it is the main code path (in contrast to the retries),
+				// we optimize strategicPatchObjectInPlace by allowing mutation. Though we have to pay
+				// back our debt by recreating originalObjMap again later-on from originalObj in the retry branch.
+				patchMap, err := strategicPatchObjectInPlace(codec, defaulter, temporaryOriginalObjMap, patchJS, versionedObjToUpdate, versionedObj)
 				if err != nil {
 					return nil, err
 				}
@@ -633,7 +642,7 @@ func patchResource(
 				}
 				objToUpdate = unversionedObjToUpdate
 				// Store unstructured representations for possible retries.
-				originalObjMap, originalPatchMap = originalMap, patchMap
+				originalPatchMap = patchMap
 			}
 			if err := checkName(objToUpdate, name, namespace, namer); err != nil {
 				return nil, err
@@ -662,7 +671,17 @@ func patchResource(
 			}
 
 			var currentPatchMap map[string]interface{}
-			if originalObjMap != nil {
+			if originalObj != nil || originalObjMap != nil {
+				if originalObjMap == nil {
+					// we had a temporaryOriginalObjMap, but it was mutated by strategicPatchObjectInPlace. Hence,
+					// have to recreate it here. Once for the whole retry loop is enough, because the retry code
+					// path does not mutate anymore.
+					originalObjMap = make(map[string]interface{})
+					if err := unstructured.DefaultConverter.ToUnstructured(originalObj, &originalObjMap); err != nil {
+						return nil, err
+					}
+				}
+
 				var err error
 				currentPatchMap, err = strategicpatch.CreateTwoWayMergeMapPatch(originalObjMap, currentObjMap, versionedObj)
 				if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -29,6 +29,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/conversion/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -74,7 +75,11 @@ func TestPatchAnonymousField(t *testing.T) {
 	}
 
 	actual := &testPatchType{}
-	_, _, err := strategicPatchObjectInPlace(codec, defaulter, original, []byte(patch), actual, &testPatchType{})
+	originalMap := make(map[string]interface{})
+	if err := unstructured.DefaultConverter.ToUnstructured(original, &originalMap); err != nil {
+		t.Fatal(err)
+	}
+	_, err := strategicPatchObjectInPlace(codec, defaulter, originalMap, []byte(patch), actual, &testPatchType{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -314,7 +319,11 @@ func TestNumberConversion(t *testing.T) {
 
 	patchJS := []byte(`{"spec":{"ports":[{"port":80,"nodePort":31789}]}}`)
 
-	_, _, err := strategicPatchObjectInPlace(codec, defaulter, currentVersionedObject, patchJS, versionedObjToUpdate, versionedObj)
+	currentVersionedObjectMap := make(map[string]interface{})
+	if err := unstructured.DefaultConverter.ToUnstructured(currentVersionedObject, &currentVersionedObjectMap); err != nil {
+		t.Fatal(err)
+	}
+	_, err := strategicPatchObjectInPlace(codec, defaulter, currentVersionedObjectMap, patchJS, versionedObjToUpdate, versionedObj)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -74,7 +74,7 @@ func TestPatchAnonymousField(t *testing.T) {
 	}
 
 	actual := &testPatchType{}
-	_, _, err := strategicPatchObject(codec, defaulter, original, []byte(patch), actual, &testPatchType{})
+	_, _, err := strategicPatchObjectInPlace(codec, defaulter, original, []byte(patch), actual, &testPatchType{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -314,7 +314,7 @@ func TestNumberConversion(t *testing.T) {
 
 	patchJS := []byte(`{"spec":{"ports":[{"port":80,"nodePort":31789}]}}`)
 
-	_, _, err := strategicPatchObject(codec, defaulter, currentVersionedObject, patchJS, versionedObjToUpdate, versionedObj)
+	_, _, err := strategicPatchObjectInPlace(codec, defaulter, currentVersionedObject, patchJS, versionedObjToUpdate, versionedObj)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/patch_test.go
+++ b/test/integration/apiserver/patch_test.go
@@ -1,0 +1,121 @@
+// +build integration,!no-etcd
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/pborman/uuid"
+
+	kapierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	apiendpointhandlers "k8s.io/apiserver/pkg/endpoints/handlers"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestPatchConflicts(t *testing.T) {
+	_, s := framework.RunAMaster(nil)
+	defer s.Close()
+
+	clientSet := clientset.NewForConfigOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
+
+	objName := "myobj"
+	ns := "patch-namespace"
+
+	if _, err := clientSet.CoreV1().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}); err != nil {
+		t.Fatalf("Error creating namespace:%v", err)
+	}
+	if _, err := clientSet.CoreV1().Secrets(ns).Create(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: objName}}); err != nil {
+		t.Fatalf("Error creating k8s resource:%v", err)
+	}
+
+	testcases := []struct {
+		client   restclient.Interface
+		resource string
+	}{
+		{
+			client:   clientSet.CoreV1().RESTClient(),
+			resource: "secrets",
+		},
+	}
+
+	for _, tc := range testcases {
+		successes := int32(0)
+
+		// Force patch to deal with resourceVersion conflicts applying non-conflicting patches in parallel.
+		// We want to ensure it handles reapplies in a retry loop without internal errors.
+		wg := sync.WaitGroup{}
+		for i := 0; i < (2 * apiendpointhandlers.MaxRetryWhenPatchConflicts); i++ {
+			wg.Add(1)
+			go func(labelName string) {
+				defer wg.Done()
+				labelValue := uuid.NewRandom().String()
+
+				obj, err := tc.client.Patch(types.StrategicMergePatchType).
+					Namespace(ns).
+					Resource(tc.resource).
+					Name(objName).
+					Body([]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}}}`, labelName, labelValue))).
+					Do().
+					Get()
+
+				if kapierrs.IsConflict(err) {
+					t.Logf("tolerated %s conflict error patching %s: %v", labelName, tc.resource, err)
+					return
+				}
+				if err != nil {
+					t.Errorf("error patching %s: %v", tc.resource, err)
+					return
+				}
+
+				accessor, err := meta.Accessor(obj)
+				if err != nil {
+					t.Errorf("error getting object from %s: %v", tc.resource, err)
+					return
+				}
+				if accessor.GetLabels()[labelName] != labelValue {
+					t.Errorf("patch of %s was ineffective, expected %s=%s, got labels %#v", tc.resource, labelName, labelValue, accessor.GetLabels())
+					return
+				}
+
+				atomic.AddInt32(&successes, 1)
+			}(fmt.Sprintf("label-%d", i))
+		}
+		wg.Wait()
+
+		// Each successful patch can cause another patch retry loop to fail at most once. Hence, for a patch
+		// retry loop to fail MaxRetryWhenPatchConflicts many times, at least MaxRetryWhenPatchConflicts must
+		// have been successful before. Hence, if less patch request fail, something is wrong with the
+		// patch handler logic.
+		if successes < apiendpointhandlers.MaxRetryWhenPatchConflicts {
+			t.Errorf("Expected at least %d successful patches for %s, got %d", apiendpointhandlers.MaxRetryWhenPatchConflicts, tc.resource, successes)
+		} else {
+			t.Logf("Got %d successful patches for %s", successes, tc.resource)
+		}
+	}
+}


### PR DESCRIPTION
`mergeMap` is in-place, i.e. modifies the input. A number of derived funcs are therefore in-place as well. This broke the retry logic of the PATCH handler. It applied the given patch to the original object and cached the `originalObjMap` for later retries. But this `originalObjMap` was modified and all retries afterwards failed.

This PR also moves @liggitt's integration test from OpenShift to kube which uncovered this issue.

It's not 100% clear whether this bug has any inconsistency implications anywhere. It seems that the PATCH handler worked fine, but retries were broken.

This is a candidate for 1.6.