### PR TITLE
Remove import of internal api package in generated external-versioned listers

### DIFF
--- a/cmd/libs/go2idl/lister-gen/generators/lister.go
+++ b/cmd/libs/go2idl/lister-gen/generators/lister.go
@@ -220,7 +220,7 @@ func (g *listerGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 
 	glog.V(5).Infof("processing type %v", t)
 	m := map[string]interface{}{
-		"Resource":   c.Universe.Function(types.Name{Package: g.internalGVPkg, Name: "Resource"}),
+		"Resource":   c.Universe.Function(types.Name{Package: t.Name.Package, Name: "Resource"}),
 		"type":       t,
 		"objectMeta": g.objectMeta,
 	}

--- a/pkg/apis/autoscaling/v2alpha1/register.go
+++ b/pkg/apis/autoscaling/v2alpha1/register.go
@@ -28,6 +28,11 @@ const GroupName = "autoscaling"
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v2alpha1"}
 
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
 var (
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, addDefaultingFuncs)
 	AddToScheme   = SchemeBuilder.AddToScheme

--- a/pkg/client/listers/apps/v1beta1/BUILD
+++ b/pkg/client/listers/apps/v1beta1/BUILD
@@ -19,7 +19,6 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//pkg/apis/apps:go_default_library",
         "//pkg/apis/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/apps/v1beta1/deployment.go
+++ b/pkg/client/listers/apps/v1beta1/deployment.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	apps "k8s.io/kubernetes/pkg/apis/apps"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s deploymentNamespaceLister) Get(name string) (*v1beta1.Deployment, error)
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(apps.Resource("deployment"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("deployment"), name)
 	}
 	return obj.(*v1beta1.Deployment), nil
 }

--- a/pkg/client/listers/apps/v1beta1/scale.go
+++ b/pkg/client/listers/apps/v1beta1/scale.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	apps "k8s.io/kubernetes/pkg/apis/apps"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s scaleNamespaceLister) Get(name string) (*v1beta1.Scale, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(apps.Resource("scale"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("scale"), name)
 	}
 	return obj.(*v1beta1.Scale), nil
 }

--- a/pkg/client/listers/apps/v1beta1/statefulset.go
+++ b/pkg/client/listers/apps/v1beta1/statefulset.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	apps "k8s.io/kubernetes/pkg/apis/apps"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s statefulSetNamespaceLister) Get(name string) (*v1beta1.StatefulSet, erro
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(apps.Resource("statefulset"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("statefulset"), name)
 	}
 	return obj.(*v1beta1.StatefulSet), nil
 }

--- a/pkg/client/listers/authentication/v1/BUILD
+++ b/pkg/client/listers/authentication/v1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/authentication:go_default_library",
         "//pkg/apis/authentication/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/authentication/v1/tokenreview.go
+++ b/pkg/client/listers/authentication/v1/tokenreview.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	authentication "k8s.io/kubernetes/pkg/apis/authentication"
 	v1 "k8s.io/kubernetes/pkg/apis/authentication/v1"
 )
 
@@ -62,7 +61,7 @@ func (s *tokenReviewLister) Get(name string) (*v1.TokenReview, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(authentication.Resource("tokenreview"), name)
+		return nil, errors.NewNotFound(v1.Resource("tokenreview"), name)
 	}
 	return obj.(*v1.TokenReview), nil
 }

--- a/pkg/client/listers/authentication/v1beta1/BUILD
+++ b/pkg/client/listers/authentication/v1beta1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/authentication:go_default_library",
         "//pkg/apis/authentication/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/authentication/v1beta1/tokenreview.go
+++ b/pkg/client/listers/authentication/v1beta1/tokenreview.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	authentication "k8s.io/kubernetes/pkg/apis/authentication"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/authentication/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *tokenReviewLister) Get(name string) (*v1beta1.TokenReview, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(authentication.Resource("tokenreview"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("tokenreview"), name)
 	}
 	return obj.(*v1beta1.TokenReview), nil
 }

--- a/pkg/client/listers/authorization/v1/BUILD
+++ b/pkg/client/listers/authorization/v1/BUILD
@@ -17,7 +17,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/authorization:go_default_library",
         "//pkg/apis/authorization/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/authorization/v1/localsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1/localsubjectaccessreview.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	authorization "k8s.io/kubernetes/pkg/apis/authorization"
 	v1 "k8s.io/kubernetes/pkg/apis/authorization/v1"
 )
 
@@ -89,7 +88,7 @@ func (s localSubjectAccessReviewNamespaceLister) Get(name string) (*v1.LocalSubj
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(authorization.Resource("localsubjectaccessreview"), name)
+		return nil, errors.NewNotFound(v1.Resource("localsubjectaccessreview"), name)
 	}
 	return obj.(*v1.LocalSubjectAccessReview), nil
 }

--- a/pkg/client/listers/authorization/v1/selfsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1/selfsubjectaccessreview.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	authorization "k8s.io/kubernetes/pkg/apis/authorization"
 	v1 "k8s.io/kubernetes/pkg/apis/authorization/v1"
 )
 
@@ -62,7 +61,7 @@ func (s *selfSubjectAccessReviewLister) Get(name string) (*v1.SelfSubjectAccessR
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(authorization.Resource("selfsubjectaccessreview"), name)
+		return nil, errors.NewNotFound(v1.Resource("selfsubjectaccessreview"), name)
 	}
 	return obj.(*v1.SelfSubjectAccessReview), nil
 }

--- a/pkg/client/listers/authorization/v1/subjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1/subjectaccessreview.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	authorization "k8s.io/kubernetes/pkg/apis/authorization"
 	v1 "k8s.io/kubernetes/pkg/apis/authorization/v1"
 )
 
