### PR TITLE
[DO NOT MERGE][Federation] Enable backwards compatibility for workload types

### DIFF
--- a/federation/pkg/federation-controller/daemonset/daemonset_controller.go
+++ b/federation/pkg/federation-controller/daemonset/daemonset_controller.go
@@ -34,6 +34,7 @@ import (
 	federationapi "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
+	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util/deletionhelper"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util/eventsink"
 	"k8s.io/kubernetes/pkg/api"
@@ -422,6 +423,7 @@ func (daemonsetcontroller *DaemonSetController) reconcileDaemonSet(namespace str
 			})
 		} else {
 			clusterDaemonSet := clusterDaemonSetObj.(*extensionsv1.DaemonSet)
+			fedutil.SetDaemonSetDefaults(clusterDaemonSet, desiredDaemonSet.Spec.TemplateGeneration)
 
 			// Update existing daemonset, if needed.
 			if !util.ObjectMetaEquivalent(desiredDaemonSet.ObjectMeta, clusterDaemonSet.ObjectMeta) ||

--- a/federation/pkg/federation-controller/deployment/deploymentcontroller.go
+++ b/federation/pkg/federation-controller/deployment/deploymentcontroller.go
@@ -581,6 +581,7 @@ func (fdc *DeploymentController) reconcileDeployment(key string) (reconciliation
 			// TODO: Update only one deployment at a time if update strategy is rolling update.
 
 			currentLd := ldObj.(*extensionsv1.Deployment)
+			fedutil.SetDeploymentDefaults(currentLd)
 			// Update existing replica set, if needed.
 			if !fedutil.DeploymentEquivalent(ld, currentLd) {
 				fdc.eventRecorder.Eventf(fd, api.EventTypeNormal, "UpdateInCluster",

--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
@@ -596,6 +596,7 @@ func (frsc *ReplicaSetController) reconcileReplicaSet(key string) (reconciliatio
 			}
 		} else {
 			currentLrs := lrsObj.(*extensionsv1.ReplicaSet)
+			fedutil.SetReplicaSetDefaults(currentLrs)
 			// Update existing replica set, if needed.
 			if !fedutil.ObjectMetaAndSpecEquivalent(lrs, currentLrs) {
 				frsc.eventRecorder.Eventf(frs, api.EventTypeNormal, "UpdateInCluster",

--- a/federation/pkg/federation-controller/util/BUILD
+++ b/federation/pkg/federation-controller/util/BUILD
@@ -21,6 +21,7 @@ go_library(
         "federated_updater.go",
         "handlers.go",
         "meta.go",
+        "replicaset.go",
         "secret.go",
     ],
     tags = ["automanaged"],

--- a/federation/pkg/federation-controller/util/BUILD
+++ b/federation/pkg/federation-controller/util/BUILD
@@ -14,6 +14,7 @@ go_library(
         "backoff.go",
         "cluster_util.go",
         "configmap.go",
+        "daemonset.go",
         "defaults.go",
         "delaying_deliverer.go",
         "deployment.go",

--- a/federation/pkg/federation-controller/util/BUILD
+++ b/federation/pkg/federation-controller/util/BUILD
@@ -14,6 +14,7 @@ go_library(
         "backoff.go",
         "cluster_util.go",
         "configmap.go",
+        "defaults.go",
         "delaying_deliverer.go",
         "deployment.go",
         "federated_informer.go",

--- a/federation/pkg/federation-controller/util/daemonset.go
+++ b/federation/pkg/federation-controller/util/daemonset.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	extensions_v1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+)
+
+// SetDaemonSetDefaults sets defaults for a daemonset retrieved from a
+// member cluster to allow backwards-compatible comparison.
+func SetDaemonSetDefaults(daemonSet *extensions_v1.DaemonSet, templateGeneration int64) {
+	extensions_v1.SetDefaults_DaemonSet(daemonSet)
+	setPodSpecDefaults(&daemonSet.Spec.Template.Spec)
+	// TemplateGeneration will have a non-zero value in 1.6 clusters
+	// but be 0 in previous versions.  Since it can only change when
+	// the template changes, it isn't useful to compare, so just set
+	// it to an explicit value.
+	daemonSet.Spec.TemplateGeneration = templateGeneration
+}

--- a/federation/pkg/federation-controller/util/defaults.go
+++ b/federation/pkg/federation-controller/util/defaults.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/kubernetes/pkg/api/v1"
+)
+
+// setPodSpecDefaults sets optional PodSpec fields to their defaults
+// to ensure that specs for older cluster versions can be compared
+// with DeepEqual.  Where a resource spec in the federation control
+// plane may have a default supplied for an optional field, an older
+// cluster would return empty values.
+func setPodSpecDefaults(podSpec *v1.PodSpec) {
+	v1.SetDefaults_PodSpec(podSpec)
+	for i, container := range podSpec.Containers {
+		v1.SetDefaults_Container(&container)
+		podSpec.Containers[i] = container
+	}
+}

--- a/federation/pkg/federation-controller/util/deployment.go
+++ b/federation/pkg/federation-controller/util/deployment.go
@@ -73,3 +73,10 @@ func DeepCopyDeployment(a *extensions_v1.Deployment) *extensions_v1.Deployment {
 		Spec:       *(DeepCopyApiTypeOrPanic(&a.Spec).(*extensions_v1.DeploymentSpec)),
 	}
 }
+
+// SetDeploymentDefaults sets defaults for a deployment retrieved from
+// a member cluster to allow backwards-compatible comparison.
+func SetDeploymentDefaults(deployment *extensions_v1.Deployment) {
+	extensions_v1.SetDefaults_Deployment(deployment)
+	setPodSpecDefaults(&deployment.Spec.Template.Spec)
+}

--- a/federation/pkg/federation-controller/util/replicaset.go
+++ b/federation/pkg/federation-controller/util/replicaset.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	extensions_v1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
+)
+
+// SetReplicaSetDefaults sets defaults for a replicaset retrieved from
+// a member cluster to allow backwards-compatible comparison.
+func SetReplicaSetDefaults(replicaSet *extensions_v1.ReplicaSet) {
+	extensions_v1.SetDefaults_ReplicaSet(replicaSet)
+	setPodSpecDefaults(&replicaSet.Spec.Template.Spec)
+}

--- a/test/e2e_federation/daemonset.go
+++ b/test/e2e_federation/daemonset.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
+	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	kubeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
@@ -259,6 +260,7 @@ func waitForDaemonSetOrFail(clientset *kubeclientset.Clientset, namespace string
 	framework.ExpectNoError(err, "Failed to verify daemonset %q in namespace %q in cluster: Present=%v", daemonset.Name, namespace, present)
 
 	if present && clusterDaemonSet != nil {
+		fedutil.SetDaemonSetDefaults(clusterDaemonSet, daemonset.Spec.TemplateGeneration)
 		Expect(util.ObjectMetaAndSpecEquivalent(clusterDaemonSet, daemonset))
 	}
 }
@@ -275,6 +277,7 @@ func waitForDaemonSetUpdateOrFail(clientset *kubeclientset.Clientset, namespace 
 	err := wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
 		clusterDaemonSet, err := clientset.Extensions().DaemonSets(namespace).Get(daemonset.Name, metav1.GetOptions{})
 		if err == nil { // We want it present, and the Get succeeded, so we're all good.
+			fedutil.SetDaemonSetDefaults(clusterDaemonSet, daemonset.Spec.TemplateGeneration)
 			if util.ObjectMetaAndSpecEquivalent(clusterDaemonSet, daemonset) {
 				By(fmt.Sprintf("Success: shard of federated daemonset %q in namespace %q in cluster is updated", daemonset.Name, namespace))
 				return true, nil

--- a/test/e2e_federation/deployment.go
+++ b/test/e2e_federation/deployment.go
@@ -198,6 +198,7 @@ func waitForDeployment(c *fedclientset.Clientset, namespace string, deploymentNa
 				return false, err
 			}
 			if err == nil {
+				fedutil.SetDeploymentDefaults(dep)
 				if !verifyDeployment(fdep, dep) {
 					By(fmt.Sprintf("Deployment meta or spec not match for cluster %q:\n    federation: %v\n    cluster: %v", cluster.name, fdep, dep))
 					return false, nil

--- a/test/e2e_federation/replicaset.go
+++ b/test/e2e_federation/replicaset.go
@@ -407,6 +407,7 @@ func waitForReplicaSet(c *fedclientset.Clientset, namespace string, replicaSetNa
 					return false, nil
 				}
 			} else {
+				fedutil.SetReplicaSetDefaults(rs)
 				if !equivalentReplicaSet(frs, rs) {
 					framework.Logf("Replicaset meta or spec does not match for cluster %q:\n    federation: %v\n    cluster: %v", cluster.name, frs, rs)
 					return false, nil


### PR DESCRIPTION
While testing federation on an openshift 1.5 cluster, I was seeing e2e failures for the workload types (deployment, replicaset, deployment) due to the resources retrieved from the 1.5 cluster differing from their equivalents in the 1.6 federation control plane.  The 1.5 objects had no value for optional fields added in 1.6, whereas the 1.6 objects had defaults applied.  This PR proposes to apply defaults to objects retrieved from member clusters so that comparison can work across kube versions.

This solves my short-term problem of testing federation on openshift, but I'm not sure what the sig's intent is with respect to supporting version skew between the control plane and member clusters.

cc: @kubernetes/sig-federation-pr-reviews @perotinus 
