### PR TITLE
Use OS-specific libs when computing client User-Agent in kubectl, etc.

### DIFF
--- a/staging/src/k8s.io/client-go/rest/BUILD
+++ b/staging/src/k8s.io/client-go/rest/BUILD
@@ -22,6 +22,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

The User-Agent reported by clients (e.g. kubectl) in request
headers should include the name of the client executable
but not the full path to that executable.

This PR changes how this name is determined by using the
operating-system specific package "path/filepath" (meant for
working with file system paths) instead of the "path" package
(meant for URL paths).

This fixes a problem on the Windows OS in the case where, if the
user has not set their PATH to point to the location of their
client executable, the User-Agent includes the full path - which
is unnecessary.

Fixes: #44419

```release-note
Use OS-specific libs when computing client User-Agent in kubectl, etc.
```
