### PR TITLE
Allow colons in file path during `kubectl cp`

### DIFF
--- a/pkg/kubectl/cmd/cp_test.go
+++ b/pkg/kubectl/cmd/cp_test.go
@@ -49,7 +49,35 @@ func TestExtractFileSpec(t *testing.T) {
 			expectedFile: "/some/file",
 		},
 		{
-			spec:      "some:bad:spec",
+			spec:              "namespace/pod:/some/file/with/timestamp-00:00:00",
+			expectedPod:       "pod",
+			expectedNamespace: "namespace",
+			expectedFile:      "/some/file/with/timestamp-00:00:00",
+		},
+		{
+			spec:         "pod:/some/file/with/timestamp-00:00:00",
+			expectedPod:  "pod",
+			expectedFile: "/some/file/with/timestamp-00:00:00",
+		},
+		{
+			spec:         "/some/file/with/timestamp-00:00:00",
+			expectedFile: "/some/file/with/timestamp-00:00:00",
+		},
+		{
+			spec:         "/some:/file",
+			expectedFile: "/some:/file",
+		},
+		{
+			spec:         "some/:/file",
+			expectedFile: "some/:/file",
+		},
+		{
+			spec:         "pod:some:file",
+			expectedPod:  "pod",
+			expectedFile: "some:file",
+		},
+		{
+			spec:      "",
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
Use a more permissive regex to allow file paths that contain colons.
The fileSpec format is `[[namespace/]pod:]file/path`, leading to:

    (?:(?:([^/:]+)/)?(?:([^/:]+):))?(.+)

- An optional non-capturing group wrapping the namespace/pod prefix
  - A optional non-capturing group wrapping the namespace and literal
    `/` separator
    - A capturing group for the namespace, matching at least one
      character that isn't a `/` or `:` separator
  - A non-capturing group wrapping the pod and `:` separator
    - A capturing group for the pod, matching at least one character
      that isn't a `/` or `:` separator
- A capturing group for the file path, matching at least one character

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This is necessary for e.g. copying a log whose file path contains a timestamp

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
