### PR TITLE
fix AWS tagging to add missing tags only

### DIFF
--- a/pkg/cloudprovider/providers/aws/tags.go
+++ b/pkg/cloudprovider/providers/aws/tags.go
@@ -174,7 +174,7 @@ func (c *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecy
 		}
 	}
 
-	if err := c.createTags(client, resourceID, lifecycle, additionalTags); err != nil {
+	if err := c.createTags(client, resourceID, lifecycle, addTags); err != nil {
 		return fmt.Errorf("error adding missing tags to resource %q: %v", resourceID, err)
 	}
 
@@ -184,9 +184,7 @@ func (c *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecy
 // createTags calls EC2 CreateTags, but adds retry-on-failure logic
 // We retry mainly because if we create an object, we cannot tag it until it is "fully created" (eventual consistency)
 // The error code varies though (depending on what we are tagging), so we simply retry on all errors
-func (t *awsTagging) createTags(client EC2, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string) error {
-	tags := t.buildTags(lifecycle, additionalTags)
-
+func (t *awsTagging) createTags(client EC2, resourceID string, lifecycle ResourceLifecycle, tags map[string]string) error {
 	if tags == nil || len(tags) == 0 {
 		return nil
 	}

--- a/pkg/cloudprovider/providers/aws/tags.go
+++ b/pkg/cloudprovider/providers/aws/tags.go
@@ -174,6 +174,10 @@ func (c *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecy
 		}
 	}
 
+	if len(addTags) == 0 {
+		return nil
+	}
+
 	if err := c.createTags(client, resourceID, lifecycle, addTags); err != nil {
 		return fmt.Errorf("error adding missing tags to resource %q: %v", resourceID, err)
 	}
@@ -184,7 +188,9 @@ func (c *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecy
 // createTags calls EC2 CreateTags, but adds retry-on-failure logic
 // We retry mainly because if we create an object, we cannot tag it until it is "fully created" (eventual consistency)
 // The error code varies though (depending on what we are tagging), so we simply retry on all errors
-func (t *awsTagging) createTags(client EC2, resourceID string, lifecycle ResourceLifecycle, tags map[string]string) error {
+func (t *awsTagging) createTags(client EC2, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string) error {
+	tags := t.buildTags(lifecycle, additionalTags)
+
 	if tags == nil || len(tags) == 0 {
 		return nil
 	}


### PR DESCRIPTION
It seems that intention of original code was to build map of missing
tags and call AWS API to add just them, but due to typo full
set of tags was always (re)added

```release-note
NONE
```
