### PR TITLE
add "/apis/" to kube-aggregator apisHandler

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -178,6 +178,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		endpointsLister: s.endpointsLister,
 	}
 	s.GenericAPIServer.HandlerContainer.Handle("/apis", apisHandler)
+	s.GenericAPIServer.HandlerContainer.Handle("/apis/", apisHandler)
 
 	apiserviceRegistrationController := NewAPIServiceRegistrationController(informerFactory.Apiregistration().InternalVersion().APIServices(), kubeInformers.Core().V1().Services(), s)
 


### PR DESCRIPTION
This makes the following two urls have the same result.
https://ip:443/apis
https://ip:443/apis/
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
