### PR TITLE
Default ObjectNameFunc for all REST Stores

### DIFF
--- a/federation/registry/cluster/etcd/etcd.go
+++ b/federation/registry/cluster/etcd/etcd.go
@@ -48,12 +48,9 @@ func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo 
 // NewREST returns a RESTStorage object that will work against clusters.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &federation.Cluster{} },
-		NewListFunc: func() runtime.Object { return &federation.ClusterList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*federation.Cluster).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &federation.Cluster{} },
+		NewListFunc:       func() runtime.Object { return &federation.ClusterList{} },
 		PredicateFunc:     cluster.MatchCluster,
 		QualifiedResource: federation.Resource("clusters"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusters"),

--- a/pkg/registry/apps/petset/storage/storage.go
+++ b/pkg/registry/apps/petset/storage/storage.go
@@ -37,12 +37,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &appsapi.StatefulSet{} },
-		NewListFunc: func() runtime.Object { return &appsapi.StatefulSetList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*appsapi.StatefulSet).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &appsapi.StatefulSet{} },
+		NewListFunc:       func() runtime.Object { return &appsapi.StatefulSetList{} },
 		PredicateFunc:     petset.MatchStatefulSet,
 		QualifiedResource: appsapi.Resource("statefulsets"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("statefulsets"),

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -36,12 +36,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
-		NewListFunc: func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*autoscaling.HorizontalPodAutoscaler).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
+		NewListFunc:       func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
 		PredicateFunc:     horizontalpodautoscaler.MatchAutoscaler,
 		QualifiedResource: autoscaling.Resource("horizontalpodautoscalers"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("horizontalpodautoscalers"),

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -37,12 +37,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against CronJobs.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &batch.CronJob{} },
-		NewListFunc: func() runtime.Object { return &batch.CronJobList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*batch.CronJob).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &batch.CronJob{} },
+		NewListFunc:       func() runtime.Object { return &batch.CronJobList{} },
 		PredicateFunc:     cronjob.MatchCronJob,
 		QualifiedResource: batch.Resource("cronjobs"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("cronjobs"),

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -52,12 +52,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against Jobs.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &batch.Job{} },
-		NewListFunc: func() runtime.Object { return &batch.JobList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*batch.Job).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &batch.Job{} },
+		NewListFunc:       func() runtime.Object { return &batch.JobList{} },
 		PredicateFunc:     job.MatchJob,
 		QualifiedResource: batch.Resource("jobs"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("jobs"),

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -36,12 +36,9 @@ type REST struct {
 // NewREST returns a registry which will store CertificateSigningRequest in the given helper
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *ApprovalREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &certificates.CertificateSigningRequest{} },
-		NewListFunc: func() runtime.Object { return &certificates.CertificateSigningRequestList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*certificates.CertificateSigningRequest).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &certificates.CertificateSigningRequest{} },
+		NewListFunc:       func() runtime.Object { return &certificates.CertificateSigningRequestList{} },
 		PredicateFunc:     csrregistry.Matcher,
 		QualifiedResource: certificates.Resource("certificatesigningrequests"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("certificatesigningrequests"),

--- a/pkg/registry/core/configmap/storage/storage.go
+++ b/pkg/registry/core/configmap/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work with ConfigMap objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.ConfigMap{} },
-		NewListFunc: func() runtime.Object { return &api.ConfigMapList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.ConfigMap).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.ConfigMap{} },
+		NewListFunc:       func() runtime.Object { return &api.ConfigMapList{} },
 		PredicateFunc:     configmap.MatchConfigMap,
 		QualifiedResource: api.Resource("configmaps"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("configmaps"),

--- a/pkg/registry/core/endpoint/storage/storage.go
+++ b/pkg/registry/core/endpoint/storage/storage.go
@@ -33,12 +33,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against endpoints.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.Endpoints{} },
-		NewListFunc: func() runtime.Object { return &api.EndpointsList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.Endpoints).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.Endpoints{} },
+		NewListFunc:       func() runtime.Object { return &api.EndpointsList{} },
 		PredicateFunc:     endpoint.MatchEndpoints,
 		QualifiedResource: api.Resource("endpoints"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("endpoints"),

--- a/pkg/registry/core/event/storage/storage.go
+++ b/pkg/registry/core/event/storage/storage.go
@@ -43,12 +43,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter, ttl uint64) *REST {
 	opts.Decorator = generic.UndecoratedStorage // TODO use watchCacheSize=-1 to signal UndecoratedStorage
 
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.Event{} },
-		NewListFunc: func() runtime.Object { return &api.EventList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.Event).Name, nil
-		},
+		Copier:        api.Scheme,
+		NewFunc:       func() runtime.Object { return &api.Event{} },
+		NewListFunc:   func() runtime.Object { return &api.EventList{} },
 		PredicateFunc: event.MatchEvent,
 		TTLFunc: func(runtime.Object, uint64, bool) (uint64, error) {
 			return ttl, nil

--- a/pkg/registry/core/limitrange/storage/storage.go
+++ b/pkg/registry/core/limitrange/storage/storage.go
@@ -33,12 +33,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.LimitRange{} },
-		NewListFunc: func() runtime.Object { return &api.LimitRangeList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.LimitRange).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.LimitRange{} },
+		NewListFunc:       func() runtime.Object { return &api.LimitRangeList{} },
 		PredicateFunc:     limitrange.MatchLimitRange,
 		QualifiedResource: api.Resource("limitranges"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("limitranges"),

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -52,12 +52,9 @@ type FinalizeREST struct {
 // NewREST returns a RESTStorage object that will work against namespaces.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *FinalizeREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.Namespace{} },
-		NewListFunc: func() runtime.Object { return &api.NamespaceList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.Namespace).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.Namespace{} },
+		NewListFunc:       func() runtime.Object { return &api.NamespaceList{} },
 		PredicateFunc:     namespace.MatchNamespace,
 		QualifiedResource: api.Resource("namespaces"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("namespaces"),

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -72,12 +72,9 @@ func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo 
 // NewStorage returns a NodeStorage object that will work against nodes.
 func NewStorage(optsGetter generic.RESTOptionsGetter, kubeletClientConfig client.KubeletClientConfig, proxyTransport http.RoundTripper) (*NodeStorage, error) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.Node{} },
-		NewListFunc: func() runtime.Object { return &api.NodeList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.Node).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.Node{} },
+		NewListFunc:       func() runtime.Object { return &api.NodeList{} },
 		PredicateFunc:     node.MatchNode,
 		QualifiedResource: api.Resource("nodes"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("nodes"),

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -35,12 +35,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.PersistentVolume{} },
-		NewListFunc: func() runtime.Object { return &api.PersistentVolumeList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.PersistentVolume).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.PersistentVolume{} },
+		NewListFunc:       func() runtime.Object { return &api.PersistentVolumeList{} },
 		PredicateFunc:     persistentvolume.MatchPersistentVolumes,
 		QualifiedResource: api.Resource("persistentvolumes"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("persistentvolumes"),

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -35,12 +35,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volume claims.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.PersistentVolumeClaim{} },
-		NewListFunc: func() runtime.Object { return &api.PersistentVolumeClaimList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.PersistentVolumeClaim).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.PersistentVolumeClaim{} },
+		NewListFunc:       func() runtime.Object { return &api.PersistentVolumeClaimList{} },
 		PredicateFunc:     persistentvolumeclaim.MatchPersistentVolumeClaim,
 		QualifiedResource: api.Resource("persistentvolumeclaims"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("persistentvolumeclaims"),

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -62,12 +62,9 @@ type REST struct {
 // NewStorage returns a RESTStorage object that will work against pods.
 func NewStorage(optsGetter generic.RESTOptionsGetter, k client.ConnectionInfoGetter, proxyTransport http.RoundTripper, podDisruptionBudgetClient policyclient.PodDisruptionBudgetsGetter) PodStorage {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.Pod{} },
-		NewListFunc: func() runtime.Object { return &api.PodList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.Pod).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.Pod{} },
+		NewListFunc:       func() runtime.Object { return &api.PodList{} },
 		PredicateFunc:     pod.MatchPod,
 		QualifiedResource: api.Resource("pods"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("pods"),

--- a/pkg/registry/core/podtemplate/storage/storage.go
+++ b/pkg/registry/core/podtemplate/storage/storage.go
@@ -32,12 +32,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against pod templates.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.PodTemplate{} },
-		NewListFunc: func() runtime.Object { return &api.PodTemplateList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.PodTemplate).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.PodTemplate{} },
+		NewListFunc:       func() runtime.Object { return &api.PodTemplateList{} },
 		PredicateFunc:     podtemplate.MatchPodTemplate,
 		QualifiedResource: api.Resource("podtemplates"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podtemplates"),

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -61,12 +61,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.ReplicationController{} },
-		NewListFunc: func() runtime.Object { return &api.ReplicationControllerList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.ReplicationController).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.ReplicationController{} },
+		NewListFunc:       func() runtime.Object { return &api.ReplicationControllerList{} },
 		PredicateFunc:     replicationcontroller.MatchController,
 		QualifiedResource: api.Resource("replicationcontrollers"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("replicationcontrollers"),

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -35,12 +35,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against resource quotas.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.ResourceQuota{} },
-		NewListFunc: func() runtime.Object { return &api.ResourceQuotaList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.ResourceQuota).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.ResourceQuota{} },
+		NewListFunc:       func() runtime.Object { return &api.ResourceQuotaList{} },
 		PredicateFunc:     resourcequota.MatchResourceQuota,
 		QualifiedResource: api.Resource("resourcequotas"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("resourcequotas"),

--- a/pkg/registry/core/secret/storage/storage.go
+++ b/pkg/registry/core/secret/storage/storage.go
@@ -32,12 +32,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against secrets.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.Secret{} },
-		NewListFunc: func() runtime.Object { return &api.SecretList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.Secret).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.Secret{} },
+		NewListFunc:       func() runtime.Object { return &api.SecretList{} },
 		PredicateFunc:     secret.Matcher,
 		QualifiedResource: api.Resource("secrets"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("secrets"),

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -35,12 +35,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against services.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.Service{} },
-		NewListFunc: func() runtime.Object { return &api.ServiceList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.Service).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.Service{} },
+		NewListFunc:       func() runtime.Object { return &api.ServiceList{} },
 		PredicateFunc:     service.MatchServices,
 		QualifiedResource: api.Resource("services"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("services"),

--- a/pkg/registry/core/serviceaccount/storage/storage.go
+++ b/pkg/registry/core/serviceaccount/storage/storage.go
@@ -33,12 +33,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against service accounts.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &api.ServiceAccount{} },
-		NewListFunc: func() runtime.Object { return &api.ServiceAccountList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*api.ServiceAccount).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &api.ServiceAccount{} },
+		NewListFunc:       func() runtime.Object { return &api.ServiceAccountList{} },
 		PredicateFunc:     serviceaccount.Matcher,
 		QualifiedResource: api.Resource("serviceaccounts"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("serviceaccounts"),

--- a/pkg/registry/extensions/daemonset/storage/storage.go
+++ b/pkg/registry/extensions/daemonset/storage/storage.go
@@ -37,12 +37,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against DaemonSets.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &extensions.DaemonSet{} },
-		NewListFunc: func() runtime.Object { return &extensions.DaemonSetList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*extensions.DaemonSet).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &extensions.DaemonSet{} },
+		NewListFunc:       func() runtime.Object { return &extensions.DaemonSetList{} },
 		PredicateFunc:     daemonset.MatchDaemonSet,
 		QualifiedResource: extensions.Resource("daemonsets"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("daemonsets"),

--- a/pkg/registry/extensions/deployment/storage/storage.go
+++ b/pkg/registry/extensions/deployment/storage/storage.go
@@ -63,12 +63,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against deployments.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *RollbackREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &extensions.Deployment{} },
-		NewListFunc: func() runtime.Object { return &extensions.DeploymentList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*extensions.Deployment).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &extensions.Deployment{} },
+		NewListFunc:       func() runtime.Object { return &extensions.DeploymentList{} },
 		PredicateFunc:     deployment.MatchDeployment,
 		QualifiedResource: extensions.Resource("deployments"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("deployments"),

--- a/pkg/registry/extensions/ingress/storage/storage.go
+++ b/pkg/registry/extensions/ingress/storage/storage.go
@@ -37,12 +37,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &extensions.Ingress{} },
-		NewListFunc: func() runtime.Object { return &extensions.IngressList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*extensions.Ingress).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &extensions.Ingress{} },
+		NewListFunc:       func() runtime.Object { return &extensions.IngressList{} },
 		PredicateFunc:     ingress.MatchIngress,
 		QualifiedResource: extensions.Resource("ingresses"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("ingresses"),

--- a/pkg/registry/extensions/networkpolicy/storage/storage.go
+++ b/pkg/registry/extensions/networkpolicy/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against network policies.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &extensionsapi.NetworkPolicy{} },
-		NewListFunc: func() runtime.Object { return &extensionsapi.NetworkPolicyList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*extensionsapi.NetworkPolicy).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &extensionsapi.NetworkPolicy{} },
+		NewListFunc:       func() runtime.Object { return &extensionsapi.NetworkPolicyList{} },
 		PredicateFunc:     networkpolicy.MatchNetworkPolicy,
 		QualifiedResource: extensionsapi.Resource("networkpolicies"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("networkpolicies"),

--- a/pkg/registry/extensions/podsecuritypolicy/storage/storage.go
+++ b/pkg/registry/extensions/podsecuritypolicy/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against PodSecurityPolicy objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &extensions.PodSecurityPolicy{} },
-		NewListFunc: func() runtime.Object { return &extensions.PodSecurityPolicyList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*extensions.PodSecurityPolicy).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &extensions.PodSecurityPolicy{} },
+		NewListFunc:       func() runtime.Object { return &extensions.PodSecurityPolicyList{} },
 		PredicateFunc:     podsecuritypolicy.MatchPodSecurityPolicy,
 		QualifiedResource: extensions.Resource("podsecuritypolicies"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podsecuritypolicies"),

--- a/pkg/registry/extensions/replicaset/storage/storage.go
+++ b/pkg/registry/extensions/replicaset/storage/storage.go
@@ -60,12 +60,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ReplicaSet.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &extensions.ReplicaSet{} },
-		NewListFunc: func() runtime.Object { return &extensions.ReplicaSetList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*extensions.ReplicaSet).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &extensions.ReplicaSet{} },
+		NewListFunc:       func() runtime.Object { return &extensions.ReplicaSetList{} },
 		PredicateFunc:     replicaset.MatchReplicaSet,
 		QualifiedResource: extensions.Resource("replicasets"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("replicasets"),

--- a/pkg/registry/extensions/thirdpartyresource/storage/storage.go
+++ b/pkg/registry/extensions/thirdpartyresource/storage/storage.go
@@ -43,12 +43,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	opts.Decorator = generic.UndecoratedStorage // TODO use watchCacheSize=-1 to signal UndecoratedStorage
 
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &extensions.ThirdPartyResource{} },
-		NewListFunc: func() runtime.Object { return &extensions.ThirdPartyResourceList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*extensions.ThirdPartyResource).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &extensions.ThirdPartyResource{} },
+		NewListFunc:       func() runtime.Object { return &extensions.ThirdPartyResourceList{} },
 		PredicateFunc:     thirdpartyresource.Matcher,
 		QualifiedResource: resource,
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource(resource.Resource),

