### PR TITLE
Put initContainers to PodSpec for some statefulset examples.

### DIFF
--- a/examples/cockroachdb/cockroachdb-statefulset.yaml
+++ b/examples/cockroachdb/cockroachdb-statefulset.yaml
@@ -77,46 +77,33 @@ spec:
     metadata:
       labels:
         app: cockroachdb
-      annotations:
-        # Init containers are run only once in the lifetime of a pod, before
-        # it's started up for the first time. It has to exit successfully
-        # before the pod's main containers are allowed to start.
-        # This particular init container does a DNS lookup for other pods in
-        # the set to help determine whether or not a cluster already exists.
-        # If any other pods exist, it creates a file in the cockroach-data
-        # directory to pass that information along to the primary container that
-        # has to decide what command-line flags to use when starting CockroachDB.
-        # This only matters when a pod's persistent volume is empty - if it has
-        # data from a previous execution, that data will always be used.
-        pod.alpha.kubernetes.io/init-containers: '[
-            {
-                "name": "bootstrap",
-                "image": "cockroachdb/cockroach-k8s-init:0.1",
-                "imagePullPolicy": "IfNotPresent",
-                "args": [
-                  "-on-start=/on-start.sh",
-                  "-service=cockroachdb"
-                ],
-                "env": [
-                  {
-                      "name": "POD_NAMESPACE",
-                      "valueFrom": {
-                          "fieldRef": {
-                              "apiVersion": "v1",
-                              "fieldPath": "metadata.namespace"
-                          }
-                      }
-                   }
-                ],
-                "volumeMounts": [
-                    {
-                        "name": "datadir",
-                        "mountPath": "/cockroach/cockroach-data"
-                    }
-                ]
-            }
-        ]'
     spec:
+      # Init containers are run only once in the lifetime of a pod, before
+      # it's started up for the first time. It has to exit successfully
+      # before the pod's main containers are allowed to start.
+      # This particular init container does a DNS lookup for other pods in
+      # the set to help determine whether or not a cluster already exists.
+      # If any other pods exist, it creates a file in the cockroach-data
+      # directory to pass that information along to the primary container that
+      # has to decide what command-line flags to use when starting CockroachDB.
+      # This only matters when a pod's persistent volume is empty - if it has
+      # data from a previous execution, that data will always be used.
+      initContainers:
+      - name: bootstrap
+        image: cockroachdb/cockroach-k8s-init:0.1
+        imagePullPolicy: IfNotPresent
+        args:
+          - "-on-start=/on-start.sh"
+          - "-service=cockroachdb"
+        env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                apiVersion: v1
+                fieldPath: metadata.namespace
+       volumeMounts:
+       - name: datadir
+         mountPath: "/cockroach/cockroach-data"
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/test/e2e/testing-manifests/statefulset/cockroachdb/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/cockroachdb/statefulset.yaml
@@ -9,45 +9,32 @@ spec:
     metadata:
       labels:
         app: cockroachdb
-      annotations:
-        # Init containers are run only once in the lifetime of a pod, before
-        # it's started up for the first time. It has to exit successfully
-        # before the pod's main containers are allowed to start.
-        # This particular init container does a DNS lookup for other pods in
-        # the set to help determine whether or not a cluster already exists.
-        # If any other pods exist, it creates a file in the cockroach-data
-        # directory to pass that information along to the primary container that
-        # has to decide what command-line flags to use when starting CockroachDB.
-        # This only matters when a pod's persistent volume is empty - if it has
-        # data from a previous execution, that data will always be used.
-        pod.alpha.kubernetes.io/init-containers: '[
-            {
-                "name": "bootstrap",
-                "image": "cockroachdb/cockroach-k8s-init:0.1",
-                "args": [
-                  "-on-start=/on-start.sh",
-                  "-service=cockroachdb"
-                ],
-                "env": [
-                  {
-                      "name": "POD_NAMESPACE",
-                      "valueFrom": {
-                          "fieldRef": {
-                              "apiVersion": "v1",
-                              "fieldPath": "metadata.namespace"
-                          }
-                      }
-                   }
-                ],
-                "volumeMounts": [
-                    {
-                        "name": "datadir",
-                        "mountPath": "/cockroach/cockroach-data"
-                    }
-                ]
-            }
-        ]'
     spec:
