### PR TITLE
Revert "[Federation] Build a simple hyperkube image on-the-fly only containing the hyperkube binary for development and testing purposes."

### DIFF
--- a/federation/develop/develop.sh
+++ b/federation/develop/develop.sh
@@ -43,9 +43,6 @@ readonly TMP_DIR="$(mktemp -d)"
 readonly FEDERATION_OUTPUT_ROOT="${LOCAL_OUTPUT_ROOT}/federation"
 readonly VERSIONS_FILE="${FEDERATION_OUTPUT_ROOT}/versions"
 
-readonly KUBE_PLATFORM=${KUBE_PLATFORM:-linux}
-readonly KUBE_ARCH=${KUBE_ARCH:-amd64}
-
 if [[ "${KUBERNETES_PROVIDER}" == "gke" || "${KUBERNETES_PROVIDER}" == "gce" ]]; then
   detect-project
   readonly KUBE_PROJECT="${KUBE_PROJECT:-${PROJECT:-}}"
@@ -70,7 +67,7 @@ function dirty_sha() {
   local -r index="${KUBE_ROOT}/.git/index"
   local -r objects_dir="${KUBE_ROOT}/.git/objects"
 
-  local -r tmp_dir="${TMP_DIR}/git/.git"
+  local -r tmp_dir="${TMP_DIR}/.git"
   local -r tmp_index="${tmp_dir}/index"
   local -r tmp_objects_dir="${tmp_dir}/objects"
 
@@ -86,7 +83,7 @@ function build_binaries() {
   cd "${KUBE_ROOT}"
   kube::build::verify_prereqs
   kube::build::build_image
-  kube::build::run_build_command make WHAT="cmd/kubectl cmd/hyperkube federation/cmd/kubefed"
+  kube::build::run_build_command make WHAT="cmd/kubectl cmd/hyperkube"
   kube::build::copy_output
 }
 
@@ -112,35 +109,10 @@ function build_image() {
 }" > "${VERSIONS_FILE}"
   kube::log::status "Wrote to version file ${VERSIONS_FILE}: ${kube_version}"
 
-  local -r binary="hyperkube"
-  local -r image="hyperkube-amd64"
-  local -r bin_path="${LOCAL_OUTPUT_BINPATH}/${KUBE_PLATFORM}/${KUBE_ARCH}/hyperkube"
-
-  if [[ ! -f "${bin_path}" ]]; then
-    echo "${bin_path} does not exist"
-    exit 1
-  fi
-
-  local docker_build_path="${TMP_DIR}/dockerbuild"
-  local docker_file_path="${docker_build_path}/Dockerfile"
-
-  rm -rf ${docker_build_path}
-  mkdir -p ${docker_build_path}
-
-  cp "${bin_path}" "${docker_build_path}/${binary}"
-  printf " FROM ubuntu:16.04 \n ADD ${binary} /${binary}\n" > ${docker_file_path}
-
-  local docker_image_tag="${KUBE_REGISTRY}:${kube_version}"
-
-  # Build the docker image on-the-fly.
-  #
-  # NOTE: This is only a temporary fix until the proposal in issue
-  # https://github.com/kubernetes/kubernetes/issues/28630 is implemented.
-  # Also, the new turn up mechanism completely obviates this step.
-  kube::log::status "Building docker image ${docker_image_tag} from the binary"
-  docker build --pull -q -t "${docker_image_tag}" ${docker_build_path} >/dev/null
-
-  rm -rf ${docker_build_path}
+  BASEIMAGE="ubuntu:16.04" \
+    REGISTRY="${KUBE_REGISTRY}" \
+    VERSION="${kube_version}" \
+    make -C "${KUBE_ROOT}/cluster/images/hyperkube" build
 }
 
 function get_version() {


### PR DESCRIPTION
Reverts kubernetes/kubernetes#43181

Federation CI and PR tests are completely broken. No time to root cause this, but the merge time of PR #43181 and failures match. So we are going to try by reverting this.