### PR TITLE
WIP - Enable scheduler and node isolation support for pre-allocated HugePages

### DIFF
--- a/hugepages-small.yaml
+++ b/hugepages-small.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: hugepages-small
+  name: hugepages-small
+spec:
+  selector:
+    matchLabels:
+      run: hugepages-small
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        run: hugepages
+    spec:
+      containers:
+      - env:
+        - name: ENABLE_HUGEPAGES
+          value: "true"
+        image: java-oom:v1
+        imagePullPolicy: IfNotPresent
+        name: hugepages
+        resources:
+          requests:
+            alpha.kubernetes.io/hugepages-2048kB: 10
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        securityContext:
+          privileged: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/hugepages.yaml
+++ b/hugepages.yaml
@@ -1,0 +1,36 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: hugepages
+  name: hugepages
+spec:
+  selector:
+    matchLabels:
+      run: hugepages
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        run: hugepages
+    spec:
+      containers:
+      - env:
+        - name: ENABLE_HUGEPAGES
+          value: "true"
+        image: java-oom:v1
+        imagePullPolicy: IfNotPresent
+        name: hugepages
+        resources:
+          requests:
+            alpha.kubernetes.io/hugepages-2048kB: 512
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        securityContext:
+          privileged: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always

--- a/pkg/api/v1/helper/helpers.go
+++ b/pkg/api/v1/helper/helpers.go
@@ -29,6 +29,12 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 )
 
