### PR TITLE
Automated cherry pick of #45349

### DIFF
--- a/pkg/api/v1/helpers.go
+++ b/pkg/api/v1/helpers.go
@@ -276,10 +276,10 @@ const (
 	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
 )
 
-// Tries to add a toleration to annotations list. Returns true if something was updated
-// false otherwise.
-func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
-	podTolerations := pod.Spec.Tolerations
+// AddOrUpdateTolerationInPodSpec tries to add a toleration to the toleration list in PodSpec.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPodSpec(spec *PodSpec, toleration *Toleration) (bool, error) {
+	podTolerations := spec.Tolerations
 
 	var newTolerations []Toleration
 	updated := false
@@ -300,8 +300,14 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 		newTolerations = append(newTolerations, *toleration)
 	}
 
-	pod.Spec.Tolerations = newTolerations
+	spec.Tolerations = newTolerations
 	return true, nil
+}
+
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
+	return AddOrUpdateTolerationInPodSpec(&pod.Spec, toleration)
 }
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,

--- a/staging/src/k8s.io/client-go/pkg/api/v1/helpers.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/helpers.go
@@ -276,10 +276,10 @@ const (
 	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
 )
 
-// Tries to add a toleration to annotations list. Returns true if something was updated
-// false otherwise.
-func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
-	podTolerations := pod.Spec.Tolerations
+// AddOrUpdateTolerationInPodSpec tries to add a toleration to the toleration list in PodSpec.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPodSpec(spec *PodSpec, toleration *Toleration) (bool, error) {
+	podTolerations := spec.Tolerations
 
 	var newTolerations []Toleration
 	updated := false
@@ -300,8 +300,14 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 		newTolerations = append(newTolerations, *toleration)
 	}
 
-	pod.Spec.Tolerations = newTolerations
+	spec.Tolerations = newTolerations
 	return true, nil
+}
+
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
+	return AddOrUpdateTolerationInPodSpec(&pod.Spec, toleration)
 }
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,


### PR DESCRIPTION
Cherry pick of #45349 on release-1.6.

#45349: Make Daemons tolerate NoExecute taints correctly

```release-note
Fix a bug that caused invalid Tolerations to be applied to Pods created by DaemonSets.
```