### PR TITLE
Don't cordon if kubectl drain won't succeed

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -235,11 +235,18 @@ func (o *DrainOptions) SetupDrain(cmd *cobra.Command, args []string) error {
 
 // RunDrain runs the 'drain' command
 func (o *DrainOptions) RunDrain() error {
+	// Run a preflight check to see if any pods currently exist that have local storage,
+	// that we would otherwise discover after cordoning.
+	_, err := o.getPodsForDeletion()
+	if err != nil {
+		return err
+	}
+
 	if err := o.RunCordonOrUncordon(true); err != nil {
 		return err
 	}
 
-	err := o.deleteOrEvictPodsSimple()
+	err = o.deleteOrEvictPodsSimple()
 	if err == nil {
 		cmdutil.PrintSuccess(o.mapper, false, o.Out, "node", o.nodeInfo.Name, false, "drained")
 	}

--- a/pkg/kubectl/cmd/drain_test.go
+++ b/pkg/kubectl/cmd/drain_test.go
@@ -412,7 +412,7 @@ func TestDrain(t *testing.T) {
 		{
 			description:  "DS-managed pod",
 			node:         node,
-			expected:     cordoned_node,
+			expected:     node,
 			pods:         []api.Pod{ds_pod},
 			rcs:          []api.ReplicationController{rc},
 			args:         []string{"node"},
@@ -422,7 +422,7 @@ func TestDrain(t *testing.T) {
 		{
 			description:  "orphaned DS-managed pod",
 			node:         node,
-			expected:     cordoned_node,
+			expected:     node,
 			pods:         []api.Pod{orphaned_ds_pod},
 			rcs:          []api.ReplicationController{},
 			args:         []string{"node"},
@@ -472,7 +472,7 @@ func TestDrain(t *testing.T) {
 		{
 			description:  "naked pod",
 			node:         node,
-			expected:     cordoned_node,
+			expected:     node,
 			pods:         []api.Pod{naked_pod},
 			rcs:          []api.ReplicationController{},
 			args:         []string{"node"},
@@ -492,7 +492,7 @@ func TestDrain(t *testing.T) {
 		{
 			description:  "pod with EmptyDir",
 			node:         node,
-			expected:     cordoned_node,
+			expected:     node,
 			pods:         []api.Pod{emptydir_pod},
 			args:         []string{"node", "--force"},
 			expectFatal:  true,
@@ -532,6 +532,7 @@ func TestDrain(t *testing.T) {
 			new_node := &api.Node{}
 			deleted := false
 			evicted := false
+			updated := false
 			f, tf, codec, ns := cmdtesting.NewAPIFactory()
 			tf.Client = &fake.RESTClient{
 				APIRegistry:          api.Registry,
@@ -608,6 +609,7 @@ func TestDrain(t *testing.T) {
 						if !reflect.DeepEqual(test.expected.Spec, new_node.Spec) {
 							t.Fatalf("%s: expected:\n%v\nsaw:\n%v\n", test.description, test.expected.Spec, new_node.Spec)
 						}
+						updated = true
 						return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, new_node)}, nil
 					case m.isFor("DELETE", "/namespaces/default/pods/bar"):
 						deleted = true
@@ -660,6 +662,9 @@ func TestDrain(t *testing.T) {
 				if deleted {
 					t.Fatalf("%s: unexpected delete when using %s", test.description, currMethod)
 				}
+			}
+			if !reflect.DeepEqual(test.expected.Spec, test.node.Spec) && !updated {
+				t.Fatalf("%s: node never updated", test.description)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of draining the node then realising that we have a pod with an
EmptyDir or similar, run a preflight check to see if any such pods exist
first.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #37592

**Special notes for your reviewer**:
Since new pods might end up being created between initially creating the
list of pods and cordoning the node, we don't reuse the list of pods
to determine what to delete. This does mean that there is still a chance
of failure after the node has been drained, if you're unlucky.

However, this might happen if deleting pods fails for reasons outside
the scope of what we can reasonably expect, and uncordoning the node
after some of the pods have been deleted is perhaps unexpected, as
discussed in #37592.

**Release note**:
```release-note
NONE
```
