### PR TITLE
remove resourcename validation in create role

### DIFF
--- a/pkg/kubectl/cmd/create_role.go
+++ b/pkg/kubectl/cmd/create_role.go
@@ -207,11 +207,6 @@ func (c *CreateRoleOptions) Validate() error {
 		}
 	}
 
-	// validate resource names, can not apply resource names to multiple resources.
-	if len(c.ResourceNames) > 0 && len(c.Resources) > 1 {
-		return fmt.Errorf("resource name(s) can not be applied to multiple resources")
-	}
-
 	return nil
 }
 

--- a/pkg/kubectl/cmd/create_role_test.go
+++ b/pkg/kubectl/cmd/create_role_test.go
@@ -256,7 +256,7 @@ func TestValidate(t *testing.T) {
 				},
 				ResourceNames: []string{"foo"},
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		"test-valid-case": {
 			roleOptions: &CreateRoleOptions{


### PR DESCRIPTION
@liggitt Since #44659 is not correct. I think we should fix the validation in create role command.