### PR TITLE
Same internal and external ip for vSphere Cloud Provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -479,16 +479,17 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 						var addressType v1.NodeAddressType
 						if strings.HasPrefix(i.HardwareAddr.String(), MAC_OUI_VC) ||
 							strings.HasPrefix(i.HardwareAddr.String(), MAC_OUI_ESX) {
-							addressType = v1.NodeExternalIP
-						} else {
-							addressType = v1.NodeInternalIP
+							v1helper.AddToNodeAddresses(&addrs,
+								v1.NodeAddress{
+									Type:    v1.NodeExternalIP,
+									Address: ipnet.IP.String(),
+								},
+								v1.NodeAddress{
+									Type:    v1.NodeInternalIP,
+									Address: ipnet.IP.String(),
+								},
+							)
 						}
-						v1helper.AddToNodeAddresses(&addrs,
-							v1.NodeAddress{
-								Type:    addressType,
-								Address: ipnet.IP.String(),
-							},
-						)
 						glog.V(4).Infof("Find local IP address %v and set type to %v", ipnet.IP.String(), addressType)
 					}
 				}
@@ -547,20 +548,19 @@ func (vs *VSphere) NodeAddresses(nodeName k8stypes.NodeName) ([]v1.NodeAddress, 
 
 	// retrieve VM's ip(s)
 	for _, v := range mvm.Guest.Net {
-		var addressType v1.NodeAddressType
 		if vs.cfg.Network.PublicNetwork == v.Network {
-			addressType = v1.NodeExternalIP
-		} else {
-			addressType = v1.NodeInternalIP
-		}
-		for _, ip := range v.IpAddress {
-			if net.ParseIP(ip).To4() != nil {
-				v1helper.AddToNodeAddresses(&addrs,
-					v1.NodeAddress{
-						Type:    addressType,
-						Address: ip,
-					},
-				)
+			for _, ip := range v.IpAddress {
+				if net.ParseIP(ip).To4() != nil {
+					v1helper.AddToNodeAddresses(&addrs,
+						v1.NodeAddress{
+							Type:    v1.NodeExternalIP,
+							Address: ip,
+						}, v1.NodeAddress{
+							Type:    v1.NodeInternalIP,
+							Address: ip,
+						},
+					)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently, vSphere Cloud Provider reports internal ip as container ip addresses. This PR modifies vSphere Cloud Provider to report same ip address as both internal and external that is provided by vmware infrastructure. 
cc @pdhamdhere @tusharnt @BaluDontu @divyenpatel @luomiao 

```release-note
vSphere cloud provider: Report same Node IP as both internal and external.
```