### PR TITLE
function level optimization:use map to get container status more quickly

### DIFF
--- a/pkg/api/v1/resource_helpers.go
+++ b/pkg/api/v1/resource_helpers.go
@@ -62,22 +62,13 @@ func (self *ResourceList) NvidiaGPU() *resource.Quantity {
 	return &resource.Quantity{}
 }
 
-func GetContainerStatus(statuses []ContainerStatus, name string) (ContainerStatus, bool) {
+func GetContainerStatusInfo(statuses []ContainerStatus) map[string]ContainerStatus {
+	info := make(map[string]ContainerStatus)
 	for i := range statuses {
-		if statuses[i].Name == name {
-			return statuses[i], true
-		}
+		name := statuses[i].Name
+		info[name] = statuses[i]
 	}
-	return ContainerStatus{}, false
-}
-
-func GetExistingContainerStatus(statuses []ContainerStatus, name string) ContainerStatus {
-	for i := range statuses {
-		if statuses[i].Name == name {
-			return statuses[i]
-		}
-	}
-	return ContainerStatus{}
+	return info
 }
 
 // IsPodAvailable returns true if a pod is available; false otherwise.

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -155,7 +155,8 @@ func (w *worker) doProbe() (keepGoing bool) {
 		return false
 	}
 
-	c, ok := v1.GetContainerStatus(status.ContainerStatuses, w.container.Name)
+	statusInfo := v1.GetContainerStatusInfo(status.ContainerStatuses)
+	c, ok := statusInfo[w.container.Name]
 	if !ok || len(c.ContainerID) == 0 {
 		// Either the container has not been created yet, or it was deleted.
 		glog.V(3).Infof("Probe target container not found: %v - %v",

--- a/pkg/kubelet/status/generate.go
+++ b/pkg/kubelet/status/generate.go
@@ -43,8 +43,9 @@ func GeneratePodReadyCondition(spec *v1.PodSpec, containerStatuses []v1.Containe
 	}
 	unknownContainers := []string{}
 	unreadyContainers := []string{}
+	statusInfo := v1.GetContainerStatusInfo(containerStatuses)
 	for _, container := range spec.Containers {
-		if containerStatus, ok := v1.GetContainerStatus(containerStatuses, container.Name); ok {
+		if containerStatus, ok := statusInfo[container.Name]; ok {
 			if !containerStatus.Ready {
 				unreadyContainers = append(unreadyContainers, container.Name)
 			}
@@ -98,8 +99,9 @@ func GeneratePodInitializedCondition(spec *v1.PodSpec, containerStatuses []v1.Co
 	}
 	unknownContainers := []string{}
 	unreadyContainers := []string{}
+	statusInfo := v1.GetContainerStatusInfo(containerStatuses)
 	for _, container := range spec.InitContainers {
-		if containerStatus, ok := v1.GetContainerStatus(containerStatuses, container.Name); ok {
+		if containerStatus, ok := statusInfo[container.Name]; ok {
 			if !containerStatus.Ready {
 				unreadyContainers = append(unreadyContainers, container.Name)
 			}

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -369,7 +369,8 @@ func runLivenessTest(f *framework.Framework, pod *v1.Pod, expectNumRestarts int,
 	By("checking the pod's current state and verifying that restartCount is present")
 	pod, err := podClient.Get(pod.Name, metav1.GetOptions{})
 	framework.ExpectNoError(err, fmt.Sprintf("getting pod %s in namespace %s", pod.Name, ns))
-	initialRestartCount := v1.GetExistingContainerStatus(pod.Status.ContainerStatuses, containerName).RestartCount
+	statusInfo := v1.GetContainerStatusInfo(pod.Status.ContainerStatuses)
+	initialRestartCount :=  statusInfo[containerName].RestartCount
 	framework.Logf("Initial restart count of pod %s is %d", pod.Name, initialRestartCount)
 
 	// Wait for the restart state to be as desired.
@@ -379,7 +380,8 @@ func runLivenessTest(f *framework.Framework, pod *v1.Pod, expectNumRestarts int,
 	for start := time.Now(); time.Now().Before(deadline); time.Sleep(2 * time.Second) {
 		pod, err = podClient.Get(pod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, fmt.Sprintf("getting pod %s", pod.Name))
-		restartCount := v1.GetExistingContainerStatus(pod.Status.ContainerStatuses, containerName).RestartCount
+		statusInfo := v1.GetContainerStatusInfo(pod.Status.ContainerStatuses)
+		restartCount :=  statusInfo[containerName].RestartCount
 		if restartCount != lastRestartCount {
 			framework.Logf("Restart count of pod %s/%s is now %d (%v elapsed)",
 				ns, pod.Name, restartCount, time.Since(start))

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -103,7 +103,8 @@ func getRestartDelay(podClient *framework.PodClient, podName string, containerNa
 		time.Sleep(time.Second)
 		pod, err := podClient.Get(podName, metav1.GetOptions{})
 		framework.ExpectNoError(err, fmt.Sprintf("getting pod %s", podName))
-		status, ok := v1.GetContainerStatus(pod.Status.ContainerStatuses, containerName)
+		statusInfo := v1.GetContainerStatusInfo(pod.Status.ContainerStatuses)
+		status, ok := statusInfo[containerName]
 		if !ok {
 			framework.Logf("getRestartDelay: status missing")
 			continue

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -414,7 +414,8 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 				for t := time.Now(); time.Since(t) < timeout; time.Sleep(framework.Poll) {
 					pod, err := c.Core().Pods(ns).Get(podName, metav1.GetOptions{})
 					framework.ExpectNoError(err, fmt.Sprintf("getting pod %s", podName))
-					stat := v1.GetExistingContainerStatus(pod.Status.ContainerStatuses, podName)
+					statusInfo := v1.GetContainerStatusInfo(pod.Status.ContainerStatuses)
+					stat := statusInfo[podName]
 					framework.Logf("Pod: %s, restart count:%d", stat.Name, stat.RestartCount)
 					if stat.RestartCount > 0 {
 						framework.Logf("Saw %v restart, succeeded...", podName)


### PR DESCRIPTION
I notice when kubernetes get container status,it will visit every element of array.It's unefficient.This pr use map to restore mid-result of container status in order to reduce visit time.