### PR TITLE
update the doc of function NewPathRecorderMux

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/mux/pathrecorder.go
@@ -71,7 +71,7 @@ type prefixHandler struct {
 	handler http.Handler
 }
 
-// NewPathRecorderMux creates a new PathRecorderMux with the given mux as the base mux.
+// NewPathRecorderMux creates a new PathRecorderMux
 func NewPathRecorderMux() *PathRecorderMux {
 	ret := &PathRecorderMux{
 		pathToHandler:   map[string]http.Handler{},


### PR DESCRIPTION
The doc of function NewPathRecorderMux() is out of date. Update it.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
