### PR TITLE
Automated cherry pick of #42973

### DIFF
--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -188,6 +188,7 @@ type vsphereVolumeMounter struct {
 func (b *vsphereVolumeMounter) GetAttributes() volume.Attributes {
 	return volume.Attributes{
 		SupportsSELinux: true,
+		Managed:         true,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #42973 on release-1.6.

#42973: Fix vsphere selinux support

```release-note
Fix [vSphere volumes in SELinux environment](https://github.com/kubernetes/kubernetes/issues/42972).
```