### PR TITLE
Quote groups in deny log message

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/rbac.go
+++ b/plugin/pkg/auth/authorizer/rbac/rbac.go
@@ -111,7 +111,7 @@ func (r *RBACAuthorizer) Authorize(requestAttributes authorizer.Attributes) (boo
 			scope = "cluster-wide"
 		}
 
-		glog.Infof("RBAC DENY: user %q groups %v cannot %s %s", requestAttributes.GetUser().GetName(), requestAttributes.GetUser().GetGroups(), operation, scope)
+		glog.Infof("RBAC DENY: user %q groups %q cannot %s %s", requestAttributes.GetUser().GetName(), requestAttributes.GetUser().GetGroups(), operation, scope)
 	}
 
 	reason := ""


### PR DESCRIPTION
Helps distinguish cases where an external authenticator is incorrectly combining multiple groups into one.

Before:
> RBAC DENY: user "bob" groups [system:masters view system:authenticated] cannot "list" resource "pods" cluster-wide

After:
> RBAC DENY: user "bob" groups ["system:masters view" "system:authenticated"] cannot "list" resource "pods" cluster-wide