### PR TITLE
Updated comments according to the logic.

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -56,8 +56,8 @@ func (o overlappingStatefulSets) Less(i, j int) bool {
 var statefulPodRegex = regexp.MustCompile("(.*)-([0-9]+)$")
 
 // getParentNameAndOrdinal gets the name of pod's parent StatefulSet and pod's ordinal as extracted from its Name. If
-// the Pod was not created by a StatefulSet, its parent is considered to be nil, and its ordinal is considered to be
-// -1.
+// the Pod was not created by a StatefulSet, its parent is considered to be empty string, and its ordinal is considered
+// to be -1.
 func getParentNameAndOrdinal(pod *v1.Pod) (string, int) {
 	parent := ""
 	ordinal := -1


### PR DESCRIPTION
Updated comments according to the logic: it'll return empty string instead of nil if failed to match the regex.