### PR TITLE
Restructure unit tests for more cert/keys.

### DIFF
--- a/pkg/kubelet/certificate/certificate_manager_test.go
+++ b/pkg/kubelet/certificate/certificate_manager_test.go
@@ -31,63 +31,82 @@ import (
 	certificatesclient "k8s.io/kubernetes/pkg/client/clientset_generated/clientset/typed/certificates/v1beta1"
 )
 
-const (
-	privateKeyData = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEA03ppJ1S3xK2UaXIatBPMbstHm8U9fwIFAj3a2WDV6FHo6zi2
-YHVwCwSVnHL6D+Q5mmlbhnUpSD8SGTLk4EESAe2h203iBOBPBhymhTWA/gAEFk23
-aP1/KlubjYN1+eyksA0lOVcO3sCuRZ64yjYJ369IfV1w8APZ4BXoFtU3uuYpjxyF
-XlydkbLqQZLrBa1B5E8hEkDn4ywNDptGjRN3gT2GMQwnaCkWiLjGK6AxTCleXnjG
-/JyEwbczv0zAE43utcYPW7qk1m5QsKMUAu4/K8y8oGBFy2ygpY1qckcgr5haehOS
-IbFEvVd2oqW8NBicKNmSlh0OcAvQQZtaXhLg/QIDAQABAoIBAFkBmUZLerjVkbQ7
-qQ+HkbBD8FSYVESjVfZWkEiTYBRSfSSbDu9UHh8VA97/6U1M8g2SMEpL/17/5J8k
-c34LBQg4urmxcuI4gioBXviLx0mgOhglB3+xyZbLTZHm9X2F4t6R+cvDX2fTUsXM
-gtvgmJFDlc/lxwXNqSKONct+W+FV/9D2H1Vzf8fQHfa+lltAy8e8MrbmGQTgev+5
-vz/UR/bZz/CHRxXVA6txgvf4AL8BYibxgx6ihW9zKHy6GykqtQ2p0T5XCkObt41S
-6KwUmIHP8CHY23MJ9BPIxYH2+lOXFLizB1VFuxRE1W+je7wVWxzQgFS4IMOLVYDD
-LtprVQUCgYEA4g9ODbyW5vvyp8mmAWAvgeunOR1aP79IIyHiwefEIup4FNo+K2wZ
-QhRPf0LsVvnthJXFWeW9arAWZRWKCFWwISq/cIIB6KXCIIsjiTUe8SYE/8bxAkvL
-0lJhWugTpOnFd8oVuRivrsIWL+SXTNiO5JOP3/qfo+HFk3dqjDhXg4MCgYEA73y1
-Cy+8vHweHKr8HTkPF13GAB1I43SvzTnGT2BT9q6Ia+zQDF1dHjnMrswD1v0+6Xmq
-lKc5M69WBVuLIAfWfMQy0WANpsEMm5MYHShJ3YEYAqBiSTUWi23nLH/Poos4IUDV
-nTAgFuoKFaG/9cLKA736zqJaiJCE/IR2/gqcYX8CgYA5PCjF/5axWt8ALmTyejjt
-Cw4mvtDHzRVll8HC2HxnXrgSh4MwGUl32o6aKQaPqu3BIO57qVhA995jr4VoQNG8
-RAd+Y9w53CX/eVsA9UslQTwIyoTg0PIFCUiO7K10lp+hia/gUmjAtXFKpPTNxxK+
-usG1ss3Sf2o3wQdgAy/dIwKBgQCcHa1fZ3UfYcG3ancDDckasFR8ipqTO+PGYt01
-rVPOwSPJRwywosQrCf62C+SM53V1eYyLbx9I5AmtYGmnLbTSjIucFYOQqtPvLspP
-Z44PSTI/tBGeK29Q4QoL5h2SljK26q7V0yN4DIUaaODb8mkCW3v967QcxikK+8ce
-AAjFPQKBgHnfVRX+00xSeNE0zya1FtQH3db9+fm3IYGK10NI/jTNF6RhUwHJ6X3+
-TR6OhnTQ2j8eAo+6IlLqlDeC1X7GDvaxqstPvGi0lZjoQQGnQqw2m58AMJu3s9fW
-2iddptVycNU0+187DIO39cM3o5s0822VUWDbmymD9cW4i8G6Yto9
------END RSA PRIVATE KEY-----`
-	certificateData = `-----BEGIN CERTIFICATE-----
-MIIDEzCCAfugAwIBAgIBATANBgkqhkiG9w0BAQsFADAjMSEwHwYDVQQDDBhrLWEt
-bm9kZS12YzFzQDE0ODYzMzM1NDgwHhcNMTcwMjA1MjIyNTQ4WhcNMTgwMjA1MjIy
-NTQ4WjAjMSEwHwYDVQQDDBhrLWEtbm9kZS12YzFzQDE0ODYzMzM1NDgwggEiMA0G
-CSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDTemknVLfErZRpchq0E8xuy0ebxT1/
-AgUCPdrZYNXoUejrOLZgdXALBJWccvoP5DmaaVuGdSlIPxIZMuTgQRIB7aHbTeIE
-4E8GHKaFNYD+AAQWTbdo/X8qW5uNg3X57KSwDSU5Vw7ewK5FnrjKNgnfr0h9XXDw
-A9ngFegW1Te65imPHIVeXJ2RsupBkusFrUHkTyESQOfjLA0Om0aNE3eBPYYxDCdo
-KRaIuMYroDFMKV5eeMb8nITBtzO/TMATje61xg9buqTWblCwoxQC7j8rzLygYEXL
-bKCljWpyRyCvmFp6E5IhsUS9V3aipbw0GJwo2ZKWHQ5wC9BBm1peEuD9AgMBAAGj
-UjBQMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMB
-Af8EBTADAQH/MBgGA1UdEQQRMA+CDWstYS1ub2RlLXZjMXMwDQYJKoZIhvcNAQEL
-BQADggEBAAHap+dwrAuejnIK8X/CA2kp2CNZgK8cQbTz6gHcAF7FESv5fL7BiYbJ
-eljhZauh1MSU7hCeXNOK92I1ba7fa8gSdQoSblf9MOmeuNJ4tTwT0y5Cv0dE7anr
-EEPWhp5BeHM10lvw/S2uPiN5CNo9pSniMamDcSC4JPXqfRbpqNQkeFOjByb/Y+ez
-t+4mGQIouLdHDbx53xc0mmDXEfxwfE5K0gcF8T9EOE/azKlVA8Fk84vjMpVR2gka
-O1eRCsCGPAnUCviFgNeH15ug+6N54DTTR6ZV/TTV64FDOcsox9nrhYcmH9sYuITi
-0WC0XoXDL9tMOyzRR1ax/a26ks3Q3IY=
------END CERTIFICATE-----`
-)
+type certificateData struct {
+	keyPEM         []byte
+	certificatePEM []byte
+	certificate    *tls.Certificate
+}
+
+var storeCertData = newCertificateData(`-----BEGIN CERTIFICATE-----
+MIICRzCCAfGgAwIBAgIJALMb7ecMIk3MMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV
+BAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNVBAcMBkxvbmRvbjEYMBYGA1UE
+CgwPR2xvYmFsIFNlY3VyaXR5MRYwFAYDVQQLDA1JVCBEZXBhcnRtZW50MRswGQYD
+VQQDDBJ0ZXN0LWNlcnRpZmljYXRlLTAwIBcNMTcwNDI2MjMyNjUyWhgPMjExNzA0
+MDIyMzI2NTJaMH4xCzAJBgNVBAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNV
+BAcMBkxvbmRvbjEYMBYGA1UECgwPR2xvYmFsIFNlY3VyaXR5MRYwFAYDVQQLDA1J
+VCBEZXBhcnRtZW50MRswGQYDVQQDDBJ0ZXN0LWNlcnRpZmljYXRlLTAwXDANBgkq
+hkiG9w0BAQEFAANLADBIAkEAtBMa7NWpv3BVlKTCPGO/LEsguKqWHBtKzweMY2CV
+tAL1rQm913huhxF9w+ai76KQ3MHK5IVnLJjYYA5MzP2H5QIDAQABo1AwTjAdBgNV
+HQ4EFgQU22iy8aWkNSxv0nBxFxerfsvnZVMwHwYDVR0jBBgwFoAU22iy8aWkNSxv
+0nBxFxerfsvnZVMwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAANBAEOefGbV
+NcHxklaW06w6OBYJPwpIhCVozC1qdxGX1dg8VkEKzjOzjgqVD30m59OFmSlBmHsl
+nkVA6wyOSDYBf3o=
+-----END CERTIFICATE-----`, `-----BEGIN RSA PRIVATE KEY-----
+MIIBUwIBADANBgkqhkiG9w0BAQEFAASCAT0wggE5AgEAAkEAtBMa7NWpv3BVlKTC
+PGO/LEsguKqWHBtKzweMY2CVtAL1rQm913huhxF9w+ai76KQ3MHK5IVnLJjYYA5M
+zP2H5QIDAQABAkAS9BfXab3OKpK3bIgNNyp+DQJKrZnTJ4Q+OjsqkpXvNltPJosf
+G8GsiKu/vAt4HGqI3eU77NvRI+mL4MnHRmXBAiEA3qM4FAtKSRBbcJzPxxLEUSwg
+XSCcosCktbkXvpYrS30CIQDPDxgqlwDEJQ0uKuHkZI38/SPWWqfUmkecwlbpXABK
+iQIgZX08DA8VfvcA5/Xj1Zjdey9FVY6POLXen6RPiabE97UCICp6eUW7ht+2jjar
+e35EltCRCjoejRHTuN9TC0uCoVipAiAXaJIx/Q47vGwiw6Y8KXsNU6y54gTbOSxX
+54LzHNk/+Q==
+-----END RSA PRIVATE KEY-----`)
+var bootstrapCertData = newCertificateData(
+	`-----BEGIN CERTIFICATE-----
+MIICRzCCAfGgAwIBAgIJANXr+UzRFq4TMA0GCSqGSIb3DQEBCwUAMH4xCzAJBgNV
+BAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNVBAcMBkxvbmRvbjEYMBYGA1UE
+CgwPR2xvYmFsIFNlY3VyaXR5MRYwFAYDVQQLDA1JVCBEZXBhcnRtZW50MRswGQYD
+VQQDDBJ0ZXN0LWNlcnRpZmljYXRlLTEwIBcNMTcwNDI2MjMyNzMyWhgPMjExNzA0
+MDIyMzI3MzJaMH4xCzAJBgNVBAYTAkdCMQ8wDQYDVQQIDAZMb25kb24xDzANBgNV
+BAcMBkxvbmRvbjEYMBYGA1UECgwPR2xvYmFsIFNlY3VyaXR5MRYwFAYDVQQLDA1J
+VCBEZXBhcnRtZW50MRswGQYDVQQDDBJ0ZXN0LWNlcnRpZmljYXRlLTEwXDANBgkq
+hkiG9w0BAQEFAANLADBIAkEAqvbkN4RShH1rL37JFp4fZPnn0JUhVWWsrP8NOomJ
+pXdBDUMGWuEQIsZ1Gf9JrCQLu6ooRyHSKRFpAVbMQ3ABJwIDAQABo1AwTjAdBgNV
+HQ4EFgQUEGBc6YYheEZ/5MhwqSUYYPYRj2MwHwYDVR0jBBgwFoAUEGBc6YYheEZ/
+5MhwqSUYYPYRj2MwDAYDVR0TBAUwAwEB/zANBgkqhkiG9w0BAQsFAANBAIyNmznk
+5dgJY52FppEEcfQRdS5k4XFPc22SHPcz77AHf5oWZ1WG9VezOZZPp8NCiFDDlDL8
+yma33a5eMyTjLD8=
+-----END CERTIFICATE-----`, `-----BEGIN RSA PRIVATE KEY-----
+MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEAqvbkN4RShH1rL37J
+Fp4fZPnn0JUhVWWsrP8NOomJpXdBDUMGWuEQIsZ1Gf9JrCQLu6ooRyHSKRFpAVbM
+Q3ABJwIDAQABAkBC2OBpGLMPHN8BJijIUDFkURakBvuOoX+/8MYiYk7QxEmfLCk6
+L6r+GLNFMfXwXcBmXtMKfZKAIKutKf098JaBAiEA10azfqt3G/5owrNA00plSyT6
+ZmHPzY9Uq1p/QTR/uOcCIQDLTkfBkLHm0UKeobbO/fSm6ZflhyBRDINy4FvwmZMt
+wQIgYV/tmQJeIh91q3wBepFQOClFykG8CTMoDUol/YyNqUkCIHfp6Rr7fGL3JIMq
+QQgf9DCK8SPZqq8DYXjdan0kKBJBAiEAyDb+07o2gpggo8BYUKSaiRCiyXfaq87f
+eVqgpBq/QN4=
+-----END RSA PRIVATE KEY-----`)
+
+func newCertificateData(certificatePEM string, keyPEM string) *certificateData {
+	certificate, err := tls.X509KeyPair([]byte(certificatePEM), []byte(keyPEM))
+	if err != nil {
+		panic(fmt.Sprintf("Unable to initialize certificate: %v", err))
+	}
+	certs, err := x509.ParseCertificates(certificate.Certificate[0])
+	if err != nil {
+		panic(fmt.Sprintf("Unable to initialize certificate leaf: %v", err))
+	}
+	certificate.Leaf = certs[0]
+	return &certificateData{
+		keyPEM:         []byte(keyPEM),
+		certificatePEM: []byte(certificatePEM),
+		certificate:    &certificate,
+	}
+}
 
 func TestNewManagerNoRotation(t *testing.T) {
-	cert, err := tls.X509KeyPair([]byte(certificateData), []byte(privateKeyData))
-	if err != nil {
-		t.Fatalf("Unable to initialize a certificate: %v", err)
-	}
-
 	store := &fakeStore{
-		cert: &cert,
+		cert: storeCertData.certificate,
 	}
 	if _, err := NewManager(&Config{
 		Template:         &x509.CertificateRequest{},
@@ -186,8 +205,8 @@ func TestNewManagerBootstrap(t *testing.T) {
 		Template:                &x509.CertificateRequest{},
 		Usages:                  []certificates.KeyUsage{},
 		CertificateStore:        store,
-		BootstrapCertificatePEM: []byte(certificateData),
-		BootstrapKeyPEM:         []byte(privateKeyData),
+		BootstrapCertificatePEM: bootstrapCertData.certificatePEM,
+		BootstrapKeyPEM:         bootstrapCertData.keyPEM,
 	})
 
 	if err != nil {
@@ -209,7 +228,7 @@ func TestNewManagerBootstrap(t *testing.T) {
 
 func TestNewManagerNoBootstrap(t *testing.T) {
 	now := time.Now()
-	cert, err := tls.X509KeyPair([]byte(certificateData), []byte(privateKeyData))
+	cert, err := tls.X509KeyPair(storeCertData.certificatePEM, storeCertData.keyPEM)
 	if err != nil {
 		t.Fatalf("Unable to initialize a certificate: %v", err)
 	}
@@ -225,8 +244,8 @@ func TestNewManagerNoBootstrap(t *testing.T) {
 		Template:                &x509.CertificateRequest{},
 		Usages:                  []certificates.KeyUsage{},
 		CertificateStore:        store,
-		BootstrapCertificatePEM: []byte(certificateData),
-		BootstrapKeyPEM:         []byte(privateKeyData),
+		BootstrapCertificatePEM: bootstrapCertData.certificatePEM,
+		BootstrapKeyPEM:         bootstrapCertData.keyPEM,
 	})
 
 	if err != nil {
@@ -247,11 +266,6 @@ func TestNewManagerNoBootstrap(t *testing.T) {
 }
 
 func TestGetCurrentCertificateOrBootstrap(t *testing.T) {
-	cert, err := tls.X509KeyPair([]byte(certificateData), []byte(privateKeyData))
-	if err != nil {
-		t.Fatalf("Unable to initialize a certificate: %v", err)
-	}
-
 	testCases := []struct {
 		description          string
 		storeCert            *tls.Certificate
@@ -263,10 +277,10 @@ func TestGetCurrentCertificateOrBootstrap(t *testing.T) {
 	}{
 		{
 			"return cert from store",
-			&cert,
+			storeCertData.certificate,
 			nil,
 			nil,
-			&cert,
+			storeCertData.certificate,
 			false,
 			"",
 		},
@@ -375,7 +389,7 @@ func (w *fakeWatch) ResultChan() <-chan watch.Event {
 			Conditions: []certificates.CertificateSigningRequestCondition{
 				condition,
 			},
-			Certificate: []byte(certificateData),
+			Certificate: []byte(storeCertData.certificatePEM),
 		},
 	}
 	csr.UID = "fake-uid"

--- a/pkg/kubelet/certificate/certificate_store_test.go
+++ b/pkg/kubelet/certificate/certificate_store_test.go
@@ -229,7 +229,7 @@ func TestLoadCertKeyBlocksPartialFile(t *testing.T) {
 	}()
 
 	pairFile := filepath.Join(dir, "kubelet-pair.pem")
-	if err := ioutil.WriteFile(pairFile, []byte(certificateData), 0600); err != nil {
+	if err := ioutil.WriteFile(pairFile, storeCertData.certificatePEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", pairFile, err)
 	}
 
@@ -250,7 +250,9 @@ func TestLoadCertKeyBlocks(t *testing.T) {
 	}()
 
 	pairFile := filepath.Join(dir, "kubelet-pair.pem")
-	if err := ioutil.WriteFile(pairFile, []byte(certificateData+"\n"+privateKeyData), 0600); err != nil {
+	data := append(storeCertData.certificatePEM, []byte("\n")...)
+	data = append(data, storeCertData.keyPEM...)
+	if err := ioutil.WriteFile(pairFile, data, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", pairFile, err)
 	}
 
@@ -278,7 +280,9 @@ func TestLoadFile(t *testing.T) {
 	}()
 
 	pairFile := filepath.Join(dir, "kubelet-pair.pem")
-	if err := ioutil.WriteFile(pairFile, []byte(certificateData+"\n"+privateKeyData), 0600); err != nil {
+	data := append(storeCertData.certificatePEM, []byte("\n")...)
+	data = append(data, storeCertData.keyPEM...)
+	if err := ioutil.WriteFile(pairFile, data, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", pairFile, err)
 	}
 
@@ -306,11 +310,11 @@ func TestUpdateNoRotation(t *testing.T) {
 		}
 	}()
 	keyFile := filepath.Join(dir, "kubelet.key")
-	if err := ioutil.WriteFile(keyFile, []byte(privateKeyData), 0600); err != nil {
+	if err := ioutil.WriteFile(keyFile, storeCertData.keyPEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", keyFile, err)
 	}
 	certFile := filepath.Join(dir, "kubelet.crt")
-	if err := ioutil.WriteFile(certFile, []byte(certificateData), 0600); err != nil {
+	if err := ioutil.WriteFile(certFile, storeCertData.certificatePEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", certFile, err)
 	}
 
@@ -319,7 +323,7 @@ func TestUpdateNoRotation(t *testing.T) {
 		t.Fatalf("Got %v while creating a new store.", err)
 	}
 
-	cert, err := s.Update([]byte(certificateData), []byte(privateKeyData))
+	cert, err := s.Update(storeCertData.certificatePEM, storeCertData.keyPEM)
 	if err != nil {
 		t.Errorf("Got %v while updating certificate store.", err)
 	}
@@ -340,11 +344,11 @@ func TestUpdateRotation(t *testing.T) {
 		}
 	}()
 	keyFile := filepath.Join(dir, "kubelet.key")
-	if err := ioutil.WriteFile(keyFile, []byte(privateKeyData), 0600); err != nil {
+	if err := ioutil.WriteFile(keyFile, storeCertData.keyPEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", keyFile, err)
 	}
 	certFile := filepath.Join(dir, "kubelet.crt")
-	if err := ioutil.WriteFile(certFile, []byte(certificateData), 0600); err != nil {
+	if err := ioutil.WriteFile(certFile, storeCertData.certificatePEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", certFile, err)
 	}
 
@@ -353,7 +357,7 @@ func TestUpdateRotation(t *testing.T) {
 		t.Fatalf("Got %v while creating a new store.", err)
 	}
 
-	cert, err := s.Update([]byte(certificateData), []byte(privateKeyData))
+	cert, err := s.Update(storeCertData.certificatePEM, storeCertData.keyPEM)
 	if err != nil {
 		t.Fatalf("Got %v while updating certificate store.", err)
 	}
@@ -374,11 +378,11 @@ func TestUpdateWithBadCertKeyData(t *testing.T) {
 		}
 	}()
 	keyFile := filepath.Join(dir, "kubelet.key")
-	if err := ioutil.WriteFile(keyFile, []byte(privateKeyData), 0600); err != nil {
+	if err := ioutil.WriteFile(keyFile, storeCertData.keyPEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", keyFile, err)
 	}
 	certFile := filepath.Join(dir, "kubelet.crt")
-	if err := ioutil.WriteFile(certFile, []byte(certificateData), 0600); err != nil {
+	if err := ioutil.WriteFile(certFile, storeCertData.certificatePEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", certFile, err)
 	}
 
@@ -387,7 +391,7 @@ func TestUpdateWithBadCertKeyData(t *testing.T) {
 		t.Fatalf("Got %v while creating a new store.", err)
 	}
 
-	cert, err := s.Update([]byte{0, 0}, []byte(privateKeyData))
+	cert, err := s.Update([]byte{0, 0}, storeCertData.keyPEM)
 	if err == nil {
 		t.Fatalf("Got no error while updating certificate store with invalid data.")
 	}
@@ -408,7 +412,9 @@ func TestCurrentPairFile(t *testing.T) {
 		}
 	}()
 	pairFile := filepath.Join(dir, prefix+"-pair.pem")
-	if err := ioutil.WriteFile(pairFile, []byte(certificateData+"\n"+privateKeyData), 0600); err != nil {
+	data := append(storeCertData.certificatePEM, []byte("\n")...)
+	data = append(data, storeCertData.keyPEM...)
+	if err := ioutil.WriteFile(pairFile, data, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", pairFile, err)
 	}
 	currentFile := filepath.Join(dir, prefix+"-current.pem")
@@ -445,11 +451,11 @@ func TestCurrentCertKeyFiles(t *testing.T) {
 		}
 	}()
 	certFile := filepath.Join(dir, "kubelet.crt")
-	if err := ioutil.WriteFile(certFile, []byte(certificateData), 0600); err != nil {
+	if err := ioutil.WriteFile(certFile, storeCertData.certificatePEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", certFile, err)
 	}
 	keyFile := filepath.Join(dir, "kubelet.key")
-	if err := ioutil.WriteFile(keyFile, []byte(privateKeyData), 0600); err != nil {
+	if err := ioutil.WriteFile(keyFile, storeCertData.keyPEM, 0600); err != nil {
 		t.Fatalf("Unable to create the file %q: %v", keyFile, err)
 	}
 


### PR DESCRIPTION
Just changing the unit tests so there is multiple cert/key pairs to be used.
No functional change, no new tests. Follow on PRs will make more use
of the multiple cert/key pairs.