@@ -62,7 +61,7 @@ func (s *subjectAccessReviewLister) Get(name string) (*v1.SubjectAccessReview, e
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(authorization.Resource("subjectaccessreview"), name)
+		return nil, errors.NewNotFound(v1.Resource("subjectaccessreview"), name)
 	}
 	return obj.(*v1.SubjectAccessReview), nil
 }

--- a/pkg/client/listers/authorization/v1beta1/BUILD
+++ b/pkg/client/listers/authorization/v1beta1/BUILD
@@ -17,7 +17,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/authorization:go_default_library",
         "//pkg/apis/authorization/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/authorization/v1beta1/localsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1beta1/localsubjectaccessreview.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	authorization "k8s.io/kubernetes/pkg/apis/authorization"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s localSubjectAccessReviewNamespaceLister) Get(name string) (*v1beta1.Loca
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(authorization.Resource("localsubjectaccessreview"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("localsubjectaccessreview"), name)
 	}
 	return obj.(*v1beta1.LocalSubjectAccessReview), nil
 }

--- a/pkg/client/listers/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1beta1/selfsubjectaccessreview.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	authorization "k8s.io/kubernetes/pkg/apis/authorization"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *selfSubjectAccessReviewLister) Get(name string) (*v1beta1.SelfSubjectAc
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(authorization.Resource("selfsubjectaccessreview"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("selfsubjectaccessreview"), name)
 	}
 	return obj.(*v1beta1.SelfSubjectAccessReview), nil
 }

--- a/pkg/client/listers/authorization/v1beta1/subjectaccessreview.go
+++ b/pkg/client/listers/authorization/v1beta1/subjectaccessreview.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	authorization "k8s.io/kubernetes/pkg/apis/authorization"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/authorization/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *subjectAccessReviewLister) Get(name string) (*v1beta1.SubjectAccessRevi
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(authorization.Resource("subjectaccessreview"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("subjectaccessreview"), name)
 	}
 	return obj.(*v1beta1.SubjectAccessReview), nil
 }

--- a/pkg/client/listers/autoscaling/v1/BUILD
+++ b/pkg/client/listers/autoscaling/v1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/pkg/client/listers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/pkg/client/listers/autoscaling/v1/horizontalpodautoscaler.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 	v1 "k8s.io/kubernetes/pkg/apis/autoscaling/v1"
 )
 
@@ -89,7 +88,7 @@ func (s horizontalPodAutoscalerNamespaceLister) Get(name string) (*v1.Horizontal
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(autoscaling.Resource("horizontalpodautoscaler"), name)
+		return nil, errors.NewNotFound(v1.Resource("horizontalpodautoscaler"), name)
 	}
 	return obj.(*v1.HorizontalPodAutoscaler), nil
 }

--- a/pkg/client/listers/autoscaling/v2alpha1/BUILD
+++ b/pkg/client/listers/autoscaling/v2alpha1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/autoscaling/v2alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/pkg/client/listers/autoscaling/v2alpha1/horizontalpodautoscaler.go
+++ b/pkg/client/listers/autoscaling/v2alpha1/horizontalpodautoscaler.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 	v2alpha1 "k8s.io/kubernetes/pkg/apis/autoscaling/v2alpha1"
 )
 
@@ -89,7 +88,7 @@ func (s horizontalPodAutoscalerNamespaceLister) Get(name string) (*v2alpha1.Hori
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(autoscaling.Resource("horizontalpodautoscaler"), name)
+		return nil, errors.NewNotFound(v2alpha1.Resource("horizontalpodautoscaler"), name)
 	}
 	return obj.(*v2alpha1.HorizontalPodAutoscaler), nil
 }

--- a/pkg/client/listers/batch/v1/BUILD
+++ b/pkg/client/listers/batch/v1/BUILD
@@ -17,7 +17,6 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//pkg/apis/batch:go_default_library",
         "//pkg/apis/batch/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/batch/v1/job.go
+++ b/pkg/client/listers/batch/v1/job.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	batch "k8s.io/kubernetes/pkg/apis/batch"
 	v1 "k8s.io/kubernetes/pkg/apis/batch/v1"
 )
 
@@ -89,7 +88,7 @@ func (s jobNamespaceLister) Get(name string) (*v1.Job, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(batch.Resource("job"), name)
+		return nil, errors.NewNotFound(v1.Resource("job"), name)
 	}
 	return obj.(*v1.Job), nil
 }

--- a/pkg/client/listers/batch/v2alpha1/BUILD
+++ b/pkg/client/listers/batch/v2alpha1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/batch:go_default_library",
         "//pkg/apis/batch/v2alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/pkg/client/listers/batch/v2alpha1/cronjob.go
+++ b/pkg/client/listers/batch/v2alpha1/cronjob.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	batch "k8s.io/kubernetes/pkg/apis/batch"
 	v2alpha1 "k8s.io/kubernetes/pkg/apis/batch/v2alpha1"
 )
 
@@ -89,7 +88,7 @@ func (s cronJobNamespaceLister) Get(name string) (*v2alpha1.CronJob, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(batch.Resource("cronjob"), name)
+		return nil, errors.NewNotFound(v2alpha1.Resource("cronjob"), name)
 	}
 	return obj.(*v2alpha1.CronJob), nil
 }

--- a/pkg/client/listers/certificates/v1beta1/BUILD
+++ b/pkg/client/listers/certificates/v1beta1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/certificates:go_default_library",
         "//pkg/apis/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/certificates/v1beta1/certificatesigningrequest.go
+++ b/pkg/client/listers/certificates/v1beta1/certificatesigningrequest.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	certificates "k8s.io/kubernetes/pkg/apis/certificates"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/certificates/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *certificateSigningRequestLister) Get(name string) (*v1beta1.Certificate
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(certificates.Resource("certificatesigningrequest"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("certificatesigningrequest"), name)
 	}
 	return obj.(*v1beta1.CertificateSigningRequest), nil
 }

