### PR TITLE
[Federation] Remove deprecated federation-apiserver-kubeconfig secret

### DIFF
--- a/federation/cmd/federation-controller-manager/app/BUILD
+++ b/federation/cmd/federation-controller-manager/app/BUILD
@@ -31,7 +31,6 @@ go_library(
         "//federation/pkg/federation-controller/replicaset:go_default_library",
         "//federation/pkg/federation-controller/secret:go_default_library",
         "//federation/pkg/federation-controller/service:go_default_library",
-        "//federation/pkg/federation-controller/util:go_default_library",
         "//pkg/util/configz:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor:github.com/golang/glog",


### PR DESCRIPTION
federation-apiserver-kubeconfig was deprecated and was supposed to be removed in 1.6.
Removing all references to it as we no longer use it.

**Release note**:
```
[Federation] Deprecated `federation-apiserver-kubeconfig` is not supported anymore. Should use `--kubeconfig` flag to specify Federation API server kubeconfig.
```

cc @kubernetes/sig-federation-pr-reviews 