### PR TITLE
Fix PathPrefix for subresources

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -1284,30 +1284,47 @@ func TestRootSelfLink(t *testing.T) {
 		takesPath: "atAPath",
 	}
 	storage["simple"] = &simpleStorage
+	storage["simple/sub"] = &simpleStorage
 	handler := handle(storage)
 	server := httptest.NewServer(handler)
 	defer server.Close()
 
-	resp, err := http.Get(server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	testCases := []struct {
+		url      string
+		selfLink string
+	}{
+		{
+			url:      server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo",
+			selfLink: "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo",
+		},
+		{
+			url:      server.URL + "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo/sub",
+			selfLink: "/" + prefix + "/" + testGroupVersion.Group + "/" + testGroupVersion.Version + "/simple/foo/sub",
+		},
 	}
 
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("Unexpected status: %d, Expected: %d, %#v", resp.StatusCode, http.StatusOK, resp)
-		body, err := ioutil.ReadAll(resp.Body)
+	for _, test := range testCases {
+		resp, err := http.Get(test.url)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		t.Logf("Data: %s", string(body))
-	}
-	var out genericapitesting.SimpleRoot
-	if _, err := extractBody(resp, &out); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 
-	if out.SelfLink != "/"+prefix+"/"+testGroupVersion.Group+"/"+testGroupVersion.Version+"/simple/foo" {
-		t.Errorf("unexpected self link: %#v", out)
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Unexpected status: %d, Expected: %d, %#v", resp.StatusCode, http.StatusOK, resp)
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			t.Logf("Data: %s", string(body))
+		}
+		var out genericapitesting.SimpleRoot
+		if _, err := extractBody(resp, &out); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if out.SelfLink != test.selfLink {
+			t.Errorf("unexpected self link: %#v", out.SelfLink)
+		}
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -393,7 +393,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			GetContext:         ctxFn,
 			SelfLinker:         a.group.Linker,
 			ClusterScoped:      true,
-			SelfLinkPathPrefix: gpath.Join(a.prefix, resourcePath) + "/",
+			SelfLinkPathPrefix: gpath.Join(a.prefix, resource) + "/",
 			SelfLinkPathSuffix: suffix,
 		}
 


### PR DESCRIPTION
before this change:
$ curl -s http://172.16.116.128:8080/api/v1/nodes/kubenet-02/status | grep selfLink
    "selfLink": "/api/v1/nodes/{name}/status/kubenet-02/status",
after this change:
$ curl -s http://172.16.116.128:8080/api/v1/nodes/kubenet-02/status | grep selfLink
    "selfLink": "/api/v1/nodes/kubenet-02/status",

related to:
#44462

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
