### PR TITLE
Rename //:ci-artifacts rule to //:push-build, and add a deprecated alias

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,7 +20,7 @@ filegroup(
 )
 
 gcs_upload(
-    name = "ci-artifacts",
+    name = "push-build",
     data = [
         ":_binary-artifacts-and-hashes",
         "//build/release-tars:release-tars-and-hashes",
@@ -31,6 +31,13 @@ gcs_upload(
         "//build/release-tars:release-tars-and-hashes": "",
         "//cluster/gce:gcs-release-artifacts-and-hashes": "extra/gce",
     },
+)
+
+# TODO: remove this alias after 2017-05-22
+alias(
+    name = "ci-artifacts",
+    actual = "push-build",
+    deprecation = "This rule will be removed after 2017-05-22. Use //:push-build instead.",
 )
 
 filegroup(


### PR DESCRIPTION
**What this PR does / why we need it**: this rule has a larger scope than just CI artifacts now, so it seems like the name should be updated to match. WDYT?

This is a separate PR to facilitate easy cherry-picking; I'd rather test-infra jobs not need to special-case.

/assign @spxtr @mikedanese 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
