### PR TITLE
Move "4 PV and 2 PVC" test to the slow suite.

### DIFF
--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -234,7 +234,7 @@ var _ = framework.KubeDescribe("PersistentVolumes [Volume]", func() {
 
 			// Create 4 PVs and 2 PVCs.
 			// Note: PVs are created before claims and no pre-binding.
-			It("should create 4 PVs and 2 PVCs: test write access", func() {
+			It("should create 4 PVs and 2 PVCs: test write access [Slow]", func() {
 				numPVs, numPVCs := 4, 2
 				pvols, claims = framework.CreatePVsPVCs(numPVs, numPVCs, c, ns, pvConfig, pvcConfig)
 				framework.WaitAndVerifyBinds(c, ns, pvols, claims, true)


### PR DESCRIPTION
**What this PR does / why we need it**: See test speeds on [testgrid](https://k8s-testgrid.appspot.com/google-gce#gce&graph-metrics=test-duration-minutes&include-filter-by-regex=test%20write%20access). For some reason, this one is very slow. We have a policy where tests taking >5min are tagged `[Slow]`.

**Release note**:
```release-note
NONE
```