### PR TITLE
Setting default size unit to Gib when unit is not specified in the PVC request

### DIFF
--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -140,6 +140,10 @@
       ```
 
       [Download example](vsphere-volume-pvc.yaml?raw=true)
+      
+      **Note**: In the above example volume size - 2GB is specified using binary SI - Gi.
+      If unit is not specified, default will be Gi.
+      For example ```storage: 2``` will generate a request to provision 2 GB Volume.
 
       Creating the persistent volume claim:
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This PR is allowing PV provisioning without specifying unit in the PVC request

Customer reported issue  https://github.com/kubernetes/kubernetes/issues/43319 - "Unable to provision vSphere volume if PVC's requested size does not have unit"

With this change, when unit is not specified in the PVC request, we are defaulting to Gib for Volume Provisioning. 


**Which issue this PR fixes**
fixes # 43319, https://github.com/vmware/kubernetes/issues/130

**Special notes for your reviewer**:
Verified provisioning PVs using following YAML, able to provision PV in Gib.

```
$ cat thin_pvc_no_units.yaml 
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: thinclaim
  annotations:
    volume.beta.kubernetes.io/storage-class: thin
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 2
```

Also verified creating StatefulSet without setting units in the volumeClaimTemplates

```
.
.
  volumeClaimTemplates:
  - metadata:
      name: www
      annotations:
        volume.beta.kubernetes.io/storage-class: thin
    spec:
      accessModes: [ "ReadWriteOnce" ]
      resources:
        requests:
          storage: 1
.
.
```
Also verified with specifying binary SI units in the request size to confirm change is not breaking existing functionality.
  
cc: @tusharnt @BaluDontu @pdhamdhere

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
None
```
