### PR TITLE
Add nonResourceURL wildcard coverage tests

### DIFF
--- a/pkg/registry/rbac/validation/policy_comparator_test.go
+++ b/pkg/registry/rbac/validation/policy_comparator_test.go
@@ -407,7 +407,12 @@ func TestNonResourceURLCovers(t *testing.T) {
 		requested string
 		want      bool
 	}{
+		{"*", "", true},
+		{"*", "/", true},
 		{"*", "/api", true},
+		{"/*", "", false},
+		{"/*", "/", true},
+		{"/*", "/foo", true},
 		{"/api", "/api", true},
 		{"/apis", "/api", false},
 		{"/api/v1", "/api", false},


### PR DESCRIPTION
Ensure `*` covering all paths is tested