### PR TITLE
Remove jobs that do not exist from active list of CronJob

### DIFF
--- a/test/e2e/cronjob.go
+++ b/test/e2e/cronjob.go
@@ -24,10 +24,12 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/controller/job"
+	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -81,7 +83,7 @@ var _ = framework.KubeDescribe("CronJob", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring no jobs are scheduled")
-		err = waitForNoJobs(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = waitForNoJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, false)
 		Expect(err).To(HaveOccurred())
 
 		By("Ensuring no job exists by listing jobs explicitly")
@@ -170,8 +172,50 @@ var _ = framework.KubeDescribe("CronJob", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring no unexpected event has happened")
-		err = checkNoUnexpectedEvents(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		err = checkNoEventWithReason(f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob", "UnexpectedJob"})
 		Expect(err).NotTo(HaveOccurred())
+
+		By("Removing cronjob")
+		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// deleted jobs should be removed from the active list
+	It("should remove from active list jobs that have been deleted", func() {
+		By("Creating a ForbidConcurrent cronjob")
+		cronJob := newTestCronJob("forbid", "*/1 * * * ?", batch.ForbidConcurrent, true)
+		cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring a job is scheduled")
+		err = waitForActiveJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, 1)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring exactly one is scheduled")
+		cronJob, err = getCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cronJob.Status.Active).Should(HaveLen(1))
+
+		By("Deleting the job")
+		job := cronJob.Status.Active[0]
+		reaper, err := kubectl.ReaperFor(batch.Kind("Job"), f.ClientSet)
+		Expect(err).NotTo(HaveOccurred())
+		timeout := 1 * time.Minute
+		err = reaper.Stop(f.Namespace.Name, job.Name, timeout, api.NewDeleteOptions(0))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring job was deleted")
+		_, err = getJob(f.ClientSet, f.Namespace.Name, job.Name)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.IsNotFound(err)).To(BeTrue())
+
+		By("Ensuring there are no active jobs in the cronjob")
+		err = waitForNoJobs(f.ClientSet, f.Namespace.Name, cronJob.Name, true)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Ensuring MissingJob event has occured")
+		err = checkNoEventWithReason(f.ClientSet, f.Namespace.Name, cronJob.Name, []string{"MissingJob"})
+		Expect(err).To(HaveOccurred())
 
 		By("Removing cronjob")
 		err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
@@ -252,15 +296,22 @@ func waitForActiveJobs(c clientset.Interface, ns, cronJobName string, active int
 	})
 }
 
-// Wait for no jobs to appear.
-func waitForNoJobs(c clientset.Interface, ns, jobName string) error {
+// Wait for jobs to appear in the active list of a cronjob or not.
+// When failIfNonEmpty is set, this fails if the active set of jobs is still non-empty after
+// the timeout. When failIfNonEmpty is not set, this fails if the active set of jobs is still
+// empty after the timeout.
+func waitForNoJobs(c clientset.Interface, ns, jobName string, failIfNonEmpty bool) error {
 	return wait.Poll(framework.Poll, cronJobTimeout, func() (bool, error) {
 		curr, err := c.Batch().CronJobs(ns).Get(jobName)
 		if err != nil {
 			return false, err
 		}
 
-		return len(curr.Status.Active) != 0, nil
+		if failIfNonEmpty {
+			return len(curr.Status.Active) == 0, nil
+		} else {
+			return len(curr.Status.Active) != 0, nil
+		}
 	})
 }
 
@@ -308,20 +359,21 @@ func waitForAnyFinishedJob(c clientset.Interface, ns string) error {
 	})
 }
 
-// checkNoUnexpectedEvents checks unexpected events didn't happen.
-// Currently only "UnexpectedJob" is checked.
-func checkNoUnexpectedEvents(c clientset.Interface, ns, cronJobName string) error {
+// checkNoEventWithReason checks no events with a reason within a list has occured
+func checkNoEventWithReason(c clientset.Interface, ns, cronJobName string, reasons []string) error {
 	sj, err := c.Batch().CronJobs(ns).Get(cronJobName)
 	if err != nil {
-		return fmt.Errorf("error in getting cronjob %s/%s: %v", ns, cronJobName, err)
+		return fmt.Errorf("Error in getting cronjob %s/%s: %v", ns, cronJobName, err)
 	}
 	events, err := c.Core().Events(ns).Search(sj)
 	if err != nil {
-		return fmt.Errorf("error in listing events: %s", err)
+		return fmt.Errorf("Error in listing events: %s", err)
 	}
 	for _, e := range events.Items {
-		if e.Reason == "UnexpectedJob" {
-			return fmt.Errorf("found unexpected event: %#v", e)
+		for _, reason := range reasons {
+			if e.Reason == reason {
+				return fmt.Errorf("Found event with reason %s: %#v", reason, e)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
This is just a cherry-pick of https://github.com/kubernetes/kubernetes/pull/39204
> What this PR does / why we need it: This PR modifies the controller for CronJob to remove from the active job list any job that does not exist anymore, to avoid staying blocked in active state forever. See #37957.
> 
> Which issue this PR fixes: fixes #37957
> 
> Special notes for your reviewer:
> 
> Release note:

ping @soltysh