### PR TITLE
kubectl logs with label selector supports specifying a container name

### DIFF
--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -187,9 +187,6 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Comm
 		if logOptions.Follow {
 			return cmdutil.UsageError(cmd, "only one of follow (-f) or selector (-l) is allowed")
 		}
-		if len(logOptions.Container) != 0 {
-			return cmdutil.UsageError(cmd, "a container cannot be specified when using a selector (-l)")
-		}
 		if logOptions.TailLines == nil {
 			logOptions.TailLines = &selectorTail
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows `kubectl logs` to take both a label selector and container name.  This allows me to fetch logs from pods by selector whose pods have multiple containers with a common name.  This is a common action when debugging components like the service-catalog that ship more than one container in their pod.  With this change, the following command lets me get logs for service-catalog.

```
$ kubectl logs -l app=sc-catalog-apiserver --namespace=service-catalog --container=apiserver
```