### PR TITLE
avoid hosts file in container overwritten

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -206,8 +206,8 @@ func makeHostsMount(podDir, podIP, hostName, hostDomainName string) (*kubecontai
 // ensureHostsFile ensures that the given host file has an up-to-date ip, host
 // name, and domain name.
 func ensureHostsFile(fileName, hostIP, hostName, hostDomainName string) error {
-	if _, err := os.Stat(fileName); os.IsExist(err) {
-		glog.V(4).Infof("kubernetes-managed etc-hosts file exits. Will not be recreated: %q", fileName)
+	if _, err := os.Stat(fileName); err == nil {
+		glog.V(4).Infof("kubernetes-managed etc-hosts file exists. Will not be recreated: %q", fileName)
 		return nil
 	}
 	var buffer bytes.Buffer


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** : fixes #44473

**Special notes for your reviewer**:

**Release note**:
```
Avoid /etc/hosts in containers to be overwritten
```
