### PR TITLE
kubeadm: Fix issue when kubeadm reset isn't working and the docker service is disabled

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -105,7 +105,7 @@ func (r *Reset) Run(out io.Writer) error {
 	}
 
 	dockerCheck := preflight.ServiceCheck{Service: "docker", CheckIfActive: true}
-	if warnings, errors := dockerCheck.Check(); len(warnings) == 0 && len(errors) == 0 {
+	if _, errors := dockerCheck.Check(); len(errors) == 0 {
 		fmt.Println("[reset] Removing kubernetes-managed containers")
 		if err := exec.Command("sh", "-c", "docker ps -a --filter name=k8s_ -q | xargs -r docker rm --force --volumes").Run(); err != nil {
 			fmt.Println("[reset] Failed to stop the running containers")


### PR DESCRIPTION
**What this PR does / why we need it**:

If the docker service is disabled, the preflight check lib will return a warning.
That warning _should not_ matter when deciding whether to reset docker state or not.
The current code skips the docker reset if the docker service is disabled, which is a bug.

Also, `Check()` must not return a `nil` slice.

It should be added that I **really don't like what we have at the moment**, I'd love to discuss with the node team to add something to CRI that basically says, "remove everything on this node" so we can stop doing this. Basically, kubeadm could talk to the specified socket (by default dockershim.sock), and call the CRI interface and say that everything should be cleaned up. This would then be cross-CRI-implementation at the same time and would work if you're using rkt, cri-o or whatever.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

helps in https://github.com/kubernetes/kubernetes/issues/43950

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
kubeadm: Make `kubeadm reset` tolerant of a disabled docker service.
```
@mikedanese @jbeda @dmmcquay @pipejakob @yujuhong @freehan 