### PR TITLE
Use groupName comment for listers/informers

### DIFF
--- a/cmd/libs/go2idl/informer-gen/generators/packages.go
+++ b/cmd/libs/go2idl/informer-gen/generators/packages.go
@@ -150,6 +150,13 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			targetGroupVersions = externalGroupVersions
 		}
 
+		// If there's a comment of the form "// +groupName=somegroup" or
+		// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
+		// group when generating.
+		if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
+			gv.Group = clientgentypes.Group(strings.SplitN(override[0], ".", 2)[0])
+		}
+
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
 			// filter out types which dont have genclient=true.

--- a/cmd/libs/go2idl/lister-gen/generators/lister.go
+++ b/cmd/libs/go2idl/lister-gen/generators/lister.go
@@ -106,6 +106,13 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			internalGVPkg = strings.Join(parts[0:len(parts)-1], "/")
 		}
 
+		// If there's a comment of the form "// +groupName=somegroup" or
+		// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
+		// group when generating.
+		if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
+			gv.Group = clientgentypes.Group(strings.SplitN(override[0], ".", 2)[0])
+		}
+
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
 			// filter out types which dont have genclient=true.


### PR DESCRIPTION
If present, use the "// +groupName" doc comment as the desired group
name when generating listers and informers.

@kubernetes/sig-api-machinery-pr-reviews @smarterclayton @deads2k @liggitt @sttts 