### PR TITLE
Fixes #43461

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -296,6 +296,22 @@ def start_master(etcd):
     set_state('kubernetes-master.components.started')
 
 
+@when('etcd.available')
+def etcd_data_change(etcd):
+    ''' Etcd scale events block master reconfiguration due to the
+        kubernetes-master.components.started state. We need a way to
+        handle these events consistenly only when the number of etcd
+        units has actually changed '''
+
+    # key off of the connection string
+    connection_string = etcd.get_connection_string()
+
+    # If the connection string changes, remove the started state to trigger
+    # handling of the master components
+    if data_changed('etcd-connect', connection_string):
+        remove_state('kubernetes-master.components.started')
+
+
 @when('kube-control.connected')
 @when('cdk-addons.configured')
 def send_cluster_dns_detail(kube_control):


### PR DESCRIPTION


**What this PR does / why we need it**:
The master-components started state triggers a daemon recycle. The guard
was to prevent the daemons from being cycled too often and interrupting
normal workflow. This additional state check is probing the etcd
connection and if changing triggers a re-configure and recycle of the api-control 
plane when etcd units are scaling up and down.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43461

**Special notes for your reviewer**:
Check the contents of /var/snap/kube-apiserver/current/args after scaling etcd both up and down and the values will have changed, and kube-apiserver will have recycled to read the new connection string.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
kubernetes-master juju charm properly detects etcd-scale events and reconfigures appropriately.
```
