### PR TITLE
Prompt secrets

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -376,7 +376,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 	}
 
 	cmds.AddCommand(alpha)
-	cmds.AddCommand(cmdconfig.NewCmdConfig(clientcmd.NewDefaultPathOptions(), out, err))
+	cmds.AddCommand(cmdconfig.NewCmdConfig(clientcmd.NewDefaultPathOptions(), in, out, err))
 	cmds.AddCommand(NewCmdPlugin(f, in, out, err))
 	cmds.AddCommand(NewCmdVersion(f, out))
 	cmds.AddCommand(NewCmdApiVersions(f, out))

--- a/pkg/kubectl/cmd/config/BUILD
+++ b/pkg/kubectl/cmd/config/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api/latest:go_default_library",
+        "//vendor/k8s.io/client-go/util/prompt:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/config/config.go
+++ b/pkg/kubectl/cmd/config/config.go
@@ -31,7 +31,7 @@ import (
 )
 
 // NewCmdConfig creates a command object for the "config" action, and adds all child commands to it.
-func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *cobra.Command {
+func NewCmdConfig(pathOptions *clientcmd.PathOptions, in io.Reader, out, errOut io.Writer) *cobra.Command {
 	if len(pathOptions.ExplicitFileFlag) == 0 {
 		pathOptions.ExplicitFileFlag = clientcmd.RecommendedConfigPathFlag
 	}
@@ -55,7 +55,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *co
 
 	cmd.AddCommand(NewCmdConfigView(out, errOut, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetCluster(out, pathOptions))
-	cmd.AddCommand(NewCmdConfigSetAuthInfo(out, pathOptions))
+	cmd.AddCommand(NewCmdConfigSetAuthInfo(in, out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetContext(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSet(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigUnset(out, pathOptions))

--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -865,7 +865,7 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config, t *tes
 
 	buf := bytes.NewBuffer([]byte{})
 
-	cmd := NewCmdConfig(clientcmd.NewDefaultPathOptions(), buf, buf)
+	cmd := NewCmdConfig(clientcmd.NewDefaultPathOptions(), buf, buf, buf)
 	cmd.SetArgs(argsToUse)
 	cmd.Execute()
 

--- a/staging/BUILD
+++ b/staging/BUILD
@@ -184,6 +184,7 @@ filegroup(
         "//staging/src/k8s.io/client-go/util/homedir:all-srcs",
         "//staging/src/k8s.io/client-go/util/integer:all-srcs",
         "//staging/src/k8s.io/client-go/util/jsonpath:all-srcs",
+        "//staging/src/k8s.io/client-go/util/prompt:all-srcs",
         "//staging/src/k8s.io/client-go/util/retry:all-srcs",
         "//staging/src/k8s.io/client-go/util/testing:all-srcs",
         "//staging/src/k8s.io/client-go/util/workqueue:all-srcs",

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -1519,6 +1519,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/prompt",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
 			"Rev": "868f2f29720b192240e18284659231b440f9cda5"
 		},

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1583,6 +1583,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/prompt",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
 			"Rev": "868f2f29720b192240e18284659231b440f9cda5"
 		},

--- a/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
@@ -44,7 +44,6 @@ go_library(
     ],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/howeyc/gopass:go_default_library",
         "//vendor/github.com/imdario/mergo:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
@@ -57,6 +56,7 @@ go_library(
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api/latest:go_default_library",
         "//vendor/k8s.io/client-go/util/homedir:go_default_library",
+        "//vendor/k8s.io/client-go/util/prompt:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/util/prompt/BUILD
+++ b/staging/src/k8s.io/client-go/util/prompt/BUILD
@@ -1,0 +1,29 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["prompt.go"],
+    tags = ["automanaged"],
+    deps = ["//vendor/github.com/howeyc/gopass:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/client-go/util/prompt/prompt.go
+++ b/staging/src/k8s.io/client-go/util/prompt/prompt.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prompt
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/howeyc/gopass"
+)
+
+const (
+	// ShowEcho is a more readable alternative to using true in Prompt
+	ShowEcho = true
+	// DontShowEcho is a more readable alternative to using false in Prompt
+	DontShowEcho = false
+	// Mask is a more readable alternative to using true in Prompt
+	Mask = true
+	// DontMask is a more readable alternative to using false in Prompt
+	DontMask = false
+)
+
+// Prompter ...
+type Prompter struct {
+	reader io.Reader
+}
+
+// NewPrompter creates a new prompter with an io.Reader
+func NewPrompter(reader io.Reader) *Prompter {
+	return &Prompter{reader: reader}
+}
+
+// Prompt retrieves user input with options for hiding the echo and masking the input.
+func (p Prompter) Prompt(field string, showEcho bool, mask bool) (result string, err error) {
+	fmt.Printf("Please enter %s: ", field)
+	if showEcho {
+		_, err = fmt.Fscan(p.reader, &result)
+	} else {
+		var data []byte
+		if mask {
+			data, err = gopass.GetPasswdMasked()
+		} else {
+			data, err = gopass.GetPasswd()
+		}
+		result = string(data)
+	}
+	return result, err
+}

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -1503,6 +1503,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/prompt",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/client-go/util/workqueue",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -1495,6 +1495,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/util/prompt",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/kube-openapi/pkg/builder",
 			"Rev": "868f2f29720b192240e18284659231b440f9cda5"
 		},


### PR DESCRIPTION
fixes #33666

```release-note
Adds --prompt-username, --prompt-password, and --prompt-token to kubectl config set-credentials
```