### PR TITLE
Added missing short form for storageclasses to kubectl's valid_resources

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -235,7 +235,7 @@ __custom_func() {
     * serviceaccounts (aka 'sa')
     * services (aka 'svc')
     * statefulsets
-    * storageclasses
+    * storageclasses (aka 'sc')
     * thirdpartyresources
     `
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
There is an alias for storageclasses (sc), but it's not shown in the list of resources printed when running `kubectl get`