### PR TITLE
Remove null -> [] slice hack

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -90,11 +90,7 @@ func Convert_v1alpha1_Etcd_To_kubeadm_Etcd(in *Etcd, out *kubeadm.Etcd, s conver
 }
 
 func autoConvert_kubeadm_Etcd_To_v1alpha1_Etcd(in *kubeadm.Etcd, out *Etcd, s conversion.Scope) error {
-	if in.Endpoints == nil {
-		out.Endpoints = make([]string, 0)
-	} else {
-		out.Endpoints = *(*[]string)(unsafe.Pointer(&in.Endpoints))
-	}
+	out.Endpoints = *(*[]string)(unsafe.Pointer(&in.Endpoints))
 	out.CAFile = in.CAFile
 	out.CertFile = in.CertFile
 	out.KeyFile = in.KeyFile
@@ -154,21 +150,13 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	out.KubernetesVersion = in.KubernetesVersion
 	out.CloudProvider = in.CloudProvider
 	out.NodeName = in.NodeName
-	if in.AuthorizationModes == nil {
-		out.AuthorizationModes = make([]string, 0)
-	} else {
-		out.AuthorizationModes = *(*[]string)(unsafe.Pointer(&in.AuthorizationModes))
-	}
+	out.AuthorizationModes = *(*[]string)(unsafe.Pointer(&in.AuthorizationModes))
 	out.Token = in.Token
 	out.TokenTTL = time.Duration(in.TokenTTL)
 	out.APIServerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.APIServerExtraArgs))
 	out.ControllerManagerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.ControllerManagerExtraArgs))
 	out.SchedulerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.SchedulerExtraArgs))
-	if in.APIServerCertSANs == nil {
-		out.APIServerCertSANs = make([]string, 0)
-	} else {
-		out.APIServerCertSANs = *(*[]string)(unsafe.Pointer(&in.APIServerCertSANs))
-	}
+	out.APIServerCertSANs = *(*[]string)(unsafe.Pointer(&in.APIServerCertSANs))
 	out.CertificatesDir = in.CertificatesDir
 	out.ImageRepository = in.ImageRepository
 	// INFO: in.CIImageRepository opted out of conversion generation
@@ -228,19 +216,11 @@ func autoConvert_kubeadm_NodeConfiguration_To_v1alpha1_NodeConfiguration(in *kub
 	out.CACertPath = in.CACertPath
 	out.DiscoveryFile = in.DiscoveryFile
 	out.DiscoveryToken = in.DiscoveryToken
-	if in.DiscoveryTokenAPIServers == nil {
-		out.DiscoveryTokenAPIServers = make([]string, 0)
-	} else {
-		out.DiscoveryTokenAPIServers = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenAPIServers))
-	}
+	out.DiscoveryTokenAPIServers = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenAPIServers))
 	out.NodeName = in.NodeName
 	out.TLSBootstrapToken = in.TLSBootstrapToken
 	out.Token = in.Token
-	if in.DiscoveryTokenCACertHashes == nil {
-		out.DiscoveryTokenCACertHashes = make([]string, 0)
-	} else {
-		out.DiscoveryTokenCACertHashes = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenCACertHashes))
-	}
+	out.DiscoveryTokenCACertHashes = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenCACertHashes))
 	out.DiscoveryTokenUnsafeSkipCAVerification = in.DiscoveryTokenUnsafeSkipCAVerification
 	return nil
 }
@@ -265,11 +245,7 @@ func Convert_v1alpha1_TokenDiscovery_To_kubeadm_TokenDiscovery(in *TokenDiscover
 func autoConvert_kubeadm_TokenDiscovery_To_v1alpha1_TokenDiscovery(in *kubeadm.TokenDiscovery, out *TokenDiscovery, s conversion.Scope) error {
 	out.ID = in.ID
 	out.Secret = in.Secret
-	if in.Addresses == nil {
-		out.Addresses = make([]string, 0)
-	} else {
-		out.Addresses = *(*[]string)(unsafe.Pointer(&in.Addresses))
-	}
+	out.Addresses = *(*[]string)(unsafe.Pointer(&in.Addresses))
 	return nil
 }
 

--- a/federation/apis/federation/v1beta1/zz_generated.conversion.go
+++ b/federation/apis/federation/v1beta1/zz_generated.conversion.go
@@ -127,11 +127,7 @@ func Convert_v1beta1_ClusterList_To_federation_ClusterList(in *ClusterList, out 
 
 func autoConvert_federation_ClusterList_To_v1beta1_ClusterList(in *federation.ClusterList, out *ClusterList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]Cluster, 0)
-	} else {
-		out.Items = *(*[]Cluster)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]Cluster)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -152,11 +148,7 @@ func Convert_v1beta1_ClusterSpec_To_federation_ClusterSpec(in *ClusterSpec, out 
 }
 
 func autoConvert_federation_ClusterSpec_To_v1beta1_ClusterSpec(in *federation.ClusterSpec, out *ClusterSpec, s conversion.Scope) error {
-	if in.ServerAddressByClientCIDRs == nil {
-		out.ServerAddressByClientCIDRs = make([]ServerAddressByClientCIDR, 0)
-	} else {
-		out.ServerAddressByClientCIDRs = *(*[]ServerAddressByClientCIDR)(unsafe.Pointer(&in.ServerAddressByClientCIDRs))
-	}
+	out.ServerAddressByClientCIDRs = *(*[]ServerAddressByClientCIDR)(unsafe.Pointer(&in.ServerAddressByClientCIDRs))
 	out.SecretRef = (*v1.LocalObjectReference)(unsafe.Pointer(in.SecretRef))
 	return nil
 }

--- a/pkg/api/v1/zz_generated.conversion.go
+++ b/pkg/api/v1/zz_generated.conversion.go
@@ -627,11 +627,7 @@ func Convert_v1_CephFSPersistentVolumeSource_To_api_CephFSPersistentVolumeSource
 }
 
 func autoConvert_api_CephFSPersistentVolumeSource_To_v1_CephFSPersistentVolumeSource(in *api.CephFSPersistentVolumeSource, out *v1.CephFSPersistentVolumeSource, s conversion.Scope) error {
-	if in.Monitors == nil {
-		out.Monitors = make([]string, 0)
-	} else {
-		out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
-	}
+	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
@@ -661,11 +657,7 @@ func Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *v1.CephFSVolume
 }
 
 func autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *v1.CephFSVolumeSource, s conversion.Scope) error {
-	if in.Monitors == nil {
-		out.Monitors = make([]string, 0)
-	} else {
-		out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
-	}
+	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
@@ -764,11 +756,7 @@ func Convert_v1_ComponentStatusList_To_api_ComponentStatusList(in *v1.ComponentS
 
 func autoConvert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.ComponentStatusList, out *v1.ComponentStatusList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.ComponentStatus, 0)
-	} else {
-		out.Items = *(*[]v1.ComponentStatus)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.ComponentStatus)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -866,11 +854,7 @@ func Convert_v1_ConfigMapList_To_api_ConfigMapList(in *v1.ConfigMapList, out *ap
 
 func autoConvert_api_ConfigMapList_To_v1_ConfigMapList(in *api.ConfigMapList, out *v1.ConfigMapList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.ConfigMap, 0)
-	} else {
-		out.Items = *(*[]v1.ConfigMap)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.ConfigMap)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -1027,11 +1011,7 @@ func Convert_v1_ContainerImage_To_api_ContainerImage(in *v1.ContainerImage, out 
 }
 
 func autoConvert_api_ContainerImage_To_v1_ContainerImage(in *api.ContainerImage, out *v1.ContainerImage, s conversion.Scope) error {
-	if in.Names == nil {
-		out.Names = make([]string, 0)
-	} else {
-		out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
-	}
+	out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
 	out.SizeBytes = in.SizeBytes
 	return nil
 }
