### PR TITLE
Fix Cluster-Autoscaler e2e on testgrid

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -163,7 +163,7 @@ var _ = framework.KubeDescribe("Cluster size autoscaling [Slow]", func() {
 		unmanagedNodes := nodeCount - status.ready
 
 		By("Schedule more pods than can fit and wait for claster to scale-up")
-		ReserveMemory(f, "memory-reservation", 100, (nodeCount+2)*memCapacityMb, false, 1*time.Second)
+		ReserveMemory(f, "memory-reservation", 100, nodeCount*memCapacityMb, false, 1*time.Second)
 		defer framework.DeleteRCAndPods(f.ClientSet, f.InternalClientset, f.Namespace.Name, "memory-reservation")
 
 		status, err = waitForScaleUpStatus(c, caOngoingScaleUpStatus, scaleUpTriggerTimeout)


### PR DESCRIPTION
Fix an e2e test failing in CI. The failures were caused by maximum nodes in test env being lower than the number of nodes required by the test.
