### PR TITLE
apimachinery/pkg/util/wait: Fix potential goroutine leak in pollInternal().

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/wait/wait.go
@@ -186,7 +186,9 @@ func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
 }
 
 func pollInternal(wait WaitFunc, condition ConditionFunc) error {
-	return WaitFor(wait, condition, NeverStop)
+	done := make(chan struct{})
+	defer close(done)
+	return WaitFor(wait, condition, done)
 }
 
 // PollImmediate tries a condition func until it returns true, an error, or the timeout


### PR DESCRIPTION
**What this PR does / why we need it**:

Without the change, the wait function wouldn't exit until the timeout
happens, so if the timeout is set to a big value and the Poll() is run
inside a loop, then the total goroutines will increase indefinitely.

This PR fixes the issue by closing the stop channel to tell the wait function
to exit immediately if condition is true or any error happens.
