### PR TITLE
use make slice to store docker objects to improve efficiency

### DIFF
--- a/pkg/kubelet/dockertools/docker_manager.go
+++ b/pkg/kubelet/dockertools/docker_manager.go
@@ -931,7 +931,6 @@ func (dm *DockerManager) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 		metrics.ContainerManagerLatency.WithLabelValues("GetPods").Observe(metrics.SinceInMicroseconds(start))
 	}()
 	pods := make(map[kubetypes.UID]*kubecontainer.Pod)
-	var result []*kubecontainer.Pod
 
 	containers, err := GetKubeletDockerContainers(dm.client, all)
 	if err != nil {
@@ -964,6 +963,7 @@ func (dm *DockerManager) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 		pod.Containers = append(pod.Containers, converted)
 	}
 
+	result := make([]*kubecontainer.Pod, 0, len(pods))
 	// Convert map to list.
 	for _, p := range pods {
 		result = append(result, p)
@@ -973,13 +973,12 @@ func (dm *DockerManager) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 
 // List all images in the local storage.
 func (dm *DockerManager) ListImages() ([]kubecontainer.Image, error) {
-	var images []kubecontainer.Image
-
 	dockerImages, err := dm.client.ListImages(dockertypes.ImageListOptions{})
 	if err != nil {
-		return images, err
+		return []kubecontainer.Image{}, err
 	}
 
+	images := make([]kubecontainer.Image, 0, len(dockerImages))
 	for _, di := range dockerImages {
 		image, err := toRuntimeImage(&di)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

we we know the slice length in advance, I think we had better use make to create the specified length of slice. This will improve some kind of performance. Since if we create a slice with []type{}, we did not know how much space runtime should reserve, since slice implementation should be continuous in memory. While when we make a slice with specified length, runtime would reserve a continuous memory space which will not result in slice movement in case of current space is not enough.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