+      # Init containers are run only once in the lifetime of a pod, before
+      # it's started up for the first time. It has to exit successfully
+      # before the pod's main containers are allowed to start.
+      # This particular init container does a DNS lookup for other pods in
+      # the set to help determine whether or not a cluster already exists.
+      # If any other pods exist, it creates a file in the cockroach-data
+      # directory to pass that information along to the primary container that
+      # has to decide what command-line flags to use when starting CockroachDB.
+      # This only matters when a pod's persistent volume is empty - if it has
+      # data from a previous execution, that data will always be used.
+      initContainers:
+      - name: bootstrap
+        image: cockroachdb/cockroach-k8s-init:0.1
+        args:
+        - "-on-start=/on-start.sh"
+        - "-service=cockroachdb"
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: datadir
+          mountPath: "/cockroach/cockroach-data"
       containers:
       - name: cockroachdb
         # Runs the master branch. Not recommended for production, but since

--- a/test/e2e/testing-manifests/statefulset/mysql-galera/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/mysql-galera/statefulset.yaml
@@ -9,53 +9,36 @@ spec:
     metadata:
       labels:
         app: mysql
-      annotations:
-        pod.alpha.kubernetes.io/init-containers: '[
-            {
-                "name": "install",
-                "image": "gcr.io/google_containers/galera-install:0.1",
-                "imagePullPolicy": "Always",
-                "args": ["--work-dir=/work-dir"],
-                "volumeMounts": [
-                    {
-                        "name": "workdir",
-                        "mountPath": "/work-dir"
-                    },
-                    {
-                        "name": "config",
-                        "mountPath": "/etc/mysql"
-                    }
-                ]
-            },
-            {
-                "name": "bootstrap",
-                "image": "debian:jessie",
-                "command": ["/work-dir/peer-finder"],
-                "args": ["-on-start=\"/work-dir/on-start.sh\"", "-service=galera"],
-                "env": [
-                  {
-                      "name": "POD_NAMESPACE",
-                      "valueFrom": {
-                          "fieldRef": {
-                              "apiVersion": "v1",
-                              "fieldPath": "metadata.namespace"
-                          }
-                      }
-                   }
-                ],
-                "volumeMounts": [
-                    {
-                        "name": "workdir",
-                        "mountPath": "/work-dir"
-                    },
-                    {
-                        "name": "config",
-                        "mountPath": "/etc/mysql"
-                    }
-                ]
-            }
-        ]'
     spec:
+      initContainers:
+      - name: install
+        image: gcr.io/google_containers/galera-install:0.1
+        imagePullPolicy: Always
+        args:
+        - "--work-dir=/work-dir"
+        volumeMounts:
+        - name: workdir
+          mountPath: "/work-dir"
+        - name: config
+          mountPath: "/etc/mysql"
+     - name: bootstrap
+       image: debian:jessie
+       command:
+       - "/work-dir/peer-finder"
+       args:
+       - -on-start="/work-dir/on-start.sh"
+       - "-service=galera"
+       env:
+       - name: POD_NAMESPACE
+         valueFrom:
+           fieldRef:
+             apiVersion: v1
+             fieldPath: metadata.namespace
+       volumeMounts:
+       - name: workdir
+         mountPath: "/work-dir"
+       - name: config
+         mountPath: "/etc/mysql"
       containers:
       - name: mysql
         image: gcr.io/google_containers/mysql-galera:e2e

--- a/test/e2e/testing-manifests/statefulset/redis/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/redis/statefulset.yaml
@@ -9,53 +9,37 @@ spec:
     metadata:
       labels:
         app: redis
-      annotations:
-        pod.alpha.kubernetes.io/init-containers: '[
-            {
-                "name": "install",
-                "image": "gcr.io/google_containers/redis-install-3.2.0:e2e",
-                "imagePullPolicy": "Always",
-                "args": ["--install-into=/opt", "--work-dir=/work-dir"],
-                "volumeMounts": [
-                    {
-                        "name": "opt",
-                        "mountPath": "/opt"
-                    },
-                    {
-                        "name": "workdir",
-                        "mountPath": "/work-dir"
-                    }
-                ]
-            },
-            {
-                "name": "bootstrap",
-                "image": "debian:jessie",
-                "command": ["/work-dir/peer-finder"],
-                "args": ["-on-start=\"/work-dir/on-start.sh\"", "-service=redis"],
-                "env": [
-                  {
-                      "name": "POD_NAMESPACE",
-                      "valueFrom": {
-                          "fieldRef": {
-                              "apiVersion": "v1",
-                              "fieldPath": "metadata.namespace"
-                          }
-                      }
-                   }
-                ],
-                "volumeMounts": [
-                    {
-                        "name": "opt",
-                        "mountPath": "/opt"
-                    },
-                    {
-                        "name": "workdir",
-                        "mountPath": "/work-dir"
-                    }
-                ]
-            }
-        ]'
     spec:
