### PR TITLE
Fix onlylocal endpoint's healthcheck nodeport logic

### DIFF
--- a/pkg/api/service/util.go
+++ b/pkg/api/service/util.go
@@ -105,9 +105,6 @@ func NeedsHealthCheck(service *api.Service) bool {
 
 // GetServiceHealthCheckNodePort Return health check node port annotation for service, if one exists
 func GetServiceHealthCheckNodePort(service *api.Service) int32 {
-	if !NeedsHealthCheck(service) {
-		return 0
-	}
 	// First check the alpha annotation and then the beta. This is so existing
 	// Services continue to work till the user decides to transition to beta.
 	// If they transition to beta, there's no way to go back to alpha without

--- a/pkg/api/v1/service/util.go
+++ b/pkg/api/v1/service/util.go
@@ -105,9 +105,6 @@ func NeedsHealthCheck(service *v1.Service) bool {
 
 // GetServiceHealthCheckNodePort Return health check node port annotation for service, if one exists
 func GetServiceHealthCheckNodePort(service *v1.Service) int32 {
-	if !NeedsHealthCheck(service) {
-		return 0
-	}
 	// First check the alpha annotation and then the beta. This is so existing
 	// Services continue to work till the user decides to transition to beta.
 	// If they transition to beta, there's no way to go back to alpha without


### PR DESCRIPTION
I was in the middle of rebasing #41162, surprisingly found the healthcheck nodeport logic in kube-proxy is still buggy. Separate this fix out as it isn't GA related.

/assign @freehan @thockin

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
