### PR TITLE
Increase pv test ns deletion timeout to the framework's default.

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -53,7 +53,8 @@ import (
 )
 
 const (
-	maxKubectlExecRetries = 5
+	maxKubectlExecRetries           = 5
+	DefaultNamespaceDeletionTimeout = 5 * time.Minute
 )
 
 // Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.
@@ -244,7 +245,7 @@ func (f *Framework) AfterEach() {
 		if TestContext.DeleteNamespace && (TestContext.DeleteNamespaceOnFailure || !CurrentGinkgoTestDescription().Failed) {
 			for _, ns := range f.namespacesToDelete {
 				By(fmt.Sprintf("Destroying namespace %q for this suite.", ns.Name))
-				timeout := 5 * time.Minute
+				timeout := DefaultNamespaceDeletionTimeout
 				if f.NamespaceDeletionTimeout != 0 {
 					timeout = f.NamespaceDeletionTimeout
 				}

--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -17,8 +17,6 @@ limitations under the License.
 package storage
 
 import (
-	"time"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -155,7 +153,7 @@ var _ = framework.KubeDescribe("PersistentVolumes:GCEPD [Volume]", func() {
 		err := c.CoreV1().Namespaces().Delete(ns, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		err = framework.WaitForNamespacesDeleted(c, []string{ns}, 3*time.Minute)
+		err = framework.WaitForNamespacesDeleted(c, []string{ns}, framework.DefaultNamespaceDeletionTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying Persistent Disk detaches")


### PR DESCRIPTION
**What this PR does / why we need it**:
Namespace deletion occasionally exceeds the test's timeout of 3 minutes.  The test framework uses a default timeout of 5 minutes, so just making it match here.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #44790

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
NONE
