### PR TITLE
Add a few missing binaries to the Bazel SERVER_TARGETS list

### DIFF
--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -68,11 +68,13 @@ NODE_TARGETS = [
 # No need to duplicate CLIENT_TARGETS or NODE_TARGETS here,
 # since we include them in the actual build rule.
 SERVER_TARGETS = [
+    "//cmd/cloud-controller-manager",
     "//cmd/hyperkube",
     "//cmd/kube-apiserver",
     "//cmd/kube-controller-manager",
     "//cmd/kubeadm",
     "//plugin/cmd/kube-scheduler",
+    "//vendor/k8s.io/kube-aggregator",
 ]
 
 # kube::golang::test_targets


### PR DESCRIPTION
**What this PR does / why we need it**: catches up our Bazel build with #41413 and #40204.

If you have clever ideas of how to keep the lists in `build/release-tars/BUILD` and `hack/lib/golang.sh` in sync I'd love hear them.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

/assign @spxtr @mikedanese 
