### PR TITLE
Fixes get -oname for unstructured objects

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -1362,6 +1362,8 @@ __EOF__
   kubectl "${kube_flags[@]}" get foos/test -o "jsonpath={.someField}"          --allow-missing-template-keys=false
   kubectl "${kube_flags[@]}" get foos      -o "go-template={{range .items}}{{.someField}}{{end}}" --allow-missing-template-keys=false
   kubectl "${kube_flags[@]}" get foos/test -o "go-template={{.someField}}"                        --allow-missing-template-keys=false
+  output_message=$(kubectl get foos/test -o name)
+  kube::test::if_has_string "${output_message}" 'foos/test'
 
   # Test patching
   kube::log::status "Testing ThirdPartyResource patching"

--- a/pkg/kubectl/cmd/util/factory_builder.go
+++ b/pkg/kubectl/cmd/util/factory_builder.go
@@ -46,7 +46,10 @@ func NewBuilderFactory(clientAccessFactory ClientAccessFactory, objectMappingFac
 }
 
 func (f *ring2Factory) PrinterForCommand(cmd *cobra.Command) (printers.ResourcePrinter, bool, error) {
-	mapper, typer := f.objectMappingFactory.Object()
+	mapper, typer, err := f.objectMappingFactory.UnstructuredObject()
+	if err != nil {
+		return nil, false, err
+	}
 	// TODO: used by the custom column implementation and the name implementation, break this dependency
 	decoders := []runtime.Decoder{f.clientAccessFactory.Decoder(true), unstructured.UnstructuredJSONScheme}
 	return PrinterForCommand(cmd, mapper, typer, decoders)

--- a/pkg/printers/name.go
+++ b/pkg/printers/name.go
@@ -62,26 +62,24 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 		}
 	}
 
-	kind := obj.GetObjectKind().GroupVersionKind()
-	if len(kind.Kind) == 0 {
-		if gvks, _, err := p.Typer.ObjectKinds(obj); err == nil {
-			for _, gvk := range gvks {
-				if mappings, err := p.Mapper.RESTMappings(gvk.GroupKind(), gvk.Version); err == nil && len(mappings) > 0 {
-					fmt.Fprintf(w, "%s/%s\n", mappings[0].Resource, name)
-				}
-			}
-		} else {
-			fmt.Fprintf(w, "<unknown>/%s\n", name)
-		}
-
-	} else {
-		if mappings, err := p.Mapper.RESTMappings(kind.GroupKind(), kind.Version); err == nil && len(mappings) > 0 {
+	groupVersionKind := obj.GetObjectKind().GroupVersionKind()
+	if len(groupVersionKind.Kind) > 0 {
+		if mappings, err := p.Mapper.RESTMappings(groupVersionKind.GroupKind(), groupVersionKind.Version); err == nil && len(mappings) > 0 {
 			fmt.Fprintf(w, "%s/%s\n", mappings[0].Resource, name)
-		} else {
-			fmt.Fprintf(w, "<unknown>/%s\n", name)
+			return nil
 		}
 	}
 
+	if gvks, _, err := p.Typer.ObjectKinds(obj); err == nil {
+		for _, gvk := range gvks {
+			if mappings, err := p.Mapper.RESTMappings(gvk.GroupKind(), gvk.Version); err == nil && len(mappings) > 0 {
+				fmt.Fprintf(w, "%s/%s\n", mappings[0].Resource, name)
+				return nil
+			}
+		}
+	}
+
+	fmt.Fprintf(w, "<unknown>/%s\n", name)
 	return nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/44832

Make sure we display kind in `kubectl get -o name` for unknown resource types.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
