### PR TITLE
remove useless code in kubelet

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -210,10 +210,6 @@ func makeHostsMount(podDir, podIP, hostName, hostDomainName string, hostAliases 
 // ensureHostsFile ensures that the given host file has an up-to-date ip, host
 // name, and domain name.
 func ensureHostsFile(fileName, hostIP, hostName, hostDomainName string, hostAliases []v1.HostAlias) error {
-	if _, err := os.Stat(fileName); os.IsExist(err) {
-		glog.V(4).Infof("kubernetes-managed etc-hosts file exits. Will not be recreated: %q", fileName)
-		return nil
-	}
 	content := hostsFileContent(hostIP, hostName, hostDomainName, hostAliases)
 	return ioutil.WriteFile(fileName, content, 0644)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This code has logical error as the etc-hosts file will be recreated even it already exists. In addition, if do not recreate etc-hosts file when it exists, the pod ip in it will be out of date when pod ips change. So remove this code as it is not needed.

**Which issue this PR fixes**: 

**Special notes for your reviewer**:
xrefer: #44481, #44473

**Release note**:
```release-note
NONE
```
