### PR TITLE
CSR modification for SANs and Key Usage

### DIFF
--- a/pkg/kubelet/util/csr/csr.go
+++ b/pkg/kubelet/util/csr/csr.go
@@ -51,6 +51,7 @@ func RequestNodeCertificate(client certificatesclient.CertificateSigningRequestI
 		return nil, fmt.Errorf("unable to generate certificate request: %v", err)
 	}
 	return RequestCertificate(client, csrData, []certificates.KeyUsage{
+		certificates.UsageServerAuth,
 		certificates.UsageDigitalSignature,
 		certificates.UsageKeyEncipherment,
 		certificates.UsageClientAuth,

--- a/pkg/kubelet/util/csr/csr.go
+++ b/pkg/kubelet/util/csr/csr.go
@@ -46,7 +46,8 @@ func RequestNodeCertificate(client certificatesclient.CertificateSigningRequestI
 	if err != nil {
 		return nil, fmt.Errorf("invalid private key for certificate request: %v", err)
 	}
-	csrData, err := certutil.MakeCSR(privateKey, subject, nil, nil)
+	sans := []string{fmt.Sprintf("%s", nodeName)}
+	csrData, err := certutil.MakeCSR(privateKey, subject, sans, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to generate certificate request: %v", err)
 	}


### PR DESCRIPTION
CSR generated during TLS bootstraping was missing both TLS Web Server Key Usage and a valid SANs as shown in https://github.com/kelseyhightower/kubernetes-the-hard-way/issues/146

This P/R added both missing fields in CSR