### PR TITLE
Bugfix: OpenAPI generator should pass generate type extensions

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/openapi/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/server/openapi/OWNERS
@@ -3,3 +3,5 @@ reviewers:
 - gmarek
 - mbohlool
 - philips
+approvers:
+- mbohlool

--- a/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi.go
@@ -127,6 +127,7 @@ func (o *openAPI) buildDefinitionRecursively(name string) error {
 	}
 	if item, ok := o.definitions[name]; ok {
 		schema := spec.Schema{
+			VendorExtensible:   item.Schema.VendorExtensible,
 			SchemaProps:        item.Schema.SchemaProps,
 			SwaggerSchemaProps: item.Schema.SwaggerSchemaProps,
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi_test.go
@@ -97,6 +97,7 @@ func (_ TestInput) OpenAPIDefinition() *openapi.OpenAPIDefinition {
 			},
 		},
 	}
+	schema.Extensions = spec.Extensions{"x-test": "test"}
 	return &openapi.OpenAPIDefinition{
 		Schema:       schema,
 		Dependencies: []string{},
@@ -383,6 +384,11 @@ func getTestInputDefinition() spec.Schema {
 						},
 					},
 				},
+			},
+		},
+		VendorExtensible: spec.VendorExtensible{
+			Extensions: spec.Extensions{
+				"x-test": "test",
 			},
 		},
 	}


### PR DESCRIPTION
OpenAPI spec generator does not pass generated type extensions (using `x-kubernetes-` tags on types). This is already working for field extensions but not for types.