### PR TITLE
Fix kube-apiserver crash when patching TPR data

### DIFF
--- a/pkg/master/thirdparty/thirdparty.go
+++ b/pkg/master/thirdparty/thirdparty.go
@@ -315,11 +315,12 @@ func (m *ThirdPartyResourceServer) thirdpartyapi(group, kind, version, pluralRes
 		Root:         apiRoot,
 		GroupVersion: externalVersion,
 
-		Creater:   thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
-		Convertor: api.Scheme,
-		Copier:    api.Scheme,
-		Defaulter: api.Scheme,
-		Typer:     api.Scheme,
+		Creater:         thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
+		Convertor:       api.Scheme,
+		Copier:          api.Scheme,
+		Defaulter:       api.Scheme,
+		Typer:           api.Scheme,
+		UnsafeConvertor: api.Scheme,
 
 		Mapper:                 thirdpartyresourcedata.NewMapper(api.Registry.GroupOrDie(extensions.GroupName).RESTMapper, kind, version, group),
 		Linker:                 api.Registry.GroupOrDie(extensions.GroupName).SelfLinker,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: While trying to do a strategic merge patch, kube-apiserver crashes with a nil pointer dereference because `UnsafeConvertor` is `nil` for TPR data resources here: https://github.com/kubernetes/kubernetes/blob/master/pkg/master/thirdparty/thirdparty.go#L314-L337.

This PR does not make strategic merge patch work on TPR data but makes sure that the kube-api server does not crash while trying to do so.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #44587

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
Fix kube-apiserver crash when attempting an unsupported strategic merge patch operation on TPR data.
```
