### PR TITLE
Admission controller plugin for storage policy management

### DIFF
--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -45,4 +45,5 @@ import (
 	_ "k8s.io/kubernetes/plugin/pkg/admission/securitycontext/scdeny"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	_ "k8s.io/kubernetes/plugin/pkg/admission/storageclass/default"
+	_ "k8s.io/kubernetes/plugin/pkg/admission/vSphereSPBMPolicy"
 )

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -39,6 +39,7 @@ const (
 	Fstype             = "fstype"
 	diskformat         = "diskformat"
 	datastore          = "datastore"
+	vmName             = "vmName"
 
 	HostFailuresToTolerateCapability    = "hostfailurestotolerate"
 	ForceProvisioningCapability         = "forceprovisioning"
@@ -103,6 +104,8 @@ func (util *VsphereDiskUtil) CreateVolume(v *vsphereVolumeProvisioner) (vmDiskPa
 		case Fstype:
 			fstype = value
 			glog.V(4).Infof("Setting fstype as %q", fstype)
+		case vmName:
+			glog.V(4).Infof("balu - Setting vmName as %q", value)
 		case HostFailuresToTolerateCapability, ForceProvisioningCapability,
 			CacheReservationCapability, DiskStripesCapability,
 			ObjectSpaceReservationCapability, IopsLimitCapability:

--- a/plugin/pkg/admission/vSphereSPBMPolicy/admission.go
+++ b/plugin/pkg/admission/vSphereSPBMPolicy/admission.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vSphereSPBMPolicy
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+
+	"github.com/golang/glog"
+
+	"k8s.io/apiserver/pkg/admission"
+	storageapi "k8s.io/kubernetes/pkg/apis/storage"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
+)
+
+func init() {
+	admission.RegisterPlugin("VSphereSPBMPolicyManager", func(config io.Reader) (admission.Interface, error) {
+		vSphereSPBMPolicyManager := NewVSphereSPBMPolicyManager()
+		return vSphereSPBMPolicyManager, nil
+	})
+}
+
+var _ = admission.Interface(&vSphereSPBMPolicyManager{})
+
+type vSphereSPBMPolicyManager struct {
+	*admission.Handler
+
+	mutex                sync.Mutex
+	cloudConfig          []byte
+	vSphereCloudProvider *vsphere.VSphere
+}
+
+var _ kubeapiserveradmission.WantsCloudConfig = &vSphereSPBMPolicyManager{}
+
+// NewVSphereSPBMPolicyManager returns an admission.Interface implementation which create SPBM storage policies to StorageClass CREATE requests.
+func NewVSphereSPBMPolicyManager() *vSphereSPBMPolicyManager {
+	return &vSphereSPBMPolicyManager{
+		// This handler gets executed only for CREATE/DELETE operation.
+		Handler: admission.NewHandler(admission.Create, admission.Delete, admission.Update),
+	}
+}
+
+func (l *vSphereSPBMPolicyManager) SetCloudConfig(cloudConfig []byte) {
+	l.cloudConfig = cloudConfig
+}
+
+func (l *vSphereSPBMPolicyManager) Admit(a admission.Attributes) (err error) {
+	glog.V(1).Infof("balu - In vsphere admission controller Admit() method, group resource is %+v", a.GetResource().GroupResource())
+	glog.V(1).Infof("balu - In vsphere admission controller Admit() method above all, operation is %+q", a.GetOperation())
+	// Make sure this request is only handled for storage classes API objects.
+	// For all other requests, just return.
+	if a.GetResource().GroupResource() != storageapi.Resource("storageclasses") {
+		return nil
+	}
+
+	// Get the storage class API object.
+	obj := a.GetObject()
+	if obj == nil {
+		glog.V(1).Infof("balu - In vsphere admission controller Admit(), obj is null")
+		return nil
+	}
+	storageClass, ok := obj.(*storageapi.StorageClass)
+	if !ok {
+		glog.V(1).Infof("balu - In vsphere admission controller Admit(), obj: %+v is not storage class", obj)
+		return nil
+	}
+
+	var storageClassParams map[string]string
+	glog.V(1).Infof("balu - In vsphere admission controller Admit(), storage class provisioner is: %+q", storageClass.Provisioner)
+	// Check if provisioner is not empty and execute only if it is a vsphere volume provisioner.
+	// For other provisioners just return back.
+	if storageClass.Provisioner != "" && storageClass.Provisioner == "kubernetes.io/vsphere-volume" {
+		// Get the storage class parameters.
+		storageClassParams = storageClass.Parameters
+		glog.V(1).Infof("balu - In vsphere admission controller, inside storageclass paramaters %+q", storageClassParams)
+		// Check for vmName parameter. Continue if exists, otherwise return.
+		if storageClassParams["vmName"] == "" {
+			glog.V(1).Infof("balu - In vsphere admission controller, no vmName paramater, operation: %q", a.GetOperation())
+			return nil
+		}
+
+		// Get the vSphere cloud provider instance registered with the API server.
+		provider, err := l.getVSphereCloudProvider()
+		if err != nil {
+			return admission.NewForbidden(a, fmt.Errorf("balu - unable to get vSphere cloud provider with err: %+v", err))
+		}
+		if provider == nil {
+			return admission.NewForbidden(a, fmt.Errorf("balu - unable to get vSphere cloud provider"))
+		}
+
+		glog.V(1).Infof("balu - In vsphere admission controller, operation is %+q", a.GetOperation())
+
+		// Check if the operation is STORAGE CLASS CREATE or DELETE.
+		if a.GetOperation() == admission.Create {
+			glog.V(1).Infof("balu - In vsphere admission controller, inside create operation is %+q", a.GetOperation())
+			// In case of CREATE STORAGE CLASS, we create a VM specified in the YAML.
+			err = provider.CreateVMWithAdmissionPlugin(storageClassParams["vmName"])
+			if err != nil {
+				return admission.NewForbidden(a, fmt.Errorf("balu - unable to create a VM with these parameters : %+q", storageClassParams["vmName"]))
+			}
+		} else if a.GetOperation() == admission.Delete {
+			glog.V(1).Infof("balu - In vsphere admission controller, inside delete operation is %+q", a.GetOperation())
+			// In case of DELETE STORAGE CLASS, we delete a VM specified in the YAML.
+			err = provider.DeleteVMWithAdmissionPlugin(storageClassParams["vmName"])
+			if err != nil {
+				return admission.NewForbidden(a, fmt.Errorf("balu - unable to delete a VM with these parameters : %+q", storageClassParams["vmName"]))
+			}
+		}
+	}
+
+	// Success
+	return nil
+}
+
+// getvSphereCloudProvider returns the vSphere cloud provider
+func (l *vSphereSPBMPolicyManager) getVSphereCloudProvider() (*vsphere.VSphere, error) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
+	if l.vSphereCloudProvider == nil {
+		var cloudConfigReader io.Reader
+		if len(l.cloudConfig) > 0 {
+			cloudConfigReader = bytes.NewReader(l.cloudConfig)
+		}
+		cloudProvider, err := cloudprovider.GetCloudProvider("vsphere", cloudConfigReader)
+		if err != nil || cloudProvider == nil {
+			return nil, err
+		}
+		vSphereCloudProvider, ok := cloudProvider.(*vsphere.VSphere)
+		if !ok {
+			// GetCloudProvider has gone very wrong
+			return nil, fmt.Errorf("error retrieving vSphere cloud provider")
+		}
+		l.vSphereCloudProvider = vSphereCloudProvider
+	}
+	return l.vSphereCloudProvider, nil
+}


