### PR TITLE
[1.6] Prefer storage.k8s.io/v1beta1 for discovery

### DIFF
--- a/pkg/registry/storage/rest/storage_storage.go
+++ b/pkg/registry/storage/rest/storage_storage.go
@@ -34,13 +34,13 @@ type RESTStorageProvider struct {
 func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(storageapi.GroupName, api.Registry, api.Scheme, api.ParameterCodec, api.Codecs)
 
-	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1beta1.SchemeGroupVersion) {
-		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
-		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1beta1.SchemeGroupVersion
-	}
 	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1.SchemeGroupVersion) {
 		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1.SchemeGroupVersion.Version] = p.v1Storage(apiResourceConfigSource, restOptionsGetter)
 		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1.SchemeGroupVersion
+	}
+	if apiResourceConfigSource.AnyResourcesForVersionEnabled(storageapiv1beta1.SchemeGroupVersion) {
+		apiGroupInfo.VersionedResourcesStorageMap[storageapiv1beta1.SchemeGroupVersion.Version] = p.v1beta1Storage(apiResourceConfigSource, restOptionsGetter)
+		apiGroupInfo.GroupMeta.GroupVersion = storageapiv1beta1.SchemeGroupVersion
 	}
 
 	return apiGroupInfo, true

--- a/staging/src/k8s.io/client-go/pkg/apis/storage/install/install.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/storage/install/install.go
@@ -38,7 +38,21 @@ func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *r
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName: storage.GroupName,
-			// TODO:  change the order when GKE supports v1
+			/*
+				DO NOT set the preferred storage version to v1 until Kubernetes 1.7. This will BREAK rolling
+				cluster upgrades if you do:
+
+				1. Start with 3 apiservers running 1.5
+				2. Upgrade 1 apiserver to 1.6
+				3. Someone sends a request to the 1.6 apiserver to create or update a storage class
+				4. The 1.6 apiserver persists it as v1
+				5. Anyone talking to the 1.5 apiservers that haven't been upgraded yet will break trying to
+				   retrieve the storage class stored as v1.
+
+				Once a cluster is 100% upgraded to 1.7, cluster administrators must run
+				`cluster/update-storage-objects.sh` prior to upgrading to 1.8. This will update all
+				storageclasses so they're stored in v1 format in etcd.
+			*/
 			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version, v1.SchemeGroupVersion.Version},
 			ImportPrefix:               "k8s.io/client-go/pkg/apis/storage",
 			RootScopedKinds:            sets.NewString("StorageClass"),


### PR DESCRIPTION
Prefer storage.k8s.io/v1beta1 for discovery, as older clients might have
a hard time if they don't know about v1.

Fixes #45134 

cc @liggitt @jsafrane @soltysh @enj @kubernetes/sig-storage-pr-reviews @kubernetes/sig-api-machinery-pr-reviews 