### PR TITLE
Kubelet nodeStatus exponential retry along with some more explicit comments on functionality.

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -110,8 +110,8 @@ const (
 	// Max amount of time to wait for the container runtime to come up.
 	maxWaitForContainerRuntime = 30 * time.Second
 
-	// nodeStatusUpdateRetry specifies how many times kubelet retries when posting node status failed.
-	nodeStatusUpdateRetry = 5
+	// nodeStatusUpdateRetryBackoff is the amount of time that we are willing to spend retrying to connect to the apiserver.
+	nodeStatusUpdateRetryMaximumTime = 20 * time.Minute
 
 	// Location of container logs.
 	ContainerLogsDir = "/var/log/containers"
@@ -822,6 +822,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 	// Finally, put the most recent version of the config on the Kubelet, so
 	// people can see how it was configured.
 	klet.kubeletConfiguration = *kubeCfg
+	go klet.backoffNotifier()
 	return klet, nil
 }
 

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/api/v1"
 	v1helper "k8s.io/kubernetes/pkg/api/v1/helper"
 	"k8s.io/kubernetes/pkg/cloudprovider"
@@ -51,7 +52,12 @@ const (
 	// maxNamesPerImageInNodeStatus is max number of names per image stored in
 	// the node status.
 	maxNamesPerImageInNodeStatus = 5
+
+	// updateNodeStatusBackoff is the key used to manage the backoff status for node updates.
+	updateNodeStatusBackoff = "updateNodeStatusBackoff"
 )
+
+var nodeUpdateBackoff = flowcontrol.NewBackOff(1*time.Second, nodeStatusUpdateRetryMaximumTime)
 
 // registerWithApiServer registers the node with the cluster master. It is safe
 // to call multiple times, but not concurrently (kl.registrationCompleted is
