### PR TITLE
Change parsing docker version

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -1096,7 +1096,7 @@ func (dm *DockerManager) pluginDisablesDockerNetworking() bool {
 
 // newDockerVersion returns a semantically versioned docker version value
 func newDockerVersion(version string) (*utilversion.Version, error) {
-	return utilversion.ParseSemantic(version)
+	return utilversion.ParseGeneric(version)
 }
 
 // apiVersion implements kubecontainer.Version interface by implementing

--- a/pkg/util/version/version_test.go
+++ b/pkg/util/version/version_test.go
@@ -205,6 +205,7 @@ func TestGenericVersions(t *testing.T) {
 		{version: "2.0.0", unparsed: "2.0.0"},
 		{version: "2.1.0", unparsed: "2.1.0"},
 		{version: "2.1.1", unparsed: "2.1.1"},
+		{version: "17.04.0-ce", unparsed: "17.4.0"},
 		{version: "42.0.0", unparsed: "42.0.0"},
 		{version: "   42.0.0", unparsed: "42.0.0", equalsPrev: true},
 		{version: "\t42.0.0  ", unparsed: "42.0.0", equalsPrev: true},


### PR DESCRIPTION
Docker recently started using following versioning values 17.04.0-ce,
which do not comply to semantic anymore. I'm switching to use generic
versioning for those.

```release-note
Accept new versioning scheme in docker.
```

@danwinship ptal