@@ -1432,11 +1412,7 @@ func Convert_v1_Endpoints_To_api_Endpoints(in *v1.Endpoints, out *api.Endpoints,
 
 func autoConvert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *v1.Endpoints, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Subsets == nil {
-		out.Subsets = make([]v1.EndpointSubset, 0)
-	} else {
-		out.Subsets = *(*[]v1.EndpointSubset)(unsafe.Pointer(&in.Subsets))
-	}
+	out.Subsets = *(*[]v1.EndpointSubset)(unsafe.Pointer(&in.Subsets))
 	return nil
 }
 
@@ -1458,11 +1434,7 @@ func Convert_v1_EndpointsList_To_api_EndpointsList(in *v1.EndpointsList, out *ap
 
 func autoConvert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *v1.EndpointsList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.Endpoints, 0)
-	} else {
-		out.Items = *(*[]v1.Endpoints)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.Endpoints)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -1602,11 +1574,7 @@ func Convert_v1_EventList_To_api_EventList(in *v1.EventList, out *api.EventList,
 
 func autoConvert_api_EventList_To_v1_EventList(in *api.EventList, out *v1.EventList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.Event, 0)
-	} else {
-		out.Items = *(*[]v1.Event)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.Event)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -2082,11 +2050,7 @@ func Convert_v1_LimitRangeList_To_api_LimitRangeList(in *v1.LimitRangeList, out 
 
 func autoConvert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out *v1.LimitRangeList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.LimitRange, 0)
-	} else {
-		out.Items = *(*[]v1.LimitRange)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.LimitRange)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -2106,11 +2070,7 @@ func Convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *v1.LimitRangeSpec, out 
 }
 
 func autoConvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *v1.LimitRangeSpec, s conversion.Scope) error {
-	if in.Limits == nil {
-		out.Limits = make([]v1.LimitRangeItem, 0)
-	} else {
-		out.Limits = *(*[]v1.LimitRangeItem)(unsafe.Pointer(&in.Limits))
-	}
+	out.Limits = *(*[]v1.LimitRangeItem)(unsafe.Pointer(&in.Limits))
 	return nil
 }
 
@@ -2151,7 +2111,7 @@ func autoConvert_api_List_To_v1_List(in *api.List, out *v1.List, s conversion.Sc
 			}
 		}
 	} else {
-		out.Items = make([]runtime.RawExtension, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -2350,11 +2310,7 @@ func Convert_v1_NamespaceList_To_api_NamespaceList(in *v1.NamespaceList, out *ap
 
 func autoConvert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *v1.NamespaceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.Namespace, 0)
-	} else {
-		out.Items = *(*[]v1.Namespace)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.Namespace)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -2566,11 +2522,7 @@ func Convert_v1_NodeList_To_api_NodeList(in *v1.NodeList, out *api.NodeList, s c
 
 func autoConvert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *v1.NodeList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.Node, 0)
-	} else {
-		out.Items = *(*[]v1.Node)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.Node)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -2630,11 +2582,7 @@ func Convert_v1_NodeSelector_To_api_NodeSelector(in *v1.NodeSelector, out *api.N
 }
 
 func autoConvert_api_NodeSelector_To_v1_NodeSelector(in *api.NodeSelector, out *v1.NodeSelector, s conversion.Scope) error {
-	if in.NodeSelectorTerms == nil {
-		out.NodeSelectorTerms = make([]v1.NodeSelectorTerm, 0)
-	} else {
-		out.NodeSelectorTerms = *(*[]v1.NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
-	}
+	out.NodeSelectorTerms = *(*[]v1.NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
 	return nil
 }
 
@@ -2678,11 +2626,7 @@ func Convert_v1_NodeSelectorTerm_To_api_NodeSelectorTerm(in *v1.NodeSelectorTerm
 }
 
 func autoConvert_api_NodeSelectorTerm_To_v1_NodeSelectorTerm(in *api.NodeSelectorTerm, out *v1.NodeSelectorTerm, s conversion.Scope) error {
-	if in.MatchExpressions == nil {
-		out.MatchExpressions = make([]v1.NodeSelectorRequirement, 0)
-	} else {
-		out.MatchExpressions = *(*[]v1.NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
-	}
+	out.MatchExpressions = *(*[]v1.NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
 	return nil
 }
 
@@ -2986,11 +2930,7 @@ func Convert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *v
 
 func autoConvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *api.PersistentVolumeClaimList, out *v1.PersistentVolumeClaimList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.PersistentVolumeClaim, 0)
-	} else {
-		out.Items = *(*[]v1.PersistentVolumeClaim)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.PersistentVolumeClaim)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -3109,7 +3049,7 @@ func autoConvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.Per
 			}
 		}
 	} else {
-		out.Items = make([]v1.PersistentVolume, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -3428,11 +3368,7 @@ func autoConvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions,
 	out.Stderr = in.Stderr
 	out.TTY = in.TTY
 	out.Container = in.Container
-	if in.Command == nil {
-		out.Command = make([]string, 0)
-	} else {
-		out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
-	}
+	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
 	return nil
 }
 
@@ -3473,7 +3409,7 @@ func autoConvert_api_PodList_To_v1_PodList(in *api.PodList, out *v1.PodList, s c
 			}
 		}
 	} else {
-		out.Items = make([]v1.Pod, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -3697,7 +3633,7 @@ func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *v1.PodSpec, s c
 			}
 		}
 	} else {
-		out.Containers = make([]v1.Container, 0)
+		out.Containers = nil
 	}
 	out.RestartPolicy = v1.RestartPolicy(in.RestartPolicy)
 	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
