### PR TITLE
allow the token controller to get secrets

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -300,8 +300,8 @@ func ClusterRoles() []rbac.ClusterRole {
 				eventsRule(),
 				rbac.NewRule("create").Groups(legacyGroup).Resources("endpoints", "secrets", "serviceaccounts").RuleOrDie(),
 				rbac.NewRule("delete").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
-				rbac.NewRule("get").Groups(legacyGroup).Resources("endpoints", "namespaces", "serviceaccounts").RuleOrDie(),
-				rbac.NewRule("update").Groups(legacyGroup).Resources("endpoints", "serviceaccounts").RuleOrDie(),
+				rbac.NewRule("get").Groups(legacyGroup).Resources("endpoints", "namespaces", "secrets", "serviceaccounts").RuleOrDie(),
+				rbac.NewRule("update").Groups(legacyGroup).Resources("endpoints", "secrets", "serviceaccounts").RuleOrDie(),
 				// Needed to check API access.  These creates are non-mutating
 				rbac.NewRule("create").Groups(authenticationGroup).Resources("tokenreviews").RuleOrDie(),
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -460,6 +460,7 @@ items:
     resources:
     - endpoints
     - namespaces
+    - secrets
     - serviceaccounts
     verbs:
     - get
@@ -467,6 +468,7 @@ items:
     - ""
     resources:
     - endpoints
+    - secrets
     - serviceaccounts
     verbs:
     - update


### PR DESCRIPTION
we need this on secret rotation here:

https://github.com/kubernetes/kubernetes/blob/2c1c0f3f7295e0d00651d6e30cfcda56239275e4/pkg/controller/serviceaccount/tokens_controller.go#L478-L481


cc @liggitt 