### PR TITLE
Implement LRU for AWS device allocator

### DIFF
--- a/pkg/cloudprovider/providers/aws/device_allocator.go
+++ b/pkg/cloudprovider/providers/aws/device_allocator.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package aws
 
-import "fmt"
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
 
 // ExistingDevices is a map of assigned devices. Presence of a key with a device
 // name in the map means that the device is allocated. Value is irrelevant and
@@ -40,48 +44,87 @@ type DeviceAllocator interface {
 	// name. Only the device suffix is returned, e.g. "ba" for "/dev/xvdba".
 	// It's up to the called to add appropriate "/dev/sd" or "/dev/xvd" prefix.
 	GetNext(existingDevices ExistingDevices) (mountDevice, error)
+
+	// Deprioritize the device so as it can't be used immediately again
+	Deprioritize(mountDevice)
+
+	// Lock the deviceAllocator
+	Lock()
+
+	// Unlock the deviceAllocator
+	Unlock()
 }
 
 type deviceAllocator struct {
-	possibleDevices []mountDevice
-	lastIndex       int
+	possibleDevices map[mountDevice]int
+	counter         int
+	deviceLock      sync.Mutex
 }
+
+var _ DeviceAllocator = &deviceAllocator{}
+
+type devicePair struct {
+	deviceName  mountDevice
+	deviceIndex int
+}
+
+type devicePairList []devicePair
+
+func (p devicePairList) Len() int           { return len(p) }
+func (p devicePairList) Less(i, j int) bool { return p[i].deviceIndex < p[j].deviceIndex }
+func (p devicePairList) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // Allocates device names according to scheme ba..bz, ca..cz
 // it moves along the ring and always picks next device until
 // device list is exhausted.
-func NewDeviceAllocator(lastIndex int) DeviceAllocator {
-	possibleDevices := []mountDevice{}
+func NewDeviceAllocator() DeviceAllocator {
+	possibleDevices := make(map[mountDevice]int)
 	for _, firstChar := range []rune{'b', 'c'} {
 		for i := 'a'; i <= 'z'; i++ {
 			dev := mountDevice([]rune{firstChar, i})
-			possibleDevices = append(possibleDevices, dev)
+			possibleDevices[dev] = 0
 		}
 	}
 	return &deviceAllocator{
 		possibleDevices: possibleDevices,
-		lastIndex:       lastIndex,
+		counter:         0,
 	}
 }
 
+// GetNext gets next available device from the pool, this function assumes that caller
+// holds the necessary lock on deviceAllocator
 func (d *deviceAllocator) GetNext(existingDevices ExistingDevices) (mountDevice, error) {
-	var candidate mountDevice
-	foundIndex := d.lastIndex
-	for {
-		candidate, foundIndex = d.nextDevice(foundIndex + 1)
-		if _, found := existingDevices[candidate]; !found {
-			d.lastIndex = foundIndex
-			return candidate, nil
-		}
-		if foundIndex == d.lastIndex {
-			return "", fmt.Errorf("no devices are available")
+	for _, devicePair := range d.sortByCount() {
+		if _, found := existingDevices[devicePair.deviceName]; !found {
+			return devicePair.deviceName, nil
 		}
 	}
+	return "", fmt.Errorf("no devices are available")
 }
 
-func (d *deviceAllocator) nextDevice(nextIndex int) (mountDevice, int) {
-	if nextIndex < len(d.possibleDevices) {
-		return d.possibleDevices[nextIndex], nextIndex
+func (d *deviceAllocator) sortByCount() devicePairList {
+	dpl := make(devicePairList, 0)
+	for deviceName, deviceIndex := range d.possibleDevices {
+		dpl = append(dpl, devicePair{deviceName, deviceIndex})
 	}
-	return d.possibleDevices[0], 0
+	sort.Sort(dpl)
+	return dpl
+}
+
+func (d *deviceAllocator) Lock() {
+	d.deviceLock.Lock()
+}
+
+func (d *deviceAllocator) Unlock() {
+	d.deviceLock.Unlock()
+}
+
+// Deprioritize the device so as it can't be used immediately again
+func (d *deviceAllocator) Deprioritize(chosen mountDevice) {
+	d.deviceLock.Lock()
+	defer d.deviceLock.Unlock()
+	if _, ok := d.possibleDevices[chosen]; ok {
+		d.counter++
+		d.possibleDevices[chosen] = d.counter
+	}
 }


### PR DESCRIPTION
On failure to attach do not use device from pool
    
In AWS environment when attach fails on the node
lets not use device from the pool. This makes sure
that a bigger pool of devices is available.

