### PR TITLE
Automated cherry pick of #44108

### DIFF
--- a/federation/pkg/federation-controller/configmap/configmap_controller.go
+++ b/federation/pkg/federation-controller/configmap/configmap_controller.go
@@ -169,7 +169,8 @@ func NewConfigMapController(client federationclientset.Interface) *ConfigMapCont
 		},
 		func(client kubeclientset.Interface, obj pkgruntime.Object) error {
 			configmap := obj.(*apiv1.ConfigMap)
-			err := client.Core().ConfigMaps(configmap.Namespace).Delete(configmap.Name, &metav1.DeleteOptions{})
+			orphanDependents := false
+			err := client.Core().ConfigMaps(configmap.Namespace).Delete(configmap.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 			return err
 		})
 

--- a/federation/pkg/federation-controller/daemonset/daemonset_controller.go
+++ b/federation/pkg/federation-controller/daemonset/daemonset_controller.go
@@ -182,7 +182,8 @@ func NewDaemonSetController(client federationclientset.Interface) *DaemonSetCont
 		func(client kubeclientset.Interface, obj pkgruntime.Object) error {
 			daemonset := obj.(*extensionsv1.DaemonSet)
 			glog.V(4).Infof("Attempting to delete daemonset: %s/%s", daemonset.Namespace, daemonset.Name)
-			err := client.Extensions().DaemonSets(daemonset.Namespace).Delete(daemonset.Name, &metav1.DeleteOptions{})
+			orphanDependents := false
+			err := client.Extensions().DaemonSets(daemonset.Namespace).Delete(daemonset.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 			if err != nil {
 				glog.Errorf("Error deleting daemonset %s/%s/: %v", daemonset.Namespace, daemonset.Name, err)
 			} else {

--- a/federation/pkg/federation-controller/deployment/deploymentcontroller.go
+++ b/federation/pkg/federation-controller/deployment/deploymentcontroller.go
@@ -201,7 +201,8 @@ func NewDeploymentController(federationClient fedclientset.Interface) *Deploymen
 		},
 		func(client kubeclientset.Interface, obj runtime.Object) error {
 			rs := obj.(*extensionsv1.Deployment)
-			err := client.Extensions().Deployments(rs.Namespace).Delete(rs.Name, &metav1.DeleteOptions{})
+			orphanDependents := false
+			err := client.Extensions().Deployments(rs.Namespace).Delete(rs.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 			return err
 		})
 

--- a/federation/pkg/federation-controller/ingress/ingress_controller.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller.go
@@ -255,7 +255,8 @@ func NewIngressController(client federationclientset.Interface) *IngressControll
 		func(client kubeclientset.Interface, obj pkgruntime.Object) error {
 			ingress := obj.(*extensionsv1beta1.Ingress)
 			glog.V(4).Infof("Attempting to delete Ingress: %v", ingress)
-			err := client.Extensions().Ingresses(ingress.Namespace).Delete(ingress.Name, &metav1.DeleteOptions{})
+			orphanDependents := false
+			err := client.Extensions().Ingresses(ingress.Namespace).Delete(ingress.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 			return err
 		})
 

--- a/federation/pkg/federation-controller/namespace/namespace_controller.go
+++ b/federation/pkg/federation-controller/namespace/namespace_controller.go
@@ -169,7 +169,8 @@ func NewNamespaceController(client federationclientset.Interface, dynamicClientP
 		},
 		func(client kubeclientset.Interface, obj runtime.Object) error {
 			namespace := obj.(*apiv1.Namespace)
-			err := client.Core().Namespaces().Delete(namespace.Name, &metav1.DeleteOptions{})
+			orphanDependents := false
+			err := client.Core().Namespaces().Delete(namespace.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 			// IsNotFound error is fine since that means the object is deleted already.
 			if errors.IsNotFound(err) {
 				return nil

--- a/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
+++ b/federation/pkg/federation-controller/replicaset/replicasetcontroller.go
@@ -209,7 +209,8 @@ func NewReplicaSetController(federationClient fedclientset.Interface) *ReplicaSe
 		},
 		func(client kubeclientset.Interface, obj runtime.Object) error {
 			rs := obj.(*extensionsv1.ReplicaSet)
-			err := client.Extensions().ReplicaSets(rs.Namespace).Delete(rs.Name, &metav1.DeleteOptions{})
+			orphanDependents := false
+			err := client.Extensions().ReplicaSets(rs.Namespace).Delete(rs.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 			return err
 		})
 

--- a/federation/pkg/federation-controller/secret/secret_controller.go
+++ b/federation/pkg/federation-controller/secret/secret_controller.go
@@ -168,7 +168,8 @@ func NewSecretController(client federationclientset.Interface) *SecretController
 		},
 		func(client kubeclientset.Interface, obj pkgruntime.Object) error {
 			secret := obj.(*apiv1.Secret)
-			err := client.Core().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{})
+			orphanDependents := false
+			err := client.Core().Secrets(secret.Namespace).Delete(secret.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 			return err
 		})
 

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -291,7 +291,8 @@ func New(federationClient fedclientset.Interface, dns dnsprovider.Interface,
 		},
 		func(client kubeclientset.Interface, obj pkgruntime.Object) error {
 			svc := obj.(*v1.Service)
-			err := client.Core().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{})
+			orphanDependents := false
+			err := client.Core().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 			return err
 		})
 

--- a/federation/pkg/kubefed/unjoin.go
+++ b/federation/pkg/kubefed/unjoin.go
@@ -194,7 +194,8 @@ func deleteConfigMapFromCluster(hostClientset internalclientset.Interface, secre
 // deleteSecret deletes the secret with the given name from the host
 // cluster.
 func deleteSecret(clientset internalclientset.Interface, name, namespace string) error {
-	return clientset.Core().Secrets(namespace).Delete(name, &metav1.DeleteOptions{})
+	orphanDependents := false
+	return clientset.Core().Secrets(namespace).Delete(name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
 }
 
 // isNotFound checks if the given error is a NotFound status error.


### PR DESCRIPTION
Cherry pick of #44108 on release-1.6.

#44108: fed: Disable orphaning of per-cluster resources on deletion.

```release-note
Fix for [federation failing to propagate cascading deletion](https://github.com/kubernetes/kubernetes/issues/44304).
```