### PR TITLE
Add patchMergeKey and patchStrategy  support to OpenAPI

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -37027,7 +37027,9 @@
     "properties": {
      "key": {
       "description": "key is the label key that the selector applies to.",
-      "type": "string"
+      "type": "string",
+      "x-kubernetes-patch-merge-key": "key",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "operator": {
       "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
@@ -37087,7 +37089,8 @@
       "type": "array",
       "items": {
        "type": "string"
-      }
+      },
+      "x-kubernetes-patch-strategy": "merge"
      },
      "generateName": {
       "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#idempotency",
@@ -37118,7 +37121,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "uid",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "resourceVersion": {
       "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency",
@@ -37613,7 +37618,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.ComponentCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds",
@@ -37834,7 +37841,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.EnvVar"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "envFrom": {
       "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
@@ -37868,7 +37877,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.ContainerPort"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "containerPort",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "readinessProbe": {
       "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes",
@@ -37907,7 +37918,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.VolumeMount"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "mountPath",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "workingDir": {
       "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
@@ -39201,7 +39214,9 @@
     "properties": {
      "key": {
       "description": "The label key that the selector applies to.",
-      "type": "string"
+      "type": "string",
+      "x-kubernetes-patch-merge-key": "key",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "operator": {
       "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
@@ -39267,7 +39282,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.NodeAddress"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "allocatable": {
       "description": "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.",
@@ -39288,7 +39305,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.NodeCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "daemonEndpoints": {
       "description": "Endpoints of daemons running on the Node.",
@@ -39982,7 +40001,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.Container"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "dnsPolicy": {
       "description": "Set DNS policy for containers within the pod. One of 'ClusterFirstWithHostNet', 'ClusterFirst' or 'Default'. Defaults to \"ClusterFirst\". To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
@@ -40009,14 +40030,18 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.LocalObjectReference"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "initContainers": {
       "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.Container"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "nodeName": {
       "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
@@ -40070,7 +40095,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.Volume"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      }
     }
    },
@@ -40082,7 +40109,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.PodCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "containerStatuses": {
       "description": "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: http://kubernetes.io/docs/user-guide/pod-states#container-statuses",
@@ -40513,7 +40542,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.ReplicationControllerCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "fullyLabeledReplicas": {
       "description": "The number of pods that have labels matching the labels of the pod template of the replication controller.",
@@ -40999,7 +41030,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.ObjectReference"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      }
     },
     "x-kubernetes-group-version-kind": [
@@ -41149,7 +41182,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.ServicePort"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "port",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "selector": {
       "description": "Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: http://kubernetes.io/docs/user-guide/services#overview",
@@ -41206,7 +41241,9 @@
      },
      "key": {
       "description": "Required. The taint key to be applied to a node.",
-      "type": "string"
+      "type": "string",
+      "x-kubernetes-patch-merge-key": "key",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "timeAdded": {
       "description": "TimeAdded represents the time at which the taint was added. It is only written for NoExecute taints.",
@@ -41227,7 +41264,9 @@
      },
      "key": {
       "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
-      "type": "string"
+      "type": "string",
+      "x-kubernetes-patch-merge-key": "key",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "operator": {
       "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
@@ -41635,7 +41674,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "observedGeneration": {
       "description": "The generation observed by the deployment controller.",
@@ -43169,7 +43210,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.apis.batch.v1.JobCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "failed": {
       "description": "Failed is the number of pods which reached Phase Failed.",
@@ -43845,7 +43888,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.apis.extensions.v1beta1.DeploymentCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "observedGeneration": {
       "description": "The generation observed by the deployment controller.",
@@ -44515,7 +44560,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.apis.extensions.v1beta1.ReplicaSetCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "fullyLabeledReplicas": {
       "description": "The number of pods that have labels matching the labels of the pod template of the replicaset.",

--- a/cmd/libs/go2idl/openapi-gen/generators/openapi.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi.go
@@ -40,13 +40,28 @@ const tagOptional = "optional"
 
 // Known values for the tag.
 const (
-	tagValueTrue       = "true"
-	tagValueFalse      = "false"
-	tagExtensionPrefix = "x-kubernetes-"
+	tagValueTrue               = "true"
+	tagValueFalse              = "false"
+	tagExtensionPrefix         = "x-kubernetes-"
+	tagPatchStrategy           = "patchStrategy"
+	tagPatchMergeKey           = "patchMergeKey"
+	patchStrategyExtensionName = "patch-strategy"
+	patchMergeKeyExtensionName = "patch-merge-key"
 )
 
 func getOpenAPITagValue(comments []string) []string {
 	return types.ExtractCommentTags("+", comments)[tagName]
+}
+
+func getSingleTagsValue(comments []string, tag string) (string, error) {
+	tags, ok := types.ExtractCommentTags("+", comments)[tag]
+	if !ok || len(tags) == 0 {
+		return "", nil
+	}
+	if len(tags) > 1 {
+		return "", fmt.Errorf("Multiple values are not allowed for tag %s", tag)
+	}
+	return tags[0], nil
 }
 
 func hasOpenAPITagValue(comments []string, value string) bool {
@@ -235,6 +250,10 @@ func getJsonTags(m *types.Member) []string {
 	return strings.Split(jsonTag, ",")
 }
 
+func getPatchTags(m *types.Member) (string, string) {
+	return reflect.StructTag(m.Tags).Get(tagPatchMergeKey), reflect.StructTag(m.Tags).Get(tagPatchStrategy)
+}
+
 func getReferableName(m *types.Member) string {
 	jsonTags := getJsonTags(m)
 	if len(jsonTags) > 0 {
@@ -308,7 +327,7 @@ func (g openAPITypeWriter) generateMembers(t *types.Type, required []string) ([]
 		if !hasOptionalTag(&m) {
 			required = append(required, name)
 		}
-		if err = g.generateProperty(&m); err != nil {
+		if err = g.generateProperty(&m, t); err != nil {
 			return required, err
 		}
 	}
@@ -364,23 +383,63 @@ func (g openAPITypeWriter) generate(t *types.Type) error {
 
 func (g openAPITypeWriter) generateExtensions(CommentLines []string) error {
 	tagValues := getOpenAPITagValue(CommentLines)
-	anyExtension := false
+	type NameValue struct {
+		Name, Value string
+	}
+	extensions := []NameValue{}
 	for _, val := range tagValues {
 		if strings.HasPrefix(val, tagExtensionPrefix) {
-			if !anyExtension {
-				g.Do("VendorExtensible: spec.VendorExtensible{\nExtensions: spec.Extensions{\n", nil)
-				anyExtension = true
-			}
 			parts := strings.SplitN(val, ":", 2)
 			if len(parts) != 2 {
 				return fmt.Errorf("Invalid extension value: %v", val)
 			}
-			g.Do("\"$.$\": ", parts[0])
-			g.Do("\"$.$\",\n", parts[1])
+			extensions = append(extensions, NameValue{parts[0], parts[1]})
 		}
 	}
-	if anyExtension {
-		g.Do("},\n},\n", nil)
+	patchMergeKeyTag, err := getSingleTagsValue(CommentLines, tagPatchMergeKey)
+	if err != nil {
+		return err
+	}
+	if len(patchMergeKeyTag) > 0 {
+		extensions = append(extensions, NameValue{tagExtensionPrefix + patchMergeKeyExtensionName, patchMergeKeyTag})
+	}
+	patchStrategyTag, err := getSingleTagsValue(CommentLines, tagPatchStrategy)
+	if err != nil {
+		return err
+	}
+	if len(patchStrategyTag) > 0 {
+		extensions = append(extensions, NameValue{tagExtensionPrefix + patchStrategyExtensionName, patchStrategyTag})
+	}
+	if len(extensions) == 0 {
+		return nil
+	}
+	g.Do("VendorExtensible: spec.VendorExtensible{\nExtensions: spec.Extensions{\n", nil)
+	for _, extension := range extensions {
+		g.Do("\"$.$\": ", extension.Name)
+		g.Do("\"$.$\",\n", extension.Value)
+	}
+	g.Do("},\n},\n", nil)
+	return nil
+}
+
+// TODO(#44005): Move this validation outside of this generator (probably to policy verifier)
+func (g openAPITypeWriter) validatePatchTags(m *types.Member, parent *types.Type) error {
+	patchMergeKeyStructTag, patchStrategyStructTag := getPatchTags(m)
+	patchMergeKeyCommentTag, err := getSingleTagsValue(m.CommentLines, tagPatchMergeKey)
+	if err != nil {
+		return err
+	}
+	patchStrategyCommentTag, err := getSingleTagsValue(m.CommentLines, tagPatchStrategy)
+	if err != nil {
+		return err
+	}
+	if patchMergeKeyStructTag != patchMergeKeyCommentTag {
+		return fmt.Errorf("patchMergeKey in comment and struct tags should match for member (%s) of (%s)",
+			m.Name, parent.Name.String())
+	}
+	if patchStrategyStructTag != patchStrategyCommentTag {
+		return fmt.Errorf("patchStrategy in comment and struct tags should match for member (%s) of (%s)",
+			m.Name, parent.Name.String())
 	}
 	return nil
 }
@@ -428,10 +487,13 @@ func (g openAPITypeWriter) generateDescription(CommentLines []string) {
 	}
 }
 
-func (g openAPITypeWriter) generateProperty(m *types.Member) error {
+func (g openAPITypeWriter) generateProperty(m *types.Member, parent *types.Type) error {
 	name := getReferableName(m)
 	if name == "" {
 		return nil
+	}
+	if err := g.validatePatchTags(m, parent); err != nil {
+		return err
 	}
 	g.Do("\"$.$\": {\n", name)
 	if err := g.generateExtensions(m.CommentLines); err != nil {

--- a/cmd/libs/go2idl/openapi-gen/generators/openapi_test.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi_test.go
@@ -111,6 +111,10 @@ type Blah struct {
 	// a member with an extension
 	// +k8s:openapi-gen=x-kubernetes-member-tag:member_test
 	WithExtension string
+	// a member with struct tag as extension
+	// +patchStrategy=ps
+	// +patchMergeKey=pmk
+	WithStructTagExtension string `+"`"+`patchStrategy:"ps" patchMergeKey:"pmk"`+"`"+`
 }
 		`)
 	if err != nil {
@@ -238,8 +242,21 @@ Type: []string{"string"},
 Format: "",
 },
 },
+"WithStructTagExtension": {
+VendorExtensible: spec.VendorExtensible{
+Extensions: spec.Extensions{
+"x-kubernetes-patch-merge-key": "pmk",
+"x-kubernetes-patch-strategy": "ps",
 },
-Required: []string{"String","Int64","Int32","Int16","Int8","Uint","Uint64","Uint32","Uint16","Uint8","Byte","Bool","Float64","Float32","ByteArray","WithExtension"},
+},
+SchemaProps: spec.SchemaProps{
+Description: "a member with struct tag as extension",
+Type: []string{"string"},
+Format: "",
+},
+},
+},
+Required: []string{"String","Int64","Int32","Int16","Int8","Uint","Uint64","Uint32","Uint16","Uint8","Byte","Bool","Float64","Float32","ByteArray","WithExtension","WithStructTagExtension"},
 },
 VendorExtensible: spec.VendorExtensible{
 Extensions: spec.Extensions{

--- a/federation/apis/federation/v1beta1/generated.proto
+++ b/federation/apis/federation/v1beta1/generated.proto
@@ -89,6 +89,8 @@ message ClusterSpec {
   // This is to help clients reach servers in the most network-efficient way possible.
   // Clients can use the appropriate server address as per the CIDR that they match.
   // In case of multiple matches, clients should use the longest matching CIDR.
+  // +patchMergeKey=clientCIDR
+  // +patchStrategy=merge
   repeated ServerAddressByClientCIDR serverAddressByClientCIDRs = 1;
 
   // Name of the secret containing kubeconfig to access this cluster.

--- a/federation/apis/federation/v1beta1/types.go
+++ b/federation/apis/federation/v1beta1/types.go
@@ -36,6 +36,8 @@ type ClusterSpec struct {
 	// This is to help clients reach servers in the most network-efficient way possible.
 	// Clients can use the appropriate server address as per the CIDR that they match.
 	// In case of multiple matches, clients should use the longest matching CIDR.
+	// +patchMergeKey=clientCIDR
+	// +patchStrategy=merge
 	ServerAddressByClientCIDRs []ServerAddressByClientCIDR `json:"serverAddressByClientCIDRs" patchStrategy:"merge" patchMergeKey:"clientCIDR" protobuf:"bytes,1,rep,name=serverAddressByClientCIDRs"`
 	// Name of the secret containing kubeconfig to access this cluster.
 	// The secret is read from the kubernetes cluster that is hosting federation control plane.

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -8805,7 +8805,9 @@
     "properties": {
      "key": {
       "description": "key is the label key that the selector applies to.",
-      "type": "string"
+      "type": "string",
+      "x-kubernetes-patch-merge-key": "key",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "operator": {
       "description": "operator represents a key's relationship to a set of values. Valid operators ard In, NotIn, Exists and DoesNotExist.",
@@ -8865,7 +8867,8 @@
       "type": "array",
       "items": {
        "type": "string"
-      }
+      },
+      "x-kubernetes-patch-strategy": "merge"
      },
      "generateName": {
       "description": "GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.\n\nIf this field is specified and the generated name exists, the server will NOT return a 409 - instead, it will either return 201 Created or 500 with Reason ServerTimeout indicating a unique name could not be found in the time allotted, and the client should retry (optionally after the time indicated in the Retry-After header).\n\nApplied only if Name is not specified. More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#idempotency",
@@ -8896,7 +8899,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "uid",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "resourceVersion": {
       "description": "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency",
@@ -9254,7 +9259,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.federation.apis.federation.v1beta1.ServerAddressByClientCIDR"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "clientCIDR",
+      "x-kubernetes-patch-strategy": "merge"
      }
     }
    },
@@ -9632,7 +9639,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.EnvVar"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "envFrom": {
       "description": "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.",
@@ -9666,7 +9675,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.ContainerPort"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "containerPort",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "readinessProbe": {
       "description": "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/pod-states#container-probes",
@@ -9705,7 +9716,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.VolumeMount"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "mountPath",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "workingDir": {
       "description": "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.",
@@ -10459,7 +10472,9 @@
     "properties": {
      "key": {
       "description": "The label key that the selector applies to.",
-      "type": "string"
+      "type": "string",
+      "x-kubernetes-patch-merge-key": "key",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "operator": {
       "description": "Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.",
@@ -10683,7 +10698,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.Container"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "dnsPolicy": {
       "description": "Set DNS policy for containers within the pod. One of 'ClusterFirstWithHostNet', 'ClusterFirst' or 'Default'. Defaults to \"ClusterFirst\". To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.",
@@ -10710,14 +10727,18 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.LocalObjectReference"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "initContainers": {
       "description": "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.Container"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "nodeName": {
       "description": "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.",
@@ -10771,7 +10792,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.Volume"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "name",
+      "x-kubernetes-patch-strategy": "merge"
      }
     }
    },
@@ -11393,7 +11416,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.api.v1.ServicePort"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "port",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "selector": {
       "description": "Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: http://kubernetes.io/docs/user-guide/services#overview",
@@ -11446,7 +11471,9 @@
      },
      "key": {
       "description": "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
-      "type": "string"
+      "type": "string",
+      "x-kubernetes-patch-merge-key": "key",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "operator": {
       "description": "Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.",
@@ -12013,7 +12040,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.apis.extensions.v1beta1.DeploymentCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "observedGeneration": {
       "description": "The generation observed by the deployment controller.",
@@ -12363,7 +12392,9 @@
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.kubernetes.pkg.apis.extensions.v1beta1.ReplicaSetCondition"
-      }
+      },
+      "x-kubernetes-patch-merge-key": "type",
+      "x-kubernetes-patch-strategy": "merge"
      },
      "fullyLabeledReplicas": {
       "description": "The number of pods that have labels matching the labels of the pod template of the replicaset.",

--- a/pkg/api/v1/generated.proto
+++ b/pkg/api/v1/generated.proto
@@ -245,6 +245,8 @@ message ComponentStatus {
 
   // List of component conditions observed
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated ComponentCondition conditions = 2;
 }
 
@@ -415,6 +417,8 @@ message Container {
   // accessible from the network.
   // Cannot be updated.
   // +optional
+  // +patchMergeKey=containerPort
+  // +patchStrategy=merge
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.
@@ -429,6 +433,8 @@ message Container {
   // List of environment variables to set in the container.
   // Cannot be updated.
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated EnvVar env = 7;
 
   // Compute Resources required by this container.
@@ -440,6 +446,8 @@ message Container {
   // Pod volumes to mount into the container's filesystem.
   // Cannot be updated.
   // +optional
+  // +patchMergeKey=mountPath
+  // +patchStrategy=merge
   repeated VolumeMount volumeMounts = 9;
 
   // Periodic probe of container liveness.
@@ -1591,6 +1599,8 @@ message NodeSelector {
 // that relates the key and values.
 message NodeSelectorRequirement {
   // The label key that the selector applies to.
+  // +patchMergeKey=key
+  // +patchStrategy=merge
   optional string key = 1;
 
   // Represents a key's relationship to a set of values.
@@ -1658,12 +1668,16 @@ message NodeStatus {
   // Conditions is an array of current observed node conditions.
   // More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated NodeCondition conditions = 4;
 
   // List of addresses reachable to the node.
   // Queried from cloud provider, if available.
   // More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated NodeAddress addresses = 5;
 
   // Endpoints of daemons running on the Node.
@@ -1869,6 +1883,8 @@ message ObjectMeta {
   // then an entry in this list will point to this controller, with the controller field set to true.
   // There cannot be more than one managing controller.
   // +optional
+  // +patchMergeKey=uid
+  // +patchStrategy=merge
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.OwnerReference ownerReferences = 13;
 
   // Must be empty before the object is deleted from the registry. Each entry
@@ -1876,6 +1892,7 @@ message ObjectMeta {
   // from the list. If the deletionTimestamp of the object is non-nil, entries
   // in this list can only be removed.
   // +optional
+  // +patchStrategy=merge
   repeated string finalizers = 14;
 
   // The name of the cluster which the object belongs to.
@@ -2562,6 +2579,8 @@ message PodSpec {
   // List of volumes that can be mounted by containers belonging to the pod.
   // More info: http://kubernetes.io/docs/user-guide/volumes
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated Volume volumes = 1;
 
   // List of initialization containers belonging to the pod.
@@ -2577,6 +2596,8 @@ message PodSpec {
   // Init containers cannot currently be added or removed.
   // Cannot be updated.
   // More info: http://kubernetes.io/docs/user-guide/containers
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated Container initContainers = 20;
 
   // List of containers belonging to the pod.
@@ -2584,6 +2605,8 @@ message PodSpec {
   // There must be at least one container in a Pod.
   // Cannot be updated.
   // More info: http://kubernetes.io/docs/user-guide/containers
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated Container containers = 2;
 
   // Restart policy for all containers within the pod.
@@ -2672,6 +2695,8 @@ message PodSpec {
   // in the case of docker, only DockerConfig type secrets are honored.
   // More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated LocalObjectReference imagePullSecrets = 15;
 
   // Specifies the hostname of the Pod
@@ -2709,6 +2734,8 @@ message PodStatus {
   // Current service state of pod.
   // More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated PodCondition conditions = 2;
 
   // A human readable message indicating details about why the pod is in this condition.
@@ -3107,6 +3134,8 @@ message ReplicationControllerStatus {
 
   // Represents the latest available observations of a replication controller's current state.
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated ReplicationControllerCondition conditions = 6;
 }
 
@@ -3468,6 +3497,8 @@ message ServiceAccount {
   // Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount.
   // More info: http://kubernetes.io/docs/user-guide/secrets
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated ObjectReference secrets = 2;
 
   // ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
@@ -3558,6 +3589,8 @@ message ServiceProxyOptions {
 message ServiceSpec {
   // The list of ports that are exposed by this service.
   // More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+  // +patchMergeKey=port
+  // +patchStrategy=merge
   repeated ServicePort ports = 1;
 
   // Route service traffic to pods with label keys and values matching this
@@ -3677,6 +3710,8 @@ message TCPSocketAction {
 // any pod that that does not tolerate the Taint.
 message Taint {
   // Required. The taint key to be applied to a node.
+  // +patchMergeKey=key
+  // +patchStrategy=merge
   optional string key = 1;
 
   // Required. The taint value corresponding to the taint key.
@@ -3700,6 +3735,8 @@ message Toleration {
   // Key is the taint key that the toleration applies to. Empty means match all taint keys.
   // If the key is empty, operator must be Exists; this combination means to match all values and all keys.
   // +optional
+  // +patchMergeKey=key
+  // +patchStrategy=merge
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -197,6 +197,8 @@ type ObjectMeta struct {
 	// then an entry in this list will point to this controller, with the controller field set to true.
 	// There cannot be more than one managing controller.
 	// +optional
+	// +patchMergeKey=uid
+	// +patchStrategy=merge
 	OwnerReferences []metav1.OwnerReference `json:"ownerReferences,omitempty" patchStrategy:"merge" patchMergeKey:"uid" protobuf:"bytes,13,rep,name=ownerReferences"`
 
 	// Must be empty before the object is deleted from the registry. Each entry
@@ -204,6 +206,7 @@ type ObjectMeta struct {
 	// from the list. If the deletionTimestamp of the object is non-nil, entries
 	// in this list can only be removed.
 	// +optional
+	// +patchStrategy=merge
 	Finalizers []string `json:"finalizers,omitempty" patchStrategy:"merge" protobuf:"bytes,14,rep,name=finalizers"`
 
 	// The name of the cluster which the object belongs to.
@@ -1637,6 +1640,8 @@ type Container struct {
 	// accessible from the network.
 	// Cannot be updated.
 	// +optional
+	// +patchMergeKey=containerPort
+	// +patchStrategy=merge
 	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
@@ -1649,6 +1654,8 @@ type Container struct {
 	// List of environment variables to set in the container.
 	// Cannot be updated.
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,7,rep,name=env"`
 	// Compute Resources required by this container.
 	// Cannot be updated.
@@ -1658,6 +1665,8 @@ type Container struct {
 	// Pod volumes to mount into the container's filesystem.
 	// Cannot be updated.
 	// +optional
+	// +patchMergeKey=mountPath
+	// +patchStrategy=merge
 	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"mountPath" protobuf:"bytes,9,rep,name=volumeMounts"`
 	// Periodic probe of container liveness.
 	// Container will be restarted if the probe fails.
@@ -1978,6 +1987,8 @@ type NodeSelectorTerm struct {
 // that relates the key and values.
 type NodeSelectorRequirement struct {
 	// The label key that the selector applies to.
+	// +patchMergeKey=key
+	// +patchStrategy=merge
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -2162,6 +2173,8 @@ type PreferredSchedulingTerm struct {
 // any pod that that does not tolerate the Taint.
 type Taint struct {
 	// Required. The taint key to be applied to a node.
+	// +patchMergeKey=key
+	// +patchStrategy=merge
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Required. The taint value corresponding to the taint key.
 	// +optional
@@ -2204,6 +2217,8 @@ type Toleration struct {
 	// Key is the taint key that the toleration applies to. Empty means match all taint keys.
 	// If the key is empty, operator must be Exists; this combination means to match all values and all keys.
 	// +optional
+	// +patchMergeKey=key
+	// +patchStrategy=merge
 	Key string `json:"key,omitempty" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Operator represents a key's relationship to the value.
 	// Valid operators are Exists and Equal. Defaults to Equal.
@@ -2261,6 +2276,8 @@ type PodSpec struct {
 	// List of volumes that can be mounted by containers belonging to the pod.
 	// More info: http://kubernetes.io/docs/user-guide/volumes
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Volumes []Volume `json:"volumes,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
 	// List of initialization containers belonging to the pod.
 	// Init containers are executed in order prior to containers being started. If any
@@ -2275,12 +2292,16 @@ type PodSpec struct {
 	// Init containers cannot currently be added or removed.
 	// Cannot be updated.
 	// More info: http://kubernetes.io/docs/user-guide/containers
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	InitContainers []Container `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.
 	// There must be at least one container in a Pod.
 	// Cannot be updated.
 	// More info: http://kubernetes.io/docs/user-guide/containers
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
 	// Restart policy for all containers within the pod.
 	// One of Always, OnFailure, Never.
@@ -2357,6 +2378,8 @@ type PodSpec struct {
 	// in the case of docker, only DockerConfig type secrets are honored.
 	// More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 	// Specifies the hostname of the Pod
 	// If not specified, the pod's hostname will be set to a system-defined value.
@@ -2444,6 +2467,8 @@ type PodStatus struct {
 	// Current service state of pod.
 	// More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []PodCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
 	// A human readable message indicating details about why the pod is in this condition.
 	// +optional
@@ -2640,6 +2665,8 @@ type ReplicationControllerStatus struct {
 
 	// Represents the latest available observations of a replication controller's current state.
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []ReplicationControllerCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 
@@ -2777,6 +2804,8 @@ type LoadBalancerIngress struct {
 type ServiceSpec struct {
 	// The list of ports that are exposed by this service.
 	// More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+	// +patchMergeKey=port
+	// +patchStrategy=merge
 	Ports []ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
 
 	// Route service traffic to pods with label keys and values matching this
@@ -2962,6 +2991,8 @@ type ServiceAccount struct {
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount.
 	// More info: http://kubernetes.io/docs/user-guide/secrets
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Secrets []ObjectReference `json:"secrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=secrets"`
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
@@ -3182,11 +3213,15 @@ type NodeStatus struct {
 	// Conditions is an array of current observed node conditions.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []NodeCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,4,rep,name=conditions"`
 	// List of addresses reachable to the node.
 	// Queried from cloud provider, if available.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Addresses []NodeAddress `json:"addresses,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,5,rep,name=addresses"`
 	// Endpoints of daemons running on the Node.
 	// +optional
@@ -4235,6 +4270,8 @@ type ComponentStatus struct {
 
 	// List of component conditions observed
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []ComponentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
 }
 

--- a/pkg/apis/apps/v1beta1/generated.proto
+++ b/pkg/apis/apps/v1beta1/generated.proto
@@ -167,6 +167,8 @@ message DeploymentStatus {
   optional int32 unavailableReplicas = 5;
 
   // Represents the latest available observations of a deployment's current state.
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated DeploymentCondition conditions = 6;
 }
 

--- a/pkg/apis/apps/v1beta1/types.go
+++ b/pkg/apis/apps/v1beta1/types.go
@@ -327,6 +327,8 @@ type DeploymentStatus struct {
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 

--- a/pkg/apis/batch/v1/generated.proto
+++ b/pkg/apis/batch/v1/generated.proto
@@ -139,6 +139,8 @@ message JobStatus {
   // Conditions represent the latest available observations of an object's current state.
   // More info: http://kubernetes.io/docs/user-guide/jobs
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated JobCondition conditions = 1;
 
   // StartTime represents time when the job was acknowledged by the Job Manager.

--- a/pkg/apis/batch/v1/types.go
+++ b/pkg/apis/batch/v1/types.go
@@ -110,6 +110,8 @@ type JobStatus struct {
 	// Conditions represent the latest available observations of an object's current state.
 	// More info: http://kubernetes.io/docs/user-guide/jobs
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []JobCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
 	// StartTime represents time when the job was acknowledged by the Job Manager.

--- a/pkg/apis/extensions/v1beta1/generated.proto
+++ b/pkg/apis/extensions/v1beta1/generated.proto
@@ -321,6 +321,8 @@ message DeploymentStatus {
   optional int32 unavailableReplicas = 5;
 
   // Represents the latest available observations of a deployment's current state.
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated DeploymentCondition conditions = 6;
 }
 
@@ -818,6 +820,8 @@ message ReplicaSetStatus {
 
   // Represents the latest available observations of a replica set's current state.
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated ReplicaSetCondition conditions = 6;
 }
 

--- a/pkg/apis/extensions/v1beta1/types.go
+++ b/pkg/apis/extensions/v1beta1/types.go
@@ -322,6 +322,8 @@ type DeploymentStatus struct {
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 
@@ -802,6 +804,8 @@ type ReplicaSetStatus struct {
 
 	// Represents the latest available observations of a replica set's current state.
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []ReplicaSetCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 

--- a/pkg/generated/openapi/zz_generated.openapi.go
+++ b/pkg/generated/openapi/zz_generated.openapi.go
@@ -683,6 +683,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
 					Properties: map[string]spec.Schema{
 						"key": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "key",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "key is the label key that the selector applies to.",
 								Type:        []string{"string"},
@@ -901,6 +907,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"ownerReferences": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "uid",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.",
 								Type:        []string{"array"},
@@ -914,6 +926,11 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"finalizers": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-strategy": "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed.",
 								Type:        []string{"array"},
@@ -1674,6 +1691,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "ClusterSpec describes the attributes of a kubernetes cluster.",
 					Properties: map[string]spec.Schema{
 						"serverAddressByClientCIDRs": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "clientCIDR",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "A map of client CIDR to server address. This is to help clients reach servers in the most network-efficient way possible. Clients can use the appropriate server address as per the CIDR that they match. In case of multiple matches, clients should use the longest matching CIDR.",
 								Type:        []string{"array"},
@@ -2197,6 +2220,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of component conditions observed",
 								Type:        []string{"array"},
@@ -2544,6 +2573,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"ports": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "containerPort",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.",
 								Type:        []string{"array"},
@@ -2570,6 +2605,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"env": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "name",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of environment variables to set in the container. Cannot be updated.",
 								Type:        []string{"array"},
@@ -2589,6 +2630,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"volumeMounts": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "mountPath",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Pod volumes to mount into the container's filesystem. Cannot be updated.",
 								Type:        []string{"array"},
@@ -4792,6 +4839,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
 					Properties: map[string]spec.Schema{
 						"key": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "key",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "The label key that the selector applies to.",
 								Type:        []string{"string"},
@@ -4941,6 +4994,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Conditions is an array of current observed node conditions. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition",
 								Type:        []string{"array"},
@@ -4954,6 +5013,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"addresses": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of addresses reachable to the node. Queried from cloud provider, if available. More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses",
 								Type:        []string{"array"},
@@ -6448,6 +6513,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "PodSpec is a description of a pod.",
 					Properties: map[string]spec.Schema{
 						"volumes": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "name",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of volumes that can be mounted by containers belonging to the pod. More info: http://kubernetes.io/docs/user-guide/volumes",
 								Type:        []string{"array"},
@@ -6461,6 +6532,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"initContainers": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "name",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, or Liveness probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers",
 								Type:        []string{"array"},
@@ -6474,6 +6551,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"containers": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "name",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/containers",
 								Type:        []string{"array"},
@@ -6584,6 +6667,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"imagePullSecrets": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "name",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod",
 								Type:        []string{"array"},
@@ -6656,6 +6745,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Current service state of pod. More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions",
 								Type:        []string{"array"},
@@ -7460,6 +7555,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Represents the latest available observations of a replication controller's current state.",
 								Type:        []string{"array"},
@@ -8231,6 +8332,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"secrets": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "name",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: http://kubernetes.io/docs/user-guide/secrets",
 								Type:        []string{"array"},
@@ -8442,6 +8549,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "ServiceSpec describes the attributes that a user creates on a service.",
 					Properties: map[string]spec.Schema{
 						"ports": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "port",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "The list of ports that are exposed by this service. More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies",
 								Type:        []string{"array"},
@@ -8621,6 +8734,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "The node this Taint is attached to has the effect \"effect\" on any pod that that does not tolerate the Taint.",
 					Properties: map[string]spec.Schema{
 						"key": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "key",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Required. The taint key to be applied to a node.",
 								Type:        []string{"string"},
@@ -8660,6 +8779,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.",
 					Properties: map[string]spec.Schema{
 						"key": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "key",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.",
 								Type:        []string{"string"},
@@ -9571,6 +9696,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Represents the latest available observations of a deployment's current state.",
 								Type:        []string{"array"},
@@ -12081,6 +12212,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 					Description: "JobStatus represents the current state of a Job.",
 					Properties: map[string]spec.Schema{
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Conditions represent the latest available observations of an object's current state. More info: http://kubernetes.io/docs/user-guide/jobs",
 								Type:        []string{"array"},
@@ -14623,6 +14760,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Represents the latest available observations of a deployment's current state.",
 								Type:        []string{"array"},
@@ -15666,6 +15809,12 @@ func GetOpenAPIDefinitions(ref openapi.ReferenceCallback) map[string]openapi.Ope
 							},
 						},
 						"conditions": {
+							VendorExtensible: spec.VendorExtensible{
+								Extensions: spec.Extensions{
+									"x-kubernetes-patch-merge-key": "type",
+									"x-kubernetes-patch-strategy":  "merge",
+								},
+							},
 							SchemaProps: spec.SchemaProps{
 								Description: "Represents the latest available observations of a replica set's current state.",
 								Type:        []string{"array"},

--- a/pkg/kubelet/api/v1alpha1/stats/types.go
+++ b/pkg/kubelet/api/v1alpha1/stats/types.go
@@ -35,6 +35,8 @@ type NodeStats struct {
 	// Stats of system daemons tracked as raw containers.
 	// The system containers are named according to the SystemContainer* constants.
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	SystemContainers []ContainerStats `json:"systemContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 	// The time at which data collection for the node-scoped (i.e. aggregate) stats was (re)started.
 	StartTime metav1.Time `json:"startTime"`
@@ -81,6 +83,8 @@ type PodStats struct {
 	// The time at which data collection for the pod-scoped (e.g. network) stats was (re)started.
 	StartTime metav1.Time `json:"startTime"`
 	// Stats of containers in the measured pod.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Containers []ContainerStats `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
 	// Stats pertaining to network resources.
 	// +optional
@@ -88,6 +92,8 @@ type PodStats struct {
 	// Stats pertaining to volume usage of filesystem resources.
 	// VolumeStats.UsedBytes is the number of bytes used by the Volume
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	VolumeStats []VolumeStats `json:"volume,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 
@@ -112,6 +118,8 @@ type ContainerStats struct {
 	// +optional
 	Logs *FsStats `json:"logs,omitempty"`
 	// User defined metrics that are exposed by containers in the pod. Typically, we expect only one container in the pod to be exposing user defined metrics. In the event of multiple containers exposing metrics, they will be combined here.
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	UserDefinedMetrics []UserDefinedMetric `json:"userDefinedMetrics,omitmepty" patchStrategy:"merge" patchMergeKey:"name"`
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -249,6 +249,8 @@ message LabelSelector {
 // relates the key and values.
 message LabelSelectorRequirement {
   // key is the label key that the selector applies to.
+  // +patchMergeKey=key
+  // +patchStrategy=merge
   optional string key = 1;
 
   // operator represents a key's relationship to a set of values.
@@ -445,6 +447,8 @@ message ObjectMeta {
   // then an entry in this list will point to this controller, with the controller field set to true.
   // There cannot be more than one managing controller.
   // +optional
+  // +patchMergeKey=uid
+  // +patchStrategy=merge
   repeated OwnerReference ownerReferences = 13;
 
   // Must be empty before the object is deleted from the registry. Each entry
@@ -452,6 +456,7 @@ message ObjectMeta {
   // from the list. If the deletionTimestamp of the object is non-nil, entries
   // in this list can only be removed.
   // +optional
+  // +patchStrategy=merge
   repeated string finalizers = 14;
 
   // The name of the cluster which the object belongs to.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -209,6 +209,8 @@ type ObjectMeta struct {
 	// then an entry in this list will point to this controller, with the controller field set to true.
 	// There cannot be more than one managing controller.
 	// +optional
+	// +patchMergeKey=uid
+	// +patchStrategy=merge
 	OwnerReferences []OwnerReference `json:"ownerReferences,omitempty" patchStrategy:"merge" patchMergeKey:"uid" protobuf:"bytes,13,rep,name=ownerReferences"`
 
 	// Must be empty before the object is deleted from the registry. Each entry
@@ -216,6 +218,7 @@ type ObjectMeta struct {
 	// from the list. If the deletionTimestamp of the object is non-nil, entries
 	// in this list can only be removed.
 	// +optional
+	// +patchStrategy=merge
 	Finalizers []string `json:"finalizers,omitempty" patchStrategy:"merge" protobuf:"bytes,14,rep,name=finalizers"`
 
 	// The name of the cluster which the object belongs to.
@@ -773,6 +776,8 @@ type LabelSelector struct {
 // relates the key and values.
 type LabelSelectorRequirement struct {
 	// key is the label key that the selector applies to.
+	// +patchMergeKey=key
+	// +patchStrategy=merge
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// operator represents a key's relationship to a set of values.
 	// Valid operators ard In, NotIn, Exists and DoesNotExist.

--- a/staging/src/k8s.io/client-go/pkg/api/v1/generated.proto
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/generated.proto
@@ -245,6 +245,8 @@ message ComponentStatus {
 
   // List of component conditions observed
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated ComponentCondition conditions = 2;
 }
 
@@ -415,6 +417,8 @@ message Container {
   // accessible from the network.
   // Cannot be updated.
   // +optional
+  // +patchMergeKey=containerPort
+  // +patchStrategy=merge
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.
@@ -429,6 +433,8 @@ message Container {
   // List of environment variables to set in the container.
   // Cannot be updated.
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated EnvVar env = 7;
 
   // Compute Resources required by this container.
@@ -440,6 +446,8 @@ message Container {
   // Pod volumes to mount into the container's filesystem.
   // Cannot be updated.
   // +optional
+  // +patchMergeKey=mountPath
+  // +patchStrategy=merge
   repeated VolumeMount volumeMounts = 9;
 
   // Periodic probe of container liveness.
@@ -1591,6 +1599,8 @@ message NodeSelector {
 // that relates the key and values.
 message NodeSelectorRequirement {
   // The label key that the selector applies to.
+  // +patchMergeKey=key
+  // +patchStrategy=merge
   optional string key = 1;
 
   // Represents a key's relationship to a set of values.
@@ -1658,12 +1668,16 @@ message NodeStatus {
   // Conditions is an array of current observed node conditions.
   // More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated NodeCondition conditions = 4;
 
   // List of addresses reachable to the node.
   // Queried from cloud provider, if available.
   // More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated NodeAddress addresses = 5;
 
   // Endpoints of daemons running on the Node.
@@ -1869,6 +1883,8 @@ message ObjectMeta {
   // then an entry in this list will point to this controller, with the controller field set to true.
   // There cannot be more than one managing controller.
   // +optional
+  // +patchMergeKey=uid
+  // +patchStrategy=merge
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.OwnerReference ownerReferences = 13;
 
   // Must be empty before the object is deleted from the registry. Each entry
@@ -1876,6 +1892,7 @@ message ObjectMeta {
   // from the list. If the deletionTimestamp of the object is non-nil, entries
   // in this list can only be removed.
   // +optional
+  // +patchStrategy=merge
   repeated string finalizers = 14;
 
   // The name of the cluster which the object belongs to.
@@ -2562,6 +2579,8 @@ message PodSpec {
   // List of volumes that can be mounted by containers belonging to the pod.
   // More info: http://kubernetes.io/docs/user-guide/volumes
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated Volume volumes = 1;
 
   // List of initialization containers belonging to the pod.
@@ -2577,6 +2596,8 @@ message PodSpec {
   // Init containers cannot currently be added or removed.
   // Cannot be updated.
   // More info: http://kubernetes.io/docs/user-guide/containers
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated Container initContainers = 20;
 
   // List of containers belonging to the pod.
@@ -2584,6 +2605,8 @@ message PodSpec {
   // There must be at least one container in a Pod.
   // Cannot be updated.
   // More info: http://kubernetes.io/docs/user-guide/containers
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated Container containers = 2;
 
   // Restart policy for all containers within the pod.
@@ -2672,6 +2695,8 @@ message PodSpec {
   // in the case of docker, only DockerConfig type secrets are honored.
   // More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated LocalObjectReference imagePullSecrets = 15;
 
   // Specifies the hostname of the Pod
@@ -2709,6 +2734,8 @@ message PodStatus {
   // Current service state of pod.
   // More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated PodCondition conditions = 2;
 
   // A human readable message indicating details about why the pod is in this condition.
@@ -3107,6 +3134,8 @@ message ReplicationControllerStatus {
 
   // Represents the latest available observations of a replication controller's current state.
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated ReplicationControllerCondition conditions = 6;
 }
 
@@ -3468,6 +3497,8 @@ message ServiceAccount {
   // Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount.
   // More info: http://kubernetes.io/docs/user-guide/secrets
   // +optional
+  // +patchMergeKey=name
+  // +patchStrategy=merge
   repeated ObjectReference secrets = 2;
 
   // ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
@@ -3558,6 +3589,8 @@ message ServiceProxyOptions {
 message ServiceSpec {
   // The list of ports that are exposed by this service.
   // More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+  // +patchMergeKey=port
+  // +patchStrategy=merge
   repeated ServicePort ports = 1;
 
   // Route service traffic to pods with label keys and values matching this
@@ -3677,6 +3710,8 @@ message TCPSocketAction {
 // any pod that that does not tolerate the Taint.
 message Taint {
   // Required. The taint key to be applied to a node.
+  // +patchMergeKey=key
+  // +patchStrategy=merge
   optional string key = 1;
 
   // Required. The taint value corresponding to the taint key.
@@ -3700,6 +3735,8 @@ message Toleration {
   // Key is the taint key that the toleration applies to. Empty means match all taint keys.
   // If the key is empty, operator must be Exists; this combination means to match all values and all keys.
   // +optional
+  // +patchMergeKey=key
+  // +patchStrategy=merge
   optional string key = 1;
 
   // Operator represents a key's relationship to the value.

--- a/staging/src/k8s.io/client-go/pkg/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/types.go
@@ -197,6 +197,8 @@ type ObjectMeta struct {
 	// then an entry in this list will point to this controller, with the controller field set to true.
 	// There cannot be more than one managing controller.
 	// +optional
+	// +patchMergeKey=uid
+	// +patchStrategy=merge
 	OwnerReferences []metav1.OwnerReference `json:"ownerReferences,omitempty" patchStrategy:"merge" patchMergeKey:"uid" protobuf:"bytes,13,rep,name=ownerReferences"`
 
 	// Must be empty before the object is deleted from the registry. Each entry
@@ -204,6 +206,7 @@ type ObjectMeta struct {
 	// from the list. If the deletionTimestamp of the object is non-nil, entries
 	// in this list can only be removed.
 	// +optional
+	// +patchStrategy=merge
 	Finalizers []string `json:"finalizers,omitempty" patchStrategy:"merge" protobuf:"bytes,14,rep,name=finalizers"`
 
 	// The name of the cluster which the object belongs to.
@@ -1637,6 +1640,8 @@ type Container struct {
 	// accessible from the network.
 	// Cannot be updated.
 	// +optional
+	// +patchMergeKey=containerPort
+	// +patchStrategy=merge
 	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
@@ -1649,6 +1654,8 @@ type Container struct {
 	// List of environment variables to set in the container.
 	// Cannot be updated.
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Env []EnvVar `json:"env,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,7,rep,name=env"`
 	// Compute Resources required by this container.
 	// Cannot be updated.
@@ -1658,6 +1665,8 @@ type Container struct {
 	// Pod volumes to mount into the container's filesystem.
 	// Cannot be updated.
 	// +optional
+	// +patchMergeKey=mountPath
+	// +patchStrategy=merge
 	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"mountPath" protobuf:"bytes,9,rep,name=volumeMounts"`
 	// Periodic probe of container liveness.
 	// Container will be restarted if the probe fails.
@@ -1978,6 +1987,8 @@ type NodeSelectorTerm struct {
 // that relates the key and values.
 type NodeSelectorRequirement struct {
 	// The label key that the selector applies to.
+	// +patchMergeKey=key
+	// +patchStrategy=merge
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Represents a key's relationship to a set of values.
 	// Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
@@ -2162,6 +2173,8 @@ type PreferredSchedulingTerm struct {
 // any pod that that does not tolerate the Taint.
 type Taint struct {
 	// Required. The taint key to be applied to a node.
+	// +patchMergeKey=key
+	// +patchStrategy=merge
 	Key string `json:"key" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Required. The taint value corresponding to the taint key.
 	// +optional
@@ -2204,6 +2217,8 @@ type Toleration struct {
 	// Key is the taint key that the toleration applies to. Empty means match all taint keys.
 	// If the key is empty, operator must be Exists; this combination means to match all values and all keys.
 	// +optional
+	// +patchMergeKey=key
+	// +patchStrategy=merge
 	Key string `json:"key,omitempty" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,1,opt,name=key"`
 	// Operator represents a key's relationship to the value.
 	// Valid operators are Exists and Equal. Defaults to Equal.
@@ -2261,6 +2276,8 @@ type PodSpec struct {
 	// List of volumes that can be mounted by containers belonging to the pod.
 	// More info: http://kubernetes.io/docs/user-guide/volumes
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Volumes []Volume `json:"volumes,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
 	// List of initialization containers belonging to the pod.
 	// Init containers are executed in order prior to containers being started. If any
@@ -2275,12 +2292,16 @@ type PodSpec struct {
 	// Init containers cannot currently be added or removed.
 	// Cannot be updated.
 	// More info: http://kubernetes.io/docs/user-guide/containers
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	InitContainers []Container `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.
 	// There must be at least one container in a Pod.
 	// Cannot be updated.
 	// More info: http://kubernetes.io/docs/user-guide/containers
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
 	// Restart policy for all containers within the pod.
 	// One of Always, OnFailure, Never.
@@ -2357,6 +2378,8 @@ type PodSpec struct {
 	// in the case of docker, only DockerConfig type secrets are honored.
 	// More info: http://kubernetes.io/docs/user-guide/images#specifying-imagepullsecrets-on-a-pod
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	ImagePullSecrets []LocalObjectReference `json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
 	// Specifies the hostname of the Pod
 	// If not specified, the pod's hostname will be set to a system-defined value.
@@ -2444,6 +2467,8 @@ type PodStatus struct {
 	// Current service state of pod.
 	// More info: http://kubernetes.io/docs/user-guide/pod-states#pod-conditions
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []PodCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
 	// A human readable message indicating details about why the pod is in this condition.
 	// +optional
@@ -2640,6 +2665,8 @@ type ReplicationControllerStatus struct {
 
 	// Represents the latest available observations of a replication controller's current state.
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []ReplicationControllerCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 
@@ -2777,6 +2804,8 @@ type LoadBalancerIngress struct {
 type ServiceSpec struct {
 	// The list of ports that are exposed by this service.
 	// More info: http://kubernetes.io/docs/user-guide/services#virtual-ips-and-service-proxies
+	// +patchMergeKey=port
+	// +patchStrategy=merge
 	Ports []ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
 
 	// Route service traffic to pods with label keys and values matching this
@@ -2962,6 +2991,8 @@ type ServiceAccount struct {
 	// Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount.
 	// More info: http://kubernetes.io/docs/user-guide/secrets
 	// +optional
+	// +patchMergeKey=name
+	// +patchStrategy=merge
 	Secrets []ObjectReference `json:"secrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=secrets"`
 
 	// ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images
@@ -3182,11 +3213,15 @@ type NodeStatus struct {
 	// Conditions is an array of current observed node conditions.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-condition
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []NodeCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,4,rep,name=conditions"`
 	// List of addresses reachable to the node.
 	// Queried from cloud provider, if available.
 	// More info: http://releases.k8s.io/HEAD/docs/admin/node.md#node-addresses
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Addresses []NodeAddress `json:"addresses,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,5,rep,name=addresses"`
 	// Endpoints of daemons running on the Node.
 	// +optional
@@ -4235,6 +4270,8 @@ type ComponentStatus struct {
 
 	// List of component conditions observed
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []ComponentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,2,rep,name=conditions"`
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/client-go/pkg/apis/apps/v1beta1/generated.proto
@@ -167,6 +167,8 @@ message DeploymentStatus {
   optional int32 unavailableReplicas = 5;
 
   // Represents the latest available observations of a deployment's current state.
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated DeploymentCondition conditions = 6;
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/apps/v1beta1/types.go
@@ -327,6 +327,8 @@ type DeploymentStatus struct {
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/batch/v1/generated.proto
+++ b/staging/src/k8s.io/client-go/pkg/apis/batch/v1/generated.proto
@@ -139,6 +139,8 @@ message JobStatus {
   // Conditions represent the latest available observations of an object's current state.
   // More info: http://kubernetes.io/docs/user-guide/jobs
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated JobCondition conditions = 1;
 
   // StartTime represents time when the job was acknowledged by the Job Manager.

--- a/staging/src/k8s.io/client-go/pkg/apis/batch/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/batch/v1/types.go
@@ -110,6 +110,8 @@ type JobStatus struct {
 	// Conditions represent the latest available observations of an object's current state.
 	// More info: http://kubernetes.io/docs/user-guide/jobs
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []JobCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 
 	// StartTime represents time when the job was acknowledged by the Job Manager.

--- a/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/generated.proto
@@ -321,6 +321,8 @@ message DeploymentStatus {
   optional int32 unavailableReplicas = 5;
 
   // Represents the latest available observations of a deployment's current state.
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated DeploymentCondition conditions = 6;
 }
 
@@ -818,6 +820,8 @@ message ReplicaSetStatus {
 
   // Represents the latest available observations of a replica set's current state.
   // +optional
+  // +patchMergeKey=type
+  // +patchStrategy=merge
   repeated ReplicaSetCondition conditions = 6;
 }
 

--- a/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/types.go
@@ -322,6 +322,8 @@ type DeploymentStatus struct {
 	UnavailableReplicas int32 `json:"unavailableReplicas,omitempty" protobuf:"varint,5,opt,name=unavailableReplicas"`
 
 	// Represents the latest available observations of a deployment's current state.
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []DeploymentCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 
@@ -802,6 +804,8 @@ type ReplicaSetStatus struct {
 
 	// Represents the latest available observations of a replica set's current state.
 	// +optional
+	// +patchMergeKey=type
+	// +patchStrategy=merge
 	Conditions []ReplicaSetCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,6,rep,name=conditions"`
 }
 


### PR DESCRIPTION
Support generating Open API extensions for strategic merge patch tags in go struct tags
Support `patchStrategy` and `patchMergeKey`.
Also support checking if the Open API extension and struct tags match.

```release-note
Support generating Open API extensions for strategic merge patch tags in go struct tags
```

cc: @pwittrock @ymqytw 

(Description mostly copied from #43833)