### PR TITLE
Add more system accounts to the authenticated_user_requests metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
@@ -129,7 +129,6 @@ func TestCompressUsername(t *testing.T) {
 	tests := []struct{ username, expected string }{
 		// Known system accounts should be reported as-is.
 		{"kubelet", "kubelet"},
-		{"kubecfg", "kubecfg"},
 		{"admin", "admin"},
 		{"system:kube-controller-manager", "system:kube-controller-manager"},
 		{"system:kube-scheduler", "system:kube-scheduler"},
@@ -158,6 +157,7 @@ func TestCompressUsername(t *testing.T) {
 		{"foo-bar-baz@k8s.io.edu.gov", "email_id"},
 		{"system:serviceaccount:default:foo-service", "system:serviceaccount"},
 		{"system:serviceaccount:my-namespace:bar", "system:serviceaccount"},
+		{"kubecfg", "other"},
 		{"whatsit", "other"},
 		{"foo-user", "other"},
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication_test.go
@@ -124,3 +124,46 @@ func TestAuthenticateRequestError(t *testing.T) {
 		t.Fatalf("contextMapper should have no stored requests: %v", contextMapper)
 	}
 }
+
+func TestCompressUsername(t *testing.T) {
+	tests := []struct{ username, expected string }{
+		// Known system accounts should be reported as-is.
+		{"kubelet", "kubelet"},
+		{"kubecfg", "kubecfg"},
+		{"admin", "admin"},
+		{"system:kube-controller-manager", "system:kube-controller-manager"},
+		{"system:kube-scheduler", "system:kube-scheduler"},
+		{"system:apiserver", "system:apiserver"},
+		{"system:anonymous", "system:anonymous"},
+		{"system:kube-proxy", "system:kube-proxy"},
+		{"system:serviceaccount:kube-system:default", "system:serviceaccount:kube-system:default"},
+		{"system:serviceaccount:kube-system:node-controller", "system:serviceaccount:kube-system:node-controller"},
+		{"system:serviceaccount:kube-system:endpoint-controller", "system:serviceaccount:kube-system:endpoint-controller"},
+		{"system:serviceaccount:kube-system:cronjob-controller", "system:serviceaccount:kube-system:cronjob-controller"},
+		{"system:serviceaccount:kube-system:generic-garbage-collector", "system:serviceaccount:kube-system:generic-garbage-collector"},
+		{"system:serviceaccount:kube-system:pod-garbage-collector", "system:serviceaccount:kube-system:pod-garbage-collector"},
+		{"system:serviceaccount:kube-system:node-problem-detector", "system:serviceaccount:kube-system:node-problem-detector"},
+		{"system:serviceaccount:kube-system:kube-dns", "system:serviceaccount:kube-system:kube-dns"},
+		{"system:serviceaccount:kube-system:namespace-controller", "system:serviceaccount:kube-system:namespace-controller"},
+		{"system:serviceaccount:kube-system:replicaset-controller", "system:serviceaccount:kube-system:replicaset-controller"},
+		{"system:serviceaccount:kube-system:deployment-controller", "system:serviceaccount:kube-system:deployment-controller"},
+		{"system:serviceaccount:kube-system:daemon-set-controller", "system:serviceaccount:kube-system:daemon-set-controller"},
+		{"system:serviceaccount:kube-system:controller-discovery", "system:serviceaccount:kube-system:controller-discovery"},
+		{"system:serviceaccount:kube-system:replication-controller", "system:serviceaccount:kube-system:replication-controller"},
+		{"system:serviceaccount:kube-system:ttl-controller", "system:serviceaccount:kube-system:ttl-controller"},
+		{"system:serviceaccount:kube-system:route-controller", "system:serviceaccount:kube-system:route-controller"},
+		{"system:serviceaccount:kube-system:service-account-controller", "system:serviceaccount:kube-system:service-account-controller"},
+		// Custom service & user accounts should be compressed.
+		{"foo@bar.com", "email_id"},
+		{"foo-bar-baz@k8s.io.edu.gov", "email_id"},
+		{"system:serviceaccount:default:foo-service", "system:serviceaccount"},
+		{"system:serviceaccount:my-namespace:bar", "system:serviceaccount"},
+		{"whatsit", "other"},
+		{"foo-user", "other"},
+	}
+	for i, test := range tests {
+		if actual := compressUsername(test.username); actual != test.expected {
+			t.Errorf("[%d  %s] expected: %q, got: %q", i, test.username, test.expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
The authenticated_user_requests metric is currently limited to a few whitelisted system accounts, and compresses the rest to broad categories. This is a useful metric to understand the request volumes of system components, so I expanded the list of whitelisted accounts to include all the accounts I saw on a fresh 1.6 cluster (kube-up.sh) without any workloads. I also added separated a `system:serviceaccount` bucket out from the `other` bucket.  See the test (`Known system accounts`) for the full list of accounts I expect the cluster to log.

FYI, here is the raw list from the 3-node cluster running over the weekend (sorted by request count):
```
$ curl -s localhost:8001/metrics | grep -E "^(authenticated_user_requests|process_start_time)" | sort -t' ' -k 2 -n -r
authenticated_user_requests{username="kubelet"} 275190
authenticated_user_requests{username="system:kube-controller-manager"} 260627
authenticated_user_requests{username="system:kube-scheduler"} 253238
authenticated_user_requests{username="system:serviceaccount:kube-system:default"} 129513
authenticated_user_requests{username="system:apiserver"} 121063
authenticated_user_requests{username="system:serviceaccount:kube-system:endpoint-controller"} 77881
authenticated_user_requests{username="system:serviceaccount:kube-system:cronjob-controller"} 49780
authenticated_user_requests{username="system:serviceaccount:kube-system:generic-garbage-collector"} 20204
authenticated_user_requests{username="system:serviceaccount:kube-system:pod-garbage-collector"} 12449
authenticated_user_requests{username="system:serviceaccount:kube-system:node-problem-detector"} 12343
authenticated_user_requests{username="system:anonymous"} 7164
authenticated_user_requests{username="system:kube-proxy"} 3360
authenticated_user_requests{username="system:serviceaccount:kube-system:kube-dns"} 2233
authenticated_user_requests{username="system:serviceaccount:kube-system:namespace-controller"} 1382
authenticated_user_requests{username="system:serviceaccount:kube-system:replicaset-controller"} 78
authenticated_user_requests{username="system:serviceaccount:kube-system:deployment-controller"} 76
authenticated_user_requests{username="kubecfg"} 64
authenticated_user_requests{username="system:serviceaccount:kube-system:daemon-set-controller"} 40
authenticated_user_requests{username="system:serviceaccount:kube-system:node-controller"} 21
authenticated_user_requests{username="system:serviceaccount:kube-system:controller-discovery"} 19
authenticated_user_requests{username="system:serviceaccount:kube-system:replication-controller"} 5
authenticated_user_requests{username="system:serviceaccount:kube-system:ttl-controller"} 4
authenticated_user_requests{username="system:serviceaccount:kube-system:route-controller"} 4
authenticated_user_requests{username="system:serviceaccount:kube-system:service-account-controller"} 3
process_start_time_seconds 1.49281853017e+09
authenticated_user_requests{username="admin"} 1
```

/cc @kubernetes/sig-scalability-pr-reviews @kubernetes/sig-auth-pr-reviews 