### PR TITLE
resolv.conf nameserver line has only one entry, ignore trailing garbage

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -229,8 +229,8 @@ func (kl *Kubelet) parseResolvConf(reader io.Reader) (nameservers []string, sear
 		if len(fields) == 0 {
 			continue
 		}
-		if fields[0] == "nameserver" {
-			nameservers = append(nameservers, fields[1:]...)
+		if fields[0] == "nameserver" && len(fields) >= 2 {
+			nameservers = append(nameservers, fields[1])
 		}
 		if fields[0] == "search" {
 			searches = fields[1:]

--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -91,6 +91,7 @@ func TestParseResolvConf(t *testing.T) {
 		{"nameserver\t1.2.3.4", []string{"1.2.3.4"}, []string{}},
 		{"nameserver \t 1.2.3.4", []string{"1.2.3.4"}, []string{}},
 		{"nameserver 1.2.3.4\nnameserver 5.6.7.8", []string{"1.2.3.4", "5.6.7.8"}, []string{}},
+		{"nameserver 1.2.3.4 #comment", []string{"1.2.3.4"}, []string{}},
 		{"search foo", []string{}, []string{"foo"}},
 		{"search foo bar", []string{}, []string{"foo", "bar"}},
 		{"search foo bar bat\n", []string{}, []string{"foo", "bar", "bat"}},


### PR DESCRIPTION
**What this PR does / why we need it**:

Per the resolv.conf man page "name servers may be  listed,  one  per  keyword." Some tools such as udhcpc take advantage of this to append comments to nameserver entries. For example: `nameserver 8.8.8.8 # eth0`. This updates the resolv.conf parser to ignore trailing garbage on nameserver lines.

**Release note**:
NONE