@@ -3840,7 +3776,7 @@ func autoConvert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateLi
 			}
 		}
 	} else {
-		out.Items = make([]v1.PodTemplate, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -4012,11 +3948,7 @@ func Convert_v1_ProjectedVolumeSource_To_api_ProjectedVolumeSource(in *v1.Projec
 }
 
 func autoConvert_api_ProjectedVolumeSource_To_v1_ProjectedVolumeSource(in *api.ProjectedVolumeSource, out *v1.ProjectedVolumeSource, s conversion.Scope) error {
-	if in.Sources == nil {
-		out.Sources = make([]v1.VolumeProjection, 0)
-	} else {
-		out.Sources = *(*[]v1.VolumeProjection)(unsafe.Pointer(&in.Sources))
-	}
+	out.Sources = *(*[]v1.VolumeProjection)(unsafe.Pointer(&in.Sources))
 	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
 	return nil
 }
@@ -4072,11 +4004,7 @@ func Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *v1.RBDVolumeSource, o
 }
 
 func autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *v1.RBDVolumeSource, s conversion.Scope) error {
-	if in.CephMonitors == nil {
-		out.CephMonitors = make([]string, 0)
-	} else {
-		out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
-	}
+	out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
 	out.RBDImage = in.RBDImage
 	out.FSType = in.FSType
 	out.RBDPool = in.RBDPool
@@ -4107,11 +4035,7 @@ func Convert_v1_RangeAllocation_To_api_RangeAllocation(in *v1.RangeAllocation, o
 func autoConvert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, out *v1.RangeAllocation, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Range = in.Range
-	if in.Data == nil {
-		out.Data = make([]byte, 0)
-	} else {
-		out.Data = *(*[]byte)(unsafe.Pointer(&in.Data))
-	}
+	out.Data = *(*[]byte)(unsafe.Pointer(&in.Data))
 	return nil
 }
 
@@ -4212,7 +4136,7 @@ func autoConvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(i
 			}
 		}
 	} else {
-		out.Items = make([]v1.ReplicationController, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -4357,11 +4281,7 @@ func Convert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *v1.ResourceQuotaL
 
 func autoConvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuotaList, out *v1.ResourceQuotaList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.ResourceQuota, 0)
-	} else {
-		out.Items = *(*[]v1.ResourceQuota)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.ResourceQuota)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -4606,7 +4526,7 @@ func autoConvert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *v1.Sec
 			}
 		}
 	} else {
-		out.Items = make([]v1.Secret, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -4814,11 +4734,7 @@ func Convert_v1_ServiceAccountList_To_api_ServiceAccountList(in *v1.ServiceAccou
 
 func autoConvert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAccountList, out *v1.ServiceAccountList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.ServiceAccount, 0)
-	} else {
-		out.Items = *(*[]v1.ServiceAccount)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.ServiceAccount)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -4859,7 +4775,7 @@ func autoConvert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *v1.
 			}
 		}
 	} else {
-		out.Items = make([]v1.Service, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/pkg/apis/admissionregistration/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/admissionregistration/v1alpha1/zz_generated.conversion.go
@@ -76,11 +76,7 @@ func autoConvert_admissionregistration_AdmissionHookClientConfig_To_v1alpha1_Adm
 	if err := Convert_admissionregistration_ServiceReference_To_v1alpha1_ServiceReference(&in.Service, &out.Service, s); err != nil {
 		return err
 	}
-	if in.CABundle == nil {
-		out.CABundle = make([]byte, 0)
-	} else {
-		out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
-	}
+	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
 
@@ -154,11 +150,7 @@ func Convert_v1alpha1_ExternalAdmissionHookConfigurationList_To_admissionregistr
 
 func autoConvert_admissionregistration_ExternalAdmissionHookConfigurationList_To_v1alpha1_ExternalAdmissionHookConfigurationList(in *admissionregistration.ExternalAdmissionHookConfigurationList, out *v1alpha1.ExternalAdmissionHookConfigurationList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1alpha1.ExternalAdmissionHookConfiguration, 0)
-	} else {
-		out.Items = *(*[]v1alpha1.ExternalAdmissionHookConfiguration)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1alpha1.ExternalAdmissionHookConfiguration)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -226,11 +218,7 @@ func Convert_v1alpha1_InitializerConfigurationList_To_admissionregistration_Init
 
 func autoConvert_admissionregistration_InitializerConfigurationList_To_v1alpha1_InitializerConfigurationList(in *admissionregistration.InitializerConfigurationList, out *v1alpha1.InitializerConfigurationList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1alpha1.InitializerConfiguration, 0)
-	} else {
-		out.Items = *(*[]v1alpha1.InitializerConfiguration)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1alpha1.InitializerConfiguration)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/apps/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1beta1/zz_generated.conversion.go
@@ -144,7 +144,7 @@ func autoConvert_apps_ControllerRevisionList_To_v1beta1_ControllerRevisionList(i
 			}
 		}
 	} else {
-		out.Items = make([]v1beta1.ControllerRevision, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -248,7 +248,7 @@ func autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensi
 			}
 		}
 	} else {
-		out.Items = make([]v1beta1.Deployment, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -571,7 +571,7 @@ func autoConvert_apps_StatefulSetList_To_v1beta1_StatefulSetList(in *apps.Statef
 			}
 		}
 	} else {
-		out.Items = make([]v1beta1.StatefulSet, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/pkg/apis/apps/v1beta2/zz_generated.conversion.go
+++ b/pkg/apis/apps/v1beta2/zz_generated.conversion.go
@@ -162,7 +162,7 @@ func autoConvert_apps_ControllerRevisionList_To_v1beta2_ControllerRevisionList(i
 			}
 		}
 	} else {
-		out.Items = make([]v1beta2.ControllerRevision, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -226,7 +226,7 @@ func autoConvert_extensions_DaemonSetList_To_v1beta2_DaemonSetList(in *extension
 			}
 		}
 	} else {
-		out.Items = make([]v1beta2.DaemonSet, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -411,7 +411,7 @@ func autoConvert_extensions_DeploymentList_To_v1beta2_DeploymentList(in *extensi
 			}
 		}
 	} else {
-		out.Items = make([]v1beta2.Deployment, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -612,7 +612,7 @@ func autoConvert_extensions_ReplicaSetList_To_v1beta2_ReplicaSetList(in *extensi
 			}
 		}
 	} else {
-		out.Items = make([]v1beta2.ReplicaSet, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -851,7 +851,7 @@ func autoConvert_apps_StatefulSetList_To_v1beta2_StatefulSetList(in *apps.Statef
 			}
 		}
 	} else {
-		out.Items = make([]v1beta2.StatefulSet, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/pkg/apis/autoscaling/v1/zz_generated.conversion.go
+++ b/pkg/apis/autoscaling/v1/zz_generated.conversion.go
@@ -183,7 +183,7 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v1_HorizontalPodAuto
 			}
 		}
 	} else {
-		out.Items = make([]v1.HorizontalPodAutoscaler, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/pkg/apis/autoscaling/v2alpha1/zz_generated.conversion.go
+++ b/pkg/apis/autoscaling/v2alpha1/zz_generated.conversion.go
@@ -168,11 +168,7 @@ func Convert_v2alpha1_HorizontalPodAutoscalerList_To_autoscaling_HorizontalPodAu
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v2alpha1_HorizontalPodAutoscalerList(in *autoscaling.HorizontalPodAutoscalerList, out *v2alpha1.HorizontalPodAutoscalerList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v2alpha1.HorizontalPodAutoscaler, 0)
-	} else {
-		out.Items = *(*[]v2alpha1.HorizontalPodAutoscaler)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v2alpha1.HorizontalPodAutoscaler)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -231,16 +227,8 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerStatus_To_v2alpha1_Horizonta
 	out.LastScaleTime = (*meta_v1.Time)(unsafe.Pointer(in.LastScaleTime))
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	if in.CurrentMetrics == nil {
-		out.CurrentMetrics = make([]v2alpha1.MetricStatus, 0)
-	} else {
-		out.CurrentMetrics = *(*[]v2alpha1.MetricStatus)(unsafe.Pointer(&in.CurrentMetrics))
-	}
-	if in.Conditions == nil {
-		out.Conditions = make([]v2alpha1.HorizontalPodAutoscalerCondition, 0)
-	} else {
-		out.Conditions = *(*[]v2alpha1.HorizontalPodAutoscalerCondition)(unsafe.Pointer(&in.Conditions))
-	}
+	out.CurrentMetrics = *(*[]v2alpha1.MetricStatus)(unsafe.Pointer(&in.CurrentMetrics))
+	out.Conditions = *(*[]v2alpha1.HorizontalPodAutoscalerCondition)(unsafe.Pointer(&in.Conditions))
 	return nil
 }
 

