### PR TITLE
Fixing build break for federation

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -60,6 +60,7 @@ ifndef VERSION
     $(error VERSION is undefined)
 endif
 	cp -r ./* ${TEMP_DIR}
+	mkdir -p ${TEMP_DIR}/cni-bin
 
 	cp ../../../_output/dockerized/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
 	chmod a+rx ${TEMP_DIR}/hyperkube


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/44555#issuecomment-296069884 is the culprit PR.
This reverts one line from that PR.

Our build is broken: https://k8s-testgrid.appspot.com/cluster-federation#build

cc @kubernetes/sig-federation-pr-reviews 