### PR TITLE
Removed 'default' row from test_owners.csv and Updated update_owners.py

### DIFF
--- a/hack/update_owners.py
+++ b/hack/update_owners.py
@@ -86,8 +86,7 @@ def write_owners(fname, owners):
     with open(fname, 'w') as f:
         out = csv.writer(f, lineterminator='\n')
         out.writerow(['name', 'owner', 'auto-assigned', 'sig'])
-        sort_key = lambda (k, v): (k != 'DEFAULT', k)  # put 'DEFAULT' first.
-        items = sorted(owners.items(), key=sort_key)
+        items = sorted(owners.items())
         for name, (owner, random_assignment, sig) in items:
             out.writerow([name, owner, int(random_assignment), sig])
 
@@ -137,7 +136,6 @@ def main():
         test_names = get_test_names_from_test_history()
     else:
         test_names = get_test_names_from_local_files()
-    test_names.add('DEFAULT')
     test_names = sorted(test_names)
     owners = load_owners(OWNERS_PATH)
 

--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -1,5 +1,4 @@
 name,owner,auto-assigned,sig
-DEFAULT,rmmh/spxtr/ixdy/apelisse/fejta,0,
 Addon update should propagate add-on file changes,eparis,1,
 AppArmor should enforce an AppArmor profile,derekwaynecarr,0,node
 AppArmor when running with AppArmor should enforce a permissive profile,yujuhong,1,node


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Removes the 'default' row from test_owners.csv and the validation/update logic associated with it in update_owners.py.  
The 'default' row is being removed because it results in too many issues being assigned to the default test owners when issues are automatically generated.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
/assign