### PR TITLE
Change second StorageClass Column to provisioner

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -86,7 +86,7 @@ var (
 	clusterRoleColumns               = []string{"NAME", "AGE"}
 	clusterRoleBindingColumns        = []string{"NAME", "AGE"}
 	clusterRoleBindingWideColumns    = []string{"ROLE", "USERS", "GROUPS", "SERVICEACCOUNTS"}
-	storageClassColumns              = []string{"NAME", "TYPE"}
+	storageClassColumns              = []string{"NAME", "PROVISIONER"}
 	statusColumns                    = []string{"STATUS", "REASON", "MESSAGE"}
 
 	// TODO: consider having 'KIND' for third party resource data


### PR DESCRIPTION
Some provisioners have key-value pairs in parameters map which key is type, here TYPE in StorageClass columns may be confused.
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storageclasses

**Release note**:

```release-note
NONE
```