--- a/pkg/apis/batch/v1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v1/zz_generated.conversion.go
@@ -147,7 +147,7 @@ func autoConvert_batch_JobList_To_v1_JobList(in *batch.JobList, out *v1.JobList,
 			}
 		}
 	} else {
-		out.Items = make([]v1.Job, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/pkg/apis/batch/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v1beta1/zz_generated.conversion.go
@@ -119,7 +119,7 @@ func autoConvert_batch_CronJobList_To_v1beta1_CronJobList(in *batch.CronJobList,
 			}
 		}
 	} else {
-		out.Items = make([]v1beta1.CronJob, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
+++ b/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
@@ -119,7 +119,7 @@ func autoConvert_batch_CronJobList_To_v2alpha1_CronJobList(in *batch.CronJobList
 			}
 		}
 	} else {
-		out.Items = make([]v2alpha1.CronJob, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
@@ -120,11 +120,7 @@ func Convert_v1beta1_CertificateSigningRequestList_To_certificates_CertificateSi
 
 func autoConvert_certificates_CertificateSigningRequestList_To_v1beta1_CertificateSigningRequestList(in *certificates.CertificateSigningRequestList, out *v1beta1.CertificateSigningRequestList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.CertificateSigningRequest, 0)
-	} else {
-		out.Items = *(*[]v1beta1.CertificateSigningRequest)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.CertificateSigningRequest)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -149,11 +145,7 @@ func Convert_v1beta1_CertificateSigningRequestSpec_To_certificates_CertificateSi
 }
 
 func autoConvert_certificates_CertificateSigningRequestSpec_To_v1beta1_CertificateSigningRequestSpec(in *certificates.CertificateSigningRequestSpec, out *v1beta1.CertificateSigningRequestSpec, s conversion.Scope) error {
-	if in.Request == nil {
-		out.Request = make([]byte, 0)
-	} else {
-		out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
-	}
+	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
 	out.Usages = *(*[]v1beta1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID

--- a/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
@@ -198,11 +198,7 @@ func Convert_v1beta1_CustomMetricCurrentStatusList_To_extensions_CustomMetricCur
 }
 
 func autoConvert_extensions_CustomMetricCurrentStatusList_To_v1beta1_CustomMetricCurrentStatusList(in *extensions.CustomMetricCurrentStatusList, out *v1beta1.CustomMetricCurrentStatusList, s conversion.Scope) error {
-	if in.Items == nil {
-		out.Items = make([]v1beta1.CustomMetricCurrentStatus, 0)
-	} else {
-		out.Items = *(*[]v1beta1.CustomMetricCurrentStatus)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.CustomMetricCurrentStatus)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -244,11 +240,7 @@ func Convert_v1beta1_CustomMetricTargetList_To_extensions_CustomMetricTargetList
 }
 
 func autoConvert_extensions_CustomMetricTargetList_To_v1beta1_CustomMetricTargetList(in *extensions.CustomMetricTargetList, out *v1beta1.CustomMetricTargetList, s conversion.Scope) error {
-	if in.Items == nil {
-		out.Items = make([]v1beta1.CustomMetricTarget, 0)
-	} else {
-		out.Items = *(*[]v1beta1.CustomMetricTarget)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.CustomMetricTarget)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -321,7 +313,7 @@ func autoConvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extension
 			}
 		}
 	} else {
-		out.Items = make([]v1beta1.DaemonSet, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -537,7 +529,7 @@ func autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensi
 			}
 		}
 	} else {
-		out.Items = make([]v1beta1.Deployment, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -734,11 +726,7 @@ func Convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in 
 }
 
 func autoConvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *v1beta1.HTTPIngressRuleValue, s conversion.Scope) error {
-	if in.Paths == nil {
-		out.Paths = make([]v1beta1.HTTPIngressPath, 0)
-	} else {
-		out.Paths = *(*[]v1beta1.HTTPIngressPath)(unsafe.Pointer(&in.Paths))
-	}
+	out.Paths = *(*[]v1beta1.HTTPIngressPath)(unsafe.Pointer(&in.Paths))
 	return nil
 }
 
@@ -836,11 +824,7 @@ func Convert_v1beta1_IngressList_To_extensions_IngressList(in *v1beta1.IngressLi
 
 func autoConvert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.IngressList, out *v1beta1.IngressList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.Ingress, 0)
-	} else {
-		out.Items = *(*[]v1beta1.Ingress)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.Ingress)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -1025,7 +1009,7 @@ func autoConvert_extensions_PodSecurityPolicyList_To_v1beta1_PodSecurityPolicyLi
 			}
 		}
 	} else {
-		out.Items = make([]v1beta1.PodSecurityPolicy, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -1208,7 +1192,7 @@ func autoConvert_extensions_ReplicaSetList_To_v1beta1_ReplicaSetList(in *extensi
 			}
 		}
 	} else {
-		out.Items = make([]v1beta1.ReplicaSet, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -1522,11 +1506,7 @@ func Convert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResource
 
 func autoConvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in *extensions.ThirdPartyResourceDataList, out *v1beta1.ThirdPartyResourceDataList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.ThirdPartyResourceData, 0)
-	} else {
-		out.Items = *(*[]v1beta1.ThirdPartyResourceData)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.ThirdPartyResourceData)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -1548,11 +1528,7 @@ func Convert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList
 
 func autoConvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in *extensions.ThirdPartyResourceList, out *v1beta1.ThirdPartyResourceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.ThirdPartyResource, 0)
