### PR TITLE
add help flag for kubelet command.

### DIFF
--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -29,7 +29,8 @@ import (
 	"k8s.io/kubernetes/cmd/kubelet/app"
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
-	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
+	"k8s.io/kubernetes/pkg/helpflag"
+	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
 	"k8s.io/kubernetes/pkg/version/verflag"
 
 	"github.com/spf13/pflag"
@@ -44,6 +45,7 @@ func main() {
 	defer logs.FlushLogs()
 
 	verflag.PrintAndExitIfRequested()
+	helpflag.PrintAndExitIfRequested()
 
 	if s.ExperimentalDockershim {
 		if err := app.RunDockershim(&s.KubeletConfiguration, s.DockershimRootDirectory); err != nil {

--- a/pkg/helpflag/BUILD
+++ b/pkg/helpflag/BUILD
@@ -1,0 +1,30 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["helpflag.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor:github.com/spf13/pflag",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/helpflag/helpflag.go
+++ b/pkg/helpflag/helpflag.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package helpflag defines general help flag for cmds such as kubelet, kube-proxy, etc
+package helpflag
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	help = pflag.BoolP("help", "h", false, "display this help and exit")
+)
+
+// PrintAndExitIfRequested prints help information and then exits zero value if -h or --help flag is detected
+func PrintAndExitIfRequested() {
+	if *help {
+		fs := pflag.CommandLine
+		fs.SetOutput(os.Stdout)
+		fmt.Fprintf(os.Stdout, "Usage of %s:\n", os.Args[0])
+		fs.PrintDefaults()
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
before this PR, when user run `kubelet --help`, help information will be printed to stderr , exit value will be 2. this is absolutely confusing!  let us assume user try to find some thing from help information, user usually run `kubelet --help|grep xxx`(just like `ls --help|grep xxx`, `rm --help|grep xxx`), but he/she will not find anything.

in this PR, help information will be printed to stdout and exit value will be 0 if and only if `--help` or `-h` flag is specified
