### PR TITLE
Add flag for controller-manager pod replicas

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -133,6 +133,7 @@ container-runtime-endpoint
 contain-pod-resources
 contention-profiling
 controllermanager-arg-overrides
+controllermanager-pod-replicas
 controller-start-interval
 core-kubeconfig
 cors-allowed-origins


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to have HA for federation controller-manager, we should be able to bring-up more than one replicas. This PR introduces a new flag to `kubefed init` to specify the number of replicas to bring-up for federation controller-manager

**Special notes for your reviewer**:
This is a sub-task of bigger work to add leader election to federation controller manager as documented in #44283

**Release note**:
```
[Federation] Add a flag `--controllermanager-pod-replicas` to `kubefed init` to specify number of replicas to bring-up for federation controller-manager.
```

cc @kubernetes/sig-federation-pr-reviews 