### PR TITLE
use StringArray in create rolebindings

### DIFF
--- a/pkg/kubectl/cmd/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding.go
@@ -54,9 +54,9 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.ClusterRoleBindingV1GeneratorName)
 	cmd.Flags().String("clusterrole", "", i18n.T("ClusterRole this ClusterRoleBinding should reference"))
-	cmd.Flags().StringSlice("user", []string{}, "usernames to bind to the role")
-	cmd.Flags().StringSlice("group", []string{}, "groups to bind to the role")
-	cmd.Flags().StringSlice("serviceaccount", []string{}, "service accounts to bind to the role")
+	cmd.Flags().StringArray("user", []string{}, "usernames to bind to the role")
+	cmd.Flags().StringArray("group", []string{}, "groups to bind to the role")
+	cmd.Flags().StringArray("serviceaccount", []string{}, "service accounts to bind to the role, in the format <namespace>:<name>")
 	return cmd
 }
 
@@ -72,9 +72,9 @@ func CreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Co
 		generator = &kubectl.ClusterRoleBindingGeneratorV1{
 			Name:            name,
 			ClusterRole:     cmdutil.GetFlagString(cmd, "clusterrole"),
-			Users:           cmdutil.GetFlagStringSlice(cmd, "user"),
-			Groups:          cmdutil.GetFlagStringSlice(cmd, "group"),
-			ServiceAccounts: cmdutil.GetFlagStringSlice(cmd, "serviceaccount"),
+			Users:           cmdutil.GetFlagStringArray(cmd, "user"),
+			Groups:          cmdutil.GetFlagStringArray(cmd, "group"),
+			ServiceAccounts: cmdutil.GetFlagStringArray(cmd, "serviceaccount"),
 		}
 	default:
 		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator: %s not supported.", generatorName))

--- a/pkg/kubectl/cmd/create_rolebinding.go
+++ b/pkg/kubectl/cmd/create_rolebinding.go
@@ -55,9 +55,9 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.RoleBindingV1GeneratorName)
 	cmd.Flags().String("clusterrole", "", i18n.T("ClusterRole this RoleBinding should reference"))
 	cmd.Flags().String("role", "", i18n.T("Role this RoleBinding should reference"))
-	cmd.Flags().StringSlice("user", []string{}, "usernames to bind to the role")
-	cmd.Flags().StringSlice("group", []string{}, "groups to bind to the role")
-	cmd.Flags().StringSlice("serviceaccount", []string{}, "service accounts to bind to the role")
+	cmd.Flags().StringArray("user", []string{}, "usernames to bind to the role")
+	cmd.Flags().StringArray("group", []string{}, "groups to bind to the role")
+	cmd.Flags().StringArray("serviceaccount", []string{}, "service accounts to bind to the role, in the format <namespace>:<name>")
 	return cmd
 }
 
@@ -73,9 +73,9 @@ func CreateRoleBinding(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Command, 
 			Name:            name,
 			ClusterRole:     cmdutil.GetFlagString(cmd, "clusterrole"),
 			Role:            cmdutil.GetFlagString(cmd, "role"),
-			Users:           cmdutil.GetFlagStringSlice(cmd, "user"),
-			Groups:          cmdutil.GetFlagStringSlice(cmd, "group"),
-			ServiceAccounts: cmdutil.GetFlagStringSlice(cmd, "serviceaccount"),
+			Users:           cmdutil.GetFlagStringArray(cmd, "user"),
+			Groups:          cmdutil.GetFlagStringArray(cmd, "group"),
+			ServiceAccounts: cmdutil.GetFlagStringArray(cmd, "serviceaccount"),
 		}
 	default:
 		return cmdutil.UsageError(cmd, fmt.Sprintf("Generator: %s not supported.", generatorName))


### PR DESCRIPTION
@liggitt I think maybe you like this.

```release-note
`kubectl create rolebinding` and `kubectl create clusterrolebinding` no longer allow specifying multiple subjects as comma-separated arguments. Use repeated `--user`, `--group`, or `--serviceaccount` arguments to specify multiple subjects. 
```