### PR TITLE
Removed hostname/subdomain annotation.

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -57,6 +57,7 @@ pkg/api/errors
 pkg/api/events
 pkg/api/install
 pkg/api/meta
+pkg/api/pod
 pkg/api/resource
 pkg/api/service
 pkg/api/v1

--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -18,20 +18,6 @@ package pod
 
 import "k8s.io/kubernetes/pkg/api"
 
-const (
-	// TODO: to be deleted after v1.3 is released. PodSpec has a dedicated Hostname field.
-	// The annotation value is a string specifying the hostname to be used for the pod e.g 'my-webserver-1'
-	PodHostnameAnnotation = "pod.beta.kubernetes.io/hostname"
-
-	// TODO: to be deleted after v1.3 is released. PodSpec has a dedicated Subdomain field.
-	// The annotation value is a string specifying the subdomain e.g. "my-web-service"
-	// If specified, on the pod itself, "<hostname>.my-web-service.<namespace>.svc.<cluster domain>" would resolve to
-	// the pod's IP.
-	// If there is a headless service named "my-web-service" in the same namespace as the pod, then,
-	// <hostname>.my-web-service.<namespace>.svc.<cluster domain>" would be resolved by the cluster DNS Server.
-	PodSubdomainAnnotation = "pod.beta.kubernetes.io/subdomain"
-)
-
 // VisitPodSecretNames invokes the visitor function with the name of every secret
 // referenced by the pod spec. If visitor returns false, visiting is short-circuited.
 // Transitive references (e.g. pod -> pvc -> pv -> secret) are not visited.

--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -24,20 +24,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 )
 
-const (
-	// TODO: to be deleted after v1.3 is released. PodSpec has a dedicated Hostname field.
-	// The annotation value is a string specifying the hostname to be used for the pod e.g 'my-webserver-1'
-	PodHostnameAnnotation = "pod.beta.kubernetes.io/hostname"
-
-	// TODO: to be deleted after v1.3 is released. PodSpec has a dedicated Subdomain field.
-	// The annotation value is a string specifying the subdomain e.g. "my-web-service"
-	// If specified, on the pod itself, "<hostname>.my-web-service.<namespace>.svc.<cluster domain>" would resolve to
-	// the pod's IP.
-	// If there is a headless service named "my-web-service" in the same namespace as the pod, then,
-	// <hostname>.my-web-service.<namespace>.svc.<cluster domain>" would be resolved by the cluster DNS Server.
-	PodSubdomainAnnotation = "pod.beta.kubernetes.io/subdomain"
-)
-
 // FindPort locates the container port for the given pod and portName.  If the
 // targetPort is a number, use that.  If the targetPort is a string, look that
 // string up in all named ports in all containers in the target pod.  If no

--- a/pkg/api/validation/BUILD
+++ b/pkg/api/validation/BUILD
@@ -19,7 +19,6 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/api/pod:go_default_library",
         "//pkg/api/service:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/api/v1:go_default_library",

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api"
-	utilpod "k8s.io/kubernetes/pkg/api/pod"
 	apiservice "k8s.io/kubernetes/pkg/api/service"
 	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/capabilities"
@@ -111,14 +110,6 @@ func ValidatePodSpecificAnnotations(annotations map[string]string, spec *api.Pod
 
 	if annotations[api.TolerationsAnnotationKey] != "" {
 		allErrs = append(allErrs, ValidateTolerationsInPodAnnotations(annotations, fldPath)...)
-	}
-
-	// TODO: remove these after we EOL the annotations.
-	if hostname, exists := annotations[utilpod.PodHostnameAnnotation]; exists {
-		allErrs = append(allErrs, ValidateDNS1123Label(hostname, fldPath.Key(utilpod.PodHostnameAnnotation))...)
-	}
-	if subdomain, exists := annotations[utilpod.PodSubdomainAnnotation]; exists {
-		allErrs = append(allErrs, ValidateDNS1123Label(subdomain, fldPath.Key(utilpod.PodSubdomainAnnotation))...)
 	}
 
 	allErrs = append(allErrs, ValidateSeccompPodAnnotations(annotations, fldPath)...)

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -213,28 +213,8 @@ func (e *EndpointController) updatePod(old, cur interface{}) {
 }
 
 func hostNameAndDomainAreEqual(pod1, pod2 *v1.Pod) bool {
-	return getHostname(pod1) == getHostname(pod2) &&
-		getSubdomain(pod1) == getSubdomain(pod2)
-}
-
-func getHostname(pod *v1.Pod) string {
-	if len(pod.Spec.Hostname) > 0 {
-		return pod.Spec.Hostname
-	}
-	if pod.Annotations != nil {
-		return pod.Annotations[podutil.PodHostnameAnnotation]
-	}
-	return ""
-}
-
-func getSubdomain(pod *v1.Pod) string {
-	if len(pod.Spec.Subdomain) > 0 {
-		return pod.Spec.Subdomain
-	}
-	if pod.Annotations != nil {
-		return pod.Annotations[podutil.PodSubdomainAnnotation]
-	}
-	return ""
+	return pod1.Spec.Hostname == pod2.Spec.Hostname &&
+		pod1.Spec.Subdomain == pod2.Spec.Subdomain
 }
 
 // When a pod is deleted, enqueue the services the pod used to be a member of.
@@ -389,9 +369,9 @@ func (e *EndpointController) syncService(key string) error {
 					ResourceVersion: pod.ObjectMeta.ResourceVersion,
 				}}
 
