### PR TITLE
Update to fluentd-gcp:1.28.3, rebased on ubuntu-slim:0.8

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -20,7 +20,7 @@
 # scope and that the Logging API has been enabled for the project
 # in the Google Developer Console.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.6
+FROM gcr.io/google-containers/ubuntu-slim:0.8
 
 MAINTAINER Mik Vyatskov "vmik@google.com"
 

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -28,8 +28,8 @@
 
 .PHONY:	build push
 
-PREFIX=gcr.io/google_containers
-TAG = 1.28.2
+PREFIX=gcr.io/google-containers
+TAG = 1.28.3
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.28.2
+    image: gcr.io/google_containers/fluentd-gcp:1.28.3
     command:
       - '/bin/sh'
       - '-c'

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.28.2
+    image: gcr.io/google_containers/fluentd-gcp:1.28.3
     resources:
       limits:
         memory: 200Mi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: similar to previous fixes here - rebasing the fluentd-gcp image to fix CVEs in upstream dependencies. #43927 is a parallel change for release-1.4.

Fixes the following CVEs:
* CVE-2016-5417 (MEDIUM)
* CVE-2016-6323 (MEDIUM)
* CVE-2016-1234 (MEDIUM)
* CVE-2016-4429 (HIGH)
* CVE-2016-3706 (MEDIUM)
* CVE-2017-6507 (MEDIUM)

**Special notes for your reviewer**:
fliuentd-gcp:1.28.3 is **not yet pushed**.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```

/assign @mwielgus @crassirostris 
/cc @timstclair 