### PR TITLE
Fixed flaky unit test in deployment.

### DIFF
--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -692,7 +692,7 @@ func TestResolveFenceposts(t *testing.T) {
 			desired:           10,
 			expectSurge:       0,
 			expectUnavailable: 0,
-			expectError:       "invalid value for IntOrString: invalid value \"oops\": strconv.ParseInt: parsing \"oops\": invalid syntax",
+			expectError:       "invalid value for IntOrString: invalid value \"oops\": strconv.Atoi: parsing \"oops\": invalid syntax",
 		},
 		{
 			maxSurge:          "55%",
@@ -700,7 +700,7 @@ func TestResolveFenceposts(t *testing.T) {
 			desired:           10,
 			expectSurge:       0,
 			expectUnavailable: 0,
-			expectError:       "invalid value for IntOrString: invalid value \"urg\": strconv.ParseInt: parsing \"urg\": invalid syntax",
+			expectError:       "invalid value for IntOrString: invalid value \"urg\": strconv.Atoi: parsing \"urg\": invalid syntax",
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed the following flaky unit test in deployment:

```
+++ [0424 04:18:52] Running tests without code coverage
--- FAIL: TestResolveFenceposts (0.00s)
   Error Trace:    deployment_util_test.go:716
	Error:		Not equal: "invalid value for IntOrString: invalid value \"oops\": strconv.ParseInt: parsing \"oops\": invalid syntax" (expected)
			        != "invalid value for IntOrString: invalid value \"oops\": strconv.Atoi: parsing \"oops\": invalid syntax" (actual)
	Messages:	An error with value "invalid value for IntOrString: invalid value "oops": strconv.ParseInt: parsing "oops": invalid syntax" is expected but got "invalid value for IntOrString: invalid value "oops": strconv.Atoi: parsing "oops": invalid syntax".

   Error Trace:    deployment_util_test.go:716
	Error:		Not equal: "invalid value for IntOrString: invalid value \"urg\": strconv.ParseInt: parsing \"urg\": invalid syntax" (expected)
			        != "invalid value for IntOrString: invalid value \"urg\": strconv.Atoi: parsing \"urg\": invalid syntax" (actual)
	Messages:	An error with value "invalid value for IntOrString: invalid value "urg": strconv.ParseInt: parsing "urg": invalid syntax" is expected but got "invalid value for IntOrString: invalid value "urg": strconv.Atoi: parsing "urg": invalid syntax".

FAIL
FAIL	k8s.io/kubernetes/pkg/controller/deployment/util	0.264s
```


**Release Note**

```release-note-none
```
