### PR TITLE
Support multi-container pod for "kubectl logs"

### DIFF
--- a/pkg/kubectl/cmd/logs_test.go
+++ b/pkg/kubectl/cmd/logs_test.go
@@ -109,27 +109,38 @@ func TestValidateLogFlags(t *testing.T) {
 	tests := []struct {
 		name     string
 		flags    map[string]string
+		args     []string
 		expected string
 	}{
 		{
 			name:     "since & since-time",
 			flags:    map[string]string{"since": "1h", "since-time": "2006-01-02T15:04:05Z"},
+			args:     []string{"foo"},
 			expected: "at most one of `sinceTime` or `sinceSeconds` may be specified",
 		},
 		{
 			name:     "negative since-time",
 			flags:    map[string]string{"since": "-1s"},
+			args:     []string{"foo"},
 			expected: "must be greater than 0",
 		},
 		{
 			name:     "negative limit-bytes",
 			flags:    map[string]string{"limit-bytes": "-100"},
+			args:     []string{"foo"},
 			expected: "must be greater than 0",
 		},
 		{
 			name:     "negative tail",
 			flags:    map[string]string{"tail": "-100"},
+			args:     []string{"foo"},
 			expected: "must be greater than or equal to 0",
+		},
+		{
+			name:     "container name combined with --all-containers",
+			flags:    map[string]string{"all-containers": "true"},
+			args:     []string{"my-pod", "my-container"},
+			expected: "--all-containers=true should not be specifiled with container",
 		},
 	}
 	for _, test := range tests {
@@ -146,7 +157,7 @@ func TestValidateLogFlags(t *testing.T) {
 			o.Complete(f, os.Stdout, cmd, args)
 			out = o.Validate().Error()
 		}
-		cmd.Run(cmd, []string{"foo"})
+		cmd.Run(cmd, test.args)
 
 		if !strings.Contains(out, test.expected) {
 			t.Errorf("%s: expected to find:\n\t%s\nfound:\n\t%s\n", test.name, test.expected, out)


### PR DESCRIPTION
kubectl logs -l will print logs for pods with the same label, however it doesn't support pods with multi containers. This change adds support to it with --all-containers.

Ussage:
$ kubectl logs my-pod --all-containers
$ kubectl logs -laa=bb --all-containers
$ kubectl logs my-pod my-container --all-containers (err: container should not combined with --all-containers)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
add --all-containers option to "kubectl log"
```

Fixes:
https://github.com/kubernetes/kubectl/issues/371