### PR TITLE
Adding krousey as a kubeadm reviewer and owner

### DIFF
--- a/cmd/kubeadm/OWNERS
+++ b/cmd/kubeadm/OWNERS
@@ -3,6 +3,7 @@ approvers:
 - jbeda
 - luxas
 - mikedanese
+- krousey
 reviewers:
 - mikedanese
 - luxas
@@ -11,3 +12,4 @@ reviewers:
 - pires
 - lukemarsden
 - dmmcquay
+- krousey


### PR DESCRIPTION
I would like to join the illustrious ranks of kubeadm owners. I plan to spend a considerable amount of time integrating this tool into our GCE and GKE deployments. If approver is too much, I would still like to be a reviewer.

I will mark this as "Do not merge" until I see approval from all current owners.