### PR TITLE
Re-architecture of scheduler perf tests to make them more extendable

### DIFF
--- a/test/integration/scheduler_perf/BUILD
+++ b/test/integration/scheduler_perf/BUILD
@@ -10,7 +10,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["util.go"],
+    srcs = [
+        "scheduler_perf_types.go",
+        "util.go",
+    ],
     tags = [
         "automanaged",
     ],

--- a/test/integration/scheduler_perf/scheduler_perf_types.go
+++ b/test/integration/scheduler_perf/scheduler_perf_types.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package benchmark
+
+// High Level Configuration for all predicates and priorities.
+type schedulerPerfConfig struct {
+	NodeAffinity *nodeAffinity
+}
+
+// nodeAffinity priority configuration details.
+type nodeAffinity struct {
+	numGroups       int    // number of Node-Pod sets with Pods NodeAffinity matching given Nodes.
+	nodeAffinityKey string // Node Selection Key.
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:



**Special notes for your reviewer**:
This is for re-architecture of scheduler, so that we can enable or disable certain predicates and priorities and see their impact.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Scheduler perf modular extensions.
```
