### PR TITLE
Update token controller test to test async retry

### DIFF
--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -369,9 +369,12 @@ func TestTokenCreation(t *testing.T) {
 		},
 		"updated serviceaccount with no secrets with resource conflict": {
 			ClientObjects: []runtime.Object{updatedServiceAccount(emptySecretReferences())},
+			IsAsync:       true,
+			MaxRetries:    1,
 
 			UpdatedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []core.Action{
+				core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, metav1.NamespaceDefault, "default"),
 				core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, metav1.NamespaceDefault, "default"),
 			},
 		},


### PR DESCRIPTION
Fixes #44819

https://github.com/kubernetes/kubernetes/pull/44625 changed the token controller to queue a retry if the live service account's resourceVersion did not match our cache.

This updates the unit test that was testing that condition to test async queue behavior (which this condition now drives)