-	} else {
-		out.Items = *(*[]v1beta1.ThirdPartyResource)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.ThirdPartyResource)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/networking/v1/zz_generated.conversion.go
+++ b/pkg/apis/networking/v1/zz_generated.conversion.go
@@ -140,11 +140,7 @@ func Convert_v1_NetworkPolicyList_To_networking_NetworkPolicyList(in *v1.Network
 
 func autoConvert_networking_NetworkPolicyList_To_v1_NetworkPolicyList(in *networking.NetworkPolicyList, out *v1.NetworkPolicyList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.NetworkPolicy, 0)
-	} else {
-		out.Items = *(*[]v1.NetworkPolicy)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.NetworkPolicy)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/policy/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/policy/v1beta1/zz_generated.conversion.go
@@ -118,11 +118,7 @@ func Convert_v1beta1_PodDisruptionBudgetList_To_policy_PodDisruptionBudgetList(i
 
 func autoConvert_policy_PodDisruptionBudgetList_To_v1beta1_PodDisruptionBudgetList(in *policy.PodDisruptionBudgetList, out *v1beta1.PodDisruptionBudgetList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.PodDisruptionBudget, 0)
-	} else {
-		out.Items = *(*[]v1beta1.PodDisruptionBudget)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.PodDisruptionBudget)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/rbac/v1/zz_generated.conversion.go
+++ b/pkg/apis/rbac/v1/zz_generated.conversion.go
@@ -74,11 +74,7 @@ func Convert_v1_ClusterRole_To_rbac_ClusterRole(in *v1.ClusterRole, out *rbac.Cl
 
 func autoConvert_rbac_ClusterRole_To_v1_ClusterRole(in *rbac.ClusterRole, out *v1.ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Rules == nil {
-		out.Rules = make([]v1.PolicyRule, 0)
-	} else {
-		out.Rules = *(*[]v1.PolicyRule)(unsafe.Pointer(&in.Rules))
-	}
+	out.Rules = *(*[]v1.PolicyRule)(unsafe.Pointer(&in.Rules))
 	return nil
 }
 
@@ -103,11 +99,7 @@ func Convert_v1_ClusterRoleBinding_To_rbac_ClusterRoleBinding(in *v1.ClusterRole
 
 func autoConvert_rbac_ClusterRoleBinding_To_v1_ClusterRoleBinding(in *rbac.ClusterRoleBinding, out *v1.ClusterRoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Subjects == nil {
-		out.Subjects = make([]v1.Subject, 0)
-	} else {
-		out.Subjects = *(*[]v1.Subject)(unsafe.Pointer(&in.Subjects))
-	}
+	out.Subjects = *(*[]v1.Subject)(unsafe.Pointer(&in.Subjects))
 	if err := Convert_rbac_RoleRef_To_v1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -132,11 +124,7 @@ func Convert_v1_ClusterRoleBindingList_To_rbac_ClusterRoleBindingList(in *v1.Clu
 
 func autoConvert_rbac_ClusterRoleBindingList_To_v1_ClusterRoleBindingList(in *rbac.ClusterRoleBindingList, out *v1.ClusterRoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.ClusterRoleBinding, 0)
-	} else {
-		out.Items = *(*[]v1.ClusterRoleBinding)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.ClusterRoleBinding)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -158,11 +146,7 @@ func Convert_v1_ClusterRoleList_To_rbac_ClusterRoleList(in *v1.ClusterRoleList, 
 
 func autoConvert_rbac_ClusterRoleList_To_v1_ClusterRoleList(in *rbac.ClusterRoleList, out *v1.ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.ClusterRole, 0)
-	} else {
-		out.Items = *(*[]v1.ClusterRole)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.ClusterRole)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -186,11 +170,7 @@ func Convert_v1_PolicyRule_To_rbac_PolicyRule(in *v1.PolicyRule, out *rbac.Polic
 }
 
 func autoConvert_rbac_PolicyRule_To_v1_PolicyRule(in *rbac.PolicyRule, out *v1.PolicyRule, s conversion.Scope) error {
-	if in.Verbs == nil {
-		out.Verbs = make([]string, 0)
-	} else {
-		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	}
+	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -216,11 +196,7 @@ func Convert_v1_Role_To_rbac_Role(in *v1.Role, out *rbac.Role, s conversion.Scop
 
 func autoConvert_rbac_Role_To_v1_Role(in *rbac.Role, out *v1.Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Rules == nil {
-		out.Rules = make([]v1.PolicyRule, 0)
-	} else {
-		out.Rules = *(*[]v1.PolicyRule)(unsafe.Pointer(&in.Rules))
-	}
+	out.Rules = *(*[]v1.PolicyRule)(unsafe.Pointer(&in.Rules))
 	return nil
 }
 
@@ -245,11 +221,7 @@ func Convert_v1_RoleBinding_To_rbac_RoleBinding(in *v1.RoleBinding, out *rbac.Ro
 
 func autoConvert_rbac_RoleBinding_To_v1_RoleBinding(in *rbac.RoleBinding, out *v1.RoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Subjects == nil {
-		out.Subjects = make([]v1.Subject, 0)
-	} else {
-		out.Subjects = *(*[]v1.Subject)(unsafe.Pointer(&in.Subjects))
-	}
+	out.Subjects = *(*[]v1.Subject)(unsafe.Pointer(&in.Subjects))
 	if err := Convert_rbac_RoleRef_To_v1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -274,11 +246,7 @@ func Convert_v1_RoleBindingList_To_rbac_RoleBindingList(in *v1.RoleBindingList, 
 
 func autoConvert_rbac_RoleBindingList_To_v1_RoleBindingList(in *rbac.RoleBindingList, out *v1.RoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.RoleBinding, 0)
-	} else {
-		out.Items = *(*[]v1.RoleBinding)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.RoleBinding)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -300,11 +268,7 @@ func Convert_v1_RoleList_To_rbac_RoleList(in *v1.RoleList, out *rbac.RoleList, s
 
 func autoConvert_rbac_RoleList_To_v1_RoleList(in *rbac.RoleList, out *v1.RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.Role, 0)
-	} else {
-		out.Items = *(*[]v1.Role)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.Role)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
@@ -74,11 +74,7 @@ func Convert_v1alpha1_ClusterRole_To_rbac_ClusterRole(in *v1alpha1.ClusterRole, 
 
 func autoConvert_rbac_ClusterRole_To_v1alpha1_ClusterRole(in *rbac.ClusterRole, out *v1alpha1.ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Rules == nil {
-		out.Rules = make([]v1alpha1.PolicyRule, 0)
-	} else {
-		out.Rules = *(*[]v1alpha1.PolicyRule)(unsafe.Pointer(&in.Rules))
-	}
+	out.Rules = *(*[]v1alpha1.PolicyRule)(unsafe.Pointer(&in.Rules))
 	return nil
 }
 
@@ -122,7 +118,7 @@ func autoConvert_rbac_ClusterRoleBinding_To_v1alpha1_ClusterRoleBinding(in *rbac
 			}
 		}
 	} else {
-		out.Subjects = make([]v1alpha1.Subject, 0)
+		out.Subjects = nil
 	}
 	if err := Convert_rbac_RoleRef_To_v1alpha1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
@@ -167,7 +163,7 @@ func autoConvert_rbac_ClusterRoleBindingList_To_v1alpha1_ClusterRoleBindingList(
 			}
 		}
 	} else {
-		out.Items = make([]v1alpha1.ClusterRoleBinding, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -190,11 +186,7 @@ func Convert_v1alpha1_ClusterRoleList_To_rbac_ClusterRoleList(in *v1alpha1.Clust
 
 func autoConvert_rbac_ClusterRoleList_To_v1alpha1_ClusterRoleList(in *rbac.ClusterRoleList, out *v1alpha1.ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1alpha1.ClusterRole, 0)
-	} else {
-		out.Items = *(*[]v1alpha1.ClusterRole)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1alpha1.ClusterRole)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -218,11 +210,7 @@ func Convert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *v1alpha1.PolicyRule, out
 }
 
 func autoConvert_rbac_PolicyRule_To_v1alpha1_PolicyRule(in *rbac.PolicyRule, out *v1alpha1.PolicyRule, s conversion.Scope) error {
-	if in.Verbs == nil {
-		out.Verbs = make([]string, 0)
-	} else {
-		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	}
+	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -248,11 +236,7 @@ func Convert_v1alpha1_Role_To_rbac_Role(in *v1alpha1.Role, out *rbac.Role, s con
 
 func autoConvert_rbac_Role_To_v1alpha1_Role(in *rbac.Role, out *v1alpha1.Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Rules == nil {
-		out.Rules = make([]v1alpha1.PolicyRule, 0)
-	} else {
-		out.Rules = *(*[]v1alpha1.PolicyRule)(unsafe.Pointer(&in.Rules))
-	}
+	out.Rules = *(*[]v1alpha1.PolicyRule)(unsafe.Pointer(&in.Rules))
 	return nil
 }
 
@@ -296,7 +280,7 @@ func autoConvert_rbac_RoleBinding_To_v1alpha1_RoleBinding(in *rbac.RoleBinding, 
 			}
 		}
 	} else {
-		out.Subjects = make([]v1alpha1.Subject, 0)
+		out.Subjects = nil
 	}
 	if err := Convert_rbac_RoleRef_To_v1alpha1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
@@ -341,7 +325,7 @@ func autoConvert_rbac_RoleBindingList_To_v1alpha1_RoleBindingList(in *rbac.RoleB
 			}
 		}
 	} else {
-		out.Items = make([]v1alpha1.RoleBinding, 0)
+		out.Items = nil
 	}
 	return nil
 }
@@ -364,11 +348,7 @@ func Convert_v1alpha1_RoleList_To_rbac_RoleList(in *v1alpha1.RoleList, out *rbac
 
 func autoConvert_rbac_RoleList_To_v1alpha1_RoleList(in *rbac.RoleList, out *v1alpha1.RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1alpha1.Role, 0)
-	} else {
-		out.Items = *(*[]v1alpha1.Role)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1alpha1.Role)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
@@ -74,11 +74,7 @@ func Convert_v1beta1_ClusterRole_To_rbac_ClusterRole(in *v1beta1.ClusterRole, ou
 
 func autoConvert_rbac_ClusterRole_To_v1beta1_ClusterRole(in *rbac.ClusterRole, out *v1beta1.ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Rules == nil {
-		out.Rules = make([]v1beta1.PolicyRule, 0)
-	} else {
-		out.Rules = *(*[]v1beta1.PolicyRule)(unsafe.Pointer(&in.Rules))
-	}
+	out.Rules = *(*[]v1beta1.PolicyRule)(unsafe.Pointer(&in.Rules))
 	return nil
 }
 
@@ -103,11 +99,7 @@ func Convert_v1beta1_ClusterRoleBinding_To_rbac_ClusterRoleBinding(in *v1beta1.C
 
 func autoConvert_rbac_ClusterRoleBinding_To_v1beta1_ClusterRoleBinding(in *rbac.ClusterRoleBinding, out *v1beta1.ClusterRoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Subjects == nil {
-		out.Subjects = make([]v1beta1.Subject, 0)
-	} else {
-		out.Subjects = *(*[]v1beta1.Subject)(unsafe.Pointer(&in.Subjects))
-	}
+	out.Subjects = *(*[]v1beta1.Subject)(unsafe.Pointer(&in.Subjects))
 	if err := Convert_rbac_RoleRef_To_v1beta1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -132,11 +124,7 @@ func Convert_v1beta1_ClusterRoleBindingList_To_rbac_ClusterRoleBindingList(in *v
 
 func autoConvert_rbac_ClusterRoleBindingList_To_v1beta1_ClusterRoleBindingList(in *rbac.ClusterRoleBindingList, out *v1beta1.ClusterRoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.ClusterRoleBinding, 0)
-	} else {
-		out.Items = *(*[]v1beta1.ClusterRoleBinding)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.ClusterRoleBinding)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -158,11 +146,7 @@ func Convert_v1beta1_ClusterRoleList_To_rbac_ClusterRoleList(in *v1beta1.Cluster
 
 func autoConvert_rbac_ClusterRoleList_To_v1beta1_ClusterRoleList(in *rbac.ClusterRoleList, out *v1beta1.ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.ClusterRole, 0)
-	} else {
-		out.Items = *(*[]v1beta1.ClusterRole)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.ClusterRole)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -186,11 +170,7 @@ func Convert_v1beta1_PolicyRule_To_rbac_PolicyRule(in *v1beta1.PolicyRule, out *
 }
 
 func autoConvert_rbac_PolicyRule_To_v1beta1_PolicyRule(in *rbac.PolicyRule, out *v1beta1.PolicyRule, s conversion.Scope) error {
-	if in.Verbs == nil {
-		out.Verbs = make([]string, 0)
-	} else {
-		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
-	}
+	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -216,11 +196,7 @@ func Convert_v1beta1_Role_To_rbac_Role(in *v1beta1.Role, out *rbac.Role, s conve
 
 func autoConvert_rbac_Role_To_v1beta1_Role(in *rbac.Role, out *v1beta1.Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Rules == nil {
-		out.Rules = make([]v1beta1.PolicyRule, 0)
-	} else {
-		out.Rules = *(*[]v1beta1.PolicyRule)(unsafe.Pointer(&in.Rules))
-	}
+	out.Rules = *(*[]v1beta1.PolicyRule)(unsafe.Pointer(&in.Rules))
 	return nil
 }
 
@@ -245,11 +221,7 @@ func Convert_v1beta1_RoleBinding_To_rbac_RoleBinding(in *v1beta1.RoleBinding, ou
 
 func autoConvert_rbac_RoleBinding_To_v1beta1_RoleBinding(in *rbac.RoleBinding, out *v1beta1.RoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Subjects == nil {
-		out.Subjects = make([]v1beta1.Subject, 0)
-	} else {
-		out.Subjects = *(*[]v1beta1.Subject)(unsafe.Pointer(&in.Subjects))
-	}
+	out.Subjects = *(*[]v1beta1.Subject)(unsafe.Pointer(&in.Subjects))
 	if err := Convert_rbac_RoleRef_To_v1beta1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -274,11 +246,7 @@ func Convert_v1beta1_RoleBindingList_To_rbac_RoleBindingList(in *v1beta1.RoleBin
 
 func autoConvert_rbac_RoleBindingList_To_v1beta1_RoleBindingList(in *rbac.RoleBindingList, out *v1beta1.RoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.RoleBinding, 0)
-	} else {
-		out.Items = *(*[]v1beta1.RoleBinding)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.RoleBinding)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -300,11 +268,7 @@ func Convert_v1beta1_RoleList_To_rbac_RoleList(in *v1beta1.RoleList, out *rbac.R
 
 func autoConvert_rbac_RoleList_To_v1beta1_RoleList(in *rbac.RoleList, out *v1beta1.RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.Role, 0)
-	} else {
-		out.Items = *(*[]v1beta1.Role)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.Role)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/scheduling/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.conversion.go
@@ -82,11 +82,7 @@ func Convert_v1alpha1_PriorityClassList_To_scheduling_PriorityClassList(in *v1al
 
 func autoConvert_scheduling_PriorityClassList_To_v1alpha1_PriorityClassList(in *scheduling.PriorityClassList, out *v1alpha1.PriorityClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1alpha1.PriorityClass, 0)
-	} else {
-		out.Items = *(*[]v1alpha1.PriorityClass)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1alpha1.PriorityClass)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/settings/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/settings/v1alpha1/zz_generated.conversion.go
@@ -105,7 +105,7 @@ func autoConvert_settings_PodPresetList_To_v1alpha1_PodPresetList(in *settings.P
 			}
 		}
 	} else {
-		out.Items = make([]v1alpha1.PodPreset, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/pkg/apis/storage/v1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1/zz_generated.conversion.go
@@ -84,11 +84,7 @@ func Convert_v1_StorageClassList_To_storage_StorageClassList(in *v1.StorageClass
 
 func autoConvert_storage_StorageClassList_To_v1_StorageClassList(in *storage.StorageClassList, out *v1.StorageClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1.StorageClass, 0)
-	} else {
-		out.Items = *(*[]v1.StorageClass)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1.StorageClass)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/apis/storage/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/storage/v1beta1/zz_generated.conversion.go
@@ -84,11 +84,7 @@ func Convert_v1beta1_StorageClassList_To_storage_StorageClassList(in *v1beta1.St
 
 func autoConvert_storage_StorageClassList_To_v1beta1_StorageClassList(in *storage.StorageClassList, out *v1beta1.StorageClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]v1beta1.StorageClass, 0)
-	} else {
-		out.Items = *(*[]v1beta1.StorageClass)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]v1beta1.StorageClass)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
@@ -326,21 +326,9 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 	if err := v1.Convert_bool_To_Pointer_bool(&in.AllowPrivileged, &out.AllowPrivileged, s); err != nil {
 		return err
 	}
-	if in.HostNetworkSources == nil {
-		out.HostNetworkSources = make([]string, 0)
-	} else {
-		out.HostNetworkSources = *(*[]string)(unsafe.Pointer(&in.HostNetworkSources))
-	}
-	if in.HostPIDSources == nil {
-		out.HostPIDSources = make([]string, 0)
-	} else {
-		out.HostPIDSources = *(*[]string)(unsafe.Pointer(&in.HostPIDSources))
-	}
-	if in.HostIPCSources == nil {
-		out.HostIPCSources = make([]string, 0)
-	} else {
-		out.HostIPCSources = *(*[]string)(unsafe.Pointer(&in.HostIPCSources))
-	}
+	out.HostNetworkSources = *(*[]string)(unsafe.Pointer(&in.HostNetworkSources))
+	out.HostPIDSources = *(*[]string)(unsafe.Pointer(&in.HostPIDSources))
+	out.HostIPCSources = *(*[]string)(unsafe.Pointer(&in.HostIPCSources))
 	if err := v1.Convert_int32_To_Pointer_int32(&in.RegistryPullQPS, &out.RegistryPullQPS, s); err != nil {
 		return err
 	}
@@ -371,11 +359,7 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 	}
 	out.ClusterDomain = in.ClusterDomain
 	out.MasterServiceNamespace = in.MasterServiceNamespace
-	if in.ClusterDNS == nil {
-		out.ClusterDNS = make([]string, 0)
-	} else {
-		out.ClusterDNS = *(*[]string)(unsafe.Pointer(&in.ClusterDNS))
-	}
+	out.ClusterDNS = *(*[]string)(unsafe.Pointer(&in.ClusterDNS))
 	out.StreamingConnectionIdleTimeout = in.StreamingConnectionIdleTimeout
 	out.NodeStatusUpdateFrequency = in.NodeStatusUpdateFrequency
 	out.ImageMinimumGCAge = in.ImageMinimumGCAge
@@ -418,11 +402,7 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 	if err := v1.Convert_bool_To_Pointer_bool(&in.RegisterSchedulable, &out.RegisterSchedulable, s); err != nil {
 		return err
 	}
-	if in.RegisterWithTaints == nil {
-		out.RegisterWithTaints = make([]core_v1.Taint, 0)
-	} else {
-		out.RegisterWithTaints = *(*[]core_v1.Taint)(unsafe.Pointer(&in.RegisterWithTaints))
-	}
+	out.RegisterWithTaints = *(*[]core_v1.Taint)(unsafe.Pointer(&in.RegisterWithTaints))
 	out.ContentType = in.ContentType
 	if err := v1.Convert_int32_To_Pointer_int32(&in.KubeAPIQPS, &out.KubeAPIQPS, s); err != nil {
 		return err
@@ -469,11 +449,7 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
 	out.SystemReservedCgroup = in.SystemReservedCgroup
 	out.KubeReservedCgroup = in.KubeReservedCgroup
-	if in.EnforceNodeAllocatable == nil {
-		out.EnforceNodeAllocatable = make([]string, 0)
-	} else {
-		out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
-	}
+	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
 	out.ExperimentalNodeAllocatableIgnoreEvictionThreshold = in.ExperimentalNodeAllocatableIgnoreEvictionThreshold
 	return nil
 }

--- a/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1/zz_generated.conversion.go
+++ b/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1/zz_generated.conversion.go
@@ -53,11 +53,7 @@ func Convert_v1alpha1_Configuration_To_resourcequota_Configuration(in *Configura
 }
 
 func autoConvert_resourcequota_Configuration_To_v1alpha1_Configuration(in *resourcequota.Configuration, out *Configuration, s conversion.Scope) error {
-	if in.LimitedResources == nil {
-		out.LimitedResources = make([]LimitedResource, 0)
-	} else {
-		out.LimitedResources = *(*[]LimitedResource)(unsafe.Pointer(&in.LimitedResources))
-	}
+	out.LimitedResources = *(*[]LimitedResource)(unsafe.Pointer(&in.LimitedResources))
 	return nil
 }
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
@@ -121,7 +121,7 @@ items:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
     name: system:node
-  subjects: []
+  subjects: null
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/zz_generated.conversion.go
@@ -123,11 +123,7 @@ func Convert_v1beta1_CustomResourceDefinitionList_To_apiextensions_CustomResourc
 
 func autoConvert_apiextensions_CustomResourceDefinitionList_To_v1beta1_CustomResourceDefinitionList(in *apiextensions.CustomResourceDefinitionList, out *CustomResourceDefinitionList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]CustomResourceDefinition, 0)
-	} else {
-		out.Items = *(*[]CustomResourceDefinition)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]CustomResourceDefinition)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -208,11 +204,7 @@ func Convert_v1beta1_CustomResourceDefinitionStatus_To_apiextensions_CustomResou
 }
 
 func autoConvert_apiextensions_CustomResourceDefinitionStatus_To_v1beta1_CustomResourceDefinitionStatus(in *apiextensions.CustomResourceDefinitionStatus, out *CustomResourceDefinitionStatus, s conversion.Scope) error {
-	if in.Conditions == nil {
-		out.Conditions = make([]CustomResourceDefinitionCondition, 0)
-	} else {
-		out.Conditions = *(*[]CustomResourceDefinitionCondition)(unsafe.Pointer(&in.Conditions))
-	}
+	out.Conditions = *(*[]CustomResourceDefinitionCondition)(unsafe.Pointer(&in.Conditions))
 	if err := Convert_apiextensions_CustomResourceDefinitionNames_To_v1beta1_CustomResourceDefinitionNames(&in.AcceptedNames, &out.AcceptedNames, s); err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/zz_generated.conversion.go
@@ -143,7 +143,7 @@ func autoConvert_testapigroup_CarpList_To_v1_CarpList(in *testapigroup.CarpList,
 			}
 		}
 	} else {
-		out.Items = make([]Carp, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -71,7 +71,7 @@ func autoConvert_apiserver_AdmissionConfiguration_To_v1alpha1_AdmissionConfigura
 			}
 		}
 	} else {
-		out.Plugins = make([]AdmissionPluginConfiguration, 0)
+		out.Plugins = nil
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/zz_generated.conversion.go
@@ -120,11 +120,7 @@ func Convert_v1alpha1_EventList_To_audit_EventList(in *EventList, out *audit.Eve
 
 func autoConvert_audit_EventList_To_v1alpha1_EventList(in *audit.EventList, out *EventList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]Event, 0)
-	} else {
-		out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -200,11 +196,7 @@ func Convert_v1alpha1_Policy_To_audit_Policy(in *Policy, out *audit.Policy, s co
 
 func autoConvert_audit_Policy_To_v1alpha1_Policy(in *audit.Policy, out *Policy, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Rules == nil {
-		out.Rules = make([]PolicyRule, 0)
-	} else {
-		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
-	}
+	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
 	return nil
 }
 
@@ -226,11 +218,7 @@ func Convert_v1alpha1_PolicyList_To_audit_PolicyList(in *PolicyList, out *audit.
 
 func autoConvert_audit_PolicyList_To_v1alpha1_PolicyList(in *audit.PolicyList, out *PolicyList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]Policy, 0)
-	} else {
-		out.Items = *(*[]Policy)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]Policy)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/zz_generated.conversion.go
@@ -120,11 +120,7 @@ func Convert_v1beta1_EventList_To_audit_EventList(in *EventList, out *audit.Even
 
 func autoConvert_audit_EventList_To_v1beta1_EventList(in *audit.EventList, out *EventList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]Event, 0)
