### PR TITLE
move constants to their own file

### DIFF
--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -11,6 +11,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "annotation_key_constants.go",
         "defaults.go",
         "doc.go",
         "field_constants.go",

--- a/pkg/api/annotation_key_constants.go
+++ b/pkg/api/annotation_key_constants.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+const (
+	// TolerationsAnnotationKey represents the key of tolerations data (json serialized)
+	// in the Annotations of a Pod.
+	TolerationsAnnotationKey string = "scheduler.alpha.kubernetes.io/tolerations"
+
+	// TaintsAnnotationKey represents the key of taints data (json serialized)
+	// in the Annotations of a Node.
+	TaintsAnnotationKey string = "scheduler.alpha.kubernetes.io/taints"
+
+	// SeccompPodAnnotationKey represents the key of a seccomp profile applied
+	// to all containers of a pod.
+	SeccompPodAnnotationKey string = "seccomp.security.alpha.kubernetes.io/pod"
+
+	// SeccompContainerAnnotationKeyPrefix represents the key of a seccomp profile applied
+	// to one container of a pod.
+	SeccompContainerAnnotationKeyPrefix string = "container.seccomp.security.alpha.kubernetes.io/"
+
+	// CreatedByAnnotation represents the key used to store the spec(json)
+	// used to create the resource.
+	CreatedByAnnotation = "kubernetes.io/created-by"
+
+	// PreferAvoidPodsAnnotationKey represents the key of preferAvoidPods data (json serialized)
+	// in the Annotations of a Node.
+	PreferAvoidPodsAnnotationKey string = "scheduler.alpha.kubernetes.io/preferAvoidPods"
+
+	// SysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
+	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
+	// key-value pairs. Only a limited set of whitelisted and isolated sysctls is supported by
+	// the kubelet. Pods with other sysctls will fail to launch.
+	SysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/sysctls"
+
+	// UnsafeSysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
+	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
+	// key-value pairs. Unsafe sysctls must be explicitly enabled for a kubelet. They are properly
+	// namespaced to a pod or a container, but their isolation is usually unclear or weak. Their use
+	// is at-your-own-risk. Pods that attempt to set an unsafe sysctl that is not enabled for a kubelet
+	// will fail to launch.
+	UnsafeSysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/unsafe-sysctls"
+
+	// ObjectTTLAnnotations represents a suggestion for kubelet for how long it can cache
+	// an object (e.g. secret, config map) before fetching it again from apiserver.
+	// This annotation can be attached to node.
+	ObjectTTLAnnotationKey string = "node.alpha.kubernetes.io/ttl"
+
+	// AffinityAnnotationKey represents the key of affinity data (json serialized)
+	// in the Annotations of a Pod.
+	// TODO: remove when alpha support for affinity is removed
+	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
+)

--- a/pkg/api/helpers.go
+++ b/pkg/api/helpers.go
@@ -429,56 +429,6 @@ func NodeSelectorRequirementsAsSelector(nsm []NodeSelectorRequirement) (labels.S
 	return selector, nil
 }
 
