### PR TITLE
fix kubedns-sa.yaml missing "namespace: kube-system" value

### DIFF
--- a/cluster/addons/dns/kubedns-sa.yaml
+++ b/cluster/addons/dns/kubedns-sa.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-dns
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
The file kubedns-sa.yaml  missing `namespace: kube-system`,  so it will create ServiceAccount kube-dns in default namespace, this will cause kube-dns deployment's pods be blocked forever;

Some logs as following：

>     - lastTransitionTime: 2017-04-06T19:02:12Z
>       lastUpdateTime: 2017-04-06T19:02:12Z
>       message: 'unable to create pods: pods "kube-dns-699984412-" is forbidden: service
>         account kube-system/kube-dns was not found, retry after the service account

**Release note**:

```release-note
NONE
```