### PR TITLE
kubeadm: move preflight kubelet check

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -175,12 +175,12 @@ func NewInit(cfgPath string, cfg *kubeadmapi.MasterConfiguration, skipPreFlight,
 		if err := preflight.RunInitMasterChecks(cfg); err != nil {
 			return nil, err
 		}
+
+		// Try to start the kubelet service in case it's inactive
+		preflight.TryStartKubelet()
 	} else {
 		fmt.Println("[preflight] Skipping pre-flight checks")
 	}
-
-	// Try to start the kubelet service in case it's inactive
-	preflight.TryStartKubelet()
 
 	return &Init{cfg: cfg, skipTokenPrint: skipTokenPrint}, nil
 }

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -156,12 +156,12 @@ func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, s
 		if err := preflight.RunJoinNodeChecks(cfg); err != nil {
 			return nil, err
 		}
+
+		// Try to start the kubelet service in case it's inactive
+		preflight.TryStartKubelet()
 	} else {
 		fmt.Println("[preflight] Skipping pre-flight checks")
 	}
-
-	// Try to start the kubelet service in case it's inactive
-	preflight.TryStartKubelet()
 
 	return &Join{cfg: cfg}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: If you passed the `--skip-preflight-checks` to kubeadm, it would still try to start up the kubelet, which is part of preflight checks. This was causing issues for test-cmds. Now, passing `--skip-preflight-checks` will skip over the kubelet check. 

**Special notes for your reviewer**: /cc @luxas @deads2k 

**Release note**:
```release-note
NONE
```