--- a/pkg/client/listers/core/v1/BUILD
+++ b/pkg/client/listers/core/v1/BUILD
@@ -33,7 +33,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/core/v1/componentstatus.go
+++ b/pkg/client/listers/core/v1/componentstatus.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -62,7 +61,7 @@ func (s *componentStatusLister) Get(name string) (*v1.ComponentStatus, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("componentstatus"), name)
+		return nil, errors.NewNotFound(v1.Resource("componentstatus"), name)
 	}
 	return obj.(*v1.ComponentStatus), nil
 }

--- a/pkg/client/listers/core/v1/configmap.go
+++ b/pkg/client/listers/core/v1/configmap.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s configMapNamespaceLister) Get(name string) (*v1.ConfigMap, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("configmap"), name)
+		return nil, errors.NewNotFound(v1.Resource("configmap"), name)
 	}
 	return obj.(*v1.ConfigMap), nil
 }

--- a/pkg/client/listers/core/v1/endpoints.go
+++ b/pkg/client/listers/core/v1/endpoints.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s endpointsNamespaceLister) Get(name string) (*v1.Endpoints, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("endpoints"), name)
+		return nil, errors.NewNotFound(v1.Resource("endpoints"), name)
 	}
 	return obj.(*v1.Endpoints), nil
 }

--- a/pkg/client/listers/core/v1/event.go
+++ b/pkg/client/listers/core/v1/event.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s eventNamespaceLister) Get(name string) (*v1.Event, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("event"), name)
+		return nil, errors.NewNotFound(v1.Resource("event"), name)
 	}
 	return obj.(*v1.Event), nil
 }

--- a/pkg/client/listers/core/v1/limitrange.go
+++ b/pkg/client/listers/core/v1/limitrange.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s limitRangeNamespaceLister) Get(name string) (*v1.LimitRange, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("limitrange"), name)
+		return nil, errors.NewNotFound(v1.Resource("limitrange"), name)
 	}
 	return obj.(*v1.LimitRange), nil
 }

--- a/pkg/client/listers/core/v1/namespace.go
+++ b/pkg/client/listers/core/v1/namespace.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -62,7 +61,7 @@ func (s *namespaceLister) Get(name string) (*v1.Namespace, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("namespace"), name)
+		return nil, errors.NewNotFound(v1.Resource("namespace"), name)
 	}
 	return obj.(*v1.Namespace), nil
 }

--- a/pkg/client/listers/core/v1/node.go
+++ b/pkg/client/listers/core/v1/node.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -62,7 +61,7 @@ func (s *nodeLister) Get(name string) (*v1.Node, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("node"), name)
+		return nil, errors.NewNotFound(v1.Resource("node"), name)
 	}
 	return obj.(*v1.Node), nil
 }

--- a/pkg/client/listers/core/v1/persistentvolume.go
+++ b/pkg/client/listers/core/v1/persistentvolume.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -62,7 +61,7 @@ func (s *persistentVolumeLister) Get(name string) (*v1.PersistentVolume, error) 
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("persistentvolume"), name)
+		return nil, errors.NewNotFound(v1.Resource("persistentvolume"), name)
 	}
 	return obj.(*v1.PersistentVolume), nil
 }

--- a/pkg/client/listers/core/v1/persistentvolumeclaim.go
+++ b/pkg/client/listers/core/v1/persistentvolumeclaim.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s persistentVolumeClaimNamespaceLister) Get(name string) (*v1.PersistentVo
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("persistentvolumeclaim"), name)
+		return nil, errors.NewNotFound(v1.Resource("persistentvolumeclaim"), name)
 	}
 	return obj.(*v1.PersistentVolumeClaim), nil
 }

--- a/pkg/client/listers/core/v1/pod.go
+++ b/pkg/client/listers/core/v1/pod.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s podNamespaceLister) Get(name string) (*v1.Pod, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("pod"), name)
+		return nil, errors.NewNotFound(v1.Resource("pod"), name)
 	}
 	return obj.(*v1.Pod), nil
 }

--- a/pkg/client/listers/core/v1/podtemplate.go
+++ b/pkg/client/listers/core/v1/podtemplate.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s podTemplateNamespaceLister) Get(name string) (*v1.PodTemplate, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("podtemplate"), name)
+		return nil, errors.NewNotFound(v1.Resource("podtemplate"), name)
 	}
 	return obj.(*v1.PodTemplate), nil
 }

--- a/pkg/client/listers/core/v1/replicationcontroller.go
+++ b/pkg/client/listers/core/v1/replicationcontroller.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s replicationControllerNamespaceLister) Get(name string) (*v1.ReplicationC
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("replicationcontroller"), name)
+		return nil, errors.NewNotFound(v1.Resource("replicationcontroller"), name)
 	}
 	return obj.(*v1.ReplicationController), nil
 }

--- a/pkg/client/listers/core/v1/resourcequota.go
+++ b/pkg/client/listers/core/v1/resourcequota.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s resourceQuotaNamespaceLister) Get(name string) (*v1.ResourceQuota, error
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("resourcequota"), name)
+		return nil, errors.NewNotFound(v1.Resource("resourcequota"), name)
 	}
 	return obj.(*v1.ResourceQuota), nil
 }

--- a/pkg/client/listers/core/v1/secret.go
+++ b/pkg/client/listers/core/v1/secret.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s secretNamespaceLister) Get(name string) (*v1.Secret, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("secret"), name)
+		return nil, errors.NewNotFound(v1.Resource("secret"), name)
 	}
 	return obj.(*v1.Secret), nil
 }

--- a/pkg/client/listers/core/v1/service.go
+++ b/pkg/client/listers/core/v1/service.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s serviceNamespaceLister) Get(name string) (*v1.Service, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("service"), name)
+		return nil, errors.NewNotFound(v1.Resource("service"), name)
 	}
 	return obj.(*v1.Service), nil
 }

