### PR TITLE
Automated cherry pick of #44199

### DIFF
--- a/pkg/kubelet/dockershim/cm/container_manager_linux.go
+++ b/pkg/kubelet/dockershim/cm/container_manager_linux.go
@@ -85,7 +85,7 @@ func (m *containerManager) doWork() {
 		glog.Errorf("Unable to get docker version: %v", err)
 		return
 	}
-	version, err := utilversion.ParseSemantic(v.Version)
+	version, err := utilversion.ParseGeneric(v.Version)
 	if err != nil {
 		glog.Errorf("Unable to parse docker version %q: %v", v.Version, err)
 		return


### PR DESCRIPTION
Cherry pick of #44199 on release-1.6.

#44199: update docker version parser for its new versioning scheme