### PR TITLE
Run SSH e2e test only if SSH keys are present

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -315,6 +315,12 @@ func SkipIfProviderIs(unsupportedProviders ...string) {
 	}
 }
 
+func SkipUnlessSSHKeyPresent() {
+	if _, err := GetSigner(TestContext.Provider); err != nil {
+		Skipf("No SSH Key for provider %s: '%v'", TestContext.Provider, err)
+	}
+}
+
 func SkipUnlessProviderIs(supportedProviders ...string) {
 	if !ProviderIs(supportedProviders...) {
 		Skipf("Only supported for providers %v (not %s)", supportedProviders, TestContext.Provider)

--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -279,6 +279,9 @@ var _ = framework.KubeDescribe("Services", func() {
 		// TODO: use the ServiceTestJig here
 		// this test uses framework.NodeSSHHosts that does not work if a Node only reports LegacyHostIP
 		framework.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
+		// this test does not work if the Node does not support SSH Key
+		framework.SkipUnlessSSHKeyPresent()
+
 		ns := f.Namespace.Name
 		numPods, servicePort := 3, 80
 

--- a/test/e2e/ssh.go
+++ b/test/e2e/ssh.go
@@ -34,6 +34,10 @@ var _ = framework.KubeDescribe("SSH", func() {
 	BeforeEach(func() {
 		// When adding more providers here, also implement their functionality in util.go's framework.GetSigner(...).
 		framework.SkipUnlessProviderIs(framework.ProvidersWithSSH...)
+
+		// This test SSH's into the node for which it needs the $HOME/.ssh/id_rsa key to be present. So
+		// we should skip if the environment does not have the key (not all CI systems support this use case)
+		framework.SkipUnlessSSHKeyPresent()
 	})
 
 	It("should SSH to all nodes and run commands", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Not all CI systems support ssh keys to be present on the node. This
supports the case where "local" provider is being used when running
e2e test, but the environment does not have a SSH key.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
