### PR TITLE
issue_43986: fix docu with non-functional proxy

### DIFF
--- a/cluster/addons/registry/README.md
+++ b/cluster/addons/registry/README.md
@@ -105,18 +105,18 @@ metadata:
   name: kube-registry-v0
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     version: v0
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     version: v0
   template:
     metadata:
       labels:
-        k8s-app: kube-registry
+        k8s-app: kube-registry-upstream
         version: v0
         kubernetes.io/cluster-service: "true"
     spec:
@@ -158,12 +158,12 @@ metadata:
   name: kube-registry
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeRegistry"
 spec:
   selector:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
   ports:
   - name: registry
     port: 5000
@@ -185,14 +185,14 @@ metadata:
   name: kube-registry-proxy
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-proxy
     kubernetes.io/cluster-service: "true"
     version: v0.4
 spec:
   template:
     metadata:
       labels:
-        k8s-app: kube-registry
+        k8s-app: kube-registry-proxy
         kubernetes.io/name: "kube-registry-proxy"
         kubernetes.io/cluster-service: "true"
         version: v0.4
@@ -215,6 +215,12 @@ spec:
           hostPort: 5000
 ```
 <!-- END MUNGE: EXAMPLE ../../saltbase/salt/kube-registry-proxy/kube-registry-proxy.yaml -->
+
+When modifying replication-controller, service and daemon-set defintions, take
+care to ensure _unique_ identifiers for the rc-svc couple and the daemon-set.
+Failing to do so will have register the localhost proxy daemon-sets to the
+upstream service. As a result they will then try to proxy themselves, which
+will, for obvious reasons, not work.
 
 This ensures that port 5000 on each node is directed to the registry `Service`.
 You should be able to verify that it is running by hitting port 5000 with a web

--- a/cluster/addons/registry/registry-rc.yaml
+++ b/cluster/addons/registry/registry-rc.yaml
@@ -4,19 +4,19 @@ metadata:
   name: kube-registry-v0
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     version: v0
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1
   selector:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     version: v0
   template:
     metadata:
       labels:
-        k8s-app: kube-registry
+        k8s-app: kube-registry-upstream
         version: v0
         kubernetes.io/cluster-service: "true"
     spec:

--- a/cluster/addons/registry/registry-svc.yaml
+++ b/cluster/addons/registry/registry-svc.yaml
@@ -4,13 +4,13 @@ metadata:
   name: kube-registry
   namespace: kube-system
   labels:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "KubeRegistry"
 spec:
   selector:
-    k8s-app: kube-registry
+    k8s-app: kube-registry-upstream
   ports:
   - name: registry
     port: 5000


### PR DESCRIPTION
The documentation defines a couple of replication-controller and service
to provision a docker-registry somewhere on the cluster and have it
available by the name viz. A record of
kube-registry.default.svc.<clustername>.

On each node, http-proxies are placed as daemon-set with the
kube-registry DNS name set as upstream, so that the registry is
available on each host under endpoint localhost:5000

Because in the documentation, selector-identifiers are the same for
"upstream" registry and proxies, the proxies themselves register under
the service intended for the upstream and now have themselves as
upstream under a different port, where connection attempts result in
"connection refused".

Adapting selectors to be unique as in this patch fixes the problem.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Patch fixes (cf. above) erroneous documentation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #43986 

**Special notes for your reviewer**:

Thank you for your consideration.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
