### PR TITLE
Remove unused function - verifyDNSPodIsRunning

### DIFF
--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -280,21 +280,6 @@ func validateTargetedProbeOutput(f *framework.Framework, pod *v1.Pod, fileNames 
 	framework.Logf("DNS probes using %s succeeded\n", pod.Name)
 }
 
-func verifyDNSPodIsRunning(f *framework.Framework) {
-	systemClient := f.ClientSet.Core().Pods(metav1.NamespaceSystem)
-	By("Waiting for DNS Service to be Running")
-	options := metav1.ListOptions{LabelSelector: dnsServiceLabelSelector.String()}
-	dnsPods, err := systemClient.List(options)
-	if err != nil {
-		framework.Failf("Failed to list all dns service pods")
-	}
-	if len(dnsPods.Items) < 1 {
-		framework.Failf("No pods match the label selector %v", dnsServiceLabelSelector.String())
-	}
-	pod := dnsPods.Items[0]
-	framework.ExpectNoError(framework.WaitForPodRunningInNamespace(f.ClientSet, &pod))
-}
-
 func createServiceSpec(serviceName, externalName string, isHeadless bool, selector map[string]string) *v1.Service {
 	headlessService := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

In ea4a7e24adf6441efbaa682d5fc28c109e3ecab8, we removed the cluster
DNS verification check from the test, but neglected to remove the
method itself.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
