### PR TITLE
Wait for controller events in resource conflict test

### DIFF
--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -325,9 +325,12 @@ func TestTokenCreation(t *testing.T) {
 		},
 		"new serviceaccount with no secrets with resource conflict": {
 			ClientObjects: []runtime.Object{updatedServiceAccount(emptySecretReferences()), createdTokenSecret()},
+			IsAsync:       true,
+			MaxRetries:    1,
 
 			AddedServiceAccount: serviceAccount(emptySecretReferences()),
 			ExpectedActions: []core.Action{
+				core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, metav1.NamespaceDefault, "default"),
 				core.NewGetAction(schema.GroupVersionResource{Version: "v1", Resource: "serviceaccounts"}, metav1.NamespaceDefault, "default"),
 			},
 		},


### PR DESCRIPTION
Fixes #45137 

same fix as #44996, missed that there was a second test involving resource conflicts