### PR TITLE
Fix: check "ok" first to avoid panic

### DIFF
--- a/plugin/pkg/scheduler/schedulercache/cache.go
+++ b/plugin/pkg/scheduler/schedulercache/cache.go
@@ -161,7 +161,7 @@ func (cache *schedulerCache) ForgetPod(pod *v1.Pod) error {
 	defer cache.mu.Unlock()
 
 	currState, ok := cache.podStates[key]
-	if currState.pod.Spec.NodeName != pod.Spec.NodeName {
+	if ok && currState.pod.Spec.NodeName != pod.Spec.NodeName {
 		return fmt.Errorf("pod %v state was assumed on a different node", key)
 	}
 


### PR DESCRIPTION
Check "ok" and then check if "currState.pod.Spec.NodeName != pod.Spec.NodeName", here if currState is nil, it will panic.

**Release note**:
```release-note
NONE
```
