### PR TITLE
add deregistration for paths

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -21,13 +21,21 @@ import (
 	"net/http"
 	"runtime/debug"
 	"sort"
+	"sync"
+	"sync/atomic"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
-// PathRecorderMux wraps a mux object and records the registered exposedPaths. It is _not_ go routine safe.
+// PathRecorderMux wraps a mux object and records the registered exposedPaths.
 type PathRecorderMux struct {
-	mux          *http.ServeMux
+	lock          sync.Mutex
+	pathToHandler map[string]http.Handler
+
+	// mux stores an *http.ServeMux and is used to handle the actual serving
+	mux atomic.Value
+
+	// exposedPaths is the list of paths that should be shown at /
 	exposedPaths []string
 
 	// pathStacks holds the stacks of all registered paths.  This allows us to show a more helpful message
@@ -37,10 +45,15 @@ type PathRecorderMux struct {
 
 // NewPathRecorderMux creates a new PathRecorderMux with the given mux as the base mux.
 func NewPathRecorderMux() *PathRecorderMux {
-	return &PathRecorderMux{
-		mux:        http.NewServeMux(),
-		pathStacks: map[string]string{},
+	ret := &PathRecorderMux{
+		pathToHandler: map[string]http.Handler{},
+		mux:           atomic.Value{},
+		exposedPaths:  []string{},
+		pathStacks:    map[string]string{},
 	}
+
+	ret.mux.Store(http.NewServeMux())
+	return ret
 }
 
 // ListedPaths returns the registered handler exposedPaths.
@@ -58,41 +71,81 @@ func (m *PathRecorderMux) trackCallers(path string) {
 	m.pathStacks[path] = string(debug.Stack())
 }
 
+// refreshMuxLocked creates a new mux and must be called while locked.  Otherwise the view of handlers may
+// not be consistent
+func (m *PathRecorderMux) refreshMuxLocked() {
+	mux := http.NewServeMux()
+	for path, handler := range m.pathToHandler {
+		mux.Handle(path, handler)
+	}
+
+	m.mux.Store(mux)
+}
+
+// Unregister removes a path from the mux.
+func (m *PathRecorderMux) Unregister(path string) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	delete(m.pathToHandler, path)
+	delete(m.pathStacks, path)
+	for i := range m.exposedPaths {
+		if m.exposedPaths[i] == path {
+			m.exposedPaths = append(m.exposedPaths[:i], m.exposedPaths[i+1:]...)
+			break
+		}
+	}
+
+	m.refreshMuxLocked()
+}
+
 // Handle registers the handler for the given pattern.
 // If a handler already exists for pattern, Handle panics.
 func (m *PathRecorderMux) Handle(path string, handler http.Handler) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	m.trackCallers(path)
 
 	m.exposedPaths = append(m.exposedPaths, path)
-	m.mux.Handle(path, handler)
+	m.pathToHandler[path] = handler
+	m.refreshMuxLocked()
 }
 
 // HandleFunc registers the handler function for the given pattern.
 // If a handler already exists for pattern, Handle panics.
 func (m *PathRecorderMux) HandleFunc(path string, handler func(http.ResponseWriter, *http.Request)) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	m.trackCallers(path)
 
 	m.exposedPaths = append(m.exposedPaths, path)
-	m.mux.HandleFunc(path, handler)
+	m.pathToHandler[path] = http.HandlerFunc(handler)
+	m.refreshMuxLocked()
 }
 
 // UnlistedHandle registers the handler for the given pattern, but doesn't list it.
 // If a handler already exists for pattern, Handle panics.
 func (m *PathRecorderMux) UnlistedHandle(path string, handler http.Handler) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	m.trackCallers(path)
 
-	m.mux.Handle(path, handler)
+	m.pathToHandler[path] = handler
+	m.refreshMuxLocked()
 }
 
 // UnlistedHandleFunc registers the handler function for the given pattern, but doesn't list it.
 // If a handler already exists for pattern, Handle panics.
 func (m *PathRecorderMux) UnlistedHandleFunc(path string, handler func(http.ResponseWriter, *http.Request)) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	m.trackCallers(path)
 
