### PR TITLE
add NodeKernelDeadlock condition

### DIFF
--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -3292,6 +3292,7 @@ const (
 	// NodeInodePressure means the kubelet is under pressure due to insufficient available inodes.
 	NodeInodePressure NodeConditionType = "InodePressure"
 	// NodeKernelDeadlock means the kernel of a node has a temporary or permanent deadlock.
+	// `NodeKernelDeadlock` is updated from node-problem-detector. In order to get this condition, users should deploy node-problem-detector.
 	NodeKernelDeadlock NodeConditionType = "KernelDeadlock"
 )
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -3291,6 +3291,8 @@ const (
 	NodeNetworkUnavailable NodeConditionType = "NetworkUnavailable"
 	// NodeInodePressure means the kubelet is under pressure due to insufficient available inodes.
 	NodeInodePressure NodeConditionType = "InodePressure"
+	// NodeKernelDeadlock means the kernel of a node has a temporary or permanent deadlock.
+	NodeKernelDeadlock NodeConditionType = "KernelDeadlock"
 )
 
 // NodeCondition contains condition information for a node.

--- a/staging/src/k8s.io/client-go/pkg/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/types.go
@@ -3292,6 +3292,7 @@ const (
 	// NodeInodePressure means the kubelet is under pressure due to insufficient available inodes.
 	NodeInodePressure NodeConditionType = "InodePressure"
 	// NodeKernelDeadlock means the kernel of a node has a temporary or permanent deadlock.
+	// `NodeKernelDeadlock` is updated from node-problem-detector. In order to get this condition, users should deploy node-problem-detector.
 	NodeKernelDeadlock NodeConditionType = "KernelDeadlock"
 )
 

--- a/staging/src/k8s.io/client-go/pkg/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/types.go
@@ -3291,6 +3291,8 @@ const (
 	NodeNetworkUnavailable NodeConditionType = "NetworkUnavailable"
 	// NodeInodePressure means the kubelet is under pressure due to insufficient available inodes.
 	NodeInodePressure NodeConditionType = "InodePressure"
+	// NodeKernelDeadlock means the kernel of a node has a temporary or permanent deadlock.
+	NodeKernelDeadlock NodeConditionType = "KernelDeadlock"
 )
 
 // NodeCondition contains condition information for a node.


### PR DESCRIPTION
Adding KernelDeadlock condition as introduced by the node problem detector [here](https://github.com/kubernetes/node-problem-detector/blob/master/config/kernel-monitor.json#L12).