### PR TITLE
Fix to not allow empty topology key when the feature AffinityInAnnotations is disabled.

### DIFF
--- a/pkg/api/validation/BUILD
+++ b/pkg/api/validation/BUILD
@@ -85,6 +85,7 @@ go_test(
         "//vendor:k8s.io/apimachinery/pkg/util/sets",
         "//vendor:k8s.io/apimachinery/pkg/util/validation/field",
         "//vendor:k8s.io/apimachinery/pkg/util/yaml",
+        "//vendor:k8s.io/apiserver/pkg/util/feature",
     ],
 )
 

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2213,6 +2213,9 @@ func ValidatePreferredSchedulingTerms(terms []api.PreferredSchedulingTerm, fldPa
 // validatePodAffinityTerm tests that the specified podAffinityTerm fields have valid data
 func validatePodAffinityTerm(podAffinityTerm api.PodAffinityTerm, allowEmptyTopologyKey bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if !utilfeature.DefaultFeatureGate.Enabled(features.AffinityInAnnotations) && len(podAffinityTerm.TopologyKey) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("topologyKey"), "can not be empty"))
+	}
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(podAffinityTerm.LabelSelector, fldPath.Child("matchExpressions"))...)
 	for _, name := range podAffinityTerm.Namespaces {
 		for _, msg := range ValidateNamespaceName(name, false) {


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/44360
@davidopp @kubernetes/sig-scheduling-pr-reviews 

