### PR TITLE
Add shashidharatd and madhusudancs as hack/ approvers.

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -13,5 +13,7 @@ approvers:
   - ixdy
   - jbeda
   - lavalamp
+  - madhusudancs
+  - shashidharatd
   - spxtr
   - zmerlynn


### PR DESCRIPTION
Federation team has a bunch of scripts in `hack/` directory and for iterating quickly we need approvers permission in this directory. Both @shashidharatd and I have made number of changes to the scripts in this directory and generally understand the scripts here well. 

**Release note**:
```release-note
NONE
```

/assign @fejta 