### PR TITLE
update kubectl apply doc for required resource name

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -74,7 +74,7 @@ const (
 var (
 	apply_long = templates.LongDesc(i18n.T(`
 		Apply a configuration to a resource by filename or stdin.
-		This resource will be created if it doesn't exist yet.
+		The resource name must be specified. This resource will be created if it doesn't exist yet.
 		To use 'apply', always create the resource initially with either 'apply' or 'create --save-config'.
 
 		JSON and YAML formats are accepted.


### PR DESCRIPTION
**What this PR does / why we need it**:
Update kubectl apply doc to illustrate that the resource name is required.

**Which issue this PR fixes** : fixes #44501

**Special notes for your reviewer**:
@liggitt @adohe @jayunit100

**Release note**:

```release-note
```
