### PR TITLE
Update bazel build to dockerize cloud-controller-manager

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -44,7 +44,13 @@ docker_build(
     ],
 )
 
+# This list should roughly match kube::build::get_docker_wrapped_binaries()
+# in build/common.sh.
 DOCKERIZED_BINARIES = {
+    "cloud-controller-manager": {
+        "base": ":busybox",
+        "target": "//cmd/cloud-controller-manager:cloud-controller-manager",
+    },
     "kube-apiserver": {
         "base": ":busybox",
         "target": "//cmd/kube-apiserver:kube-apiserver",

--- a/build/common.sh
+++ b/build/common.sh
@@ -86,6 +86,8 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
   debian_iptables_version=v7
+  ### If you change any of these lists, please also update DOCKERIZED_BINARIES
+  ### in build/BUILD.
   case $1 in
     "amd64")
         local targets=(

--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -11,6 +11,7 @@ load("@io_kubernetes_build//defs:deb.bzl", "k8s_deb", "deb_data")
 filegroup(
     name = "debs",
     srcs = [
+        ":cloud-controller-manager.deb",
         ":kubeadm.deb",
         ":kubectl.deb",
         ":kubelet.deb",
@@ -28,6 +29,7 @@ filegroup(
         },
     ],
 ) for binary in [
+    "cloud-controller-manager",
     "kubectl",
     "kube-apiserver",
     "kube-controller-manager",
@@ -81,6 +83,11 @@ pkg_tar(
     name = "kubernetes-cni-data",
     package_dir = "/opt/cni",
     deps = ["@kubernetes_cni//file"],
+)
+
+k8s_deb(
+    name = "cloud-controller-manager",
+    description = "Kubernetes Cloud Controller Manager",
 )
 
 k8s_deb(


### PR DESCRIPTION
**What this PR does / why we need it**: followup to #45154. Also added a comment so that hopefully this sort of followup isn't needed again. :)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```

/assign @mikedanese @luxas 
