### PR TITLE
Adds support for updating pods at Bind time

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2509,7 +2509,8 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) field.ErrorList {
 	mungedPod.Spec.Tolerations = oldPod.Spec.Tolerations
 	allErrs = append(allErrs, validateOnlyAddedTolerations(newPod.Spec.Tolerations, oldPod.Spec.Tolerations, specPath.Child("tolerations"))...)
 
-	if !apiequality.Semantic.DeepEqual(mungedPod.Spec, oldPod.Spec) {
+	pending := newPod.Status.Phase == "Pending"
+	if !apiequality.Semantic.DeepEqual(mungedPod.Spec, oldPod.Spec) && !pending {
 		//TODO: Pinpoint the specific field that causes the invalid error after we have strategic merge diff
 		allErrs = append(allErrs, field.Forbidden(specPath, "pod updates may not change fields other than `spec.containers[*].image`, `spec.initContainers[*].image`, `spec.activeDeadlineSeconds` or `spec.tolerations` (only additions to existing tolerations)"))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is for the  specific use case of the [pod preset admission controller](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/pod-preset.md).

Stated in the different parts of the design proposal:
> mounting of Secrets, or setting additional environment variables, may not be known at Pod deployment time, but may be required at Pod creation time.

This is the current behavior and works correctly.
However, this is also true when going through the scheduler extender where I would like to be able to set additional environment variables / mount secrets at "bind time".

The "bind time" describes the fact that the scheduler will set the node to which the pod is assigned.
Thus at the time the scheduler extender wants to set these additional environment variables, the pod has already been created but hasn't been assigned a node and is still in the pending state.

I'm opening this PR to see if this is acceptable to the community (which I suspect isn't) and if it's not how we could solve the problem of updating env / mounts at "bind time".

If the design is approved I would submit in another PR an update to the Pod presets to allow updates at bind time.

**Release note**:
```release-note
Adds support for updating pods in pod presets at Bind time
```
