### PR TITLE
Change the default CLUSTER_IP_RANGE used by e2e

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -80,7 +80,7 @@ ETCD_QUORUM_READ="${ENABLE_ETCD_QUORUM_READ:-false}"
 MASTER_TAG="${INSTANCE_PREFIX}-master"
 NODE_TAG="${INSTANCE_PREFIX}-minion"
 
-CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.180.0.0/14}"
+CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.100.0.0/14}"
 MASTER_IP_RANGE="${MASTER_IP_RANGE:-10.246.0.0/24}"
 # NODE_IP_RANGE is used when ENABLE_IP_ALIASES=true. It is the primary range in
 # the subnet and is the range used for node instance IPs.

--- a/test/e2e/framework/firewall_util.go
+++ b/test/e2e/framework/firewall_util.go
@@ -120,12 +120,11 @@ func GetClusterName(instancePrefix string) string {
 }
 
 // GetClusterIpRange returns the CLUSTER_IP_RANGE env we set for e2e cluster.
-// From cluster/gce/config-test.sh, cluster ip range is set up using below command:
-// CLUSTER_IP_RANGE="${CLUSTER_IP_RANGE:-10.180.0.0/14}"
-// Warning: this need to be consistent with the CLUSTER_IP_RANGE in startup scripts,
-// which is hardcoded currently.
+//
+// Warning: this MUST be consistent with the CLUSTER_IP_RANGE set in
+// gce/config-test.sh.
 func GetClusterIpRange() string {
-	return "10.180.0.0/14"
+	return "10.100.0.0/14"
 }
 
 // GetE2eFirewalls returns all firewall rules we create for an e2e cluster.


### PR DESCRIPTION
The existing choice intersects with the range reserved for auto
subnets and cannot be used with some GCP features.

```release-note
NONE
```