### PR TITLE
Add more metadata about dynamically provisioned PVs using PV annotation

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -696,7 +696,13 @@ func (r *glusterfsVolumeProvisioner) Provision() (*v1.PersistentVolume, error) {
 	}
 
 	gidStr := strconv.FormatInt(int64(gid), 10)
-	pv.Annotations = map[string]string{volumehelper.VolumeGidAnnotationKey: gidStr}
+
+	pv.Annotations = map[string]string{
+		volumehelper.VolumeGidAnnotationKey: gidStr,
+		"kubernetes.io/createdby":           "heketi-dynamic-provisioner",
+		"gluster.org/type":                  "file",
+		"Description":                       "Gluster: Dynamically provisioned PV",
+	}
 
 	pv.Spec.Capacity = v1.ResourceList{
 		v1.ResourceName(v1.ResourceStorage): resource.MustParse(fmt.Sprintf("%dGi", sizeGB)),


### PR DESCRIPTION

This patch add below fields to Gluster dynamic pvs.

"Description: "Gluster: dynamically provisioned PVs"
"Creator": "heketi-dynamic"
"Type": "file"

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

