### PR TITLE
Re-enabled HPA upgrade e2e test

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -33,8 +33,7 @@ var upgradeTests = []upgrades.Test{
 	&upgrades.DeploymentUpgradeTest{},
 	&upgrades.JobUpgradeTest{},
 	&upgrades.ConfigMapUpgradeTest{},
-	// Disabling until can be debugged, causing upgrade jobs to timeout
-	// &upgrades.HPAUpgradeTest{},
+	&upgrades.HPAUpgradeTest{},
 	&upgrades.PersistentVolumeUpgradeTest{},
 	&upgrades.DaemonSetUpgradeTest{},
 	&upgrades.IngressUpgradeTest{},


### PR DESCRIPTION
Re-enabled HPA upgrade e2e test.

```release-note
NONE
```