-	} else {
-		out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -200,11 +196,7 @@ func Convert_v1beta1_Policy_To_audit_Policy(in *Policy, out *audit.Policy, s con
 
 func autoConvert_audit_Policy_To_v1beta1_Policy(in *audit.Policy, out *Policy, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	if in.Rules == nil {
-		out.Rules = make([]PolicyRule, 0)
-	} else {
-		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
-	}
+	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
 	return nil
 }
 
@@ -226,11 +218,7 @@ func Convert_v1beta1_PolicyList_To_audit_PolicyList(in *PolicyList, out *audit.P
 
 func autoConvert_audit_PolicyList_To_v1beta1_PolicyList(in *audit.PolicyList, out *PolicyList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]Policy, 0)
-	} else {
-		out.Items = *(*[]Policy)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]Policy)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.conversion.go
@@ -143,7 +143,7 @@ func autoConvert_example_PodList_To_v1_PodList(in *example.PodList, out *PodList
 			}
 		}
 	} else {
-		out.Items = make([]Pod, 0)
+		out.Items = nil
 	}
 	return nil
 }

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -29,8 +29,6 @@ import (
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
 
-	"reflect"
-
 	"github.com/golang/glog"
 )
 
@@ -792,15 +790,6 @@ func (g *genConversion) doStruct(inType, outType *types.Type, sw *generator.Snip
 			outMemberType = &copied
 		}
 
