### PR TITLE
remove strings.Compare(), use string native operation

### DIFF
--- a/pkg/apis/storage/validation/validation.go
+++ b/pkg/apis/storage/validation/validation.go
@@ -42,7 +42,7 @@ func ValidateStorageClassUpdate(storageClass, oldStorageClass *storage.StorageCl
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("parameters"), "updates to parameters are forbidden."))
 	}
 
-	if strings.Compare(storageClass.Provisioner, oldStorageClass.Provisioner) != 0 {
+	if storageClass.Provisioner != oldStorageClass.Provisioner {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("provisioner"), "updates to provisioner are forbidden."))
 	}
 	return allErrs

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -622,7 +622,7 @@ func (pc *PCCloud) DiskIsAttached(pdID string, nodeName k8stypes.NodeName) (bool
 	}
 
 	for _, vm := range disk.VMs {
-		if strings.Compare(vm, vmID) == 0 {
+		if vm == vmID {
 			return true, nil
 		}
 	}

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -2143,7 +2143,7 @@ func TestPrintService(t *testing.T) {
 		printService(&test.service, buf, printers.PrintOptions{})
 		// We ignore time
 		if buf.String() != test.expect {
-			t.Fatalf("Expected: %s, got: %s %d", test.expect, buf.String(), strings.Compare(test.expect, buf.String()))
+			t.Fatalf("Expected: %s, but got: %s", test.expect, buf.String())
 		}
 		buf.Reset()
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers.go
@@ -55,7 +55,7 @@ func (s ByPriority) Len() int      { return len(s) }
 func (s ByPriority) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s ByPriority) Less(i, j int) bool {
 	if s[i].Spec.Priority == s[j].Spec.Priority {
-		return strings.Compare(s[i].Name, s[j].Name) < 0
+		return s[i].Name < s[j].Name
 	}
 	return s[i].Spec.Priority < s[j].Spec.Priority
 }

--- a/vendor/github.com/coreos/etcd/auth/simple_token.go
+++ b/vendor/github.com/coreos/etcd/auth/simple_token.go
@@ -134,7 +134,7 @@ func (as *authStore) invalidateUser(username string) {
 	as.simpleTokenKeeper.tokensMu.Lock()
 	as.simpleTokensMu.Lock()
 	for token, name := range as.simpleTokens {
-		if strings.Compare(name, username) == 0 {
+		if name == username {
 			delete(as.simpleTokens, token)
 			as.simpleTokenKeeper.deleteSimpleToken(token)
 		}

--- a/vendor/github.com/coreos/etcd/auth/store.go
+++ b/vendor/github.com/coreos/etcd/auth/store.go
@@ -441,7 +441,7 @@ func (as *authStore) UserGrantRole(r *pb.AuthUserGrantRoleRequest) (*pb.AuthUser
 	}
 
 	idx := sort.SearchStrings(user.Roles, r.Role)
-	if idx < len(user.Roles) && strings.Compare(user.Roles[idx], r.Role) == 0 {
+	if idx < len(user.Roles) && user.Roles[idx] == r.Role {
 		plog.Warningf("user %s is already granted role %s", r.User, r.Role)
 		return &pb.AuthUserGrantRoleResponse{}, nil
 	}
@@ -506,7 +506,7 @@ func (as *authStore) UserRevokeRole(r *pb.AuthUserRevokeRoleRequest) (*pb.AuthUs
 	}
 
 	for _, role := range user.Roles {
-		if strings.Compare(role, r.Role) != 0 {
+		if role != r.Role {
 			updatedUser.Roles = append(updatedUser.Roles, role)
 		}
 	}


### PR DESCRIPTION
I notice strings.Compare() appears in some code.we can directly use native operator.