--- a/pkg/client/listers/core/v1/serviceaccount.go
+++ b/pkg/client/listers/core/v1/serviceaccount.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	api "k8s.io/kubernetes/pkg/api"
 	v1 "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -89,7 +88,7 @@ func (s serviceAccountNamespaceLister) Get(name string) (*v1.ServiceAccount, err
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("serviceaccount"), name)
+		return nil, errors.NewNotFound(v1.Resource("serviceaccount"), name)
 	}
 	return obj.(*v1.ServiceAccount), nil
 }

--- a/pkg/client/listers/extensions/v1beta1/BUILD
+++ b/pkg/client/listers/extensions/v1beta1/BUILD
@@ -26,7 +26,6 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/extensions/v1beta1/daemonset.go
+++ b/pkg/client/listers/extensions/v1beta1/daemonset.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s daemonSetNamespaceLister) Get(name string) (*v1beta1.DaemonSet, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("daemonset"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("daemonset"), name)
 	}
 	return obj.(*v1beta1.DaemonSet), nil
 }

--- a/pkg/client/listers/extensions/v1beta1/deployment.go
+++ b/pkg/client/listers/extensions/v1beta1/deployment.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s deploymentNamespaceLister) Get(name string) (*v1beta1.Deployment, error)
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("deployment"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("deployment"), name)
 	}
 	return obj.(*v1beta1.Deployment), nil
 }

--- a/pkg/client/listers/extensions/v1beta1/ingress.go
+++ b/pkg/client/listers/extensions/v1beta1/ingress.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s ingressNamespaceLister) Get(name string) (*v1beta1.Ingress, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("ingress"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("ingress"), name)
 	}
 	return obj.(*v1beta1.Ingress), nil
 }

--- a/pkg/client/listers/extensions/v1beta1/podsecuritypolicy.go
+++ b/pkg/client/listers/extensions/v1beta1/podsecuritypolicy.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *podSecurityPolicyLister) Get(name string) (*v1beta1.PodSecurityPolicy, 
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("podsecuritypolicy"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("podsecuritypolicy"), name)
 	}
 	return obj.(*v1beta1.PodSecurityPolicy), nil
 }

--- a/pkg/client/listers/extensions/v1beta1/replicaset.go
+++ b/pkg/client/listers/extensions/v1beta1/replicaset.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s replicaSetNamespaceLister) Get(name string) (*v1beta1.ReplicaSet, error)
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("replicaset"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("replicaset"), name)
 	}
 	return obj.(*v1beta1.ReplicaSet), nil
 }

--- a/pkg/client/listers/extensions/v1beta1/scale.go
+++ b/pkg/client/listers/extensions/v1beta1/scale.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s scaleNamespaceLister) Get(name string) (*v1beta1.Scale, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("scale"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("scale"), name)
 	}
 	return obj.(*v1beta1.Scale), nil
 }

--- a/pkg/client/listers/extensions/v1beta1/thirdpartyresource.go
+++ b/pkg/client/listers/extensions/v1beta1/thirdpartyresource.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *thirdPartyResourceLister) Get(name string) (*v1beta1.ThirdPartyResource
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("thirdpartyresource"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("thirdpartyresource"), name)
 	}
 	return obj.(*v1beta1.ThirdPartyResource), nil
 }

--- a/pkg/client/listers/imagepolicy/v1alpha1/BUILD
+++ b/pkg/client/listers/imagepolicy/v1alpha1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/imagepolicy:go_default_library",
         "//pkg/apis/imagepolicy/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/imagepolicy/v1alpha1/imagereview.go
+++ b/pkg/client/listers/imagepolicy/v1alpha1/imagereview.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	imagepolicy "k8s.io/kubernetes/pkg/apis/imagepolicy"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1"
 )
 
@@ -62,7 +61,7 @@ func (s *imageReviewLister) Get(name string) (*v1alpha1.ImageReview, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(imagepolicy.Resource("imagereview"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("imagereview"), name)
 	}
 	return obj.(*v1alpha1.ImageReview), nil
 }

--- a/pkg/client/listers/policy/v1alpha1/BUILD
+++ b/pkg/client/listers/policy/v1alpha1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/policy:go_default_library",
         "//pkg/apis/policy/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/pkg/client/listers/policy/v1alpha1/poddisruptionbudget.go
+++ b/pkg/client/listers/policy/v1alpha1/poddisruptionbudget.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	policy "k8s.io/kubernetes/pkg/apis/policy"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/policy/v1alpha1"
 )
 
@@ -89,7 +88,7 @@ func (s podDisruptionBudgetNamespaceLister) Get(name string) (*v1alpha1.PodDisru
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(policy.Resource("poddisruptionbudget"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("poddisruptionbudget"), name)
 	}
 	return obj.(*v1alpha1.PodDisruptionBudget), nil
 }

--- a/pkg/client/listers/policy/v1beta1/BUILD
+++ b/pkg/client/listers/policy/v1beta1/BUILD
@@ -18,7 +18,6 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
-        "//pkg/apis/policy:go_default_library",
         "//pkg/apis/policy/v1beta1:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/client/listers/policy/v1beta1/eviction.go
+++ b/pkg/client/listers/policy/v1beta1/eviction.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	policy "k8s.io/kubernetes/pkg/apis/policy"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/policy/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s evictionNamespaceLister) Get(name string) (*v1beta1.Eviction, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(policy.Resource("eviction"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("eviction"), name)
 	}
 	return obj.(*v1beta1.Eviction), nil
 }

--- a/pkg/client/listers/policy/v1beta1/poddisruptionbudget.go
+++ b/pkg/client/listers/policy/v1beta1/poddisruptionbudget.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	policy "k8s.io/kubernetes/pkg/apis/policy"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/policy/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s podDisruptionBudgetNamespaceLister) Get(name string) (*v1beta1.PodDisrup
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(policy.Resource("poddisruptionbudget"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("poddisruptionbudget"), name)
 	}
 	return obj.(*v1beta1.PodDisruptionBudget), nil
 }

