### PR TITLE
Automated cherry pick of #44860

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.5.1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.5.2",
                 "command": [
                     "./run.sh",
                     "--kubernetes=http://127.0.0.1:8080?inClusterConfig=f",


### PR DESCRIPTION
Cherry pick of #44860 on release-1.6.

#44860: Bump Cluster Autoscaler to 0.5.2

```release-note
Fix problems with scaling up the cluster when unschedulable pods have some persistent volume claims.
```