### PR TITLE
Print a newline after ginkgo tests so the test infra doesn't think th…

### DIFF
--- a/pkg/kubectl/cmd/util/openapi/BUILD
+++ b/pkg/kubectl/cmd/util/openapi/BUILD
@@ -8,24 +8,6 @@ load(
     "go_test",
 )
 
-go_test(
-    name = "go_default_test",
-    srcs = [
-        "openapi_cache_test.go",
-        "openapi_getter_test.go",
-        "openapi_test.go",
-    ],
-    library = ":go_default_library",
-    tags = ["automanaged"],
-    deps = [
-        "//vendor/github.com/go-openapi/loads:go_default_library",
-        "//vendor/github.com/go-openapi/spec:go_default_library",
-        "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-    ],
-)
-
 go_library(
     name = "go_default_library",
     srcs = [
@@ -47,11 +29,24 @@ go_library(
 
 go_test(
     name = "go_default_xtest",
-    srcs = ["openapi_suite_test.go"],
+    size = "small",
+    srcs = [
+        "openapi_cache_test.go",
+        "openapi_getter_test.go",
+        "openapi_suite_test.go",
+        "openapi_test.go",
+    ],
+    data = ["//api/openapi-spec:swagger-spec"],
     tags = ["automanaged"],
     deps = [
+        "//pkg/kubectl/cmd/util/openapi:go_default_library",
+        "//vendor/github.com/go-openapi/loads:go_default_library",
+        "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/config:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/types:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
     ],
 )
 
@@ -66,4 +61,9 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+filegroup(
+    name = "testdata",
+    srcs = glob(["testdata/*"]),
 )

--- a/pkg/kubectl/cmd/util/openapi/openapi.go
+++ b/pkg/kubectl/cmd/util/openapi/openapi.go
@@ -133,8 +133,8 @@ type Type struct {
 	Extensions spec.Extensions
 }
 
-// newOpenAPIData parses the resource definitions in openapi data by groupversionkind and name
-func newOpenAPIData(s *spec.Swagger) (*Resources, error) {
+// NewOpenAPIData parses the resource definitions in openapi data by groupversionkind and name
+func NewOpenAPIData(s *spec.Swagger) (*Resources, error) {
 	o := &Resources{
 		GroupVersionKindToName: map[schema.GroupVersionKind]string{},
 		NameToDefinition:       map[string]Kind{},
@@ -338,7 +338,7 @@ func (o *Resources) nameForDefinitionField(s spec.Schema) string {
 	return strings.Replace(p, "/definitions/", "", -1)
 }
 
-// getGroupVersionKind implements openAPIData
+// getGroupVersionKind implements OpenAPIData
 // getGVK parses the gropuversionkind for a resource definition from the x-kubernetes
 // extensions
 // Expected format for s.Extensions: map[string][]map[string]string

--- a/pkg/kubectl/cmd/util/openapi/openapi_cache.go
+++ b/pkg/kubectl/cmd/util/openapi/openapi_cache.go
@@ -37,31 +37,31 @@ func init() {
 
 const openapiFileName = "openapi_cache"
 
-type cachingOpenAPIClient struct {
+type CachingOpenAPIClient struct {
 	version      string
 	client       discovery.OpenAPISchemaInterface
 	cacheDirName string
 }
 
-// newCachingOpenAPIClient returns a new discovery.OpenAPISchemaInterface
+// NewCachingOpenAPIClient returns a new discovery.OpenAPISchemaInterface
 // that will read the openapi spec from a local cache if it exists, and
 // if not will then fetch an openapi spec using a client.
 // client: used to fetch a new openapi spec if a local cache is not found
 // version: the server version and used as part of the cache file location
 // cacheDir: the directory under which the cache file will be written
-func newCachingOpenAPIClient(client discovery.OpenAPISchemaInterface, version, cacheDir string) *cachingOpenAPIClient {
-	return &cachingOpenAPIClient{
+func NewCachingOpenAPIClient(client discovery.OpenAPISchemaInterface, version, cacheDir string) *CachingOpenAPIClient {
+	return &CachingOpenAPIClient{
 		client:       client,
 		version:      version,
 		cacheDirName: cacheDir,
 	}
 }
 
-// openAPIData returns an openapi spec.
+// OpenAPIData returns an openapi spec.
 // It will first attempt to read the spec from a local cache
 // If it cannot read a local cache, it will read the file
 // using the client and then write the cache.
-func (c *cachingOpenAPIClient) openAPIData() (*Resources, error) {
+func (c *CachingOpenAPIClient) OpenAPIData() (*Resources, error) {
 	// Try to use the cached version
 	if c.useCache() {
 		doc, err := c.readOpenAPICache()
@@ -77,7 +77,7 @@ func (c *cachingOpenAPIClient) openAPIData() (*Resources, error) {
 		return nil, err
 	}
 
-	oa, err := newOpenAPIData(s)
+	oa, err := NewOpenAPIData(s)
 	if err != nil {
 		glog.V(2).Infof("Failed to parse openapi data %v", err)
 		return nil, err
@@ -97,12 +97,12 @@ func (c *cachingOpenAPIClient) openAPIData() (*Resources, error) {
 }
 
 // useCache returns true if the client should try to use the cache file
-func (c *cachingOpenAPIClient) useCache() bool {
+func (c *CachingOpenAPIClient) useCache() bool {
 	return len(c.version) > 0 && len(c.cacheDirName) > 0
 }
 
 // readOpenAPICache tries to read the openapi spec from the local file cache
-func (c *cachingOpenAPIClient) readOpenAPICache() (*Resources, error) {
+func (c *CachingOpenAPIClient) readOpenAPICache() (*Resources, error) {
 	// Get the filename to read
 	filename := c.openAPICacheFilename()
 
@@ -119,7 +119,7 @@ func (c *cachingOpenAPIClient) readOpenAPICache() (*Resources, error) {
 }
 
 // decodeSpec binary decodes the openapi spec
-func (c *cachingOpenAPIClient) decodeSpec(data []byte) (*Resources, error) {
+func (c *CachingOpenAPIClient) decodeSpec(data []byte) (*Resources, error) {
 	b := bytes.NewBuffer(data)
 	d := gob.NewDecoder(b)
 	parsed := &Resources{}
@@ -128,7 +128,7 @@ func (c *cachingOpenAPIClient) decodeSpec(data []byte) (*Resources, error) {
 }
 
 // encodeSpec binary encodes the openapi spec
-func (c *cachingOpenAPIClient) encodeSpec(parsed *Resources) ([]byte, error) {
+func (c *CachingOpenAPIClient) encodeSpec(parsed *Resources) ([]byte, error) {
 	b := &bytes.Buffer{}
 	e := gob.NewEncoder(b)
 	err := e.Encode(parsed)
@@ -138,7 +138,7 @@ func (c *cachingOpenAPIClient) encodeSpec(parsed *Resources) ([]byte, error) {
 
 // writeToCache tries to write the openapi spec to the local file cache.
 // writes the data to a new tempfile, and then links the cache file and the tempfile
-func (c *cachingOpenAPIClient) writeToCache(parsed *Resources) error {
+func (c *CachingOpenAPIClient) writeToCache(parsed *Resources) error {
 	// Get the constant filename used to read the cache.
 	cacheFile := c.openAPICacheFilename()
 
@@ -168,7 +168,7 @@ func (c *cachingOpenAPIClient) writeToCache(parsed *Resources) error {
 }
 
 // openAPICacheFilename returns the filename to read the cache from
-func (c *cachingOpenAPIClient) openAPICacheFilename() string {
+func (c *CachingOpenAPIClient) openAPICacheFilename() string {
 	// Cache using the client and server versions
 	return filepath.Join(c.cacheDirName, c.version, version.Get().GitVersion, openapiFileName)
 }

--- a/pkg/kubectl/cmd/util/openapi/openapi_getter.go
+++ b/pkg/kubectl/cmd/util/openapi/openapi_getter.go
@@ -38,7 +38,7 @@ var _ Getter = &synchronizedOpenAPIGetter{}
 
 // Getter is an interface for fetching openapi specs and parsing them into an Resources struct
 type Getter interface {
-	// openAPIData returns the parsed openAPIData
+	// OpenAPIData returns the parsed OpenAPIData
 	Get() (*Resources, error)
 }
 
@@ -55,8 +55,8 @@ func NewOpenAPIGetter(cacheDir, serverVersion string, openAPIClient discovery.Op
 // Resources implements Getter
 func (g *synchronizedOpenAPIGetter) Get() (*Resources, error) {
 	g.Do(func() {
-		client := newCachingOpenAPIClient(g.openAPIClient, g.serverVersion, g.cacheDir)
-		result, err := client.openAPIData()
+		client := NewCachingOpenAPIClient(g.openAPIClient, g.serverVersion, g.cacheDir)
+		result, err := client.OpenAPIData()
 		if err != nil {
 			g.err = err
 			return

--- a/pkg/kubectl/cmd/util/openapi/openapi_getter_test.go
+++ b/pkg/kubectl/cmd/util/openapi/openapi_getter_test.go
@@ -14,29 +14,31 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package openapi
+package openapi_test
 
 import (
 	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
 )
 
 var _ = Describe("Getting the Resources", func() {
 	var client *fakeOpenAPIClient
-	var expectedData *Resources
-	var instance Getter
+	var expectedData *openapi.Resources
+	var instance openapi.Getter
 
 	BeforeEach(func() {
 		client = &fakeOpenAPIClient{}
 		d, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
 
-		expectedData, err = newOpenAPIData(d)
+		expectedData, err = openapi.NewOpenAPIData(d)
 		Expect(err).To(BeNil())
 
-		instance = NewOpenAPIGetter("", "", client)
+		instance = openapi.NewOpenAPIGetter("", "", client)
 	})
 
 	Context("when the server returns a successful result", func() {

--- a/pkg/kubectl/cmd/util/openapi/openapi_suite_test.go
+++ b/pkg/kubectl/cmd/util/openapi/openapi_suite_test.go
@@ -18,12 +18,32 @@ package openapi_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/config"
+	. "github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
 
+	"fmt"
 	"testing"
 )
 
 func TestOpenapi(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Openapi Suite")
+	RunSpecsWithDefaultAndCustomReporters(t, "Openapi Suite", []Reporter{newlineReporter{}})
 }
+
+// Print a newline after the default newlineReporter due to issue
+// https://github.com/jstemmer/go-junit-report/issues/31
+type newlineReporter struct{}
+
+func (newlineReporter) SpecSuiteWillBegin(config GinkgoConfigType, summary *SuiteSummary) {}
+
+func (newlineReporter) BeforeSuiteDidRun(setupSummary *SetupSummary) {}
+
+func (newlineReporter) AfterSuiteDidRun(setupSummary *SetupSummary) {}
+
+func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
+
+func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}
+
+// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
+func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }

--- a/pkg/kubectl/cmd/util/openapi/openapi_test.go
+++ b/pkg/kubectl/cmd/util/openapi/openapi_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package openapi
+package openapi_test
 
 import (
 	"fmt"
@@ -24,14 +24,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
 )
 
 var _ = Describe("Reading apps/v1beta1/Deployment from openAPIData", func() {
-	var instance *Resources
+	var instance *openapi.Resources
 	BeforeEach(func() {
 		s, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
-		instance, err = newOpenAPIData(s)
+		instance, err = openapi.NewOpenAPIData(s)
 		Expect(err).To(BeNil())
 	})
 
@@ -48,7 +49,7 @@ var _ = Describe("Reading apps/v1beta1/Deployment from openAPIData", func() {
 		Expect(name).To(Equal(deploymentName))
 	})
 
-	var definition Kind
+	var definition openapi.Kind
 	It("should find the definition by name", func() {
 		var found bool
 		definition, found = instance.NameToDefinition[deploymentName]
@@ -73,31 +74,31 @@ var _ = Describe("Reading apps/v1beta1/Deployment from openAPIData", func() {
 
 	It("should find the definition fields", func() {
 		By("for 'kind'")
-		Expect(definition.Fields).To(HaveKeyWithValue("kind", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("kind", openapi.Type{
 			TypeName:    "string",
 			IsPrimitive: true,
 		}))
 
 		By("for 'apiVersion'")
-		Expect(definition.Fields).To(HaveKeyWithValue("apiVersion", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("apiVersion", openapi.Type{
 			TypeName:    "string",
 			IsPrimitive: true,
 		}))
 
 		By("for 'metadata'")
-		Expect(definition.Fields).To(HaveKeyWithValue("metadata", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("metadata", openapi.Type{
 			TypeName: "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
 			IsKind:   true,
 		}))
 
 		By("for 'spec'")
-		Expect(definition.Fields).To(HaveKeyWithValue("spec", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("spec", openapi.Type{
 			TypeName: "io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentSpec",
 			IsKind:   true,
 		}))
 
 		By("for 'status'")
-		Expect(definition.Fields).To(HaveKeyWithValue("status", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("status", openapi.Type{
 			TypeName: "io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentStatus",
 			IsKind:   true,
 		}))
@@ -105,17 +106,17 @@ var _ = Describe("Reading apps/v1beta1/Deployment from openAPIData", func() {
 })
 
 var _ = Describe("Reading apps/v1beta1/DeploymentStatus from openAPIData", func() {
-	var instance *Resources
+	var instance *openapi.Resources
 	BeforeEach(func() {
 		d, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
-		instance, err = newOpenAPIData(d)
+		instance, err = openapi.NewOpenAPIData(d)
 		Expect(err).To(BeNil())
 	})
 
 	deploymentStatusName := "io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentStatus"
 
-	var definition Kind
+	var definition openapi.Kind
 	It("should find the definition by name", func() {
 		var found bool
 		definition, found = instance.NameToDefinition[deploymentStatusName]
@@ -135,16 +136,16 @@ var _ = Describe("Reading apps/v1beta1/DeploymentStatus from openAPIData", func(
 
 	It("should find the definition fields", func() {
 		By("for 'availableReplicas'")
-		Expect(definition.Fields).To(HaveKeyWithValue("availableReplicas", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("availableReplicas", openapi.Type{
 			TypeName:    "integer",
 			IsPrimitive: true,
 		}))
 
 		By("for 'conditions'")
-		Expect(definition.Fields).To(HaveKeyWithValue("conditions", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("conditions", openapi.Type{
 			TypeName: "io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentCondition array",
 			IsArray:  true,
-			ElementType: &Type{
+			ElementType: &openapi.Type{
 				TypeName: "io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentCondition",
 				IsKind:   true,
 			},
@@ -157,17 +158,17 @@ var _ = Describe("Reading apps/v1beta1/DeploymentStatus from openAPIData", func(
 })
 
 var _ = Describe("Reading apps/v1beta1/DeploymentSpec from openAPIData", func() {
-	var instance *Resources
+	var instance *openapi.Resources
 	BeforeEach(func() {
 		d, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
-		instance, err = newOpenAPIData(d)
+		instance, err = openapi.NewOpenAPIData(d)
 		Expect(err).To(BeNil())
 	})
 
 	deploymentSpecName := "io.k8s.kubernetes.pkg.apis.apps.v1beta1.DeploymentSpec"
 
-	var definition Kind
+	var definition openapi.Kind
 	It("should find the definition by name", func() {
 		var found bool
 		definition, found = instance.NameToDefinition[deploymentSpecName]
@@ -187,7 +188,7 @@ var _ = Describe("Reading apps/v1beta1/DeploymentSpec from openAPIData", func() 
 
 	It("should find the definition fields", func() {
 		By("for 'template'")
-		Expect(definition.Fields).To(HaveKeyWithValue("template", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("template", openapi.Type{
 			TypeName: "io.k8s.kubernetes.pkg.api.v1.PodTemplateSpec",
 			IsKind:   true,
 		}))
@@ -195,17 +196,17 @@ var _ = Describe("Reading apps/v1beta1/DeploymentSpec from openAPIData", func() 
 })
 
 var _ = Describe("Reading v1/ObjectMeta from openAPIData", func() {
-	var instance *Resources
+	var instance *openapi.Resources
 	BeforeEach(func() {
 		d, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
-		instance, err = newOpenAPIData(d)
+		instance, err = openapi.NewOpenAPIData(d)
 		Expect(err).To(BeNil())
 	})
 
 	objectMetaName := "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
 
-	var definition Kind
+	var definition openapi.Kind
 	It("should find the definition by name", func() {
 		var found bool
 		definition, found = instance.NameToDefinition[objectMetaName]
@@ -225,10 +226,10 @@ var _ = Describe("Reading v1/ObjectMeta from openAPIData", func() {
 
 	It("should find the definition fields", func() {
 		By("for 'finalizers'")
-		Expect(definition.Fields).To(HaveKeyWithValue("finalizers", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("finalizers", openapi.Type{
 			TypeName: "string array",
 			IsArray:  true,
-			ElementType: &Type{
+			ElementType: &openapi.Type{
 				TypeName:    "string",
 				IsPrimitive: true,
 			},
@@ -238,10 +239,10 @@ var _ = Describe("Reading v1/ObjectMeta from openAPIData", func() {
 		}))
 
 		By("for 'ownerReferences'")
-		Expect(definition.Fields).To(HaveKeyWithValue("ownerReferences", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("ownerReferences", openapi.Type{
 			TypeName: "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference array",
 			IsArray:  true,
-			ElementType: &Type{
+			ElementType: &openapi.Type{
 				TypeName: "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference",
 				IsKind:   true,
 			},
@@ -252,10 +253,10 @@ var _ = Describe("Reading v1/ObjectMeta from openAPIData", func() {
 		}))
 
 		By("for 'labels'")
-		Expect(definition.Fields).To(HaveKeyWithValue("labels", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("labels", openapi.Type{
 			TypeName: "string map",
 			IsMap:    true,
-			ElementType: &Type{
+			ElementType: &openapi.Type{
 				TypeName:    "string",
 				IsPrimitive: true,
 			},
@@ -264,17 +265,17 @@ var _ = Describe("Reading v1/ObjectMeta from openAPIData", func() {
 })
 
 var _ = Describe("Reading v1/NodeStatus from openAPIData", func() {
-	var instance *Resources
+	var instance *openapi.Resources
 	BeforeEach(func() {
 		d, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
-		instance, err = newOpenAPIData(d)
+		instance, err = openapi.NewOpenAPIData(d)
 		Expect(err).To(BeNil())
 	})
 
 	nodeStatusName := "io.k8s.kubernetes.pkg.api.v1.NodeStatus"
 
-	var definition Kind
+	var definition openapi.Kind
 	It("should find the definition by name", func() {
 		var found bool
 		definition, found = instance.NameToDefinition[nodeStatusName]
@@ -294,10 +295,10 @@ var _ = Describe("Reading v1/NodeStatus from openAPIData", func() {
 
 	It("should find the definition fields", func() {
 		By("for 'allocatable'")
-		Expect(definition.Fields).To(HaveKeyWithValue("allocatable", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("allocatable", openapi.Type{
 			TypeName: "io.k8s.apimachinery.pkg.api.resource.Quantity map",
 			IsMap:    true,
-			ElementType: &Type{
+			ElementType: &openapi.Type{
 				TypeName: "io.k8s.apimachinery.pkg.api.resource.Quantity",
 				IsKind:   true,
 			},
@@ -306,16 +307,16 @@ var _ = Describe("Reading v1/NodeStatus from openAPIData", func() {
 })
 
 var _ = Describe("Reading Utility Definitions from openAPIData", func() {
-	var instance *Resources
+	var instance *openapi.Resources
 	BeforeEach(func() {
 		d, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
-		instance, err = newOpenAPIData(d)
+		instance, err = openapi.NewOpenAPIData(d)
 		Expect(err).To(BeNil())
 	})
 
 	Context("for util.intstr.IntOrString", func() {
-		var definition Kind
+		var definition openapi.Kind
 		It("should find the definition by name", func() {
 			intOrStringName := "io.k8s.apimachinery.pkg.util.intstr.IntOrString"
 			var found bool
@@ -327,7 +328,7 @@ var _ = Describe("Reading Utility Definitions from openAPIData", func() {
 	})
 
 	Context("for apis.meta.v1.Time", func() {
-		var definition Kind
+		var definition openapi.Kind
 		It("should find the definition by name", func() {
 			intOrStringName := "io.k8s.apimachinery.pkg.apis.meta.v1.Time"
 			var found bool
@@ -340,11 +341,11 @@ var _ = Describe("Reading Utility Definitions from openAPIData", func() {
 })
 
 var _ = Describe("When parsing the openAPIData", func() {
-	var instance *Resources
+	var instance *openapi.Resources
 	BeforeEach(func() {
 		d, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
-		instance, err = newOpenAPIData(d)
+		instance, err = openapi.NewOpenAPIData(d)
 		Expect(err).To(BeNil())
 	})
 
@@ -369,17 +370,17 @@ var _ = Describe("When parsing the openAPIData", func() {
 })
 
 var _ = Describe("Reading authorization/v1/SubjectAccessReviewSpec from openAPIData", func() {
-	var instance *Resources
+	var instance *openapi.Resources
 	BeforeEach(func() {
 		d, err := data.OpenAPISchema()
 		Expect(err).To(BeNil())
-		instance, err = newOpenAPIData(d)
+		instance, err = openapi.NewOpenAPIData(d)
 		Expect(err).To(BeNil())
 	})
 
 	subjectAccessReviewSpecName := "io.k8s.kubernetes.pkg.apis.authorization.v1.SubjectAccessReviewSpec"
 
-	var definition Kind
+	var definition openapi.Kind
 	It("should find the definition by name", func() {
 		var found bool
 		definition, found = instance.NameToDefinition[subjectAccessReviewSpecName]
@@ -390,13 +391,13 @@ var _ = Describe("Reading authorization/v1/SubjectAccessReviewSpec from openAPID
 
 	It("should find the definition fields", func() {
 		By("for 'allocatable'")
-		Expect(definition.Fields).To(HaveKeyWithValue("extra", Type{
+		Expect(definition.Fields).To(HaveKeyWithValue("extra", openapi.Type{
 			TypeName: "string array map",
 			IsMap:    true,
-			ElementType: &Type{
+			ElementType: &openapi.Type{
 				TypeName: "string array",
 				IsArray:  true,
-				ElementType: &Type{
+				ElementType: &openapi.Type{
 					TypeName:    "string",
 					IsPrimitive: true,
 				},


### PR DESCRIPTION
Fixes #45279

Print a newline after ginkgo tests so the test infra doesn't think that they fail

```release-note
NONE
```
