### PR TITLE
add subresource support to kube auth can-i

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -667,6 +667,7 @@ storage-media-type
 storage-version
 storage-versions
 streaming-connection-idle-timeout
+subresource
 suicide-timeout
 sync-frequency
 system-cgroups

--- a/pkg/kubectl/cmd/auth/cani.go
+++ b/pkg/kubectl/cmd/auth/cani.go
@@ -45,6 +45,7 @@ type CanIOptions struct {
 
 	Verb         string
 	Resource     schema.GroupVersionResource
+	Subresource  string
 	ResourceName string
 
 	Out io.Writer
@@ -70,7 +71,10 @@ var (
 		kubectl auth can-i '*' '*'
 
 		# Check to see if I can get the job named "bar" in namespace "foo"
-		kubectl auth can-i list jobs.batch/bar -n foo`)
+		kubectl auth can-i list jobs.batch/bar -n foo
+
+		# check to see if I can read pod logs
+		kubectl auth can-i get pods --subresource=log`)
 )
 
 func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
@@ -101,6 +105,7 @@ func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 
 	cmd.Flags().BoolVar(&o.AllNamespaces, "all-namespaces", o.AllNamespaces, "If true, check the specified action in all namespaces.")
 	cmd.Flags().BoolVarP(&o.Quiet, "quiet", "q", o.Quiet, "If true, suppress output and just return the exit code.")
+	cmd.Flags().StringVar(&o.Subresource, "subresource", "", "SubResource such as pod/log or deployment/scale")
 	return cmd
 }
 
@@ -149,11 +154,12 @@ func (o *CanIOptions) RunAccessCheck() (bool, error) {
 	sar := &authorizationapi.SelfSubjectAccessReview{
 		Spec: authorizationapi.SelfSubjectAccessReviewSpec{
 			ResourceAttributes: &authorizationapi.ResourceAttributes{
-				Namespace: o.Namespace,
-				Verb:      o.Verb,
-				Group:     o.Resource.Group,
-				Resource:  o.Resource.Resource,
-				Name:      o.ResourceName,
+				Namespace:   o.Namespace,
+				Verb:        o.Verb,
+				Group:       o.Resource.Group,
+				Resource:    o.Resource.Resource,
+				Subresource: o.Subresource,
+				Name:        o.ResourceName,
 			},
 		},
 	}

--- a/pkg/kubectl/cmd/auth/cani_test.go
+++ b/pkg/kubectl/cmd/auth/cani_test.go
@@ -92,6 +92,18 @@ func TestRunAccessCheck(t *testing.T) {
 				`{"resourceAttributes":{"verb":"get","group":"extensions","resource":"deployments","name":"foo"}}`,
 			},
 		},
+		{
+			name: "sub resource",
+			o: &CanIOptions{
+				AllNamespaces: true,
+				Subresource:   "log",
+			},
+			args:    []string{"get", "pods"},
+			allowed: true,
+			expectedBodyStrings: []string{
+				`{"resourceAttributes":{"verb":"get","resource":"pods","subresource":"log"}}`,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Eg:
    kubectl auth can-i get pods --sub-resource=log

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
