### PR TITLE
Add a fallback 'nc' command for environments where icmp is blocked.

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4839,15 +4839,36 @@ func LaunchWebserverPod(f *Framework, podName, nodeName string) (ip string) {
 // host. An error will be returned if the host is not reachable from the pod.
 //
 // An empty nodeName will use the schedule to choose where the pod is executed.
-func CheckConnectivityToHost(f *Framework, nodeName, podName, host string, timeout int) error {
+func CheckConnectivityToHost(f *Framework, nodeName, podName, host string, timeout, port int) error {
 	contName := fmt.Sprintf("%s-container", podName)
 
-	command := []string{
+	pingCommand := []string{
 		"ping",
 		"-c", "3", // send 3 pings
 		"-W", "2", // wait at most 2 seconds for a reply
 		"-w", strconv.Itoa(timeout),
 		host,
+	}
+
+	ncCommand := []string{
+		"nc",
+		"-w", strconv.Itoa(timeout),
+		host,
+		strconv.Itoa(port), // TODO: Add an optional port number here?
+	}
+
+	pingCmdStr := strings.Join(pingCommand, " ")
+	ncCmdStr := strings.Join(ncCommand, " ")
+
+	var command []string
+	if port == -1 {
+		command = pingCommand
+	} else {
+		command = []string{
+			"sh",
+			"-c",
+			fmt.Sprintf("\"%s || %s\"", pingCmdStr, ncCmdStr),
+		}
 	}
 
 	pod := &v1.Pod{

--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -48,7 +48,7 @@ var _ = framework.KubeDescribe("Networking", func() {
 	It("should provide Internet connection for containers [Conformance]", func() {
 		By("Running container which tries to ping 8.8.8.8")
 		framework.ExpectNoError(
-			framework.CheckConnectivityToHost(f, "", "ping-test", "8.8.8.8", 30))
+			framework.CheckConnectivityToHost(f, "", "ping-test", "8.8.8.8", 30, 53))
 	})
 
 	// First test because it has no dependencies on variables created later on.


### PR DESCRIPTION
In Azure, ICMP is blocked for outbound hosts, so we fallback to trying a simple 'nc' command in such cases.

In places where 'ping' works correctly, this should have no effect.

@ixdy @fejta @kubernetes/sig-testing-bugs 