### PR TITLE
skip procfs-dependent metrics test if not on linux

### DIFF
--- a/test/integration/metrics/metrics_test.go
+++ b/test/integration/metrics/metrics_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,6 +86,10 @@ func checkForExpectedMetrics(t *testing.T, metrics []*prometheuspb.MetricFamily,
 }
 
 func TestMasterProcessMetrics(t *testing.T) {
+	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
+		t.Skipf("not supported on GOOS=%s", runtime.GOOS)
+	}
+
 	_, s := framework.RunAMaster(nil)
 	defer s.Close()
 
@@ -95,7 +100,6 @@ func TestMasterProcessMetrics(t *testing.T) {
 	checkForExpectedMetrics(t, metrics, []string{
 		"process_start_time_seconds",
 		"process_cpu_seconds_total",
-		"go_goroutines",
 		"process_open_fds",
 		"process_resident_memory_bytes",
 	})


### PR DESCRIPTION
**What this PR does / why we need it**: #40774 removed build tags on integration tests, which uncovered the fact that a test in `test/integration/metrics` relies on `procfs`. This PR follows the convention used in `pkg/util/procfs` to gate the test on `runtime.GOOS`

**Release note**:
```release-note
NONE
```

/cc @kubernetes/sig-testing-pr-reviews