### PR TITLE
Fix crash in kubectl run

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -413,7 +413,9 @@ func waitForPod(podClient coreclient.PodsGetter, ns, name string, exitCondition 
 		ev, err := watch.Until(0, w, func(ev watch.Event) (bool, error) {
 			return exitCondition(ev)
 		})
-		result = ev.Object.(*api.Pod)
+		if ev != nil {
+			result = ev.Object.(*api.Pod)
+		}
 		return err
 	})
 	return result, err


### PR DESCRIPTION
I observed the problem in k8s 1.5.1, but the code is still there, so fixing it.
Here's the old backtrace - happened due to network disconnection during `kubectl run`:

```
ivan4th@i4mac:~$ kubectl run --rm -it alpine1 --image=alpine:3.5 --restart=Never /bin/sh
Waiting for pod default/alpine1 to be running, status is Pending, pod ready: false
If you don't see a command prompt, try pressing enter.
/ # panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xe8706]

goroutine 1 [running]:
panic(0x11e0d80, 0xc420016090)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
k8s.io/kubernetes/pkg/kubectl/cmd.waitForPod.func2(0xc400000008, 0x14783a0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/run.go:432 +0x126
k8s.io/kubernetes/pkg/util/interrupt.(*Handler).Run(0xc420379230, 0xc4206c11f0, 0x0, 0x0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/util/interrupt/interrupt.go:103 +0x109
k8s.io/kubernetes/pkg/kubectl/cmd.waitForPod(0x208c8c0, 0xc4204832c0, 0xc4204395d0, 0x7, 0xc4204395a0, 0x7, 0x1477e10, 0xc4206e6040, 0x0, 0x0, ...)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/run.go:434 +0x49e
k8s.io/kubernetes/pkg/kubectl/cmd.waitForPodTerminated(0x208c8c0, 0xc4204832c0, 0xc4204395d0, 0x7, 0xc4204395a0, 0x7, 0x1c48020, 0xc42002c010, 0xc420124300, 0x0, ...)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/run.go:458 +0xea
k8s.io/kubernetes/pkg/kubectl/cmd.Run(0x1c61040, 0xc4203106e0, 0x1c47fe0, 0xc42002c008, 0x1c48020, 0xc42002c010, 0x1c48020, 0xc42002c018, 0xc42047e6c0, 0xc42006d200, ...)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/run.go:304 +0xe37
k8s.io/kubernetes/pkg/kubectl/cmd.NewCmdRun.func1(0xc42047e6c0, 0xc42006d200, 0x2, 0x6)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/run.go:98 +0x144
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute(0xc42047e6c0, 0xc42006d140, 0x6, 0x6, 0xc42047e6c0, 0xc42006d140)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:603 +0x439
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc4204dbb00, 0xc420438e50, 0x1, 0x1)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:689 +0x367
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute(0xc4204dbb00, 0xc4203106e0, 0x1c47fe0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:648 +0x2b
k8s.io/kubernetes/cmd/kubectl/app.Run(0x0, 0x0)
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubectl/app/kubectl.go:38 +0xd5
main.main()
        /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/cmd/kubectl/kubectl.go:26 +0x22
```