### PR TITLE
kube-proxy: filter INPUT as well as OUTPUT

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -357,6 +357,7 @@ func CleanupLeftovers(ipt utiliptables.Interface) (encounteredError bool) {
 		table utiliptables.Table
 		chain utiliptables.Chain
 	}{
+		{utiliptables.TableFilter, utiliptables.ChainInput},
 		{utiliptables.TableFilter, utiliptables.ChainOutput},
 		{utiliptables.TableNAT, utiliptables.ChainOutput},
 		{utiliptables.TableNAT, utiliptables.ChainPrerouting},
@@ -790,6 +791,7 @@ func (proxier *Proxier) syncProxyRules() {
 			table utiliptables.Table
 			chain utiliptables.Chain
 		}{
+			{utiliptables.TableFilter, utiliptables.ChainInput},
 			{utiliptables.TableFilter, utiliptables.ChainOutput},
 			{utiliptables.TableNAT, utiliptables.ChainOutput},
 			{utiliptables.TableNAT, utiliptables.ChainPrerouting},


### PR DESCRIPTION
We need to apply filter rules on the way in (nodeports) and out (cluster
IPs).  Testing here is insufficient to have caught this - will come back
for that.

Fixes #43969

@justinsb since you have the best repro, can you test?  It passes what I think is repro.

@ethernetdan we will want this in 1.6.x

Fix bug with service nodeports that have no backends not being rejected, when they should be.  This is not a regression vs v1.5 - it's a fix that didn't quite fix hard enough.

```release-note
kube-proxy handling of services with no endpoints now applies to both INPUT and OUTPUT chains, preventing socket leak.
```
