### PR TITLE
Control visibility of client-go/pkg/api

### DIFF
--- a/staging/src/k8s.io/client-go/pkg/api/BUILD
+++ b/staging/src/k8s.io/client-go/pkg/api/BUILD
@@ -23,6 +23,13 @@ go_library(
         "zz_generated.deepcopy.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//vendor/k8s.io/client-go/pkg/api:__subpackages__",
+        "//vendor/k8s.io/client-go/pkg/apis:__subpackages__",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/install:__subpackages__",
+        "//vendor/k8s.io/metrics/pkg/apis:__subpackages__",
+        "//vendor/k8s.io/metrics/pkg/client:__subpackages__",
+    ],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",

--- a/staging/src/k8s.io/client-go/pkg/api/helper/BUILD
+++ b/staging/src/k8s.io/client-go/pkg/api/helper/BUILD
@@ -12,6 +12,9 @@ go_library(
     name = "go_default_library",
     srcs = ["helpers.go"],
     tags = ["automanaged"],
+    visibility = [
+        "//pkg/controller/bootstrap:__subpackages__",
+    ],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/client-go/pkg/api/install/BUILD
+++ b/staging/src/k8s.io/client-go/pkg/api/install/BUILD
@@ -11,6 +11,13 @@ go_library(
     name = "go_default_library",
     srcs = ["install.go"],
     tags = ["automanaged"],
+    visibility = [
+        "//pkg/client/tests:__subpackages__",
+        "//pkg/controller/podautoscaler/metrics:__subpackages__",
+        "//vendor/k8s.io/apiserver/pkg/endpoints/handlers:__subpackages__",
+        "//vendor/k8s.io/apiserver/pkg/storage/tests:__subpackages__",
+        "//vendor/k8s.io/client-go/kubernetes/fake:__subpackages__",
+    ],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/announced:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",


### PR DESCRIPTION
k8s.io/client-go/pkg/api is going to disappear after https://github.com/kubernetes/kubernetes/issues/44065 is done. We need to add more dependencies on it.

Currently we still have a few visibility exceptions, we need to fix all of them.