### PR TITLE
trivial: Fix internalversion package initialization

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/register.go
@@ -63,14 +63,14 @@ func addToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 	)
 	// ListOptions is the only options struct which needs conversion (it exposes labels and fields
 	// as selectors for convenience). The other types have only a single representation today.
-	scheme.AddKnownTypes(SchemeGroupVersion,
+	scheme.AddKnownTypes(groupVersion,
 		&ListOptions{},
 		&metav1.GetOptions{},
 		&metav1.ExportOptions{},
 		&metav1.DeleteOptions{},
 	)
 	// Allow delete options to be decoded across all version in this scheme (we may want to be more clever than this)
-	scheme.AddUnversionedTypes(SchemeGroupVersion, &metav1.DeleteOptions{})
+	scheme.AddUnversionedTypes(groupVersion, &metav1.DeleteOptions{})
 	metav1.AddToGroupVersion(scheme, metav1.SchemeGroupVersion)
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch fixes the addToGroupVersion() function to use the parameter passed in instead of the global variable.

**Release note**:
NONE