### PR TITLE
CRI: clarify the behavior of PodSandboxStatus and ContainerStatus

### DIFF
--- a/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.pb.go
@@ -2937,7 +2937,8 @@ type RuntimeServiceClient interface {
 	// This call is idempotent, and must not return an error if the sandbox has
 	// already been removed.
 	RemovePodSandbox(ctx context.Context, in *RemovePodSandboxRequest, opts ...grpc.CallOption) (*RemovePodSandboxResponse, error)
-	// PodSandboxStatus returns the status of the PodSandbox.
+	// PodSandboxStatus returns the status of the PodSandbox. If the PodSandbox is not
+	// present, returns an error.
 	PodSandboxStatus(ctx context.Context, in *PodSandboxStatusRequest, opts ...grpc.CallOption) (*PodSandboxStatusResponse, error)
 	// ListPodSandbox returns a list of PodSandboxes.
 	ListPodSandbox(ctx context.Context, in *ListPodSandboxRequest, opts ...grpc.CallOption) (*ListPodSandboxResponse, error)
@@ -2957,7 +2958,8 @@ type RuntimeServiceClient interface {
 	RemoveContainer(ctx context.Context, in *RemoveContainerRequest, opts ...grpc.CallOption) (*RemoveContainerResponse, error)
 	// ListContainers lists all containers by filters.
 	ListContainers(ctx context.Context, in *ListContainersRequest, opts ...grpc.CallOption) (*ListContainersResponse, error)
-	// ContainerStatus returns status of the container.
+	// ContainerStatus returns status of the container. If the container is not
+	// present, returns an error.
 	ContainerStatus(ctx context.Context, in *ContainerStatusRequest, opts ...grpc.CallOption) (*ContainerStatusResponse, error)
 	// ExecSync runs a command in a container synchronously.
 	ExecSync(ctx context.Context, in *ExecSyncRequest, opts ...grpc.CallOption) (*ExecSyncResponse, error)
@@ -3166,7 +3168,8 @@ type RuntimeServiceServer interface {
 	// This call is idempotent, and must not return an error if the sandbox has
 	// already been removed.
 	RemovePodSandbox(context.Context, *RemovePodSandboxRequest) (*RemovePodSandboxResponse, error)
-	// PodSandboxStatus returns the status of the PodSandbox.
+	// PodSandboxStatus returns the status of the PodSandbox. If the PodSandbox is not
+	// present, returns an error.
 	PodSandboxStatus(context.Context, *PodSandboxStatusRequest) (*PodSandboxStatusResponse, error)
 	// ListPodSandbox returns a list of PodSandboxes.
 	ListPodSandbox(context.Context, *ListPodSandboxRequest) (*ListPodSandboxResponse, error)
@@ -3186,7 +3189,8 @@ type RuntimeServiceServer interface {
 	RemoveContainer(context.Context, *RemoveContainerRequest) (*RemoveContainerResponse, error)
 	// ListContainers lists all containers by filters.
 	ListContainers(context.Context, *ListContainersRequest) (*ListContainersResponse, error)
-	// ContainerStatus returns status of the container.
+	// ContainerStatus returns status of the container. If the container is not
+	// present, returns an error.
 	ContainerStatus(context.Context, *ContainerStatusRequest) (*ContainerStatusResponse, error)
 	// ExecSync runs a command in a container synchronously.
 	ExecSync(context.Context, *ExecSyncRequest) (*ExecSyncResponse, error)

--- a/pkg/kubelet/api/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/api/v1alpha1/runtime/api.proto
@@ -36,7 +36,8 @@ service RuntimeService {
     // This call is idempotent, and must not return an error if the sandbox has
     // already been removed.
     rpc RemovePodSandbox(RemovePodSandboxRequest) returns (RemovePodSandboxResponse) {}
-    // PodSandboxStatus returns the status of the PodSandbox.
+    // PodSandboxStatus returns the status of the PodSandbox. If the PodSandbox is not
+    // present, returns an error.
     rpc PodSandboxStatus(PodSandboxStatusRequest) returns (PodSandboxStatusResponse) {}
     // ListPodSandbox returns a list of PodSandboxes.
     rpc ListPodSandbox(ListPodSandboxRequest) returns (ListPodSandboxResponse) {}
@@ -57,7 +58,8 @@ service RuntimeService {
     rpc RemoveContainer(RemoveContainerRequest) returns (RemoveContainerResponse) {}
     // ListContainers lists all containers by filters.
     rpc ListContainers(ListContainersRequest) returns (ListContainersResponse) {}
-    // ContainerStatus returns status of the container.
+    // ContainerStatus returns status of the container. If the container is not
+    // present, returns an error.
     rpc ContainerStatus(ContainerStatusRequest) returns (ContainerStatusResponse) {}
 
     // ExecSync runs a command in a container synchronously.


### PR DESCRIPTION

**What this PR does / why we need it**:
Currently, we define that ImageStatus should return `nil, nil` when requested image doesn't exist, and kubelet is relying on this behavior now.

However, we haven't clearly defined the behavior of PodSandboxStatus and ContainerStatus. Currently, they return error when requested sandbox/container doesn't exist, and kubelet is also relying on this behavior.

**Which issue this PR fixes** 

Fixes #44885.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
