### PR TITLE
Fix kube-up functionality for ubuntu cloud provider.

### DIFF
--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -30,6 +30,7 @@ if [ -f "${KUBE_ROOT}/cluster/env.sh" ]; then
     source "${KUBE_ROOT}/cluster/env.sh"
 fi
 
+source "${KUBE_ROOT}/cluster/common.sh"
 source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 

--- a/cluster/ubuntu/util.sh
+++ b/cluster/ubuntu/util.sh
@@ -19,7 +19,6 @@
 set -e
 
 SSH_OPTS="-oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oLogLevel=ERROR -C"
-source "${KUBE_ROOT}/cluster/common.sh"
 
 MASTER=""
 MASTER_IP=""
@@ -373,6 +372,7 @@ function detect-nodes() {
 
 # Instantiate a kubernetes cluster on ubuntu
 function kube-up() {
+  source "${KUBE_ROOT}/cluster/common.sh"
   export KUBE_CONFIG_FILE=${KUBE_CONFIG_FILE:-${KUBE_ROOT}/cluster/ubuntu/config-default.sh}
   source "${KUBE_CONFIG_FILE}"
 
@@ -704,6 +704,8 @@ function check-pods-torn-down() {
 
 # Delete a kubernetes cluster
 function kube-down() {
+
+  source "${KUBE_ROOT}/cluster/common.sh"
   export KUBECTL_PATH="${KUBE_ROOT}/cluster/ubuntu/binaries/kubectl"
 
   export KUBE_CONFIG_FILE=${KUBE_CONFIG_FILE:-${KUBE_ROOT}/cluster/ubuntu/config-default.sh}


### PR DESCRIPTION
cluster/kube-up.sh needs access to verify-kube-binaries
bash function in cluster/common.sh. The current code sources
in cluster/ubuntu/util.sh which sources cluster/common.sh.
However, cluster/ubuntu/util.sh is also copied onto the master/minion
ubuntu machines during deployment (where cluster/common.sh is not
present) resulting in error.

The fix is to include cluster/common.sh in cluster/kube-up.sh

Also, another small fix in get-kube-binaries, fix download url
from
DOWNLOAD_URL_PREFIX="${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}"
to
DOWNLOAD_URL_PREFIX="${KUBERNETES_RELEASE_URL}/v${KUBE_VERSION}"

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: kube-up.sh for ubuntu cloud provider is broken.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: Discussed over slack with @resouer who recommended I send in this PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