@@ -60,18 +66,15 @@ func (kl *Kubelet) registerWithApiServer() {
 	if kl.registrationCompleted {
 		return
 	}
-	step := 100 * time.Millisecond
 
+	// Avoid overlimiting attempts to re-register, to prevent pod draining inspite api-server problems.
+	backoff := flowcontrol.NewBackOff(100*time.Millisecond, 7*time.Second)
 	for {
-		time.Sleep(step)
-		step = step * 2
-		if step >= 7*time.Second {
-			step = 7 * time.Second
-		}
-
+		backoff.Next("registerAPIServer", kl.clock.Now())
+		kl.clock.Sleep(backoff.Get("registerAPIServer"))
 		node, err := kl.initialNode()
 		if err != nil {
-			glog.Errorf("Unable to construct v1.Node object for kubelet: %v", err)
+			glog.Errorf("Unable to construct v1.Node object for kubelet: %v.", err)
 			continue
 		}
 
@@ -319,16 +322,48 @@ func (kl *Kubelet) syncNodeStatus() {
 	}
 }
 
+// backoffNotifier will report periodic backoff state.
+func (kl *Kubelet) backoffNotifier() {
+	// Periodically update on the backoff state, especially important after 1 second, where we have frequent polling.
+	for {
+		if nodeUpdateBackoff.Get(updateNodeStatusBackoff).Seconds() > .01 {
+			glog.Warning("Notice: kubelet updata status is in backoff state, next retry will be in: ", nodeUpdateBackoff.Get(updateNodeStatusBackoff))
+		}
+		time.Sleep(10 * time.Second)
+	}
+}
+
 // updateNodeStatus updates node status to master with retries.
 func (kl *Kubelet) updateNodeStatus() error {
-	for i := 0; i < nodeStatusUpdateRetry; i++ {
-		if err := kl.tryUpdateNodeStatus(i); err != nil {
-			glog.Errorf("Error updating node status, will retry: %v", err)
+	// If a fresh call to update node status is made, we will respond optimistically, backoff will increase quickly if we're wrong.
+	nodeUpdateBackoff.Reset(updateNodeStatusBackoff)
+
+	attempts := 0
+	// continue retrying until we exceed the maximum time allowed.
+	start := kl.clock.Now()
+
+	// Retry until backoff is breached.  Termination of this loop is gauranteed, unless the backoff clock is lying.
+	for {
+		nextEstimatedBackoff := kl.clock.Since(start).Minutes() + nodeUpdateBackoff.Get(updateNodeStatusBackoff).Minutes()
+		// This is the error/timeout termination condition: Modify with caution.
+		if nextEstimatedBackoff >= nodeStatusUpdateRetryMaximumTime.Minutes() {
+			return fmt.Errorf("Couldn't reach the apiserver after backoff attempts %v.  The next backoff will be longer than max allowed time of %v", attempts, nodeStatusUpdateRetryMaximumTime)
+		}
+		err := kl.tryUpdateNodeStatus(attempts)
+		attempts += 1
+		// Termination condition: succeeded in updating the node status.
+		if err != nil {
+			glog.Infof("Error (%v) updating node status.", err)
 		} else {
+			// If we get this far, then we eventually updated status within the allowed timeframe, so the kubelet status is up to date.
+			// This is the normal termination condition: Modify with caution.
+			nodeUpdateBackoff.Reset(updateNodeStatusBackoff)
 			return nil
 		}
+		// If we get here, then we failed at updating the node.  Bump the backoff and iterate.
+		nodeUpdateBackoff.Next(updateNodeStatusBackoff, kl.clock.Now())
+		kl.clock.Sleep(nodeUpdateBackoff.Get(updateNodeStatusBackoff))
 	}
-	return fmt.Errorf("update node status exceeds retry count")
 }
 
 // tryUpdateNodeStatus tries to update node status to master. If ReconcileCBR0

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -820,8 +820,8 @@ func (kl *Kubelet) setNodeOODCondition(node *v1.Node) {
 			Status: v1.ConditionUnknown,
 		}
 		// nodeOODCondition cannot be appended to node.Status.Conditions here because it gets
-		// copied to the slice. So if we append nodeOODCondition to the slice here none of the
-		// updates we make to nodeOODCondition below are reflected in the slice.
+		// copied (rather then a being written as a pointer) to the slice.  The copy would be
+		// inaccurate since we may mutate later.
 		newOODCondition = true
 	}
 

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -863,11 +863,22 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 func TestUpdateNodeStatusError(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
+	// Note that by default this is a fake clock.
 	kubelet := testKubelet.kubelet
 	// No matching node for the kubelet
 	testKubelet.fakeKubeClient.ReactionChain = fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{}}).ReactionChain
+
+	// Now start a timer on the fake clock and wait for it to trip.
+	start := testKubelet.fakeClock.Now()
+
 	assert.Error(t, kubelet.updateNodeStatus())
-	assert.Len(t, testKubelet.fakeKubeClient.Actions(), nodeStatusUpdateRetry)
+
+	retriedOverTime := kubelet.clock.Since(start).Minutes() > 15
+	stoppedSoonEnough := kubelet.clock.Since(start).Minutes() < 21
+
+	assert.Len(t, testKubelet.fakeKubeClient.Actions(), 10, "retries are logartihmic WRT to the max time.")
+	assert.True(t, retriedOverTime, "retried until %v minutes", nodeStatusUpdateRetryMaximumTime.Minutes())
+	assert.True(t, stoppedSoonEnough, "stopped before %v minutes", nodeStatusUpdateRetryMaximumTime.Minutes())
 }
 
 func TestRegisterWithApiServer(t *testing.T) {


### PR DESCRIPTION
This is a WIP PR for discussing some ideas on making the kubelet node communication easier to predict, debug, and sustain in terms of NodeNotReady diagnosis and consistency.

Fixes #44561 .

Now, when we kill the API Server the backoffs are controlled... **before**
```
E0417 21:11:12.052718    9822 kubelet_node_status.go:326] Error updating node status, will retry: error getting node "127.0.0.1": Get https://localhost:6443/api/v1/nodes/127.0.0.
1?resourceVersion=0: dial tcp [::1]:6443: getsockopt: connection refused
E0417 21:11:12.053402    9822 kubelet_node_status.go:326] Error updating node status, will retry: error getting node "127.0.0.1": Get https://localhost:6443/api/v1/nodes/127.0.0.
1: dial tcp [::1]:6443: getsockopt: connection refused
E0417 21:11:12.054091    9822 kubelet_node_status.go:326] Error updating node status, will retry: error getting node "127.0.0.1": Get https://localhost:6443/api/v1/nodes/127.0.0.
1: dial tcp [::1]:6443: getsockopt: connection refused
E0417 21:11:12.054586    9822 kubelet_node_status.go:326] Error updating node status, will retry: error getting node "127.0.0.1": Get https://localhost:6443/api/v1/nodes/127.0.0.
1: dial tcp [::1]:6443: getsockopt: connection refused
E0417 21:11:12.055098    9822 kubelet_node_status.go:326] Error updating node status, will retry: error getting node "127.0.0.1": Get https://localhost:6443/api/v1/nodes/127.0.0.
1: dial tcp [::1]:6443: getsockopt: connection refused
```
**after**
```
W0419 17:44:59.861436   25744 kubelet_node_status.go:332] Notice: kubelet updata status is in backoff state, next retry will be in: 4s
I0419 17:45:01.863772   25744 kubelet_node_status.go:363] Error (error getting node "127.0.0.1": Get https://localhost:6443/api/v1/nodes/127.0.0.1: dial tcp [::1]:6443: getsockopt: connection refused) updating node status.
W0419 17:45:04.619038   25744 docker_sandbox.go:285] Couldn't find network status for kube-system/kube-dns-806549836-t8v7j through plugin: invalid network status for
 - exit status 1
 - exit status 1
W0419 17:45:04.861603   25744 kubelet_node_status.go:332] Notice: kubelet updata status is in backoff state, next retry will be in: 8s
W0419 17:45:09.861795   25744 kubelet_node_status.go:332] Notice: kubelet updata status is in backoff state, next retry will be in: 8s
I0419 17:45:09.864717   25744 kubelet_node_status.go:363] Error (error getting node "127.0.0.1": Get https://localhost:6443/api/v1/nodes/127.0.0.1: dial tcp [::1]:6443: getsockopt: connection refused) updating node status.
W0419 17:45:14.862035   25744 kubelet_node_status.go:332] Notice: kubelet updata status is in backoff state, next retry will be in: 16s
W0419 17:45:19.862311   25744 kubelet_node_status.go:332] Notice: kubelet updata status is in backoff state, next retry will be in: 16s
W0419 17:45:24.862507   25744 kubelet_node_status.go:332] Notice: kubelet updata status is in backoff state, next retry will be in: 16s
I0419 17:45:25.865818   25744 kubelet_node_status.go:363] Error (error getting node "127.0.0.1": Get https://localhost:6443/api/v1/nodes/127.0.0.1: dial tcp [::1]:6443: getsockopt: connection refused) updating node status.
W0419 17:45:29.862682   25744 kubelet_node_status.go:332] Notice: kubelet updata status is in backoff state, next retry will be in: 32s
```

(01,02,04,08, etc..)

**conclusion** 

This is a step forward in terms of getting the kubelet to reliably reconnect with the APIServer after chaos scenarios.  It avoids burst attempts at connecting and gaurantees that the attempts will be spread over a long time period, both reducing burst load on apiserver while increasing odds that *eventually* the kubelet will come back online.   