### PR TITLE
Allow to use generateName for kubectl apply

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -249,7 +249,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 		}
 
 		if err := info.Get(); err != nil {
-			if !errors.IsNotFound(err) {
+			if !errors.IsNotFound(err) && len(info.Name) != 0 {
 				return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving current configuration of:\n%v\nfrom server for:", info), info.Source, err)
 			}
 			// Create the resource if it doesn't exist


### PR DESCRIPTION
**What this PR does / why we need it**:
For `kubectl apply`, there is error if use generateName without name in metadata. There is no error if use generateName with name in metadata, but the generateName will not take effect. This PR allow to independently use generateName for `kubectl apply`.

**Which issue this PR fixes** : fixes #44501

**Special notes for your reviewer**:

```
Allow to use generateName in metadata for kubectl apply
```
