### PR TITLE
Removing hack/udpate-staging* from update-all.sh

### DIFF
--- a/hack/godep-restore.sh
+++ b/hack/godep-restore.sh
@@ -25,5 +25,9 @@ source "${KUBE_ROOT}/hack/lib/util.sh"
 kube::util::ensure_godep_version v79
 
 echo "Starting to download all kubernetes godeps. This takes a while"
-GOPATH=${GOPATH}:${KUBE_ROOT}/staging godep restore "$@"
+if ! GOPATH=${GOPATH}:${KUBE_ROOT}/staging godep restore "$@"; then
+  echo "\"godep restore\" failed. Removing the packages that caused the failure from your GOPATH might solve the problem."
+  exit 1
+fi
+  
 echo "Download finished"

--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -70,8 +70,6 @@ BASH_TARGETS="
 	update-openapi-spec
 	update-api-reference-docs
 	update-federation-openapi-spec
-	update-staging-client-go
-	update-staging-godeps
 	update-bazel"
 
 for t in $BASH_TARGETS; do

--- a/hack/update-staging-godeps.sh
+++ b/hack/update-staging-godeps.sh
@@ -99,7 +99,10 @@ for repo in $(ls ${KUBE_ROOT}/staging/src/k8s.io); do
   updateGodepManifest "${repo}"
 
   if [ "${FAIL_ON_DIFF}" == true ]; then
-    diff --ignore-matching-lines='^\s*\"GoVersion\":' --ignore-matching-line='^\s*\"GodepVersion\":' --ignore-matching-lines='^\s*\"Comment\"' -u "${KUBE_ROOT}/staging/src/k8s.io/${repo}/Godeps" "${TMP_GOPATH}/src/k8s.io/${repo}/Godeps/Godeps.json"
+    if ! diff --ignore-matching-lines='^\s*\"GoVersion\":' --ignore-matching-line='^\s*\"GodepVersion\":' --ignore-matching-lines='^\s*\"Comment\"' -u "${KUBE_ROOT}/staging/src/k8s.io/${repo}/Godeps" "${TMP_GOPATH}/src/k8s.io/${repo}/Godeps/Godeps.json"; then
+      echo "staging/src/k8s.io/${repo}/Godeps is out of date. Please run hack/update-staging-godeps.sh. Note that the script is NOT included in hack/update-all.sh."
+      exit 1
+    fi
   fi
   if [ "${DRY_RUN}" != true ]; then
     cp "${TMP_GOPATH}/src/k8s.io/${repo}/Godeps/Godeps.json" "${KUBE_ROOT}/staging/src/k8s.io/${repo}/Godeps"

--- a/staging/copy.sh
+++ b/staging/copy.sh
@@ -224,7 +224,7 @@ if [ "${FAIL_ON_CHANGES}" = true ]; then
     echo "${CLIENT_REPO} up to date."
     exit 0
   else
-    echo "${CLIENT_REPO} is out of date. Please run hack/update-staging-client-go.sh"
+    echo "${CLIENT_REPO} is out of date. Please run hack/update-staging-client-go.sh. Note that the script is NOT included in hack/update-all.sh."
     exit 1
   fi
 fi


### PR DESCRIPTION
Addressing https://github.com/kubernetes/kubernetes/issues/36770#issuecomment-296420835

More discussion at https://github.com/kubernetes/kubernetes/pull/44519#issuecomment-294539964

A summary of the discussion: `godep restore` doesn't work reliably when the GOPATH is not clean. The two update-staging* scripts rely on `godep restore`, thus causing troubles to developers. This PR removes the two scripts from update-all.sh, but keeps the coresonding verification in the verify-all.sh, so developers only have to run the update-staging* scripts when necessary.

cc @thockin @kargakis 