### PR TITLE
Add hack/lib to kubernetes release tarball

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -476,6 +476,10 @@ EOF
   cp -R "${KUBE_ROOT}/federation/manifests" "${release_stage}/federation/"
   cp -R "${KUBE_ROOT}/federation/deploy" "${release_stage}/federation/"
 
+  # Include hack/lib as a dependency for the cluster/ scripts
+  mkdir -p "${release_stage}/hack"
+  cp -R "${KUBE_ROOT}/hack/lib" "${release_stage}/hack/"
+
   cp -R "${KUBE_ROOT}/examples" "${release_stage}/"
   cp -R "${KUBE_ROOT}/docs" "${release_stage}/"
   cp "${KUBE_ROOT}/README.md" "${release_stage}/"

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -228,6 +228,7 @@ pkg_tar(
         "//cluster:all-srcs",
         "//docs:all-srcs",
         "//examples:all-srcs",
+        "//hack/lib:all-srcs",
         "//third_party/htpasswd:all-srcs",
     ],
     package_dir = "kubernetes",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Add hack/lib to kubernetes release tarball, to fix an issue with https://get.k8s.io/ script introduced in #42748.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
Fixes https://github.com/kubernetes/kubernetes/pull/42748#issuecomment-295412268

**Special notes for your reviewer**:
I'm new to bazel, so hopefully I'm not off-base here :)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

cc: @ixdy @dcbw @smarterclayton 