### PR TITLE
Skip inspecting pod network if unknown namespace

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -266,6 +266,9 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 	if err != nil {
 		return nil, fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}
+	if netnsPath == "" {
+		return nil, fmt.Errorf("Cannot find the network namespace, skipping pod network status for container %q", id)
+	}
 
 	ip, err := network.GetPodIP(plugin.execer, plugin.nsenterPath, netnsPath, network.DefaultInterfaceName)
 	if err != nil {

--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -558,6 +558,9 @@ func (plugin *kubenetNetworkPlugin) GetPodNetworkStatus(namespace string, name s
 	if err != nil {
 		return nil, fmt.Errorf("Kubenet failed to retrieve network namespace path: %v", err)
 	}
+	if netnsPath == "" {
+		return nil, fmt.Errorf("Cannot find the network namespace, skipping pod network status for container %q", id)
+	}
 	ip, err := network.GetPodIP(plugin.execer, plugin.nsenterPath, netnsPath, network.DefaultInterfaceName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

If we fail to determine the network namespace of a container we still try to inspect the state - even though there is no way for it to succeed. This leads to errors like:

> NetworkPlugin cni failed on the status hook for pod "X": Unexpected command output nsenter: cannot open : No such file or directory

Instead, if we cannot determine the network namespace, we should just exit with a (hopefully) more clear error message.

I left the wording as assuming a terminated pod, based on:
https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/helpers.go#L208-L211

ref: 
https://github.com/kubernetes-incubator/bootkube/issues/475
https://github.com/coreos/coreos-kubernetes/issues/856