### PR TITLE
fix for PVCs remains in pending state forever

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -1270,17 +1270,32 @@ func (vs *VSphere) CreateVolume(volumeOptions *VolumeOptions) (volumePath string
 
 		// 2. Reconfigure the VM to attach the disk with the VSAN policy configured.
 		vmDiskPath, err := vs.createVirtualDiskWithPolicy(ctx, dc, ds, dummyVM, volumeOptions)
+		fileAlreadyExist := false
 		if err != nil {
-			glog.Errorf("Failed to attach the disk to VM: %q with err: %+v", DummyVMName, err)
-			return "", err
+			vmDiskPath = filepath.Clean(ds.Path(VolDir)) + "/" + volumeOptions.Name + ".vmdk"
+			errorMessage := fmt.Sprintf("Cannot complete the operation because the file or folder %s already exists", vmDiskPath)
+			if errorMessage == err.Error() {
+				//Skip error and continue to Detach Disk, Disk was already created on the datastore.
+				fileAlreadyExist = true
+				glog.V(1).Infof("File: %v is already exists", vmDiskPath)
+			} else {
+				glog.Errorf("Failed to attach the disk to VM: %q with err: %+v", DummyVMName, err)
+				return "", err
+			}
 		}
 
 		dummyVMNodeName := vmNameToNodeName(DummyVMName)
 		// 3. Detach the disk from the dummy VM.
 		err = vs.DetachDisk(vmDiskPath, dummyVMNodeName)
 		if err != nil {
-			glog.Errorf("Failed to detach the disk: %q from VM: %q with err: %+v", vmDiskPath, DummyVMName, err)
-			return "", fmt.Errorf("Failed to create the volume: %q with err: %+v", volumeOptions.Name, err)
+			errorMessage := "No vSphere disk ID found"
+			if errorMessage == err.Error() && fileAlreadyExist {
+				// Disk was already detached from the helper VM, and present on the datastore.
+				glog.V(1).Infof("File: %v is already detached", vmDiskPath)
+			} else {
+				glog.Errorf("Failed to detach the disk: %q from VM: %q with err: %+v", vmDiskPath, DummyVMName, err)
+				return "", fmt.Errorf("Failed to create the volume: %q with err: %+v", volumeOptions.Name, err)
+			}
 		}
 		destVolPath = vmDiskPath
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
With policy based volume provisioning we are using helper vm to provision volumes, Disk is first attached to the helper VM, and then detached from this VM.

In case when VPXD goes down or vCenter becomes inaccessible while the disk is still attached to helper VM, volume is considered as not provisioned.

When vpxd/vCenter is available back, Kubernetes will retry creating the same disk. but the disk is already present on the datastore, so call will always fail with `"Cannot complete the operation because the file or folder already exists"`. this can keep PVC provisioning request to remain in `pending` state forever.

This fix is catching the error returned from VC, and allowing to use the disk provisioned before vpxd crash and bind it with the pvc request. Fix also ensures to allow using the disk, present on the datastore, but detached from the helper vm.


**Which issue this PR fixes**: 
fixes # https://github.com/vmware/kubernetes/issues/124

**Special notes for your reviewer**:
Verified the fix, with running test for both cases mentioned above.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
None
```
cc: @BaluDontu  @luomiao  @tusharnt @pdhamdhere