--- a/pkg/client/listers/rbac/v1alpha1/BUILD
+++ b/pkg/client/listers/rbac/v1alpha1/BUILD
@@ -18,7 +18,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/rbac:go_default_library",
         "//pkg/apis/rbac/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/rbac/v1alpha1/clusterrole.go
+++ b/pkg/client/listers/rbac/v1alpha1/clusterrole.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
 )
 
@@ -62,7 +61,7 @@ func (s *clusterRoleLister) Get(name string) (*v1alpha1.ClusterRole, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("clusterrole"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("clusterrole"), name)
 	}
 	return obj.(*v1alpha1.ClusterRole), nil
 }

--- a/pkg/client/listers/rbac/v1alpha1/clusterrolebinding.go
+++ b/pkg/client/listers/rbac/v1alpha1/clusterrolebinding.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
 )
 
@@ -62,7 +61,7 @@ func (s *clusterRoleBindingLister) Get(name string) (*v1alpha1.ClusterRoleBindin
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("clusterrolebinding"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("clusterrolebinding"), name)
 	}
 	return obj.(*v1alpha1.ClusterRoleBinding), nil
 }

--- a/pkg/client/listers/rbac/v1alpha1/role.go
+++ b/pkg/client/listers/rbac/v1alpha1/role.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
 )
 
@@ -89,7 +88,7 @@ func (s roleNamespaceLister) Get(name string) (*v1alpha1.Role, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("role"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("role"), name)
 	}
 	return obj.(*v1alpha1.Role), nil
 }

--- a/pkg/client/listers/rbac/v1alpha1/rolebinding.go
+++ b/pkg/client/listers/rbac/v1alpha1/rolebinding.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/rbac/v1alpha1"
 )
 
@@ -89,7 +88,7 @@ func (s roleBindingNamespaceLister) Get(name string) (*v1alpha1.RoleBinding, err
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("rolebinding"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("rolebinding"), name)
 	}
 	return obj.(*v1alpha1.RoleBinding), nil
 }

--- a/pkg/client/listers/rbac/v1beta1/BUILD
+++ b/pkg/client/listers/rbac/v1beta1/BUILD
@@ -18,7 +18,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/rbac:go_default_library",
         "//pkg/apis/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/rbac/v1beta1/clusterrole.go
+++ b/pkg/client/listers/rbac/v1beta1/clusterrole.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *clusterRoleLister) Get(name string) (*v1beta1.ClusterRole, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("clusterrole"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("clusterrole"), name)
 	}
 	return obj.(*v1beta1.ClusterRole), nil
 }

--- a/pkg/client/listers/rbac/v1beta1/clusterrolebinding.go
+++ b/pkg/client/listers/rbac/v1beta1/clusterrolebinding.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *clusterRoleBindingLister) Get(name string) (*v1beta1.ClusterRoleBinding
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("clusterrolebinding"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("clusterrolebinding"), name)
 	}
 	return obj.(*v1beta1.ClusterRoleBinding), nil
 }

--- a/pkg/client/listers/rbac/v1beta1/role.go
+++ b/pkg/client/listers/rbac/v1beta1/role.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s roleNamespaceLister) Get(name string) (*v1beta1.Role, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("role"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("role"), name)
 	}
 	return obj.(*v1beta1.Role), nil
 }

--- a/pkg/client/listers/rbac/v1beta1/rolebinding.go
+++ b/pkg/client/listers/rbac/v1beta1/rolebinding.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/rbac/v1beta1"
 )
 
@@ -89,7 +88,7 @@ func (s roleBindingNamespaceLister) Get(name string) (*v1beta1.RoleBinding, erro
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("rolebinding"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("rolebinding"), name)
 	}
 	return obj.(*v1beta1.RoleBinding), nil
 }

--- a/pkg/client/listers/settings/v1alpha1/BUILD
+++ b/pkg/client/listers/settings/v1alpha1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/settings:go_default_library",
         "//pkg/apis/settings/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/pkg/client/listers/settings/v1alpha1/podpreset.go
+++ b/pkg/client/listers/settings/v1alpha1/podpreset.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	settings "k8s.io/kubernetes/pkg/apis/settings"
 	v1alpha1 "k8s.io/kubernetes/pkg/apis/settings/v1alpha1"
 )
 
@@ -89,7 +88,7 @@ func (s podPresetNamespaceLister) Get(name string) (*v1alpha1.PodPreset, error) 
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(settings.Resource("podpreset"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("podpreset"), name)
 	}
 	return obj.(*v1alpha1.PodPreset), nil
 }

--- a/pkg/client/listers/storage/v1/BUILD
+++ b/pkg/client/listers/storage/v1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/storage:go_default_library",
         "//pkg/apis/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/storage/v1/storageclass.go
+++ b/pkg/client/listers/storage/v1/storageclass.go
@@ -23,7 +23,6 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	storage "k8s.io/kubernetes/pkg/apis/storage"
 	v1 "k8s.io/kubernetes/pkg/apis/storage/v1"
 )
 
@@ -62,7 +61,7 @@ func (s *storageClassLister) Get(name string) (*v1.StorageClass, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(storage.Resource("storageclass"), name)
+		return nil, errors.NewNotFound(v1.Resource("storageclass"), name)
 	}
 	return obj.(*v1.StorageClass), nil
 }

--- a/pkg/client/listers/storage/v1beta1/BUILD
+++ b/pkg/client/listers/storage/v1beta1/BUILD
@@ -15,7 +15,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//pkg/apis/storage:go_default_library",
         "//pkg/apis/storage/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/listers/storage/v1beta1/storageclass.go
+++ b/pkg/client/listers/storage/v1beta1/storageclass.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	storage "k8s.io/kubernetes/pkg/apis/storage"
 	v1beta1 "k8s.io/kubernetes/pkg/apis/storage/v1beta1"
 )
 
