### PR TITLE
serviceaccount admission: return correct tokens

### DIFF
--- a/plugin/pkg/admission/serviceaccount/BUILD
+++ b/plugin/pkg/admission/serviceaccount/BUILD
@@ -43,12 +43,14 @@ go_test(
         "//pkg/api:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/fake:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion:go_default_library",
+        "//pkg/client/listers/core/internalversion:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/apiserver/pkg/admission",
+        "//vendor:k8s.io/client-go/tools/cache",
     ],
 )
 

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -287,18 +287,20 @@ func (s *serviceAccount) getReferencedServiceAccountToken(serviceAccount *api.Se
 
 // getServiceAccountTokens returns all ServiceAccountToken secrets for the given ServiceAccount
 func (s *serviceAccount) getServiceAccountTokens(serviceAccount *api.ServiceAccount) ([]*api.Secret, error) {
-	tokens, err := s.secretLister.Secrets(serviceAccount.Namespace).List(labels.Everything())
+	secrets, err := s.secretLister.Secrets(serviceAccount.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err
 	}
 
-	for _, token := range tokens {
-		if token.Type != api.SecretTypeServiceAccountToken {
+	tokens := []*api.Secret{}
+
+	for _, secret := range secrets {
+		if secret.Type != api.SecretTypeServiceAccountToken {
 			continue
 		}
 
-		if serviceaccount.InternalIsServiceAccountToken(token, serviceAccount) {
-			tokens = append(tokens, token)
+		if serviceaccount.InternalIsServiceAccountToken(secret, serviceAccount) {
+			tokens = append(tokens, secret)
 		}
 	}
 	return tokens, nil


### PR DESCRIPTION
Fix a bug in serviceaccount admission introduced when we switched
everything to use shared informers. That change accidentally reused the
list of secrets instead of creating a new one, resulting in all secrets
in the namespace being returned as possible service account tokens,
instead of limiting it only to the actual service account tokens, as it
did before the shared informer conversion. This also adds a unit test to
ensure there is no future regression here.

This will need to be cherry-picked to 1.6.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fixed an issue mounting the wrong secret into pods as a service account token.
```

cc @smarterclayton @liggitt @sttts @derekwaynecarr @calebamiles @ethernetdan @eparis 