### PR TITLE
WIP: recover hyperkube container

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -32,6 +32,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     nfs-common \
     glusterfs-client \
     cifs-utils \
+    curl \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
     && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* # CACHEBUST
@@ -41,8 +42,14 @@ RUN cp /usr/bin/nsenter /nsenter
 # Copy the the cni-bin folder into /opt/cni/bin
 COPY cni-bin/bin /opt/cni/bin
 
+COPY setup-files.sh make-ca-cert.sh /
+
+# Manifests for the docker guide
+COPY static-pods /etc/kubernetes/manifests/
+
+
 # Create symlinks for each hyperkube server
-# Also create symlinks to /usr/local/bin/ where the server image binaries live, so the hyperkube image may be 
+# Also create symlinks to /usr/local/bin/ where the server image binaries live, so the hyperkube image may be
 # used instead of gcr.io/google_containers/kube-* without any modifications.
 # TODO: replace manual symlink creation with --make-symlink command once
 # cross-building with qemu supports go binaries. See #28702
@@ -66,3 +73,4 @@ RUN ln -s /hyperkube /apiserver \
 
 # Copy the hyperkube binary
 COPY hyperkube /hyperkube
+COPY kubeconfig.yaml /kubeconfig.yaml

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -61,6 +61,9 @@ ifndef VERSION
 endif
 	cp -r ./* ${TEMP_DIR}
 	mkdir -p ${TEMP_DIR}/cni-bin
+	
+	cp ../../saltbase/salt/generate-cert/make-ca-cert.sh ${TEMP_DIR}
+
 
 	cp ../../../_output/dockerized/bin/linux/${ARCH}/hyperkube ${TEMP_DIR}
 	chmod a+rx ${TEMP_DIR}/hyperkube
@@ -70,6 +73,12 @@ endif
 ifeq ($(CACHEBUST),1)
 	cd ${TEMP_DIR} && sed -i.back "s|CACHEBUST|$(shell uuidgen)|g" Dockerfile
 endif
+
+	cd ${TEMP_DIR} && sed -i "s|REGISTRY|${REGISTRY}|g" static-pods/*.json
+	cd ${TEMP_DIR} && sed -i "s|ARCH|${ARCH}|g" static-pods/*.json
+	cd ${TEMP_DIR} && sed -i "s|VERSION|${VERSION}|g" static-pods/*.json
+
+
 
 ifeq ($(ARCH),amd64)
 	# When building "normally" for amd64, remove the whole line, it has no part in the amd64 image
@@ -86,7 +95,7 @@ endif
 	curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/cni-${ARCH}-${CNI_RELEASE}.tar.gz | tar -xz -C ${TEMP_DIR}/cni-bin
 
 	docker build --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
-	rm -rf "${TEMP_DIR}"
+	echo "Build dir: ${TEMP_DIR}"
 
 push: build
 	gcloud docker -- push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}

--- a/cluster/images/hyperkube/kubeconfig.yaml
+++ b/cluster/images/hyperkube/kubeconfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Config
+preferences: {}
+current-context: default
+clusters:
+- cluster:
+    server: http://localhost:8080
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: ""
+  name: default
+users: {}

--- a/cluster/images/hyperkube/setup-files.sh
+++ b/cluster/images/hyperkube/setup-files.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2015 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is intended to set up the files necessary to run a master.
+# It currently creates:
+#  * The basic auth file for access to the kubernetes api server
+#  * Service tokens for accessing the kubernetes api server
+#  * The CA cert and keys for HTTPS access to the kubernetes api server
+
+echo "starting script"
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+create_token() {
+  echo $(cat /dev/urandom | base64 | tr -d "=+/" | dd bs=32 count=1 2> /dev/null)
+}
+
+# Additional address of the API server to be added to the
+# list of Subject Alternative Names of the server TLS certificate
+# Should contain internal IP, i.e. IP:10.0.0.1 for 10.0.0.0/24 cluster IP range
+EXTRA_SANS=$1
+DATA_DIR=/srv/kubernetes
+
+# Files in /data are persistent across reboots, so we don't want to re-create the files if they already
+# exist, because the state is persistent in etcd too, and we don't want a conflict between "old" data in
+# etcd and "new" data that this script would create for apiserver. Therefore, if the file exist, skip it.
+if [[ ! -f ${DATA_DIR}/ca.crt ]]; then
+
+	# Create HTTPS certificates
+	groupadd -f -r kube-cert
+
+	# hostname -I gets the ip of the node
+	/make-ca-cert.sh $(hostname -I | awk '{print $1}') ${EXTRA_SANS}
+
+	echo "Certificates created $(date)"
+else
+	echo "Certificates already found, not recreating."
+fi
+
+if [[ ! -f ${DATA_DIR}/basic_auth.csv ]]; then
+
+	# Create basic token authorization
+	echo "admin,admin,admin" > ${DATA_DIR}/basic_auth.csv
+
+	echo "basic_auth.csv created $(date)"
+else
+	echo "basic_auth.csv already found, not recreating."
+fi
+
+if [[ ! -f ${DATA_DIR}/known_tokens.csv ]]; then
+
+	# Create known tokens for service accounts
+	echo "$(create_token),admin,admin" >> ${DATA_DIR}/known_tokens.csv
+	echo "$(create_token),kubelet,kubelet" >> ${DATA_DIR}/known_tokens.csv
+	echo "$(create_token),kube_proxy,kube_proxy" >> ${DATA_DIR}/known_tokens.csv
+
+	echo "known_tokens.csv created $(date)"
+else
+	echo "known_tokens.csv already found, not recreating."
+fi
+
+while true; do
+  echo "sleeping"
+  sleep 3600
+done

--- a/cluster/images/hyperkube/static-pods/etcd.json
+++ b/cluster/images/hyperkube/static-pods/etcd.json
@@ -1,0 +1,36 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "k8s-etcd",
+    "namespace": "kube-system"
+  },
+  "spec": {
+    "hostNetwork": true,
+    "containers": [
+      {
+        "name": "etcd",
+        "image": "gcr.io/google_containers/etcd-amd64:3.0.17",
+        "command": [
+          "/usr/local/bin/etcd",
+          "--listen-client-urls=http://127.0.0.1:2379,http://127.0.0.1:4001",
+          "--advertise-client-urls=http://127.0.0.1:2379,http://127.0.0.1:4001",
+          "--data-dir=/var/etcd/data"
+        ],
+        "volumeMounts": [
+          {
+            "name": "varetcd",
+            "mountPath": "/var/etcd",
+            "readOnly": false
+          }
+        ]
+      }
+    ],
+    "volumes":[
+      {
+        "name": "varetcd",
+        "emptyDir": {}
+      }
+    ]
+  }
+}

--- a/cluster/images/hyperkube/static-pods/master.json
+++ b/cluster/images/hyperkube/static-pods/master.json
@@ -1,0 +1,90 @@
+{
+"apiVersion": "v1",
+"kind": "Pod",
+"metadata": {
+  "name": "k8s-master",
+  "namespace": "kube-system"
+},
+"spec":{
+  "hostNetwork": true,
+  "containers":[
+    {
+      "name": "controller-manager",
+      "image": "REGISTRY/hyperkube-ARCH:VERSION",
+      "command": [
+        "/hyperkube",
+        "controller-manager",
+        "--master=127.0.0.1:8080",
+        "--service-account-private-key-file=/srv/kubernetes/server.key",
+        "--root-ca-file=/srv/kubernetes/ca.crt",
+        "--min-resync-period=3m",
+        "--leader-elect=true",
+        "--v=2"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    },
+    {
+      "name": "apiserver",
+      "image": "REGISTRY/hyperkube-ARCH:VERSION",
+      "command": [
+        "/hyperkube",
+        "apiserver",
+        "--service-cluster-ip-range=10.0.0.1/24",
+        "--insecure-bind-address=127.0.0.1",
+        "--etcd-servers=http://127.0.0.1:2379",
+        "--admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,DefaultTolerationSeconds",
+        "--client-ca-file=/srv/kubernetes/ca.crt",
+        "--basic-auth-file=/srv/kubernetes/basic_auth.csv",
+        "--min-request-timeout=300",
+        "--tls-cert-file=/srv/kubernetes/server.cert",
+        "--tls-private-key-file=/srv/kubernetes/server.key",
+        "--token-auth-file=/srv/kubernetes/known_tokens.csv",
+        "--allow-privileged=true",
+        "--v=2"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    },
+    {
+      "name": "scheduler",
+      "image": "REGISTRY/hyperkube-ARCH:VERSION",
+      "command": [
+        "/hyperkube",
+        "scheduler",
+        "--master=127.0.0.1:8080",
+        "--leader-elect=true",
+        "--v=2"
+      ]
+    },
+    {
+      "name": "setup",
+      "image": "REGISTRY/hyperkube-ARCH:VERSION",
+      "command": [
+        "/setup-files.sh",
+        "IP:10.0.0.1,DNS:kubernetes,DNS:kubernetes.default,DNS:kubernetes.default.svc,DNS:kubernetes.default.svc.cluster.local"
+      ],
+      "volumeMounts": [
+        {
+          "name": "data",
+          "mountPath": "/srv/kubernetes"
+        }
+      ]
+    }
+  ],
+  "volumes": [
+    {
+      "name": "data",
+      "emptyDir": {}
+    }
+  ]
+ }
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, in Dashboard we use Hyperkube container v1.5 to execute integration tests during travis build. 
https://github.com/kubernetes/dashboard/blob/master/build/hyperkube.sh

The Hyperkube Container was broken with v1.6 release. The remaining parts have been removed with this PR https://github.com/kubernetes/kubernetes/commit/b814b624474a387eb05172ac8155c79be3fca8b3

The PR did remove docker-multinode (which is replaced by kubeadm), but also removed docker-singlenode which is used currently by Dashboard to do integration-testing. 

So, in order for the Dashboard project to upgarde to Kubernetes 1.6, I see the following options:
1. Switch to kubeadm. We would have to refactor our build scripts, at least. Not sure if kubeadm is the right tool for our purpose. The benefits would be that we run our integration tests against a production-like setup of kubernetes. 
2. Recover hyperkube (singlenode). I tried and fixed a few small issues in this PR to make Hyperkube work again. After that I could execute the Dashboard integaration tests. So, I do not see any major blocker

I am not decided and open for suggestions or comments.

@bryk, @luxas, @kubernetes/dashboard-maintainers 