### PR TITLE
Enable service account token lookup by default

### DIFF
--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -26,7 +26,7 @@ source "$ROOT/${KUBE_CONFIG_FILE:-"config-default.sh"}"
 source "$KUBE_ROOT/cluster/common.sh"
 
 export LIBVIRT_DEFAULT_URI=qemu:///system
-export SERVICE_ACCOUNT_LOOKUP=${SERVICE_ACCOUNT_LOOKUP:-false}
+export SERVICE_ACCOUNT_LOOKUP=${SERVICE_ACCOUNT_LOOKUP:-true}
 export ADMISSION_CONTROL=${ADMISSION_CONTROL:-NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota}
 readonly POOL=kubernetes
 readonly POOL_PATH=/var/lib/libvirt/images/kubernetes

--- a/cluster/rackspace/cloud-config/master-cloud-config.yaml
+++ b/cluster/rackspace/cloud-config/master-cloud-config.yaml
@@ -135,7 +135,7 @@ coreos:
         --token-auth-file=/var/lib/kube-apiserver/known_tokens.csv \
         --v=2 \
         --service-account-key-file=/var/run/kubernetes/kube-serviceaccount.key \
-        --service-account-lookup=false \
+        --service-account-lookup=true \
         --admission-control=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,DefaultTolerationSeconds,ResourceQuota
         Restart=always
         RestartSec=5

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -361,7 +361,7 @@ function start_etcd {
 }
 
 function set_service_accounts {
-    SERVICE_ACCOUNT_LOOKUP=${SERVICE_ACCOUNT_LOOKUP:-false}
+    SERVICE_ACCOUNT_LOOKUP=${SERVICE_ACCOUNT_LOOKUP:-true}
     SERVICE_ACCOUNT_KEY=${SERVICE_ACCOUNT_KEY:-/tmp/kube-serviceaccount.key}
     # Generate ServiceAccount key if needed
     if [[ ! -f "${SERVICE_ACCOUNT_KEY}" ]]; then

--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -147,7 +147,7 @@ func (s *BuiltInAuthenticationOptions) WithRequestHeader() *BuiltInAuthenticatio
 }
 
 func (s *BuiltInAuthenticationOptions) WithServiceAccounts() *BuiltInAuthenticationOptions {
-	s.ServiceAccounts = &ServiceAccountAuthenticationOptions{}
+	s.ServiceAccounts = &ServiceAccountAuthenticationOptions{Lookup: true}
 	return s
 }
 

--- a/test/fixtures/doc-yaml/getting-started-guides/coreos/cloud-configs/master.yaml
+++ b/test/fixtures/doc-yaml/getting-started-guides/coreos/cloud-configs/master.yaml
@@ -90,7 +90,7 @@ coreos:
         ExecStartPre=/opt/bin/wupiao 127.0.0.1:2379/v2/machines
         ExecStart=/opt/bin/kube-apiserver \
         --service-account-key-file=/opt/bin/kube-serviceaccount.key \
-        --service-account-lookup=false \
+        --service-account-lookup=true \
         --admission-control=NamespaceLifecycle,NamespaceAutoProvision,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota \
         --runtime-config=api/v1 \
         --allow-privileged=true \


### PR DESCRIPTION
Fixes #24167

```release-note
kube-apiserver: --service-account-lookup now defaults to true, requiring the Secret API object containing the token to exist in order for a service account token to be valid. This enables service account tokens to be revoked by deleting the Secret object containing the token.
```