### PR TITLE
[Federation][Kubefed] Bug fix to enable disabling federation controllers through override args

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -912,7 +912,7 @@ func marshallOverrides(overrideArgString string) (map[string]string, error) {
 	argsMap := make(map[string]string)
 	overrideArgs := strings.Split(overrideArgString, ",")
 	for _, overrideArg := range overrideArgs {
-		splitArg := strings.Split(overrideArg, "=")
+		splitArg := strings.SplitN(overrideArg, "=", 2)
 		if len(splitArg) != 2 {
 			return nil, fmt.Errorf("wrong format for override arg: %s", overrideArg)
 		}

--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -322,8 +322,10 @@ func TestMarshallAndMergeOverrides(t *testing.T) {
 			expectedErr:    "wrong format for override arg: wrong-format-arg",
 		},
 		{
-			overrideParams: "wrong-format-arg=override=wrong-format-arg=override",
-			expectedErr:    "wrong format for override arg: wrong-format-arg=override=wrong-format-arg=override",
+			// TODO: Multiple arg values separated by , are not supported yet
+			overrideParams: "multiple-equalto-char=first-key=1",
+			expectedSet:    sets.NewString("arg2=val2", "arg1=val1", "multiple-equalto-char=first-key=1"),
+			expectedErr:    "",
 		},
 		{
 			overrideParams: "=wrong-format-only-value",


### PR DESCRIPTION
Targets https://github.com/kubernetes/kubernetes/issues/42761

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/42761

**Special notes for your reviewer**:
@marun @perotinus @nikhiljindal 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
NONE 
```
