### PR TITLE
Fix pv upgrade test failure

### DIFF
--- a/test/e2e/upgrades/persistent_volumes.go
+++ b/test/e2e/upgrades/persistent_volumes.go
@@ -33,7 +33,7 @@ type PersistentVolumeUpgradeTest struct {
 func (PersistentVolumeUpgradeTest) Name() string { return "persistent-volume-upgrade" }
 
 const (
-	pvTestFile string = "/mnt/pv_upgrade_test"
+	pvTestFile string = "/mnt/volume1/pv_upgrade_test"
 	pvTestData string = "keep it pv"
 	pvWriteCmd string = "echo \"" + pvTestData + "\" > " + pvTestFile
 	pvReadCmd  string = "cat " + pvTestFile
@@ -99,7 +99,7 @@ func (t *PersistentVolumeUpgradeTest) Teardown(f *framework.Framework) {
 
 // testPod creates a pod that consumes a pv and prints it out. The output is then verified.
 func (t *PersistentVolumeUpgradeTest) testPod(f *framework.Framework, cmd string) {
-	pod := framework.CreatePod(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{t.pvc}, false, cmd)
+	pod := framework.MakePod(f.Namespace.Name, []*v1.PersistentVolumeClaim{t.pvc}, false, cmd)
 	expectedOutput := []string{pvTestData}
 	f.TestContainerOutput("pod consumes pv", pod, 0, expectedOutput)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
2 changes were made that broke the pv upgrade test:
1. MakePod() was changed so that the volume mount point is at /mnt/volume<n> instead of /mnt.  This change updates the path that the pod writes to.
2. The MakePod() call was changed to CreatePod(), which creates the pod and expects a long running pod.  But the upgrade test uses a short running pod, and the call to TestContainerOutput() will also create the pod. This changes it back to MakePod()


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #44168

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
NONE
