### PR TITLE
Update gazel to v17

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -24,7 +24,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 # TODO(spxtr): Remove this line once Bazel is the only way to build.
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
-go get -u gopkg.in/mikedanese/gazel.v16/gazel
+go get -u gopkg.in/mikedanese/gazel.v17/gazel
 
 for path in ${GOPATH//:/ }; do
   if [[ -e "${path}/bin/gazel" ]]; then

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -20,7 +20,7 @@ set -o pipefail
 export KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
-go get gopkg.in/mikedanese/gazel.v16/gazel
+go get gopkg.in/mikedanese/gazel.v17/gazel
 
 # Remove generated files prior to running gazel.
 # TODO(spxtr): Remove this line once Bazel is the only way to build.


### PR DESCRIPTION
**What this PR does / why we need it**: gazel v17 has a bugfix for creating the `vendor/BUILD` file from scratch. there should be no other changes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

/assign @mikedanese @spxtr 
