### PR TITLE
Kubelet:rkt Fix the hostPath Volume creation

### DIFF
--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1319,11 +1319,14 @@ func (r *Runtime) setupPodNetwork(pod *v1.Pod) (string, string, error) {
 func createHostPathVolumes(pod *v1.Pod) (err error) {
 	for _, v := range pod.Spec.Volumes {
 		if v.VolumeSource.HostPath != nil {
-			err = os.MkdirAll(v.HostPath.Path, os.ModePerm)
-			if err != nil && !os.IsExist(err) {
-				return err
+			_, err = os.Stat(v.HostPath.Path)
+			if os.IsNotExist(err) {
+				if err = os.MkdirAll(v.HostPath.Path, os.ModePerm); err != nil {
+					glog.Errorf("Create volume HostPath %q for Pod %q failed: %q", v.HostPath.Path, format.Pod(pod), err.Error())
+					return err
+				}
+				glog.V(4).Infof("Created volume HostPath %q for Pod %q", v.HostPath.Path, format.Pod(pod))
 			}
-			glog.V(4).Infof("Created volume HostPath %q for Pod %q", v.HostPath.Path, format.Pod(pod))
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fix the `hostPath` volume when the path exist and it's not a directory.
At the moment, the creation of a `hostPath` volume for an existing file leads to this error:

> kubelet[1984]: E0413 07:53:16.480922    1984 pod_workers.go:184] Error syncing pod 38359a57-1fb1-11e7-a484-76870fe7db83, skipping: failed to SyncPod: mkdir /usr/share/coreos/lsb-release: not a directory

**Special notes for your reviewer**:

You can have a look to the difference with this [gist](https://gist.github.com/JulienBalestra/28ae15efc8a1393d350300880c07ff4f)


