### PR TITLE
kubeadm: Wait for node before updating labels and taints

### DIFF
--- a/cmd/kubeadm/app/phases/apiconfig/BUILD
+++ b/cmd/kubeadm/app/phases/apiconfig/BUILD
@@ -17,10 +17,12 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
         "//pkg/bootstrap/api:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/apimachinery/pkg/util/strategicpatch",
+        "//vendor:k8s.io/apimachinery/pkg/util/wait",
         "//vendor:k8s.io/client-go/kubernetes",
         "//vendor:k8s.io/client-go/pkg/api/v1",
         "//vendor:k8s.io/client-go/pkg/apis/rbac/v1beta1",

--- a/cmd/kubeadm/app/phases/apiconfig/setupmaster.go
+++ b/cmd/kubeadm/app/phases/apiconfig/setupmaster.go
@@ -25,34 +25,28 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/pkg/util/node"
 )
 
 const apiCallRetryInterval = 500 * time.Millisecond
 
 // TODO: Can we think of any unit tests here? Or should this code just be covered through integration/e2e tests?
 
-// It's safe to do this for alpha, as we don't have HA and there is no way we can get
-// more then one node here (TODO(phase1+) use os.Hostname)
-func findMyself(client *clientset.Clientset) (*v1.Node, error) {
-	nodeList, err := client.Nodes().List(metav1.ListOptions{})
-	if err != nil {
-		return nil, fmt.Errorf("unable to list nodes [%v]", err)
-	}
-	if len(nodeList.Items) < 1 {
-		return nil, fmt.Errorf("no nodes found")
-	}
-	node := &nodeList.Items[0]
-	return node, nil
-}
-
 func attemptToUpdateMasterRoleLabelsAndTaints(client *clientset.Clientset) error {
-	n, err := findMyself(client)
-	if err != nil {
-		return err
-	}
+	var n *v1.Node
+
+	// Wait for current node registration
+	wait.PollInfinite(kubeadmconstants.APICallRetryInterval, func() (bool, error) {
+		var err error
+		if n, err = client.Nodes().Get(node.GetHostname(""), metav1.GetOptions{}); err != nil {
+			return true, nil
+		}
+		return false, nil
+	})
 
 	oldData, err := json.Marshal(n)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds again (removed in #43881) waiting for at last single node appearance during kubeadm attempt to update master role labels and taints.

**Which issue this PR fixes**:
fixes kubernetes/kubeadm#221

**Release note**:
```NONE
```