### PR TITLE
More RC/RS controller logging updates

### DIFF
--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -219,8 +219,8 @@ func (rsc *ReplicaSetController) updateRS(old, cur interface{}) {
 	// this function), but in general extra resyncs shouldn't be
 	// that bad as ReplicaSets that haven't met expectations yet won't
 	// sync, and all the listing is done using local stores.
-	if oldRS.Status.Replicas != curRS.Status.Replicas {
-		glog.V(4).Infof("Observed updated replica count for ReplicaSet: %v, %d->%d", curRS.Name, oldRS.Status.Replicas, curRS.Status.Replicas)
+	if *(oldRS.Spec.Replicas) != *(curRS.Spec.Replicas) {
+		glog.V(4).Infof("Replica set %v updated. Desired pod count change: %d->%d", curRS.Name, *(oldRS.Spec.Replicas), *(curRS.Spec.Replicas))
 	}
 	rsc.enqueueReplicaSet(cur)
 }

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -214,7 +214,7 @@ func (rm *ReplicationManager) updateRC(old, cur interface{}) {
 	// this function), but in general extra resyncs shouldn't be
 	// that bad as rcs that haven't met expectations yet won't
 	// sync, and all the listing is done using local stores.
-	if oldRC.Spec.Replicas != curRC.Spec.Replicas {
+	if *(oldRC.Spec.Replicas) != *(curRC.Spec.Replicas) {
 		glog.V(4).Infof("Replication controller %v updated. Desired pod count change: %d->%d", curRC.Name, *(oldRC.Spec.Replicas), *(curRC.Spec.Replicas))
 	}
 	rm.enqueueController(cur)


### PR DESCRIPTION
We were comparing the address of the old and new RC.spec.replicas and we
have to compare the values. This only affects logging.

Update RS controller to match RC controller to log when spec.replicas
changes, not status.replicas.

@kargakis @janetkuo @sttts @liggitt 