### PR TITLE
fix cluster scoped self-link

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -393,7 +393,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			GetContext:         ctxFn,
 			SelfLinker:         a.group.Linker,
 			ClusterScoped:      true,
-			SelfLinkPathPrefix: gpath.Join(a.prefix, resourcePath, "/"),
+			SelfLinkPathPrefix: gpath.Join(a.prefix, resourcePath) + "/",
 			SelfLinkPathSuffix: suffix,
 		}
 


### PR DESCRIPTION
Might fix #37622, definitely fixes the cluster-scoped resource problem.  Looks like it was just a typo when compared against  https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go#L451

@adohe @DirectXMan12