### PR TITLE
Make get-kube.sh work properly the "ci/latest" pointer

### DIFF
--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -41,7 +41,7 @@ set -o pipefail
 
 KUBE_ROOT=$(cd $(dirname "${BASH_SOURCE}")/.. && pwd)
 
-KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://storage.googleapis.com/kubernetes-release/release}"
+KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL:-https://dl.k8s.io}"
 
 function detect_kube_release() {
   if [[ -n "${KUBE_VERSION:-}" ]]; then

--- a/cluster/get-kube.sh
+++ b/cluster/get-kube.sh
@@ -81,7 +81,7 @@ KUBE_CI_VERSION_REGEX="^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-(be
 #   KUBE_VERSION
 function set_binary_version() {
   if [[ "${1}" =~ "/" ]]; then
-    export KUBE_VERSION=$(curl -fL "https://dl.k8s.io/${1}.txt")
+    export KUBE_VERSION=$(curl -fsSL "https://dl.k8s.io/${1}.txt")
   else
     export KUBE_VERSION=${1}
   fi
@@ -93,7 +93,9 @@ function download_kube_binaries {
   (
     cd kubernetes
     if [[ -x ./cluster/get-kube-binaries.sh ]]; then
-      ./cluster/get-kube-binaries.sh
+      # Make sure to use the same download URL in get-kube-binaries.sh
+      KUBERNETES_RELEASE_URL="${KUBERNETES_RELEASE_URL}" \
+        ./cluster/get-kube-binaries.sh
     fi
   )
 }
@@ -177,15 +179,15 @@ release=${KUBERNETES_RELEASE:-"release/stable"}
 # Validate Kubernetes release version.
 # Translate a published version <bucket>/<version> (e.g. "release/stable") to version number.
 set_binary_version "${release}"
-if [[ ${KUBE_VERSION} =~ ${KUBE_RELEASE_VERSION_REGEX} ]]; then
-  release_url="${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/${file}"
-elif [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
-  release_url="${KUBERNETES_CI_RELEASE_URL}/${KUBE_VERSION}/${file}"
-else
+if [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
+  # Override KUBERNETES_RELEASE_URL to point to the CI bucket;
+  # this will be used by get-kube-binaries.sh.
+  KUBERNETES_RELEASE_URL="${KUBERNETES_CI_RELEASE_URL}"
+elif ! [[ ${KUBE_VERSION} =~ ${KUBE_RELEASE_VERSION_REGEX} ]]; then
   echo "Version doesn't match regexp" >&2
   exit 1
 fi
-
+kubernetes_tar_url="${KUBERNETES_RELEASE_URL}/${KUBE_VERSION}/${file}"
 
 need_download=true
 if [[ -r "${PWD}/${file}" ]]; then
@@ -199,7 +201,7 @@ fi
 
 if "${need_download}"; then
   echo "Downloading kubernetes release ${KUBE_VERSION}"
-  echo "  from ${release_url}"
+  echo "  from ${kubernetes_tar_url}"
   echo "  to ${PWD}/${file}"
 fi
 
@@ -225,9 +227,9 @@ fi
 
 if "${need_download}"; then
   if [[ $(which curl) ]]; then
-    curl -fL --retry 3 --keepalive-time 2 "${release_url}" -o "${file}"
+    curl -fL --retry 3 --keepalive-time 2 "${kubernetes_tar_url}" -o "${file}"
   elif [[ $(which wget) ]]; then
-    wget "${release_url}"
+    wget "${kubernetes_tar_url}"
   else
     echo "Couldn't find curl or wget.  Bailing out."
     exit 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: this is a (late) followup from #36419, fixing a bug discovered in https://github.com/kubernetes/kubernetes/pull/36419#issuecomment-265679578.

Basically, `get-kube-binaries.sh` looks at `$KUBERNETES_RELEASE_URL`, but we weren't properly overriding it in `get-kube.sh` when downloading binaries from the CI release bucket. With this change, we set the variable correctly, and everything works:

```console
$ KUBERNETES_RELEASE=ci/latest ~/code/kubernetes/src/k8s.io/kubernetes/cluster/get-kube.sh
Downloading kubernetes release v1.7.0-alpha.0.2068+3a3dc827e45426
  from https://dl.k8s.io/ci/v1.7.0-alpha.0.2068+3a3dc827e45426/kubernetes.tar.gz
  to /tmp/foo/kubernetes.tar.gz
Is this ok? [Y]/n

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   161  100   161    0     0   1004      0 --:--:-- --:--:-- --:--:--  1006
100 6023k  100 6023k    0     0  10.9M      0 --:--:-- --:--:-- --:--:-- 10.9M
Unpacking kubernetes release v1.7.0-alpha.0.2068+3a3dc827e45426
Kubernetes release: v1.7.0-alpha.0.2068+3a3dc827e45426
Server: linux/amd64  (to override, set KUBERNETES_SERVER_ARCH)
Client: linux/amd64  (autodetected)

Will download kubernetes-server-linux-amd64.tar.gz from https://dl.k8s.io/ci/v1.7.0-alpha.0.2068+3a3dc827e45426
Will download and extract kubernetes-client-linux-amd64.tar.gz from https://dl.k8s.io/ci/v1.7.0-alpha.0.2068+3a3dc827e45426
Is this ok? [Y]/n

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   161  100   161    0     0    991      0 --:--:-- --:--:-- --:--:--   987
100  348M  100  348M    0     0  39.1M      0  0:00:08  0:00:08 --:--:-- 34.2M
               
md5sum(kubernetes-server-linux-amd64.tar.gz)=e71c9b48f6551797a74de2b83b501c44
sha1sum(kubernetes-server-linux-amd64.tar.gz)=688dcf567b60e27e3d9bf97436154543432768cf
               
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   161  100   161    0     0   1019      0 --:--:-- --:--:-- --:--:--  1025
100 29.0M  100 29.0M    0     0  32.2M      0 --:--:-- --:--:-- --:--:-- 95.4M
               
md5sum(kubernetes-client-linux-amd64.tar.gz)=8e6a90298411ae5a0e943b1c0e182b1d
sha1sum(kubernetes-client-linux-amd64.tar.gz)=187a2d2c1c6ae1ead32ec4c1fa51f695223edaae
               
Extracting /tmp/foo/kubernetes/client/kubernetes-client-linux-amd64.tar.gz into /tmp/foo/kubernetes/platforms/linux/amd64
Add '/tmp/foo/kubernetes/client/bin' to your PATH to use newly-installed binaries.
Creating a kubernetes on gce...
...

```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
