### PR TITLE
examples/guestbook: remove not useful/inaccurate comments

### DIFF
--- a/examples/guestbook/all-in-one/frontend.yaml
+++ b/examples/guestbook/all-in-one/frontend.yaml
@@ -10,7 +10,6 @@ spec:
   # an external load-balanced IP for the frontend service.
   # type: LoadBalancer
   ports:
-    # the port that this service should serve on
   - port: 80
   selector:
     app: guestbook
@@ -20,21 +19,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: frontend
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: guestbook
-  #   tier: frontend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 3
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     tier: frontend
   template:
     metadata:
       labels:
@@ -54,7 +40,7 @@ spec:
           # If your cluster config does not include a dns service, then to
           # instead access environment variables to find service host
           # info, comment out the 'value: dns' line above, and uncomment the
-          # line below.
+          # line below:
           # value: env
         ports:
         - containerPort: 80

--- a/examples/guestbook/all-in-one/guestbook-all-in-one.yaml
+++ b/examples/guestbook/all-in-one/guestbook-all-in-one.yaml
@@ -8,7 +8,6 @@ metadata:
     role: master
 spec:
   ports:
-    # the port that this service should serve on
   - port: 6379
     targetPort: 6379
   selector:
@@ -20,23 +19,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-master
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: master
-  #   tier: backend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 1
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     role: master
-  #     tier: backend
   template:
     metadata:
       labels:
@@ -64,7 +48,6 @@ metadata:
     role: slave
 spec:
   ports:
-    # the port that this service should serve on
   - port: 6379
   selector:
     app: redis
@@ -75,23 +58,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-slave
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: slave
-  #   tier: backend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 2
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     role: slave
-  #     tier: backend
   template:
     metadata:
       labels:
@@ -112,7 +80,7 @@ spec:
           # If your cluster config does not include a dns service, then to
           # instead access an environment variable to find the master
           # service's host, comment out the 'value: dns' line above, and
-          # uncomment the line below.
+          # uncomment the line below:
           # value: env
         ports:
         - containerPort: 6379
@@ -129,7 +97,6 @@ spec:
   # an external load-balanced IP for the frontend service.
   # type: LoadBalancer
   ports:
-    # the port that this service should serve on
   - port: 80
   selector:
     app: guestbook
@@ -139,21 +106,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: frontend
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: guestbook
-  #   tier: frontend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 3
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     tier: frontend
   template:
     metadata:
       labels:
@@ -173,7 +127,7 @@ spec:
           # If your cluster config does not include a dns service, then to
           # instead access environment variables to find service host
           # info, comment out the 'value: dns' line above, and uncomment the
-          # line below.
+          # line below:
           # value: env
         ports:
         - containerPort: 80

--- a/examples/guestbook/all-in-one/redis-slave.yaml
+++ b/examples/guestbook/all-in-one/redis-slave.yaml
@@ -8,7 +8,6 @@ metadata:
     tier: backend
 spec:
   ports:
-    # the port that this service should serve on
   - port: 6379
   selector:
     app: redis
@@ -19,23 +18,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-slave
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: slave
-  #   tier: backend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 2
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     role: slave
-  #     tier: backend
   template:
     metadata:
       labels:
@@ -56,7 +40,7 @@ spec:
           # If your cluster config does not include a dns service, then to
           # instead access an environment variable to find the master
           # service's host, comment out the 'value: dns' line above, and
-          # uncomment the line below.
+          # uncomment the line below:
           # value: env
         ports:
         - containerPort: 6379

--- a/examples/guestbook/frontend-deployment.yaml
+++ b/examples/guestbook/frontend-deployment.yaml
@@ -2,21 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: frontend
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: guestbook
-  #   tier: frontend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 3
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     tier: frontend
   template:
     metadata:
       labels:
@@ -36,7 +23,7 @@ spec:
           # If your cluster config does not include a dns service, then to
           # instead access environment variables to find service host
           # info, comment out the 'value: dns' line above, and uncomment the
-          # line below.
+          # line below:
           # value: env
         ports:
         - containerPort: 80

