### PR TITLE
Refactor gcr.io/google_containers/elasticsearch to alpine

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/.gitignore
+++ b/cluster/addons/fluentd-elasticsearch/es-image/.gitignore
@@ -1,0 +1,1 @@
+elasticsearch_logging_discovery

--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,15 +16,19 @@
 # to work with Kubernetes logging. Inspired by the Dockerfile
 # dockerfile/elasticsearch
 
-FROM java:openjdk-8-jre
+FROM java:openjdk-8-jre-alpine
 
 
-ENV DEBIAN_FRONTEND noninteractive
 ENV ELASTICSEARCH_VERSION 2.4.1
 
-RUN apt-get update \
-    && apt-get install -y curl gosu \
-    && apt-get clean
+RUN apk update && \
+    apk --no-cache add \
+        --repository https://dl-3.alpinelinux.org/alpine/edge/testing \
+        --repository https://dl-3.alpinelinux.org/alpine/edge/community \
+        curl \
+        shadow \
+        tar \
+        gosu
 
 RUN set -x \
     && cd / \
@@ -44,6 +48,7 @@ COPY elasticsearch_logging_discovery /
 RUN useradd --no-create-home --user-group elasticsearch \
     && mkdir /data \
     && chown -R elasticsearch:elasticsearch /elasticsearch
+
 
 VOLUME ["/data"]
 EXPOSE 9200 9300

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 # The current value of the tag to be used for building and
 # pushing an image to gcr.io
-TAG = v2.4.1-2
+TAG = v2.4.1-3
 
 build:	elasticsearch_logging_discovery
 	docker build --pull -t gcr.io/google_containers/elasticsearch:$(TAG) .
@@ -25,7 +25,7 @@ push:
 	gcloud docker -- push gcr.io/google_containers/elasticsearch:$(TAG)
 
 elasticsearch_logging_discovery:
-	go build -a -ldflags "-w" elasticsearch_logging_discovery.go
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-w" elasticsearch_logging_discovery.go
 
 clean:
 	rm elasticsearch_logging_discovery

--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2015 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cluster/addons/fluentd-elasticsearch/es-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/es-image/run.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
-# Copyright 2015 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/build.sh
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/build.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2015 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cluster/addons/fluentd-elasticsearch/kibana-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/kibana-image/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright 2015 The Kubernetes Authors.
+# Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
This reduces the image size of the gcr.io/google_containers/elasticsearch image.

Before:
```
REPOSITORY                                                                       TAG                    IMAGE ID            CREATED             SIZE
gcr.io/google_containers/elasticsearch                                           v2.4.1-2               6941e43df81a        4 weeks ago         419MB
```
After:
```
REPOSITORY                                                                       TAG                    IMAGE ID            CREATED             SIZE
gcr.io/google_containers/elasticsearch                                           v2.4.1-2               24ad40c21a52        About an hour ago   178MB
```

**Special notes for your reviewer**:
I used a workaround to make the elasticsearch_logging_discovery binary work with alpine. (See [stackoverflow](https://stackoverflow.com/questions/34729748/installed-go-binary-not-found-in-path-on-alpine-linux-docker/35613430#35613430)). Alternatively this can be solved by setting ```CGO_ENABLED=0```when compiling the binary. I didn't feel comfortable chaing the Makefile though, since I'm no golang expert.  Feedback wanted!