### PR TITLE
Introduce visibility rules to kubernetes code.

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -15,6 +15,7 @@ filegroup(
         ":package-srcs",
         "//build/debs:all-srcs",
         "//build/release-tars:all-srcs",
+        "//build/visible_to:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/build/visible_to/BUILD
+++ b/build/visible_to/BUILD
@@ -1,0 +1,369 @@
+# Package groups defined for use in kubernetes visibility rules.
+#
+# See associated README.md for explanation.
+#
+# Style suggestions:
+#
+#  - Sort package group definitions by name.
+#
+#  - Prefer obvious package group names.
+#
+#    E.g "pkg_kubectl_cmd_util_CONSUMERS" names a group
+#    of packages allowed to depend on (consume) the
+#    //pkg/kubectl/cmd/util package.
+#
+#
+#  - A group name ending in _BAD wants to be deleted.
+#
+#    Such a group wants to contract, rather than expand.
+#    It likely exists to permit a legacy unintentional
+#    dependency that requires more work to remove.
+#
+#  - Prefer defining new groups to expanding groups.
+#
+#    The former permits tight targeting, the latter can
+#    allow unnecessary visibility and thus bad deps.
+#
+
+package_group(
+    name = "COMMON_generators",
+    packages = [
+        "//cmd/gendocs",
+        "//cmd/genman",
+        "//cmd/genslateyaml",
+        "//cmd/genyaml",
+    ],
+)
+
+package_group(
+    name = "COMMON_release",
+    packages = [
+        "//build",
+        "//build/debs",
+    ],
+)
+
+package_group(
+    name = "COMMON_testing",
+    packages = [
+        "//test/e2e",
+        "//test/e2e/framework",
+        "//test/integration/etcd",
+        "//test/integration/framework",
+        "//test/integration/kubectl",
+    ],
+)
+
+package_group(
+    name = "FEDERATION_BAD",
+    packages = [
+        "//federation/cmd/kubefed/app",
+        "//federation/pkg/kubefed",
+        "//federation/pkg/kubefed/init",
+        "//federation/pkg/kubefed/testing",
+        "//federation/pkg/kubefed/util",
+    ],
+)
+
+package_group(
+    name = "KUBEADM_BAD",
+    packages = [
+        "//cmd/kubeadm/app",
+        "//cmd/kubeadm/app/cmd",
+        "//cmd/kubeadm/app/master",
+    ],
+)
+
+package_group(
+    name = "cmd_kubectl_CONSUMERS",
+    packages = [
+        "//cmd",
+    ],
+)
+
+package_group(
+    name = "cmd_kubectl_app_CONSUMERS",
+    packages = [
+        "//cmd/kubectl",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_CONSUMERS_BAD",
+    includes = [
+        ":FEDERATION_BAD",
+        ":KUBEADM_BAD",
+    ],
+    packages = [
+        "//cmd/clicheck",
+        "//cmd/hyperkube",
+        "//pkg",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_CONSUMERS",
+    includes = [
+        ":COMMON_generators",
+        ":pkg_kubectl_CONSUMERS_BAD",
+    ],
+    packages = [
+        "//cmd/kubectl",
+        "//cmd/kubectl/app",
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/auth",
+        "//pkg/kubectl/cmd/config",
+        "//pkg/kubectl/cmd/rollout",
+        "//pkg/kubectl/cmd/set",
+        "//pkg/kubectl/cmd/testing",
+        "//pkg/kubectl/cmd/util",
+        "//pkg/kubectl/cmd/util/editor",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_CONSUMERS_BAD",
+    includes = [
+        ":FEDERATION_BAD",
+    ],
+    packages = [
+        "//cmd/clicheck",
+        "//cmd/hyperkube",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_CONSUMERS",
+    includes = [
+        ":COMMON_generators",
+        ":pkg_kubectl_cmd_CONSUMERS_BAD",
+    ],
+    packages = [
+        "//cmd/kubectl",
+        "//cmd/kubectl/app",
+        "//pkg/kubectl",
+        "//pkg/kubectl/cmd",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_auth_CONSUMERS",
+    packages = [
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/rollout",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_config_CONSUMERS",
+    packages = [
+        "//pkg/kubectl/cmd",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_rollout_CONSUMERS",
+    packages = [
+        "//pkg/kubectl/cmd",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_set_CONSUMERS",
+    packages = [
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/rollout",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_templates_CONSUMERS_BAD",
+    packages = [
+        "//federation/pkg/kubefed/init",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_templates_CONSUMERS",
+    includes = [
+        ":COMMON_generators",
+        ":COMMON_testing",
+        ":FEDERATION_BAD",
+    ],
+    packages = [
+        "//cmd/kubectl",
+        "//cmd/kubectl/app",
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/auth",
+        "//pkg/kubectl/cmd/config",
+        "//pkg/kubectl/cmd/rollout",
+        "//pkg/kubectl/cmd/set",
+        "//pkg/kubectl/cmd/templates",
+        "//pkg/kubectl/cmd/util",
+        "//pkg/kubectl/cmd/util/sanity",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_testdata_edit_CONSUMERS",
+    packages = [
+        "//pkg/kubectl/cmd",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_testing_CONSUMERS_BAD",
+    packages = [
+        "//federation/pkg/kubefed",
+        "//federation/pkg/kubefed/init",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_testing_CONSUMERS",
+    includes = [
+        ":pkg_kubectl_cmd_testing_CONSUMERS_BAD",
+    ],
+    packages = [
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/auth",
+        "//pkg/kubectl/cmd/set",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_util_CONSUMERS_BAD",
+    includes = [
+        ":FEDERATION_BAD",
+        ":KUBEADM_BAD",
+    ],
+    packages = [
+        "//cmd/clicheck",
+        "//cmd/hyperkube",
+        "//cmd/kube-proxy/app",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_util_CONSUMERS",
+    includes = [
+        ":COMMON_generators",
+        ":COMMON_testing",
+        ":pkg_kubectl_cmd_util_CONSUMERS_BAD",
+    ],
+    packages = [
+        "//cmd/kubectl",
+        "//cmd/kubectl/app",
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/auth",
+        "//pkg/kubectl/cmd/config",
+        "//pkg/kubectl/cmd/rollout",
+        "//pkg/kubectl/cmd/set",
+        "//pkg/kubectl/cmd/testing",
+        "//pkg/kubectl/cmd/util",
+        "//pkg/kubectl/cmd/util/editor",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_util_editor_CONSUMERS",
+    packages = [
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/util",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_util_jsonmerge_CONSUMERS",
+    packages = [
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/util",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_cmd_util_sanity_CONSUMERS",
+    packages = [
+        "//cmd/clicheck",
+        "//pkg/kubectl/cmd/util",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_metricsutil_CONSUMERS_BAD",
+    includes = [
+        ":FEDERATION_BAD",
+    ],
+    packages = [
+        "//cmd/clicheck",
+        "//cmd/hyperkube",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_metricsutil_CONSUMERS",
+    includes = [
+        ":COMMON_generators",
+        ":pkg_kubectl_metricsutil_CONSUMERS_BAD",
+    ],
+    packages = [
+        "//cmd/kubectl",
+        "//cmd/kubectl/app",
+        "//pkg/kubectl",
+        "//pkg/kubectl/cmd",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_resource_CONSUMERS_BAD",
+    packages = [
+        "//federation/pkg/kubefed",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_resource_CONSUMERS",
+    includes = [
+        ":COMMON_generators",
+        ":COMMON_testing",
+        ":pkg_kubectl_resource_CONSUMERS_BAD",
+    ],
+    packages = [
+        "//cmd/kubectl",
+        "//cmd/kubectl/app",
+        "//pkg/kubectl",
+        "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/auth",
+        "//pkg/kubectl/cmd/config",
+        "//pkg/kubectl/cmd/rollout",
+        "//pkg/kubectl/cmd/set",
+        "//pkg/kubectl/cmd/testing",
+        "//pkg/kubectl/cmd/util",
+        "//pkg/kubectl/cmd/util/editor",
+    ],
+)
+
+package_group(
+    name = "pkg_kubectl_testing_CONSUMERS",
+    packages = [
+        "//pkg/kubectl",
+        "//pkg/printers/internalversion",
+    ],
+)
+
+# Added by ./hack/verify-bazel.sh; should be excluded from
+# that script since it makes no sense here.
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+)
+
+# Added by ./hack/verify-bazel.sh; should be excluded from
+# that script since it makes no sense here.
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//build/visible_to:COMMON_release"],
+)

--- a/build/visible_to/OWNERS
+++ b/build/visible_to/OWNERS
@@ -1,0 +1,24 @@
+reviewers:
+  - brendandburns
+  - dchen1107
+  - ixdy
+  - jbeda
+  - jregan
+  - lavalamp
+  - mikedanese
+  - pwittrock
+  - smarterclayton
+  - thockin
+approvers:
+  - bgrant0607
+  - brendandburns
+  - dchen1107
+  - ixdy
+  - jbeda
+  - jregan
+  - lavalamp
+  - mikedanese
+  - pwittrock
+  - smarterclayton
+  - thockin
+  - wojtek-t

--- a/build/visible_to/README.md
+++ b/build/visible_to/README.md
@@ -1,0 +1,184 @@
+# Package Groups Used in Kubernetes Visibility Rules
+
+## Background
+
+`BUILD` rules define dependencies, answering the question:
+on what packages does _foo_ depend?
+
+The `BUILD` file in this package allows one to define
+_allowed_ reverse dependencies, answering the question:
+given a package _foo_, what other specific packages are
+allowed to depend on it?
+
+This is done via visibility rules.
+
+Visibility rules discourage unintended, spurious
+dependencies that blur code boundaries, slow CICD queues and
+generally inhibit progress.
+
+#### Facts
+
+* A package is any directory that contains a `BUILD` file.
+
+* A `package_group` is a `BUILD` file rule that defines a named
+  set of packages for use in other rules, e.g., given
+  ```
+  package_group(
+    name = "database_CONSUMERS",
+    packages = [
+        "//foo/dbinitializer",
+        "//foo/backend/...",  # `backend` and everything below it
+    ],
+  )
+  ```
+  one can specify the following visibility rule in any `BUILD` rule:
+  ```
+  visibility = [ "//build/visible_to:database_CONSUMERS" ],
+  ``` 
+
+* A visibility rule takes a list of package groups as its
+  argument - or one of the pre-defined groups
+  `//visibility:private` or `//visibility:public`.
+
+* If no visibility is explicitly defined, a package is
+  _private_ by default.
+
+* Violations in visibility cause `make bazel-build` to fail,
+  which in turn causes the submit queue to fail - that's the
+  enforcement.
+
+#### Why define all package groups meant for visibility here (in one file)?
+
+ * Ease discovery of appropriate groups for use in a rule.
+ * Ease reuse (inclusions) of commonly used groups.
+ * Consistent style:
+    * easy to read `//build/visible_to:math_library_CONSUMERS` rules,
+    * call out bad dependencies for eventual removal.
+ * Make it more obvious in code reviews when visibility is being
+   modified.
+ * One set of `OWNERS` to manage visibility.
+
+The alternative is to use special [package literals] directly
+in visibility rules, e.g. 
+
+```
+  visibility = [
+        "//foo/dbinitializer:__pkg__",
+        "//foo/backend:__subpackages__",
+  ],
+```
+
+The difference in style is similar to the difference between
+using a named static constant like `MAX_NODES` rather than a
+literal like `12`.  Names are preferable to literals for intent
+documentation, search, changing one place rather than _n_,
+associating usage in distant code blocks, etc.
+
+
+## Rule Examples
+
+#### Nobody outside this package can depend on me.
+
+```
+visibility = ["//visibility:private"],
+```
+
+Since this is the default, there's no reason to use this
+rule except as a means to override, for some specific
+target, some broader, whole-package visibility rule.
+
+#### Anyone can depend on me (eschew this).
+
+```
+visibility = ["//visibility:public"],
+```
+
+#### Only some servers can depend on me.
+
+Appropriate for, say, backend storage utilities.
+
+```
+visibility = ["//visible_to:server_foo","//visible_to:server_bar"].
+```
+
+#### Both some client and some server can see me.
+
+Appropriate for shared API definition files and generated code:
+
+```
+visibility = ["//visible_to:client_foo,//visible_to:server_foo"],
+```
+
+## Handy commands
+
+#### Quickly check for visibility violations
+```
+bazel build --check_visibility --nobuild \
+    //cmd/... //pkg/... //federation/... //plugin/... \
+    //third_party/... //examples/... //test/... //vendor/k8s.io/...
+```
+
+#### Who depends on target _q_?
+
+To create a seed set for a visibility group, one can ask what
+packages currently depend on (must currently be able to see) a
+given Go library target?  It's a time consuming query.
+
+```
+q=//pkg/kubectl/cmd:go_default_library
+bazel query "rdeps(...,${q})" | \
+    grep go_default_library | \
+    sed 's/\(.*\):go_default_library/ "\1",/'
+```
+
+#### What targets below _p_ are visible to anyone?
+
+A means to look for things one missed when locking down _p_.
+
+```
+p=//pkg/kubectl/cmd
+bazel query "visible(...,${p}/...)"
+```
+
+#### What packages below _p_ may target _q_ depend on without violating visibility rules?
+
+A means to pinpoint unexpected visibility.
+
+```
+p=//pkg/kubectl
+q=//cmd/kubelet:kubelet
+bazel query "visible(${q},${p}/...)" | more
+```
+
+#### What packages does target _q_ need?
+
+```
+q=//cmd/kubectl:kubectl
+bazel query "buildfiles(deps($q))" | \
+    grep -v @bazel_tools | \
+    grep -v @io_bazel_rules | \
+    grep -v @io_kubernetes_build | \
+    grep -v @local_config | \
+    grep -v @local_jdk | \
+    grep -v //visible_to: | \
+    sed 's/:BUILD//' | \
+    sort | uniq > ~/KUBECTL_BUILD.txt
+```
+
+or try
+
+```
+bazel query --nohost_deps --noimplicit_deps \
+    "kind('source file', deps($q))" | wc -
+```
+
+
+#### How does kubectl depend on pkg/util/parsers?
+
+```
+bazel query "somepath(cmd/kubectl:kubectl, pkg/util/parsers:go_default_library)"
+```
+
+ 
+
+[package literals]: https://bazel.build/versions/master/docs/be/common-definitions.html#common.visibility

--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -19,6 +17,9 @@ go_binary(
     library = ":go_default_library",
     linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:COMMON_release",
+    ],
 )
 
 go_library(
@@ -32,7 +33,6 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
@@ -42,4 +42,7 @@ filegroup(
         "//cmd/kubectl/app:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:cmd_kubectl_CONSUMERS",
+    ],
 )

--- a/cmd/kubectl/app/BUILD
+++ b/cmd/kubectl/app/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -11,6 +9,9 @@ go_library(
     name = "go_default_library",
     srcs = ["kubectl.go"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:cmd_kubectl_app_CONSUMERS",
+    ],
     deps = [
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/kubectl/cmd:go_default_library",
@@ -25,11 +26,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:cmd_kubectl_app_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -47,6 +45,10 @@ go_library(
         "versioned_client.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:COMMON_testing",
+        "//build/visible_to:pkg_kubectl_CONSUMERS",
+    ],
     deps = [
         "//federation/apis/federation/v1beta1:go_default_library",
         "//pkg/api:go_default_library",
@@ -181,7 +183,6 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
@@ -195,4 +196,7 @@ filegroup(
         "//pkg/kubectl/testing:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -66,6 +64,9 @@ go_library(
         "version.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_CONSUMERS",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/annotations:go_default_library",
@@ -249,7 +250,6 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
@@ -266,4 +266,7 @@ filegroup(
         "//pkg/kubectl/cmd/util:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/auth/BUILD
+++ b/pkg/kubectl/cmd/auth/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -15,6 +13,9 @@ go_library(
         "cani.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_auth_CONSUMERS",
+    ],
     deps = [
         "//pkg/apis/authorization:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion:go_default_library",
@@ -31,13 +32,15 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_auth_CONSUMERS",
+    ],
 )
 
 go_test(

--- a/pkg/kubectl/cmd/config/BUILD
+++ b/pkg/kubectl/cmd/config/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -27,6 +25,9 @@ go_library(
         "view.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_config_CONSUMERS",
+    ],
     deps = [
         "//pkg/kubectl/cmd/templates:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
@@ -77,11 +78,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_config_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/rollout/BUILD
+++ b/pkg/kubectl/cmd/rollout/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -18,6 +16,9 @@ go_library(
         "rollout_undo.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_rollout_CONSUMERS",
+    ],
     deps = [
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd/set:go_default_library",
@@ -40,11 +41,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_rollout_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/set/BUILD
+++ b/pkg/kubectl/cmd/set/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -19,6 +17,7 @@ go_library(
         "set_subject.go",
     ],
     tags = ["automanaged"],
+    visibility = ["//build/visible_to:pkg_kubectl_cmd_set_CONSUMERS"],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/rbac:go_default_library",
@@ -75,11 +74,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_set_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/templates/BUILD
+++ b/pkg/kubectl/cmd/templates/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -17,6 +15,9 @@ go_library(
         "templates.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_templates_CONSUMERS",
+    ],
     deps = [
         "//pkg/util/term:go_default_library",
         "//vendor/github.com/MakeNowJust/heredoc:go_default_library",
@@ -30,11 +31,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_templates_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/testdata/edit/BUILD
+++ b/pkg/kubectl/cmd/testdata/edit/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -25,11 +23,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_testdata_edit_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/testing/BUILD
+++ b/pkg/kubectl/cmd/testing/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -11,6 +9,9 @@ go_library(
     name = "go_default_library",
     srcs = ["fake.go"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_testing_CONSUMERS",
+    ],
     deps = [
         "//federation/client/clientset_generated/federation_internalclientset:go_default_library",
         "//pkg/api:go_default_library",
@@ -41,11 +42,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_testing_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -22,6 +20,9 @@ go_library(
         "shortcut_restmapper.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_util_CONSUMERS",
+    ],
     deps = [
         "//federation/apis/federation:go_default_library",
         "//federation/client/clientset_generated/federation_internalclientset:go_default_library",
@@ -89,6 +90,9 @@ go_test(
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:COMMON_testing",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/testapi:go_default_library",
@@ -132,7 +136,6 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
@@ -145,4 +148,5 @@ filegroup(
         "//pkg/kubectl/cmd/util/sanity:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = ["//build/visible_to:pkg_kubectl_cmd_util_CONSUMERS"],
 )

--- a/pkg/kubectl/cmd/util/editor/BUILD
+++ b/pkg/kubectl/cmd/util/editor/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -15,6 +13,9 @@ go_library(
         "editor.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_util_editor_CONSUMERS",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/kubectl:go_default_library",
@@ -49,11 +50,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_util_editor_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/util/jsonmerge/BUILD
+++ b/pkg/kubectl/cmd/util/jsonmerge/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -23,11 +21,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_util_jsonmerge_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/cmd/util/sanity/BUILD
+++ b/pkg/kubectl/cmd/util/sanity/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -11,6 +9,9 @@ go_library(
     name = "go_default_library",
     srcs = ["cmd_sanity.go"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_util_sanity_CONSUMERS",
+    ],
     deps = [
         "//pkg/kubectl/cmd/templates:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
@@ -21,11 +22,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_cmd_util_sanity_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/metricsutil/BUILD
+++ b/pkg/kubectl/metricsutil/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -14,6 +12,9 @@ go_library(
         "metrics_printer.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_metricsutil_CONSUMERS",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/validation:go_default_library",
@@ -31,11 +32,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_metricsutil_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/resource/BUILD
+++ b/pkg/kubectl/resource/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -22,6 +20,9 @@ go_library(
         "visitor.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_resource_CONSUMERS",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/validation:go_default_library",
@@ -89,11 +90,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_resource_CONSUMERS",
+    ],
 )

--- a/pkg/kubectl/testing/BUILD
+++ b/pkg/kubectl/testing/BUILD
@@ -1,5 +1,3 @@
-package(default_visibility = ["//visibility:public"])
-
 licenses(["notice"])
 
 load(
@@ -14,6 +12,9 @@ go_library(
         "types.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_testing_CONSUMERS",
+    ],
     deps = [
         "//vendor/github.com/ugorji/go/codec:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -26,11 +27,13 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
-    visibility = ["//visibility:private"],
 )
 
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = [
+        "//build/visible_to:pkg_kubectl_testing_CONSUMERS",
+    ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Use rules to identify "bad" dependencies on kubectl code for later refactoring or removal, and prevent their reintroduction.

**Which issue this PR fixes**

First in a series of PRs to address kubernetes/community#598

**Release note**:
```release-note
NONE
```
