### PR TITLE
Kubelet: Make heartbeat logic explicit.

### DIFF
--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -417,6 +417,7 @@ test/images/serve_hostname
 test/integration/examples
 test/integration/federation
 test/integration/metrics
+test/integration/node
 test/integration/objectmeta
 test/integration/openshift
 test/soak/cauldron

--- a/pkg/controller/node/nodecontroller.go
+++ b/pkg/controller/node/nodecontroller.go
@@ -82,8 +82,6 @@ var (
 )
 
 const (
-	// nodeStatusUpdateRetry controls the number of retries of writing NodeStatus update.
-	nodeStatusUpdateRetry = 5
 	// controls how often NodeController will try to evict Pods from non-responsive Nodes.
 	nodeEvictionPeriod = 100 * time.Millisecond
 	// Burst value for all eviction rate limiters
@@ -92,6 +90,10 @@ const (
 	apiserverStartupGracePeriod = 10 * time.Minute
 	// The amount of time the nodecontroller should sleep between retrying NodeStatus updates
 	retrySleepTime = 20 * time.Millisecond
+
+	// This needs to be identical to the value for NodeStatusUpdateRetry in the kubelet, and should be
+	// enforced as such in the integration tests.  It is duplicated to avoid a package dependency.
+	NodeStatusUpdateRetry = 5
 )
 
 type zoneState string
@@ -125,15 +127,16 @@ type NodeController struct {
 	// it doesn't receive update for this amount of time, it will start posting "NodeReady==
 	// ConditionUnknown". The amount of time before which NodeController start evicting pods
 	// is controlled via flag 'pod-eviction-timeout'.
-	// Note: be cautious when changing the constant, it must work with nodeStatusUpdateFrequency
+	// Note: be cautious when changing the constant, it must work with NodeStatusUpdateFrequency
+	// which should be shared and common between all kubelets.
 	// in kubelet. There are several constraints:
-	// 1. nodeMonitorGracePeriod must be N times more than nodeStatusUpdateFrequency, where
-	//    N means number of retries allowed for kubelet to post node status. It is pointless
-	//    to make nodeMonitorGracePeriod be less than nodeStatusUpdateFrequency, since there
-	//    will only be fresh values from Kubelet at an interval of nodeStatusUpdateFrequency.
-	//    The constant must be less than podEvictionTimeout.
-	// 2. nodeMonitorGracePeriod can't be too large for user experience - larger value takes
-	//    longer for user to see up-to-date node status.
+	// 1. nodeMonitorGracePeriod MUST be >= NodeStatusUpdateRetry * NodeStatusUpdateFrequency.
+	//    	Otherwise: there may be fresh values from the kubelet that are otherwise missed.
+	//    Also, nodeMonitorGracePeriod MUST be < podEvictionTimeout.
+	//    	Otherwise, we may evict a pod before its node was truly declared unhealthy.
+	// 2. nodeMonitorGracePeriod logically must be <= NodeStatusUpdateRetry * NodeStatusUpdateFrequency,
+	// 	Since the status will not change after this all the retries for status are completed.
+	// Hence from (1) and (2), the grace period is best set NodeStatusUpdateRetry * NodeStatusUpdateFrequency.
 	nodeMonitorGracePeriod time.Duration
 	// Value controlling NodeController monitoring period, i.e. how often does NodeController
 	// check node status posted from kubelet. This value should be lower than nodeMonitorGracePeriod.
@@ -611,7 +614,7 @@ func (nc *NodeController) monitorNodeStatus() error {
 			continue
 		}
 		node := nodeCopy.(*v1.Node)
-		if err := wait.PollImmediate(retrySleepTime, retrySleepTime*nodeStatusUpdateRetry, func() (bool, error) {
+		if err := wait.PollImmediate(retrySleepTime, retrySleepTime*NodeStatusUpdateRetry, func() (bool, error) {
 			gracePeriod, observedReadyCondition, currentReadyCondition, err = nc.tryUpdateNodeStatus(node)
 			if err == nil {
 				return true, nil

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -14,6 +14,7 @@ go_library(
         "active_deadline.go",
         "disk_manager.go",
         "doc.go",
+        "heartbeat.go",
         "kubelet.go",
         "kubelet_cadvisor.go",
         "kubelet_getters.go",
@@ -146,6 +147,7 @@ go_test(
     srcs = [
         "active_deadline_test.go",
         "disk_manager_test.go",
+        "heartbeat_test.go",
         "kubelet_cadvisor_test.go",
         "kubelet_getters_test.go",
         "kubelet_network_test.go",

--- a/pkg/kubelet/heartbeat.go
+++ b/pkg/kubelet/heartbeat.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,54 +21,56 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+
 	"k8s.io/client-go/util/clock"
 )
 
 const (
 	// These constants should be reviewed and updated very carefully.
-	// nodeStatusUpdateRetry the normal default for how many times kubelet retries when posting node status failed.
-	// this constant is a convention that is expected to be depended on externaly by other components.
+
+	// NodeStatusUpdateRetry is how many times the kubelet retries to post its node status after a failed attempt.
+	// Note that this is exported so that we can write tests to confirm it is consistent across the node controller.
 	NodeStatusUpdateRetry      = 5
 	nodeRegistrationMaxBackoff = 7 * time.Second
 
 	// Less critical constants subject to change.
+
 	nodeStatusBurstRetry = 5 * time.Millisecond
 )
 
-// This module externalizes logic for heartbeating and retrying of communication with the API server.
-// It is intended to externalize functionality that other components (like the controller) may depend on
+// This module encapsulates logic for heartbeating and retrying of communication with the API server.
 
-// registerInitiallyWithInfiniteRetry continually attempts to register, returning an error if it ever gives up.
-// We retry infinitely because registration is a prerequisite to proper kubelet functioning.
-func registerInitiallyWithInfiniteRetry(theClock clock.Clock, register func() bool) error {
+// registerInitiallyWithInfiniteRetry continually runs a function until it succeeds, backing off
+// using specific timings we set for initial registration flow.  Specifically designed for initial registration,
+// but lives here to make timing policy easily transparent.
+func registerInitiallyWithInfiniteRetry(theClock clock.Clock, register func() bool, message string) error {
 	try := 0
 	step := 100 * time.Millisecond
 	complete := false
 	for !complete {
-		glog.Infof("Attempting to register the apiserver (attempt %v)", try)
-		try = try + 1
+		try++
+		glog.Infof("Attempting to run registration function (%v) (attempt %v)", message, try)
 		theClock.Sleep(step)
-		step = step * 2
+		step *= 2
 		if step >= nodeRegistrationMaxBackoff {
 			step = nodeRegistrationMaxBackoff
 		}
 		complete = register()
 	}
-	glog.Infof("Succesfully registered with API server after %v tries.", try)
+	glog.Infof("Succesfully completed registration function (%v) after %v tries.", message, try)
 	return nil
 }
 
-// updateNodeStatusWithRetry retries to update Node status several times in a short burst.  We don't have
-// a traditional backoff here because we want to implement a heartbeat style for communication, controlled via
-// the kubelet's sync loop.  This may change in the future.
-func updateNodeStatusWithRetry(theClock clock.Clock, update func() error) error {
+// updateNodeStatusWithBurstRetry runs a function several times with burst retries.  Specifically designed for
+// node status updates.
+func updateNodeStatusWithBurstRetry(theClock clock.Clock, update func() error, message string) error {
 	for i := 0; i < NodeStatusUpdateRetry; i++ {
-		if err := update(); err != nil {
-			// TODO: Considering to put some small exponential backoff (1ms->100ms)
-			theClock.Sleep(nodeStatusBurstRetry)
-		} else {
+		// Success condition
+		if err := update(); err == nil {
 			return nil
 		}
+		// TODO: Consider a small exponential backoff (1ms->100ms).
+		theClock.Sleep(nodeStatusBurstRetry)
 	}
-	return fmt.Errorf("Failed at updating status %v times consecutively.  Giving up !", NodeStatusUpdateRetry)
+	return fmt.Errorf("failed at running update function (%v), %v times consecutively.  Giving up !", message, NodeStatusUpdateRetry)
 }

--- a/pkg/kubelet/heartbeat.go
+++ b/pkg/kubelet/heartbeat.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/client-go/util/clock"
+)
+
+const (
+	// These constants should be reviewed and updated very carefully.
+	// nodeStatusUpdateRetry the normal default for how many times kubelet retries when posting node status failed.
+	// this constant is a convention that is expected to be depended on externaly by other components.
+	NodeStatusUpdateRetry      = 5
+	nodeRegistrationMaxBackoff = 7 * time.Second
+
+	// Less critical constants subject to change.
+	nodeStatusBurstRetry = 5 * time.Millisecond
+)
+
+// This module externalizes logic for heartbeating and retrying of communication with the API server.
+// It is intended to externalize functionality that other components (like the controller) may depend on
+
+// registerInitiallyWithInfiniteRetry continually attempts to register, returning an error if it ever gives up.
+// We retry infinitely because registration is a prerequisite to proper kubelet functioning.
+func registerInitiallyWithInfiniteRetry(theClock clock.Clock, register func() bool) error {
+	try := 0
+	step := 100 * time.Millisecond
+	complete := false
+	for !complete {
+		glog.Infof("Attempting to register the apiserver (attempt %v)", try)
+		try = try + 1
+		theClock.Sleep(step)
+		step = step * 2
+		if step >= nodeRegistrationMaxBackoff {
+			step = nodeRegistrationMaxBackoff
+		}
+		complete = register()
+	}
+	glog.Infof("Succesfully registered with API server after %v tries.", try)
+	return nil
+}
+
+// updateNodeStatusWithRetry retries to update Node status several times in a short burst.  We don't have
+// a traditional backoff here because we want to implement a heartbeat style for communication, controlled via
+// the kubelet's sync loop.  This may change in the future.
+func updateNodeStatusWithRetry(theClock clock.Clock, update func() error) error {
+	for i := 0; i < NodeStatusUpdateRetry; i++ {
+		if err := update(); err != nil {
+			// TODO: Considering to put some small exponential backoff (1ms->100ms)
+			theClock.Sleep(nodeStatusBurstRetry)
+		} else {
+			return nil
+		}
+	}
+	return fmt.Errorf("Failed at updating status %v times consecutively.  Giving up !", NodeStatusUpdateRetry)
+}

--- a/pkg/kubelet/heartbeat_test.go
+++ b/pkg/kubelet/heartbeat_test.go
@@ -1,10 +1,27 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package kubelet
 
 import (
 	"fmt"
-	"k8s.io/client-go/util/clock"
 	"testing"
 	"time"
+
+	"k8s.io/client-go/util/clock"
 )
 
 func TestInitialRegistration(t *testing.T) {
@@ -12,22 +29,24 @@ func TestInitialRegistration(t *testing.T) {
 	start := time.Now()
 	clock := clock.NewFakeClock(start)
 	err := registerInitiallyWithInfiniteRetry(clock, func() bool {
-		tries = tries + 1
+		tries++
 		// 10,000 is an arbitrarily large number which indicates that retries continue forever.
-		if tries < 10000 {
+		if tries < 10*1000 {
 			return false
 		}
 		return true
-	})
+	}, "test initial reg")
 	elapsed := clock.Since(start).Seconds()
 	if err != nil {
-		t.Fatal("Something went wrong, the test should have returned with no error.")
+		t.Fatalf("Something went wrong, the test should have returned with no error.")
 	}
-	if clock.Since(start).Seconds() < 70000-500 {
-		t.Fatal("Backoff should have gone up to 70,000 seconds, but was too low: %v", elapsed)
+
+	// Allow 1% deviation from the rough estimate of 70,000 seconds, since it is okay to have jitter.
+	if elapsed < (70*1000)-700 {
+		t.Fatalf("Backoff should have gone up to 70,000 seconds, but was too low: %v", elapsed)
 	}
-	if clock.Since(start).Seconds() > 80000 {
-		t.Fatal("Backoff should be less then 80,000 seconds, but was too high: %v.", elapsed)
+	if elapsed > (70*1000)+700 {
+		t.Fatalf("Backoff should be less then 80,000 seconds, but was too high: %v.", elapsed)
 	}
 }
 
@@ -35,13 +54,13 @@ func TestNodeStatusBurst(t *testing.T) {
 	start := time.Now()
 	clock := clock.NewFakeClock(start)
 	tries := 0
-	err := updateNodeStatusWithRetry(clock, func() error {
+	err := updateNodeStatusWithBurstRetry(clock, func() error {
 		if tries == 4 {
 			return nil
 		}
-		tries = tries + 1
+		tries++
 		return fmt.Errorf("retry me!")
-	})
+	}, "test node status burst")
 	if err != nil {
 		t.Fatal("Several retries should have occured, with the last one succeeded, but it failed.")
 	}

--- a/pkg/kubelet/heartbeat_test.go
+++ b/pkg/kubelet/heartbeat_test.go
@@ -1,0 +1,54 @@
+package kubelet
+
+import (
+	"fmt"
+	"k8s.io/client-go/util/clock"
+	"testing"
+	"time"
+)
+
+func TestInitialRegistration(t *testing.T) {
+	tries := 0
+	start := time.Now()
+	clock := clock.NewFakeClock(start)
+	err := registerInitiallyWithInfiniteRetry(clock, func() bool {
+		tries = tries + 1
+		// 10,000 is an arbitrarily large number which indicates that retries continue forever.
+		if tries < 10000 {
+			return false
+		}
+		return true
+	})
+	elapsed := clock.Since(start).Seconds()
+	if err != nil {
+		t.Fatal("Something went wrong, the test should have returned with no error.")
+	}
+	if clock.Since(start).Seconds() < 70000-500 {
+		t.Fatal("Backoff should have gone up to 70,000 seconds, but was too low: %v", elapsed)
+	}
+	if clock.Since(start).Seconds() > 80000 {
+		t.Fatal("Backoff should be less then 80,000 seconds, but was too high: %v.", elapsed)
+	}
+}
+
+func TestNodeStatusBurst(t *testing.T) {
+	start := time.Now()
+	clock := clock.NewFakeClock(start)
+	tries := 0
+	err := updateNodeStatusWithRetry(clock, func() error {
+		if tries == 4 {
+			return nil
+		}
+		tries = tries + 1
+		return fmt.Errorf("retry me!")
+	})
+	if err != nil {
+		t.Fatal("Several retries should have occured, with the last one succeeded, but it failed.")
+	}
+
+	// This bursty behaviour isn't necessarily ideal, but we assert it for the sake of being explicit.
+	// See TODO's in the heartbeat module for future updates.
+	if clock.Since(start).Seconds() > .03 {
+		t.Fatal("Several retries should have completed within roughly 25 milliseconds")
+	}
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -110,9 +110,6 @@ const (
 	// Max amount of time to wait for the container runtime to come up.
 	maxWaitForContainerRuntime = 30 * time.Second
 
-	// nodeStatusUpdateRetry specifies how many times kubelet retries when posting node status failed.
-	nodeStatusUpdateRetry = 5
-
 	// Location of container logs.
 	ContainerLogsDir = "/var/log/containers"
 

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -190,7 +190,7 @@ func (kl *Kubelet) GetRuntime() kubecontainer.Runtime {
 // GetNode returns the node info for the configured node name of this Kubelet.
 func (kl *Kubelet) GetNode() (*v1.Node, error) {
 	if kl.standaloneMode {
-		return kl.initialNode()
+		return kl.tryPopulateInitialNodeData()
 	}
 	return kl.nodeInfo.GetNodeInfo(string(kl.nodeName))
 }
@@ -206,7 +206,7 @@ func (kl *Kubelet) getNodeAnyWay() (*v1.Node, error) {
 			return n, nil
 		}
 	}
-	return kl.initialNode()
+	return kl.tryPopulateInitialNodeData()
 }
 
 // GetNodeConfig returns the container manager node config.

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -23,7 +23,6 @@ import (
 	goruntime "runtime"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/golang/glog"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -53,36 +52,34 @@ const (
 	maxNamesPerImageInNodeStatus = 5
 )
 
-// registerWithApiServer registers the node with the cluster master. It is safe
+// registerWithApiServerWithRetry registers the node with the cluster master. It is safe
 // to call multiple times, but not concurrently (kl.registrationCompleted is
 // not locked).
-func (kl *Kubelet) registerWithApiServer() {
+func (kl *Kubelet) registerWithApiServerWithRetry() {
 	if kl.registrationCompleted {
 		return
 	}
-	step := 100 * time.Millisecond
 
-	for {
-		time.Sleep(step)
-		step = step * 2
-		if step >= 7*time.Second {
-			step = 7 * time.Second
-		}
+	var completedNode *v1.Node = nil
 
-		node, err := kl.initialNode()
-		if err != nil {
-			glog.Errorf("Unable to construct v1.Node object for kubelet: %v", err)
-			continue
-		}
+	registerInitiallyWithInfiniteRetry(kl.clock,
+		func() bool {
+			// Possible error can happen when querying cloud info, so may need retrying.
+			node, err := kl.tryPopulateInitialNodeData()
+			if err != nil {
+				glog.Errorf("unable to construct v1.Node object for kubelet: %v", err)
+				return false
+			}
+			completedNode = node
+			return true
+		}, "populate initial node with metadata")
 
-		glog.Infof("Attempting to register node %s", node.Name)
-		registered := kl.tryRegisterWithApiServer(node)
-		if registered {
-			glog.Infof("Successfully registered node %s", node.Name)
-			kl.registrationCompleted = true
-			return
-		}
-	}
+	registerInitiallyWithInfiniteRetry(kl.clock,
+		func() bool {
+			// Once node is created, try to register.  Again, this might need to be retried.
+			glog.Infof("Attempting to register node %s", completedNode.Name)
+			return kl.tryRegisterWithApiServer(completedNode)
+		}, "register with API Server")
 }
 
 // tryRegisterWithApiServer makes an attempt to register the given node with
@@ -186,9 +183,11 @@ func (kl *Kubelet) reconcileCMADAnnotationWithExistingNode(node, existingNode *v
 	return true
 }
 
-// initialNode constructs the initial v1.Node for this Kubelet, incorporating node
+// tryPopulateInitialNodeData constructs the initial v1.Node for this Kubelet, incorporating node
 // labels, information from the cloud provider, and Kubelet configuration.
-func (kl *Kubelet) initialNode() (*v1.Node, error) {
+// Note that the information content may be acquired from external sources here, so failure
+// is entirely possible, and retry may be necessary.
+func (kl *Kubelet) tryPopulateInitialNodeData() (*v1.Node, error) {
 	node := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: string(kl.nodeName),
@@ -312,28 +311,15 @@ func (kl *Kubelet) syncNodeStatus() {
 	}
 	if kl.registerNode {
 		// This will exit immediately if it doesn't need to do anything.
-		kl.registerWithApiServer()
+		kl.registerWithApiServerWithRetry()
 	}
-	if err := kl.updateNodeStatus(); err != nil {
+	if err := kl.updateNodeStatusWithRetry(); err != nil {
 		glog.Errorf("Unable to update node status: %v", err)
 	}
 }
 
-// updateNodeStatus updates node status to master with retries.
-func (kl *Kubelet) updateNodeStatus() error {
-	for i := 0; i < nodeStatusUpdateRetry; i++ {
-		if err := kl.tryUpdateNodeStatus(i); err != nil {
-			glog.Errorf("Error updating node status, will retry: %v", err)
-		} else {
-			return nil
-		}
-	}
-	return fmt.Errorf("update node status exceeds retry count")
-}
-
-// tryUpdateNodeStatus tries to update node status to master. If ReconcileCBR0
-// is set, this function will also confirm that cbr0 is configured correctly.
-func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
+// updateNodeStatusWithRetry updates node status to master with retries.
+func (kl *Kubelet) updateNodeStatusWithRetry() error {
 	// In large clusters, GET and PUT operations on Node objects coming
 	// from here are the majority of load on apiserver and etcd.
 	// To reduce the load on etcd, we are serving GET operations from
@@ -341,9 +327,17 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 	// seem to cause more conflict - the delays are pretty small).
 	// If it result in a conflict, all retries are served directly from etcd.
 	opts := metav1.GetOptions{}
-	if tryNumber == 0 {
-		util.FromApiserverCache(&opts)
-	}
+	util.FromApiserverCache(&opts)
+	err := updateNodeStatusWithBurstRetry(kl.clock, func() error {
+		return kl.tryUpdateNodeStatus(opts)
+	}, "update node status with the master")
+
+	return err
+}
+
+// tryUpdateNodeStatus tries to update node status to master. If ReconcileCBR0
+// is set, this function will also confirm that cbr0 is configured correctly.
+func (kl *Kubelet) tryUpdateNodeStatus(opts metav1.GetOptions) error {
 	node, err := kl.kubeClient.Core().Nodes().Get(string(kl.nodeName), opts)
 	if err != nil {
 		return fmt.Errorf("error getting node %q: %v", kl.nodeName, err)

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -38,6 +38,7 @@ filegroup(
         "//test/integration/federation:all-srcs",
         "//test/integration/framework:all-srcs",
         "//test/integration/metrics:all-srcs",
+        "//test/integration/node:all-srcs",
         "//test/integration/objectmeta:all-srcs",
         "//test/integration/openshift:all-srcs",
         "//test/integration/scheduler_perf:all-srcs",

--- a/test/integration/node/BUILD
+++ b/test/integration/node/BUILD
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["nodecontroller_test.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/controller/node:go_default_library",
+        "//pkg/kubelet:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/test/integration/node/nodecontroller_test.go
+++ b/test/integration/node/nodecontroller_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/controller/node"
+	"k8s.io/kubernetes/pkg/kubelet"
+)
+
+func TestKubeletNodeControllerConsistency(t *testing.T) {
+	// For details see the heartbeat module in the kubelet.
+	if kubelet.NodeStatusUpdateRetry != node.NodeStatusUpdateRetry {
+		t.Fatalf("kubelet and node controller should share the same constant value for NodeStatusUpdateRetry %v, %v", kubelet.NodeStatusUpdateRetry, node.NodeStatusUpdateRetry)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

We need this PR as an incremental step in code hygeine and documentation  in making the kubelet's heartbeat easier to reason about & improve over time.

The retry logic for kubelets is hard to reason about, and there is no regression to check that it isn't violated.

This PR

- Cleans the constants for the retry logic with clear and definitive descriptions.
- Modularizes retry logic into one place with precise unit tests for its functionality.
- Adds an integration test to confirm that the constants between NC and kubelet is identical.

Does not change the behavior of the system.

Part of #45029  which will pave the way for talking about how we should backoff.  Also improves the logging story for infinite retries and so on in "my kubelet is a zombie and i don't know why"  issues.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

 #45029

**Release note**:
```release-note

Make kubelet apiserver registration/update behaviour more transparent and improve logging conventions.

```