### PR DESCRIPTION
1. What is the current problem?

- Till now we completely rely on kubernetes to issue a request to the vSphere cloud provider for volume management. All our volume management code resides in our implementation to the Kubernetes cloud provider interface. For example, consider our newly designed vSphere SPBM storage policy management feature where the user specifies the policy parameters in the storage class definition. Right now, we defer the policy creation until a PVC is created which is not the right user experience at all. 

- As a user, I want the policy to be created immediately after the storage class is created. (GOOD USER EXPERIENCE). But the problem is CREATE/DELETE storage class request doesn't generate a request to the vSphere Cloud provider interface where we manage all our code.

- So, inorder to overcome this problem we need a way to intercept the storage class API request before it gets provisioned successfully on the Kubernetes API SERVER. For this, we move onto Kubernetes admissions controller plugins which will help us achieve this functionality. Inorder to accomplish some advanced features in Kubernetes, we require an admission control plug-in to be enabled in order to properly support the feature. As a result, a Kubernetes API server that is not properly configured with the right set of admission control plug-ins is an incomplete server and will not support all the features you expect.

2. Let's take a use case.

- When the user wants to create a storage class with SPBM policy attributes. User creates a storage class with storage policy attributes.
```
kind: StorageClass
apiVersion: storage.k8s.io/v1beta1
metadata:
  name: Prodspbmpolicy
provisioner: kubernetes.io/vsphere-volume
parameters:
  hostFailuresToTolerate: 2
  proportionalCapacity:1
```

- The STORAGECLASS CREATE request will be intercepted by our new admission controller plugin we have written and will create a SPBM policy out of it which in this case is "spbmpolicy".
Here we create a SPBM policy with the same name as the storage class.
The storage class is a global entity in a kubernetes cluster and hence its name is unique in a single cluster.

- If the user creates a storage class with the same name in a different kubernetes cluster, we have 2 options. We either error out to the user that a SPBM policy is already created. Please use a different name (I think this is not a good USER EXPERIENCE). Append, storageclassName with some UNIQUE_ID for a cluster, that helps differentiate storage classes with the same name across multiple kubernetes cluster. (This is a good user experience but have to identify what UNIQUE_ID can be used that is unique for a cluster).

- User creates a PVC with the above created storage class.
```
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: policy-claim
  annotations:
    volume.beta.kubernetes.io/storage-class: Prodspbmpolicy
spec:
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 2Gi
```
The vSphere cloud provider will create a persistent volume with the policy configured with "Prodspbmpolicy" Name already created on the VC.