### PR TITLE
select one api endpoint at random when deploying kubernetes-core charm

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+import random
 import shutil
 
 from shlex import split
@@ -319,7 +320,7 @@ def start_worker(kube_api, kube_control, cni):
     # set --allow-privileged flag for kubelet
     set_privileged()
 
-    create_config(servers[0])
+    create_config(random.choice(servers))
     configure_worker_services(servers, dns, cluster_cidr)
     set_state('kubernetes-worker.config.created')
     restart_unit_services()
@@ -475,7 +476,7 @@ def configure_worker_services(api_servers, dns, cluster_cidr):
     kube_proxy_opts.add('kubeconfig', kubeconfig_path)
     kube_proxy_opts.add('logtostderr', 'true')
     kube_proxy_opts.add('v', '0')
-    kube_proxy_opts.add('master', ','.join(api_servers), strict=True)
+    kube_proxy_opts.add('master', random.choice(api_servers), strict=True)
 
     cmd = ['snap', 'set', 'kubelet'] + kubelet_opts.to_s().split(' ')
     check_call(cmd)


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a bug in the kubernetes-worker Juju charm code that attempted to give kube-proxy more than one api endpoint.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/255

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fixes a bug in the kubernetes-worker Juju charm code that attempted to give kube-proxy more than one api endpoint.
```
