### PR TITLE
Coverage: shasum command not supported on CentOS

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -27,6 +27,16 @@ kube::golang::setup_env
 KUBE_CACHE_MUTATION_DETECTOR="${KUBE_CACHE_MUTATION_DETECTOR:-true}"
 export KUBE_CACHE_MUTATION_DETECTOR
 
+# Handle case where OS has sha#sum commands, instead of shasum.
+if which shasum >/dev/null 2>&1; then
+  SHA1SUM="shasum -a1"
+elif which sha1sum >/dev/null 2>&1; then
+  SHA1SUM="sha1sum"
+else
+  echo "Failed to find shasum or sha1sum utility." >&2
+  exit 1
+fi
+
 kube::test::find_dirs() {
   (
     cd ${KUBE_ROOT}
@@ -189,7 +199,7 @@ junitFilenamePrefix() {
   # barely fits there and in coverage mode test names are
   # appended to generated file names, easily exceeding
   # 255 chars in length. So let's just use a sha1 hash of it.
-  local KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"|shasum -a 1|awk '{print $1}')"
+  local KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"| ${SHA1SUM} |awk '{print $1}')"
   echo "${KUBE_JUNIT_REPORT_DIR}/junit_${KUBE_TEST_API_HASH}_$(kube::util::sortable_date)"
 }
 
@@ -239,7 +249,7 @@ runTests() {
   fi
 
   # Create coverage report directories.
-  KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"|shasum -a 1|awk '{print $1}')"
+  KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"| ${SHA1SUM} |awk '{print $1}')"
   cover_report_dir="/tmp/k8s_coverage/${KUBE_TEST_API_HASH}/$(kube::util::sortable_date)"
   cover_profile="coverage.out"  # Name for each individual coverage profile
   kube::log::status "Saving coverage output in '${cover_report_dir}'"


### PR DESCRIPTION
Centos has sha1sum, instead of "shasum -a1". Modified script to
check for existence fo shasum, and if not present, use sha1sum
for coverage test processing.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Allows coverage test to run under CentOS. Needed for development using that OS.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #45425 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
