### PR TITLE
Adding note on how to use datastore cluster for volume provisioning

### DIFF
--- a/examples/volumes/vsphere/README.md
+++ b/examples/volumes/vsphere/README.md
@@ -94,6 +94,11 @@
           volumePath: "[datastore1] volumes/myDisk"
           fsType: ext4
       ```
+      In the above example datastore1 is located in the root folder. If datastore is member of Datastore Cluster or located in sub folder, the folder path needs to be provided in the VolumePath as below. 
+      ```yaml
+      vsphereVolume:
+          VolumePath:	"[DatastoreCluster/datastore1] volumes/myDisk" 
+      ```
 
       [Download example](vsphere-volume-pv.yaml?raw=true)
 
@@ -233,7 +238,13 @@
       parameters:
           diskformat: zeroedthick
           datastore: VSANDatastore
-      ```
+      ```     
+      If datastore is member of DataStore Cluster or within some sub folder, the datastore folder path needs to be provided in the datastore parameter as below.
+
+       ```yaml
+       parameters:
+          datastore:	DatastoreCluster/VSANDatastore
+       ```
 
       [Download example](vsphere-volume-sc-with-datastore.yaml?raw=true)
       Creating the storageclass:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Recently https://github.com/kubernetes/kubernetes/pull/44868 is merged which allows using datastore cluster for static and dynamic PVs.

Sample is required in the Read me file to help user, how they can specify path in the yaml for datastore within cluster.


**Which issue this PR fixes**
fixes # https://github.com/vmware/kubernetes/issues/129

**Special notes for your reviewer**:
@BaluDontu @tusharnt

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
