### PR TITLE
Improvement on Kubectl CheatSheet base64 examples

### DIFF
--- a/docs/user-guide/kubectl-cheatsheet.md
+++ b/docs/user-guide/kubectl-cheatsheet.md
@@ -50,8 +50,8 @@ metadata:
   name: mysecret
 type: Opaque
 data:
-  password: $(echo "s33msi4" | base64)
-  username: $(echo "jane" | base64)
+  password: $(echo -n "s33msi4" | base64)
+  username: $(echo -n "jane" | base64)
 EOF
 
 # TODO: kubectl-explain example


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Little improvement on a kubectl cheat sheet example.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

`echo blah | base64` will actually result in the base64 of `blah\n`, which will usually not be intended by the user.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
