### PR TITLE
Azure disk: dealing with missing disk probe

### DIFF
--- a/pkg/volume/azure_dd/attacher.go
+++ b/pkg/volume/azure_dd/attacher.go
@@ -171,6 +171,10 @@ func (attacher *azureDiskAttacher) WaitForAttach(spec *volume.Spec, lunStr strin
 	err = wait.Poll(checkSleepDuration, timeout, func() (bool, error) {
 		glog.V(4).Infof("Checking Azure disk %q(lun %s) is attached.", volumeSource.DiskName, lunStr)
 		if devicePath, err = findDiskByLun(lun, &osIOHandler{}, exe); err == nil {
+			if len(devicePath) == 0 {
+				glog.Warningf("cannot find attached Azure disk %q(lun %s) locally.", volumeSource.DiskName, lunStr)
+				return false, fmt.Errorf("cannot find attached Azure disk %q(lun %s) locally.", volumeSource.DiskName, lunStr)
+			}
 			glog.V(4).Infof("Successfully found attached Azure disk %q(lun %s, device path %s).", volumeSource.DiskName, lunStr, devicePath)
 			return true, nil
 		} else {

--- a/pkg/volume/azure_dd/vhd_util.go
+++ b/pkg/volume/azure_dd/vhd_util.go
@@ -31,6 +31,7 @@ import (
 type ioHandler interface {
 	ReadDir(dirname string) ([]os.FileInfo, error)
 	WriteFile(filename string, data []byte, perm os.FileMode) error
+	Readlink(name string) (string, error)
 }
 
 type osIOHandler struct{}
@@ -41,56 +42,83 @@ func (handler *osIOHandler) ReadDir(dirname string) ([]os.FileInfo, error) {
 func (handler *osIOHandler) WriteFile(filename string, data []byte, perm os.FileMode) error {
 	return ioutil.WriteFile(filename, data, perm)
 }
+func (handler *osIOHandler) Readlink(name string) (string, error) {
+	return os.Readlink(name)
+}
 
-// given a LUN find the VHD device path like /dev/sdb
-// VHD disks under sysfs are like /sys/bus/scsi/devices/3:0:1:0
-// return empty string if no disk is found
+// exclude those used by azure as resource and OS root in /dev/disk/azure
+func listAzureDiskPath(io ioHandler) []string {
+	azureDiskPath := "/dev/disk/azure/"
+	var azureDiskList []string
+	if dirs, err := io.ReadDir(azureDiskPath); err == nil {
+		for _, f := range dirs {
+			name := f.Name()
+			diskPath := azureDiskPath + name
+			if link, linkErr := io.Readlink(diskPath); linkErr == nil {
+				sd := link[(strings.LastIndex(link, "/") + 1):]
+				azureDiskList = append(azureDiskList, sd)
+			}
+		}
+	}
+	glog.V(12).Infof("Azure sys disks paths: %v", azureDiskList)
+	return azureDiskList
+}
+
+// given a LUN find the VHD device path like /dev/sdd
+// exclude those disks used by Azure resources and OS root
 func findDiskByLun(lun int, io ioHandler, exe exec.Interface) (string, error) {
+	azureDisks := listAzureDiskPath(io)
+	return findDiskByLunWithConstraint(lun, io, exe, azureDisks)
+}
+
+// look for device /dev/sdX and validate it is a VHD
+// return empty string if no disk is found
+func findDiskByLunWithConstraint(lun int, io ioHandler, exe exec.Interface, azureDisks []string) (string, error) {
 	var err error
 	sys_path := "/sys/bus/scsi/devices"
 	if dirs, err := io.ReadDir(sys_path); err == nil {
 		for _, f := range dirs {
 			name := f.Name()
-			// look for path like /sys/bus/scsi/devices/3:0:1:0
+			// look for path like /sys/bus/scsi/devices/3:0:0:1
 			arr := strings.Split(name, ":")
 			if len(arr) < 4 {
 				continue
 			}
-			target, err := strconv.Atoi(arr[0])
+			// extract LUN from the path.
+			// LUN is the last index of the array, i.e. 1 in /sys/bus/scsi/devices/3:0:0:1
+			l, err := strconv.Atoi(arr[3])
 			if err != nil {
-				glog.Errorf("failed to parse target from %v (%v), err %v", arr[0], name, err)
+				// unknown path format, continue to read the next one
+				glog.Errorf("failed to parse lun from %v (%v), err %v", arr[3], name, err)
 				continue
 			}
-
-			// as observed, targets 0-3 are used by OS disks. Skip them
-			if target > 3 {
-				l, err := strconv.Atoi(arr[3])
+			if lun == l {
+				// find the matching LUN
+				// read vendor and model to ensure it is a VHD disk
+				vendor := path.Join(sys_path, name, "vendor")
+				model := path.Join(sys_path, name, "model")
+				out, err := exe.Command("cat", vendor, model).CombinedOutput()
 				if err != nil {
-					// unknown path format, continue to read the next one
-					glog.Errorf("failed to parse lun from %v (%v), err %v", arr[3], name, err)
+					glog.Errorf("failed to cat device vendor and model, err: %v", err)
 					continue
 				}
-				if lun == l {
-					// find the matching LUN
-					// read vendor and model to ensure it is a VHD disk
-					vendor := path.Join(sys_path, name, "vendor")
-					model := path.Join(sys_path, name, "model")
-					out, err := exe.Command("cat", vendor, model).CombinedOutput()
-					if err != nil {
-						glog.Errorf("failed to cat device vendor and model, err: %v", err)
-						continue
+				matched, err := regexp.MatchString("^MSFT[ ]{0,}\nVIRTUAL DISK[ ]{0,}\n$", strings.ToUpper(string(out)))
+				if err != nil || !matched {
+					glog.V(4).Infof("doesn't match VHD, output %v, error %v", string(out), err)
+					continue
+				}
+				// find a disk, validate name
+				dir := path.Join(sys_path, name, "block")
+				if dev, err := io.ReadDir(dir); err == nil {
+					found := false
+					for _, diskName := range azureDisks {
+						glog.V(12).Infof("validating disk %q with sys disk %q", dev[0].Name(), diskName)
+						if string(dev[0].Name()) == diskName {
+							found = true
+							break
+						}
 					}
-					matched, err := regexp.MatchString("^MSFT[ ]{0,}\nVIRTUAL DISK[ ]{0,}\n$", strings.ToUpper(string(out)))
-					if err != nil || !matched {
-						glog.V(4).Infof("doesn't match VHD, output %v, error %v", string(out), err)
-						continue
-					}
-					// find it!
-					dir := path.Join(sys_path, name, "block")
-					dev, err := io.ReadDir(dir)
-					if err != nil {
-						glog.Errorf("failed to read %s", dir)
-					} else {
+					if !found {
 						return "/dev/" + dev[0].Name(), nil
 					}
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
While Azure disks are expected to attach to SCSI host 3 and above on general purpose instances, on certain Azure instances disks are under SCSI host 2. 

This fix searches all LUNs but excludes those used by Azure sys disks, based on udev rules [here](https://raw.githubusercontent.com/Azure/WALinuxAgent/master/config/66-azure-storage.rules)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