-			hostname := getHostname(pod)
+			hostname := pod.Spec.Hostname
 			if len(hostname) > 0 &&
-				getSubdomain(pod) == service.Name &&
+				pod.Spec.Subdomain == service.Name &&
 				service.Namespace == pod.Namespace {
 				epa.Hostname = hostname
 			}

--- a/pkg/controller/statefulset/BUILD
+++ b/pkg/controller/statefulset/BUILD
@@ -20,7 +20,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
-        "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/apps/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/client/informers/informers_generated/externalversions/apps/v1beta1:go_default_library",
@@ -57,7 +56,6 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/apps/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset/fake:go_default_library",
         "//pkg/client/informers/informers_generated/externalversions:go_default_library",

--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/client-go/tools/record"
 
 	"k8s.io/kubernetes/pkg/api/v1"
-	podapi "k8s.io/kubernetes/pkg/api/v1/pod"
 	apps "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
 	appslisters "k8s.io/kubernetes/pkg/client/listers/apps/v1beta1"
@@ -401,7 +400,7 @@ func TestStatefulPodControlUpdatePodConflictFailure(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	updatedPod := newStatefulSetPod(set, 0)
-	updatedPod.Annotations[podapi.PodHostnameAnnotation] = "wrong"
+	updatedPod.Spec.Hostname = "wrong"
 	indexer.Add(updatedPod)
 	podLister := corelisters.NewPodLister(indexer)
 	control := NewRealStatefulPodControl(fakeClient, nil, podLister, nil, recorder)

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -23,7 +23,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api/v1"
-	podapi "k8s.io/kubernetes/pkg/api/v1/pod"
 	apps "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 	"k8s.io/kubernetes/pkg/controller"
 
@@ -108,9 +107,8 @@ func identityMatches(set *apps.StatefulSet, pod *v1.Pod) bool {
 		set.Name == parent &&
 		pod.Name == getPodName(set, ordinal) &&
 		pod.Namespace == set.Namespace &&
-		pod.Annotations != nil &&
-		pod.Annotations[podapi.PodHostnameAnnotation] == pod.Name &&
-		pod.Annotations[podapi.PodSubdomainAnnotation] == set.Spec.ServiceName
+		pod.Spec.Hostname == pod.Name &&
+		pod.Spec.Subdomain == set.Spec.ServiceName
 }
 
 // storageMatches returns true if pod's Volumes cover the set of PersistentVolumeClaims
@@ -182,11 +180,8 @@ func updateStorage(set *apps.StatefulSet, pod *v1.Pod) {
 func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	pod.Name = getPodName(set, getOrdinal(pod))
 	pod.Namespace = set.Namespace
-	if pod.Annotations == nil {
-		pod.Annotations = make(map[string]string)
-	}
-	pod.Annotations[podapi.PodHostnameAnnotation] = pod.Name
-	pod.Annotations[podapi.PodSubdomainAnnotation] = set.Spec.ServiceName
+	pod.Spec.Hostname = pod.Name
+	pod.Spec.Subdomain = set.Spec.ServiceName
 }
 
 // isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady, and if the init

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"k8s.io/kubernetes/pkg/api/v1"
-	podapi "k8s.io/kubernetes/pkg/api/v1/pod"
 	apps "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 	"k8s.io/kubernetes/pkg/controller"
 )
@@ -79,12 +78,12 @@ func TestIdentityMatches(t *testing.T) {
 		t.Error("identity matches for a Pod with the wrong namespace")
 	}
 	pod = newStatefulSetPod(set, 1)
-	delete(pod.Annotations, podapi.PodHostnameAnnotation)
+	pod.Spec.Hostname = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with no hostname")
 	}
 	pod = newStatefulSetPod(set, 1)
-	delete(pod.Annotations, podapi.PodSubdomainAnnotation)
+	pod.Spec.Subdomain = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with no subdomain")
 	}
@@ -138,7 +137,7 @@ func TestUpdateIdentity(t *testing.T) {
 		t.Error("updateIdentity failed to update the Pods namespace")
 	}
 	pod = newStatefulSetPod(set, 1)
-	delete(pod.Annotations, podapi.PodHostnameAnnotation)
+	pod.Spec.Hostname = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with no hostname")
 	}
@@ -147,22 +146,13 @@ func TestUpdateIdentity(t *testing.T) {
 		t.Error("updateIdentity failed to update the Pod's hostname")
 	}
 	pod = newStatefulSetPod(set, 1)
