### PR TITLE
Add mirror of nfs-provisioner to test/images for pushing to GCR

### DIFF
--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -830,7 +830,7 @@ func startExternalProvisioner(c clientset.Interface, ns string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "nfs-provisioner",
-					Image: "quay.io/kubernetes_incubator/nfs-provisioner:v1.0.6",
+					Image: "gcr.io/google_containers/nfs-provisioner:v1.0.7",
 					SecurityContext: &v1.SecurityContext{
 						Capabilities: &v1.Capabilities{
 							Add: []v1.Capability{"DAC_READ_SEARCH"},

--- a/test/images/volumes-tester/nfs-provisioner/Makefile
+++ b/test/images/volumes-tester/nfs-provisioner/Makefile
@@ -1,0 +1,32 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TAG = v1.0.7
+PREFIX = gcr.io/google_containers
+INCUBATOR_PREFIX = quay.io/kubernetes_incubator
+
+all: push
+
+container: image
+
+image:
+	docker pull $(INCUBATOR_PREFIX)/nfs-provisioner:$(TAG) # Pull the nfs-provisioner image from the quay incubator repository
+	docker tag $(INCUBATOR_PREFIX)/nfs-provisioner:$(TAG) $(PREFIX)/nfs-provisioner:$(TAG) # Create a gcr tag that refers to it
+	docker tag $(PREFIX)/nfs-provisioner $(PREFIX)/nfs-provisioner:$(TAG) # Add the latest tag to the versioned image
+
+push: image
+	gcloud docker -- push $(PREFIX)/nfs-provisioner # Push image tagged as latest to repository
+	gcloud docker -- push $(PREFIX)/nfs-provisioner:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+
+clean:

--- a/test/images/volumes-tester/nfs-provisioner/README.md
+++ b/test/images/volumes-tester/nfs-provisioner/README.md
@@ -1,0 +1,7 @@
+# NFS external provisioner container for testing
+
+This container is simply a mirror of the NFS external provisioner whose code lives at
+https://github.com/kubernetes-incubator/external-storage/tree/master/nfs
+
+Used by test/e2e/* to test the kubernetes-side interface for external provisioners
+https://github.com/kubernetes/kubernetes/pull/30285


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/pull/44358#issuecomment-296964830 and https://groups.google.com/forum/#!topic/kubernetes-sig-testing/oZ4GbTt1riE for full context. We want to move this image being used in the e2e test from quay to gcr, to hopefully reduce flakes where the image pulling just mysteriously fails. (And to stop overloading the user-facing quay repo with misleading stats of hundreds of pulls per day!)

I tried checking in the actual code of nfs-provisioner so that we can build the entire container here, but building it is effectively impossible without dependency management because both kube and the program depend on client-go. It would be pretty excessive to check in all that code here. So I hope just mirroring it from the official quay repo by retagging it is good enough, let's decide...

@jsafrane @saad-ali wdyt

```release-note
NONE
```
