### PR TITLE
Define const annotation variable once

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -385,6 +385,9 @@ const (
 	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
 	// It's currently still used and will be held for backwards compatibility
 	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
+
+	// MountOptionAnnotation defines mount option annotation used in PVs
+	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
 )
 
 // +genclient=true

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -434,6 +434,9 @@ const (
 	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
 	// It's currently still used and will be held for backwards compatibility
 	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
+
+	// MountOptionAnnotation defines mount option annotation used in PVs
+	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
 )
 
 // +genclient=true

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -156,8 +156,6 @@ const (
 	// Name of a volume in external cloud that is being provisioned and thus
 	// should be ignored by rest of Kubernetes.
 	ProvisionedVolumeName = "placeholder-for-provisioning"
-	// Mount options annotations
-	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
 )
 
 // ProvisionableVolumePlugin is an extended interface of VolumePlugin and is

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -386,7 +386,7 @@ func MountOptionFromSpec(spec *Spec, options ...string) []string {
 	pv := spec.PersistentVolume
 
 	if pv != nil {
-		if mo, ok := pv.Annotations[MountOptionAnnotation]; ok {
+		if mo, ok := pv.Annotations[v1.MountOptionAnnotation]; ok {
 			moList := strings.Split(mo, ",")
 			return JoinMountOptions(moList, options)
 		}

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -362,7 +362,7 @@ func TestMountOptionFromSpec(t *testing.T) {
 
 func createVolumeSpecWithMountOption(name string, mountOptions string, spec v1.PersistentVolumeSpec) *Spec {
 	annotations := map[string]string{
-		MountOptionAnnotation: mountOptions,
+		v1.MountOptionAnnotation: mountOptions,
 	}
 	objMeta := metav1.ObjectMeta{
 		Name:        name,

--- a/pkg/volume/validation/pv_validation.go
+++ b/pkg/volume/validation/pv_validation.go
@@ -21,9 +21,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-// MountOptionAnnotation defines mount option annotation used in PVs
-const MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
-
 // ValidatePersistentVolume validates PV object for plugin specific validation
 // We can put here validations which are specific to volume types.
 func ValidatePersistentVolume(pv *api.PersistentVolume) field.ErrorList {
@@ -50,9 +47,9 @@ func checkMountOption(pv *api.PersistentVolume) field.ErrorList {
 		return allErrs
 	}
 	// any other type if mount option is present lets return error
-	if _, ok := pv.Annotations[MountOptionAnnotation]; ok {
+	if _, ok := pv.Annotations[api.MountOptionAnnotation]; ok {
 		metaField := field.NewPath("metadata")
-		allErrs = append(allErrs, field.Forbidden(metaField.Child("annotations", MountOptionAnnotation), "may not specify mount options for this volume type"))
+		allErrs = append(allErrs, field.Forbidden(metaField.Child("annotations", api.MountOptionAnnotation), "may not specify mount options for this volume type"))
 	}
 	return allErrs
 }

--- a/pkg/volume/validation/pv_validation_test.go
+++ b/pkg/volume/validation/pv_validation_test.go
@@ -68,7 +68,7 @@ func TestValidatePersistentVolumes(t *testing.T) {
 
 func testVolumeWithMountOption(name string, namespace string, mountOptions string, spec api.PersistentVolumeSpec) *api.PersistentVolume {
 	annotations := map[string]string{
-		MountOptionAnnotation: mountOptions,
+		api.MountOptionAnnotation: mountOptions,
 	}
 	objMeta := metav1.ObjectMeta{
 		Name:        name,

--- a/staging/src/k8s.io/client-go/pkg/api/types.go
+++ b/staging/src/k8s.io/client-go/pkg/api/types.go
@@ -385,6 +385,9 @@ const (
 	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
 	// It's currently still used and will be held for backwards compatibility
 	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
+
+	// MountOptionAnnotation defines mount option annotation used in PVs
+	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
 )
 
 // +genclient=true

--- a/staging/src/k8s.io/client-go/pkg/api/v1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/types.go
@@ -434,6 +434,9 @@ const (
 	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
 	// It's currently still used and will be held for backwards compatibility
 	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
+
+	// MountOptionAnnotation defines mount option annotation used in PVs
+	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
 )
 
 // +genclient=true


### PR DESCRIPTION
We do not need to define the const annotation var twice in pkg/volume and pkg/volume/validation


**Release note**:
```release-note
NONE
```
