### PR TITLE
Hostname patch for vsphere provider limitations with juju

### DIFF
--- a/cluster/juju/layers/kubernetes-master/exec.d/vmware-patch/charm-pre-install
+++ b/cluster/juju/layers/kubernetes-master/exec.d/vmware-patch/charm-pre-install
@@ -1,0 +1,17 @@
+#!/bin/bash
+MY_HOSTNAME=$(hostname)
+
+: ${JUJU_UNIT_NAME:=`uuidgen`}
+
+
+if [ "${MY_HOSTNAME}" == "ubuntuguest" ]; then
+    juju-log "Detected broken vsphere integration. Applying hostname override"
+
+    FRIENDLY_HOSTNAME=$(echo $JUJU_UNIT_NAME | tr / -)
+    juju-log "Setting hostname to $FRIENDLY_HOSTNAME"
+    if [ ! -f /etc/hostname.orig ]; then
+      mv /etc/hostname /etc/hostname.orig
+    fi
+    echo "${FRIENDLY_HOSTNAME}" > /etc/hostname
+    hostname $FRIENDLY_HOSTNAME
+fi

--- a/cluster/juju/layers/kubernetes-worker/exec.d/vmware-patch/charm-pre-install
+++ b/cluster/juju/layers/kubernetes-worker/exec.d/vmware-patch/charm-pre-install
@@ -1,0 +1,17 @@
+#!/bin/bash
+MY_HOSTNAME=$(hostname)
+
+: ${JUJU_UNIT_NAME:=`uuidgen`}
+
+
+if [ "${MY_HOSTNAME}" == "ubuntuguest" ]; then
+    juju-log "Detected broken vsphere integration. Applying hostname override"
+
+    FRIENDLY_HOSTNAME=$(echo $JUJU_UNIT_NAME | tr / -)
+    juju-log "Setting hostname to $FRIENDLY_HOSTNAME"
+    if [ ! -f /etc/hostname.orig ]; then
+      mv /etc/hostname /etc/hostname.orig
+    fi
+    echo "${FRIENDLY_HOSTNAME}" > /etc/hostname
+    hostname $FRIENDLY_HOSTNAME
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
The Juju VSphere provider doesn't set a unique hostname which causes issues when scaling worker-pools and they all have the hostname `ubuntuguest`. Instead we assign the JUJU_UNIT_NAME to that hostname to prevent the collision which allows the master to sort out that there are multiple units and not one attempting re-registration.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/237

**Special notes for your reviewer**:
The charm-pre-exec runs before it installs the charm software so the validation can happen quickly. Check hostname output, as well as kubectl get no post deployment.


```release-note
Resolves juju vsphere hostname bug showing only a single node in a scaled node-pool.
```
