### PR TITLE
Fixed misspelled http URL in the cluster-dns example

### DIFF
--- a/examples/cluster-dns/dns-frontend-pod.yaml
+++ b/examples/cluster-dns/dns-frontend-pod.yaml
@@ -11,6 +11,6 @@ spec:
       command:
         - python
         - client.py
-        - http://dns-backend.development.cluster.local:8000
+        - http://dns-backend.development.svc.cluster.local:8000
       imagePullPolicy: Always
   restartPolicy: Never


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes wrong  http URL in the examples/cluster-dns. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
none

**Release note**:
none
