### PR TITLE
Move remain ESIPP tests to the slow suite

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1325,7 +1325,7 @@ var _ = framework.KubeDescribe("ESIPP [Slow]", func() {
 		}
 	})
 
-	It("should only target nodes with endpoints [Feature:ExternalTrafficLocalOnly]", func() {
+	It("should only target nodes with endpoints", func() {
 		namespace := f.Namespace.Name
 		serviceName := "external-local"
 		jig := framework.NewServiceTestJig(cs, serviceName)
@@ -1385,7 +1385,7 @@ var _ = framework.KubeDescribe("ESIPP [Slow]", func() {
 		}
 	})
 
-	It("should work from pods [Feature:ExternalTrafficLocalOnly]", func() {
+	It("should work from pods", func() {
 		namespace := f.Namespace.Name
 		serviceName := "external-local"
 		jig := framework.NewServiceTestJig(cs, serviceName)
@@ -1432,7 +1432,7 @@ var _ = framework.KubeDescribe("ESIPP [Slow]", func() {
 		}
 	})
 
-	It("should handle updates to source ip annotation [Feature:ExternalTrafficLocalOnly]", func() {
+	It("should handle updates to source ip annotation", func() {
 		namespace := f.Namespace.Name
 		serviceName := "external-local"
 		jig := framework.NewServiceTestJig(cs, serviceName)


### PR DESCRIPTION
Continue PR of #38149.

It moves the remain ESIPP tests to the slow suite to help capture breaking changes.

/assign @thockin @freehan 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
