### PR TITLE
Document the NodePort workflow for kubernetes-worker

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/README.md
+++ b/cluster/juju/layers/kubernetes-worker/README.md
@@ -70,3 +70,31 @@ re-render configuration and disrupt the worker services.
 
 External access to pods must be performed through a [Kubernetes
 Ingress Resource](http://kubernetes.io/docs/user-guide/ingress/).
+
+When using NodePort type networking, there is no automation in exposing the
+ports selected by kubernetes or chosen by the user. They will need to be
+opened manually and can be performed across an entire worker pool.
+
+If your NodePort service port selected is `30510` you can open this across all
+members of a worker pool named `kubernetes-worker` like so:
+
+```
+juju run --application kubernetes-worker open-port 30510/tcp
+```
+
+Don't forget to expose the kubernetes-worker application if its not already
+exposed, as this can cause confusion once the port has been opened and the
+service is not reachable.
+
+Note: When debugging connection issues with NodePort services, its important
+to first check the kube-proxy service on the worker units. If kube-proxy is not
+running, the associated port-mapping will not be configured in the iptables
+rulechains. 
+
+If you need to close the NodePort once a workload has been terminated, you can
+follow the same steps inversely.
+
+```
+juju run --application kubernetes-worker close-port 30510
+```
+


### PR DESCRIPTION
closes
https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/259

NodePort networking model has no daemon listening to lend a hand so any
NodePort services will need to be manually declared and exposed.


**What this PR does / why we need it**: Updates the documentation around using NodePort networking with the kubernetes-worker charm.


**Special notes for your reviewer**: This is a working fix for using NodePort style networking with kubernetes-workers in the juju ecosystem. Declaring a simple workload as type NodePort, then following the updated documentation will make it reachable via the open-world network connection.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Documented NodePort networking for CDK.
```
