### PR TITLE
[Federation]Fix get incorrect cluster condition

### DIFF
--- a/federation/pkg/federation-controller/cluster/cluster_client.go
+++ b/federation/pkg/federation-controller/cluster/cluster_client.go
@@ -106,7 +106,7 @@ func (self *ClusterClient) GetClusterHealthStatus() *federation_v1beta1.ClusterS
 		if !strings.EqualFold(string(body), "ok") {
 			clusterStatus.Conditions = append(clusterStatus.Conditions, newClusterNotReadyCondition, newNodeNotOfflineCondition)
 		} else {
-			clusterStatus.Conditions = append(clusterStatus.Conditions, newClusterReadyCondition)
+			clusterStatus.Conditions = append(clusterStatus.Conditions, newClusterReadyCondition, newNodeNotOfflineCondition)
 		}
 	}
 	return &clusterStatus

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -773,17 +773,23 @@ func getClusterConditionPredicate() federationcache.ClusterConditionPredicate {
 	return func(cluster v1beta1.Cluster) bool {
 		// If we have no info, don't accept
 		if len(cluster.Status.Conditions) == 0 {
+			glog.V(4).Infof("Ignoring cluster %v without condition", cluster.Name)
 			return false
 		}
 		for _, cond := range cluster.Status.Conditions {
 			//We consider the cluster for load balancing only when its ClusterReady condition status
 			//is ConditionTrue
-			if cond.Type == v1beta1.ClusterReady && cond.Status != v1.ConditionTrue {
-				glog.V(4).Infof("Ignoring cluster %v with %v condition status %v", cluster.Name, cond.Type, cond.Status)
-				return false
+			if cond.Type == v1beta1.ClusterReady {
+				if cond.Status == v1.ConditionTrue {
+					return true
+				} else {
+					glog.V(4).Infof("Ignoring cluster %v with %v condition status %v", cluster.Name, cond.Type, cond.Status)
+					return false
+				}
 			}
 		}
-		return true
+		glog.V(4).Infof("Ignoring cluster %v without %v condition", cluster.Name, v1beta1.ClusterReady)
+		return false
 	}
 }
 

--- a/federation/pkg/federation-controller/service/servicecontroller_test.go
+++ b/federation/pkg/federation-controller/service/servicecontroller_test.go
@@ -54,18 +54,32 @@ func TestGetClusterConditionPredicate(t *testing.T) {
 			cluster: v1beta1.Cluster{
 				Status: v1beta1.ClusterStatus{
 					Conditions: []v1beta1.ClusterCondition{
-						{Type: v1beta1.ClusterReady, Status: v1.ConditionTrue},
+						{Type: v1beta1.ClusterOffline, Status: v1.ConditionTrue},
 					},
 				},
 			},
-			expectAccept:      true,
-			name:              "basic",
+			expectAccept:      false,
+			name:              "offline",
 			serviceController: &serviceController,
 		},
 		{
 			cluster: v1beta1.Cluster{
 				Status: v1beta1.ClusterStatus{
 					Conditions: []v1beta1.ClusterCondition{
+						{Type: v1beta1.ClusterOffline, Status: v1.ConditionFalse},
+						{Type: v1beta1.ClusterReady, Status: v1.ConditionTrue},
+					},
+				},
+			},
+			expectAccept:      true,
+			name:              "ready",
+			serviceController: &serviceController,
+		},
+		{
+			cluster: v1beta1.Cluster{
+				Status: v1beta1.ClusterStatus{
+					Conditions: []v1beta1.ClusterCondition{
+						{Type: v1beta1.ClusterOffline, Status: v1.ConditionFalse},
 						{Type: v1beta1.ClusterReady, Status: v1.ConditionFalse},
 					},
 				},


### PR DESCRIPTION
When cluster has not v1beta1.ClusterReady condition,
getClusterConditionPredicate() will return true,
but it is false actually.