### PR TITLE
Exclude master from LoadBalancer / NodePort

### DIFF
--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -16,6 +16,7 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/api/v1/helper:go_default_library",


### PR DESCRIPTION
The servicecontroller documents that the master is excluded from the
LoadBalancer / NodePort, but this is broken for clusters where we are
using taints for the master (as introduced in 1.6), instead of marking
the master as unschedulable.

This restores the desired documented behaviour, by excluding nodes that
are labeled as masters with the new 1.6 labels, even if they use the new
1.6 taints.

Fix #33884

```release-note
Exclude nodes labeled as master from LoadBalancer / NodePort; restores documented behaviour.
```