-	delete(pod.Annotations, podapi.PodSubdomainAnnotation)
+	pod.Spec.Subdomain = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with no subdomain")
 	}
 	updateIdentity(set, pod)
 	if !identityMatches(set, pod) {
 		t.Error("updateIdentity failed to update the Pod's subdomain")
-	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Annotations = nil
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod no annotations")
-	}
-	updateIdentity(set, pod)
-	if !identityMatches(set, pod) {
-		t.Error("updateIdentity failed to update the Pod's annotations")
 	}
 }
 

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -37,7 +37,6 @@ go_library(
         "//cmd/kubelet/app/options:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
-        "//pkg/api/v1/pod:go_default_library",
         "//pkg/api/v1/validation:go_default_library",
         "//pkg/apis/componentconfig:go_default_library",
         "//pkg/apis/componentconfig/v1alpha1:go_default_library",

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
-	utilpod "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/api/v1/validation"
 	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -250,23 +249,15 @@ func truncatePodHostnameIfNeeded(podName, hostname string) (string, error) {
 func (kl *Kubelet) GeneratePodHostNameAndDomain(pod *v1.Pod) (string, string, error) {
 	// TODO(vmarmol): Handle better.
 	clusterDomain := kl.clusterDomain
-	podAnnotations := pod.Annotations
-	if podAnnotations == nil {
-		podAnnotations = make(map[string]string)
-	}
+
 	hostname := pod.Name
 	if len(pod.Spec.Hostname) > 0 {
 		if msgs := utilvalidation.IsDNS1123Label(pod.Spec.Hostname); len(msgs) != 0 {
 			return "", "", fmt.Errorf("Pod Hostname %q is not a valid DNS label: %s", pod.Spec.Hostname, strings.Join(msgs, ";"))
 		}
 		hostname = pod.Spec.Hostname
-	} else {
-		hostnameCandidate := podAnnotations[utilpod.PodHostnameAnnotation]
-		if len(utilvalidation.IsDNS1123Label(hostnameCandidate)) == 0 {
-			// use hostname annotation, if specified.
-			hostname = hostnameCandidate
-		}
 	}
+
 	hostname, err := truncatePodHostnameIfNeeded(pod.Name, hostname)
 	if err != nil {
 		return "", "", err
@@ -278,12 +269,8 @@ func (kl *Kubelet) GeneratePodHostNameAndDomain(pod *v1.Pod) (string, string, er
 			return "", "", fmt.Errorf("Pod Subdomain %q is not a valid DNS label: %s", pod.Spec.Subdomain, strings.Join(msgs, ";"))
 		}
 		hostDomain = fmt.Sprintf("%s.%s.svc.%s", pod.Spec.Subdomain, pod.Namespace, clusterDomain)
-	} else {
-		subdomainCandidate := pod.Annotations[utilpod.PodSubdomainAnnotation]
-		if len(utilvalidation.IsDNS1123Label(subdomainCandidate)) == 0 {
-			hostDomain = fmt.Sprintf("%s.%s.svc.%s", subdomainCandidate, pod.Namespace, clusterDomain)
-		}
 	}
+
 	return hostname, hostDomain, nil
 }
 

--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -94,7 +94,6 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/api/annotations:go_default_library",
         "//pkg/api/v1:go_default_library",
-        "//pkg/api/v1/pod:go_default_library",
         "//pkg/api/v1/service:go_default_library",
         "//pkg/apis/apps/v1beta1:go_default_library",
         "//pkg/apis/batch:go_default_library",

--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -106,15 +105,9 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd string, useAnnotatio
 		},
 	}
 
-	if useAnnotation {
-		dnsPod.ObjectMeta.Annotations = map[string]string{
-			pod.PodHostnameAnnotation:  dnsTestPodHostName,
-			pod.PodSubdomainAnnotation: dnsTestServiceName,
-		}
-	} else {
-		dnsPod.Spec.Hostname = dnsTestPodHostName
-		dnsPod.Spec.Subdomain = dnsTestServiceName
-	}
+	dnsPod.Spec.Hostname = dnsTestPodHostName
+	dnsPod.Spec.Subdomain = dnsTestServiceName
+
 	return dnsPod
 }
 
@@ -439,10 +432,8 @@ var _ = framework.KubeDescribe("DNS", func() {
 		By("creating a pod to probe DNS")
 		pod1 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, true)
 		pod1.ObjectMeta.Labels = testServiceSelector
-		pod1.ObjectMeta.Annotations = map[string]string{
-			pod.PodHostnameAnnotation:  podHostname,
-			pod.PodSubdomainAnnotation: serviceName,
-		}
+		pod1.Spec.Hostname = podHostname
+		pod1.Spec.Subdomain = serviceName
 
 		validateDNSResults(f, pod1, append(wheezyFileNames, jessieFileNames...))
 	})


### PR DESCRIPTION
fixes #44135

```release-note
Remove `pod.beta.kubernetes.io/hostname` and `pod.beta.kubernetes.io/subdomain` annotations. 
Users should use `pod.spec.hostname` and `pod.spec.subdomain` instead.
```