### PR TITLE
Mark Stackdriver Logging e2e tests with a feature

### DIFF
--- a/test/e2e/cluster-logging/sd_load.go
+++ b/test/e2e/cluster-logging/sd_load.go
@@ -33,7 +33,7 @@ const (
 )
 
 // TODO(crassirostris): Remove Flaky once test is stable
-var _ = framework.KubeDescribe("Cluster level logging using GCL [Slow] [Flaky]", func() {
+var _ = framework.KubeDescribe("Cluster level logging using GCL [Feature:StackdriverLogging]", func() {
 	f := framework.NewDefaultFramework("gcl-logging-load")
 
 	It("should create a constant load with long-living pods and ensure logs delivery", func() {


### PR DESCRIPTION
Makes Stackdriver Logging e2e tests, except for the most basic one, run in the separate tests suites, prepared by https://github.com/kubernetes/test-infra/pull/2542