### PR TITLE
Update kubernetes-e2e charm to use snaps

### DIFF
--- a/cluster/juju/layers/kubernetes-e2e/actions/test
+++ b/cluster/juju/layers/kubernetes-e2e/actions/test
@@ -2,6 +2,8 @@
 
 set -ex
 
+export PATH="$PATH:/snap/bin"
+
 # Grab the action parameter values
 FOCUS=$(action-get focus)
 SKIP=$(action-get skip)
@@ -26,7 +28,7 @@ ACTION_JUNIT_TGZ=$ACTION_JUNIT.tar.gz
 # This initializes an e2e build log with the START TIMESTAMP.
 echo "JUJU_E2E_START=$(date -u +%s)" | tee $ACTION_LOG
 echo "JUJU_E2E_VERSION=$(kubectl version | grep Server | cut -d " " -f 5 | cut -d ":" -f 2 | sed s/\"// | sed s/\",//)" | tee -a $ACTION_LOG
-ginkgo -nodes=$PARALLELISM $(which e2e.test) -- \
+GINKGO_ARGS="-nodes=$PARALLELISM" kubernetes-test.e2e \
   -kubeconfig /home/ubuntu/.kube/config \
   -host $SERVER \
   -ginkgo.focus $FOCUS \

--- a/cluster/juju/layers/kubernetes-e2e/config.yaml
+++ b/cluster/juju/layers/kubernetes-e2e/config.yaml
@@ -1,0 +1,6 @@
+options:
+  channel:
+    type: string
+    default: "stable"
+    description: |
+      Snap channel to install Kubernetes snaps from

--- a/cluster/juju/layers/kubernetes-e2e/layer.yaml
+++ b/cluster/juju/layers/kubernetes-e2e/layer.yaml
@@ -2,6 +2,7 @@ repo: https://github.com/juju-solutions/layer-kubernetes-e2e
 includes:
   - layer:basic
   - layer:tls-client
+  - layer:snap
   - interface:http
 options:
   tls-client:

--- a/cluster/juju/layers/kubernetes-e2e/metadata.yaml
+++ b/cluster/juju/layers/kubernetes-e2e/metadata.yaml
@@ -15,15 +15,11 @@ requires:
   kubernetes-master:
     interface: http
 resources:
-  e2e_amd64:
+  kubectl:
     type: file
-    filename: e2e_amd64.tar.gz
-    description: Tarball of the e2e binary, and kubectl binary for amd64
-  e2e_ppc64el:
+    filename: kubectl.snap
+    description: kubectl snap
+  kubernetes-test:
     type: file
-    filename: e2e_ppc64le.tar.gz
-    description: Tarball of the e2e binary, and kubectl binary for ppc64le
-  e2e_s390x:
-    type: file
-    filename: e2e_s390x.tar.gz
-    description: Tarball of the e2e binary, and kubectl binary for s390x
+    filename: kubernetes-test.snap
+    description: kubernetes-test snap

--- a/cluster/juju/layers/kubernetes-e2e/reactive/kubernetes_e2e.py
+++ b/cluster/juju/layers/kubernetes-e2e/reactive/kubernetes_e2e.py
@@ -17,6 +17,7 @@
 import os
 
 from charms import layer
+from charms.layer import snap
 
 from charms.reactive import hook
 from charms.reactive import is_state
@@ -37,7 +38,7 @@ from subprocess import check_output
 @hook('upgrade-charm')
 def reset_delivery_states():
     ''' Remove the state set when resources are unpacked. '''
-    remove_state('kubernetes-e2e.installed')
+    install_snaps()
 
 
 @when('kubernetes-e2e.installed')
@@ -65,52 +66,19 @@ def messaging():
     hookenv.status_set('active', 'Ready to test.')
 
 
-@when_not('kubernetes-e2e.installed')
-def install_kubernetes_e2e():
+@when('config.changed.channel')
+def channel_changed():
+    install_snaps()
+
+
+def install_snaps():
     ''' Deliver the e2e and kubectl components from the binary resource stream
     packages declared in the charm '''
-    charm_dir = os.getenv('CHARM_DIR')
-    arch = determine_arch()
-
-    # Get the resource via resource_get
-    resource = 'e2e_{}'.format(arch)
-    try:
-        archive = hookenv.resource_get(resource)
-    except Exception:
-        message = 'Error fetching the {} resource.'.format(resource)
-        hookenv.log(message)
-        hookenv.status_set('blocked', message)
-        return
-
-    if not archive:
-        hookenv.log('Missing {} resource.'.format(resource))
-        hookenv.status_set('blocked', 'Missing {} resource.'.format(resource))
-        return
-
-    # Handle null resource publication, we check if filesize < 1mb
-    filesize = os.stat(archive).st_size
-    if filesize < 1000000:
-        hookenv.status_set('blocked',
-                           'Incomplete {} resource.'.format(resource))
-        return
-
-    hookenv.status_set('maintenance',
-                       'Unpacking {} resource.'.format(resource))
-
-    unpack_path = '{}/files/kubernetes'.format(charm_dir)
-    os.makedirs(unpack_path, exist_ok=True)
-    cmd = ['tar', 'xfvz', archive, '-C', unpack_path]
-    hookenv.log(cmd)
-    check_call(cmd)
-
-    services = ['e2e.test', 'ginkgo', 'kubectl']
-
-    for service in services:
-        unpacked = '{}/{}'.format(unpack_path, service)
-        app_path = '/usr/local/bin/{}'.format(service)
-        install = ['install', '-v', unpacked, app_path]
-        call(install)
-
+    channel = hookenv.config('channel')
+    hookenv.status_set('maintenance', 'Installing kubectl snap')
+    snap.install('kubectl', channel=channel, classic=True)
+    hookenv.status_set('maintenance', 'Installing kubernetes-test snap')
+    snap.install('kubernetes-test', channel=channel, classic=True)
     set_state('kubernetes-e2e.installed')
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This updates the kubernetes-e2e charm to use snaps instead of Juju resources for payload delivery.

The main advantage of this is that it decouples the charm from the e2e payload, allowing us to support multiple versions of Kubernetes with a single release of the charm.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Update kubernetes-e2e charm to use snaps
```
