### PR TITLE
cluster/log-dump - chmod files before dumping

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -154,6 +154,10 @@ function save-logs() {
     else
         files="${kern_logfile} ${files} ${initd_logfiles} ${supervisord_logfiles}"
     fi
+
+    echo "Changing logfiles to be world-readable for download"
+    log-dump-ssh "${node_name}" "sudo chmod -R a+r /var/log" || true
+
     echo "Copying '${files}' from ${node_name}"
     copy-logs-from-node "${node_name}" "${dir}" "${files}"
 }


### PR DESCRIPTION
We make the files world-readable, so that installation techniques that
lock down the logfiles can still be dumped.

Issue https://github.com/kubernetes/test-infra/issues/2397

```release-note
NONE
```
