### PR TITLE
refer to const

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -725,7 +725,7 @@ func (dm *DockerManager) runContainer(
 
 	userNsMode := ""
 	if opts.EnableHostUserNamespace {
-		userNsMode = "host"
+		userNsMode = namespaceModeHost
 	}
 
 	hc := &dockercontainer.HostConfig{


### PR DESCRIPTION
kubelet/dockertools: use host const more consistently