-	m.mux.HandleFunc(path, handler)
+	m.pathToHandler[path] = http.HandlerFunc(handler)
+	m.refreshMuxLocked()
 }
 
 // ServeHTTP makes it an http.Handler
 func (m *PathRecorderMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	m.mux.ServeHTTP(w, r)
+	m.mux.Load().(*http.ServeMux).ServeHTTP(w, r)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers.go
@@ -19,6 +19,8 @@ package apiregistration
 import (
 	"sort"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func SortedByGroup(servers []*APIService) [][]*APIService {
@@ -56,4 +58,11 @@ func (s ByPriority) Less(i, j int) bool {
 		return strings.Compare(s[i].Name, s[j].Name) < 0
 	}
 	return s[i].Spec.Priority < s[j].Spec.Priority
+}
+
+// APIServiceNameToGroupVersion returns the GroupVersion for a given apiServiceName.  The name
+// must be valid, but any object you get back from an informer will be valid.
+func APIServiceNameToGroupVersion(apiServiceName string) schema.GroupVersion {
+	tokens := strings.SplitN(apiServiceName, ".", 2)
+	return schema.GroupVersion{Group: tokens[1], Version: tokens[0]}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis_test.go
@@ -338,13 +338,13 @@ func TestAPIGroupMissing(t *testing.T) {
 		t.Fatalf("expected %v, got %v", http.StatusForbidden, resp.StatusCode)
 	}
 
-	// groupName still has no api services for it (like it was deleted), it should 404
+	// groupName still has no api services for it (like it was deleted), it should delegate
 	resp, err = http.Get(server.URL + "/apis/groupName/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if resp.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected %v, got %v", http.StatusNotFound, resp.StatusCode)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected %v, got %v", http.StatusForbidden, resp.StatusCode)
 	}
 
 	// missing group should delegate still has no api services for it (like it was deleted)

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -64,7 +64,12 @@ type proxyHandlingInfo struct {
 }
 
 func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	handlingInfo := r.handlingInfo.Load().(proxyHandlingInfo)
+	value := r.handlingInfo.Load()
+	if value == nil {
+		r.localDelegate.ServeHTTP(w, req)
+		return
+	}
+	handlingInfo := value.(proxyHandlingInfo)
 	if handlingInfo.local {
 		r.localDelegate.ServeHTTP(w, req)
 		return
@@ -196,8 +201,4 @@ func (r *proxyHandler) updateAPIService(apiService *apiregistrationapi.APIServic
 	}
 	newInfo.proxyRoundTripper, newInfo.transportBuildingError = restclient.TransportFor(newInfo.restConfig)
 	r.handlingInfo.Store(newInfo)
-}
-
-func (r *proxyHandler) removeAPIService() {
-	r.handlingInfo.Store(proxyHandlingInfo{})
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -83,13 +83,6 @@ func TestProxyHandler(t *testing.T) {
 	targetServer := httptest.NewTLSServer(target)
 	defer targetServer.Close()
 
-	handler := &proxyHandler{
-		localDelegate: http.NewServeMux(),
-	}
-
-	server := httptest.NewServer(handler)
-	defer server.Close()
-
 	tests := map[string]struct {
 		user       user.Info
 		path       string
@@ -161,45 +154,53 @@ func TestProxyHandler(t *testing.T) {
 
 	for name, tc := range tests {
 		target.Reset()
-		handler.contextMapper = &fakeRequestContextMapper{user: tc.user}
-		handler.removeAPIService()
-		if tc.apiService != nil {
-			handler.updateAPIService(tc.apiService, tc.apiService.Spec.Service.Name+"."+tc.apiService.Spec.Service.Namespace+".svc")
-			curr := handler.handlingInfo.Load().(proxyHandlingInfo)
-			curr.destinationHost = targetServer.Listener.Addr().String()
-			handler.handlingInfo.Store(curr)
-		}
 
-		resp, err := http.Get(server.URL + tc.path)
-		if err != nil {
-			t.Errorf("%s: %v", name, err)
-			continue
-		}
-		if e, a := tc.expectedStatusCode, resp.StatusCode; e != a {
-			body, _ := httputil.DumpResponse(resp, true)
-			t.Logf("%s: %v", name, string(body))
-			t.Errorf("%s: expected %v, got %v", name, e, a)
-			continue
-		}
-		bytes, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Errorf("%s: %v", name, err)
-			continue
-		}
-		if !strings.Contains(string(bytes), tc.expectedBody) {
-			t.Errorf("%s: expected %q, got %q", name, tc.expectedBody, string(bytes))
-			continue
-		}
+		func() {
+			handler := &proxyHandler{
+				localDelegate: http.NewServeMux(),
+			}
+			handler.contextMapper = &fakeRequestContextMapper{user: tc.user}
+			server := httptest.NewServer(handler)
+			defer server.Close()
 
-		if e, a := tc.expectedCalled, target.called; e != a {
-			t.Errorf("%s: expected %v, got %v", name, e, a)
-			continue
-		}
-		// this varies every test
-		delete(target.headers, "X-Forwarded-Host")
-		if e, a := tc.expectedHeaders, target.headers; !reflect.DeepEqual(e, a) {
-			t.Errorf("%s: expected %v, got %v", name, e, a)
-			continue
-		}
+			if tc.apiService != nil {
+				handler.updateAPIService(tc.apiService, tc.apiService.Spec.Service.Name+"."+tc.apiService.Spec.Service.Namespace+".svc")
+				curr := handler.handlingInfo.Load().(proxyHandlingInfo)
+				curr.destinationHost = targetServer.Listener.Addr().String()
+				handler.handlingInfo.Store(curr)
+			}
+
+			resp, err := http.Get(server.URL + tc.path)
+			if err != nil {
+				t.Errorf("%s: %v", name, err)
+				return
+			}
+			if e, a := tc.expectedStatusCode, resp.StatusCode; e != a {
+				body, _ := httputil.DumpResponse(resp, true)
+				t.Logf("%s: %v", name, string(body))
+				t.Errorf("%s: expected %v, got %v", name, e, a)
+				return
+			}
+			bytes, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Errorf("%s: %v", name, err)
+				return
+			}
+			if !strings.Contains(string(bytes), tc.expectedBody) {
+				t.Errorf("%s: expected %q, got %q", name, tc.expectedBody, string(bytes))
+				return
+			}
+
+			if e, a := tc.expectedCalled, target.called; e != a {
+				t.Errorf("%s: expected %v, got %v", name, e, a)
+				return
+			}
+			// this varies every test
+			delete(target.headers, "X-Forwarded-Host")
+			if e, a := tc.expectedHeaders, target.headers; !reflect.DeepEqual(e, a) {
+				t.Errorf("%s: expected %v, got %v", name, e, a)
+				return
+			}
+		}()
 	}
 }


### PR DESCRIPTION
Aggregation and TPRs require the ability to de-register endpoints.  This adds the capability and makes it threadsafe.