### PR TITLE
OWNERS: add directxman12 to pkg/apis/autoscaling

### DIFF
--- a/pkg/apis/autoscaling/OWNERS
+++ b/pkg/apis/autoscaling/OWNERS
@@ -17,3 +17,4 @@ reviewers:
 - mbohlool
 - david-mcmahon
 - jianhuiz
+- directxman12

--- a/staging/src/k8s.io/client-go/pkg/apis/autoscaling/OWNERS
+++ b/staging/src/k8s.io/client-go/pkg/apis/autoscaling/OWNERS
@@ -17,3 +17,4 @@ reviewers:
 - mbohlool
 - david-mcmahon
 - jianhuiz
+- directxman12


### PR DESCRIPTION
Added directxman12 (current SIG lead of SIG-autoscaling) as a reviewer for pkg/apis/autoscaling.

**Release note**:
```release-note
NONE
```
