### PR TITLE
Bump rules_go to latest

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,6 @@
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "7828452850597b52b49ec603b23f8ad2bcb22aed",
+    commit = "cfdcbdc1d17e6dc3c48bbda4fce760949e58e381",
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 
@@ -18,7 +18,9 @@ git_repository(
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
 
-go_repositories()
+go_repositories(
+    go_version = "1.7.5",
+)
 
 # for building docker base images
 debs = (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: updates the Bazel go_rules dependency which provides several important bugfixes and feature enhancements. It's still using go1.7.5, so all tests should still pass.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

/assign @mikedanese @spxtr 
