### PR TITLE
kubeadm: remove func arg that isn't being used

### DIFF
--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -60,7 +60,7 @@ var (
 // WriteStaticPodManifests builds manifest objects based on user provided configuration and then dumps it to disk
 // where kubelet will pick and schedule them.
 func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
-	volumes := []api.Volume{k8sVolume(cfg)}
+	volumes := []api.Volume{k8sVolume()}
 	volumeMounts := []api.VolumeMount{k8sVolumeMount()}
 
 	if isCertsVolumeMountNeeded() {
@@ -69,7 +69,7 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 	}
 
 	if isPkiVolumeMountNeeded() {
-		volumes = append(volumes, pkiVolume(cfg))
+		volumes = append(volumes, pkiVolume())
 		volumeMounts = append(volumeMounts, pkiVolumeMount())
 	}
 
@@ -106,7 +106,7 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 			LivenessProbe: componentProbe(10251, "/healthz", api.URISchemeHTTP),
 			Resources:     componentResources("100m"),
 			Env:           getProxyEnvVars(),
-		}, k8sVolume(cfg)),
+		}, k8sVolume()),
 	}
 
 	// Add etcd static pod spec only if external etcd is not configured
@@ -117,7 +117,7 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 			VolumeMounts:  []api.VolumeMount{certsVolumeMount(), etcdVolumeMount(cfg.Etcd.DataDir), k8sVolumeMount()},
 			Image:         images.GetCoreImage(images.KubeEtcdImage, cfg, kubeadmapi.GlobalEnvParams.EtcdImage),
 			LivenessProbe: componentProbe(2379, "/health", api.URISchemeHTTP),
-		}, certsVolume(cfg), etcdVolume(cfg), k8sVolume(cfg))
+		}, certsVolume(cfg), etcdVolume(cfg), k8sVolume())
 
 		etcdPod.Spec.SecurityContext = &api.PodSecurityContext{
 			SELinuxOptions: &api.SELinuxOptions{
@@ -196,7 +196,7 @@ func isPkiVolumeMountNeeded() bool {
 	return false
 }
 
-func pkiVolume(cfg *kubeadmapi.MasterConfiguration) api.Volume {
+func pkiVolume() api.Volume {
 	return api.Volume{
 		Name: "pki",
 		VolumeSource: api.VolumeSource{
@@ -230,7 +230,7 @@ func flockVolumeMount() api.VolumeMount {
 	}
 }
 
-func k8sVolume(cfg *kubeadmapi.MasterConfiguration) api.Volume {
+func k8sVolume() api.Volume {
 	return api.Volume{
 		Name: "k8s",
 		VolumeSource: api.VolumeSource{

--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -259,11 +259,9 @@ func TestCertsVolumeMount(t *testing.T) {
 
 func TestK8sVolume(t *testing.T) {
 	var tests = []struct {
-		cfg      *kubeadmapi.MasterConfiguration
 		expected api.Volume
 	}{
 		{
-			cfg: &kubeadmapi.MasterConfiguration{},
 			expected: api.Volume{
 				Name: "k8s",
 				VolumeSource: api.VolumeSource{
@@ -274,7 +272,7 @@ func TestK8sVolume(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actual := k8sVolume(rt.cfg)
+		actual := k8sVolume()
 		if actual.Name != rt.expected.Name {
 			t.Errorf(
 				"failed k8sVolume:\n\texpected: %s\n\t  actual: %s",

--- a/cmd/kubeadm/app/master/selfhosted.go
+++ b/cmd/kubeadm/app/master/selfhosted.go
@@ -41,7 +41,7 @@ var (
 )
 
 func CreateSelfHostedControlPlane(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
-	volumes := []v1.Volume{k8sVolume(cfg)}
+	volumes := []v1.Volume{k8sVolume()}
 	volumeMounts := []v1.VolumeMount{k8sVolumeMount()}
 	if isCertsVolumeMountNeeded() {
 		volumes = append(volumes, certsVolume(cfg))
@@ -49,7 +49,7 @@ func CreateSelfHostedControlPlane(cfg *kubeadmapi.MasterConfiguration, client *c
 	}
 
 	if isPkiVolumeMountNeeded() {
-		volumes = append(volumes, pkiVolume(cfg))
+		volumes = append(volumes, pkiVolume())
 		volumeMounts = append(volumeMounts, pkiVolumeMount())
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**: Functions had args passed to them that weren't being used. See https://github.com/kubernetes/kubernetes/pull/44601 for more details. 

**Special notes for your reviewer**: @luxas

**Release note**:
```release-note
NONE
```