--- a/pkg/registry/extensions/thirdpartyresourcedata/storage/storage.go
+++ b/pkg/registry/extensions/thirdpartyresourcedata/storage/storage.go
@@ -47,12 +47,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter, group, kind string) *REST {
 	opts.ResourcePrefix = "/ThirdPartyResourceData/" + group + "/" + strings.ToLower(kind) + "s"
 
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &extensions.ThirdPartyResourceData{} },
-		NewListFunc: func() runtime.Object { return &extensions.ThirdPartyResourceDataList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*extensions.ThirdPartyResourceData).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &extensions.ThirdPartyResourceData{} },
+		NewListFunc:       func() runtime.Object { return &extensions.ThirdPartyResourceDataList{} },
 		PredicateFunc:     thirdpartyresourcedata.Matcher,
 		QualifiedResource: resource,
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource(resource.Resource),

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -37,12 +37,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against pod disruption budgets.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &policyapi.PodDisruptionBudget{} },
-		NewListFunc: func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*policyapi.PodDisruptionBudget).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &policyapi.PodDisruptionBudget{} },
+		NewListFunc:       func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} },
 		PredicateFunc:     poddisruptionbudget.MatchPodDisruptionBudget,
 		QualifiedResource: policyapi.Resource("poddisruptionbudgets"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("poddisruptionbudgets"),

--- a/pkg/registry/rbac/clusterrole/storage/storage.go
+++ b/pkg/registry/rbac/clusterrole/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ClusterRole objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &rbac.ClusterRole{} },
-		NewListFunc: func() runtime.Object { return &rbac.ClusterRoleList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*rbac.ClusterRole).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &rbac.ClusterRole{} },
+		NewListFunc:       func() runtime.Object { return &rbac.ClusterRoleList{} },
 		PredicateFunc:     clusterrole.Matcher,
 		QualifiedResource: rbac.Resource("clusterroles"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusterroles"),

--- a/pkg/registry/rbac/clusterrolebinding/storage/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ClusterRoleBinding objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &rbac.ClusterRoleBinding{} },
-		NewListFunc: func() runtime.Object { return &rbac.ClusterRoleBindingList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*rbac.ClusterRoleBinding).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &rbac.ClusterRoleBinding{} },
+		NewListFunc:       func() runtime.Object { return &rbac.ClusterRoleBindingList{} },
 		PredicateFunc:     clusterrolebinding.Matcher,
 		QualifiedResource: rbac.Resource("clusterrolebindings"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusterrolebindings"),

--- a/pkg/registry/rbac/role/storage/storage.go
+++ b/pkg/registry/rbac/role/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against Role objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &rbac.Role{} },
-		NewListFunc: func() runtime.Object { return &rbac.RoleList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*rbac.Role).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &rbac.Role{} },
+		NewListFunc:       func() runtime.Object { return &rbac.RoleList{} },
 		PredicateFunc:     role.Matcher,
 		QualifiedResource: rbac.Resource("roles"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("roles"),

--- a/pkg/registry/rbac/rolebinding/storage/storage.go
+++ b/pkg/registry/rbac/rolebinding/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against RoleBinding objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &rbac.RoleBinding{} },
-		NewListFunc: func() runtime.Object { return &rbac.RoleBindingList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*rbac.RoleBinding).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &rbac.RoleBinding{} },
+		NewListFunc:       func() runtime.Object { return &rbac.RoleBindingList{} },
 		PredicateFunc:     rolebinding.Matcher,
 		QualifiedResource: rbac.Resource("rolebindings"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("rolebindings"),

--- a/pkg/registry/settings/podpreset/storage/storage.go
+++ b/pkg/registry/settings/podpreset/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &settingsapi.PodPreset{} },
-		NewListFunc: func() runtime.Object { return &settingsapi.PodPresetList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*settingsapi.PodPreset).GetName(), nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &settingsapi.PodPreset{} },
+		NewListFunc:       func() runtime.Object { return &settingsapi.PodPresetList{} },
 		PredicateFunc:     podpreset.Matcher,
 		QualifiedResource: settingsapi.Resource("podpresets"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podpresets"),

--- a/pkg/registry/storage/storageclass/storage/storage.go
+++ b/pkg/registry/storage/storageclass/storage/storage.go
@@ -34,12 +34,9 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:      api.Scheme,
-		NewFunc:     func() runtime.Object { return &storageapi.StorageClass{} },
-		NewListFunc: func() runtime.Object { return &storageapi.StorageClassList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*storageapi.StorageClass).Name, nil
-		},
+		Copier:            api.Scheme,
+		NewFunc:           func() runtime.Object { return &storageapi.StorageClass{} },
+		NewListFunc:       func() runtime.Object { return &storageapi.StorageClassList{} },
 		PredicateFunc:     storageclass.MatchStorageClasses,
 		QualifiedResource: storageapi.Resource("storageclasses"),
 		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("storageclass"),

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1194,6 +1194,16 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 
 	e.EnableGarbageCollection = opts.EnableGarbageCollection
 
