### PR TITLE
Add an Informer example in client-go

### DIFF
--- a/staging/src/k8s.io/client-go/examples/informer/BUILD
+++ b/staging/src/k8s.io/client-go/examples/informer/BUILD
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_binary",
+    "go_library",
+)
+
+go_binary(
+    name = "informer",
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)

--- a/staging/src/k8s.io/client-go/examples/informer/BUILD
+++ b/staging/src/k8s.io/client-go/examples/informer/BUILD
@@ -20,7 +20,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/client-go/examples/informer/BUILD
+++ b/staging/src/k8s.io/client-go/examples/informer/BUILD
@@ -21,10 +21,10 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/informers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
@@ -37,9 +37,11 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/examples/informer/BUILD
+++ b/staging/src/k8s.io/client-go/examples/informer/BUILD
@@ -6,6 +6,7 @@ load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_binary",
     "go_library",
+    "go_test",
 )
 
 go_binary(
@@ -21,9 +22,24 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
+        "//vendor/k8s.io/client-go/informers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/client-go/informers:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/examples/informer/README.md
+++ b/staging/src/k8s.io/client-go/examples/informer/README.md
@@ -1,0 +1,34 @@
+# Informer Example
+
+Informers provide a high-level API for creating custom controllers for Kubernetes resources.
+
+This particular example demonstrates:
+
+* How to write an Informer against a core resource type.
+* How to handle add, update and delete events.
+
+The [thirdparty-resources example](../third-party-resources) demonstrates how to use informers against a thirdparty resource.
+
+## Running
+
+To run the example outside the Kubernetes cluster you need to supply the path to a Kubernetes config file.
+
+```sh
+go run main.go -kubeconfig=$HOME/.kube/config -logtostderr
+```
+
+By default `glog` logs to files.
+Use the `-logtostderr` command line argument so that you can see the output on the console.
+
+## Running Inside a Kubernetes Cluster
+
+You can also run the example inside a Kubernetes cluster.
+In this case it will use [in Cluster configuration](../in-cluster/),
+and you don't need to supply `-kubeconfig` or `-master` command line flags.
+
+## Use Cases
+
+* Building controllers that coordinate other resources.
+  Most controllers in [k8s.io/kubernetes/pkg/controller](https://godoc.org/k8s.io/kubernetes/pkg/controller) use informers.
+* Capturing resource events for logging to external systems
+  (e.g. monitor non-"Normal" events and publish metrics to a time series database)

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -20,7 +20,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"time"
 
 	"github.com/golang/glog"
 
@@ -117,7 +116,7 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	factory := informers.NewSharedInformerFactory(clientset, time.Hour*24)
+	factory := informers.NewSharedInformerFactory(clientset, 0)
 	controller := NewPodLoggingController(factory)
 	stop := make(chan struct{})
 	defer close(stop)

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -62,9 +63,10 @@ func (c *PodLoggingController) podAdd(obj interface{}) {
 }
 
 func (c *PodLoggingController) podUpdate(old, new interface{}) {
+	newPod := new.(*v1.Pod)
 	key, err := cache.MetaNamespaceKeyFunc(new)
 	if err == nil {
-		glog.Infof("POD UPDATED. %q", key)
+		glog.Infof("POD UPDATED. %q, %s", key, newPod.Status.Phase)
 	} else {
 		glog.Error(err)
 	}

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -34,11 +34,15 @@ import (
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
+// PodLoggingController logs the name and namespace of pods that are added,
+// deleted, or updated
 type PodLoggingController struct {
 	informerFactory informers.SharedInformerFactory
 	podInformer     coreinformers.PodInformer
 }
 
+// Run starts shared informers and waits for the shared informer cache to
+// synchronize.
 func (c *PodLoggingController) Run(stopCh chan struct{}) error {
 	// Starts all the shared informers that have been created by the factory so
 	// far.
@@ -69,6 +73,7 @@ func (c *PodLoggingController) podDelete(obj interface{}) {
 	glog.Infof("POD DELETED: %s/%s", pod.Namespace, pod.Name)
 }
 
+// NewPodLoggingController creates a PodLoggingController
 func NewPodLoggingController(informerFactory informers.SharedInformerFactory) *PodLoggingController {
 	podInformer := informerFactory.Core().V1().Pods()
 

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -19,12 +19,11 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 
-	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
@@ -55,82 +54,44 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	source := cache.NewListWatchFromClient(
-		clientset.Core().RESTClient(),
-		"pods",
-		v1.NamespaceAll,
-		fields.Everything())
+	factory := informers.NewSharedInformerFactory(clientset, time.Second*0)
 
-	store, controller := cache.NewInformer(
-		source,
-
-		// The object type.
-		&v1.Pod{},
-
-		// resyncPeriod
-		// Every resyncPeriod, all resources in the cache will retrigger events.
-		// Set to 0 to disable the resync.
-		time.Second*0,
-
-		// Your custom resource event handlers.
-		cache.ResourceEventHandlerFuncs{
-			// Takes a single argument of type interface{}.
-			// Called on controller startup and when new resources are created.
-			AddFunc: create,
-
-			// Takes two arguments of type interface{}.
-			// Called on resource update and every resyncPeriod on existing resources.
-			UpdateFunc: update,
-
-			// Takes a single argument of type interface{}.
-			// Called on resource deletion.
-			DeleteFunc: delete,
-		})
+	informer := factory.Core().V1().Pods().Informer()
 
 	stop := make(chan struct{})
 	defer close(stop)
 
 	// the controller run starts the event processing loop
-	go controller.Run(stop)
+	go informer.Run(stop)
 
 	// wait until a store finished its initial synchronization
-	cache.WaitForCacheSync(stop, controller.HasSynced)
+	cache.WaitForCacheSync(stop, informer.HasSynced)
 
-	// store can be used to List and Get
-	// NEVER modify objects from the store. It's a read-only, local cache.
-	glog.Info("listing pods from store:")
-	for _, obj := range store.List() {
-		pod := obj.(*v1.Pod)
-		glog.Info(pod.ObjectMeta.Name)
-	}
+	informer.AddEventHandler(
+		// Your custom resource event handlers.
+		cache.ResourceEventHandlerFuncs{
+			// Called on creation
+			AddFunc: func(obj interface{}) {
+				pod := obj.(*v1.Pod)
+				glog.Infof("POD CREATED: %s/%s", pod.Namespace, pod.Name)
+			},
+			// Called on resource update and every resyncPeriod on existing resources.
+			// The Generation will not change unless the Pod has changed.
+			UpdateFunc: func(old, new interface{}) {
+				oldPod := old.(*v1.Pod)
+				newPod := new.(*v1.Pod)
+				glog.Infof(
+					"POD UPDATED. %s/%s %s",
+					oldPod.Namespace, oldPod.Name, newPod.Status.Phase,
+				)
+			},
+			// Called on resource deletion.
+			DeleteFunc: func(obj interface{}) {
+				pod := obj.(*v1.Pod)
+				glog.Infof("POD DELETED: %s/%s", pod.Namespace, pod.Name)
+			},
+		},
+	)
 
 	select {}
-}
-
-// Handler functions as per the controller above.
-// Note the coercion of the interface{} into a pointer of the expected type.
-func create(obj interface{}) {
-	pod := obj.(*v1.Pod)
-
-	glog.Info("POD CREATED:", podWithNamespace(pod))
-}
-
-func update(old, new interface{}) {
-	oldPod := old.(*v1.Pod)
-	newPod := new.(*v1.Pod)
-
-	glog.Info("POD UPDATED:")
-	glog.Info("old:", podWithNamespace(oldPod))
-	glog.Info("new:", podWithNamespace(newPod))
-}
-
-func delete(obj interface{}) {
-	pod := obj.(*v1.Pod)
-
-	glog.Info("POD DELETED:", podWithNamespace(pod))
-}
-
-// convenience functions
-func podWithNamespace(pod *v1.Pod) string {
-	return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
 }

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Note: the example only works with the code within the same release/branch.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
+	// Only required to authenticate against GKE clusters
+	// _ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+func main() {
+	var kubeconfig string
+	var master string
+
+	flag.StringVar(&kubeconfig, "kubeconfig", "", "absolute path to the kubeconfig file")
+	flag.StringVar(&master, "master", "", "master url")
+	flag.Parse()
+
+	// BuildConfigFromFlags builds configs from a master url or a kubeconfig
+	// filepath. If neither masterUrl nor kubeconfigPath are passed, it falls back
+	// to inClusterConfig. If inClusterConfig fails, it falls back to the default
+	// config.
+	config, err := clientcmd.BuildConfigFromFlags(master, kubeconfig)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	source := cache.NewListWatchFromClient(
+		clientset.Core().RESTClient(),
+		"pods",
+		v1.NamespaceAll,
+		fields.Everything())
+
+	store, controller := cache.NewInformer(
+		source,
+
+		// The object type.
+		&v1.Pod{},
+
+		// resyncPeriod
+		// Every resyncPeriod, all resources in the cache will retrigger events.
+		// Set to 0 to disable the resync.
+		time.Second*0,
+
+		// Your custom resource event handlers.
+		cache.ResourceEventHandlerFuncs{
+			// Takes a single argument of type interface{}.
+			// Called on controller startup and when new resources are created.
+			AddFunc: create,
+
+			// Takes two arguments of type interface{}.
+			// Called on resource update and every resyncPeriod on existing resources.
+			UpdateFunc: update,
+
+			// Takes a single argument of type interface{}.
+			// Called on resource deletion.
+			DeleteFunc: delete,
+		})
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	// the controller run starts the event processing loop
+	go controller.Run(stop)
+
+	// wait until a store finished its initial synchronization
+	cache.WaitForCacheSync(stop, controller.HasSynced)
+
+	// store can be used to List and Get
+	// NEVER modify objects from the store. It's a read-only, local cache.
+	glog.Info("listing pods from store:")
+	for _, obj := range store.List() {
+		pod := obj.(*v1.Pod)
+		glog.Info(pod.ObjectMeta.Name)
+	}
+
+	select {}
+}
+
+// Handler functions as per the controller above.
+// Note the coercion of the interface{} into a pointer of the expected type.
+func create(obj interface{}) {
+	pod := obj.(*v1.Pod)
+
+	glog.Info("POD CREATED:", podWithNamespace(pod))
+}
+
+func update(old, new interface{}) {
+	oldPod := old.(*v1.Pod)
+	newPod := new.(*v1.Pod)
+
+	glog.Info("POD UPDATED:")
+	glog.Info("old:", podWithNamespace(oldPod))
+	glog.Info("new:", podWithNamespace(newPod))
+}
+
+func delete(obj interface{}) {
+	pod := obj.(*v1.Pod)
+
+	glog.Info("POD DELETED:", podWithNamespace(pod))
+}
+
+// convenience functions
+func podWithNamespace(pod *v1.Pod) string {
+	return fmt.Sprintf("%s/%s", pod.Namespace, pod.Name)
+}

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/golang/glog"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -54,22 +53,30 @@ func (c *PodLoggingController) Run(stopCh chan struct{}) error {
 }
 
 func (c *PodLoggingController) podAdd(obj interface{}) {
-	pod := obj.(*v1.Pod)
-	glog.Infof("POD CREATED: %s/%s", pod.Namespace, pod.Name)
+	key, err := cache.MetaNamespaceKeyFunc(obj)
+	if err == nil {
+		glog.Infof("POD CREATED. %q", key)
+	} else {
+		glog.Error(err)
+	}
 }
 
 func (c *PodLoggingController) podUpdate(old, new interface{}) {
-	oldPod := old.(*v1.Pod)
-	newPod := new.(*v1.Pod)
-	glog.Infof(
-		"POD UPDATED. %s/%s %s",
-		oldPod.Namespace, oldPod.Name, newPod.Status.Phase,
-	)
+	key, err := cache.MetaNamespaceKeyFunc(new)
+	if err == nil {
+		glog.Infof("POD UPDATED. %q", key)
+	} else {
+		glog.Error(err)
+	}
 }
 
 func (c *PodLoggingController) podDelete(obj interface{}) {
-	pod := obj.(*v1.Pod)
-	glog.Infof("POD DELETED: %s/%s", pod.Namespace, pod.Name)
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err == nil {
+		glog.Infof("POD DELETED: %q", key)
+	} else {
+		glog.Error(err)
+	}
 }
 
 // NewPodLoggingController creates a PodLoggingController

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -54,7 +54,7 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	factory := informers.NewSharedInformerFactory(clientset, time.Second*0)
+	factory := informers.NewSharedInformerFactory(clientset, time.Second*10)
 
 	informer := factory.Core().V1().Pods().Informer()
 

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	// Only required to authenticate against GKE clusters

--- a/staging/src/k8s.io/client-go/examples/informer/main.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main.go
@@ -54,7 +54,7 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	factory := informers.NewSharedInformerFactory(clientset, time.Second*10)
+	factory := informers.NewSharedInformerFactory(clientset, time.Hour*24)
 
 	informer := factory.Core().V1().Pods().Informer()
 

--- a/staging/src/k8s.io/client-go/examples/informer/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/staging/src/k8s.io/client-go/examples/informer/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,11 +24,11 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/pkg/api/v1"
 	clienttesting "k8s.io/client-go/testing"
 )
 

--- a/staging/src/k8s.io/client-go/examples/informer/main_test.go
+++ b/staging/src/k8s.io/client-go/examples/informer/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+func podForTest() *v1.Pod {
+	p := &v1.Pod{}
+	p.SetName(fmt.Sprintf("%d", rand.Int()))
+	p.SetNamespace(fmt.Sprintf("%d", rand.Int()))
+	return p
+}
+
+func TestMain(t *testing.T) {
+	pod1 := podForTest()
+	pod2 := podForTest()
+	pod3 := podForTest()
+	type testCase struct {
+		description       string
+		initial           []runtime.Object
+		add               []runtime.Object
+		update            []runtime.Object
+		delete            []runtime.Object
+		expectedLineCount int64
+	}
+	testCases := []testCase{
+		{
+			description:       "Single initial pod",
+			initial:           []runtime.Object{pod1},
+			expectedLineCount: 1,
+		},
+		{
+			description:       "Multiple initial pods",
+			initial:           []runtime.Object{pod1, pod2},
+			expectedLineCount: 2,
+		},
+		{
+			description:       "Pod added later",
+			initial:           []runtime.Object{pod1, pod2},
+			add:               []runtime.Object{pod3},
+			expectedLineCount: 3,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(
+			tc.description,
+			func(t *testing.T) {
+				initialLineCount := glog.Stats.Info.Lines()
+				clientset := fake.NewSimpleClientset(tc.initial...)
+				factory := informers.NewSharedInformerFactory(
+					clientset,
+					time.Hour*24,
+				)
+				c := NewPodLoggingController(factory)
+
+				stop := make(chan struct{})
+				defer close(stop)
+
+				err := c.Run(stop)
+				if err != nil {
+					t.Error(err)
+				}
+				for _, podToAdd := range tc.add {
+					// Type conversion + type assertion? Is this the only way?
+					p := interface{}(podToAdd).(*v1.Pod)
+					// XXX: I expected this to trigger the
+					// cache.ResourceEventHandlerFuncs but it doesn't.
+					_, err = clientset.Core().Pods(p.Namespace).Create(p)
+					if err != nil {
+						t.Error(err)
+					}
+				}
+				actualLineCount := glog.Stats.Info.Lines() - initialLineCount
+
+				if tc.expectedLineCount != actualLineCount {
+					t.Errorf(
+						"Line count mismatch. Expected %d. Got %d",
+						tc.expectedLineCount,
+						actualLineCount,
+					)
+				}
+			},
+		)
+	}
+}


### PR DESCRIPTION
This PR adds an example demonstrating how to use the client-go library to set up an Informer to print out Pod events and to maintain a local store containing Pod configuration synchronized with the Kubernetes API server.

I've copied the work started in https://github.com/kubernetes/client-go/pull/30 and addressed most of the outstanding code review comments:
https://github.com/kubernetes/client-go/pull/30

```release-note
```