-const (
-	// TolerationsAnnotationKey represents the key of tolerations data (json serialized)
-	// in the Annotations of a Pod.
-	TolerationsAnnotationKey string = "scheduler.alpha.kubernetes.io/tolerations"
-
-	// TaintsAnnotationKey represents the key of taints data (json serialized)
-	// in the Annotations of a Node.
-	TaintsAnnotationKey string = "scheduler.alpha.kubernetes.io/taints"
-
-	// SeccompPodAnnotationKey represents the key of a seccomp profile applied
-	// to all containers of a pod.
-	SeccompPodAnnotationKey string = "seccomp.security.alpha.kubernetes.io/pod"
-
-	// SeccompContainerAnnotationKeyPrefix represents the key of a seccomp profile applied
-	// to one container of a pod.
-	SeccompContainerAnnotationKeyPrefix string = "container.seccomp.security.alpha.kubernetes.io/"
-
-	// CreatedByAnnotation represents the key used to store the spec(json)
-	// used to create the resource.
-	CreatedByAnnotation = "kubernetes.io/created-by"
-
-	// PreferAvoidPodsAnnotationKey represents the key of preferAvoidPods data (json serialized)
-	// in the Annotations of a Node.
-	PreferAvoidPodsAnnotationKey string = "scheduler.alpha.kubernetes.io/preferAvoidPods"
-
-	// SysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
-	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
-	// key-value pairs. Only a limited set of whitelisted and isolated sysctls is supported by
-	// the kubelet. Pods with other sysctls will fail to launch.
-	SysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/sysctls"
-
-	// UnsafeSysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
-	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
-	// key-value pairs. Unsafe sysctls must be explicitly enabled for a kubelet. They are properly
-	// namespaced to a pod or a container, but their isolation is usually unclear or weak. Their use
-	// is at-your-own-risk. Pods that attempt to set an unsafe sysctl that is not enabled for a kubelet
-	// will fail to launch.
-	UnsafeSysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/unsafe-sysctls"
-
-	// ObjectTTLAnnotations represents a suggestion for kubelet for how long it can cache
-	// an object (e.g. secret, config map) before fetching it again from apiserver.
-	// This annotation can be attached to node.
-	ObjectTTLAnnotationKey string = "node.alpha.kubernetes.io/ttl"
-
-	// AffinityAnnotationKey represents the key of affinity data (json serialized)
-	// in the Annotations of a Pod.
-	// TODO: remove when alpha support for affinity is removed
-	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
-)
-
 // GetTolerationsFromPodAnnotations gets the json serialized tolerations data from Pod.Annotations
 // and converts it to the []Toleration type in api.
 func GetTolerationsFromPodAnnotations(annotations map[string]string) ([]Toleration, error) {

--- a/staging/src/k8s.io/client-go/pkg/api/annotation_key_constants.go
+++ b/staging/src/k8s.io/client-go/pkg/api/annotation_key_constants.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+const (
+	// TolerationsAnnotationKey represents the key of tolerations data (json serialized)
+	// in the Annotations of a Pod.
+	TolerationsAnnotationKey string = "scheduler.alpha.kubernetes.io/tolerations"
+
+	// TaintsAnnotationKey represents the key of taints data (json serialized)
+	// in the Annotations of a Node.
+	TaintsAnnotationKey string = "scheduler.alpha.kubernetes.io/taints"
+
+	// SeccompPodAnnotationKey represents the key of a seccomp profile applied
+	// to all containers of a pod.
+	SeccompPodAnnotationKey string = "seccomp.security.alpha.kubernetes.io/pod"
+
+	// SeccompContainerAnnotationKeyPrefix represents the key of a seccomp profile applied
+	// to one container of a pod.
+	SeccompContainerAnnotationKeyPrefix string = "container.seccomp.security.alpha.kubernetes.io/"
+
+	// CreatedByAnnotation represents the key used to store the spec(json)
+	// used to create the resource.
+	CreatedByAnnotation = "kubernetes.io/created-by"
+
+	// PreferAvoidPodsAnnotationKey represents the key of preferAvoidPods data (json serialized)
+	// in the Annotations of a Node.
+	PreferAvoidPodsAnnotationKey string = "scheduler.alpha.kubernetes.io/preferAvoidPods"
+
+	// SysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
+	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
+	// key-value pairs. Only a limited set of whitelisted and isolated sysctls is supported by
+	// the kubelet. Pods with other sysctls will fail to launch.
+	SysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/sysctls"
+
+	// UnsafeSysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
+	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
+	// key-value pairs. Unsafe sysctls must be explicitly enabled for a kubelet. They are properly
+	// namespaced to a pod or a container, but their isolation is usually unclear or weak. Their use
+	// is at-your-own-risk. Pods that attempt to set an unsafe sysctl that is not enabled for a kubelet
+	// will fail to launch.
+	UnsafeSysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/unsafe-sysctls"
+
+	// ObjectTTLAnnotations represents a suggestion for kubelet for how long it can cache
+	// an object (e.g. secret, config map) before fetching it again from apiserver.
+	// This annotation can be attached to node.
+	ObjectTTLAnnotationKey string = "node.alpha.kubernetes.io/ttl"
+
+	// AffinityAnnotationKey represents the key of affinity data (json serialized)
+	// in the Annotations of a Pod.
+	// TODO: remove when alpha support for affinity is removed
+	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
+)

--- a/staging/src/k8s.io/client-go/pkg/api/helpers.go
+++ b/staging/src/k8s.io/client-go/pkg/api/helpers.go
@@ -429,56 +429,6 @@ func NodeSelectorRequirementsAsSelector(nsm []NodeSelectorRequirement) (labels.S
 	return selector, nil
 }
 
-const (
-	// TolerationsAnnotationKey represents the key of tolerations data (json serialized)
-	// in the Annotations of a Pod.
-	TolerationsAnnotationKey string = "scheduler.alpha.kubernetes.io/tolerations"
-
-	// TaintsAnnotationKey represents the key of taints data (json serialized)
-	// in the Annotations of a Node.
-	TaintsAnnotationKey string = "scheduler.alpha.kubernetes.io/taints"
-
-	// SeccompPodAnnotationKey represents the key of a seccomp profile applied
-	// to all containers of a pod.
-	SeccompPodAnnotationKey string = "seccomp.security.alpha.kubernetes.io/pod"
-
-	// SeccompContainerAnnotationKeyPrefix represents the key of a seccomp profile applied
-	// to one container of a pod.
-	SeccompContainerAnnotationKeyPrefix string = "container.seccomp.security.alpha.kubernetes.io/"
-
-	// CreatedByAnnotation represents the key used to store the spec(json)
-	// used to create the resource.
-	CreatedByAnnotation = "kubernetes.io/created-by"
-
-	// PreferAvoidPodsAnnotationKey represents the key of preferAvoidPods data (json serialized)
-	// in the Annotations of a Node.
-	PreferAvoidPodsAnnotationKey string = "scheduler.alpha.kubernetes.io/preferAvoidPods"
-
-	// SysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
-	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
-	// key-value pairs. Only a limited set of whitelisted and isolated sysctls is supported by
-	// the kubelet. Pods with other sysctls will fail to launch.
-	SysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/sysctls"
-
-	// UnsafeSysctlsPodAnnotationKey represents the key of sysctls which are set for the infrastructure
-	// container of a pod. The annotation value is a comma separated list of sysctl_name=value
-	// key-value pairs. Unsafe sysctls must be explicitly enabled for a kubelet. They are properly
-	// namespaced to a pod or a container, but their isolation is usually unclear or weak. Their use
-	// is at-your-own-risk. Pods that attempt to set an unsafe sysctl that is not enabled for a kubelet
-	// will fail to launch.
-	UnsafeSysctlsPodAnnotationKey string = "security.alpha.kubernetes.io/unsafe-sysctls"
-
-	// ObjectTTLAnnotations represents a suggestion for kubelet for how long it can cache
-	// an object (e.g. secret, config map) before fetching it again from apiserver.
-	// This annotation can be attached to node.
-	ObjectTTLAnnotationKey string = "node.alpha.kubernetes.io/ttl"
-
-	// AffinityAnnotationKey represents the key of affinity data (json serialized)
-	// in the Annotations of a Pod.
-	// TODO: remove when alpha support for affinity is removed
-	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
-)
-
 // GetTolerationsFromPodAnnotations gets the json serialized tolerations data from Pod.Annotations
 // and converts it to the []Toleration type in api.
 func GetTolerationsFromPodAnnotations(annotations map[string]string) ([]Toleration, error) {

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -13539,6 +13539,7 @@ go_library(
 go_library(
     name = "k8s.io/client-go/pkg/api",
     srcs = [
+        "k8s.io/client-go/pkg/api/annotation_key_constants.go",
         "k8s.io/client-go/pkg/api/defaults.go",
         "k8s.io/client-go/pkg/api/doc.go",
         "k8s.io/client-go/pkg/api/field_constants.go",


### PR DESCRIPTION
A step towards #44065

These constants are part of the API and will be moved to k8s.io/api. The helper functions are not and will remain in the main repo. This PR separates them to different files. Next step is put all the helper functions into sub-packages, so that the package `k8s.io/kubernetes/pkg/api` only contains code we want to move to k8s.io/api.

I added the retest-not-required label because this just moves code to another file in the same package.