### PR TITLE
Fix etcd semver validation by using 'sort -V'

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -36,12 +36,12 @@ kube::etcd::validate() {
 
   # validate installed version is at least equal to minimum
   version=$(etcd --version | tail -n +1 | head -n 1 | cut -d " " -f 3)
-  if [[ "${version}" < "${ETCD_VERSION}" ]]; then
+  if [[ "`echo -e "${version}\n${ETCD_VERSION}" | sort -rV | head -n 1`" != "$version" ]]; then
    export PATH=$KUBE_ROOT/third_party/etcd:$PATH
    hash etcd
    echo $PATH
    version=$(etcd --version | head -n 1 | cut -d " " -f 3)
-   if [[ "${version}" < "${ETCD_VERSION}" ]]; then
+   if [[ "`echo -e "${version}\n${ETCD_VERSION}" | sort -rV | head -n 1`" != "$version" ]]; then
     kube::log::usage "etcd version ${ETCD_VERSION} or greater required."
     kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."
     exit 1


### PR DESCRIPTION
The old check would erroneously say e.g. v3.0.6 is greater than v3.0.17 which is obviously false. So hack/local-up-cluster.sh would be allowed to run and things would break because etcd does not meet the minimum. sort -V validates it correctly.
```release-note
NONE
```