@@ -62,7 +61,7 @@ func (s *storageClassLister) Get(name string) (*v1beta1.StorageClass, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(storage.Resource("storageclass"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("storageclass"), name)
 	}
 	return obj.(*v1beta1.StorageClass), nil
 }

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/apps:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/deployment.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	apps "k8s.io/client-go/pkg/apis/apps"
 	v1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s deploymentNamespaceLister) Get(name string) (*v1beta1.Deployment, error)
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(apps.Resource("deployment"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("deployment"), name)
 	}
 	return obj.(*v1beta1.Deployment), nil
 }

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/scale.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/scale.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	apps "k8s.io/client-go/pkg/apis/apps"
 	v1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s scaleNamespaceLister) Get(name string) (*v1beta1.Scale, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(apps.Resource("scale"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("scale"), name)
 	}
 	return obj.(*v1beta1.Scale), nil
 }

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/statefulset.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	apps "k8s.io/client-go/pkg/apis/apps"
 	v1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s statefulSetNamespaceLister) Get(name string) (*v1beta1.StatefulSet, erro
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(apps.Resource("statefulset"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("statefulset"), name)
 	}
 	return obj.(*v1beta1.StatefulSet), nil
 }

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/autoscaling:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v1/horizontalpodautoscaler.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	autoscaling "k8s.io/client-go/pkg/apis/autoscaling"
 	v1 "k8s.io/client-go/pkg/apis/autoscaling/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s horizontalPodAutoscalerNamespaceLister) Get(name string) (*v1.Horizontal
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(autoscaling.Resource("horizontalpodautoscaler"), name)
+		return nil, errors.NewNotFound(v1.Resource("horizontalpodautoscaler"), name)
 	}
 	return obj.(*v1.HorizontalPodAutoscaler), nil
 }

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v2alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v2alpha1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/autoscaling:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/autoscaling/v2alpha1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v2alpha1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v2alpha1/horizontalpodautoscaler.go
@@ -21,7 +21,6 @@ package v2alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	autoscaling "k8s.io/client-go/pkg/apis/autoscaling"
 	v2alpha1 "k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s horizontalPodAutoscalerNamespaceLister) Get(name string) (*v2alpha1.Hori
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(autoscaling.Resource("horizontalpodautoscaler"), name)
+		return nil, errors.NewNotFound(v2alpha1.Resource("horizontalpodautoscaler"), name)
 	}
 	return obj.(*v2alpha1.HorizontalPodAutoscaler), nil
 }

--- a/staging/src/k8s.io/client-go/listers/batch/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/batch/v1/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/batch:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/batch/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/listers/batch/v1/job.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	batch "k8s.io/client-go/pkg/apis/batch"
 	v1 "k8s.io/client-go/pkg/apis/batch/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s jobNamespaceLister) Get(name string) (*v1.Job, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(batch.Resource("job"), name)
+		return nil, errors.NewNotFound(v1.Resource("job"), name)
 	}
 	return obj.(*v1.Job), nil
 }

--- a/staging/src/k8s.io/client-go/listers/batch/v2alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/batch/v2alpha1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/batch:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/listers/batch/v2alpha1/cronjob.go
@@ -21,7 +21,6 @@ package v2alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	batch "k8s.io/client-go/pkg/apis/batch"
 	v2alpha1 "k8s.io/client-go/pkg/apis/batch/v2alpha1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s cronJobNamespaceLister) Get(name string) (*v2alpha1.CronJob, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(batch.Resource("cronjob"), name)
+		return nil, errors.NewNotFound(v2alpha1.Resource("cronjob"), name)
 	}
 	return obj.(*v2alpha1.CronJob), nil
 }

--- a/staging/src/k8s.io/client-go/listers/certificates/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/certificates/v1beta1/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/certificates:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	certificates "k8s.io/client-go/pkg/apis/certificates"
 	v1beta1 "k8s.io/client-go/pkg/apis/certificates/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *certificateSigningRequestLister) Get(name string) (*v1beta1.Certificate
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(certificates.Resource("certificatesigningrequest"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("certificatesigningrequest"), name)
 	}
 	return obj.(*v1beta1.CertificateSigningRequest), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/core/v1/BUILD
@@ -36,7 +36,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/api:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/componentstatus.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *componentStatusLister) Get(name string) (*v1.ComponentStatus, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("componentstatus"), name)
+		return nil, errors.NewNotFound(v1.Resource("componentstatus"), name)
 	}
 	return obj.(*v1.ComponentStatus), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/configmap.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s configMapNamespaceLister) Get(name string) (*v1.ConfigMap, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("configmap"), name)
+		return nil, errors.NewNotFound(v1.Resource("configmap"), name)
 	}
 	return obj.(*v1.ConfigMap), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/endpoints.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s endpointsNamespaceLister) Get(name string) (*v1.Endpoints, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("endpoints"), name)
+		return nil, errors.NewNotFound(v1.Resource("endpoints"), name)
 	}
 	return obj.(*v1.Endpoints), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/event.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s eventNamespaceLister) Get(name string) (*v1.Event, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("event"), name)
+		return nil, errors.NewNotFound(v1.Resource("event"), name)
 	}
 	return obj.(*v1.Event), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/limitrange.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s limitRangeNamespaceLister) Get(name string) (*v1.LimitRange, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("limitrange"), name)
+		return nil, errors.NewNotFound(v1.Resource("limitrange"), name)
 	}
 	return obj.(*v1.LimitRange), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/namespace.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *namespaceLister) Get(name string) (*v1.Namespace, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("namespace"), name)
+		return nil, errors.NewNotFound(v1.Resource("namespace"), name)
 	}
 	return obj.(*v1.Namespace), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/node.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *nodeLister) Get(name string) (*v1.Node, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("node"), name)
