### PR TITLE
Check the error before parsing the apiversion

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -420,6 +420,9 @@ func (ds *dockerService) getDockerAPIVersion() (*semver.Version, error) {
 	} else {
 		dv, err = ds.getDockerVersion()
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	apiVersion, err := semver.Parse(dv.APIVersion)
 	if err != nil {


### PR DESCRIPTION
This fixes #44027

```release-note
Fix [Kubelet panic when Docker is not running](https://github.com/kubernetes/kubernetes/issues/44027).
```