### PR TITLE
Use docker_bundle rule from new rules_docker repo

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,25 +1,32 @@
-git_repository(
+http_archive(
     name = "io_bazel_rules_go",
-    commit = "805fd1566500997379806373feb05e138a4dfe28",
-    remote = "https://github.com/bazelbuild/rules_go.git",
+    sha256 = "a1cae429e9d591017421150e3173478c46c693bc594322c7fa7e6cb5f672ef59",
+    strip_prefix = "rules_go-805fd1566500997379806373feb05e138a4dfe28",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/805fd1566500997379806373feb05e138a4dfe28.tar.gz"],
 )
 
-git_repository(
+http_archive(
     name = "io_kubernetes_build",
-    commit = "684e550a2f006dbe3cf3b3d481d3f19217b228f7",
-    remote = "https://github.com/kubernetes/repo-infra.git",
+    sha256 = "1d146ccc034d3a9d8f5f02237144b78be135a0fb06935b37c745a2e7fcfecfed",
+    strip_prefix = "repo-infra-684e550a2f006dbe3cf3b3d481d3f19217b228f7",
+    urls = ["https://github.com/kubernetes/repo-infra/archive/684e550a2f006dbe3cf3b3d481d3f19217b228f7.tar.gz"],
 )
 
-git_repository(
+# This contains a patch to not prepend ./ to tarfiles produced by pkg_tar.
+# When merged upstream, we'll no longer need to use ixdy's fork:
+# https://bazel-review.googlesource.com/#/c/10390/
+http_archive(
     name = "io_bazel",
-    commit = "b571b72961b9244059bdf96818948623cebf342e",
-    remote = "https://github.com/ixdy/bazel.git",
+    sha256 = "667d32da016b1e2f63cf345cd3583989ec4a165034df383a01996d93635753a0",
+    strip_prefix = "bazel-df2c687c22bdd7c76f3cdcc85f38fefd02f0b844",
+    urls = ["https://github.com/ixdy/bazel/archive/df2c687c22bdd7c76f3cdcc85f38fefd02f0b844.tar.gz"],
 )
 
-git_repository(
+http_archive(
     name = "io_bazel_rules_docker",
-    commit = "52d9faf209ff6d16eb850b6b66d03483735e0633",
-    remote = "https://github.com/bazelbuild/rules_docker.git",
+    sha256 = "261fbd8fda1d06a12a0479019b46acd302c6aaa8df8e49383dc37917f20492a1",
+    strip_prefix = "rules_docker-52d9faf209ff6d16eb850b6b66d03483735e0633",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/52d9faf209ff6d16eb850b6b66d03483735e0633.tar.gz"],
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,15 +12,24 @@ git_repository(
 
 git_repository(
     name = "io_bazel",
-    commit = "1fe52dd4b2d77a740648bc1509b68acae49deffc",
+    commit = "b571b72961b9244059bdf96818948623cebf342e",
     remote = "https://github.com/ixdy/bazel.git",
 )
 
+git_repository(
+    name = "io_bazel_rules_docker",
+    commit = "52d9faf209ff6d16eb850b6b66d03483735e0633",
+    remote = "https://github.com/bazelbuild/rules_docker.git",
+)
+
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories")
 
 go_repositories(
     go_version = "1.8.1",
 )
+
+docker_repositories()
 
 # for building docker base images
 debs = (

--- a/build/BUILD
+++ b/build/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel//tools/build_defs/docker:docker.bzl", "docker_build")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_build", "docker_bundle")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 
 filegroup(
@@ -69,31 +69,32 @@ DOCKERIZED_BINARIES = {
     },
 }
 
+[docker_build(
+    name = binary + "-internal",
+    base = meta["base"],
+    cmd = ["/usr/bin/" + binary],
+    debs = [
+        "//build/debs:%s.deb" % binary,
+    ],
+    symlinks = {
+        # Some cluster startup scripts expect to find the binaries in /usr/local/bin,
+        # but the debs install the binaries into /usr/bin.
+        "/usr/local/bin/" + binary: "/usr/bin/" + binary,
+    },
+) for binary, meta in DOCKERIZED_BINARIES.items()]
+
+[docker_bundle(
+    name = binary,
+    images = {"gcr.io/google_containers/%s:{STABLE_DOCKER_TAG}" % binary: binary + "-internal"},
+    stamp = True,
+) for binary in DOCKERIZED_BINARIES.keys()]
+
 [genrule(
     name = binary + "_docker_tag",
     srcs = [meta["target"]],
     outs = [binary + ".docker_tag"],
     cmd = "grep ^STABLE_DOCKER_TAG bazel-out/stable-status.txt | awk '{print $$2}' >$@",
     stamp = 1,
-) for binary, meta in DOCKERIZED_BINARIES.items()]
-
-[docker_build(
-    name = binary,
-    base = meta["base"],
-    cmd = ["/usr/bin/" + binary],
-    debs = [
-        "//build/debs:%s.deb" % binary,
-    ],
-    image_tags = [
-        "@%s.docker_tag" % binary,
-    ],
-    repository = "gcr.io/google_containers/" + binary,
-    repository_append_package = False,
-    symlinks = {
-        # Some cluster startup scripts expect to find the binaries in /usr/local/bin,
-        # but the debs install the binaries into /usr/bin.
-        "/usr/local/bin/" + binary: "/usr/bin/" + binary,
-    },
 ) for binary, meta in DOCKERIZED_BINARIES.items()]
 
 release_filegroup(

--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 load("@io_kubernetes_build//defs:deb.bzl", "k8s_deb", "deb_data")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 

--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 
 filegroup(

--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 licenses(["notice"])
 

--- a/cluster/addons/BUILD
+++ b/cluster/addons/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "addon-srcs",

--- a/cluster/gce/BUILD
+++ b/cluster/gce/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("@io_kubernetes_build//defs:build.bzl", "release_filegroup")
 
 pkg_tar(

--- a/cluster/saltbase/BUILD
+++ b/cluster/saltbase/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "package-srcs",

--- a/federation/BUILD
+++ b/federation/BUILD
@@ -2,7 +2,7 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 filegroup(
     name = "package-srcs",


### PR DESCRIPTION
**What this PR does / why we need it**: switched to using the new `docker_bundle` rule from `rules_docker` instead of my patched `docker_build` rule. This also brings in some fixes for the docker rules that were missing from my fork.

Additionally, I switched out the `git_repository` rules for `http_archive` rules, since that seems to be recommended by the bazel docs (and might be faster). 

Lastly, I updated the `pkg_tar` rules to use my patch, which doesn't prepend `./` to files inside the tarballs.
This one should likely be merged upstream in the near future.

I think this is the last of the changes necessary to have `bazel run //:ci-artifacts` working properly to support using bazel for e2e in CI.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
