### PR TITLE
Automated cherry pick of #44178

### DIFF
--- a/cluster/addons/dns/kubedns-sa.yaml
+++ b/cluster/addons/dns/kubedns-sa.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kube-dns
+  namespace: kube-system
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
Cherry pick of #44178 on release-1.6.

#44178: fix kubedns-sa.yaml missing "namespace: kube-system" value

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Add "namespace: kube-system" to kubedns-sa.yaml.
```