### PR TITLE
Adds the cifs-common package

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -18,8 +18,9 @@ config:
 options:
   basic:
     packages:
-      - 'nfs-common'
+      - 'cifs-utils'
       - 'ceph-common'
+      - 'nfs-common'
       - 'socat'
   tls-client:
     ca_certificate_path: '/root/cdk/ca.crt'


### PR DESCRIPTION
**What this PR does / why we need it**:  Enables mounting of CIFS volumes. Required for Azure.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/227

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Added CIFS PV support for Juju Charms
```
