### PR TITLE
Remove ObjectMetaFor

### DIFF
--- a/pkg/api/v1/meta.go
+++ b/pkg/api/v1/meta.go
@@ -35,6 +35,8 @@ func (meta *ObjectMeta) GetUID() types.UID                   { return meta.UID }
 func (meta *ObjectMeta) SetUID(uid types.UID)                { meta.UID = uid }
 func (meta *ObjectMeta) GetResourceVersion() string          { return meta.ResourceVersion }
 func (meta *ObjectMeta) SetResourceVersion(version string)   { meta.ResourceVersion = version }
+func (meta *ObjectMeta) GetGeneration() int64                { return meta.Generation }
+func (meta *ObjectMeta) SetGeneration(generation int64)      { meta.Generation = generation }
 func (meta *ObjectMeta) GetSelfLink() string                 { return meta.SelfLink }
 func (meta *ObjectMeta) SetSelfLink(selfLink string)         { meta.SelfLink = selfLink }
 func (meta *ObjectMeta) GetCreationTimestamp() metav1.Time   { return meta.CreationTimestamp }
@@ -44,6 +46,10 @@ func (meta *ObjectMeta) SetCreationTimestamp(creationTimestamp metav1.Time) {
 func (meta *ObjectMeta) GetDeletionTimestamp() *metav1.Time { return meta.DeletionTimestamp }
 func (meta *ObjectMeta) SetDeletionTimestamp(deletionTimestamp *metav1.Time) {
 	meta.DeletionTimestamp = deletionTimestamp
+}
+func (meta *ObjectMeta) GetDeletionGracePeriodSeconds() *int64 { return meta.DeletionGracePeriodSeconds }
+func (meta *ObjectMeta) SetDeletionGracePeriodSeconds(deletionGracePeriodSeconds *int64) {
+	meta.DeletionGracePeriodSeconds = deletionGracePeriodSeconds
 }
 func (meta *ObjectMeta) GetLabels() map[string]string                 { return meta.Labels }
 func (meta *ObjectMeta) SetLabels(labels map[string]string)           { meta.Labels = labels }

--- a/pkg/registry/core/service/BUILD
+++ b/pkg/registry/core/service/BUILD
@@ -65,6 +65,7 @@ go_test(
         "//pkg/registry/core/service/portallocator:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
+        "//vendor:k8s.io/apimachinery/pkg/api/meta",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/util/intstr",

--- a/pkg/registry/core/service/rest_test.go
+++ b/pkg/registry/core/service/rest_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
@@ -98,7 +99,11 @@ func TestServiceRegistryCreate(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	created_service := created_svc.(*api.Service)
-	if !metav1.HasObjectMetaSystemFieldValues(&created_service.ObjectMeta) {
+	objMeta, err := meta.Accessor(created_service)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !metav1.HasObjectMetaSystemFieldValues(objMeta) {
 		t.Errorf("storage did not populate object meta field values")
 	}
 	if created_service.Name != "foo" {
@@ -218,7 +223,11 @@ func TestServiceRegistryCreateMultiNodePortsService(t *testing.T) {
 			t.Fatalf("Unexpected error: %v", err)
 		}
 		created_service := created_svc.(*api.Service)
-		if !metav1.HasObjectMetaSystemFieldValues(&created_service.ObjectMeta) {
+		objMeta, err := meta.Accessor(created_service)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !metav1.HasObjectMetaSystemFieldValues(objMeta) {
 			t.Errorf("storage did not populate object meta field values")
 		}
 		if created_service.Name != test.name {

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
@@ -228,7 +228,7 @@ func NewUIDPreconditions(uid string) *Preconditions {
 }
 
 // HasObjectMetaSystemFieldValues returns true if fields that are managed by the system on ObjectMeta have values.
-func HasObjectMetaSystemFieldValues(meta *ObjectMeta) bool {
-	return !meta.CreationTimestamp.Time.IsZero() ||
-		len(meta.UID) != 0
+func HasObjectMetaSystemFieldValues(meta Object) bool {
+	return !meta.GetCreationTimestamp().Time.IsZero() ||
+		len(meta.GetUID()) != 0
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/meta.go
@@ -17,24 +17,9 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
-
-// ObjectMetaFor returns a pointer to a provided object's ObjectMeta.
-// TODO: allow runtime.Unknown to extract this object
-// TODO: Remove this function and use meta.ObjectMetaAccessor() instead.
-func ObjectMetaFor(obj runtime.Object) (*ObjectMeta, error) {
-	v, err := conversion.EnforcePtr(obj)
-	if err != nil {
-		return nil, err
-	}
-	var meta *ObjectMeta
-	err = runtime.FieldPtr(v, "ObjectMeta", &meta)
-	return meta, err
-}
 
 // TODO: move this, Object, List, and Type to a different package
 type ObjectMetaAccessor interface {
@@ -56,12 +41,16 @@ type Object interface {
 	SetUID(uid types.UID)
 	GetResourceVersion() string
 	SetResourceVersion(version string)
+	GetGeneration() int64
+	SetGeneration(generation int64)
 	GetSelfLink() string
 	SetSelfLink(selfLink string)
 	GetCreationTimestamp() Time
 	SetCreationTimestamp(timestamp Time)
 	GetDeletionTimestamp() *Time
 	SetDeletionTimestamp(timestamp *Time)
+	GetDeletionGracePeriodSeconds() *int64
+	SetDeletionGracePeriodSeconds(*int64)
 	GetLabels() map[string]string
 	SetLabels(labels map[string]string)
 	GetAnnotations() map[string]string
@@ -132,6 +121,8 @@ func (meta *ObjectMeta) GetUID() types.UID                   { return meta.UID }
 func (meta *ObjectMeta) SetUID(uid types.UID)                { meta.UID = uid }
 func (meta *ObjectMeta) GetResourceVersion() string          { return meta.ResourceVersion }
 func (meta *ObjectMeta) SetResourceVersion(version string)   { meta.ResourceVersion = version }
+func (meta *ObjectMeta) GetGeneration() int64                { return meta.Generation }
+func (meta *ObjectMeta) SetGeneration(generation int64)      { meta.Generation = generation }
 func (meta *ObjectMeta) GetSelfLink() string                 { return meta.SelfLink }
 func (meta *ObjectMeta) SetSelfLink(selfLink string)         { meta.SelfLink = selfLink }
 func (meta *ObjectMeta) GetCreationTimestamp() Time          { return meta.CreationTimestamp }
@@ -141,6 +132,10 @@ func (meta *ObjectMeta) SetCreationTimestamp(creationTimestamp Time) {
 func (meta *ObjectMeta) GetDeletionTimestamp() *Time { return meta.DeletionTimestamp }
 func (meta *ObjectMeta) SetDeletionTimestamp(deletionTimestamp *Time) {
 	meta.DeletionTimestamp = deletionTimestamp
+}
+func (meta *ObjectMeta) GetDeletionGracePeriodSeconds() *int64 { return meta.DeletionGracePeriodSeconds }
+func (meta *ObjectMeta) SetDeletionGracePeriodSeconds(deletionGracePeriodSeconds *int64) {
+	meta.DeletionGracePeriodSeconds = deletionGracePeriodSeconds
 }
 func (meta *ObjectMeta) GetLabels() map[string]string                 { return meta.Labels }
 func (meta *ObjectMeta) SetLabels(labels map[string]string)           { meta.Labels = labels }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -126,6 +126,20 @@ func getNestedString(obj map[string]interface{}, fields ...string) string {
 	return ""
 }
 
+func getNestedInt64(obj map[string]interface{}, fields ...string) int64 {
+	if str, ok := getNestedField(obj, fields...).(int64); ok {
+		return str
+	}
+	return 0
+}
+
+func getNestedInt64Pointer(obj map[string]interface{}, fields ...string) *int64 {
+	if str, ok := getNestedField(obj, fields...).(*int64); ok {
+		return str
+	}
+	return nil
+}
+
 func getNestedSlice(obj map[string]interface{}, fields ...string) []string {
 	if m, ok := getNestedField(obj, fields...).([]interface{}); ok {
 		strSlice := make([]string, 0, len(m))
@@ -355,6 +369,14 @@ func (u *Unstructured) SetResourceVersion(version string) {
 	u.setNestedField(version, "metadata", "resourceVersion")
 }
 
+func (u *Unstructured) GetGeneration() int64 {
+	return getNestedInt64(u.Object, "metadata", "generation")
+}
+
+func (u *Unstructured) SetGeneration(generation int64) {
+	u.setNestedField(generation, "metadata", "generation")
+}
+
 func (u *Unstructured) GetSelfLink() string {
 	return getNestedString(u.Object, "metadata", "selfLink")
 }
@@ -386,6 +408,14 @@ func (u *Unstructured) GetDeletionTimestamp() *metav1.Time {
 func (u *Unstructured) SetDeletionTimestamp(timestamp *metav1.Time) {
 	ts, _ := timestamp.MarshalQueryParameter()
 	u.setNestedField(ts, "metadata", "deletionTimestamp")
+}
+
+func (u *Unstructured) GetDeletionGracePeriodSeconds() *int64 {
+	return getNestedInt64Pointer(u.Object, "metadata", "deletionGracePeriodSeconds")
+}
+
+func (u *Unstructured) SetDeletionGracePeriodSeconds(deletionGracePeriodSeconds *int64) {
+	u.setNestedField(deletionGracePeriodSeconds, "metadata", "deletionGracePeriodSeconds")
 }
 
 func (u *Unstructured) GetLabels() map[string]string {

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/meta.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/meta.go
@@ -23,16 +23,16 @@ import (
 )
 
 // FillObjectMetaSystemFields populates fields that are managed by the system on ObjectMeta.
-func FillObjectMetaSystemFields(ctx genericapirequest.Context, meta *metav1.ObjectMeta) {
-	meta.CreationTimestamp = metav1.Now()
+func FillObjectMetaSystemFields(ctx genericapirequest.Context, meta metav1.Object) {
+	meta.SetCreationTimestamp(metav1.Now())
 	// allows admission controllers to assign a UID earlier in the request processing
 	// to support tracking resources pending creation.
 	uid, found := genericapirequest.UIDFrom(ctx)
 	if !found {
 		uid = uuid.NewUUID()
 	}
-	meta.UID = uid
-	meta.SelfLink = ""
+	meta.SetUID(uid)
+	meta.SetSelfLink("")
 }
 
 // ValidNamespace returns false if the namespace on the context differs from
@@ -40,10 +40,10 @@ func FillObjectMetaSystemFields(ctx genericapirequest.Context, meta *metav1.Obje
 // the context.
 //
 // TODO(sttts): move into pkg/genericapiserver/endpoints
-func ValidNamespace(ctx genericapirequest.Context, resource *metav1.ObjectMeta) bool {
+func ValidNamespace(ctx genericapirequest.Context, resource metav1.Object) bool {
 	ns, ok := genericapirequest.NamespaceFrom(ctx)
-	if len(resource.Namespace) == 0 {
-		resource.Namespace = ns
+	if len(resource.GetNamespace()) == 0 {
+		resource.SetNamespace(ns)
 	}
-	return ns == resource.Namespace && ok
+	return ns == resource.GetNamespace() && ok
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/meta_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/meta_test.go
@@ -19,6 +19,7 @@ package rest
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apiserver/pkg/apis/example"
@@ -49,11 +50,15 @@ func TestFillObjectMetaSystemFields(t *testing.T) {
 func TestHasObjectMetaSystemFieldValues(t *testing.T) {
 	ctx := genericapirequest.NewDefaultContext()
 	resource := metav1.ObjectMeta{}
-	if metav1.HasObjectMetaSystemFieldValues(&resource) {
+	objMeta, err := meta.Accessor(&resource)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if metav1.HasObjectMetaSystemFieldValues(objMeta) {
 		t.Errorf("the resource does not have all fields yet populated, but incorrectly reports it does")
 	}
 	FillObjectMetaSystemFields(ctx, &resource)
-	if !metav1.HasObjectMetaSystemFieldValues(&resource) {
+	if !metav1.HasObjectMetaSystemFieldValues(objMeta) {
 		t.Errorf("the resource does have all fields populated, but incorrectly reports it does not")
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -63,16 +63,16 @@ type RESTUpdateStrategy interface {
 // TODO: add other common fields that require global validation.
 func validateCommonFields(obj, old runtime.Object, strategy RESTUpdateStrategy) (field.ErrorList, error) {
 	allErrs := field.ErrorList{}
-	objectMeta, err := metav1.ObjectMetaFor(obj)
+	objectMeta, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get new object metadata: %v", err)
 	}
-	oldObjectMeta, err := metav1.ObjectMetaFor(old)
+	oldObjectMeta, err := meta.Accessor(old)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get old object metadata: %v", err)
 	}
-	allErrs = append(allErrs, genericvalidation.ValidateObjectMeta(objectMeta, strategy.NamespaceScoped(), path.ValidatePathSegmentName, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, genericvalidation.ValidateObjectMetaUpdate(objectMeta, oldObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, genericvalidation.ValidateObjectMetaAccessor(objectMeta, strategy.NamespaceScoped(), path.ValidatePathSegmentName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, genericvalidation.ValidateObjectMetaAccessorUpdate(objectMeta, oldObjectMeta, field.NewPath("metadata"))...)
 
 	return allErrs, nil
 }
@@ -90,19 +90,19 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx genericapirequest.Context, ob
 			return errors.NewBadRequest("the namespace of the provided object does not match the namespace sent on the request")
 		}
 	} else {
-		objectMeta.Namespace = metav1.NamespaceNone
+		objectMeta.SetNamespace(metav1.NamespaceNone)
 	}
 	// Ensure requests cannot update generation
-	oldMeta, err := metav1.ObjectMetaFor(old)
+	oldMeta, err := meta.Accessor(old)
 	if err != nil {
 		return err
 	}
-	objectMeta.Generation = oldMeta.Generation
+	objectMeta.SetGeneration(oldMeta.GetGeneration())
 
 	strategy.PrepareForUpdate(ctx, obj, old)
 
 	// ClusterName is ignored and should not be saved
-	objectMeta.ClusterName = ""
+	objectMeta.SetClusterName("")
 
 	// Ensure some common fields, like UID, are validated for all resources.
 	errs, err := validateCommonFields(obj, old, strategy)
@@ -112,7 +112,7 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx genericapirequest.Context, ob
 
 	errs = append(errs, strategy.ValidateUpdate(ctx, obj, old)...)
 	if len(errs) > 0 {
-		return errors.NewInvalid(kind.GroupKind(), objectMeta.Name, errs)
+		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
 	}
 
 	strategy.Canonicalize(obj)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/net/context"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -161,12 +160,12 @@ func checkPreconditions(key string, preconditions *storage.Preconditions, out ru
 	if preconditions == nil {
 		return nil
 	}
-	objMeta, err := metav1.ObjectMetaFor(out)
+	objMeta, err := meta.Accessor(out)
 	if err != nil {
 		return storage.NewInternalErrorf("can't enforce preconditions %v on un-introspectable object %v, got error: %v", *preconditions, out, err)
 	}
-	if preconditions.UID != nil && *preconditions.UID != objMeta.UID {
-		errMsg := fmt.Sprintf("Precondition failed: UID in precondition: %v, UID in object meta: %v", preconditions.UID, objMeta.UID)
+	if preconditions.UID != nil && *preconditions.UID != objMeta.GetUID() {
+		errMsg := fmt.Sprintf("Precondition failed: UID in precondition: %v, UID in object meta: %v", preconditions.UID, objMeta.GetUID())
 		return storage.NewInvalidObjError(key, errMsg)
 	}
 	return nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -30,7 +30,6 @@ import (
 	"golang.org/x/net/context"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -559,12 +558,12 @@ func checkPreconditions(key string, preconditions *storage.Preconditions, out ru
 	if preconditions == nil {
 		return nil
 	}
-	objMeta, err := metav1.ObjectMetaFor(out)
+	objMeta, err := meta.Accessor(out)
 	if err != nil {
 		return storage.NewInternalErrorf("can't enforce preconditions %v on un-introspectable object %v, got error: %v", *preconditions, out, err)
 	}
-	if preconditions.UID != nil && *preconditions.UID != objMeta.UID {
-		errMsg := fmt.Sprintf("Precondition failed: UID in precondition: %v, UID in object meta: %v", *preconditions.UID, objMeta.UID)
+	if preconditions.UID != nil && *preconditions.UID != objMeta.GetUID() {
+		errMsg := fmt.Sprintf("Precondition failed: UID in precondition: %v, UID in object meta: %v", *preconditions.UID, objMeta.GetUID())
 		return storage.NewInvalidObjError(key, errMsg)
 	}
 	return nil

--- a/staging/src/k8s.io/client-go/pkg/api/v1/meta.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/meta.go
@@ -35,6 +35,8 @@ func (meta *ObjectMeta) GetUID() types.UID                   { return meta.UID }
 func (meta *ObjectMeta) SetUID(uid types.UID)                { meta.UID = uid }
 func (meta *ObjectMeta) GetResourceVersion() string          { return meta.ResourceVersion }
 func (meta *ObjectMeta) SetResourceVersion(version string)   { meta.ResourceVersion = version }
+func (meta *ObjectMeta) GetGeneration() int64                { return meta.Generation }
+func (meta *ObjectMeta) SetGeneration(generation int64)      { meta.Generation = generation }
 func (meta *ObjectMeta) GetSelfLink() string                 { return meta.SelfLink }
 func (meta *ObjectMeta) SetSelfLink(selfLink string)         { meta.SelfLink = selfLink }
 func (meta *ObjectMeta) GetCreationTimestamp() metav1.Time   { return meta.CreationTimestamp }
@@ -44,6 +46,10 @@ func (meta *ObjectMeta) SetCreationTimestamp(creationTimestamp metav1.Time) {
 func (meta *ObjectMeta) GetDeletionTimestamp() *metav1.Time { return meta.DeletionTimestamp }
 func (meta *ObjectMeta) SetDeletionTimestamp(deletionTimestamp *metav1.Time) {
 	meta.DeletionTimestamp = deletionTimestamp
+}
+func (meta *ObjectMeta) GetDeletionGracePeriodSeconds() *int64 { return meta.DeletionGracePeriodSeconds }
+func (meta *ObjectMeta) SetDeletionGracePeriodSeconds(deletionGracePeriodSeconds *int64) {
+	meta.DeletionGracePeriodSeconds = deletionGracePeriodSeconds
 }
 func (meta *ObjectMeta) GetLabels() map[string]string                 { return meta.Labels }
 func (meta *ObjectMeta) SetLabels(labels map[string]string)           { meta.Labels = labels }

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -8414,6 +8414,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//vendor:k8s.io/apimachinery/pkg/api/equality",
+        "//vendor:k8s.io/apimachinery/pkg/api/meta",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1/validation",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
@@ -10424,6 +10425,7 @@ go_test(
     library = ":k8s.io/apiserver/pkg/registry/rest",
     tags = ["automanaged"],
     deps = [
+        "//vendor:k8s.io/apimachinery/pkg/api/meta",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/util/uuid",
         "//vendor:k8s.io/apiserver/pkg/apis/example",
@@ -10468,6 +10470,7 @@ go_library(
     deps = [
         "//vendor:k8s.io/apimachinery/pkg/api/equality",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
+        "//vendor:k8s.io/apimachinery/pkg/api/meta",
         "//vendor:k8s.io/apimachinery/pkg/api/validation/path",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/internalversion",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",


### PR DESCRIPTION
Builds on https://github.com/kubernetes/kubernetes/pull/43767

The second commit removes `ObjectMetaFor`.  This was debt we left around after we created the interfaces.  Fixing this makes it possible to start running `Unstructured` through generic storage.

@kubernetes/sig-api-machinery-pr-reviews @smarterclayton @lavalamp 