### PR TITLE
coredns: support IPv6 record set

### DIFF
--- a/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
+++ b/federation/pkg/dnsprovider/providers/aws/route53/route53_test.go
@@ -288,7 +288,7 @@ func TestResourceRecordSetsReplaceAll(t *testing.T) {
 	tests.CommonTestResourceRecordSetsReplaceAll(t, zone)
 }
 
-/* TestResourceRecordSetsHonorsType verifies that we can add records of the same name but different types */
+/* TestResourceRecordSetsDifferentTypes verifies that we can add records of the same name but different types */
 func TestResourceRecordSetsDifferentTypes(t *testing.T) {
 	zone := firstZone(t)
 	tests.CommonTestResourceRecordSetsDifferentTypes(t, zone)

--- a/federation/pkg/dnsprovider/providers/coredns/coredns_test.go
+++ b/federation/pkg/dnsprovider/providers/coredns/coredns_test.go
@@ -176,6 +176,9 @@ func TestResourceRecordSetsAddSuccess(t *testing.T) {
 	addRrsetOrFail(t, sets, set)
 	defer sets.StartChangeset().Remove(set).Apply()
 	t.Logf("Successfully added resource record set: %v", set)
+	if sets.Zone().ID() != zone.ID() {
+		t.Errorf("Zone for rrset does not match expected")
+	}
 }
 
 /* TestResourceRecordSetsAdditionVisible verifies that added RRS is visible after addition */
@@ -254,8 +257,14 @@ func TestResourceRecordSetsReplace(t *testing.T) {
 	tests.CommonTestResourceRecordSetsReplace(t, zone)
 }
 
-/* TestResourceRecordSetsReplaceAll verifies that we can remove an RRS and create one with a different name*/
+/* TestResourceRecordSetsReplaceAll verifies that we can remove an RRS and create one with a different name */
 func TestResourceRecordSetsReplaceAll(t *testing.T) {
 	zone := firstZone(t)
 	tests.CommonTestResourceRecordSetsReplaceAll(t, zone)
+}
+
+/* TestResourceRecordSetsDifferentTypes verifies that we can add records with same name, but different types */
+func TestResourceRecordSetsDifferentTypes(t *testing.T) {
+	zone := firstZone(t)
+	tests.CommonTestResourceRecordSetsDifferentTypes(t, zone)
 }

--- a/federation/pkg/dnsprovider/providers/coredns/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/coredns/rrsets.go
@@ -74,6 +74,10 @@ func (rrsets ResourceRecordSets) Get(name string) ([]dnsprovider.ResourceRecordS
 			rrset.rrsType = rrstype.CNAME
 		case ip.To4() != nil:
 			rrset.rrsType = rrstype.A
+		case ip.To16() != nil:
+			rrset.rrsType = rrstype.AAAA
+		default:
+			// Cannot occur
 		}
 		rrset.rrdatas = append(rrset.rrdatas, service.Host)
 		rrset.ttl = int64(service.TTL)

--- a/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
@@ -266,7 +266,7 @@ func TestResourceRecordSetsReplaceAll(t *testing.T) {
 	tests.CommonTestResourceRecordSetsReplaceAll(t, zone)
 }
 
-/* TestResourceRecordSetsHonorsType verifies that we can add records of the same name but different types */
+/* TestResourceRecordSetsDifferentType verifies that we can add records of the same name but different types */
 func TestResourceRecordSetsDifferentTypes(t *testing.T) {
 	zone := firstZone(t)
 	tests.CommonTestResourceRecordSetsDifferentTypes(t, zone)

--- a/federation/pkg/dnsprovider/tests/commontests.go
+++ b/federation/pkg/dnsprovider/tests/commontests.go
@@ -32,7 +32,6 @@ func CommonTestResourceRecordSetsReplace(t *testing.T, zone dnsprovider.Zone) {
 	rrset := rrsets.New("alpha.test.com", []string{"8.8.4.4"}, 40, rrstype.A)
 	addRrsetOrFail(t, sets, rrset)
 	defer sets.StartChangeset().Remove(rrset).Apply()
-	t.Logf("Successfully added resource record set: %v", rrset)
 
 	// Replace the record (change ttl and rrdatas)
 	newRrset := rrsets.New("alpha.test.com", []string{"8.8.8.8"}, 80, rrstype.A)
@@ -40,9 +39,9 @@ func CommonTestResourceRecordSetsReplace(t *testing.T, zone dnsprovider.Zone) {
 	if err != nil {
 		t.Errorf("Failed to replace resource record set %v -> %v: %v", rrset, newRrset, err)
 	} else {
+		defer sets.StartChangeset().Remove(newRrset).Apply()
 		t.Logf("Correctly replaced resource record %v -> %v", rrset, newRrset)
 	}
-	defer sets.StartChangeset().Remove(newRrset).Apply()
 
 	// Check that the record was updated
 	assertHasRecord(t, sets, newRrset)
@@ -56,7 +55,6 @@ func CommonTestResourceRecordSetsReplaceAll(t *testing.T, zone dnsprovider.Zone)
 	rrset := rrsets.New("alpha.test.com", []string{"8.8.4.4"}, 40, rrstype.A)
 	addRrsetOrFail(t, sets, rrset)
 	defer sets.StartChangeset().Remove(rrset).Apply()
-	t.Logf("Successfully added resource record set: %v", rrset)
 
 	newRrset := rrsets.New("beta.test.com", []string{"8.8.8.8"}, 80, rrstype.A)
 
@@ -74,7 +72,7 @@ func CommonTestResourceRecordSetsReplaceAll(t *testing.T, zone dnsprovider.Zone)
 	assertNotHasRecord(t, sets, rrset.Name(), rrset.Type())
 }
 
-/* CommonTestResourceRecordSetsHonorsType verifies that we can add records of the same name but different types */
+/* CommonTestResourceRecordSetsDifferentType verifies that we can add records of the same name but different types */
 func CommonTestResourceRecordSetsDifferentTypes(t *testing.T, zone dnsprovider.Zone) {
 	rrsets, _ := zone.ResourceRecordSets()
 
@@ -82,7 +80,6 @@ func CommonTestResourceRecordSetsDifferentTypes(t *testing.T, zone dnsprovider.Z
 	rrset := rrsets.New("alpha.test.com", []string{"8.8.4.4"}, 40, rrstype.A)
 	addRrsetOrFail(t, sets, rrset)
 	defer sets.StartChangeset().Remove(rrset).Apply()
-	t.Logf("Successfully added resource record set: %v", rrset)
 
 	aaaaRrset := rrsets.New("alpha.test.com", []string{"2001:4860:4860::8888"}, 80, rrstype.AAAA)
 
@@ -190,6 +187,8 @@ func assertEquivalent(t *testing.T, l, r dnsprovider.ResourceRecordSet) {
 func addRrsetOrFail(t *testing.T, rrsets dnsprovider.ResourceRecordSets, rrset dnsprovider.ResourceRecordSet) {
 	err := rrsets.StartChangeset().Add(rrset).Apply()
 	if err != nil {
-		t.Fatalf("Failed to add recordsets: %v", err)
+		t.Fatalf("Failed to add recordset %v: %v", rrset, err)
+	} else {
+		t.Logf("Successfully added resource record set: %v", rrset)
 	}
 }


### PR DESCRIPTION
Added support for AAAA record for coredns and included unit test.
Refactored common test code to reduce duplication from added test and
existing tests.
Fixed function names in comments for Google and AWS tests to match
actual test name in this area.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Adding IPv6 support to kubernetes, once piece at a time. :)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #44351

**Special notes for your reviewer**:
In addition to the change and unit test method, I did some minor refactoring (since the UT was a near clone of an existing test). Fixed typos in related test methods' comment lines. Please let me know if this is OK (I was thinking it was a small change, but don't know the protocol here), or if I need to break it into multiple commits.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
