### PR TITLE
Update cluster-autoscaler logging config

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -30,7 +30,7 @@
                     "./run.sh",
                     "--kubernetes=http://127.0.0.1:8080?inClusterConfig=f",
                     "--v=4",
-                    "--stderrthreshold=info",
+                    "--logtostderr=true",
                     "--write-status-configmap=true",
                     "{{params}}"
                 ],


### PR DESCRIPTION
Previously cluster-autoscaler would duplicate all logs,
writing to master /var/log and /tmp inside pod.

```release-note
cluster-autoscaler: Fix duplicate writing of logs.
```