### PR TITLE
Include system:authenticated group when impersonating

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation_test.go
@@ -215,7 +215,7 @@ func TestImpersonationFilter(t *testing.T) {
 			impersonationUserExtras: map[string][]string{"scopes": {"scope-a", "scope-b"}},
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:admin",
-				Groups: []string{},
+				Groups: []string{"system:authenticated"},
 				Extra:  map[string][]string{"scopes": {"scope-a", "scope-b"}},
 			},
 			expectedCode: http.StatusOK,
@@ -229,7 +229,7 @@ func TestImpersonationFilter(t *testing.T) {
 			impersonationUser: "tester",
 			expectedUser: &user.DefaultInfo{
 				Name:   "tester",
-				Groups: []string{},
+				Groups: []string{"system:authenticated"},
 				Extra:  map[string][]string{},
 			},
 			expectedCode: http.StatusOK,
@@ -257,7 +257,48 @@ func TestImpersonationFilter(t *testing.T) {
 			impersonationUser: "system:serviceaccount:foo:default",
 			expectedUser: &user.DefaultInfo{
 				Name:   "system:serviceaccount:foo:default",
-				Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo"},
+				Groups: []string{"system:serviceaccounts", "system:serviceaccounts:foo", "system:authenticated"},
+				Extra:  map[string][]string{},
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "anonymous-username-prevents-adding-authenticated-group",
+			user: &user.DefaultInfo{
+				Name: "system:admin",
+			},
+			impersonationUser: "system:anonymous",
+			expectedUser: &user.DefaultInfo{
+				Name:   "system:anonymous",
+				Groups: []string{},
+				Extra:  map[string][]string{},
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "unauthenticated-group-prevents-adding-authenticated-group",
+			user: &user.DefaultInfo{
+				Name: "system:admin",
+			},
+			impersonationUser:   "unknown",
+			impersonationGroups: []string{"system:unauthenticated"},
+			expectedUser: &user.DefaultInfo{
+				Name:   "unknown",
+				Groups: []string{"system:unauthenticated"},
+				Extra:  map[string][]string{},
+			},
+			expectedCode: http.StatusOK,
+		},
+		{
+			name: "unauthenticated-group-prevents-double-adding-authenticated-group",
+			user: &user.DefaultInfo{
+				Name: "system:admin",
+			},
+			impersonationUser:   "unknown",
+			impersonationGroups: []string{"system:authenticated"},
+			expectedUser: &user.DefaultInfo{
+				Name:   "unknown",
+				Groups: []string{"system:authenticated"},
 				Extra:  map[string][]string{},
 			},
 			expectedCode: http.StatusOK,


### PR DESCRIPTION
Fixes #43227

An authorized impersonation request solely for a specific username previously resulted in a `user.Info` that did not include either the `system:authenticated` or `system:unauthenticated` groups. That meant that permissions intended to be granted to all users, like discovery, would be denied the impersonated user.

This allows `kubectl get pods --as=<username>` to work as expected

```release-note
API requests using impersonation now include the `system:authenticated` group in the impersonated user automatically.
```