### PR TITLE
Kubeadm multi master support and bug fixes.

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -57,6 +57,15 @@ type MasterConfiguration struct {
 
 	// FeatureGates enabled by the user
 	FeatureGates map[string]bool
+
+	MasterCertificates *MasterCertificates
+	// Public Addr or DNS
+	PublicAddress string
+	//Masters Count
+	Count int
+
+	//required for cloud providers. To make right tag for resources
+	ClusterName string
 }
 
 type API struct {
@@ -86,7 +95,8 @@ type Etcd struct {
 	DataDir   string
 	ExtraArgs map[string]string
 	// Image specifies which container image to use for running etcd. If empty, automatically populated by kubeadm using the image repository and default etcd version
-	Image string
+	Image     string
+	Discovery string
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -117,6 +127,21 @@ type NodeConfiguration struct {
 	// without CA verification via DiscoveryTokenCACertHashes. This can weaken
 	// the security of kubeadm since other nodes can impersonate the master.
 	DiscoveryTokenUnsafeSkipCAVerification bool
+	CloudProvider                          string
+}
+
+type MasterCertificates struct {
+	CAKeyPem                string
+	CACertPem               string
+	APIServerKeyPem         string
+	APIServerCertPem        string
+	APIClientServerKeyPem   string
+	APIClientServerCertPem  string
+	SAKeyPem                string
+	FrontProxyKeyPem        string
+	FrontProxyCertPem       string
+	FrontProxyClientKeyPem  string
+	FrontProxyClientCertPem string
 }
 
 // GetControlPlaneImageRepository returns name of image repository

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -52,6 +52,15 @@ type MasterConfiguration struct {
 
 	// FeatureGates enabled by the user
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
+
+	MasterCertificates *MasterCertificates `json:"masterCertificates"`
+	// Public Addr or DNS
+	PublicAddress string `json:"publicAddress"`
+	//Masters Count
+	Count int `json:"count"`
+
+	//required for cloud providers. To make right tag for resources
+	ClusterName string `json:"clusterName"`
 }
 
 type API struct {
@@ -82,6 +91,8 @@ type Etcd struct {
 	ExtraArgs map[string]string `json:"extraArgs,omitempty"`
 	// Image specifies which container image to use for running etcd. If empty, automatically populated by kubeadm using the image repository and default etcd version
 	Image string `json:"image"`
+	//Discovery URL for etcd cluster
+	Discovery string `json:"discovery"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -110,5 +121,20 @@ type NodeConfiguration struct {
 	// DiscoveryTokenUnsafeSkipCAVerification allows token-based discovery
 	// without CA verification via DiscoveryTokenCACertHashes. This can weaken
 	// the security of kubeadm since other nodes can impersonate the master.
-	DiscoveryTokenUnsafeSkipCAVerification bool `json:"discoveryTokenUnsafeSkipCAVerification"`
+	DiscoveryTokenUnsafeSkipCAVerification bool   `json:"discoveryTokenUnsafeSkipCAVerification"`
+	CloudProvider                          string `json:"cloudProvider"`
+}
+
+type MasterCertificates struct {
+	CAKeyPem                string `json:"caKeyPem"`
+	CACertPem               string `json:"caCertPem"`
+	APIServerKeyPem         string `json:"apiServerKeyPem"`
+	APIServerCertPem        string `json:"apiServerCertPem"`
+	APIClientServerKeyPem   string `json:"apiClientServerKeyPem"`
+	APIClientServerCertPem  string `json:"apiClientServerCertPem"`
+	SAKeyPem                string `json:"saKeyPem"`
+	FrontProxyKeyPem        string `json:"frontProxyKeyPem"`
+	FrontProxyCertPem       string `json:"frontProxyCertPem"`
+	FrontProxyClientKeyPem  string `json:"frontProxyClientKeyPem"`
+	FrontProxyClientCertPem string `json:"frontProxyClientCertPem"`
 }

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -150,6 +150,17 @@ func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiext.MasterConfigur
 		&cfg.API.AdvertiseAddress, "apiserver-advertise-address", cfg.API.AdvertiseAddress,
 		"The IP address the API Server will advertise it's listening on. 0.0.0.0 means the default network interface's address.",
 	)
+	flagSet.StringVar(
+		&cfg.PublicAddress, "public-address", cfg.PublicAddress,
+		"The PublicAddress address e.g. LoadBalancer",
+	)
+	flagSet.IntVar(
+		&cfg.Count, "master-count", cfg.Count,
+		"Master count",
+	)
+	flagSet.StringVar(
+		&cfg.ClusterName, "cluster-name", cfg.ClusterName,
+		"Cluster name. Used for tagging cloud provider resources")
 	flagSet.Int32Var(
 		&cfg.API.BindPort, "apiserver-bind-port", cfg.API.BindPort,
 		"Port for the API Server to bind to",
@@ -303,7 +314,8 @@ func (i *Init) Run(out io.Writer) error {
 		}
 
 		// PHASE 2: Generate kubeconfig files for the admin and the kubelet
-		if err := kubeconfigphase.CreateInitKubeConfigFiles(kubeConfigDir, i.cfg); err != nil {
+		err = kubeconfigphase.CreateInitKubeConfigFiles(kubeConfigDir, i.cfg)
+		if err != nil {
 			return err
 		}
 

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -170,6 +170,9 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, k8sVersion *versio
 	} else {
 		defaultArguments["experimental-bootstrap-token-auth"] = "true"
 	}
+	if cfg.Count > 0 {
+		defaultArguments["apiserver-count"] = fmt.Sprintf("%d", cfg.Count)
+	}
 
 	command = append(command, kubeadmutil.BuildArgumentListFromMap(defaultArguments, cfg.APIServerExtraArgs)...)
 	command = append(command, getAuthzParameters(cfg.AuthorizationModes)...)

--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -31,6 +31,7 @@ import (
 
 const (
 	caCertsVolumeName       = "ca-certs"
+	k8sVolumeName           = "k8s"
 	caCertsVolumePath       = "/etc/ssl/certs"
 	caCertsPkiVolumeName    = "ca-certs-etc-pki"
 	flexvolumeDirVolumeName = "flexvolume-dir"
@@ -54,6 +55,7 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 	mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeCertificatesVolumeName, cfg.CertificatesDir, cfg.CertificatesDir, true, &hostPathDirectoryOrCreate)
 	// Read-only mount for the ca certs (/etc/ssl/certs) directory
 	mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, caCertsVolumeName, caCertsVolumePath, caCertsVolumePath, true, &hostPathDirectoryOrCreate)
+	mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, k8sVolumeName, kubeadmconstants.KubernetesDir, kubeadmconstants.KubernetesDir, true, &hostPathDirectoryOrCreate)
 
 	// If external etcd is specified, mount the directories needed for accessing the CA/serving certs and the private key
 	if len(cfg.Etcd.Endpoints) != 0 {
@@ -73,6 +75,7 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 	// Mount for the flexvolume directory (/usr/libexec/kubernetes/kubelet-plugins/volume/exec) directory
 	// Flexvolume dir must NOT be readonly as it is used for third-party plugins to integrate with their storage backends via unix domain socket.
 	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, flexvolumeDirVolumeName, flexvolumeDirVolumePath, flexvolumeDirVolumePath, false, &hostPathDirectoryOrCreate)
+	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, k8sVolumeName, kubeadmconstants.KubernetesDir, kubeadmconstants.KubernetesDir, true, &hostPathDirectoryOrCreate)
 
 	// HostPath volumes for the scheduler
 	// Read-only mount for the scheduler kubeconfig file

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -20,11 +20,13 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/net"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
+	"k8s.io/kubernetes/pkg/util/node"
 )
 
 const (
@@ -35,7 +37,10 @@ const (
 func CreateLocalEtcdStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.MasterConfiguration) error {
 
 	// gets etcd StaticPodSpec, actualized for the current MasterConfiguration
-	spec := GetEtcdPodSpec(cfg)
+	spec, err := GetEtcdPodSpec(cfg)
+	if err != nil {
+		return err
+	}
 
 	// writes etcd StaticPod to disk
 	if err := staticpodutil.WriteStaticPodToDisk(kubeadmconstants.Etcd, manifestDir, spec); err != nil {
@@ -48,27 +53,93 @@ func CreateLocalEtcdStaticPodManifestFile(manifestDir string, cfg *kubeadmapi.Ma
 
 // GetEtcdPodSpec returns the etcd static Pod actualized to the context of the current MasterConfiguration
 // NB. GetEtcdPodSpec methods holds the information about how kubeadm creates etcd static pod mainfests.
-func GetEtcdPodSpec(cfg *kubeadmapi.MasterConfiguration) v1.Pod {
+func GetEtcdPodSpec(cfg *kubeadmapi.MasterConfiguration) (v1.Pod, error) {
 	pathType := v1.HostPathDirectoryOrCreate
+	etcdCommand, err := getEtcdCommand(cfg)
+	if err != nil {
+		return v1.Pod{}, err
+	}
 	return staticpodutil.ComponentPod(v1.Container{
 		Name:    kubeadmconstants.Etcd,
-		Command: getEtcdCommand(cfg),
+		Command: etcdCommand,
 		Image:   images.GetCoreImage(kubeadmconstants.Etcd, cfg.ImageRepository, "", cfg.Etcd.Image),
 		// Mount the etcd datadir path read-write so etcd can store data in a more persistent manner
-		VolumeMounts:  []v1.VolumeMount{staticpodutil.NewVolumeMount(etcdVolumeName, cfg.Etcd.DataDir, false)},
+		VolumeMounts:  []v1.VolumeMount{
+			staticpodutil.NewVolumeMount(etcdVolumeName, cfg.Etcd.DataDir, false),
+			certsVolumeMount(),
+			k8sVolumeMount(),
+		},
 		LivenessProbe: staticpodutil.ComponentProbe(2379, "/health", v1.URISchemeHTTP),
-	}, []v1.Volume{staticpodutil.NewVolume(etcdVolumeName, cfg.Etcd.DataDir, &pathType)})
+	}, []v1.Volume{
+		staticpodutil.NewVolume(etcdVolumeName, cfg.Etcd.DataDir, &pathType),
+		certsVolume(cfg),
+		k8sVolume(),
+	}), nil
 }
 
 // getEtcdCommand builds the right etcd command from the given config object
-func getEtcdCommand(cfg *kubeadmapi.MasterConfiguration) []string {
-	defaultArguments := map[string]string{
-		"listen-client-urls":    "http://127.0.0.1:2379",
-		"advertise-client-urls": "http://127.0.0.1:2379",
-		"data-dir":              cfg.Etcd.DataDir,
+func getEtcdCommand(cfg *kubeadmapi.MasterConfiguration) ([]string, error) {
+	var defaultArguments map[string]string
+	if len(cfg.Etcd.Discovery) > 1 {
+		//Use etcd discovery for multi master
+		name := node.GetHostname(cfg.NodeName)
+		ip, err := net.ChooseHostInterface()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get host interface address for etcd [%v]", err)
+		}
+		defaultArguments = map[string]string{
+			"name": name,
+			"initial-advertise-peer-urls": fmt.Sprintf("http://%v:2380", ip.String()),
+			"listen-peer-urls":            fmt.Sprintf("http://%v:2380", ip.String()),
+			"listen-client-urls":          fmt.Sprintf("http://%v:2379,http://127.0.0.1:2379", ip.String()),
+			"advertise-client-urls":       fmt.Sprintf("http://%v:2379", ip.String()),
+			"discovery":                   cfg.Etcd.Discovery,
+			"data-dir":                    cfg.Etcd.DataDir,
+		}
+	} else {
+		defaultArguments = map[string]string{
+			"listen-client-urls":    "http://127.0.0.1:2379",
+			"advertise-client-urls": "http://127.0.0.1:2379",
+			"data-dir":              cfg.Etcd.DataDir,
+		}
 	}
 
 	command := []string{"etcd"}
 	command = append(command, kubeadmutil.BuildArgumentListFromMap(defaultArguments, cfg.Etcd.ExtraArgs)...)
-	return command
+	return command, nil
+}
+
+// certsVolume exposes host SSL certificates to pod containers.
+// TODO(phase1+) make path configurable
+func certsVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
+	return v1.Volume{
+		Name: "certs",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{Path: "/etc/ssl/certs"},
+		},
+	}
+}
+
+func certsVolumeMount() v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      "certs",
+		MountPath: "/etc/ssl/certs",
+	}
+}
+
+func k8sVolume() v1.Volume {
+	return v1.Volume{
+		Name: "k8s",
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{Path: kubeadmconstants.KubernetesDir},
+		},
+	}
+}
+
+func k8sVolumeMount() v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      "k8s",
+		MountPath: kubeadmconstants.KubernetesDir,
+		ReadOnly:  true,
+	}
 }

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -64,7 +64,7 @@ func GetEtcdPodSpec(cfg *kubeadmapi.MasterConfiguration) (v1.Pod, error) {
 		Command: etcdCommand,
 		Image:   images.GetCoreImage(kubeadmconstants.Etcd, cfg.ImageRepository, "", cfg.Etcd.Image),
 		// Mount the etcd datadir path read-write so etcd can store data in a more persistent manner
-		VolumeMounts:  []v1.VolumeMount{
+		VolumeMounts: []v1.VolumeMount{
 			staticpodutil.NewVolumeMount(etcdVolumeName, cfg.Etcd.DataDir, false),
 			certsVolumeMount(),
 			k8sVolumeMount(),

--- a/cmd/kubeadm/app/phases/etcd/local_test.go
+++ b/cmd/kubeadm/app/phases/etcd/local_test.go
@@ -37,7 +37,10 @@ func TestGetEtcdPodSpec(t *testing.T) {
 	}
 
 	// Executes GetEtcdPodSpec
-	spec := GetEtcdPodSpec(cfg)
+	spec, err := GetEtcdPodSpec(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Assert each specs refers to the right pod
 	if spec.Spec.Containers[0].Name != kubeadmconstants.Etcd {
@@ -115,7 +118,7 @@ func TestGetEtcdCommand(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actual := getEtcdCommand(rt.cfg)
+		actual, _ := getEtcdCommand(rt.cfg)
 		sort.Strings(actual)
 		sort.Strings(rt.expected)
 		if !reflect.DeepEqual(actual, rt.expected) {


### PR DESCRIPTION
This pull request contains support for multi master kubernetes installation.
We added some additional configuration parameter for it:
1. public-address - It's IP address or DNS name(aws don't have IP for ELB) of LoadBalancer. It is't apiserver_advertise_address.
2. master-count - Initial number of masters. Required to bootstrap etcd service.
3. etcd-discovery - Address of a etcd discovery service.

Also we introduced new command to generate one file for masters configuration. This file will contains all common required parameter to start kuberenetes masters: certificates, tokens,.... 
```
 kubeadm configure [same arguments as init]
```
Output of this command may be used to start masters nodes:
```
kubeadm configure --public-address=my.server.com  --kubernetes-version=stable --cluster-name=test --master-count=3 --etcd-discovery=https://discovery.etcd.io > master.yaml
#on the first node
kubeadm init --config=master.yaml  --apiserver-advertise-address=192.168.1.121
#on the second 
kubeadm init --config=master.yaml  --apiserver-advertise-address=192.168.1.122
#on the third
kubeadm init --config=master.yaml  --apiserver-advertise-address=192.168.1.123
```

Bug Fixes:
1. Kubernetes Node name on the AWS cluster is not the node hostname.
2. Etcd mount path by default is empty.