### PR TITLE
Fix yet another bug in OpenAPI extension generation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi.go
@@ -132,7 +132,9 @@ func (o *openAPI) buildDefinitionRecursively(name string) error {
 			SwaggerSchemaProps: item.Schema.SwaggerSchemaProps,
 		}
 		if extensions != nil {
-			schema.Extensions = spec.Extensions{}
+			if schema.Extensions == nil {
+				schema.Extensions = spec.Extensions{}
+			}
 			for k, v := range extensions {
 				schema.Extensions[k] = v
 			}

--- a/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/openapi/openapi_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -203,7 +204,7 @@ func getConfig(fullMethods bool) (*openapi.Config, *restful.Container) {
 			if strings.HasPrefix(friendlyName, "go_default_test") {
 				friendlyName = "openapi" + friendlyName[len("go_default_test"):]
 			}
-			return friendlyName, nil
+			return friendlyName, spec.Extensions{"x-test2": "test2"}
 		},
 	}, container
 }
@@ -388,7 +389,8 @@ func getTestInputDefinition() spec.Schema {
 		},
 		VendorExtensible: spec.VendorExtensible{
 			Extensions: spec.Extensions{
-				"x-test": "test",
+				"x-test":  "test",
+				"x-test2": "test2",
 			},
 		},
 	}
@@ -412,6 +414,11 @@ func getTestOutputDefinition() spec.Schema {
 						Type:        spec.StringOrArray{"string"},
 					},
 				},
+			},
+		},
+		VendorExtensible: spec.VendorExtensible{
+			Extensions: spec.Extensions{
+				"x-test2": "test2",
 			},
 		},
 	}
@@ -441,7 +448,16 @@ func TestBuildSwaggerSpec(t *testing.T) {
 		},
 	}
 	err := o.init(container.RegisteredWebServices())
-	if assert.NoError(err) {
-		assert.Equal(expected, o.swagger)
+	if !assert.NoError(err) {
+		return
 	}
+	expected_json, err := json.Marshal(expected)
+	if !assert.NoError(err) {
+		return
+	}
+	actual_json, err := json.Marshal(o.swagger)
+	if !assert.NoError(err) {
+		return
+	}
+	assert.Equal(string(expected_json), string(actual_json))
 }


### PR DESCRIPTION
A comment extension for a type is ignored if the type already has extensions (e.g. GVK).