### PR TITLE
move PD delete to AfterEach

### DIFF
--- a/test/e2e/persistent_volumes-gce.go
+++ b/test/e2e/persistent_volumes-gce.go
@@ -107,12 +107,9 @@ var _ = framework.KubeDescribe("PersistentVolumes:GCEPD [Volume]", func() {
 			framework.DeletePodWithWait(f, c, clientPod)
 			framework.PVPVCCleanup(c, ns, pv, pvc)
 			clientPod, pv, pvc, node = nil, nil, nil, ""
-		}
-	})
-
-	AddCleanupAction(func() {
-		if len(diskName) > 0 {
-			framework.DeletePDWithRetry(diskName)
+			if diskName != "" {
+				framework.DeletePDWithRetry(diskName)
+			}
 		}
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug in PersistentVolume E2E that causes GCEPDs to be left un-deleted after a test ends.

```release-note
None
```
