### PR TITLE
flexvolume: read a response from stdout

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -257,6 +257,10 @@ func (eic execInContainer) SetStdout(out io.Writer) {
 	//unimplemented
 }
 
+func (eic execInContainer) SetStderr(err io.Writer) {
+	//unimplemented
+}
+
 func (eic execInContainer) Stop() {
 	//unimplemented
 }

--- a/pkg/probe/exec/exec_test.go
+++ b/pkg/probe/exec/exec_test.go
@@ -44,6 +44,8 @@ func (f *FakeCmd) SetStdin(in io.Reader) {}
 
 func (f *FakeCmd) SetStdout(out io.Writer) {}
 
+func (f *FakeCmd) SetStderr(err io.Writer) {}
+
 func (f *FakeCmd) Stop() {}
 
 type fakeExitError struct {

--- a/pkg/util/exec/exec.go
+++ b/pkg/util/exec/exec.go
@@ -49,6 +49,7 @@ type Cmd interface {
 	SetDir(dir string)
 	SetStdin(in io.Reader)
 	SetStdout(out io.Writer)
+	SetStderr(err io.Writer)
 	// Stops the command by sending SIGTERM. It is not guaranteed the
 	// process will stop before this function returns. If the process is not
 	// responding, an internal timer function will send a SIGKILL to force
@@ -97,6 +98,10 @@ func (cmd *cmdWrapper) SetStdin(in io.Reader) {
 
 func (cmd *cmdWrapper) SetStdout(out io.Writer) {
 	cmd.Stdout = out
+}
+
+func (cmd *cmdWrapper) SetStderr(err io.Writer) {
+	cmd.Stderr = err
 }
 
 // CombinedOutput is part of the Cmd interface.

--- a/pkg/util/exec/fake_exec.go
+++ b/pkg/util/exec/fake_exec.go
@@ -52,6 +52,7 @@ type FakeCmd struct {
 	Dirs                 []string
 	Stdin                io.Reader
 	Stdout               io.Writer
+	Stderr               io.Writer
 }
 
 func InitFakeCmd(fake *FakeCmd, cmd string, args ...string) Cmd {
@@ -86,8 +87,15 @@ func (fake *FakeCmd) CombinedOutput() ([]byte, error) {
 	return fake.CombinedOutputScript[i]()
 }
 
+func (fake *FakeCmd) SetStderr(err io.Writer) {
+	fake.Stderr = err
+}
+
 func (fake *FakeCmd) Output() ([]byte, error) {
-	return nil, fmt.Errorf("unimplemented")
+	if fake.Stderr != nil {
+		fake.Stderr.Write([]byte("test message\nanother test message"))
+	}
+	return fake.CombinedOutput()
 }
 
 func (fake *FakeCmd) Stop() {

--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -17,9 +17,13 @@ limitations under the License.
 package flexvolume
 
 import (
+	"bufio"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
+	"sync"
 	"time"
 
 	"github.com/golang/glog"
@@ -124,7 +128,35 @@ func (dc *DriverCall) Run() (*DriverStatus, error) {
 		defer timer.Stop()
 	}
 
-	output, execErr := cmd.CombinedOutput()
+	errPipe, errwPipe, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+	defer errPipe.Close()
+	defer errwPipe.Close()
+	cmd.SetStderr(errwPipe)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r := bufio.NewReaderSize(errPipe, 4096)
+		for {
+			l, _, err := r.ReadLine()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				glog.Errorf("FlexVolume: Unable to read Stderr: %s", err)
+				break
+			}
+			glog.Warningf("FlexVolume: %s", string(l))
+		}
+	}()
+
+	output, execErr := cmd.Output()
+	errwPipe.Close()
+	wg.Wait()
 	if execErr != nil {
 		if timeout {
 			return nil, TimeoutError


### PR DESCRIPTION
Currently we call cmd.CombinedOutput to read responses, but this method
reads data from stderr and stdout.

It isn't a common practice. Usually useful data are got from stdout
and stderr is used to output error messages or diagnostics.

Messages from stderr will be printed in the kubelet log, so it allows us
to add some diagnostics in plugins.

Signed-off-by: Andrei Vagin <avagin@gmail.com>

```release-note
flexvolume: read responses from stdout and use stderr for error and diagnostic messages
```
