### PR TITLE
Allow disabling log dump for nodes (in preparation for using logexporter)

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -248,6 +248,11 @@ function dump_nodes() {
 }
 
 setup
-echo "Dumping master and node logs to ${report_dir}"
+echo "Dumping master logs to ${report_dir}"
 dump_masters
-dump_nodes
+if [[ "${DUMP_ONLY_MASTER_LOGS:-}" != "true" ]]; then
+  echo "Dumping node logs to ${report_dir}"
+  dump_nodes
+else
+  echo "Skipping dumping of node logs"
+fi


### PR DESCRIPTION
This is, in part, a change required for allowing usage of [logexporter](https://github.com/kubernetes/test-infra/tree/master/logexporter) for dumping node logs to GCS directly, instead of doing it through log-dump.sh.

cc @kubernetes/test-infra-maintainers @wojtek-t @gmarek @fejta 