### PR TITLE
switch to gorilla mux

### DIFF
--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -411,6 +411,14 @@
 			"Rev": "12f19e5e04d617182cffa5c11f189ef0013b9791"
 		},
 		{
+			"ImportPath": "github.com/gorilla/context",
+			"Rev": "215affda49addc4c8ef7e2534915df2c8c35c6cd"
+		},
+		{
+			"ImportPath": "github.com/gorilla/mux",
+			"Rev": "8096f47503459bcc74d1f4c487b7e6e42e5746b5"
+		},
+		{
 			"ImportPath": "github.com/grpc-ecosystem/go-grpc-prometheus",
 			"Rev": "2500245aa6110c562d17020fb31a2c133d737799"
 		},

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -479,7 +479,14 @@ func (c completedConfig) buildHandlers(s *GenericAPIServer, delegate http.Handle
 		}
 	}
 
-	installAPI(s, c.Config, delegate)
+	installAPI(s, c.Config)
+	if delegate != nil {
+		s.FallThroughHandler.NotFoundHandler(delegate)
+	} else if c.EnableIndex {
+		s.FallThroughHandler.NotFoundHandler(routes.NotFoundIndex{
+			PathProvider: s.listedPathProvider,
+		})
+	}
 
 	s.Handler = c.BuildHandlerChainFunc(s.HandlerContainer.ServeMux, c.Config)
 
@@ -500,15 +507,9 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 	return handler
 }
 
