### PR TITLE
Added informer to third-party-resources example of client-go

### DIFF
--- a/staging/src/k8s.io/client-go/examples/third-party-resources/BUILD
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/BUILD
@@ -31,11 +31,14 @@ go_library(
     srcs = [
         "main.go",
         "types.go",
+        "watch.go",
     ],
     tags = ["automanaged"],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
@@ -44,6 +47,7 @@ go_library(
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
         "//vendor/k8s.io/client-go/pkg/apis/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/watch.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/watch.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+func Watch(client *rest.RESTClient) {
+
+	stop := make(chan struct{}, 1)
+	source := cache.NewListWatchFromClient(
+		client,
+		"examples",
+		v1.NamespaceAll,
+		fields.Everything())
+
+	store, controller := cache.NewInformer(
+		source,
+
+		// The object type.
+		&Example{},
+
+		// resyncPeriod
+		// Every resyncPeriod, all resources in the cache will retrigger events.
+		// Set to 0 to disable the resync.
+		time.Second*60,
+
+		// Your custom resource event handlers.
+		cache.ResourceEventHandlerFuncs{
+			// Takes a single argument of type interface{}.
+			// Called on controller startup and when new resources are created.
+			AddFunc: create,
+
+			// Takes two arguments of type interface{}.
+			// Called on resource update and every resyncPeriod on existing resources.
+			UpdateFunc: update,
+
+			// Takes a single argument of type interface{}.
+			// Called on resource deletion.
+			DeleteFunc: delete,
+		})
+
+	// store can be used to List and Get
+	// NEVER modify objects from the store. It's a read-only, local cache.
+	fmt.Println("listing examples from store:")
+	for _, obj := range store.List() {
+		example := obj.(*Example)
+
+		// This will likely be empty the first run, but may not
+		fmt.Printf("%#v\n", example)
+	}
+
+	// the controller run starts the event processing loop
+	go controller.Run(stop)
+
+	// and now we block on a signal
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	s := <-signals
+	fmt.Printf("received signal %#v, exiting...\n", s)
+	close(stop)
+	os.Exit(0)
+}
+
+// Handler functions as per the controller above.
+// Note the coercion of the interface{} into a pointer of the expected type.
+
+func create(obj interface{}) {
+	example := obj.(*Example)
+
+	fmt.Println("CREATED:", printExample(example))
+}
+
+func update(old, new interface{}) {
+	oldExample := old.(*Example)
+	newExample := new.(*Example)
+
+	fmt.Printf("UPDATED:\n  old: %s\n  new: %s\n", printExample(oldExample), printExample(newExample))
+}
+
+func delete(obj interface{}) {
+	example := obj.(*Example)
+
+	fmt.Println("DELETED:", printExample(example))
+}
+
+// convenience functions
+func printExample(example *Example) string {
+	return fmt.Sprintf("%s/%s, APIVersion: %s, Kind: %s, Value: %#v", example.Metadata.Namespace, example.Metadata.Name, example.APIVersion, example.Kind, example)
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

Demonstrates how to list and watch third party objects (i.e., objects
of a Kind defined by a ThirdPartyResource).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

This makes a small contribution toward https://github.com/kubernetes/client-go/issues/128

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
