### PR TITLE
remove warning infomation when using '*'

### DIFF
--- a/pkg/kubectl/cmd/auth/cani.go
+++ b/pkg/kubectl/cmd/auth/cani.go
@@ -180,6 +180,10 @@ func (o *CanIOptions) RunAccessCheck() (bool, error) {
 }
 
 func (o *CanIOptions) resourceFor(mapper meta.RESTMapper, resourceArg string) schema.GroupVersionResource {
+	if resourceArg == "*" {
+		return schema.GroupVersionResource{Resource: resourceArg}
+	}
+
 	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(strings.ToLower(resourceArg))
 	gvr := schema.GroupVersionResource{}
 	if fullySpecifiedGVR != nil {


### PR DESCRIPTION
```
#kubectl auth can-i "*" "*"
Warning: the server doesn't have a resource type '*'
yes
```