+// IsHugePageResourceName returns true if the resource name has the huge page
+// resource prefix.
+func IsHugePageResourceName(name v1.ResourceName) bool {
+	return strings.HasPrefix(string(name), "alpha.kubernetes.io/hugepages-")
+}
+
 // IsOpaqueIntResourceName returns true if the resource name has the opaque
 // integer resource prefix.
 func IsOpaqueIntResourceName(name v1.ResourceName) bool {

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cadvisor
 
 import (
+	"strconv"
+
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -31,5 +33,8 @@ func CapacityFromMachineInfo(info *cadvisorapi.MachineInfo) v1.ResourceList {
 			int64(info.MemoryCapacity),
 			resource.BinarySI),
 	}
+	//  TODO: clean this up, we will need to support each size (not just default)
+	hugepagesName := "alpha.kubernetes.io/hugepages-" + strconv.Itoa(int(info.HugePageSize)) + "kB"
+	c[v1.ResourceName(hugepagesName)] = *resource.NewQuantity(int64(info.HugePagesTotal), resource.DecimalSI)
 	return c
 }

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/golang/glog"
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -90,6 +91,8 @@ func ResourceConfigForPod(pod *v1.Pod) *ResourceConfig {
 	memoryLimits := int64(0)
 	memoryLimitsDeclared := true
 	cpuLimitsDeclared := true
+	// TODO: demo is just a single size for now (2MB)
+	hugePageLimit := int64(0)
 	for _, container := range pod.Spec.Containers {
 		cpuRequests += container.Resources.Requests.Cpu().MilliValue()
 		cpuLimits += container.Resources.Limits.Cpu().MilliValue()
@@ -99,6 +102,12 @@ func ResourceConfigForPod(pod *v1.Pod) *ResourceConfig {
 		memoryLimits += container.Resources.Limits.Memory().Value()
 		if container.Resources.Limits.Memory().IsZero() {
 			memoryLimitsDeclared = false
+		}
+
+		hugePage, found := container.Resources.Requests[v1.ResourceName("alpha.kubernetes.io/hugepages-2048kB")]
+		if found {
+			glog.Infof("FOUND HUGEPAGE LIMIT: %v", hugePage.String())
+			hugePageLimit += hugePage.Value() * int64(2*1024*1024)
 		}
 	}
 
@@ -129,6 +138,7 @@ func ResourceConfigForPod(pod *v1.Pod) *ResourceConfig {
 		shares := int64(MinShares)
 		result.CpuShares = &shares
 	}
+	result.HugePageLimit = &hugePageLimit
 	return result
 }
 

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -31,6 +31,9 @@ type ResourceConfig struct {
 	CpuQuota *int64
 	// CPU quota period.
 	CpuPeriod *int64
+
+	// TODO: right now, I am hardcoding as always 2048kb page size for demo
+	HugePageLimit *int64
 }
 
 // CgroupName is the abstract name of a cgroup prior to any driver specific conversion.

--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -70,6 +70,7 @@ type Resource struct {
 	Memory             int64
 	NvidiaGPU          int64
 	OpaqueIntResources map[v1.ResourceName]int64
+	HugePages          map[v1.ResourceName]int64
 }
 
 func (r *Resource) ResourceList() v1.ResourceList {
@@ -79,6 +80,9 @@ func (r *Resource) ResourceList() v1.ResourceList {
 		v1.ResourceNvidiaGPU: *resource.NewQuantity(r.NvidiaGPU, resource.DecimalSI),
 	}
 	for rName, rQuant := range r.OpaqueIntResources {
+		result[rName] = *resource.NewQuantity(rQuant, resource.DecimalSI)
+	}
+	for rName, rQuant := range r.HugePages {
 		result[rName] = *resource.NewQuantity(rQuant, resource.DecimalSI)
 	}
 	return result
@@ -94,6 +98,10 @@ func (r *Resource) Clone() *Resource {
 	for k, v := range r.OpaqueIntResources {
 		res.OpaqueIntResources[k] = v
 	}
+	res.HugePages = make(map[v1.ResourceName]int64)
+	for k, v := range r.HugePages {
+		res.HugePages[k] = v
+	}
 	return res
 }
 
@@ -107,6 +115,18 @@ func (r *Resource) SetOpaque(name v1.ResourceName, quantity int64) {
 		r.OpaqueIntResources = map[v1.ResourceName]int64{}
 	}
 	r.OpaqueIntResources[name] = quantity
+}
+
+func (r *Resource) AddHugePages(name v1.ResourceName, quantity int64) {
+	r.SetHugePages(name, r.HugePages[name]+quantity)
+}
+
+func (r *Resource) SetHugePages(name v1.ResourceName, quantity int64) {
+	// Lazily allocate opaque integer resource map.
+	if r.HugePages == nil {
+		r.HugePages = map[v1.ResourceName]int64{}
+	}
+	r.HugePages[name] = quantity
 }
 
 // NewNodeInfo returns a ready to use empty NodeInfo object.
@@ -266,6 +286,12 @@ func (n *NodeInfo) addPod(pod *v1.Pod) {
 	for rName, rQuant := range res.OpaqueIntResources {
 		n.requestedResource.OpaqueIntResources[rName] += rQuant
 	}
+	if n.requestedResource.HugePages == nil && len(res.HugePages) > 0 {
+		n.requestedResource.HugePages = map[v1.ResourceName]int64{}
+	}
+	for rName, rQuant := range res.HugePages {
+		n.requestedResource.HugePages[rName] += rQuant
+	}
 	n.nonzeroRequest.MilliCPU += non0_cpu
 	n.nonzeroRequest.Memory += non0_mem
 	n.pods = append(n.pods, pod)
@@ -321,6 +347,12 @@ func (n *NodeInfo) removePod(pod *v1.Pod) error {
 			for rName, rQuant := range res.OpaqueIntResources {
 				n.requestedResource.OpaqueIntResources[rName] -= rQuant
 			}
+			if len(res.HugePages) > 0 && n.requestedResource.HugePages == nil {
+				n.requestedResource.HugePages = map[v1.ResourceName]int64{}
+			}
+			for rName, rQuant := range res.HugePages {
+				n.requestedResource.HugePages[rName] -= rQuant
+			}
 			n.nonzeroRequest.MilliCPU -= non0_cpu
 			n.nonzeroRequest.Memory -= non0_mem
 
@@ -348,6 +380,9 @@ func calculateResource(pod *v1.Pod) (res Resource, non0_cpu int64, non0_mem int6
 			default:
 				if v1helper.IsOpaqueIntResourceName(rName) {
 					res.AddOpaque(rName, rQuant.Value())
+				}
+				if v1helper.IsHugePageResourceName(rName) {
+					res.AddHugePages(rName, rQuant.Value())
 				}
 			}
 		}
@@ -390,6 +425,9 @@ func (n *NodeInfo) SetNode(node *v1.Node) error {
 		default:
 			if v1helper.IsOpaqueIntResourceName(rName) {
 				n.allocatableResource.SetOpaque(rName, rQuant.Value())
+			}
+			if v1helper.IsHugePageResourceName(rName) {
+				n.allocatableResource.SetHugePages(rName, rQuant.Value())
 			}
 		}
 	}

--- a/vendor/github.com/google/cadvisor/info/v1/machine.go
+++ b/vendor/github.com/google/cadvisor/info/v1/machine.go
@@ -154,6 +154,14 @@ type MachineInfo struct {
 	// The amount of memory (in bytes) in this machine
 	MemoryCapacity uint64 `json:"memory_capacity"`
 
+	// The default hugepage size (in kB) on this machine.
+	// TODO: this should be a slice of supported sizes
+	HugePageSize uint64 `json:"hugepage_size"`
+
+	// The number of hugepage of the default size on this machine.
+	// TODO: this should be a slice of supported sizes.
+	HugePagesTotal uint64 `json:"hugepages_total"`
+
 	// The machine id
 	MachineID string `json:"machine_id"`
 

--- a/vendor/github.com/google/cadvisor/machine/info.go
+++ b/vendor/github.com/google/cadvisor/machine/info.go
@@ -65,6 +65,25 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 		return nil, err
 	}
 
+	// TODO: find out number of hugepages by size
+	meminfo, err := ioutil.ReadFile(filepath.Join(rootFs, "/proc/meminfo"))
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: read from /sys/kernel/mm/hugepages/hugepages-${size}kB directories
+	// TODO: right now, i am just reporting the default huge page size.
+	hugepageSize, err := GetHugePageSize(string(meminfo))
+	if err != nil {
+		glog.Errorf("Failed to get hugepage size information: %v", err)
+	}
+	hugepagesTotal, err := GetHugePagesTotal(string(meminfo))
+	if err != nil {
+		glog.Errorf("Failed to get hugepages total information: %v", err)
+	}
+	glog.Infof("FOUND HUGEPAGE SIZE: %v", hugepageSize)
+	glog.Infof("FOUND HUGEPAGES TOTAL: %v", hugepagesTotal)
+
 	filesystems, err := fsInfo.GetGlobalFsInfo()
 	if err != nil {
 		glog.Errorf("Failed to get global filesystem information: %v", err)
@@ -108,6 +127,8 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 		CloudProvider:  cloudProvider,
 		InstanceType:   instanceType,
 		InstanceID:     instanceID,
+		HugePageSize:   hugepageSize,
+		HugePagesTotal: hugepagesTotal,
 	}
 
 	for i := range filesystems {


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR does the following:

1. kubelet/cadvisor is able to discover the default HugePage size on the machine
1. kubelet/cadvisor is able to discover the number of pre-allocated HugePages for that size on machine
1. kubelet reports number of HugePages by configured size as node capacity/allocatable quantity
1. kubelet pod cgroup manager limits the number of hugepages that can be consumed by a pod to 0 by default (used to be unlimited)
1. kubelet pod cgroup sets the amount of hugepages that can be consumed by a pod based on its request
1. scheduler can schedule pods to nodes with hugepages with right hugepage size

Not yet complete:

1. i think hugepage requests should only be allowed by G or Bu pods
1. should not support over-commit on pod spec for hugepages (i.e. request must equal limit), for now just look at request
1. code only looks at the default hugepage size for the host, and not all supported sizes.  if we want a node to support both 2MB and 1Gi hugepage sizes at the same time, we would need to not use /proc/meminfo and just look at /sys/fs/ configuration for hugepages (would do before finishing feature)
1. we would need to add support to ResourceQuota for hugepages to control usage
1. on numa machines, number of hugepages allocated to a node are divided amongst each numa node.  if/when we ever add support for numa affinity or cpu affinity, the kubelet would ideally direct pods to a numa node that can fit the huge page request.  this is really only pertinent if we do cpu affinity, as it doesn't really impact the accounting behavior and controlled consumption presented here.
1. to consume hugepages, users must be a member of a group on the node that are entitled to consume them (vm.hugetlb_shm_group), this is more a doc thing than anything else.  right now, my demo just runs privileged pods.

Why we need it:

1. hugepages are often used to back JVM applications that run w/ large heap sizes
1. hugepages are often used to back large stateful applications (oracle, mysql, postgres, etc.) to minimize misses in TLB
1. hugepages are often used to back large memory caches (i.e. memcached)

**Special notes for your reviewer**:
At this point, this PR is intended to facilitate discussion in sig-node/sig-scheduling and the resource mgmt wg.  If we agree to pursue this capability in 1.7 for sig-node, I would break it into a series of PRs.

Example deployment (where jvm is optionally backed by hugepages, app in question just keeps consuming memory up to jvm heap size to demonstrate usage of hugepages)

```
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  labels:
    run: hugepages
  name: hugepages
spec:
  selector:
    matchLabels:
      run: hugepages
  strategy:
    rollingUpdate:
      maxSurge: 1
      maxUnavailable: 1
    type: RollingUpdate
  template:
    metadata:
      labels:
        run: hugepages
    spec:
      containers:
      - env:
        - name: ENABLE_HUGEPAGES
          value: "true"
        image: derekwaynecarr/java-oom:v1
        imagePullPolicy: IfNotPresent
        name: hugepages
        resources:
          requests:
            alpha.kubernetes.io/hugepages-2048kB: 512
        terminationMessagePath: /dev/termination-log
        terminationMessagePolicy: File
        securityContext:
          privileged: true
      dnsPolicy: ClusterFirst
      restartPolicy: Always
```