-func installAPI(s *GenericAPIServer, c *Config, delegate http.Handler) {
-	switch {
-	case c.EnableIndex:
-		routes.Index{}.Install(s.listedPathProvider, c.FallThroughHandler, delegate)
-
-	case delegate != nil:
-		// if we have a delegate, allow it to handle everything that's unmatched even if
-		// the index is disabled.
-		s.FallThroughHandler.UnlistedHandleFunc("/", delegate.ServeHTTP)
+func installAPI(s *GenericAPIServer, c *Config) {
+	if c.EnableIndex {
+		routes.Index{}.Install(s.listedPathProvider, c.FallThroughHandler)
 	}
 	if c.SwaggerConfig != nil && c.EnableSwaggerUI {
 		routes.SwaggerUI{}.Install(s.FallThroughHandler)

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -197,7 +197,7 @@ type emptyDelegate struct {
 }
 
 func (s emptyDelegate) UnprotectedHandler() http.Handler {
-	return http.NotFoundHandler()
+	return nil
 }
 func (s emptyDelegate) PostStartHooks() map[string]postStartHookEntry {
 	return map[string]postStartHookEntry{}

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/profiling.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/profiling.go
@@ -17,6 +17,7 @@ limitations under the License.
 package routes
 
 import (
+	"net/http"
 	"net/http/pprof"
 
 	"k8s.io/apiserver/pkg/server/mux"
@@ -27,7 +28,7 @@ type Profiling struct{}
 
 // Install adds the Profiling webservice to the given mux.
 func (d Profiling) Install(c *mux.PathRecorderMux) {
-	c.UnlistedHandleFunc("/debug/pprof/", pprof.Index)
+	c.UnlistedHandlePrefix("/debug/pprof/", http.HandlerFunc(pprof.Index))
 	c.UnlistedHandleFunc("/debug/pprof/profile", pprof.Profile)
 	c.UnlistedHandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	c.UnlistedHandleFunc("/debug/pprof/trace", pprof.Trace)

--- a/staging/src/k8s.io/apiserver/pkg/server/routes/swaggerui.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/routes/swaggerui.go
@@ -36,5 +36,5 @@ func (l SwaggerUI) Install(c *mux.PathRecorderMux) {
 		Prefix:   "third_party/swagger-ui",
 	})
 	prefix := "/swagger-ui/"
-	c.Handle(prefix, http.StripPrefix(prefix, fileServer))
+	c.HandlePrefix(prefix, http.StripPrefix(prefix, fileServer))
 }

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -167,6 +167,14 @@
 			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 		},
 		{
+			"ImportPath": "github.com/gorilla/context",
+			"Rev": "215affda49addc4c8ef7e2534915df2c8c35c6cd"
+		},
+		{
+			"ImportPath": "github.com/gorilla/mux",
+			"Rev": "8096f47503459bcc74d1f4c487b7e6e42e5746b5"
+		},
+		{
 			"ImportPath": "github.com/grpc-ecosystem/go-grpc-prometheus",
 			"Rev": "2500245aa6110c562d17020fb31a2c133d737799"
 		},

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -173,12 +173,10 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 	apisHandler := &apisHandler{
 		codecs:          Codecs,
 		lister:          s.lister,
-		delegate:        s.GenericAPIServer.FallThroughHandler,
 		serviceLister:   s.serviceLister,
 		endpointsLister: s.endpointsLister,
 	}
-	s.GenericAPIServer.HandlerContainer.Handle("/apis", apisHandler)
-	s.GenericAPIServer.HandlerContainer.Handle("/apis/", apisHandler)
+	s.GenericAPIServer.FallThroughHandler.Handle("/apis", apisHandler)
 
 	apiserviceRegistrationController := NewAPIServiceRegistrationController(informerFactory.Apiregistration().InternalVersion().APIServices(), kubeInformers.Core().V1().Services(), s)
 
@@ -221,7 +219,6 @@ func (s *APIAggregator) AddAPIService(apiService *apiregistration.APIService, de
 	proxyHandler.updateAPIService(apiService, destinationHost)
 	s.proxyHandlers[apiService.Name] = proxyHandler
 	s.GenericAPIServer.FallThroughHandler.Handle(proxyPath, proxyHandler)
-	s.GenericAPIServer.FallThroughHandler.UnlistedHandle(proxyPath+"/", proxyHandler)
 
 	// if we're dealing with the legacy group, we're done here
 	if apiService.Name == legacyAPIServiceName {
@@ -245,7 +242,6 @@ func (s *APIAggregator) AddAPIService(apiService *apiregistration.APIService, de
 	}
 	// aggregation is protected
 	s.GenericAPIServer.FallThroughHandler.Handle(groupPath, groupDiscoveryHandler)
-	s.GenericAPIServer.FallThroughHandler.UnlistedHandle(groupPath+"/", groupDiscoveryHandler)
 	s.handledGroups.Insert(apiService.Spec.Group)
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis.go
@@ -40,8 +40,6 @@ type apisHandler struct {
 
 	serviceLister   v1listers.ServiceLister
 	endpointsLister v1listers.EndpointsLister
-
-	delegate http.Handler
 }
 
 var discoveryGroup = metav1.APIGroup{
@@ -59,12 +57,6 @@ var discoveryGroup = metav1.APIGroup{
 }
 
 func (r *apisHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	// don't handle URLs that aren't /apis
-	if req.URL.Path != "/apis" && req.URL.Path != "/apis/" {
-		r.delegate.ServeHTTP(w, req)
-		return
-	}
-
 	discoveryGroupList := &metav1.APIGroupList{
 		// always add OUR api group to the list first.  Since we'll never have a registered APIService for it
 		// and since this is the crux of the API, having this first will give our names priority.  It's good to be king.
@@ -165,12 +157,6 @@ type apiGroupHandler struct {
 }
 
 func (r *apiGroupHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	// don't handle URLs that aren't /apis/<groupName>
-	if req.URL.Path != "/apis/"+r.groupName && req.URL.Path != "/apis/"+r.groupName+"/" {
-		r.delegate.ServeHTTP(w, req)
-		return
-	}
-
 	apiServices, err := r.lister.List(labels.Everything())
 	if statusErr, ok := err.(*apierrors.StatusError); ok && err != nil {
 		responsewriters.WriteRawJSON(int(statusErr.Status().Code), statusErr.Status(), w)

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy.go
@@ -71,6 +71,10 @@ func (r *proxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 	handlingInfo := value.(proxyHandlingInfo)
 	if handlingInfo.local {
+		if r.localDelegate == nil {
+			http.Error(w, "", http.StatusNotFound)
+			return
+		}
 		r.localDelegate.ServeHTTP(w, req)
 		return
 	}

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -159,6 +159,14 @@
 			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
 		},
 		{
+			"ImportPath": "github.com/gorilla/context",
+			"Rev": "215affda49addc4c8ef7e2534915df2c8c35c6cd"
+		},
+		{
+			"ImportPath": "github.com/gorilla/mux",
+			"Rev": "8096f47503459bcc74d1f4c487b7e6e42e5746b5"
+		},
+		{
 			"ImportPath": "github.com/grpc-ecosystem/go-grpc-prometheus",
 			"Rev": "2500245aa6110c562d17020fb31a2c133d737799"
 		},

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -11056,6 +11056,7 @@ go_library(
     deps = [
         "//vendor:github.com/emicklei/go-restful",
         "//vendor:github.com/golang/glog",
+        "//vendor:github.com/gorilla/mux",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",


### PR DESCRIPTION
The default golang mux doesn't have a way to listen at `/apis/` without "stealing" the entire tree.  We do that pretty often.  Gorilla mux (which we already have vendored) does have that ability.


This brings in that library and starts making use of the feature.

@liggitt since you were looking at the previous too.