### PR TITLE
Fixed flaky unit test.

### DIFF
--- a/pkg/util/env/env_test.go
+++ b/pkg/util/env/env_test.go
@@ -55,7 +55,7 @@ func TestGetEnvAsIntOrFallback(t *testing.T) {
 	os.Setenv(key, "not-an-int")
 	returnVal, err := GetEnvAsIntOrFallback(key, 1)
 	assert.Equal(expected, returnVal)
-	assert.EqualError(err, "strconv.ParseInt: parsing \"not-an-int\": invalid syntax")
+	assert.EqualError(err, "strconv.Atoi: parsing \"not-an-int\": invalid syntax")
 }
 
 func TestGetEnvAsFloat64OrFallback(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed the following flaky unit test:

```
--- FAIL: TestGetEnvAsIntOrFallback (0.00s)
   Error Trace:    env_test.go:58
	Error:		Not equal: "strconv.ParseInt: parsing \"not-an-int\": invalid syntax" (expected)
			        != "strconv.Atoi: parsing \"not-an-int\": invalid syntax" (actual)
	Messages:	An error with value "strconv.ParseInt: parsing "not-an-int": invalid syntax" is expected but got "strconv.Atoi: parsing "not-an-int": invalid syntax".

FAIL
FAIL	k8s.io/kubernetes/pkg/util/env	0.005s
```

**Release Note**
```release-note-none
```
