### PR TITLE
apimachinery: make explicit that meta.KindToResource is only a guess

### DIFF
--- a/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/scale_expansion.go
+++ b/pkg/client/clientset_generated/clientset/typed/extensions/v1beta1/scale_expansion.go
@@ -34,7 +34,7 @@ func (c *scales) Get(kind string, name string) (result *v1beta1.Scale, err error
 
 	// TODO this method needs to take a proper unambiguous kind
 	fullyQualifiedKind := schema.GroupVersionKind{Kind: kind}
-	resource, _ := meta.KindToResource(fullyQualifiedKind)
+	resource, _ := meta.UnsafeGuessKindToResource(fullyQualifiedKind)
 
 	err = c.client.Get().
 		Namespace(c.ns).
@@ -51,7 +51,7 @@ func (c *scales) Update(kind string, scale *v1beta1.Scale) (result *v1beta1.Scal
 
 	// TODO this method needs to take a proper unambiguous kind
 	fullyQualifiedKind := schema.GroupVersionKind{Kind: kind}
-	resource, _ := meta.KindToResource(fullyQualifiedKind)
+	resource, _ := meta.UnsafeGuessKindToResource(fullyQualifiedKind)
 
 	err = c.client.Put().
 		Namespace(scale.Namespace).

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/scale_expansion.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/scale_expansion.go
@@ -34,7 +34,7 @@ func (c *scales) Get(kind string, name string) (result *extensions.Scale, err er
 
 	// TODO this method needs to take a proper unambiguous kind
 	fullyQualifiedKind := schema.GroupVersionKind{Kind: kind}
-	resource, _ := meta.KindToResource(fullyQualifiedKind)
+	resource, _ := meta.UnsafeGuessKindToResource(fullyQualifiedKind)
 
 	err = c.client.Get().
 		Namespace(c.ns).
@@ -51,7 +51,7 @@ func (c *scales) Update(kind string, scale *extensions.Scale) (result *extension
 
 	// TODO this method needs to take a proper unambiguous kind
 	fullyQualifiedKind := schema.GroupVersionKind{Kind: kind}
-	resource, _ := meta.KindToResource(fullyQualifiedKind)
+	resource, _ := meta.UnsafeGuessKindToResource(fullyQualifiedKind)
 
 	err = c.client.Put().
 		Namespace(scale.Namespace).

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -28,7 +28,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -385,12 +384,7 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 	if outputFormat != "" {
 		return f.PrintObject(cmd, mapper, newRc, out)
 	}
-	kinds, _, err := api.Scheme.ObjectKinds(newRc)
-	if err != nil {
-		return err
-	}
-	_, res := meta.KindToResource(kinds[0])
-	cmdutil.PrintSuccess(mapper, false, out, res.Resource, oldName, dryrun, message)
+	cmdutil.PrintSuccess(mapper, false, out, "replicationcontrollers", oldName, dryrun, message)
 	return nil
 }
 

--- a/pkg/master/thirdparty/thirdparty.go
+++ b/pkg/master/thirdparty/thirdparty.go
@@ -110,7 +110,7 @@ func (m *ThirdPartyResourceServer) HasThirdPartyResource(rsrc *extensions.ThirdP
 	if entry == nil {
 		return false, nil
 	}
-	plural, _ := meta.KindToResource(schema.GroupVersionKind{
+	plural, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{
 		Group:   group,
 		Version: rsrc.Versions[0].Name,
 		Kind:    kind,
@@ -258,7 +258,7 @@ func (m *ThirdPartyResourceServer) InstallThirdPartyResource(rsrc *extensions.Th
 	if len(rsrc.Versions) == 0 {
 		return fmt.Errorf("ThirdPartyResource %s has no defined versions", rsrc.Name)
 	}
-	plural, _ := meta.KindToResource(schema.GroupVersionKind{
+	plural, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{
 		Group:   group,
 		Version: rsrc.Versions[0].Name,
 		Kind:    kind,

--- a/pkg/registry/extensions/thirdpartyresourcedata/codec.go
+++ b/pkg/registry/extensions/thirdpartyresourcedata/codec.go
@@ -74,7 +74,7 @@ type thirdPartyResourceDataMapper struct {
 var _ meta.RESTMapper = &thirdPartyResourceDataMapper{}
 
 func (t *thirdPartyResourceDataMapper) getResource() schema.GroupVersionResource {
-	plural, _ := meta.KindToResource(t.getKind())
+	plural, _ := meta.UnsafeGuessKindToResource(t.getKind())
 
 	return plural
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -116,7 +116,7 @@ func NewDefaultRESTMapper(defaultGroupVersions []schema.GroupVersion, f VersionI
 }
 
 func (m *DefaultRESTMapper) Add(kind schema.GroupVersionKind, scope RESTScope) {
-	plural, singular := KindToResource(kind)
+	plural, singular := UnsafeGuessKindToResource(kind)
 
 	m.singularToPlural[singular] = plural
 	m.pluralToSingular[plural] = singular
@@ -136,10 +136,10 @@ var unpluralizedSuffixes = []string{
 	"endpoints",
 }
 
-// KindToResource converts Kind to a resource name.
+// UnsafeGuessKindToResource converts Kind to a resource name.
 // Broken. This method only "sort of" works when used outside of this package.  It assumes that Kinds and Resources match
 // and they aren't guaranteed to do so.
-func KindToResource(kind schema.GroupVersionKind) ( /*plural*/ schema.GroupVersionResource /*singular*/, schema.GroupVersionResource) {
+func UnsafeGuessKindToResource(kind schema.GroupVersionKind) ( /*plural*/ schema.GroupVersionResource /*singular*/, schema.GroupVersionResource) {
 	kindName := kind.Kind
 	if len(kindName) == 0 {
 		return schema.GroupVersionResource{}, schema.GroupVersionResource{}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper_test.go
@@ -485,7 +485,7 @@ func TestKindToResource(t *testing.T) {
 	for i, testCase := range testCases {
 		version := schema.GroupVersion{}
 
-		plural, singular := KindToResource(version.WithKind(testCase.Kind))
+		plural, singular := UnsafeGuessKindToResource(version.WithKind(testCase.Kind))
 		if singular != version.WithResource(testCase.Singular) || plural != version.WithResource(testCase.Plural) {
 			t.Errorf("%d: unexpected plural and singular: %v %v", i, plural, singular)
 		}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/scale_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/scale_expansion.go
@@ -34,7 +34,7 @@ func (c *scales) Get(kind string, name string) (result *v1beta1.Scale, err error
 
 	// TODO this method needs to take a proper unambiguous kind
 	fullyQualifiedKind := schema.GroupVersionKind{Kind: kind}
-	resource, _ := meta.KindToResource(fullyQualifiedKind)
+	resource, _ := meta.UnsafeGuessKindToResource(fullyQualifiedKind)
 
 	err = c.client.Get().
 		Namespace(c.ns).
@@ -51,7 +51,7 @@ func (c *scales) Update(kind string, scale *v1beta1.Scale) (result *v1beta1.Scal
 
 	// TODO this method needs to take a proper unambiguous kind
 	fullyQualifiedKind := schema.GroupVersionKind{Kind: kind}
-	resource, _ := meta.KindToResource(fullyQualifiedKind)
+	resource, _ := meta.UnsafeGuessKindToResource(fullyQualifiedKind)
 
 	err = c.client.Put().
 		Namespace(scale.Namespace).


### PR DESCRIPTION
All non-test code using `KindToResource` is suspicious and should be fixed with a real RESTMapper.