--- a/examples/guestbook/frontend-service.yaml
+++ b/examples/guestbook/frontend-service.yaml
@@ -10,7 +10,6 @@ spec:
   # an external load-balanced IP for the frontend service.
   # type: LoadBalancer
   ports:
-    # the port that this service should serve on
   - port: 80
   selector:
     app: guestbook

--- a/examples/guestbook/legacy/frontend-controller.yaml
+++ b/examples/guestbook/legacy/frontend-controller.yaml
@@ -2,20 +2,8 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: frontend
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-    # app: guestbook
-    # tier: frontend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 3
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   app: guestbook
-  #   tier: frontend
   template:
     metadata:
       labels:
@@ -35,7 +23,7 @@ spec:
           # If your cluster config does not include a dns service, then to
           # instead access environment variables to find service host
           # info, comment out the 'value: dns' line above, and uncomment the
-          # line below.
+          # line below:
           # value: env
         ports:
         - containerPort: 80

--- a/examples/guestbook/legacy/redis-master-controller.yaml
+++ b/examples/guestbook/legacy/redis-master-controller.yaml
@@ -2,22 +2,12 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: redis-master
-  # these labels can be applied automatically 
-  # from the labels in the pod template if not set
   labels:
     app: redis
     role: master
     tier: backend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 1
-  # selector can be applied automatically 
-  # from the labels in the pod template if not set
-  # selector:
-  #   app: guestbook
-  #   role: master
-  #   tier: backend
   template:
     metadata:
       labels:

--- a/examples/guestbook/legacy/redis-slave-controller.yaml
+++ b/examples/guestbook/legacy/redis-slave-controller.yaml
@@ -2,22 +2,12 @@ apiVersion: v1
 kind: ReplicationController
 metadata:
   name: redis-slave
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
   labels:
     app: redis
     role: slave
     tier: backend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 2
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   app: guestbook
-  #   role: slave
-  #   tier: backend
   template:
     metadata:
       labels:
@@ -38,7 +28,7 @@ spec:
           # If your cluster config does not include a dns service, then to
           # instead access an environment variable to find the master
           # service's host, comment out the 'value: dns' line above, and
-          # uncomment the line below.
+          # uncomment the line below:
           # value: env
         ports:
         - containerPort: 6379

--- a/examples/guestbook/redis-master-deployment.yaml
+++ b/examples/guestbook/redis-master-deployment.yaml
@@ -2,23 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-master
-  # these labels can be applied automatically 
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: master
-  #   tier: backend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 1
-  # selector can be applied automatically 
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     role: master
-  #     tier: backend
   template:
     metadata:
       labels:

--- a/examples/guestbook/redis-master-service.yaml
+++ b/examples/guestbook/redis-master-service.yaml
@@ -8,7 +8,6 @@ metadata:
     tier: backend
 spec:
   ports:
-    # the port that this service should serve on
   - port: 6379
     targetPort: 6379
   selector:

--- a/examples/guestbook/redis-slave-deployment.yaml
+++ b/examples/guestbook/redis-slave-deployment.yaml
@@ -2,23 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: redis-slave
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: slave
-  #   tier: backend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 2
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     role: slave
-  #     tier: backend
   template:
     metadata:
       labels:
@@ -39,7 +24,7 @@ spec:
           # If your cluster config does not include a dns service, then to
           # instead access an environment variable to find the master
           # service's host, comment out the 'value: dns' line above, and
-          # uncomment the line below.
+          # uncomment the line below:
           # value: env
         ports:
         - containerPort: 6379

--- a/examples/guestbook/redis-slave-service.yaml
+++ b/examples/guestbook/redis-slave-service.yaml
@@ -8,7 +8,6 @@ metadata:
     tier: backend
 spec:
   ports:
-    # the port that this service should serve on
   - port: 6379
   selector:
     app: redis


### PR DESCRIPTION
The comments removed in this patch are either inaccurate or
does not serve any purpose as they're already applies as uncommented
in the tutorial and explained in the walkthrough text.

```release-note
NONE
```

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>