### PR TITLE
Remove 'beta' from default storage class annotation (storage/util)

### DIFF
--- a/pkg/apis/storage/util/helpers.go
+++ b/pkg/apis/storage/util/helpers.go
@@ -20,8 +20,8 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // IsDefaultStorageClassAnnotation represents a StorageClass annotation that
 // marks a class as the default StorageClass
-//TODO: Update IsDefaultStorageClassannotation and remove Beta when no longer used
-const IsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
+//TODO: remove Beta when no longer used
+const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
 
 // IsDefaultAnnotationText returns a pretty Yes/No String if


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This is a follow up to: #42991 where I believe this file was overlooked.

It removes `beta` from the default storageclass annotation.

Without this fix you are not able to specify a default storage class like this:

```yaml
apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: standard
  annotations:
    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/aws-ebs
 parameters:
   type: gp2
```

because the annotation is ignored in: https://github.com/kubernetes/kubernetes/blob/master/plugin/pkg/admission/storageclass/default/admission.go#L129

**Special notes for your reviewer**:


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fixed recognition of default storage class in DefaultStorageClass admission plugin.
```

/cc @jsafrane