### PR TITLE
Don't rebuild service map in iptables kube-proxy all the time

### DIFF
--- a/pkg/proxy/iptables/BUILD
+++ b/pkg/proxy/iptables/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//pkg/util/iptables:go_default_library",
         "//pkg/util/sysctl:go_default_library",
         "//pkg/util/version:go_default_library",
-        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",


### PR DESCRIPTION
A sibling PR to https://github.com/kubernetes/kubernetes/pull/44494 (doing pretty much the same for services that we did for endpoints).