### PR TITLE
Remove the Federated Ingress DNS test that never worked and probably will never in the foreseeable future.

### DIFF
--- a/test/e2e_federation/ingress.go
+++ b/test/e2e_federation/ingress.go
@@ -248,22 +248,6 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 				}
 			})
 
-			PIt("should be able to discover a federated ingress service via DNS", func() {
-				// we are about the ingress name
-				svcDNSNames := []string{
-					fmt.Sprintf("%s.%s", FederatedIngressServiceName, ns),
-					fmt.Sprintf("%s.%s.svc.cluster.local.", FederatedIngressServiceName, ns),
-					// TODO these two entries are not set yet
-					//fmt.Sprintf("%s.%s.%s", FederatedIngressServiceName, ns, federationName),
-					//fmt.Sprintf("%s.%s.%s.svc.cluster.local.", FederatedIngressServiceName, ns, federationName),
-				}
-				// check dns records in underlying cluster
-				for i, DNSName := range svcDNSNames {
-					discoverService(f, DNSName, true, "federated-ingress-e2e-discovery-pod-"+strconv.Itoa(i))
-				}
-				// TODO check dns record in global dns server
-			})
-
 			PIt("should be able to connect to a federated ingress via its load balancer", func() {
 				By(fmt.Sprintf("Waiting for Federated Ingress on %v", jig.ing.Name))
 				// check the traffic on federation ingress


### PR DESCRIPTION
The initial idea was to expose federated ingresses via DNS, in addition to the global VIP in case of GCP, the same way federated services are exposed. But this ran into a bunch of challenges and the discussion slowly died down. We are not going to add this feature in the foreseeable future and it doesn't make sense to have this dead code lying around. Even if we add the DNS feature, we can always bring this test back from version control. That's what version control systems are for, after all.

**Release note**:
```release-note
NONE
```

/assign @csbell 

cc @kubernetes/sig-federation-pr-reviews 
