### PR TITLE
nits in service e2e test logging

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -1371,12 +1371,12 @@ var _ = framework.KubeDescribe("ESIPP [Slow]", func() {
 			// All other nodes should fail the healthcheck on the service healthCheckNodePort
 			for n, publicIP := range ips {
 				expectedSuccess := nodes.Items[n].Name == endpointNodeName
-				framework.Logf("Health checking %s, http://%s:%d/%s, expectedSuccess %v", nodes.Items[n].Name, publicIP, healthCheckNodePort, path, expectedSuccess)
+				framework.Logf("Health checking %s, http://%s:%d%s, expectedSuccess %v", nodes.Items[n].Name, publicIP, healthCheckNodePort, path, expectedSuccess)
 				pass, fail, err := jig.TestHTTPHealthCheckNodePort(publicIP, healthCheckNodePort, path, 5)
 				if expectedSuccess && pass < threshold {
-					framework.Failf("Expected %s successes on %v/%v, got %d, err %v", threshold, endpointNodeName, path, pass, err)
+					framework.Failf("Expected %d successes on %v%v, got %d, err %v", threshold, endpointNodeName, path, pass, err)
 				} else if !expectedSuccess && fail < threshold {
-					framework.Failf("Expected %s failures on %v/%v, got %d, err %v", threshold, endpointNodeName, path, fail, err)
+					framework.Failf("Expected %d failures on %v%v, got %d, err %v", threshold, endpointNodeName, path, fail, err)
 				}
 				// Make sure the loadbalancer picked up the helth check change
 				jig.TestReachableHTTP(ingressIP, svcTCPPort, framework.KubeProxyLagTimeout)


### PR DESCRIPTION
Saw some weird logs from CI [gce-alpha-features](https://k8s-testgrid.appspot.com/google-gce#gce-alpha-features&width=5).
```
...
Health checking bootstrap-e2e-minion-group-3tm9, http://35.188.44.206:32733//healthz, expectedSuccess true
...
Expected %!!(MISSING)s(int=2) failures on bootstrap-e2e-minion-group-8h0q//healthz, got 0, err 
...
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