-		// Determine if our destination field is a slice that should be output when empty.
-		// If it is, ensure a nil source slice converts to a zero-length destination slice.
-		// See http://issue.k8s.io/43203
-		persistEmptySlice := false
-		if outMemberType.Kind == types.Slice {
-			jsonTag := reflect.StructTag(outMember.Tags).Get("json")
-			persistEmptySlice = len(jsonTag) > 0 && !strings.Contains(jsonTag, ",omitempty")
-		}
-
 		args := argsFromType(inMemberType, outMemberType).With("name", inMember.Name)
 
 		// try a direct memory copy for any type that has exactly equivalent values
@@ -816,15 +805,7 @@ func (g *genConversion) doStruct(inType, outType *types.Type, sw *generator.Snip
 				sw.Do("out.$.name$ = *(*$.outType|raw$)($.Pointer|raw$(&in.$.name$))\n", args)
 				continue
 			case types.Slice:
-				if persistEmptySlice {
-					sw.Do("if in.$.name$ == nil {\n", args)
-					sw.Do("out.$.name$ = make($.outType|raw$, 0)\n", args)
-					sw.Do("} else {\n", nil)
-					sw.Do("out.$.name$ = *(*$.outType|raw$)($.Pointer|raw$(&in.$.name$))\n", args)
-					sw.Do("}\n", nil)
-				} else {
-					sw.Do("out.$.name$ = *(*$.outType|raw$)($.Pointer|raw$(&in.$.name$))\n", args)
-				}
+				sw.Do("out.$.name$ = *(*$.outType|raw$)($.Pointer|raw$(&in.$.name$))\n", args)
 				continue
 			}
 		}
