### PR TITLE
Cherry pick #45179 on release-1.6

### DIFF
--- a/test/e2e_node/jenkins/jenkins-ci-ubuntu.properties
+++ b/test/e2e_node/jenkins/jenkins-ci-ubuntu.properties
@@ -1,0 +1,10 @@
+GCE_HOSTS=
+GCE_IMAGE_CONFIG_PATH=
+GCE_IMAGES=ubuntu-gke-1604-xenial-v20170420-1
+GCE_IMAGE_PROJECT=ubuntu-os-gke-cloud
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ubuntu-node
+CLEANUP=true
+GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
+KUBELET_ARGS='--cgroups-per-qos=true --cgroup-root=/'
+TIMEOUT=1h

--- a/test/e2e_node/jenkins/jenkins-serial-ubuntu.properties
+++ b/test/e2e_node/jenkins/jenkins-serial-ubuntu.properties
@@ -1,0 +1,12 @@
+GCE_HOSTS=
+GCE_IMAGE_CONFIG_PATH=
+GCE_IMAGES=ubuntu-gke-1604-xenial-v20170420-1
+GCE_IMAGE_PROJECT=ubuntu-os-gke-cloud
+GCE_ZONE=us-central1-f
+GCE_PROJECT=k8s-jkns-ubuntu-node-serial
+CLEANUP=true
+GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]"'
+TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
+KUBELET_ARGS='--cgroups-per-qos=true --cgroup-root=/'
+PARALLELISM=1
+TIMEOUT=3h


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry pick of https://github.com/kubernetes/kubernetes/pull/45179 on release-1.6.

These config files are needed to run Ubuntu node e2e tests. We want to cherry-pick them into the 1.6 release branch in order to run the tests against 1.6.

**Special notes for your reviewer**:

The changes only touch tests so it should be safe.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
NONE
```

/assign @dchen1107 