### PR TITLE
Automated cherry pick of #44570 #44862

### DIFF
--- a/pkg/client/unversioned/clientcmd/client_config.go
+++ b/pkg/client/unversioned/clientcmd/client_config.go
@@ -446,13 +446,13 @@ func (inClusterClientConfig) Namespace() (string, bool, error) {
 	// This way assumes you've set the POD_NAMESPACE environment variable using the downward API.
 	// This check has to be done first for backwards compatibility with the way InClusterConfig was originally set up
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
-		return ns, true, nil
+		return ns, false, nil
 	}
 
 	// Fall back to the namespace associated with the service account token, if available
 	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
-			return ns, true, nil
+			return ns, false, nil
 		}
 	}
 

--- a/pkg/client/unversioned/clientcmd/merged_client_builder.go
+++ b/pkg/client/unversioned/clientcmd/merged_client_builder.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/restclient"
 	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
 )
@@ -134,12 +135,26 @@ func (config *DeferredLoadingClientConfig) Namespace() (string, bool, error) {
 		return "", false, err
 	}
 
-	ns, ok, err := mergedKubeConfig.Namespace()
+	ns, overridden, err := mergedKubeConfig.Namespace()
 	// if we get an error and it is not empty config, or if the merged config defined an explicit namespace, or
 	// if in-cluster config is not possible, return immediately
-	if (err != nil && !IsEmptyConfig(err)) || ok || !config.icc.Possible() {
+	if (err != nil && !IsEmptyConfig(err)) || overridden || !config.icc.Possible() {
 		// return on any error except empty config
-		return ns, ok, err
+		return ns, overridden, err
+	}
+
+	if len(ns) > 0 {
+		// if we got a non-default namespace from the kubeconfig, use it
+		if ns != api.NamespaceDefault {
+			return ns, false, nil
+		}
+
+		// if we got a default namespace, determine whether it was explicit or implicit
+		if raw, err := mergedKubeConfig.RawConfig(); err == nil {
+			if context := raw.Contexts[raw.CurrentContext]; context != nil && len(context.Namespace) > 0 {
+				return ns, false, nil
+			}
+		}
 	}
 
 	glog.V(4).Infof("Using in-cluster namespace")

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -446,13 +446,13 @@ func (inClusterClientConfig) Namespace() (string, bool, error) {
 	// This way assumes you've set the POD_NAMESPACE environment variable using the downward API.
 	// This check has to be done first for backwards compatibility with the way InClusterConfig was originally set up
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
-		return ns, true, nil
+		return ns, false, nil
 	}
 
 	// Fall back to the namespace associated with the service account token, if available
 	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
-			return ns, true, nil
+			return ns, false, nil
 		}
 	}
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -134,12 +135,26 @@ func (config *DeferredLoadingClientConfig) Namespace() (string, bool, error) {
 		return "", false, err
 	}
 
-	ns, ok, err := mergedKubeConfig.Namespace()
+	ns, overridden, err := mergedKubeConfig.Namespace()
 	// if we get an error and it is not empty config, or if the merged config defined an explicit namespace, or
 	// if in-cluster config is not possible, return immediately
-	if (err != nil && !IsEmptyConfig(err)) || ok || !config.icc.Possible() {
+	if (err != nil && !IsEmptyConfig(err)) || overridden || !config.icc.Possible() {
 		// return on any error except empty config
-		return ns, ok, err
+		return ns, overridden, err
+	}
+
+	if len(ns) > 0 {
+		// if we got a non-default namespace from the kubeconfig, use it
+		if ns != api.NamespaceDefault {
+			return ns, false, nil
+		}
+
+		// if we got a default namespace, determine whether it was explicit or implicit
+		if raw, err := mergedKubeConfig.RawConfig(); err == nil {
+			if context := raw.Contexts[raw.CurrentContext]; context != nil && len(context.Namespace) > 0 {
+				return ns, false, nil
+			}
+		}
 	}
 
 	glog.V(4).Infof("Using in-cluster namespace")


### PR DESCRIPTION
Cherry pick of #44570 #44862 on release-1.5.

#44570: Explicit namespace from kubeconfig should override in-cluster
#44862: Stop treating in-cluster-config namespace as an override