+		return nil, errors.NewNotFound(v1.Resource("node"), name)
 	}
 	return obj.(*v1.Node), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/persistentvolume.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *persistentVolumeLister) Get(name string) (*v1.PersistentVolume, error) 
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("persistentvolume"), name)
+		return nil, errors.NewNotFound(v1.Resource("persistentvolume"), name)
 	}
 	return obj.(*v1.PersistentVolume), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/persistentvolumeclaim.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s persistentVolumeClaimNamespaceLister) Get(name string) (*v1.PersistentVo
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("persistentvolumeclaim"), name)
+		return nil, errors.NewNotFound(v1.Resource("persistentvolumeclaim"), name)
 	}
 	return obj.(*v1.PersistentVolumeClaim), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/pod.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s podNamespaceLister) Get(name string) (*v1.Pod, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("pod"), name)
+		return nil, errors.NewNotFound(v1.Resource("pod"), name)
 	}
 	return obj.(*v1.Pod), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/podtemplate.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s podTemplateNamespaceLister) Get(name string) (*v1.PodTemplate, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("podtemplate"), name)
+		return nil, errors.NewNotFound(v1.Resource("podtemplate"), name)
 	}
 	return obj.(*v1.PodTemplate), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/replicationcontroller.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s replicationControllerNamespaceLister) Get(name string) (*v1.ReplicationC
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("replicationcontroller"), name)
+		return nil, errors.NewNotFound(v1.Resource("replicationcontroller"), name)
 	}
 	return obj.(*v1.ReplicationController), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/resourcequota.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s resourceQuotaNamespaceLister) Get(name string) (*v1.ResourceQuota, error
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("resourcequota"), name)
+		return nil, errors.NewNotFound(v1.Resource("resourcequota"), name)
 	}
 	return obj.(*v1.ResourceQuota), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/secret.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s secretNamespaceLister) Get(name string) (*v1.Secret, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("secret"), name)
+		return nil, errors.NewNotFound(v1.Resource("secret"), name)
 	}
 	return obj.(*v1.Secret), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/service.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s serviceNamespaceLister) Get(name string) (*v1.Service, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("service"), name)
+		return nil, errors.NewNotFound(v1.Resource("service"), name)
 	}
 	return obj.(*v1.Service), nil
 }

--- a/staging/src/k8s.io/client-go/listers/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/serviceaccount.go
@@ -21,7 +21,6 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	api "k8s.io/client-go/pkg/api"
 	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s serviceAccountNamespaceLister) Get(name string) (*v1.ServiceAccount, err
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(api.Resource("serviceaccount"), name)
+		return nil, errors.NewNotFound(v1.Resource("serviceaccount"), name)
 	}
 	return obj.(*v1.ServiceAccount), nil
 }

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/extensions:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/daemonset.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	extensions "k8s.io/client-go/pkg/apis/extensions"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s daemonSetNamespaceLister) Get(name string) (*v1beta1.DaemonSet, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("daemonset"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("daemonset"), name)
 	}
 	return obj.(*v1beta1.DaemonSet), nil
 }

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/deployment.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	extensions "k8s.io/client-go/pkg/apis/extensions"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s deploymentNamespaceLister) Get(name string) (*v1beta1.Deployment, error)
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("deployment"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("deployment"), name)
 	}
 	return obj.(*v1beta1.Deployment), nil
 }

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/ingress.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	extensions "k8s.io/client-go/pkg/apis/extensions"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s ingressNamespaceLister) Get(name string) (*v1beta1.Ingress, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("ingress"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("ingress"), name)
 	}
 	return obj.(*v1beta1.Ingress), nil
 }

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	extensions "k8s.io/client-go/pkg/apis/extensions"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *podSecurityPolicyLister) Get(name string) (*v1beta1.PodSecurityPolicy, 
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("podsecuritypolicy"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("podsecuritypolicy"), name)
 	}
 	return obj.(*v1beta1.PodSecurityPolicy), nil
 }

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/replicaset.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	extensions "k8s.io/client-go/pkg/apis/extensions"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s replicaSetNamespaceLister) Get(name string) (*v1beta1.ReplicaSet, error)
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("replicaset"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("replicaset"), name)
 	}
 	return obj.(*v1beta1.ReplicaSet), nil
 }

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/scale.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/scale.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	extensions "k8s.io/client-go/pkg/apis/extensions"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s scaleNamespaceLister) Get(name string) (*v1beta1.Scale, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("scale"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("scale"), name)
 	}
 	return obj.(*v1beta1.Scale), nil
 }

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/thirdpartyresource.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/thirdpartyresource.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	extensions "k8s.io/client-go/pkg/apis/extensions"
 	v1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *thirdPartyResourceLister) Get(name string) (*v1beta1.ThirdPartyResource
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(extensions.Resource("thirdpartyresource"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("thirdpartyresource"), name)
 	}
 	return obj.(*v1beta1.ThirdPartyResource), nil
 }

--- a/staging/src/k8s.io/client-go/listers/policy/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/policy/v1beta1/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/policy:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1beta1/eviction.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	policy "k8s.io/client-go/pkg/apis/policy"
 	v1beta1 "k8s.io/client-go/pkg/apis/policy/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s evictionNamespaceLister) Get(name string) (*v1beta1.Eviction, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(policy.Resource("eviction"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("eviction"), name)
 	}
 	return obj.(*v1beta1.Eviction), nil
 }

