### PR TITLE
`failure-domain` is no longer used in command line arg.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/well_known_labels.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/well_known_labels.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1
 
 const (
-	// If you add a new topology domain here, also consider adding it to the set of default values
-	// for the scheduler's --failure-domain command-line argument.
 	LabelHostname          = "kubernetes.io/hostname"
 	LabelZoneFailureDomain = "failure-domain.beta.kubernetes.io/zone"
 	LabelZoneRegion        = "failure-domain.beta.kubernetes.io/region"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
