### PR TITLE
apimachinery: NotRegisteredErr for known kinds not registered in target GV

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/error.go
@@ -24,16 +24,27 @@ import (
 )
 
 type notRegisteredErr struct {
-	gvk schema.GroupVersionKind
-	t   reflect.Type
+	gvk    schema.GroupVersionKind
+	target GroupVersioner
+	t      reflect.Type
 }
 
-// NewNotRegisteredErr is exposed for testing.
-func NewNotRegisteredErr(gvk schema.GroupVersionKind, t reflect.Type) error {
-	return &notRegisteredErr{gvk: gvk, t: t}
+func NewNotRegisteredErrForKind(gvk schema.GroupVersionKind) error {
+	return &notRegisteredErr{gvk: gvk}
+}
+
+func NewNotRegisteredErrForType(t reflect.Type) error {
+	return &notRegisteredErr{t: t}
+}
+
+func NewNotRegisteredErrForTarget(t reflect.Type, target GroupVersioner) error {
+	return &notRegisteredErr{t: t, target: target}
 }
 
 func (k *notRegisteredErr) Error() string {
+	if k.t != nil && k.target != nil {
+		return fmt.Sprintf("%v is not suitable for converting to %q", k.t, k.target)
+	}
 	if k.t != nil {
 		return fmt.Sprintf("no kind is registered for the type %v", k.t)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -243,7 +243,7 @@ func (s *Scheme) ObjectKinds(obj Object) ([]schema.GroupVersionKind, bool, error
 
 	gvks, ok := s.typeToGVK[t]
 	if !ok {
-		return nil, false, NewNotRegisteredErr(schema.GroupVersionKind{}, t)
+		return nil, false, NewNotRegisteredErrForType(t)
 	}
 	_, unversionedType := s.unversionedTypes[t]
 
@@ -281,7 +281,7 @@ func (s *Scheme) New(kind schema.GroupVersionKind) (Object, error) {
 	if t, exists := s.unversionedKinds[kind.Kind]; exists {
 		return reflect.New(t).Interface().(Object), nil
 	}
-	return nil, NewNotRegisteredErr(kind, nil)
+	return nil, NewNotRegisteredErrForKind(kind)
 }
 
 // AddGenericConversionFunc adds a function that accepts the ConversionFunc call pattern
@@ -492,7 +492,7 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 	}
 	kinds, ok := s.typeToGVK[t]
 	if !ok || len(kinds) == 0 {
-		return nil, NewNotRegisteredErr(schema.GroupVersionKind{}, t)
+		return nil, NewNotRegisteredErrForType(t)
 	}
 
 	gvk, ok := target.KindForGroupVersionKinds(kinds)
@@ -506,8 +506,7 @@ func (s *Scheme) convertToVersion(copy bool, in Object, target GroupVersioner) (
 			return copyAndSetTargetKind(copy, s, in, unversionedKind)
 		}
 
-		// TODO: should this be a typed error?
-		return nil, fmt.Errorf("%v is not suitable for converting to %q", t, target)
+		return nil, NewNotRegisteredErrForTarget(t, target)
 	}
 
 	// target wants to use the existing type, set kind and return (no conversion necessary)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -129,7 +129,7 @@ func TestDecode(t *testing.T) {
 		{
 			data:        []byte(`{"kind":"Test","apiVersion":"other/blah","value":1,"Other":"test"}`),
 			into:        &testDecodable{},
-			typer:       &mockTyper{err: runtime.NewNotRegisteredErr(schema.GroupVersionKind{}, nil)},
+			typer:       &mockTyper{err: runtime.NewNotRegisteredErrForKind(schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"})},
 			expectedGVK: &schema.GroupVersionKind{Kind: "Test", Group: "other", Version: "blah"},
 			expectedObject: &testDecodable{
 				Other: "test",

--- a/staging/src/k8s.io/client-go/dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_test.go
@@ -556,3 +556,11 @@ func TestPatch(t *testing.T) {
 		}
 	}
 }
+
+func TestVersionedParameterEncoderWithV1Fallback(t *testing.T) {
+	enc := VersionedParameterEncoderWithV1Fallback
+	_, err := enc.EncodeParameters(&metav1.ListOptions{}, schema.GroupVersion{Group: "foo.bar.com", Version: "v4"})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes the fall back to core v1 for *Options in the parameter encoder of the dynamic client.

The dynamic client uses NotRegisteredErr to fall back to core v1 if ListOptions is not known
in the given GV. This commit fixes the case that ListOptions is known in some group, but not
in the given one.