### PR TITLE
Adjust the precedence of invocation for getting host ip address

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -446,17 +446,16 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		} else if addr := net.ParseIP(kl.hostname); addr != nil {
 			ipAddr = addr
 		} else {
-			var addrs []net.IP
-			addrs, err = net.LookupIP(node.Name)
-			for _, addr := range addrs {
-				if !addr.IsLoopback() && addr.To4() != nil {
-					ipAddr = addr
-					break
-				}
-			}
-
+			ipAddr, _ = utilnet.ChooseHostInterface()
 			if ipAddr == nil {
-				ipAddr, err = utilnet.ChooseHostInterface()
+				var addrs []net.IP
+				addrs, err = net.LookupIP(node.Name)
+				for _, addr := range addrs {
+					if !addr.IsLoopback() && addr.To4() != nil {
+						ipAddr = addr
+						break
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION

The time out duration of `net.LoopupIP` is almost 45s in my workaround. Due to this the kubelet could not post the node status normally. Even if the default node status updating frequency is 10s+, actually, the frequency is 55s. this duration will cause the master(node controller) can not get the nodes status in grace period. So when i check the nodes status from master by using kubectl get nodes -w, the outputs:

```
[root@admin etc]# kubectl get nodes -w
NAME        STATUS     AGE       VERSION
k8s-node1   NotReady   1h        v1.7.0-alpha.1.206+e18843d353b21c-dirty
k8s-node1   Ready     1h        v1.7.0-alpha.1.332+284615d79d9db4
k8s-node1   NotReady   1h        v1.7.0-alpha.1.332+284615d79d9db4
k8s-node1   NotReady   1h        v1.7.0-alpha.1.332+284615d79d9db4
k8s-node1   Ready     1h        v1.7.0-alpha.1.332+284615d79d9db4
```

**log:** kube-controller.INFO

```
I0412 17:08:10.119644    3268 nodecontroller.go:969] node k8s-node1 hasn't been updated for 55.201756101s. Last ready condition is: {Type:Ready Status:Unknown LastHeartbeatTime:2017-04-12 17:07:06 +0800 CST LastTransitionTime:2017-04-12 17:07:54.924521652 +0800 CST Reason:NodeStatusUnknown Message:Kubelet stopped posting node status.}
I0412 17:08:10.119704    3268 nodecontroller.go:997] node k8s-node1 hasn't been updated for 55.201826947s. Last OutOfDisk is: &NodeCondition{Type:OutOfDisk,Status:Unknown,LastHeartbeatTime:2017-04-12 17:07:06 +0800 CST,LastTransitionTime:2017-04-12 17:07:54.924521985 +0800 CST,Reason:NodeStatusUnknown,Message:Kubelet stopped posting node status.,}
I0412 17:08:10.119740    3268 nodecontroller.go:997] node k8s-node1 hasn't been updated for 55.201862437s. Last MemoryPressure is: &NodeCondition{Type:MemoryPressure,Status:Unknown,LastHeartbeatTime:2017-04-12 17:07:06 +0800 CST,LastTransitionTime:2017-04-12 17:07:54.924521985 +0800 CST,Reason:NodeStatusUnknown,Message:Kubelet stopped posting node status.,}
I0412 17:08:10.119765    3268 nodecontroller.go:997] node k8s-node1 hasn't been updated for 55.201889127s. Last DiskPressure is: &NodeCondition{Type:DiskPressure,Status:Unknown,LastHeartbeatTime:2017-04-12 17:07:06 +0800 CST,LastTransitionTime:2017-04-12 17:07:54.924521985 +0800 CST,Reason:NodeStatusUnknown,Message:Kubelet stopped posting node status.,}

```
**what is PR does?**
This PR take priority to call `utilnet.ChooseHostInterface()`, if the result not success, then call `net.LookupIP(node.Name)` . This can avoid of posting node status timeout result in the nodes status transition frequently in some context.