### PR TITLE
Disable the kubelet part of metrics collection in kubemark

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -324,8 +324,9 @@ func (f *Framework) AfterEach() {
 
 	if TestContext.GatherMetricsAfterTest {
 		By("Gathering metrics")
+		// Grab apiserver metrics and nodes' kubelet metrics (for non-kubemark case).
 		// TODO: enable Scheduler and ControllerManager metrics grabbing when Master's Kubelet will be registered.
-		grabber, err := metrics.NewMetricsGrabber(f.ClientSet, true, false, false, true)
+		grabber, err := metrics.NewMetricsGrabber(f.ClientSet, !ProviderIs("kubemark"), false, false, true)
 		if err != nil {
 			Logf("Failed to create MetricsGrabber (skipping metrics gathering): %v", err)
 		} else {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/45038

This should fix it, as we are just interested in getting the apiserver metrics from kubemark master.

cc @wojtek-t @gmarek 