### PR TITLE
Set Node ExternalIP for local-up-cluster scenarios

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -470,6 +470,7 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		node.Status.Addresses = nodeAddresses
 	} else {
 		var ipAddr net.IP
+		var externalIpAddr net.IP
 		var err error
 
 		// 1) Use nodeIP if set
@@ -478,9 +479,11 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		// 4) Try to get the IP from the network interface used as default gateway
 		if kl.nodeIP != nil {
 			ipAddr = kl.nodeIP
+			externalIpAddr = kl.nodeIP
 			node.ObjectMeta.Annotations[kubeletapis.AnnotationProvidedIPAddr] = kl.nodeIP.String()
 		} else if addr := net.ParseIP(kl.hostname); addr != nil {
 			ipAddr = addr
+			externalIpAddr = addr
 		} else {
 			var addrs []net.IP
 			addrs, err = net.LookupIP(node.Name)
@@ -504,6 +507,11 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 			{Type: v1.NodeInternalIP, Address: ipAddr.String()},
 			{Type: v1.NodeHostName, Address: kl.GetHostname()},
 		}
+		if externalIpAddr != nil {
+			node.Status.Addresses = append(node.Status.Addresses,
+				v1.NodeAddress{Type: v1.NodeExternalIP, Address: externalIpAddr.String()})
+		}
+
 	}
 	return nil
 }

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -218,6 +218,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 			Addresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "127.0.0.1"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},
+				{Type: v1.NodeExternalIP, Address: "127.0.0.1"},
 			},
 			Images: expectedImageList,
 		},
@@ -376,6 +377,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 			Addresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "127.0.0.1"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},
+				{Type: v1.NodeExternalIP, Address: "127.0.0.1"},
 			},
 			// images will be sorted from max to min in node status.
 			Images: []v1.ContainerImage{
@@ -503,6 +505,7 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 			Addresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "127.0.0.1"},
 				{Type: v1.NodeHostName, Address: testKubeletHostname},
+				{Type: v1.NodeExternalIP, Address: "127.0.0.1"},
 			},
 			Images: []v1.ContainerImage{
 				{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

When a cloud provider is not specified which is common in
local-up-cluster scenarios, there should be a way to set the
ExternalIP for a node as we should still be able to run tests
like the following that checks if external ip's are present
on the node:
```
Services [It] should be able to up and down services
```

So if "--node-ip" is set or if HostnameOverride has an ip address,
then we should add another entry for external ip address.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
