### PR TITLE
Use global RBAC group name if the package has been included

### DIFF
--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -796,7 +796,7 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 			},
 		},
 		RoleRef: rbacv1beta1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
+			APIGroup: rbacv1beta1.GroupName,
 			Kind:     "Role",
 			Name:     "federation-system:federation-controller-manager",
 		},

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/fake/fake_clusterrole.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/fake/fake_clusterrole.go
@@ -31,7 +31,7 @@ type FakeClusterRoles struct {
 	Fake *FakeRbacV1alpha1
 }
 
-var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "clusterroles"}
+var clusterrolesResource = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "clusterroles"}
 
 func (c *FakeClusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
@@ -31,7 +31,7 @@ type FakeClusterRoleBindings struct {
 	Fake *FakeRbacV1alpha1
 }
 
-var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "clusterrolebindings"}
+var clusterrolebindingsResource = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "clusterrolebindings"}
 
 func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/fake/fake_role.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/fake/fake_role.go
@@ -32,7 +32,7 @@ type FakeRoles struct {
 	ns   string
 }
 
-var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "roles"}
+var rolesResource = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "roles"}
 
 func (c *FakeRoles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/fake/fake_rolebinding.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1alpha1/fake/fake_rolebinding.go
@@ -32,7 +32,7 @@ type FakeRoleBindings struct {
 	ns   string
 }
 
-var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "rolebindings"}
+var rolebindingsResource = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "rolebindings"}
 
 func (c *FakeRoleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/fake/fake_clusterrole.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/fake/fake_clusterrole.go
@@ -31,7 +31,7 @@ type FakeClusterRoles struct {
 	Fake *FakeRbacV1beta1
 }
 
-var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterroles"}
+var clusterrolesResource = schema.GroupVersionResource{Group: v1beta1.GroupName, Version: "v1beta1", Resource: "clusterroles"}
 
 func (c *FakeClusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
@@ -31,7 +31,7 @@ type FakeClusterRoleBindings struct {
 	Fake *FakeRbacV1beta1
 }
 
-var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterrolebindings"}
+var clusterrolebindingsResource = schema.GroupVersionResource{Group: v1beta1.GroupName, Version: "v1beta1", Resource: "clusterrolebindings"}
 
 func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/fake/fake_role.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/fake/fake_role.go
@@ -32,7 +32,7 @@ type FakeRoles struct {
 	ns   string
 }
 
-var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "roles"}
+var rolesResource = schema.GroupVersionResource{Group: v1beta1.GroupName, Version: "v1beta1", Resource: "roles"}
 
 func (c *FakeRoles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/fake/fake_rolebinding.go
+++ b/pkg/client/clientset_generated/clientset/typed/rbac/v1beta1/fake/fake_rolebinding.go
@@ -32,7 +32,7 @@ type FakeRoleBindings struct {
 	ns   string
 }
 
-var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "rolebindings"}
+var rolebindingsResource = schema.GroupVersionResource{Group: v1beta1.GroupName, Version: "v1beta1", Resource: "rolebindings"}
 
 func (c *FakeRoleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_clusterrole.go
@@ -31,7 +31,7 @@ type FakeClusterRoles struct {
 	Fake *FakeRbac
 }
 
-var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "", Resource: "clusterroles"}
+var clusterrolesResource = schema.GroupVersionResource{Group: rbac.GroupName, Version: "", Resource: "clusterroles"}
 
 func (c *FakeClusterRoles) Create(clusterRole *rbac.ClusterRole) (result *rbac.ClusterRole, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_clusterrolebinding.go
@@ -31,7 +31,7 @@ type FakeClusterRoleBindings struct {
 	Fake *FakeRbac
 }
 
-var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "", Resource: "clusterrolebindings"}
+var clusterrolebindingsResource = schema.GroupVersionResource{Group: rbac.GroupName, Version: "", Resource: "clusterrolebindings"}
 
 func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *rbac.ClusterRoleBinding) (result *rbac.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_role.go
@@ -32,7 +32,7 @@ type FakeRoles struct {
 	ns   string
 }
 
-var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "", Resource: "roles"}
+var rolesResource = schema.GroupVersionResource{Group: rbac.GroupName, Version: "", Resource: "roles"}
 
 func (c *FakeRoles) Create(role *rbac.Role) (result *rbac.Role, err error) {
 	obj, err := c.Fake.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_rolebinding.go
@@ -32,7 +32,7 @@ type FakeRoleBindings struct {
 	ns   string
 }
 
-var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "", Resource: "rolebindings"}
+var rolebindingsResource = schema.GroupVersionResource{Group: rbac.GroupName, Version: "", Resource: "rolebindings"}
 
 func (c *FakeRoleBindings) Create(roleBinding *rbac.RoleBinding) (result *rbac.RoleBinding, err error) {
 	obj, err := c.Fake.

--- a/pkg/kubectl/cmd/create_rolebinding_test.go
+++ b/pkg/kubectl/cmd/create_rolebinding_test.go
@@ -34,7 +34,7 @@ import (
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
-var groupVersion = schema.GroupVersion{Group: "rbac.authorization.k8s.io", Version: "v1alpha1"}
+var groupVersion = schema.GroupVersion{Group: rbac.GroupName, Version: "v1alpha1"}
 
 func TestCreateRoleBinding(t *testing.T) {
 	expectBinding := &rbac.RoleBinding{
@@ -49,12 +49,12 @@ func TestCreateRoleBinding(t *testing.T) {
 		Subjects: []rbac.Subject{
 			{
 				Kind:     rbac.UserKind,
-				APIGroup: "rbac.authorization.k8s.io",
+				APIGroup: rbac.GroupName,
 				Name:     "fake-user",
 			},
 			{
 				Kind:     rbac.GroupKind,
-				APIGroup: "rbac.authorization.k8s.io",
+				APIGroup: rbac.GroupName,
 				Name:     "fake-group",
 			},
 			{

--- a/pkg/kubectl/rolebinding_test.go
+++ b/pkg/kubectl/rolebinding_test.go
@@ -94,12 +94,12 @@ func TestRoleBindingGenerate(t *testing.T) {
 				Subjects: []rbac.Subject{
 					{
 						Kind:     rbac.UserKind,
-						APIGroup: "rbac.authorization.k8s.io",
+						APIGroup: rbac.GroupName,
 						Name:     "fake-user",
 					},
 					{
 						Kind:     rbac.GroupKind,
-						APIGroup: "rbac.authorization.k8s.io",
+						APIGroup: rbac.GroupName,
 						Name:     "fake-group",
 					},
 					{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy_test.go
@@ -82,8 +82,8 @@ func TestCovers(t *testing.T) {
 // one resource per rule to make the "does not already contain" check easy
 var additionalAdminPowers = []rbac.PolicyRule{
 	rbac.NewRule("create").Groups("authorization.k8s.io").Resources("localsubjectaccessreviews").RuleOrDie(),
-	rbac.NewRule(bootstrappolicy.ReadWrite...).Groups("rbac.authorization.k8s.io").Resources("rolebindings").RuleOrDie(),
-	rbac.NewRule(bootstrappolicy.ReadWrite...).Groups("rbac.authorization.k8s.io").Resources("roles").RuleOrDie(),
+	rbac.NewRule(bootstrappolicy.ReadWrite...).Groups(rbac.GroupName).Resources("rolebindings").RuleOrDie(),
+	rbac.NewRule(bootstrappolicy.ReadWrite...).Groups(rbac.GroupName).Resources("roles").RuleOrDie(),
 }
 
 func TestAdminEditRelationship(t *testing.T) {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
@@ -31,7 +31,7 @@ type FakeClusterRoles struct {
 	Fake *FakeRbacV1alpha1
 }
 
-var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "clusterroles"}
+var clusterrolesResource = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "clusterroles"}
 
 func (c *FakeClusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
@@ -31,7 +31,7 @@ type FakeClusterRoleBindings struct {
 	Fake *FakeRbacV1alpha1
 }
 
-var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "clusterrolebindings"}
+var clusterrolebindingsResource = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "clusterrolebindings"}
 
 func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
@@ -32,7 +32,7 @@ type FakeRoles struct {
 	ns   string
 }
 
-var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "roles"}
+var rolesResource = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "roles"}
 
 func (c *FakeRoles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
@@ -32,7 +32,7 @@ type FakeRoleBindings struct {
 	ns   string
 }
 
-var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Resource: "rolebindings"}
+var rolebindingsResource = schema.GroupVersionResource{Group: v1alpha1.GroupName, Version: "v1alpha1", Resource: "rolebindings"}
 
 func (c *FakeRoleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
@@ -31,7 +31,7 @@ type FakeClusterRoles struct {
 	Fake *FakeRbacV1beta1
 }
 
-var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterroles"}
+var clusterrolesResource = schema.GroupVersionResource{Group: v1beta1.GroupName, Version: "v1beta1", Resource: "clusterroles"}
 
 func (c *FakeClusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
@@ -31,7 +31,7 @@ type FakeClusterRoleBindings struct {
 	Fake *FakeRbacV1beta1
 }
 
-var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "clusterrolebindings"}
+var clusterrolebindingsResource = schema.GroupVersionResource{Group: v1beta1.GroupName, Version: "v1beta1", Resource: "clusterrolebindings"}
 
 func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
@@ -32,7 +32,7 @@ type FakeRoles struct {
 	ns   string
 }
 
-var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "roles"}
+var rolesResource = schema.GroupVersionResource{Group: v1beta1.GroupName, Version: "v1beta1", Resource: "roles"}
 
 func (c *FakeRoles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 	obj, err := c.Fake.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
@@ -32,7 +32,7 @@ type FakeRoleBindings struct {
 	ns   string
 }
 
-var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Resource: "rolebindings"}
+var rolebindingsResource = schema.GroupVersionResource{Group: v1beta1.GroupName, Version: "v1beta1", Resource: "rolebindings"}
 
 func (c *FakeRoleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
 	obj, err := c.Fake.

--- a/test/e2e/framework/authorizer_util.go
+++ b/test/e2e/framework/authorizer_util.go
@@ -77,7 +77,7 @@ func BindClusterRole(c v1beta1rbac.ClusterRoleBindingsGetter, clusterRole, ns st
 			Name: ns + "--" + clusterRole,
 		},
 		RoleRef: rbacv1beta1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
+			APIGroup: rbacv1beta1.GroupName,
 			Kind:     "ClusterRole",
 			Name:     clusterRole,
 		},
@@ -98,7 +98,7 @@ func BindClusterRoleInNamespace(c v1beta1rbac.RoleBindingsGetter, clusterRole, n
 			Name: ns + "--" + clusterRole,
 		},
 		RoleRef: rbacv1beta1.RoleRef{
-			APIGroup: "rbac.authorization.k8s.io",
+			APIGroup: rbacv1beta1.GroupName,
 			Kind:     "ClusterRole",
 			Name:     clusterRole,
 		},

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -313,13 +313,13 @@ func TestRBAC(t *testing.T) {
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "create-rolebindings"},
 						Rules: []rbacapi.PolicyRule{
-							rbacapi.NewRule("create").Groups("rbac.authorization.k8s.io").Resources("rolebindings").RuleOrDie(),
+							rbacapi.NewRule("create").Groups(rbacapi.GroupName).Resources("rolebindings").RuleOrDie(),
 						},
 					},
 					{
 						ObjectMeta: metav1.ObjectMeta{Name: "bind-any-clusterrole"},
 						Rules: []rbacapi.PolicyRule{
-							rbacapi.NewRule("bind").Groups("rbac.authorization.k8s.io").Resources("clusterroles").RuleOrDie(),
+							rbacapi.NewRule("bind").Groups(rbacapi.GroupName).Resources("clusterroles").RuleOrDie(),
 						},
 					},
 				},
@@ -391,23 +391,23 @@ func TestRBAC(t *testing.T) {
 				{"job-writer-namespace", "GET", "batch", "jobs", "job-namespace", "pi", "", http.StatusOK},
 
 				// cannot bind role anywhere
-				{"user-with-no-permissions", "POST", "rbac.authorization.k8s.io", "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusForbidden},
+				{"user-with-no-permissions", "POST", rbacapi.GroupName, "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusForbidden},
 				// can only bind role in namespace where they have explicit bind permission
-				{"any-rolebinding-writer-namespace", "POST", "rbac.authorization.k8s.io", "rolebindings", "forbidden-namespace", "", writeJobsRoleBinding, http.StatusForbidden},
+				{"any-rolebinding-writer-namespace", "POST", rbacapi.GroupName, "rolebindings", "forbidden-namespace", "", writeJobsRoleBinding, http.StatusForbidden},
 				// can only bind role in namespace where they have covering permissions
-				{"job-writer-namespace", "POST", "rbac.authorization.k8s.io", "rolebindings", "forbidden-namespace", "", writeJobsRoleBinding, http.StatusForbidden},
-				{"job-writer-namespace", "POST", "rbac.authorization.k8s.io", "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusCreated},
-				{superUser, "DELETE", "rbac.authorization.k8s.io", "rolebindings", "job-namespace", "pi", "", http.StatusOK},
+				{"job-writer-namespace", "POST", rbacapi.GroupName, "rolebindings", "forbidden-namespace", "", writeJobsRoleBinding, http.StatusForbidden},
+				{"job-writer-namespace", "POST", rbacapi.GroupName, "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusCreated},
+				{superUser, "DELETE", rbacapi.GroupName, "rolebindings", "job-namespace", "pi", "", http.StatusOK},
 				// can bind role in any namespace where they have covering permissions
-				{"job-writer", "POST", "rbac.authorization.k8s.io", "rolebindings", "forbidden-namespace", "", writeJobsRoleBinding, http.StatusCreated},
-				{superUser, "DELETE", "rbac.authorization.k8s.io", "rolebindings", "forbidden-namespace", "pi", "", http.StatusOK},
+				{"job-writer", "POST", rbacapi.GroupName, "rolebindings", "forbidden-namespace", "", writeJobsRoleBinding, http.StatusCreated},
+				{superUser, "DELETE", rbacapi.GroupName, "rolebindings", "forbidden-namespace", "pi", "", http.StatusOK},
 				// cannot bind role because they don't have covering permissions
-				{"nonescalating-rolebinding-writer", "POST", "rbac.authorization.k8s.io", "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusForbidden},
+				{"nonescalating-rolebinding-writer", "POST", rbacapi.GroupName, "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusForbidden},
 				// can bind role because they have explicit bind permission
-				{"any-rolebinding-writer", "POST", "rbac.authorization.k8s.io", "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusCreated},
-				{superUser, "DELETE", "rbac.authorization.k8s.io", "rolebindings", "job-namespace", "pi", "", http.StatusOK},
-				{"any-rolebinding-writer-namespace", "POST", "rbac.authorization.k8s.io", "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusCreated},
-				{superUser, "DELETE", "rbac.authorization.k8s.io", "rolebindings", "job-namespace", "pi", "", http.StatusOK},
+				{"any-rolebinding-writer", "POST", rbacapi.GroupName, "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusCreated},
+				{superUser, "DELETE", rbacapi.GroupName, "rolebindings", "job-namespace", "pi", "", http.StatusOK},
+				{"any-rolebinding-writer-namespace", "POST", rbacapi.GroupName, "rolebindings", "job-namespace", "", writeJobsRoleBinding, http.StatusCreated},
+				{superUser, "DELETE", rbacapi.GroupName, "rolebindings", "job-namespace", "pi", "", http.StatusOK},
 			},
 		},
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:

I found there are a lot of same RBAC group names(`rbac.authorization.k8s.io`) used at some point, even though the package where the global const group name defined has been included. So this PR just replace the `rbac.authorization.k8s.io` by global group name.

**Which issue this PR fixes**:

no issue

