### PR TITLE
Automated cherry pick of #45376

### DIFF
--- a/cmd/kubeadm/app/phases/apiconfig/setupmaster.go
+++ b/cmd/kubeadm/app/phases/apiconfig/setupmaster.go
@@ -61,7 +61,7 @@ func attemptToUpdateMasterRoleLabelsAndTaints(client *clientset.Clientset) error
 
 	// The master node is tainted and labelled accordingly
 	n.ObjectMeta.Labels[kubeadmconstants.LabelNodeRoleMaster] = ""
-	n.Spec.Taints = []v1.Taint{{Key: kubeadmconstants.LabelNodeRoleMaster, Value: "", Effect: "NoSchedule"}}
+	n.Spec.Taints = append(n.Spec.Taints, v1.Taint{Key: kubeadmconstants.LabelNodeRoleMaster, Value: "", Effect: "NoSchedule"})
 
 	newData, err := json.Marshal(n)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #45376 on release-1.6.

#45376: kubeadm: Fix the tainting of the master node