### PR TITLE
nodecontroller.go: delete redundant para.

### DIFF
--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -505,7 +505,7 @@ func (nc *NodeController) onNodeDelete(originalObj interface{}) {
 			glog.Errorf("Received unexpected object: %v", obj)
 			return
 		}
-		node, ok = deletedState.Obj.(*v1.Node)
+		_, ok = deletedState.Obj.(*v1.Node)
 		if !ok {
 			glog.Errorf("DeletedFinalStateUnknown contained non-Node object: %v", deletedState.Obj)
 			return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

  nodecontroller.go: delete redundant para.
  para. 'node' is not used.
  golang did not warn because it has a same name para. before.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
NONE