### PR TITLE
Automated cherry pick of #43951

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -105,7 +105,7 @@ func (r *Reset) Run(out io.Writer) error {
 	}
 
 	dockerCheck := preflight.ServiceCheck{Service: "docker", CheckIfActive: true}
-	if warnings, errors := dockerCheck.Check(); len(warnings) == 0 && len(errors) == 0 {
+	if _, errors := dockerCheck.Check(); len(errors) == 0 {
 		fmt.Println("[reset] Removing kubernetes-managed containers")
 		if err := exec.Command("sh", "-c", "docker ps | grep 'k8s_' | awk '{print $1}' | xargs -r docker rm --force --volumes").Run(); err != nil {
 			fmt.Println("[reset] Failed to stop the running containers")


### PR DESCRIPTION
Cherry pick of #43951 on release-1.6.

#43951: Don't fail on warnings from the docker activeness check