### PR TITLE
make unstructured items correspond to other items for storage

### DIFF
--- a/pkg/apimachinery/tests/api_meta_help_test.go
+++ b/pkg/apimachinery/tests/api_meta_help_test.go
@@ -316,7 +316,7 @@ func TestSetListToMatchingType(t *testing.T) {
 		t.Fatalf("Expected %v, got %v", e, a)
 	}
 	for i := range list {
-		if e, a := list[i], pl.Items[i]; e != a {
+		if e, a := list[i], &pl.Items[i]; !reflect.DeepEqual(e, a) {
 			t.Fatalf("%d: unmatched: %s", i, diff.ObjectDiff(e, a))
 		}
 	}

--- a/pkg/apimachinery/tests/apis_meta_v1_unstructed_unstructure_test.go
+++ b/pkg/apimachinery/tests/apis_meta_v1_unstructed_unstructure_test.go
@@ -89,7 +89,7 @@ func TestDecode(t *testing.T) {
 			json: []byte(`{"items": [{"metadata": {"name": "object1"}, "apiVersion": "test", "kind": "test_kind"}, {"metadata": {"name": "object2"}, "apiVersion": "test", "kind": "test_kind"}], "apiVersion": "test", "kind": "test_list"}`),
 			want: &unstructured.UnstructuredList{
 				Object: map[string]interface{}{"apiVersion": "test", "kind": "test_list"},
-				Items: []*unstructured.Unstructured{
+				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
 							"metadata":   map[string]interface{}{"name": "object1"},

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -182,7 +182,7 @@ func runEdit(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args 
 					},
 				}
 				for _, info := range infos {
-					l.Items = append(l.Items, info.Object.(*unstructured.Unstructured))
+					l.Items = append(l.Items, *info.Object.(*unstructured.Unstructured))
 				}
 				originalObj = l
 			}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -339,7 +339,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 				},
 			}
 			for _, info := range infos {
-				list.Items = append(list.Items, info.Object.(*unstructured.Unstructured))
+				list.Items = append(list.Items, *info.Object.(*unstructured.Unstructured))
 			}
 			obj = list
 		} else {
@@ -367,7 +367,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 			}
 
 			for _, item := range items {
-				list.Items = append(list.Items, item.(*unstructured.Unstructured))
+				list.Items = append(list.Items, *item.(*unstructured.Unstructured))
 			}
 			if err := printer.PrintObj(list, out); err != nil {
 				errs = append(errs, err)

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -590,7 +590,7 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 	cmd.Run(cmd, []string{"pods,services"})
 
 	actual := tf.CommandPrinter.(*testPrinter).Objects
-	fn := func(obj runtime.Object) *unstructured.Unstructured {
+	fn := func(obj runtime.Object) unstructured.Unstructured {
 		data, err := runtime.Encode(api.Codecs.LegacyCodec(schema.GroupVersion{Version: "v1"}), obj)
 		if err != nil {
 			panic(err)
@@ -599,12 +599,12 @@ func TestGetMultipleTypeObjectsAsList(t *testing.T) {
 		if err := encjson.Unmarshal(data, &out.Object); err != nil {
 			panic(err)
 		}
-		return out
+		return *out
 	}
 
 	expected := &unstructured.UnstructuredList{
 		Object: map[string]interface{}{"kind": "List", "apiVersion": "v1", "metadata": map[string]interface{}{}, "selfLink": "", "resourceVersion": ""},
-		Items: []*unstructured.Unstructured{
+		Items: []unstructured.Unstructured{
 			fn(&pods.Items[0]),
 			fn(&pods.Items[1]),
 			fn(&svc.Items[0]),

--- a/pkg/kubectl/sorting_printer_test.go
+++ b/pkg/kubectl/sorting_printer_test.go
@@ -275,7 +275,7 @@ func TestSortingPrinter(t *testing.T) {
 					"kind":       "List",
 					"apiVersion": "v1",
 				},
-				Items: []*unstructured.Unstructured{
+				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
 							"kind":       "ReplicationController",
@@ -308,7 +308,7 @@ func TestSortingPrinter(t *testing.T) {
 					"kind":       "List",
 					"apiVersion": "v1",
 				},
-				Items: []*unstructured.Unstructured{
+				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
 							"kind":       "ReplicationController",
@@ -345,7 +345,7 @@ func TestSortingPrinter(t *testing.T) {
 					"kind":       "List",
 					"apiVersion": "v1",
 				},
-				Items: []*unstructured.Unstructured{
+				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
 							"kind":       "ReplicationController",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -441,7 +441,7 @@ type UnstructuredList struct {
 	Object map[string]interface{}
 
 	// Items is a list of unstructured objects.
-	Items []*Unstructured `json:"items"`
+	Items []Unstructured `json:"items"`
 }
 
 // MarshalJSON ensures that the unstructured list object produces proper
@@ -642,7 +642,7 @@ func (s unstructuredJSONScheme) decodeToList(data []byte, list *UnstructuredList
 			unstruct.SetKind(itemKind)
 			unstruct.SetAPIVersion(listAPIVersion)
 		}
-		list.Items = append(list.Items, unstruct)
+		list.Items = append(list.Items, *unstruct)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
@@ -21,7 +21,7 @@ import "testing"
 func TestUnstructuredList(t *testing.T) {
 	list := &UnstructuredList{
 		Object: map[string]interface{}{"kind": "List", "apiVersion": "v1"},
-		Items: []*Unstructured{
+		Items: []Unstructured{
 			{Object: map[string]interface{}{"kind": "Pod", "apiVersion": "v1", "metadata": map[string]interface{}{"name": "test"}}},
 		},
 	}

--- a/staging/src/k8s.io/client-go/dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_test.go
@@ -90,9 +90,9 @@ func TestList(t *testing.T) {
 					"apiVersion": "vTest",
 					"kind":       "rTestList",
 				},
-				Items: []*unstructured.Unstructured{
-					getObject("vTest", "rTest", "item1"),
-					getObject("vTest", "rTest", "item2"),
+				Items: []unstructured.Unstructured{
+					*getObject("vTest", "rTest", "item1"),
+					*getObject("vTest", "rTest", "item2"),
 				},
 			},
 		},
@@ -108,9 +108,9 @@ func TestList(t *testing.T) {
 					"apiVersion": "vTest",
 					"kind":       "rTestList",
 				},
-				Items: []*unstructured.Unstructured{
-					getObject("vTest", "rTest", "item1"),
-					getObject("vTest", "rTest", "item2"),
+				Items: []unstructured.Unstructured{
+					*getObject("vTest", "rTest", "item1"),
+					*getObject("vTest", "rTest", "item2"),
 				},
 			},
 		},

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -106,7 +106,7 @@ func TestDynamicClient(t *testing.T) {
 		t.Fatalf("expected one pod, got %d", len(unstructuredList.Items))
 	}
 
-	got, err := unstructuredToPod(unstructuredList.Items[0])
+	got, err := unstructuredToPod(&unstructuredList.Items[0])
 	if err != nil {
 		t.Fatalf("unexpected error converting Unstructured to v1.Pod: %v", err)
 	}


### PR DESCRIPTION
"normal" `Items` elements include the struct itself, not a pointer to the struct.  Some of the deeper bits of storage rely on this behavior in reflective paths.

This updates the `UnstructuredList` to be "normal".

@kubernetes/sig-api-machinery-pr-reviews 