### PR TITLE
Re-enable federated ingress test that was disabled due to a federated service deletion bug.

### DIFF
--- a/test/e2e_federation/ingress.go
+++ b/test/e2e_federation/ingress.go
@@ -264,7 +264,7 @@ var _ = framework.KubeDescribe("Federated ingresses [Feature:Federation]", func(
 				// TODO check dns record in global dns server
 			})
 
-			PIt("should be able to connect to a federated ingress via its load balancer", func() {
+			It("should be able to connect to a federated ingress via its load balancer", func() {
 				By(fmt.Sprintf("Waiting for Federated Ingress on %v", jig.ing.Name))
 				// check the traffic on federation ingress
 				jig.waitForFederatedIngress()


### PR DESCRIPTION
The details of the bug is described in PR #44626. We believe this bug fixes the flakiness in this test and hence we are re-enabling this test to get some mileage on it. If it turns out to be a problem again we are going to revert this back.

**Release note**:
```release-note
NONE
```

/assign @csbell 

cc @kubernetes/sig-federation-pr-reviews 