### PR TITLE
Make metrics filenames for e2e tests indicate the test better

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -348,7 +348,7 @@ func (f *Framework) AfterEach() {
 					Logf(summaries[i].PrintHumanReadable())
 				} else {
 					// TODO: learn to extract test name and append it to the kind instead of timestamp.
-					filePath := path.Join(TestContext.ReportDir, summaries[i].SummaryKind()+now.Format(time.RFC3339)+".txt")
+					filePath := path.Join(TestContext.ReportDir, summaries[i].SummaryKind()+"_"+f.BaseName+"_"+now.Format(time.RFC3339)+".txt")
 					if err := ioutil.WriteFile(filePath, []byte(summaries[i].PrintHumanReadable()), 0644); err != nil {
 						Logf("Failed to write file %v with test performance data: %v", filePath, err)
 					}
@@ -361,7 +361,7 @@ func (f *Framework) AfterEach() {
 					Logf("Finished")
 				} else {
 					// TODO: learn to extract test name and append it to the kind instead of timestamp.
-					filePath := path.Join(TestContext.ReportDir, summaries[i].SummaryKind()+now.Format(time.RFC3339)+".json")
+					filePath := path.Join(TestContext.ReportDir, summaries[i].SummaryKind()+"_"+f.BaseName+"_"+now.Format(time.RFC3339)+".json")
 					if err := ioutil.WriteFile(filePath, []byte(summaries[i].PrintJSON()), 0644); err != nil {
 						Logf("Failed to write file %v with test performance data: %v", filePath, err)
 					}


### PR DESCRIPTION
Currently the names of the json files with metrics for e2e tests are named by appending the `SummaryKind` with a timestamp of the test. It took me some time to figure out which file corresponds to which e2e test due to this. Changing it to have the testname instead of the timestamp.

cc @wojtek-t @gmarek 