### PR TITLE
Add return to prevent calling addToClientMap() again

### DIFF
--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -237,6 +237,7 @@ func New(federationClient fedclientset.Interface, dns dnsprovider.Interface,
 				if !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) {
 					// update when spec is changed
 					s.clusterCache.addToClientMap(cur)
+					return
 				}
 
 				pred := getClusterConditionPredicate()


### PR DESCRIPTION
When cluster's condition changed to ready from not-ready and cluster's spec has been changed, servicecontroller will call addToClientMap() twice. 
Actually, after servicecontroller check cluster's spec and  call addToClientMap(), we should return.