### PR TITLE
Automated cherry pick of #42512

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -817,7 +817,7 @@ func newAWSCloud(config io.Reader, awsServices Services) (*Cloud, error) {
 		deviceAllocators: make(map[types.NodeName]DeviceAllocator),
 	}
 
-	if cfg.Global.VPC != "" && cfg.Global.KubernetesClusterTag != "" {
+	if cfg.Global.VPC != "" && (cfg.Global.KubernetesClusterTag != "" || cfg.Global.KubernetesClusterID != "") {
 		// When the master is running on a different AWS account, cloud provider or on-premise
 		// build up a dummy instance and use the VPC from the nodes account
 		glog.Info("Master is configured to run on a AWS account, different cloud provider or on-premise")


### PR DESCRIPTION
Cherry pick of #42512 on release-1.6.

#42512: AWS: add KubernetesClusterID as additional option when VPC is