### PR TITLE
Fetch VM UUID from - /sys/class/dmi/id/product_serial

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -80,6 +80,8 @@ const (
 	NonSupportedControllerTypeErrMsg = "Disk is attached to non-supported controller type"
 	FileAlreadyExistErrMsg           = "File requested already exist"
 	CleanUpDummyVMRoutine_Interval   = 5
+	UUIDPath                         = "/sys/class/dmi/id/product_serial"
+	UUIDPrefix                       = "VMware-"
 )
 
 // Controller types that are currently supported for hot attach of disks
@@ -227,24 +229,46 @@ func init() {
 	})
 }
 
+// UUID gets the BIOS UUID via the sys interface.  This UUID is known by vsphere
+func getvmUUID() (string, error) {
+	id, err := ioutil.ReadFile(UUIDPath)
+	if err != nil {
+		return "", fmt.Errorf("error retrieving vm uuid: %s", err)
+	}
+	uuidFromFile := string(id[:])
+	//strip leading and trailing white space and new line char
+	uuid := strings.TrimSpace(uuidFromFile)
+	// check the uuid starts with "VMware-"
+	if !strings.HasPrefix(uuid, UUIDPrefix) {
+		return "", fmt.Errorf("Failed to match Prefix, UUID read from the file is %v", uuidFromFile)
+	}
+	// Strip the prefix and while spaces and -
+	uuid = strings.Replace(uuid[len(UUIDPrefix):(len(uuid))], " ", "", -1)
+	uuid = strings.Replace(uuid, "-", "", -1)
+	if len(uuid) != 32 {
+		return "", fmt.Errorf("Length check failed, UUID read from the file is %v", uuidFromFile)
+	}
+	// need to add dashes, e.g. "564d395e-d807-e18a-cb25-b79f65eb2b9f"
+	uuid = fmt.Sprintf("%s-%s-%s-%s-%s", uuid[0:8], uuid[8:12], uuid[12:16], uuid[16:20], uuid[20:32])
+	return uuid, nil
+}
+
 // Returns the name of the VM on which this code is running.
-// Prerequisite: this code assumes VMWare vmtools or open-vm-tools to be installed in the VM.
 // Will attempt to determine the machine's name via it's UUID in this precedence order, failing if neither have a UUID:
 // * cloud config value VMUUID
 // * sysfs entry
 func getVMName(client *govmomi.Client, cfg *VSphereConfig) (string, error) {
 	var vmUUID string
+	var err error
 
 	if cfg.Global.VMUUID != "" {
 		vmUUID = cfg.Global.VMUUID
 	} else {
 		// This needs root privileges on the host, and will fail otherwise.
-		vmUUIDbytes, err := ioutil.ReadFile("/sys/devices/virtual/dmi/id/product_uuid")
+		vmUUID, err = getvmUUID()
 		if err != nil {
 			return "", err
 		}
-
-		vmUUID = string(vmUUIDbytes)
 		cfg.Global.VMUUID = vmUUID
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Current code fetch VM uuid using uuid reported at `'/sys/devices/virtual/dmi/id/product_uuid'.` This doesn't work with all the distros like Ubuntu 16.04 and Fedora. 

updating code to fetch VM uuid from `/sys/class/dmi/id/product_serial`



**Which issue this PR fixes**
fixes #

**Special notes for your reviewer**:
Verified UUID  is matching with VM UUID on ubuntu 16.04, Cent OS 7.3 , and Photon OS

@BaluDontu @tusharnt

**Release note**:
```release-note
vSphere cloud provider: Fix fetching of VM UUID on Ubuntu 16.04 and Fedora.
```
