### PR TITLE
CRI: Fix StopContainer timeout

### DIFF
--- a/pkg/kubelet/remote/remote_runtime.go
+++ b/pkg/kubelet/remote/remote_runtime.go
@@ -209,7 +209,11 @@ func (r *RemoteRuntimeService) StartContainer(containerID string) error {
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
 func (r *RemoteRuntimeService) StopContainer(containerID string, timeout int64) error {
-	ctx, cancel := getContextWithTimeout(r.timeout)
+	ctx, cancel := getContextWithTimeout(time.Duration(timeout) * time.Second)
+	if timeout == 0 {
+		// Use default timeout if stop timeout is 0.
+		ctx, cancel = getContextWithTimeout(r.timeout)
+	}
 	defer cancel()
 
 	_, err := r.runtimeClient.StopContainer(ctx, &runtimeapi.StopContainerRequest{


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/44956.

I verified this PR with the example provided in https://github.com/kubernetes/kubernetes/issues/44956, and now pod deletion will respect grace period timeout:
```
NAME                         READY     STATUS        RESTARTS   AGE
gracefully-terminating-pod   1/1       Terminating   0          6m
```

@dchen1107 @yujuhong @feiskyer /cc @kubernetes/sig-node-bugs 