### PR TITLE
Don't panic if we can't find groupmeta for version

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
@@ -282,7 +282,11 @@ func (m *APIRegistrationManager) RESTMapper(versionPatterns ...schema.GroupVersi
 	for enabledVersion := range m.enabledVersions {
 		if !unionedGroups.Has(enabledVersion.Group) {
 			unionedGroups.Insert(enabledVersion.Group)
-			groupMeta := m.groupMetaMap[enabledVersion.Group]
+			groupMeta, ok := m.groupMetaMap[enabledVersion.Group]
+			if !ok {
+				glog.Warningf("Could not find Group Metadata for %s, skipping REST Mapping", enabledVersion.Group)
+				continue
+			}
 			unionMapper = append(unionMapper, groupMeta.RESTMapper)
 		}
 	}


### PR DESCRIPTION
This fixes #43430.  There are cases where a cluster is restored after a
TPR has been created.  The TPR enables and registers its version, but
has no group metadata.  Therefore, this lookup panics in that case.
I've added a warning instead, since this is not a fatal error.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** fixes #43430

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
