### PR TITLE
Assign label to pod when exec 'kubectl run' command with flags "--expose=true" and "--restart=Never"

### DIFF
--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -76,7 +76,7 @@ func (DeploymentV1Beta1) Generate(genericParams map[string]interface{}) (runtime
 		return nil, err
 	}
 
-	labels, err := getLabels(params, true, name)
+	labels, err := getLabels(params, name)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func (DeploymentAppsV1Beta1) Generate(genericParams map[string]interface{}) (run
 		return nil, err
 	}
 
-	labels, err := getLabels(params, true, name)
+	labels, err := getLabels(params, name)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func (DeploymentAppsV1Beta1) Generate(genericParams map[string]interface{}) (run
 }
 
 // getLabels returns map of labels.
-func getLabels(params map[string]string, defaultRunLabel bool, name string) (map[string]string, error) {
+func getLabels(params map[string]string, name string) (map[string]string, error) {
 	labelString, found := params["labels"]
 	var labels map[string]string
 	var err error
@@ -219,7 +219,7 @@ func getLabels(params map[string]string, defaultRunLabel bool, name string) (map
 		if err != nil {
 			return nil, err
 		}
-	} else if defaultRunLabel {
+	} else {
 		labels = map[string]string{
 			"run": name,
 		}
@@ -330,7 +330,7 @@ func (JobV1) Generate(genericParams map[string]interface{}) (runtime.Object, err
 		return nil, err
 	}
 
-	labels, err := getLabels(params, true, name)
+	labels, err := getLabels(params, name)
 	if err != nil {
 		return nil, err
 	}
@@ -424,7 +424,7 @@ func (CronJobV2Alpha1) Generate(genericParams map[string]interface{}) (runtime.O
 		return nil, err
 	}
 
-	labels, err := getLabels(params, true, name)
+	labels, err := getLabels(params, name)
 	if err != nil {
 		return nil, err
 	}
@@ -637,7 +637,7 @@ func (BasicReplicationController) Generate(genericParams map[string]interface{})
 		return nil, err
 	}
 
-	labels, err := getLabels(params, true, name)
+	labels, err := getLabels(params, name)
 	if err != nil {
 		return nil, err
 	}
@@ -785,7 +785,7 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 		return nil, err
 	}
 
-	labels, err := getLabels(params, false, name)
+	labels, err := getLabels(params, name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -417,7 +417,8 @@ func TestGeneratePod(t *testing.T) {
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
+					Name:   "foo",
+					Labels: map[string]string{"run": "foo"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -451,7 +452,8 @@ func TestGeneratePod(t *testing.T) {
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
+					Name:   "foo",
+					Labels: map[string]string{"run": "foo"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -484,7 +486,8 @@ func TestGeneratePod(t *testing.T) {
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
+					Name:   "foo",
+					Labels: map[string]string{"run": "foo"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
@@ -513,7 +516,8 @@ func TestGeneratePod(t *testing.T) {
 			},
 			expected: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo",
+					Name:   "foo",
+					Labels: map[string]string{"run": "foo"},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
As the title says and issue #40503 mentioned.
cc @tanapoln 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #40503

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
