### PR TITLE
Fix ceph-secret type to kubernetes.io/rbd in kubernetes-master charm

### DIFF
--- a/cluster/juju/layers/kubernetes-master/templates/ceph-secret.yaml
+++ b/cluster/juju/layers/kubernetes-master/templates/ceph-secret.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ceph-secret
-type: Opaque
+type: kubernetes.io/rbd
 data:
   key: {{ secret }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This fixes the type of the ceph-secret secret that's created by the kubernetes-master charm.

Without the `kubernetes.io/rbd` type, automatic provisioning of PVCs doesn't work.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fix ceph-secret type to kubernetes.io/rbd in kubernetes-master charm
```
