### PR TITLE
fix kubeadm init when certdir changed

### DIFF
--- a/cmd/kubeadm/app/master/BUILD
+++ b/cmd/kubeadm/app/master/BUILD
@@ -18,6 +18,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	api "k8s.io/client-go/pkg/api/v1"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	bootstrapapi "k8s.io/kubernetes/pkg/bootstrap/api"
@@ -71,6 +72,11 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 	if isPkiVolumeMountNeeded() {
 		volumes = append(volumes, pkiVolume(cfg))
 		volumeMounts = append(volumeMounts, pkiVolumeMount())
+	}
+
+	if cfg.CertificatesDir != kubeadmapiext.DefaultCertificatesDir {
+		volumes = append(volumes, newVolume("certdir", cfg.CertificatesDir))
+		volumeMounts = append(volumeMounts, newVolumeMount("certdir", cfg.CertificatesDir))
 	}
 
 	k8sVersion, err := version.ParseSemantic(cfg.KubernetesVersion)
@@ -149,6 +155,22 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 		}
 	}
 	return nil
+}
+
+func newVolume(name, path string) api.Volume {
+	return api.Volume{
+		Name: name,
+		VolumeSource: api.VolumeSource{
+			HostPath: &api.HostPathVolumeSource{Path: path},
+		},
+	}
+}
+
+func newVolumeMount(name, path string) api.VolumeMount {
+	return api.VolumeMount{
+		Name:      name,
+		MountPath: path,
+	}
 }
 
 // etcdVolume exposes a path on the host in order to guarantee data survival during reboot.

--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -121,6 +121,77 @@ func TestWriteStaticPodManifests(t *testing.T) {
 	}
 }
 
+func TestNewVolume(t *testing.T) {
+	var tests = []struct {
+		name     string
+		path     string
+		expected api.Volume
+	}{
+		{
+			name: "foo",
+			path: "/etc/foo",
+			expected: api.Volume{
+				Name: "foo",
+				VolumeSource: api.VolumeSource{
+					HostPath: &api.HostPathVolumeSource{Path: "/etc/foo"},
+				}},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := newVolume(rt.name, rt.path)
+		if actual.Name != rt.expected.Name {
+			t.Errorf(
+				"failed newVolume:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.Name,
+				actual.Name,
+			)
+		}
+		if actual.VolumeSource.HostPath.Path != rt.expected.VolumeSource.HostPath.Path {
+			t.Errorf(
+				"failed newVolume:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.VolumeSource.HostPath.Path,
+				actual.VolumeSource.HostPath.Path,
+			)
+		}
+	}
+}
+
+func TestNewVolumeMount(t *testing.T) {
+	var tests = []struct {
+		name     string
+		path     string
+		expected api.VolumeMount
+	}{
+		{
+			name: "foo",
+			path: "/etc/foo",
+			expected: api.VolumeMount{
+				Name:      "foo",
+				MountPath: "/etc/foo",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := newVolumeMount(rt.name, rt.path)
+		if actual.Name != rt.expected.Name {
+			t.Errorf(
+				"failed newVolumeMount:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.Name,
+				actual.Name,
+			)
+		}
+		if actual.MountPath != rt.expected.MountPath {
+			t.Errorf(
+				"failed newVolumeMount:\n\texpected: %s\n\t  actual: %s",
+				rt.expected.MountPath,
+				actual.MountPath,
+			)
+		}
+	}
+}
+
 func TestEtcdVolume(t *testing.T) {
 	var tests = []struct {
 		cfg      *kubeadmapi.MasterConfiguration


### PR DESCRIPTION
If --cert-dir specified, `kubeadm init`  failed.