### PR TITLE
Add some supported PV types

### DIFF
--- a/pkg/volume/validation/pv_validation.go
+++ b/pkg/volume/validation/pv_validation.go
@@ -46,7 +46,11 @@ func checkMountOption(pv *api.PersistentVolume) field.ErrorList {
 		pv.Spec.AzureFile != nil ||
 		pv.Spec.VsphereVolume != nil ||
 		pv.Spec.AzureDisk != nil ||
-		pv.Spec.PhotonPersistentDisk != nil {
+		pv.Spec.PhotonPersistentDisk != nil ||
+		pv.Spec.Flocker != nil ||
+		pv.Spec.ScaleIO != nil ||
+		pv.Spec.FC != nil ||
+		pv.Spec.PortworxVolume != nil {
 		return allErrs
 	}
 	// any other type if mount option is present lets return error


### PR DESCRIPTION
Flocker,ScaleIO,FC and PortworxVolume are also supported

According to :
https://kubernetes.io/docs/concepts/storage/persistent-volumes/#types-of-persistent-volumes
https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go#L309


**Release note**:
```release-note
NONE
```
