### PR TITLE
e2e test fix: Wait longer when first creating ELB

### DIFF
--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -594,9 +594,9 @@ func (config *NetworkingTestConfig) getNamespacesClient() coreclientset.Namespac
 	return config.f.ClientSet.Core().Namespaces()
 }
 
-func CheckReachabilityFromPod(expectToBeReachable bool, namespace, pod, target string) {
+func CheckReachabilityFromPod(expectToBeReachable bool, timeout time.Duration, namespace, pod, target string) {
 	cmd := fmt.Sprintf("wget -T 5 -qO- %q", target)
-	err := wait.PollImmediate(Poll, 2*time.Minute, func() (bool, error) {
+	err := wait.PollImmediate(Poll, timeout, func() (bool, error) {
 		_, err := RunHostCmd(namespace, pod, cmd)
 		if expectToBeReachable && err != nil {
 			Logf("Expect target to be reachable. But got err: %v. Retry until timeout", err)


### PR DESCRIPTION
On any cloud (GCE or AWS), a lag between creating the LoadBalancer and
having it actually start serving traffic is expected.  On AWS the lag is
larger, and we weren't correctly using the longer wait on our first
request.

Use a longer wait period on our first request.

Fix #44695

```release-note
NONE
```
