### PR TITLE
docs:examples:guestbook: don't advice untagged image

### DIFF
--- a/examples/guestbook/README.md
+++ b/examples/guestbook/README.md
@@ -142,7 +142,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        image: gcr.io/google_containers/redis:e2e
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Using untagged images means no version at all, this can cause weird problems.
Right now, `redis:latest` is no longer compatible with the redis version used in the slave service of the example.