### PR TITLE
support GPU CRI in cadvisor

### DIFF
--- a/vendor/github.com/google/cadvisor/info/v1/container.go
+++ b/vendor/github.com/google/cadvisor/info/v1/container.go
@@ -41,6 +41,12 @@ type MemorySpec struct {
 	SwapLimit uint64 `json:"swap_limit,omitempty"`
 }
 
+type GpuSpec struct {
+	Limit        uint64	`json:"limit,omitempty"`
+	MemoryTotal  []uint64	`json:"memory_total,omitempty"`
+	PowerLimit   []float64	`json:"power_limit,omitempty"`
+}
+
 type ContainerSpec struct {
 	// Time at which the container was created.
 	CreationTime time.Time `json:"creation_time,omitempty"`
@@ -55,6 +61,9 @@ type ContainerSpec struct {
 
 	HasMemory bool       `json:"has_memory"`
 	Memory    MemorySpec `json:"memory,omitempty"`
+
+	HasGpu bool	`json:"has_gpu"`
+	Gpu    GpuSpec	`json:"gpu,omitempty"`
 
 	HasNetwork bool `json:"has_network"`
 
@@ -306,6 +315,13 @@ type CpuStats struct {
 	LoadAverage int32 `json:"load_average"`
 }
 
+type GpuStats struct {
+	CoreUsage	[]uint64	`json:"core_usage,omitempty"`
+	MemoryUsage	[]uint64	`json:"memory_usage,omitempty"`
+	PowerDraw	[]float64	`json:"power_draw,omitempty"`
+	Temperature	[]float64	`json:"temperature,omitempty"`
+}
+
 type PerDiskStats struct {
 	Major uint64            `json:"major"`
 	Minor uint64            `json:"minor"`
@@ -504,6 +520,7 @@ type ContainerStats struct {
 	DiskIo    DiskIoStats  `json:"diskio,omitempty"`
 	Memory    MemoryStats  `json:"memory,omitempty"`
 	Network   NetworkStats `json:"network,omitempty"`
+	Gpu       GpuStats     `json:"gpu,omitempty"`
 
 	// Filesystem statistics
 	Filesystem []FsStats `json:"filesystem,omitempty"`

--- a/vendor/github.com/google/cadvisor/manager/container.go
+++ b/vendor/github.com/google/cadvisor/manager/container.go
@@ -561,6 +561,7 @@ func getGpuSpec(container *containerData) *info.GpuSpec {
 				return nil
 			}
 
+			// obtain gpu spec from map using the index of gpu device
 			if _, ok := gpuSpecMap[temp]; ok {
 				gpuNum++
 				gpuSpec.MemoryTotal = append(gpuSpec.MemoryTotal, gpuSpecMap[temp].memoryTotal)
@@ -569,12 +570,14 @@ func getGpuSpec(container *containerData) *info.GpuSpec {
 		}
 	}
 	if gpuNum > 0 {
+		// gpuSpec.Limit represents for the total number of gpus attached with
 		gpuSpec.Limit = uint64(gpuNum)
 	}
 
 	return gpuSpec
 }
 
+// collect gpu stats from gpuStatsMap
 func getGpuStats(container *containerData) *info.GpuStats {
 	client, err := docker.Client()
 	if err != nil {

--- a/vendor/github.com/google/cadvisor/manager/manager.go
+++ b/vendor/github.com/google/cadvisor/manager/manager.go
@@ -388,6 +388,7 @@ func (self *manager) getContainerData(containerName string) (*containerData, err
 	return cont, nil
 }
 
+// continuously collect gpu spec if error occured, or just collect once.
 func (self *manager) tickGpuSpec(quit chan error) {
 	ticker := time.Tick(5 * time.Second)
 	for {
@@ -454,6 +455,7 @@ func (self *manager) collectGpuSpec() bool {
 	return true
 }
 
+// collects gpu stats in every tick time
 func (self *manager) tickGpuStats(duration time.Duration, quit chan error) {
 	ticker := time.Tick(duration)
 	for {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
As discussed at length, we need to support CRI to collect gpu stats in cadvisor. We have done this in our project and I would like to make this PR to give a try.

The design comes in the following steps:
1. Containers should combine their attached gpus' spec and stats when doing housekeeping.
2. We start a single thread using nvidia-smi command to collect all gpu spec. Gpu spec includes three params: core_limit, memory_total and power_limit. Core_limit represents for the number of gpus attached to the container, it's an uint64 number; Memory_total represents the total memory of each attached gpu, it's a slice consisting of uint64 numbers; power_limit represents for the power limit of each attached gpu, also is a slice but consisting of float64 numbers. Considering the spec of gpu would not change once we get the info, we only collect the spec of all gpus once.
3. Gpu stats collection also be done in another single thread, but repeats every tick time. To avoid a large amount of callings to GPU, we consider calling nvidia-smi every tick time and store the data to a map called gpuStatsMap, and containers will get gpu stats from this map when doing its housekeeping. By using command "nvidia-smi --format=csv,noheader,nounits --query-gpu=utilization.gpu,memory.used,power.draw,temperature.gpu" we can get the core_usage memory_usage power_draw and temperature of all gpus in the node. When container is doing its housekeeping, it would first finds out which gpus it attaches with, and gets stats from the gpuStatsMap using the gpu index. The index mapping between GPU and gpuStatsMap connects like this:
	a) device path such as /dev/nvidia1 is mounted to container, and we get the index "1". The device path can be obtained using HostConfig.Devices via dockerClient.
	b) nvidia-smi prints out all gpu data in index order, then we can connect them using the index such as "1".
	c) using the index as the key to get value from the gpuStatsMap.
4. Fullfill some structs representing for gpu spec and stats in v1/container.go, including GpuSpec struct and GpuStats struct.

Some improvements in the future:
1. Abstract an interface to be compatible with different GPUS. The interface would expose several methods such as CollectGpuSpec() and CollectGpuStats().
2. Dealing with more other exceptions with nvidia-smi command.
3. Support nvml lib but this may not be done in this PR for what had been discussed before.

This PR is still working in progress, if any suggestions please let me know :)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
[kubernetes/community#414](https://github.com/kubernetes/community/pull/414)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```support cadvisor collecting gpu stats.
