### PR TITLE
kubelet: ignore errors from GetPodNetworkStatus()

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -238,9 +238,11 @@ func (ds *dockerService) getIPFromPlugin(sandbox *dockertypes.ContainerJSON) (st
 	cID := kubecontainer.BuildContainerID(runtimeName, sandbox.ID)
 	networkStatus, err := ds.network.GetPodNetworkStatus(metadata.Namespace, metadata.Name, cID)
 	if err != nil {
-		// This might be a sandbox that somehow ended up without a default
-		// interface (eth0). We can't distinguish this from a more serious
-		// error, so callers should probably treat it as non-fatal.
+		// Ignore errors for now; PLEG races against network
+		// setup and asks for status (including IP) before
+		// the pod network is ready
+		// TODO(dcbw): don't call GetPodNetworkStatus() until we know
+		// networking is set up
 		return "", err
 	}
 	if networkStatus == nil {

--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -361,7 +361,11 @@ func (dm *DockerManager) determineContainerIP(podNamespace, podName string, cont
 	if !isHostNetwork && dm.network.PluginName() != knetwork.DefaultPluginName {
 		netStatus, err := dm.network.GetPodNetworkStatus(podNamespace, podName, kubecontainer.DockerID(container.ID).ContainerID())
 		if err != nil {
-			glog.Error(err)
+			// Ignore errors for now; PLEG races against network
+			// setup and asks for status (including IP) before
+			// the pod network is ready
+			// TODO(dcbw): don't call GetPodNetworkStatus() until
+			// we know networking is set up
 			return result, err
 		} else if netStatus != nil {
 			result = netStatus.IP.String()

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -2373,10 +2373,14 @@ func (r *Runtime) GetPodStatus(uid kubetypes.UID, name, namespace string) (*kube
 		}
 	} else {
 		containerID := kubecontainer.ContainerID{ID: string(uid)}
-		status, err := r.network.GetPodNetworkStatus(namespace, name, containerID)
-		if err != nil {
-			glog.Warningf("rkt: %v", err)
-		} else if status != nil {
+
+		// Ignore errors for now; PLEG races against network
+		// setup and asks for status (including IP) before
+		// the pod network is ready
+		// TODO(dcbw): don't call GetPodNetworkStatus() until we know
+		// networking is set up
+		status, _ := r.network.GetPodNetworkStatus(namespace, name, containerID)
+		if status != nil {
 			// status can be nil when the pod is running on the host network, in which case the pod IP
 			// will be populated by the upper layer.
 			podStatus.IP = status.IP.String()


### PR DESCRIPTION
GenericPLEG's 1s relist() loop races against pod network setup.  It
may be called after the infra container has started but before
network setup is done, since PLEG and the runtime's SyncPod() run
in different goroutines.

Since runtimes don't currently gate pod IP checking based on whether
the pod's network is actually ready or not, errors from IP checking
spam logs for no reason.

Long-term fix is for runtimes to not bother checking for a pod IP
during pod status updates when they know the pod's network isn't
set up yet, which they should know becuase they control pod network
setup.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=1434950

Mar 22 12:18:17 ip-172-31-43-89 atomic-openshift-node: E0322
   12:18:17.651013   25624 docker_manager.go:378] NetworkPlugin
   cni failed on the status hook for pod 'pausepods22' - Unexpected
   command output Device "eth0" does not exist.

@eparis @knobunc @kubernetes/rh-networking @kubernetes/sig-network-bugs 