### PR TITLE
Restore "Setting endpoints" log message

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -671,6 +671,7 @@ func accumulateEndpointsMap(endpoints *api.Endpoints, hostname string,
 				}
 				(*newEndpoints)[svcPort] = append((*newEndpoints)[svcPort], epInfo)
 			}
+			glog.V(3).Infof("Setting endpoints for %q to %+v", svcPort, (*newEndpoints)[svcPort])
 		}
 	}
 }

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -671,7 +671,13 @@ func accumulateEndpointsMap(endpoints *api.Endpoints, hostname string,
 				}
 				(*newEndpoints)[svcPort] = append((*newEndpoints)[svcPort], epInfo)
 			}
-			glog.V(3).Infof("Setting endpoints for %q to %+v", svcPort, (*newEndpoints)[svcPort])
+			if glog.V(3) {
+				newEPList := []string{}
+				for _, ep := range (*newEndpoints)[svcPort] {
+					newEPList = append(newEPList, ep.endpoint)
+				}
+				glog.Infof("Setting endpoints for %q to %+v", svcPort, newEPList)
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

The "Setting endpoints" message from kube-proxy at high verbosity was
lost as part of a larger simplification in kubernetes/kubernetes#42747.

This change brings it back, simply outputting the just-constructed
addresses list.

I need this message to monitor delays in propagating endpoints changes across nodes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
