### PR TITLE
prevent panic on setting nil deletion timestamp

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -406,6 +406,10 @@ func (u *Unstructured) GetDeletionTimestamp() *metav1.Time {
 }
 
 func (u *Unstructured) SetDeletionTimestamp(timestamp *metav1.Time) {
+	if timestamp == nil {
+		u.setNestedField(nil, "metadata", "deletionTimestamp")
+		return
+	}
 	ts, _ := timestamp.MarshalQueryParameter()
 	u.setNestedField(ts, "metadata", "deletionTimestamp")
 }


### PR DESCRIPTION
Setting a nil deletionstamp on unstructured causes panics.  This is done when preparing for create.