### PR TITLE
Automated cherry pick of #44421 #44513

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"net"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -58,6 +59,7 @@ var (
 		},
 		[]string{"verb", "resource"},
 	)
+	kubectlExeRegexp = regexp.MustCompile(`^.*((?i:kubectl\.exe))`)
 )
 
 // Register all metrics.
@@ -114,9 +116,7 @@ func cleanUserAgent(ua string) string {
 		return "Browser"
 	}
 	// If an old "kubectl.exe" has passed us its full path, we discard the path portion.
-	if exeIdx := strings.LastIndex(strings.ToLower(ua), "kubectl.exe"); exeIdx != -1 {
-		return ua[exeIdx:]
-	}
+	ua = kubectlExeRegexp.ReplaceAllString(ua, "$1")
 	return ua
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -109,8 +109,13 @@ func InstrumentRouteFunc(verb, resource string, routeFunc restful.RouteFunction)
 }
 
 func cleanUserAgent(ua string) string {
+	// We collapse all "web browser"-type user agents into one "browser" to reduce metric cardinality.
 	if strings.HasPrefix(ua, "Mozilla/") {
 		return "Browser"
+	}
+	// If an old "kubectl.exe" has passed us its full path, we discard the path portion.
+	if exeIdx := strings.LastIndex(strings.ToLower(ua), "kubectl.exe"); exeIdx != -1 {
+		return ua[exeIdx:]
 	}
 	return ua
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -19,6 +19,8 @@ package metrics
 import "testing"
 
 func TestCleanUserAgent(t *testing.T) {
+	panicBuf := []byte{198, 73, 129, 133, 90, 216, 104, 29, 13, 134, 209, 233, 30, 0, 22}
+
 	for _, tc := range []struct {
 		In  string
 		Out string
@@ -38,6 +40,11 @@ func TestCleanUserAgent(t *testing.T) {
 		{
 			In:  `C:\Program Files\kubectl.exe/v1.5.4`,
 			Out: "kubectl.exe/v1.5.4",
+		},
+		{
+			// This malicious input courtesy of enisoc.
+			In:  string(panicBuf) + "kubectl.exe",
+			Out: "kubectl.exe",
 		},
 	} {
 		if cleanUserAgent(tc.In) != tc.Out {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics_test.go
@@ -31,6 +31,14 @@ func TestCleanUserAgent(t *testing.T) {
 			In:  "kubectl/v1.2.4",
 			Out: "kubectl/v1.2.4",
 		},
+		{
+			In:  `C:\Users\Kubernetes\kubectl.exe/v1.5.4`,
+			Out: "kubectl.exe/v1.5.4",
+		},
+		{
+			In:  `C:\Program Files\kubectl.exe/v1.5.4`,
+			Out: "kubectl.exe/v1.5.4",
+		},
 	} {
 		if cleanUserAgent(tc.In) != tc.Out {
 			t.Errorf("Failed to clean User-Agent: %s", tc.In)


### PR DESCRIPTION
Cherry pick of #44421 #44513 on release-1.6.

#44421: Drop leading path of KUBECTL.EXE if it shows up in
#44513: Use regexp instead of substring to do search and replace.