### PR TITLE
Fixing the kubernetes-e2e charm README to use the containers namespace.

### DIFF
--- a/cluster/juju/layers/kubernetes-e2e/README.md
+++ b/cluster/juju/layers/kubernetes-e2e/README.md
@@ -20,7 +20,7 @@ and then relate the `kubernetes-e2e` charm.
 
 ```shell
 juju deploy kubernetes-core
-juju deploy kubernetes-e2e
+juju deploy cs:~containers/kubernetes-e2e
 juju add-relation kubernetes-e2e kubernetes-master
 juju add-relation kubernetes-e2e easyrsa
 ```


### PR DESCRIPTION

**What this PR does / why we need it**: The deploy command is not correct in the README.

**Which issue this PR fixes**: fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/251

**Special notes for your reviewer**: This is a text based change to the kubernetes-e2e charm README

**Release note**:
```release-note
NONE
```

A user pointed out the instructions in the kubernetes-e2e README were incorrect. Fixing that.