### PR TITLE
Automated cherry pick of #44047

### DIFF
--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -388,6 +388,9 @@ func (ds *dockerService) getDockerAPIVersion() (*semver.Version, error) {
 	} else {
 		dv, err = ds.getDockerVersion()
 	}
+	if err != nil {
+		return nil, err
+	}
 
 	apiVersion, err := semver.Parse(dv.APIVersion)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #44047 on release-1.6.

#44047: Check the error before parsing the apiversion

```release-note
Fix [Kubelet panic when Docker is not running](https://github.com/kubernetes/kubernetes/issues/44027).
```