### PR TITLE
Closes #44392

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/actions.yaml
+++ b/cluster/juju/layers/kubernetes-worker/actions.yaml
@@ -1,6 +1,17 @@
 pause:
     description: |
       Cordon the unit, draining all active workloads.
+    params:
+      delete-local-data:
+        type: boolean
+        description: Force deletion of local storage to enable a drain
+        default: False
+      force:
+        type: boolean
+        description: |
+            Continue even if there are pods not managed by a RC, RS, Job, DS or SS
+        default: False
+
 resume:
     description: |
       UnCordon the unit, enabling workload scheduling.

--- a/cluster/juju/layers/kubernetes-worker/actions/pause
+++ b/cluster/juju/layers/kubernetes-worker/actions/pause
@@ -4,6 +4,25 @@ set -ex
 
 export PATH=$PATH:/snap/bin
 
+DELETE_LOCAL_DATA=$(action-get delete-local-data)
+FORCE=$(action-get force)
+
+# placeholder for additional flags to the command
+export EXTRA_FLAGS=""
+
+# Determine if we have extra flags
+if [[ "${DELETE_LOCAL_DATA}" == "True" || "${DELETE_LOCAL_DATA}" == "true" ]]; then
+  EXTRA_FLAGS="${EXTRA_FLAGS} --delete-local-data=true"
+fi
+
+if [[ "${FORCE}" == "True" || "${FORCE}" == "true" ]]; then
+  EXTRA_FLAGS="${EXTRA_FLAGS} --force"
+fi
+
+
+# Cordon and drain the unit
 kubectl --kubeconfig=/root/cdk/kubeconfig cordon $(hostname)
-kubectl --kubeconfig=/root/cdk/kubeconfig drain $(hostname) --force
+kubectl --kubeconfig=/root/cdk/kubeconfig drain $(hostname) ${EXTRA_FLAGS}
+
+# Set status to indicate the unit is paused and under maintenance.
 status-set 'waiting' 'Kubernetes unit paused'


### PR DESCRIPTION

**What this PR does / why we need it**:

Fix the pause action with regard to the new behavior where
--delete-local-data=false by default. Historically --force was all that
was required, this flag has changed to be more descriptive of the
actions it's taking.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #44392


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Added support to the pause action in the kubernetes-worker charm for new flag --delete-local-data
```
