### PR TITLE
[CRI] Return success if ImageNotFound in RemoveImage() 

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/helpers.go
+++ b/pkg/kubelet/dockershim/libdocker/helpers.go
@@ -129,3 +129,9 @@ func matchImageIDOnly(inspected dockertypes.ImageInspect, image string) bool {
 	glog.V(4).Infof("The reference %s does not directly refer to the given image's ID (%q)", image, inspected.ID)
 	return false
 }
+
+// isImageNotFoundError returns whether the err is caused by image not found in docker
+// TODO: Use native error tester once ImageNotFoundError is supported in docker-engine client(eg. ImageRemove())
+func isImageNotFoundError(err error) bool {
+	return strings.Contains(err.Error(), "No such image:")
+}

--- a/pkg/kubelet/dockershim/libdocker/kube_docker_client.go
+++ b/pkg/kubelet/dockershim/libdocker/kube_docker_client.go
@@ -382,6 +382,9 @@ func (d *kubeDockerClient) RemoveImage(image string, opts dockertypes.ImageRemov
 	if ctxErr := contextError(ctx); ctxErr != nil {
 		return nil, ctxErr
 	}
+	if isImageNotFoundError(err) {
+		return nil, ImageNotFoundError{ID: image}
+	}
 	return resp, err
 }
 


### PR DESCRIPTION
Signed-off-by: Crazykev <crazykev@zju.edu.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

**Sorry for close the [old one](https://github.com/kubernetes/kubernetes/pull/44381) mistakenly,  rebase and move to here.**
RemoveImage() operation should be idempotent, [ref](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/api/v1alpha1/runtime/api.proto#L89-L92)
 @feiskyer @Random-Liu PTAL


**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
