### PR TITLE
Create a docker image for the cloud controller manager

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -89,6 +89,7 @@ kube::build::get_docker_wrapped_binaries() {
   case $1 in
     "amd64")
         local targets=(
+          cloud-controller-manager,busybox
           kube-apiserver,busybox
           kube-controller-manager,busybox
           kube-scheduler,busybox
@@ -97,6 +98,7 @@ kube::build::get_docker_wrapped_binaries() {
         );;
     "arm")
         local targets=(
+          cloud-controller-manager,armel/busybox
           kube-apiserver,armel/busybox
           kube-controller-manager,armel/busybox
           kube-scheduler,armel/busybox
@@ -105,6 +107,7 @@ kube::build::get_docker_wrapped_binaries() {
         );;
     "arm64")
         local targets=(
+          cloud-controller-manager,aarch64/busybox
           kube-apiserver,aarch64/busybox
           kube-controller-manager,aarch64/busybox
           kube-scheduler,aarch64/busybox
@@ -113,6 +116,7 @@ kube::build::get_docker_wrapped_binaries() {
         );;
     "ppc64le")
         local targets=(
+          cloud-controller-manager,ppc64le/busybox
           kube-apiserver,ppc64le/busybox
           kube-controller-manager,ppc64le/busybox
           kube-scheduler,ppc64le/busybox
@@ -121,6 +125,7 @@ kube::build::get_docker_wrapped_binaries() {
         );;
     "s390x")
         local targets=(
+          cloud-controller-manager,s390x/busybox
           kube-apiserver,s390x/busybox
           kube-controller-manager,s390x/busybox
           kube-scheduler,s390x/busybox


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

If you want to test the cloud-controller-manager our currently, you have to grab the binary from the CI or the release builds, put it in a Dockerfile, build the image and possibly upload the image to a registry, only to be able to test the new cloud stuff out. This is overly complex and should just work like any other component like the core controller manager that has its own docker image pushed automatically for it.

This PR makes the release scripts create an image for the cloud controller manager.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Create and push a docker image for the cloud-controller-manager
```

cc @thockin @wlan0 @roberthbailey @mikedanese 