### PR TITLE
Drop leading path of KUBECTL.EXE if it shows up in User-Agent.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -109,8 +109,13 @@ func InstrumentRouteFunc(verb, resource string, routeFunc restful.RouteFunction)
 }
 
 func cleanUserAgent(ua string) string {
+	// We collapse all "web browser"-type user agents into one "browser" to reduce metric cardinality.
 	if strings.HasPrefix(ua, "Mozilla/") {
 		return "Browser"
+	}
+	// If an old "kubectl.exe" has passed us its full path, we discard the path portion.
+	if exeIdx := strings.LastIndex(strings.ToLower(ua), "kubectl.exe"); exeIdx != -1 {
+		return ua[exeIdx:]
 	}
 	return ua
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -31,6 +31,14 @@ func TestCleanUserAgent(t *testing.T) {
 			In:  "kubectl/v1.2.4",
 			Out: "kubectl/v1.2.4",
 		},
+		{
+			In:  `C:\Users\Kubernetes\kubectl.exe/v1.5.4`,
+			Out: "kubectl.exe/v1.5.4",
+		},
+		{
+			In:  `C:\Program Files\kubectl.exe/v1.5.4`,
+			Out: "kubectl.exe/v1.5.4",
+		},
 	} {
 		if cleanUserAgent(tc.In) != tc.Out {
 			t.Errorf("Failed to clean User-Agent: %s", tc.In)


### PR DESCRIPTION
Partial fix for #44419 

```release-note
kube-apiserver now drops unneeded path information if an older version of Windows kubectl sends it.
```