### PR TITLE
Add abbreviated alias for RBAC resource

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -203,8 +203,8 @@ __custom_func() {
 
     * all
     * certificatesigningrequests (aka 'csr')
-    * clusterrolebindings
-    * clusterroles
+    * clusterrolebindings (aka 'crb')
+    * clusterroles (aka 'cr')
     * clusters (valid only for federation apiservers)
     * componentstatuses (aka 'cs')
     * configmaps (aka 'cm')
@@ -229,7 +229,7 @@ __custom_func() {
     * replicasets (aka 'rs')
     * replicationcontrollers (aka 'rc')
     * resourcequotas (aka 'quota')
-    * rolebindings
+    * rolebindings (aka 'rb')
     * roles
     * secrets
     * serviceaccounts (aka 'sa')

--- a/pkg/kubectl/cmd/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create_clusterrole.go
@@ -52,6 +52,7 @@ func NewCmdCreateClusterRole(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command
 	}
 	cmd := &cobra.Command{
 		Use:     "clusterrole NAME --verb=verb --resource=resource.group [--resource-name=resourcename] [--dry-run]",
+		Aliases: []string{"cr"},
 		Short:   clusterRoleLong,
 		Long:    clusterRoleLong,
 		Example: clusterRoleExample,

--- a/pkg/kubectl/cmd/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding.go
@@ -41,6 +41,7 @@ var (
 func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]",
+		Aliases: []string{"crb"},
 		Short:   i18n.T("Create a ClusterRoleBinding for a particular ClusterRole"),
 		Long:    clusterRoleBindingLong,
 		Example: clusterRoleBindingExample,

--- a/pkg/kubectl/cmd/create_rolebinding.go
+++ b/pkg/kubectl/cmd/create_rolebinding.go
@@ -41,6 +41,7 @@ var (
 func NewCmdCreateRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]",
+		Aliases: []string{"rb"},
 		Short:   i18n.T("Create a RoleBinding for a particular Role or ClusterRole"),
 		Long:    roleBindingLong,
 		Example: roleBindingExample,

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -138,6 +138,18 @@ var ResourcesShortcutStatic = []ResourceShortcuts{
 		ShortForm: schema.GroupResource{Group: "extensions", Resource: "psp"},
 		LongForm:  schema.GroupResource{Group: "extensions", Resource: "podSecurityPolicies"},
 	},
+	{
+		ShortForm: schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "crb"},
+		LongForm:  schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "cr"},
+		LongForm:  schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "rb"},
+		LongForm:  schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "rolebindings"},
+	},
 }
 
 // ResourceShortFormFor looks up for a short form of resource names.

--- a/pkg/registry/rbac/clusterrole/storage/storage.go
+++ b/pkg/registry/rbac/clusterrole/storage/storage.go
@@ -55,3 +55,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 
 	return &REST{store}
 }
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"cr"}
+}

--- a/pkg/registry/rbac/clusterrolebinding/storage/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/storage/storage.go
@@ -55,3 +55,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 
 	return &REST{store}
 }
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"crb"}
+}

--- a/pkg/registry/rbac/rolebinding/storage/storage.go
+++ b/pkg/registry/rbac/rolebinding/storage/storage.go
@@ -55,3 +55,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 
 	return &REST{store}
 }
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"rb"}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add  abbreviated alias for RBAC resource, it can make the RBAC related resource more easily to use just like other resources do, especially for the long name resources.

**Which issue this PR fixes**:

there is no issue for this PR.
