### PR TITLE
[Federation] Add support for federation-only objects

### DIFF
--- a/federation/pkg/federation-controller/configmap/configmap_controller.go
+++ b/federation/pkg/federation-controller/configmap/configmap_controller.go
@@ -330,7 +330,10 @@ func (configmapcontroller *ConfigMapController) reconcileConfigMap(configmap typ
 		glog.Errorf("Error in retrieving obj from store: %v, %v", ok, err)
 		return
 	}
-
+	if util.IsFederationOnlyObject(configMap) {
+		glog.V(4).Infof("Skipping federation-only ConfigMap: %s", key)
+		return
+	}
 	// Check if deletion has been requested.
 	if configMap.DeletionTimestamp != nil {
 		if err := configmapcontroller.delete(configMap); err != nil {

--- a/federation/pkg/federation-controller/daemonset/daemonset_controller.go
+++ b/federation/pkg/federation-controller/daemonset/daemonset_controller.go
@@ -364,6 +364,10 @@ func (daemonsetcontroller *DaemonSetController) reconcileDaemonSet(namespace str
 		daemonsetcontroller.deliverDaemonSet(namespace, daemonsetName, 0, true)
 		return
 	}
+	if util.IsFederationOnlyObject(baseDaemonSet) {
+		glog.V(4).Infof("Skipping federation-only DaemonSet: %s", key)
+		return
+	}
 	if baseDaemonSet.DeletionTimestamp != nil {
 		if err := daemonsetcontroller.delete(baseDaemonSet); err != nil {
 			glog.Errorf("Failed to delete %s: %v", daemonsetName, err)

--- a/federation/pkg/federation-controller/deployment/deploymentcontroller.go
+++ b/federation/pkg/federation-controller/deployment/deploymentcontroller.go
@@ -497,6 +497,10 @@ func (fdc *DeploymentController) reconcileDeployment(key string) (reconciliation
 		glog.Errorf("Error in retrieving obj from store: %v, %v", ok, err)
 		return statusError, err
 	}
+	if fedutil.IsFederationOnlyObject(fd) {
+		glog.V(4).Infof("Skipping federation-only Deployment: %s", key)
+		return statusAllOk, nil
+	}
 
 	if fd.DeletionTimestamp != nil {
 		if err := fdc.delete(fd); err != nil {

--- a/federation/pkg/federation-controller/ingress/ingress_controller.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller.go
@@ -743,7 +743,10 @@ func (ic *IngressController) reconcileIngress(ingress types.NamespacedName) {
 	} else {
 		glog.V(4).Infof("Base (federated) ingress: %v", baseIngress)
 	}
-
+	if util.IsFederationOnlyObject(baseIngress) {
+		glog.V(4).Infof("Skipping federation-only Ingress: %s", key)
+		return
+	}
 	if baseIngress.DeletionTimestamp != nil {
 		if err := ic.delete(baseIngress); err != nil {
 			glog.Errorf("Failed to delete %s: %v", ingress, err)

--- a/federation/pkg/federation-controller/namespace/namespace_controller.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller.go
@@ -363,6 +363,10 @@ func (nc *NamespaceController) reconcileNamespace(namespace string) {
 		nc.deliverNamespace(namespace, 0, true)
 		return
 	}
+	if util.IsFederationOnlyObject(baseNamespace) {
+		glog.V(4).Infof("Skipping federation-only Namespace: %s", namespace)
+		return
+	}
 	if baseNamespace.DeletionTimestamp != nil {
 		if err := nc.delete(baseNamespace); err != nil {
 			glog.Errorf("Failed to delete %s: %v", namespace, err)

--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
@@ -510,6 +510,10 @@ func (frsc *ReplicaSetController) reconcileReplicaSet(key string) (reconciliatio
 		frsc.deliverReplicaSetByKey(key, 0, true)
 		return statusError, err
 	}
+	if fedutil.IsFederationOnlyObject(frs) {
+		glog.V(4).Infof("Skipping federation-only ReplicaSet: %s", key)
+		return statusAllOk, nil
+	}
 	if frs.DeletionTimestamp != nil {
 		if err := frsc.delete(frs); err != nil {
 			glog.Errorf("Failed to delete %s: %v", frs, err)

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -985,6 +985,10 @@ func (s *ServiceController) syncService(key string) error {
 			return err
 		}
 		service := copy.(*v1.Service)
+		if util.IsFederationOnlyObject(service) {
+			glog.V(4).Infof("Skipping federation-only Service: %s", key)
+			return nil
+		}
 		cachedService = s.serviceCache.getOrCreate(key)
 		err, retryDelay = s.processServiceUpdate(cachedService, service, key)
 	}

--- a/federation/pkg/federation-controller/sync/controller.go
+++ b/federation/pkg/federation-controller/sync/controller.go
@@ -351,6 +351,10 @@ func (s *FederationSyncController) reconcile(namespacedName types.NamespacedName
 	}
 	obj := copiedObj.(pkgruntime.Object)
 	meta := s.adapter.ObjectMeta(obj)
+	if util.IsFederationOnlyObject(obj) {
+		glog.V(4).Infof("Skipping federation-only %q: %s", kind, key)
+		return
+	}
 
 	if meta.DeletionTimestamp != nil {
 		if err := s.delete(obj, namespacedName); err != nil {

--- a/federation/pkg/federation-controller/util/BUILD
+++ b/federation/pkg/federation-controller/util/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/controller/deployment/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",

--- a/federation/pkg/federation-controller/util/meta.go
+++ b/federation/pkg/federation-controller/util/meta.go
@@ -19,9 +19,14 @@ package util
 import (
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/api"
+)
+
+const (
+	FederationOnlyAnnotation = "federation.kubernetes.io/federation-only"
 )
 
 // Copies cluster-independent, user provided data from the given ObjectMeta struct. If in
@@ -91,4 +96,17 @@ func DeepCopyApiTypeOrPanic(item interface{}) interface{} {
 		panic(err)
 	}
 	return result
+}
+
+func IsFederationOnlyObject(object runtime.Object) bool {
+	accessor, err := meta.Accessor(object)
+	if err != nil {
+		return false
+	}
+	annotations := accessor.GetAnnotations()
+	federationOnlyObject, exist := annotations[FederationOnlyAnnotation]
+	if exist && federationOnlyObject == "true" {
+		return true
+	}
+	return false
 }

--- a/federation/pkg/federation-controller/util/meta_test.go
+++ b/federation/pkg/federation-controller/util/meta_test.go
@@ -115,3 +115,30 @@ func TestObjectMetaAndSpec(t *testing.T) {
 	assert.False(t, ObjectMetaAndSpecEquivalent(&s1, &s3))
 	assert.False(t, ObjectMetaAndSpecEquivalent(&s2, &s3))
 }
+
+func TestIsFederationOnlyObject(t *testing.T) {
+	testCases := []struct {
+		configMap      api_v1.ConfigMap
+		expectedResult bool
+	}{
+		{
+			configMap: api_v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expectedResult: false,
+		},
+		{
+			configMap: api_v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						FederationOnlyAnnotation: "true",
+					},
+				},
+			},
+			expectedResult: true,
+		},
+	}
+	for i, tc := range testCases {
+		assert.Equal(t, tc.expectedResult, IsFederationOnlyObject(&tc.configMap), "testcase - %d", i)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Federation controllers tries to sync all the objects created in federation api server. For few scenarios it is required that the object exist only in federation and should not be synced to federated cluster. This pr adds support to create such objects which should exist only in federation by using annotation.

**Special notes for your reviewer**:
This is a sub-task of bigger work to add leader election to federation controller manager as documented in #44283, we need to create a ConfigMap object which should exist only in federation and should not be synced to federated clusters.

**Release note**:
```
[Federation] federation-only object can now be created by adding "federation.kubernetes.io/federation-only" annotation
```
cc @kubernetes/sig-federation-pr-reviews 