### PR TITLE
Extend timeouts in timed_workers_test

### DIFF
--- a/pkg/controller/node/timed_workers_test.go
+++ b/pkg/controller/node/timed_workers_test.go
@@ -89,7 +89,7 @@ func TestCancel(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	then := now.Add(100 * time.Millisecond)
+	then := now.Add(time.Second)
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
 	queue.AddWork(NewWorkArgs("3", "3"), now, then)
@@ -119,7 +119,7 @@ func TestCancelAndReadd(t *testing.T) {
 		return nil
 	})
 	now := time.Now()
-	then := now.Add(100 * time.Millisecond)
+	then := now.Add(time.Second)
 	queue.AddWork(NewWorkArgs("1", "1"), now, then)
 	queue.AddWork(NewWorkArgs("2", "2"), now, then)
 	queue.AddWork(NewWorkArgs("3", "3"), now, then)


### PR DESCRIPTION
Fix #45375

If it won't be enough I'll rewrite it to allow injectable timers.