+      initContainers:
+      - name: install
+        image: gcr.io/google_containers/redis-install-3.2.0:e2e
+        imagePullPolicy: Always
+        args:
+        - "--install-into=/opt"
+        - "--work-dir=/work-dir"
+        volumeMounts:
+        - name: opt
+          mountPath: "/opt"
+        - name: workdir
+          mountPath: "/work-dir"
+     - name: bootstrap
+       image: debian:jessie
+       command:
+       - "/work-dir/peer-finder"
+       args:
+       - -on-start="/work-dir/on-start.sh"
+       - "-service=redis"
+       env:
+       - name: POD_NAMESPACE
+         valueFrom:
+           fieldRef:
+             apiVersion: v1
+             fieldPath: metadata.namespace
+       volumeMounts:
+       - name: opt
+         mountPath: "/opt"
+       - name: workdir
+         mountPath: "/work-dir"
       containers:
       - name: redis
         image: debian:jessie

--- a/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
@@ -9,57 +9,39 @@ spec:
     metadata:
       labels:
         app: zk
-      annotations:
-        pod.alpha.kubernetes.io/init-containers: '[
-            {
-                "name": "install",
-                "image": "gcr.io/google_containers/zookeeper-install-3.5.0-alpha:e2e",
-                "imagePullPolicy": "Always",
-                "args": ["--install-into=/opt", "--work-dir=/work-dir"],
-                "volumeMounts": [
-                    {
-                        "name": "opt",
-                        "mountPath": "/opt/"
-                    },
-                    {
-                        "name": "workdir",
-                        "mountPath": "/work-dir"
-                    }
-                ]
-            },
-            {
-                "name": "bootstrap",
-                "image": "java:openjdk-8-jre",
-                "command": ["/work-dir/peer-finder"],
-                "args": ["-on-start=\"/work-dir/on-start.sh\"", "-service=zk"],
-                "env": [
-                  {
-                      "name": "POD_NAMESPACE",
-                      "valueFrom": {
-                          "fieldRef": {
-                              "apiVersion": "v1",
-                              "fieldPath": "metadata.namespace"
-                          }
-                      }
-                   }
-                ],
-                "volumeMounts": [
-                    {
-                        "name": "opt",
-                        "mountPath": "/opt"
-                    },
-                    {
-                        "name": "workdir",
-                        "mountPath": "/work-dir"
-                    },
-                    {
-                        "name": "datadir",
-                        "mountPath": "/tmp/zookeeper"
-                    }
-                ]
-            }
-        ]'
     spec:
+      initContainers:
+      - name: install
+        image: gcr.io/google_containers/zookeeper-install-3.5.0-alpha:e2e
+        imagePullPolicy: Always
+        args:
+        - "--install-into=/opt"
+        - "--work-dir=/work-dir"
+        volumeMounts:
+        - name: opt
+          mountPath: "/opt/"
+        - name: workdir
+          mountPath: "/work-dir"
+     - name: bootstrap
+       image: java:openjdk-8-jre
+       command:
+       - "/work-dir/peer-finder"
+       args:
+       - -on-start="/work-dir/on-start.sh"
+       - "-service=zk"
+       env:
+       - name: POD_NAMESPACE
+         valueFrom:
+           fieldRef:
+             apiVersion: v1
+             fieldPath: metadata.namespace
+      volumeMounts:
+      - name: opt
+        mountPath: "/opt"
+      - name: workdir
+        mountPath: "/work-dir"
+      - name: datadir
+        mountPath: "/tmp/zookeeper"
       containers:
       - name: zk
         image: java:openjdk-8-jre


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Fixed https://github.com/kubernetes/kubernetes/issues/45405

The `init container` is [graduated to GA](https://github.com/kubernetes/kubernetes/pull/38382) , so some test YAML templates needs to be updated to not use `annotations`.

The following are the two places that needs update:
1. [cockroachdb](https://github.com/kubernetes/kubernetes/blob/master/examples/cockroachdb/cockroachdb-statefulset.yaml)
2. [e2e statefulset test](https://github.com/kubernetes/kubernetes/tree/master/test/e2e/testing-manifests/statefulset)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
