### PR TITLE
Use correct option name in the kubernetes-worker layer registry action

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -98,7 +98,7 @@ if create_response == 0:
 
     if check_cm_response == 0:
         # There is an existing ConfigMap, patch it
-        patch = '{"data":{"max-body-size":"1024m"}}'
+        patch = '{"data":{"body-size":"1024m"}}'
         patch_cm_command = kubectl + ['patch', 'cm', cm_name, '-p', patch]
         patch_cm_response = call(patch_cm_command)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: It fixes #44920 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #44920 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
Ensure kubernetes-worker juju layer registry action uses correct ingress controller option name
```
