### PR TITLE
make deployment unit tests need to respect subresources

### DIFF
--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -226,7 +226,7 @@ func (f *fixture) run_(deploymentName string, startInformers bool, expectError b
 		}
 
 		expectedAction := f.actions[i]
-		if !expectedAction.Matches(action.GetVerb(), action.GetResource().Resource) {
+		if !(expectedAction.Matches(action.GetVerb(), action.GetResource().Resource) && action.GetSubresource() == expectedAction.GetSubresource()) {
 			f.t.Errorf("Expected\n\t%#v\ngot\n\t%#v", expectedAction, action)
 			continue
 		}


### PR DESCRIPTION
Fixes #42569
I check all the unit test code related to `Matches` method, seems there's only one line we could change to not break previous testing logic
@kargakis ptal, thanks

/assign @kargakis 