### PR TITLE
Also upload debs to bin/$OS/$ARCH

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -14,6 +14,7 @@ filegroup(
         "//build:docker-artifacts-and-hashes",
         "//build:node-targets-and-hashes",
         "//build:server-targets-and-hashes",
+        "//build/debs:debs-and-hashes",
     ],
     visibility = ["//visibility:private"],
 )

--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -2,13 +2,14 @@ package(default_visibility = ["//visibility:public"])
 
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 load("@io_kubernetes_build//defs:deb.bzl", "k8s_deb", "deb_data")
+load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 
 # We do not include kube-scheduler, kube-controller-manager,
 # kube-apiserver, and kube-proxy in this list even though we
 # produce debs for them. We recommend that they be run in docker
 # images. We use the debs that we produce here to build those
 # images.
-filegroup(
+release_filegroup(
     name = "debs",
     srcs = [
         ":kubeadm.deb",


### PR DESCRIPTION
**What this PR does / why we need it**: the bazel-built debs are used by the kubeadm e2e tests, so upload them too.

https://github.com/kubernetes/kubernetes/pull/44591#issuecomment-298084453

/assign @pipejakob 
/cc @mikedanese @spxtr 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```