### PR TITLE
Reset local endpoints count to 0 for existing OnlyLocal services...

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -570,6 +570,11 @@ func buildNewEndpointsMap(allEndpoints []*api.Endpoints, curMap proxyEndpointMap
 				glog.V(4).Infof("Stale endpoint %v -> %v", svcPort, ep.endpoint)
 				staleSet[endpointServicePair{endpoint: ep.endpoint, servicePortName: svcPort}] = true
 			}
+
+			// Reset local endpoints count to 0 for existing OnlyLocal services.
+			if ep.isLocal {
+				hcEndpoints[svcPort.NamespacedName] = 0
+			}
 		}
 	}
 

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1729,7 +1729,9 @@ func Test_buildNewEndpointsMap(t *testing.T) {
 			endpoint:        "1.1.1.1:11",
 			servicePortName: makeServicePortName("ns1", "ep1", ""),
 		}},
-		expectedHealthchecks: map[types.NamespacedName]int{},
+		expectedHealthchecks: map[types.NamespacedName]int{
+			makeNSN("ns1", "ep1"): 0,
+		},
 	}, {
 		// Case[8]: add an IP and port
 		newEndpoints: []*api.Endpoints{
@@ -2050,6 +2052,7 @@ func Test_buildNewEndpointsMap(t *testing.T) {
 			servicePortName: makeServicePortName("ns4", "ep4", "p45"),
 		}},
 		expectedHealthchecks: map[types.NamespacedName]int{
+			makeNSN("ns2", "ep2"): 0,
 			makeNSN("ns4", "ep4"): 1,
 		},
 	}}


### PR DESCRIPTION
...before counting the new ones.

Fixes #44311. I'm still running tests on my cluster.

@thockin @freehan 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
