### PR TITLE
Use global group name instread of local variable

### DIFF
--- a/cmd/kubeadm/app/phases/apiconfig/clusterroles.go
+++ b/cmd/kubeadm/app/phases/apiconfig/clusterroles.go
@@ -39,8 +39,8 @@ const (
 	clusterRoleKind    = "ClusterRole"
 	roleKind           = "Role"
 	serviceAccountKind = "ServiceAccount"
-	rbacAPIGroup       = "rbac.authorization.k8s.io"
 	anonymousUser      = "system:anonymous"
+
 )
 
 // TODO: Are there any unit tests that could be made for this file other than duplicating all values and logic in a separate file?
@@ -116,7 +116,7 @@ func CreateRoleBindings(clientset *clientset.Clientset) error {
 				Namespace: metav1.NamespacePublic,
 			},
 			RoleRef: rbac.RoleRef{
-				APIGroup: rbacAPIGroup,
+				APIGroup: rbac.GroupName,
 				Kind:     roleKind,
 				Name:     BootstrapSignerClusterRoleName,
 			},
@@ -145,7 +145,7 @@ func CreateClusterRoleBindings(clientset *clientset.Clientset) error {
 				Name: "kubeadm:kubelet-bootstrap",
 			},
 			RoleRef: rbac.RoleRef{
-				APIGroup: rbacAPIGroup,
+				APIGroup: rbac.GroupName,
 				Kind:     clusterRoleKind,
 				Name:     NodeBootstrapperClusterRoleName,
 			},
@@ -161,7 +161,7 @@ func CreateClusterRoleBindings(clientset *clientset.Clientset) error {
 				Name: "kubeadm:node-proxier",
 			},
 			RoleRef: rbac.RoleRef{
-				APIGroup: rbacAPIGroup,
+				APIGroup: rbac.GroupName,
 				Kind:     clusterRoleKind,
 				Name:     KubeProxyClusterRoleName,
 			},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -42,7 +42,6 @@ const (
 	certificatesGroup   = "certificates.k8s.io"
 	extensionsGroup     = "extensions"
 	policyGroup         = "policy"
-	rbacGroup           = "rbac.authorization.k8s.io"
 	storageGroup        = "storage.k8s.io"
 )
 
@@ -140,7 +139,7 @@ func ClusterRoles() []rbac.ClusterRole {
 
 				// additional admin powers
 				rbac.NewRule("create").Groups(authorizationGroup).Resources("localsubjectaccessreviews").RuleOrDie(),
-				rbac.NewRule(ReadWrite...).Groups(rbacGroup).Resources("roles", "rolebindings").RuleOrDie(),
+				rbac.NewRule(ReadWrite...).Groups(rbac.GroupName).Resources("roles", "rolebindings").RuleOrDie(),
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Use global group name like PR(https://github.com/kubernetes/kubernetes/pull/44717) does, but not generated and test files.

**Which issue this PR fixes**
no issue