### PR TITLE
validateClusterInfo: use clientcmdapi.NewCluster()

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -167,7 +167,8 @@ func ConfirmUsable(config clientcmdapi.Config, passedContextName string) error {
 func validateClusterInfo(clusterName string, clusterInfo clientcmdapi.Cluster) []error {
 	validationErrors := make([]error, 0)
 
-	if reflect.DeepEqual(clientcmdapi.Cluster{}, clusterInfo) {
+	emptyCluster := clientcmdapi.NewCluster()
+	if reflect.DeepEqual(*emptyCluster, clusterInfo) {
 		return []error{ErrEmptyCluster}
 	}
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
@@ -187,7 +187,7 @@ func TestValidateEmptyContext(t *testing.T) {
 
 func TestValidateEmptyClusterInfo(t *testing.T) {
 	config := clientcmdapi.NewConfig()
-	config.Clusters["empty"] = &clientcmdapi.Cluster{}
+	config.Clusters["empty"] = clientcmdapi.NewCluster()
 	test := configValidationTest{
 		config:                 config,
 		expectedErrorSubstring: []string{"cluster has no server defined"},
@@ -196,6 +196,19 @@ func TestValidateEmptyClusterInfo(t *testing.T) {
 	test.testCluster("empty", t)
 	test.testConfig(t)
 }
+
+func TestValidateClusterInfoErrEmptyCluster(t *testing.T) {
+	cluster := clientcmdapi.NewCluster()
+	errs := validateClusterInfo("", *cluster)
+
+	if len(errs) != 1 {
+		t.Fatalf("unexpected errors: %v", errs)
+	}
+	if errs[0] != ErrEmptyCluster {
+		t.Errorf("unexpected error: %v", errs[0])
+	}
+}
+
 func TestValidateMissingCAFileClusterInfo(t *testing.T) {
 	config := clientcmdapi.NewConfig()
 	config.Clusters["missing ca"] = &clientcmdapi.Cluster{


### PR DESCRIPTION
Change validateClusterInfo to use clientcmdapi.NewCluster() instead of
clientcmdapi.Cluster{} when comparing against the passed in clusterInfo.
clusterInfo most likely will be a combination of
clientcmdapi.NewCluster() merged with potential overrides. This is
necessary because otherwise, the DeepEqual between what is supposed to
be an empty Cluster and clusterInfo will fail, resulting in an error
that doesn't allow fall-through to checking for in-cluster
configuration.

https://github.com/kubernetes/kubernetes/pull/40508 changed `DirectClientConfig.getContext()` to start with a `clientcmdapi.NewCluster()` instead of the zero value for `clientcmdapi.Cluster`. This means that the `Extensions` map in the `Cluster` is initialized instead of `nil`, which breaks the `DeepEqual` test unless you compare `clusterInfo` against an initialized `clientcmdapi.NewCluster()`.

cc @smarterclayton @sttts @vjsamuel @liggitt @deads2k @soltysh @fabianofranz @kubernetes/sig-api-machinery-pr-reviews 