### PR TITLE
Use ObjectGetter Interface instead of clientset.Interface for leaderelection pkg

### DIFF
--- a/pkg/client/leaderelection/BUILD
+++ b/pkg/client/leaderelection/BUILD
@@ -31,7 +31,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//pkg/client/clientset_generated/clientset/fake:go_default_library",
+        "//pkg/client/clientset_generated/clientset/typed/core/v1/fake:go_default_library",
         "//pkg/client/leaderelection/resourcelock:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/leaderelection/leaderelection_test.go
+++ b/pkg/client/leaderelection/leaderelection_test.go
@@ -28,7 +28,7 @@ import (
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api/v1"
-	fakeclientset "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
+	fakecorev1 "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/core/v1/fake"
 	rl "k8s.io/kubernetes/pkg/client/leaderelection/resourcelock"
 )
 
@@ -219,7 +219,7 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 			Identity:      "baz",
 			EventRecorder: &record.FakeRecorder{},
 		}
-		c := &fakeclientset.Clientset{Fake: core.Fake{}}
+		c := &fakecorev1.FakeCoreV1{Fake: &core.Fake{}}
 		for _, reactor := range test.reactors {
 			c.AddReactor(reactor.verb, objectType, reactor.reaction)
 		}

--- a/pkg/client/leaderelection/resourcelock/BUILD
+++ b/pkg/client/leaderelection/resourcelock/BUILD
@@ -17,7 +17,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//pkg/client/clientset_generated/clientset:go_default_library",
+        "//pkg/client/clientset_generated/clientset/typed/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],

--- a/pkg/client/leaderelection/resourcelock/configmaplock.go
+++ b/pkg/client/leaderelection/resourcelock/configmaplock.go
@@ -23,7 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	corev1client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/core/v1"
 )
 
 // TODO: This is almost a exact replica of Endpoints lock.
@@ -35,7 +35,7 @@ type ConfigMapLock struct {
 	// ConfigMapMeta should contain a Name and a Namespace of an
 	// ConfigMapMeta object that the Leadercmlector will attempt to lead.
 	ConfigMapMeta metav1.ObjectMeta
-	Client        clientset.Interface
+	Client        corev1client.ConfigMapsGetter
 	LockConfig    ResourceLockConfig
 	cm            *v1.ConfigMap
 }
@@ -44,7 +44,7 @@ type ConfigMapLock struct {
 func (cml *ConfigMapLock) Get() (*LeaderElectionRecord, error) {
 	var record LeaderElectionRecord
 	var err error
-	cml.cm, err = cml.Client.Core().ConfigMaps(cml.ConfigMapMeta.Namespace).Get(cml.ConfigMapMeta.Name, metav1.GetOptions{})
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Get(cml.ConfigMapMeta.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (cml *ConfigMapLock) Create(ler LeaderElectionRecord) error {
 	if err != nil {
 		return err
 	}
-	cml.cm, err = cml.Client.Core().ConfigMaps(cml.ConfigMapMeta.Namespace).Create(&v1.ConfigMap{
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Create(&v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cml.ConfigMapMeta.Name,
 			Namespace: cml.ConfigMapMeta.Namespace,
@@ -87,7 +87,7 @@ func (cml *ConfigMapLock) Update(ler LeaderElectionRecord) error {
 		return err
 	}
 	cml.cm.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
-	cml.cm, err = cml.Client.Core().ConfigMaps(cml.ConfigMapMeta.Namespace).Update(cml.cm)
+	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(cml.cm)
 	return err
 }
 

--- a/pkg/client/leaderelection/resourcelock/endpointslock.go
+++ b/pkg/client/leaderelection/resourcelock/endpointslock.go
@@ -23,14 +23,14 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
+	corev1client "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/core/v1"
 )
 
 type EndpointsLock struct {
 	// EndpointsMeta should contain a Name and a Namespace of an
 	// Endpoints object that the LeaderElector will attempt to lead.
 	EndpointsMeta metav1.ObjectMeta
-	Client        clientset.Interface
+	Client        corev1client.EndpointsGetter
 	LockConfig    ResourceLockConfig
 	e             *v1.Endpoints
 }
@@ -39,7 +39,7 @@ type EndpointsLock struct {
 func (el *EndpointsLock) Get() (*LeaderElectionRecord, error) {
 	var record LeaderElectionRecord
 	var err error
-	el.e, err = el.Client.Core().Endpoints(el.EndpointsMeta.Namespace).Get(el.EndpointsMeta.Name, metav1.GetOptions{})
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Get(el.EndpointsMeta.Name, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (el *EndpointsLock) Create(ler LeaderElectionRecord) error {
 	if err != nil {
 		return err
 	}
-	el.e, err = el.Client.Core().Endpoints(el.EndpointsMeta.Namespace).Create(&v1.Endpoints{
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Create(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      el.EndpointsMeta.Name,
 			Namespace: el.EndpointsMeta.Namespace,
@@ -82,7 +82,7 @@ func (el *EndpointsLock) Update(ler LeaderElectionRecord) error {
 		return err
 	}
 	el.e.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
-	el.e, err = el.Client.Core().Endpoints(el.EndpointsMeta.Namespace).Update(el.e)
+	el.e, err = el.Client.Endpoints(el.EndpointsMeta.Namespace).Update(el.e)
 	return err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We plan to reuse leaderelection pkg to add leader election function to federation controller manager, but the current implementation uses kubernetes clientset.Interface and federation clientset does not satisfy all the interface methods. It would be better if the leaderelection package use rest.Interface which is also supported by federation clientset.
This pr is to refactor leaderelection pkg to use rest.Interface instead of clientset.Interface

**Special notes for your reviewer**:
This is a sub-task of bigger work to add leader election to federation controller manager as documented in #44283

**Release note**:
```
NONE
```
