### PR TITLE
kubeadm: fail explicitly when using (stable,latest) in airgapped env

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -26,14 +26,12 @@ import (
 const (
 	DefaultServiceDNSDomain  = "cluster.local"
 	DefaultServicesSubnet    = "10.96.0.0/12"
-	DefaultKubernetesVersion = "latest-1.6"
-	// This is only for clusters without internet, were the latest stable version can't be determined
-	DefaultKubernetesFallbackVersion = "v1.6.0"
-	DefaultAPIBindPort               = 6443
-	DefaultDiscoveryBindPort         = 9898
-	DefaultAuthorizationMode         = "RBAC"
-	DefaultCACertPath                = "/etc/kubernetes/pki/ca.crt"
-	DefaultCertificatesDir           = "/etc/kubernetes/pki"
+	DefaultKubernetesVersion = "stable"
+	DefaultAPIBindPort       = 6443
+	DefaultDiscoveryBindPort = 9898
+	DefaultAuthorizationMode = "RBAC"
+	DefaultCACertPath        = "/etc/kubernetes/pki/ca.crt"
+	DefaultCertificatesDir   = "/etc/kubernetes/pki"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -46,7 +44,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 
 func SetDefaults_MasterConfiguration(obj *MasterConfiguration) {
 	if obj.KubernetesVersion == "" {
-		obj.KubernetesVersion = DefaultKubernetesFallbackVersion
+		obj.KubernetesVersion = DefaultKubernetesVersion
 	}
 
 	if obj.API.BindPort == 0 {

--- a/cmd/kubeadm/app/cmd/defaults.go
+++ b/cmd/kubeadm/app/cmd/defaults.go
@@ -22,7 +22,6 @@ import (
 
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	tokenutil "k8s.io/kubernetes/cmd/kubeadm/app/util/token"
@@ -45,11 +44,7 @@ func setInitDynamicDefaults(cfg *kubeadmapi.MasterConfiguration) error {
 	// Validate version argument
 	ver, err := kubeadmutil.KubernetesReleaseVersion(cfg.KubernetesVersion)
 	if err != nil {
-		if cfg.KubernetesVersion != kubeadmapiext.DefaultKubernetesVersion {
-			return err
-		} else {
-			ver = kubeadmapiext.DefaultKubernetesFallbackVersion
-		}
+		return err
 	}
 	cfg.KubernetesVersion = ver
 


### PR DESCRIPTION
This is unintuitive and unnecessary behavior

This makes kubernetes deploy the proper version of the control plane.

```release-note
kubeadm: Remove hard-coded default version when fetching stable version from the web fails. Fixes [kubeadm 1.6.1 deploying 1.6.0 control plane](https://github.com/kubernetes/kubeadm/issues/224).
```