@@ -874,11 +855,7 @@ func (g *genConversion) doStruct(inType, outType *types.Type, sw *generator.Snip
 			sw.Do("in, out := &in.$.name$, &out.$.name$\n", args)
 			g.generateFor(inMemberType, outMemberType, sw)
 			sw.Do("} else {\n", nil)
-			if persistEmptySlice {
-				sw.Do("out.$.name$ = make($.outType|raw$, 0)\n", args)
-			} else {
-				sw.Do("out.$.name$ = nil\n", args)
-			}
+			sw.Do("out.$.name$ = nil\n", args)
 			sw.Do("}\n", nil)
 		case types.Struct:
 			if g.isDirectlyAssignable(inMemberType, outMemberType) {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/zz_generated.conversion.go
@@ -123,11 +123,7 @@ func Convert_v1beta1_APIServiceList_To_apiregistration_APIServiceList(in *APISer
 
 func autoConvert_apiregistration_APIServiceList_To_v1beta1_APIServiceList(in *apiregistration.APIServiceList, out *APIServiceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]APIService, 0)
-	} else {
-		out.Items = *(*[]APIService)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]APIService)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -157,11 +153,7 @@ func autoConvert_apiregistration_APIServiceSpec_To_v1beta1_APIServiceSpec(in *ap
 	out.Group = in.Group
 	out.Version = in.Version
 	out.InsecureSkipTLSVerify = in.InsecureSkipTLSVerify
-	if in.CABundle == nil {
-		out.CABundle = make([]byte, 0)
-	} else {
-		out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
-	}
+	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	out.GroupPriorityMinimum = in.GroupPriorityMinimum
 	out.VersionPriority = in.VersionPriority
 	return nil

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1alpha1/zz_generated.conversion.go
@@ -78,11 +78,7 @@ func Convert_custom_metrics_MetricValue_To_v1alpha1_MetricValue(in *custom_metri
 
 func autoConvert_v1alpha1_MetricValueList_To_custom_metrics_MetricValueList(in *MetricValueList, out *custom_metrics.MetricValueList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]custom_metrics.MetricValue, 0)
-	} else {
-		out.Items = *(*[]custom_metrics.MetricValue)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]custom_metrics.MetricValue)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -93,11 +89,7 @@ func Convert_v1alpha1_MetricValueList_To_custom_metrics_MetricValueList(in *Metr
 
 func autoConvert_custom_metrics_MetricValueList_To_v1alpha1_MetricValueList(in *custom_metrics.MetricValueList, out *MetricValueList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]MetricValue, 0)
-	} else {
-		out.Items = *(*[]MetricValue)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]MetricValue)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/zz_generated.conversion.go
@@ -110,11 +110,7 @@ func Convert_v1alpha1_NodeMetricsList_To_metrics_NodeMetricsList(in *NodeMetrics
 
 func autoConvert_metrics_NodeMetricsList_To_v1alpha1_NodeMetricsList(in *metrics.NodeMetricsList, out *NodeMetricsList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]NodeMetrics, 0)
-	} else {
-		out.Items = *(*[]NodeMetrics)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]NodeMetrics)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -140,11 +136,7 @@ func autoConvert_metrics_PodMetrics_To_v1alpha1_PodMetrics(in *metrics.PodMetric
 	out.ObjectMeta = in.ObjectMeta
 	out.Timestamp = in.Timestamp
 	out.Window = in.Window
-	if in.Containers == nil {
-		out.Containers = make([]ContainerMetrics, 0)
-	} else {
-		out.Containers = *(*[]ContainerMetrics)(unsafe.Pointer(&in.Containers))
-	}
+	out.Containers = *(*[]ContainerMetrics)(unsafe.Pointer(&in.Containers))
 	return nil
 }
 
@@ -166,11 +158,7 @@ func Convert_v1alpha1_PodMetricsList_To_metrics_PodMetricsList(in *PodMetricsLis
 
 func autoConvert_metrics_PodMetricsList_To_v1alpha1_PodMetricsList(in *metrics.PodMetricsList, out *PodMetricsList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]PodMetrics, 0)
-	} else {
-		out.Items = *(*[]PodMetrics)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]PodMetrics)(unsafe.Pointer(&in.Items))
 	return nil
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/zz_generated.conversion.go
@@ -85,11 +85,7 @@ func Convert_v1alpha1_FischerList_To_wardle_FischerList(in *FischerList, out *wa
 
 func autoConvert_wardle_FischerList_To_v1alpha1_FischerList(in *wardle.FischerList, out *FischerList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]Fischer, 0)
-	} else {
-		out.Items = *(*[]Fischer)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]Fischer)(unsafe.Pointer(&in.Items))
 	return nil
 }
 
@@ -143,11 +139,7 @@ func Convert_v1alpha1_FlunderList_To_wardle_FlunderList(in *FlunderList, out *wa
 
 func autoConvert_wardle_FlunderList_To_v1alpha1_FlunderList(in *wardle.FlunderList, out *FlunderList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	if in.Items == nil {
-		out.Items = make([]Flunder, 0)
-	} else {
-		out.Items = *(*[]Flunder)(unsafe.Pointer(&in.Items))
-	}
+	out.Items = *(*[]Flunder)(unsafe.Pointer(&in.Items))
 	return nil
 }
 


### PR DESCRIPTION
Closes #44593

When 1.6 added protobuf storage, the storage layer lost the ability to persist slice fields with empty but non-null values.

As a workaround, we tried to convert empty slice fields to `[]`, rather than `null`. Compressing `null` -> `[]` was just as much of an API breakage as `[]` -> `null`, but was hoped to cause fewer problems in clients that don't do null checks.

Because of conversion optimizations around converting lists of objects, the `null` -> `[]` hack was discovered to only apply to individual get requests, not to a list of objects. 1.6 and 1.7 was released with this behavior, and the world didn't explode. 1.7 documented the breaking API change that `null` and `[]` should be considered equivalent, unless otherwise noted on a particular field.

This PR:

* Reverts the earlier attempt (https://github.com/kubernetes/kubernetes/pull/43422) at ensuring non-null json slice output in conversion
* Makes results of `get` consistent with the results of `list` (which helps naive clients that do deepequal comparisons of objects obtained via list/watch and get), and allows empty slice fields to be returned as `null`

```release-note
Protobuf serialization does not distinguish between `[]` and `null`.
API fields previously capable of storing and returning either `[]` and `null` via JSON API requests (for example, the Endpoints `subsets` field) can now store only `null` when created using the protobuf content-type or stored in etcd using protobuf serialization (the default in 1.6+). JSON API clients should tolerate `null` values for such fields, and treat `null` and `[]` as equivalent in meaning unless specifically documented otherwise for a particular field.
```