### PR TITLE
Fix the default CNI plugin binary directory

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -98,6 +98,9 @@ type NetworkPluginSettings struct {
 	NonMasqueradeCIDR string
 	// PluginName is the name of the plugin, runtime shim probes for
 	PluginName string
+	// PluginDir is the full path of the directory in which to search
+	// for network plugins.
+	PluginDir string
 	// PluginBinDir is the directory in which the binaries for the plugin with
 	// PluginName is kept. The admin is responsible for provisioning these
 	// binaries before-hand.
@@ -184,7 +187,7 @@ func NewDockerService(client dockertools.DockerInterface, seccompProfileRoot str
 	}
 	// dockershim currently only supports CNI plugins.
 	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDir, pluginSettings.PluginBinDir)
-	cniPlugins = append(cniPlugins, kubenet.NewPlugin(pluginSettings.PluginBinDir))
+	cniPlugins = append(cniPlugins, kubenet.NewPlugin(pluginSettings.PluginDir))
 	netHost := &dockerNetworkHost{
 		pluginSettings.LegacyRuntimeHost,
 		&namespaceGetter{ds},

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -520,17 +520,13 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 		}
 	}
 
-	// TODO: These need to become arguments to a standalone docker shim.
-	binDir := kubeCfg.CNIBinDir
-	if binDir == "" {
-		binDir = kubeCfg.NetworkPluginDir
-	}
 	pluginSettings := dockershim.NetworkPluginSettings{
 		HairpinMode:       klet.hairpinMode,
 		NonMasqueradeCIDR: klet.nonMasqueradeCIDR,
 		PluginName:        kubeCfg.NetworkPluginName,
+		PluginDir:         kubeCfg.NetworkPluginDir,
 		PluginConfDir:     kubeCfg.CNIConfDir,
-		PluginBinDir:      binDir,
+		PluginBinDir:      kubeCfg.CNIBinDir,
 		MTU:               int(kubeCfg.NetworkPluginMTU),
 	}
 


### PR DESCRIPTION
When CNIBinDir is empty, the probing function will use the right default
`/opt/cni/bin` path.
