### PR TITLE
bazel: statically link dockerized components

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -32,17 +32,10 @@ docker_build(
 )
 
 docker_build(
-    name = "busybox-libc",
+    name = "busybox-net",
     base = ":busybox",
     debs = [
         "@libc_deb//file",
-    ],
-)
-
-docker_build(
-    name = "busybox-net",
-    base = ":busybox-libc",
-    debs = [
         "@iptables_deb//file",
         "@iproute2_deb//file",
         "@libnetlink_deb//file",
@@ -52,15 +45,15 @@ docker_build(
 
 DOCKERIZED_BINARIES = {
     "kube-apiserver": {
-        "base": ":busybox-libc",
+        "base": ":busybox",
         "target": "//cmd/kube-apiserver:kube-apiserver",
     },
     "kube-controller-manager": {
-        "base": ":busybox-libc",
+        "base": ":busybox",
         "target": "//cmd/kube-controller-manager:kube-controller-manager",
     },
     "kube-scheduler": {
-        "base": ":busybox-libc",
+        "base": ":busybox",
         "target": "//plugin/cmd/kube-scheduler:kube-scheduler",
     },
     "kube-proxy": {

--- a/cmd/cloud-controller-manager/BUILD
+++ b/cmd/cloud-controller-manager/BUILD
@@ -10,7 +10,14 @@ load(
 
 go_binary(
     name = "cloud-controller-manager",
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     library = ":go_default_library",
+    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
 )
 

--- a/cmd/kube-apiserver/BUILD
+++ b/cmd/kube-apiserver/BUILD
@@ -10,6 +10,12 @@ load(
 
 go_binary(
     name = "kube-apiserver",
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     library = ":go_default_library",
     linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],

--- a/cmd/kube-controller-manager/BUILD
+++ b/cmd/kube-controller-manager/BUILD
@@ -10,6 +10,12 @@ load(
 
 go_binary(
     name = "kube-controller-manager",
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     library = ":go_default_library",
     linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],

--- a/cmd/kube-proxy/BUILD
+++ b/cmd/kube-proxy/BUILD
@@ -10,6 +10,12 @@ load(
 
 go_binary(
     name = "kube-proxy",
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     library = ":go_default_library",
     linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],

--- a/cmd/kubeadm/BUILD
+++ b/cmd/kubeadm/BUILD
@@ -10,6 +10,12 @@ load(
 
 go_binary(
     name = "kubeadm",
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     library = ":go_default_library",
     linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],

--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -10,6 +10,12 @@ load(
 
 go_binary(
     name = "kubectl",
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     library = ":go_default_library",
     linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],

--- a/plugin/cmd/kube-scheduler/BUILD
+++ b/plugin/cmd/kube-scheduler/BUILD
@@ -10,6 +10,12 @@ load(
 
 go_binary(
     name = "kube-scheduler",
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     library = ":go_default_library",
     linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],

--- a/staging/src/k8s.io/kube-aggregator/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/BUILD
@@ -10,7 +10,14 @@ load(
 
 go_binary(
     name = "kube-aggregator",
+    gc_linkopts = [
+        "-linkmode",
+        "external",
+        "-extldflags",
+        "-static",
+    ],
     library = ":go_default_library",
+    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
 )
 


### PR DESCRIPTION
and remove libc from docker images when it's not needed.