--- a/staging/src/k8s.io/client-go/listers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1beta1/poddisruptionbudget.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	policy "k8s.io/client-go/pkg/apis/policy"
 	v1beta1 "k8s.io/client-go/pkg/apis/policy/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s podDisruptionBudgetNamespaceLister) Get(name string) (*v1beta1.PodDisrup
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(policy.Resource("poddisruptionbudget"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("poddisruptionbudget"), name)
 	}
 	return obj.(*v1beta1.PodDisruptionBudget), nil
 }

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/rbac:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/rbac/v1alpha1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	rbac "k8s.io/client-go/pkg/apis/rbac"
 	v1alpha1 "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *clusterRoleLister) Get(name string) (*v1alpha1.ClusterRole, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("clusterrole"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("clusterrole"), name)
 	}
 	return obj.(*v1alpha1.ClusterRole), nil
 }

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	rbac "k8s.io/client-go/pkg/apis/rbac"
 	v1alpha1 "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *clusterRoleBindingLister) Get(name string) (*v1alpha1.ClusterRoleBindin
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("clusterrolebinding"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("clusterrolebinding"), name)
 	}
 	return obj.(*v1alpha1.ClusterRoleBinding), nil
 }

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/role.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	rbac "k8s.io/client-go/pkg/apis/rbac"
 	v1alpha1 "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s roleNamespaceLister) Get(name string) (*v1alpha1.Role, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("role"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("role"), name)
 	}
 	return obj.(*v1alpha1.Role), nil
 }

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/rolebinding.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	rbac "k8s.io/client-go/pkg/apis/rbac"
 	v1alpha1 "k8s.io/client-go/pkg/apis/rbac/v1alpha1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s roleBindingNamespaceLister) Get(name string) (*v1alpha1.RoleBinding, err
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("rolebinding"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("rolebinding"), name)
 	}
 	return obj.(*v1alpha1.RoleBinding), nil
 }

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/rbac:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	rbac "k8s.io/client-go/pkg/apis/rbac"
 	v1beta1 "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *clusterRoleLister) Get(name string) (*v1beta1.ClusterRole, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("clusterrole"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("clusterrole"), name)
 	}
 	return obj.(*v1beta1.ClusterRole), nil
 }

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	rbac "k8s.io/client-go/pkg/apis/rbac"
 	v1beta1 "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *clusterRoleBindingLister) Get(name string) (*v1beta1.ClusterRoleBinding
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("clusterrolebinding"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("clusterrolebinding"), name)
 	}
 	return obj.(*v1beta1.ClusterRoleBinding), nil
 }

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/role.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	rbac "k8s.io/client-go/pkg/apis/rbac"
 	v1beta1 "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s roleNamespaceLister) Get(name string) (*v1beta1.Role, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("role"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("role"), name)
 	}
 	return obj.(*v1beta1.Role), nil
 }

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/rolebinding.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	rbac "k8s.io/client-go/pkg/apis/rbac"
 	v1beta1 "k8s.io/client-go/pkg/apis/rbac/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s roleBindingNamespaceLister) Get(name string) (*v1beta1.RoleBinding, erro
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(rbac.Resource("rolebinding"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("rolebinding"), name)
 	}
 	return obj.(*v1beta1.RoleBinding), nil
 }

--- a/staging/src/k8s.io/client-go/listers/settings/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/settings/v1alpha1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/settings:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/settings/v1alpha1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/listers/settings/v1alpha1/podpreset.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	settings "k8s.io/client-go/pkg/apis/settings"
 	v1alpha1 "k8s.io/client-go/pkg/apis/settings/v1alpha1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -89,7 +88,7 @@ func (s podPresetNamespaceLister) Get(name string) (*v1alpha1.PodPreset, error) 
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(settings.Resource("podpreset"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("podpreset"), name)
 	}
 	return obj.(*v1alpha1.PodPreset), nil
 }

--- a/staging/src/k8s.io/client-go/listers/storage/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/storage:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/storage/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/storageclass.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	storage "k8s.io/client-go/pkg/apis/storage"
 	v1 "k8s.io/client-go/pkg/apis/storage/v1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *storageClassLister) Get(name string) (*v1.StorageClass, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(storage.Resource("storageclass"), name)
+		return nil, errors.NewNotFound(v1.Resource("storageclass"), name)
 	}
 	return obj.(*v1.StorageClass), nil
 }

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/client-go/pkg/apis/storage:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/storage/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	storage "k8s.io/client-go/pkg/apis/storage"
 	v1beta1 "k8s.io/client-go/pkg/apis/storage/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )
@@ -62,7 +61,7 @@ func (s *storageClassLister) Get(name string) (*v1beta1.StorageClass, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(storage.Resource("storageclass"), name)
+		return nil, errors.NewNotFound(v1beta1.Resource("storageclass"), name)
 	}
 	return obj.(*v1beta1.StorageClass), nil
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/autoscaling/v2alpha1/register.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/autoscaling/v2alpha1/register.go
@@ -28,6 +28,11 @@ const GroupName = "autoscaling"
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v2alpha1"}
 
+// Resource takes an unqualified resource and returns a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
 var (
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes, addDefaultingFuncs)
 	AddToScheme   = SchemeBuilder.AddToScheme

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1/register.go
@@ -27,6 +27,11 @@ const GroupName = "apiregistration.k8s.io"
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 
+// Resource takes an unqualified resource and returns back a Group qualified GroupResource
+func Resource(resource string) schema.GroupResource {
+	return SchemeGroupVersion.WithResource(resource).GroupResource()
+}
+
 var (
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
 	AddToScheme   = SchemeBuilder.AddToScheme

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1alpha1/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1alpha1/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1alpha1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1alpha1/apiservice.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
-	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	v1alpha1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1alpha1"
 )
 
@@ -62,7 +61,7 @@ func (s *aPIServiceLister) Get(name string) (*v1alpha1.APIService, error) {
 		return nil, err
 	}
 	if !exists {
-		return nil, errors.NewNotFound(apiregistration.Resource("apiservice"), name)
+		return nil, errors.NewNotFound(v1alpha1.Resource("apiservice"), name)
 	}
 	return obj.(*v1alpha1.APIService), nil
 }


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/kubernetes/pull/44523

One line change in cmd/libs/go2idl/lister-gen/generators/lister.go, and simple changes in pkg/apis/autoscaling/v2alpha1/register.go, other changes are generated.

The internal api package will be eliminated from client-go, so these imports should be removed. Also, it's more correct to report the versioned resource in the error.