### PR TITLE
Create _output/release-{stage,tars} directories with make bazel-release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -529,5 +529,5 @@ bazel-release:
 	@echo "$$BAZEL_BUILD_HELP_INFO"
 else
 bazel-release:
-	bazel build //build/release-tars
+	hack/make-rules/bazel-release.sh
 endif

--- a/hack/make-rules/bazel-release.sh
+++ b/hack/make-rules/bazel-release.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+KUBE_VERBOSE="${KUBE_VERBOSE:-1}"
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+ARCH_TARBALL_REGEX="^kubernetes-([^-]+)-([^.]+)\.tar.gz$"
+RELEASE_TAR_OUTPUT_DIR="${KUBE_ROOT}/_output/release-tars"
+RELEASE_STAGE_OUTPUT_DIR="${KUBE_ROOT}/_output/release-stage"
+
+rm -rf "${RELEASE_TAR_OUTPUT_DIR}" "${RELEASE_STAGE_OUTPUT_DIR}"
+
+kube::log::status "Running bazel build"
+bazel build //build/release-tars
+
+kube::log::status "Building _output/release-tars and _output/release-stage"
+mkdir -p "${RELEASE_TAR_OUTPUT_DIR}"
+for tarfile in "${KUBE_ROOT}"/bazel-bin/build/release-tars/*.tar.gz; do
+  # Resolve the bazel-bin symlink
+  real_tarfile=$(kube::realpath "${tarfile}")
+  ln -sf "${real_tarfile}" "${RELEASE_TAR_OUTPUT_DIR}"
+  tarfile_name="${real_tarfile##*/}"
+
+  # Extract the arch-specific tarballs into the release-stage directory.
+  # This is basically opposite of what the legacy build system does, but this is
+  # the easiest way to reuse the rules in build/release-tars/BUILD.
+  if [[ "${tarfile_name}" =~ ${ARCH_TARBALL_REGEX} ]]; then
+    # _output/release-stage gets dirs like client/linux-amd64,
+    # server/linux-amd64, etc.
+    output_dir="${RELEASE_STAGE_OUTPUT_DIR}/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    mkdir -p "${output_dir}"
+    tar -C "${output_dir}" -xzf "${real_tarfile}"
+  fi
+done
+
+# Special-case the "full" kubernetes tarball
+output_dir="${RELEASE_STAGE_OUTPUT_DIR}/full"
+mkdir -p "${output_dir}"
+tar -C "${output_dir}" -xzf \
+  "${KUBE_ROOT}/bazel-bin/build/release-tars/kubernetes.tar.gz"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: combined with #41914, makes `kubernetes/release/push-build.sh` work, a necessary prerequisite for e2e jobs using bazel-built artifacts.

This implementation is a little gross - we build the tarballs using bazel, then extract them to create the staging directories, rather than creating staging directories and using them to create the tarballs (as is done in the shell-based build).

This is less shell code than the legacy shell build, though, so it's maybe an improvement? The tarball extraction only takes a few seconds, it seems.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/release/issues/250

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

/assign @mikedanese @spxtr 