### PR TITLE
add tests for managed hosts file content

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -213,6 +213,12 @@ func ensureHostsFile(fileName, hostIP, hostName, hostDomainName string) error {
 		glog.V(4).Infof("kubernetes-managed etc-hosts file exits. Will not be recreated: %q", fileName)
 		return nil
 	}
+	content := hostsFileContent(hostIP, hostName, hostDomainName)
+	return ioutil.WriteFile(fileName, content, 0644)
+}
+
+// hostsFileContent is the content of the managed etc hosts
+func hostsFileContent(hostIP, hostName, hostDomainName string) []byte {
 	var buffer bytes.Buffer
 	buffer.WriteString("# Kubernetes-managed hosts file.\n")
 	buffer.WriteString("127.0.0.1\tlocalhost\n")                      // ipv4 localhost
@@ -226,7 +232,7 @@ func ensureHostsFile(fileName, hostIP, hostName, hostDomainName string) error {
 	} else {
 		buffer.WriteString(fmt.Sprintf("%s\t%s\n", hostIP, hostName))
 	}
-	return ioutil.WriteFile(fileName, buffer.Bytes(), 0644)
+	return buffer.Bytes()
 }
 
 // truncatePodHostnameIfNeeded truncates the pod hostname if it's longer than 63 chars.

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -114,6 +114,49 @@ func TestMakeMounts(t *testing.T) {
 	assert.Equal(t, expectedMounts, mounts, "mounts of container %+v", container)
 }
 
+func TestHostsFileContent(t *testing.T) {
+	testCases := []struct {
+		hostIP          string
+		hostName        string
+		hostDomainName  string
+		expectedContent string
+	}{
+		{
+			"123.45.67.89",
+			"podFoo",
+			"",
+			`# Kubernetes-managed hosts file.
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::0	ip6-localnet
+fe00::0	ip6-mcastprefix
+fe00::1	ip6-allnodes
+fe00::2	ip6-allrouters
+123.45.67.89	podFoo
+`,
+		},
+		{
+			"203.0.113.1",
+			"podFoo",
+			"domainFoo",
+			`# Kubernetes-managed hosts file.
+127.0.0.1	localhost
+::1	localhost ip6-localhost ip6-loopback
+fe00::0	ip6-localnet
+fe00::0	ip6-mcastprefix
+fe00::1	ip6-allnodes
+fe00::2	ip6-allrouters
+203.0.113.1	podFoo.domainFoo	podFoo
+`,
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualContent := string(hostsFileContent(testCase.hostIP, testCase.hostName, testCase.hostDomainName))
+		assert.Equal(t, testCase.expectedContent, actualContent, "hosts file content not expected")
+	}
+}
+
 func TestRunInContainerNoSuchPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()


### PR DESCRIPTION
**What this PR does / why we need it**: a tiny refactor to separate concerns host file content from the logic ensuring that the file exists, and also adds unit test.

This is to prepare extending the host file logic to include customized entries described in https://github.com/kubernetes/kubernetes/issues/43632. I'm wary of changing that logic in absence of any unit tests.

**Release note**:
```release-note
NONE
```