### PR TITLE
List all pods on node added for attach_detach controller

### DIFF
--- a/pkg/controller/volume/attachdetach/BUILD
+++ b/pkg/controller/volume/attachdetach/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//pkg/volume/util/operationexecutor:go_default_library",
         "//pkg/volume/util/volumehelper:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -328,8 +328,7 @@ func (adc *attachDetachController) nodeUpdate(oldObj, newObj interface{}) {
 	}
 	adc.processVolumesInUse(nodeName, node.Status.VolumesInUse)
 
-	oldNode, ok := oldObj.(*v1.Node)
-	if ok && oldNode != nil {
+	if oldNode, ok := oldObj.(*v1.Node); ok {
 		_, oldManaged := oldNode.Annotations[volumehelper.ControllerManagedAttachAnnotation]
 		_, newManaged := node.Annotations[volumehelper.ControllerManagedAttachAnnotation]
 		if !oldManaged && newManaged {

--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -47,7 +48,6 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util/operationexecutor"
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
-	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (


### PR DESCRIPTION
To ensure all pods with volumes are managed immediately upon a node
becoming managed. This most commonly happens at startup of the
controller manager.

This may produce duplicate pod processing, but this should be minimal
since nodes are generally added at slow rate. If it's a problem we'll
need to move to a worker queue approach and keep track of all nodes
so pods can be requeued for processing.

Main drawback is at startup. The attach detach controller may end up
processing all pods twice in the worse case. And without a node index
it will list all the pods for every node in the cluster.