### PR TITLE
Updates e2e_node test to allow both kubenet and cni to be specified f…

### DIFF
--- a/test/e2e_node/remote/node_conformance.go
+++ b/test/e2e_node/remote/node_conformance.go
@@ -254,8 +254,8 @@ func stopKubelet(host, workspace string) error {
 
 // RunTest runs test on the node.
 func (c *ConformanceRemote) RunTest(host, workspace, results, junitFilePrefix, testArgs, _ string, timeout time.Duration) (string, error) {
-	// Install the cni plugin.
-	if err := installCNI(host, workspace); err != nil {
+	// Install the cni plugins and add a basic CNI configuration.
+	if err := setupCNI(host, workspace); err != nil {
 		return "", err
 	}
 

--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -135,8 +135,8 @@ func updateCOSMounterPath(args, host, workspace string) (string, error) {
 
 // RunTest runs test on the node.
 func (n *NodeE2ERemote) RunTest(host, workspace, results, junitFilePrefix, testArgs, ginkgoArgs string, timeout time.Duration) (string, error) {
-	// Install the cni plugin.
-	if err := installCNI(host, workspace); err != nil {
+	// Install the cni plugins and add a basic CNI configuration.
+	if err := setupCNI(host, workspace); err != nil {
 		return "", err
 	}
 

--- a/test/e2e_node/remote/utils.go
+++ b/test/e2e_node/remote/utils.go
@@ -27,13 +27,30 @@ import (
 // utils.go contains functions used across test suites.
 
 const (
-	cniRelease   = "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"
-	cniDirectory = "cni"
-	cniURL       = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-" + cniRelease + ".tar.gz"
+	cniRelease       = "0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff"
+	cniDirectory     = "cni" // The CNI tarball creates the "bin" directory under "cni".
+	cniConfDirectory = "cni/net.d"
+	cniURL           = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-" + cniRelease + ".tar.gz"
 )
 
-// Install the cni plugin.
-func installCNI(host, workspace string) error {
+const cniConfig = `{
+  "name": "mynet",
+  "type": "bridge",
+  "bridge": "mynet0",
+  "isDefaultGateway": true,
+  "forceAddress": false,
+  "ipMasq": true,
+  "hairpinMode": true,
+  "ipam": {
+    "type": "host-local",
+    "subnet": "10.10.0.0/16"
+  }
+}
+`
+
+// Install the cni plugin and add basic bridge configuration to the
+// configuration directory.
+func setupCNI(host, workspace string) error {
 	glog.V(2).Infof("Install CNI on %q", host)
 	cniPath := filepath.Join(workspace, cniDirectory)
 	cmd := getSSHCommand(" ; ",
@@ -42,6 +59,16 @@ func installCNI(host, workspace string) error {
 	)
 	if output, err := SSH(host, "sh", "-c", cmd); err != nil {
 		return fmt.Errorf("failed to install cni plugin on %q: %v output: %q", host, err, output)
+	}
+
+	glog.V(2).Infof("Adding CNI configuration on %q", host)
+	cniConfigPath := filepath.Join(workspace, cniConfDirectory)
+	cmd = getSSHCommand(" ; ",
+		fmt.Sprintf("mkdir -p %s", cniConfigPath),
+		fmt.Sprintf("echo %s > %s", quote(cniConfig), filepath.Join(cniConfigPath, "mynet.conf")),
+	)
+	if output, err := SSH(host, "sh", "-c", cmd); err != nil {
+		return fmt.Errorf("failed to write cni configuration on %q: %v output: %q", host, err, output)
 	}
 	return nil
 }
@@ -94,4 +121,9 @@ func cleanupNodeProcesses(host string) {
 	// If we are unable to stop existing running k8s processes, we should see messages in the kubelet/apiserver/etcd
 	// logs about failing to bind the required ports.
 	SSH(host, "sh", "-c", cmd)
+}
+
+// Quotes a shell literal so it can be nested within another shell scope.
+func quote(s string) string {
+	return fmt.Sprintf("'\"'\"'%s'\"'\"'", s)
 }

--- a/test/e2e_node/remote/utils.go
+++ b/test/e2e_node/remote/utils.go
@@ -61,6 +61,9 @@ func setupCNI(host, workspace string) error {
 		return fmt.Errorf("failed to install cni plugin on %q: %v output: %q", host, err, output)
 	}
 
+	// The added CNI network config is not needed for kubenet. It is only
+	// used when testing the CNI network plugin, but is added in both cases
+	// for consistency and simplicity.
 	glog.V(2).Infof("Adding CNI configuration on %q", host)
 	cniConfigPath := filepath.Join(workspace, cniConfDirectory)
 	cmd = getSSHCommand(" ; ",

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -147,13 +147,20 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--v", LOG_VERBOSITY_LEVEL, "--logtostderr",
 	)
 	// Enable kubenet by default.
-	cniDir, err := getCNIDirectory()
+	cniBinDir, err := getCNIBinDirectory()
 	if err != nil {
 		return nil, err
 	}
+
+	cniConfDir, err := getCNIConfDirectory()
+	if err != nil {
+		return nil, err
+	}
+
 	cmdArgs = append(cmdArgs,
 		"--network-plugin=kubenet",
-		"--network-plugin-dir", cniDir)
+		"--cni-bin-dir", cniBinDir,
+		"--cni-conf-dir", cniConfDir)
 
 	// Keep hostname override for convenience.
 	if framework.TestContext.NodeName != "" { // If node name is specified, set hostname override.
@@ -194,14 +201,22 @@ func createPodManifestDirectory() (string, error) {
 	return path, nil
 }
 
-// getCNIDirectory returns CNI directory.
-func getCNIDirectory() (string, error) {
+// getCNIBinDirectory returns CNI directory.
+func getCNIBinDirectory() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
-	// TODO(random-liu): Make sure the cni directory name is the same with that in remote/remote.go
 	return filepath.Join(cwd, "cni", "bin"), nil
+}
+
+// getCNIConfDirectory returns CNI Configuration directory.
+func getCNIConfDirectory() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(cwd, "cni", "net.d"), nil
 }
 
 // adjustArgsForSystemd escape special characters in kubelet arguments for systemd. Systemd


### PR DESCRIPTION
…or the network plugin.

This adds a simple CNI configuration which is added to the node during test setup.
This also modifies the default flags in services/kubelet.go to specify the "cni-bin-dir"
and the "cni-conf-dir" and removes the "network-plugin-dir" flag.  This leaves the default
network plugin to kubenet.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
