### PR TITLE
skip integration test when run make bazel-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -517,7 +517,7 @@ bazel-test:
 	@echo "$$BAZEL_TEST_HELP_INFO"
 else
 bazel-test:
-	bazel test --flaky_test_attempts=3 //cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...
+	bazel test --test_tag_filters=-integration --flaky_test_attempts=3 //cmd/... //pkg/... //federation/... //plugin/... //third_party/... //hack/... //hack:verify-all //vendor/k8s.io/...
 endif
 
 ifeq ($(PRINT_HELP),y)

--- a/test/integration/federation/BUILD
+++ b/test/integration/federation/BUILD
@@ -13,7 +13,10 @@ go_test(
         "api_test.go",
         "crud_test.go",
     ],
-    tags = ["automanaged"],
+    tags = [
+        "automanaged",
+        "integration",
+    ],
     deps = [
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/pkg/federatedtypes:go_default_library",


### PR DESCRIPTION
we should opt for a seperate target for integration tests. This is breaking @deads2k who is trying to add an integration test in staging.