### PR TITLE
Fix golint verify error

### DIFF
--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -99,7 +99,7 @@ func newRS(namespace string) *v1beta1.ReplicaSet {
 	}
 }
 
-var cascDel string = `
+var cascDel = `
 {
   "kind": "DeleteOptions",
   "apiVersion": "` + api.Registry.GroupOrDie(api.GroupName).GroupVersion.String() + `",


### PR DESCRIPTION
I don't know why CI pass the hack/verify-golint.sh test.
But in my environment I get this:

> staging/src/k8s.io/client-go/util/workqueue/queue_test.go is in package workqueue_test, not workqueue
Errors from golint:
test/integration/apiserver/apiserver_test.go:102:13: should omit type string from declaration of var cascDel; it will be inferred from the right-hand side
Please fix the above errors. You can test via "golint" and commit the result.
!!! Error in hack/verify-golint.sh:98
  Error in hack/verify-golint.sh:98. 'false' exited with status 1
Call stack:
  1: hack/verify-golint.sh:98 main(...)
Exiting with status 1

This change fix this err in my environment.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
