### PR TITLE
Use OS-specific libs when computing client User-Agent in kubectl, etc.

### DIFF
--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -14565,6 +14565,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//vendor:github.com/google/gofuzz",
+        "//vendor:github.com/stretchr/testify/assert",
         "//vendor:k8s.io/apimachinery/pkg/api/equality",
         "//vendor:k8s.io/apimachinery/pkg/api/errors",
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",


### PR DESCRIPTION
This PR fixes issue 44419 in the release branch.
This PR is a patchable version of mainline PR #44423 for 1.6 release branch

The original full PR
  https://github.com/kubernetes/kubernetes/pull/44423
came after a large PR
  https://github.com/kubernetes/kubernetes/pull/40777
that split /vendor/BUILD into hundreds of BUILD files.

Thus PR 44423's version of rest/BUILD does not exist
in the 1.6 release branch, and had to be tweaked here.

```release-note
Fix for [Windows kubectl sending full path to binary in User Agent](https://github.com/kubernetes/kubernetes/issues/44419).
```