### PR TITLE
kubelet: use the base filename to check if the filename starts with a dot

### DIFF
--- a/pkg/kubelet/config/file_linux.go
+++ b/pkg/kubelet/config/file_linux.go
@@ -22,6 +22,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/golang/glog"
@@ -81,7 +82,7 @@ func (s *sourceFile) watch() error {
 
 func (s *sourceFile) processEvent(e *inotify.Event) error {
 	// Ignore file start with dots
-	if strings.HasPrefix(e.Name, ".") {
+	if strings.HasPrefix(filepath.Base(e.Name), ".") {
 		glog.V(4).Infof("Ignored pod manifest: %s, because it starts with dots", e.Name)
 		return nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug in https://github.com/kubernetes/kubernetes/pull/39196. The goal was to ignore files that start with a dot but the value used is the full absolute filename including path.

**Which issue this PR fixes**: fixes #44450

@yujuhong

**Release note**:
```release-note
kubelet config should actually ignore files starting with dots
```
