### PR TITLE
basic logging and additional documentation for healthz installer

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/BUILD
@@ -18,6 +18,7 @@ go_library(
         "doc.go",
         "healthz.go",
     ],
+    deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -20,7 +20,10 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
+
+	"github.com/golang/glog"
 )
 
 // HealthzChecker is a named healthz checker.
@@ -58,11 +61,18 @@ func NamedCheck(name string, check func(r *http.Request) error) HealthzChecker {
 	return &healthzCheck{name, check}
 }
 
-// InstallHandler registers a handler for health checking on the path "/healthz" to mux.
+// InstallHandler registers handlers for health checking on the path
+// "/healthz" to mux. *All handlers* for mux must be specified in
+// exactly one call to InstallHandler. Calling InstallHandler more
+// than once for the same mux will result in a panic.
 func InstallHandler(mux mux, checks ...HealthzChecker) {
 	if len(checks) == 0 {
+		glog.V(5).Info("No default health checks specified. Installing the ping handler.")
 		checks = []HealthzChecker{PingHealthz}
 	}
+
+	glog.V(5).Info("Installing healthz checkers:", strings.Join(checkerNames(checks...), ", "))
+
 	mux.Handle("/healthz", handleRootHealthz(checks...))
 	for _, check := range checks {
 		mux.Handle(fmt.Sprintf("/healthz/%v", check.Name()), adaptCheckToHandler(check.Check))
@@ -131,4 +141,18 @@ func adaptCheckToHandler(c func(r *http.Request) error) http.HandlerFunc {
 			fmt.Fprint(w, "ok")
 		}
 	})
+}
+
+// checkerNames returns the names of the checks in the same order as passed in.
+func checkerNames(checks ...HealthzChecker) []string {
+	if len(checks) > 0 {
+		// accumulate the names of checks for printing them out.
+		checkerNames := make([]string, 0, len(checks))
+		for _, check := range checks {
+			// quote the Name so we can disambiguate
+			checkerNames = append(checkerNames, fmt.Sprintf("%q", check.Name()))
+		}
+		return checkerNames
+	}
+	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 )
 
@@ -79,4 +80,33 @@ func TestMulitipleChecks(t *testing.T) {
 			t.Errorf("case[%d] Expected:\n%v\ngot:\n%v\n", i, test.expectedResponse, w.Body.String())
 		}
 	}
+}
+
+func TestCheckerNames(t *testing.T) {
+	n1 := "n1"
+	n2 := "n2"
+	c1 := &healthzCheck{name: n1}
+	c2 := &healthzCheck{name: n2}
+
+	testCases := []struct {
+		desc string
+		have []HealthzChecker
+		want []string
+	}{
+		{"no checker", []HealthzChecker{}, []string{}},
+		{"one checker", []HealthzChecker{c1}, []string{n1}},
+		{"other checker", []HealthzChecker{c2}, []string{n2}},
+		{"checker order", []HealthzChecker{c1, c2}, []string{n1, n2}},
+		{"different checker order", []HealthzChecker{c2, c1}, []string{n2, n1}},
+	}
+
+	for _, tc := range testCases {
+		result := checkerNames(tc.have...)
+		t.Run(tc.desc, func(t *testing.T) {
+			if reflect.DeepEqual(tc.want, result) {
+				t.Errorf("want %#v, got %#v", tc.want, result)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
@pmorie upstream logging
 - InstallHandler is the public interface through which all interaction
   occurs.
 - It is good to know whether the default ping is occurring to know due
   to manual installation or automatic installation.
 - It is good to know how many handlers are installed to see whether
   code changes are taking effect.

**What this PR does / why we need it**:
add logging for external users of the genericapiserver

**Special notes for your reviewer**:
This should run exactly once at startup. 

**Release note**:
```release-note
NONE
```
