### PR TITLE
Default FEDERATION_KUBE_CONTEXT to FEDERATION_NAME in federation e2e up/down scripts.

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -24,7 +24,7 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 # kubefed configuration
 FEDERATION_NAME="${FEDERATION_NAME:-e2e-federation}"
 FEDERATION_NAMESPACE=${FEDERATION_NAMESPACE:-federation-system}
-FEDERATION_KUBE_CONTEXT="${FEDERATION_KUBE_CONTEXT:-e2e-federation}"
+FEDERATION_KUBE_CONTEXT="${FEDERATION_KUBE_CONTEXT:-${FEDERATION_NAME}}"
 HOST_CLUSTER_ZONE="${FEDERATION_HOST_CLUSTER_ZONE:-}"
 # If $HOST_CLUSTER_ZONE isn't specified, arbitrarily choose
 # last zone as the host cluster zone.

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -108,7 +108,7 @@ function join_clusters() {
         "${context}" \
         --federation-system-namespace=${FEDERATION_NAMESPACE} \
         --host-cluster-context="${HOST_CLUSTER_CONTEXT}" \
-        --context="${FEDERATION_NAME}" \
+        --context="${FEDERATION_KUBE_CONTEXT}" \
         --secret-name="${context//_/-}"    # Replace "_" by "-"
   done
 }

--- a/hack/federated-ginkgo-e2e.sh
+++ b/hack/federated-ginkgo-e2e.sh
@@ -21,10 +21,14 @@ set -o pipefail
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 source "${KUBE_ROOT}/cluster/kube-util.sh"
+source "${KUBE_ROOT}/federation/cluster/common.sh"
 
 : "${FEDERATION_HOST_CLUSTER_ZONE?Must set FEDERATION_HOST_CLUSTER_ZONE env var}"
 
 (
     set-federation-zone-vars "${FEDERATION_HOST_CLUSTER_ZONE}"
+    # Export FEDERATION_KUBE_CONTEXT to ensure that it is available to
+    # ginkgo-e2e.sh and is thus passed on to the federation tests.
+    export FEDERATION_KUBE_CONTEXT
     "${KUBE_ROOT}/hack/ginkgo-e2e.sh" $@
 )


### PR DESCRIPTION
This is consistent with how kubefed creates kubeconfig contexts.

**Release note**:
-->
```release-note
NONE
```