+	if e.ObjectNameFunc == nil {
+		e.ObjectNameFunc = func(obj runtime.Object) (string, error) {
+			accessor, err := meta.Accessor(obj)
+			if err != nil {
+				return "", err
+			}
+			return accessor.GetName(), nil
+		}
+	}
+
 	if e.Storage == nil {
 		capacity := DefaultWatchCacheSize
 		if e.WatchCacheSize != 0 {

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -33,12 +33,9 @@ type REST struct {
 func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST {
 	strategy := apiservice.NewStrategy(scheme)
 	store := &genericregistry.Store{
-		Copier:      scheme,
-		NewFunc:     func() runtime.Object { return &apiregistration.APIService{} },
-		NewListFunc: func() runtime.Object { return &apiregistration.APIServiceList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*apiregistration.APIService).Name, nil
-		},
+		Copier:            scheme,
+		NewFunc:           func() runtime.Object { return &apiregistration.APIService{} },
+		NewListFunc:       func() runtime.Object { return &apiregistration.APIServiceList{} },
 		PredicateFunc:     apiservice.MatchAPIService,
 		QualifiedResource: apiregistration.Resource("apiservices"),
 		WatchCacheSize:    100,

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/etcd.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/etcd.go
@@ -33,12 +33,9 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST
 	strategy := NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		Copier:      scheme,
-		NewFunc:     func() runtime.Object { return &wardle.Flunder{} },
-		NewListFunc: func() runtime.Object { return &wardle.FlunderList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*wardle.Flunder).Name, nil
-		},
+		Copier:            scheme,
+		NewFunc:           func() runtime.Object { return &wardle.Flunder{} },
+		NewListFunc:       func() runtime.Object { return &wardle.FlunderList{} },
 		PredicateFunc:     MatchFlunder,
 		QualifiedResource: wardle.Resource("flunders"),
 


### PR DESCRIPTION
All `Store`s in Kubernetes follow the same logic for determining the name of an object.  This change makes it so that `CompleteWithOptions` defaults the `ObjectNameFunc` if it is not specified.  Thus a user does not need to remember to use `ObjectMeta.Name`.  Using the wrong field as the name can lead to an object which has a name that bypasses normal object name validation.

Signed-off-by: Monis Khan <mkhan@redhat.com>

cc @liggitt @soltysh for review

**Release note**:

```
NONE
```
