### PR TITLE
fix nonResourceURL in policy comparator

### DIFF
--- a/pkg/registry/rbac/validation/policy_comparator.go
+++ b/pkg/registry/rbac/validation/policy_comparator.go
@@ -125,7 +125,7 @@ func nonResourceURLCovers(ownerPath, subPath string) bool {
 	if ownerPath == subPath {
 		return true
 	}
-	return strings.HasSuffix(ownerPath, "*") && strings.HasPrefix(subPath, strings.TrimRight(ownerPath, "*"))
+	return strings.HasSuffix(ownerPath, "/*") && strings.HasPrefix(subPath, strings.TrimRight(ownerPath, "*"))
 }
 
 // ruleCovers determines whether the ownerRule (which may have multiple verbs, resources, and resourceNames) covers


### PR DESCRIPTION
We doesn't handle the wildcard '*' in policy comparator.
if nonResourceURL is *,  `strings.TrimRight(ownerPath, "*")` will return a empty string.  The result will be wrong. 