### PR TITLE
Update gen_api_ref_docs to use same diff method as verify

### DIFF
--- a/hack/lib/swagger.sh
+++ b/hack/lib/swagger.sh
@@ -130,17 +130,10 @@ kube::swagger::gen_api_ref_docs() {
   while read file; do
     if [[ -e "${output_dir}/${file}" && -e "${output_tmp}/${file}" ]]; then
       echo "comparing ${output_dir}/${file} with ${output_tmp}/${file}"
-      # Filter all munges from original content.
-      original=$(cat "${output_dir}/${file}")
-      generated=$(cat "${output_tmp}/${file}")
-
-      # Filter out meaningless lines with timestamps
-      original=$(echo "${original}" | grep -v "Last updated" || :)
-      generated=$(echo "${generated}" | grep -v "Last updated" || :)
 
       # By now, the contents should be normalized and stripped of any
       # auto-managed content.
-      if diff -B >/dev/null <(echo "${original}") <(echo "${generated}"); then
+      if diff -NauprB -I 'Last update' "${output_dir}/${file}" "${output_tmp}/${file}" >/dev/null; then
         # actual contents same, overwrite generated with original.
         cp "${output_dir}/${file}" "${output_tmp}/${file}"
       fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Fixes an issue where there is a discrepancy between the update and verify diff methods for the api-reference-docs. This can create a situation where verify will see changes, but update won't fix them.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #31129

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
