### PR TITLE
Move hollow-node's initContainer from annotation to field

### DIFF
--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -12,18 +12,13 @@ spec:
     metadata:
       labels:
         name: hollow-node
-      annotations:
-        pod.beta.kubernetes.io/init-containers: '[
-          {
-            "name": "init-inotify-limit",
-            "image": "busybox",
-            "command": ["sysctl", "-w", "fs.inotify.max_user_instances=200"],
-            "securityContext": {
-              "privileged": true
-            }
-          }
-        ]'
     spec:
+      initContainers:
+      - name: init-inotify-limit
+        image: busybox
+        command: ['sysctl', '-w', 'fs.inotify.max_user_instances=200']
+        securityContext:
+          privileged: true
       volumes:
       - name: kubeconfig-volume
         secret:


### PR DESCRIPTION
In 1.6, we have moved init containers spec from beta annotation to field. Updating this in kubemark hollow-node.

This should solve issues with setting of default fields (like ImagePullPolicy) in the container spec for older versions of apiservers too (as annotation->field change has been cherry picked for older releases too). We noticed this issue in https://github.com/kubernetes/kubernetes/issues/45290 where an old apiserver apparently wasn't setting default ImagePullPolicy for container spec inside annotations.

cc @wojtek-t @gmarek @gamename
