### PR TITLE
Replacing “Pod Injection Policy” with “Pod Preset” in the code documentation

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -45948,7 +45948,7 @@
     ]
    },
    "io.k8s.kubernetes.pkg.apis.settings.v1alpha1.PodPresetSpec": {
-    "description": "PodPresetSpec is a description of a pod injection policy.",
+    "description": "PodPresetSpec is a description of a pod preset.",
     "properties": {
      "env": {
       "description": "Env defines the collection of EnvVar to inject into containers.",

--- a/api/swagger-spec/settings.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/settings.k8s.io_v1alpha1.json
@@ -1020,7 +1020,7 @@
    },
    "v1alpha1.PodPresetSpec": {
     "id": "v1alpha1.PodPresetSpec",
-    "description": "PodPresetSpec is a description of a pod injection policy.",
+    "description": "PodPresetSpec is a description of a pod preset.",
     "properties": {
      "selector": {
       "$ref": "v1.LabelSelector",

--- a/docs/api-reference/settings.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/settings.k8s.io/v1alpha1/definitions.html
@@ -2473,7 +2473,7 @@ Populated by the system when a graceful deletion is requested. Read-only. More i
 <div class="sect2">
 <h3 id="_v1alpha1_podpresetspec">v1alpha1.PodPresetSpec</h3>
 <div class="paragraph">
-<p>PodPresetSpec is a description of a pod injection policy.</p>
+<p>PodPresetSpec is a description of a pod preset.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>

--- a/pkg/apis/settings/types.go
+++ b/pkg/apis/settings/types.go
@@ -34,7 +34,7 @@ type PodPreset struct {
 	Spec PodPresetSpec
 }
 
-// PodPresetSpec is a description of a pod injection policy.
+// PodPresetSpec is a description of a pod preset.
 type PodPresetSpec struct {
 	// Selector is a label query over a set of resources, in this case pods.
 	// Required.

--- a/pkg/apis/settings/v1alpha1/generated.proto
+++ b/pkg/apis/settings/v1alpha1/generated.proto
@@ -51,7 +51,7 @@ message PodPresetList {
   repeated PodPreset items = 2;
 }
 
-// PodPresetSpec is a description of a pod injection policy.
+// PodPresetSpec is a description of a pod preset.
 message PodPresetSpec {
   // Selector is a label query over a set of resources, in this case pods.
   // Required.

--- a/pkg/apis/settings/v1alpha1/types.go
+++ b/pkg/apis/settings/v1alpha1/types.go
@@ -34,7 +34,7 @@ type PodPreset struct {
 	Spec PodPresetSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
-// PodPresetSpec is a description of a pod injection policy.
+// PodPresetSpec is a description of a pod preset.
 type PodPresetSpec struct {
 	// Selector is a label query over a set of resources, in this case pods.
 	// Required.

--- a/pkg/apis/settings/v1alpha1/types_swagger_doc_generated.go
+++ b/pkg/apis/settings/v1alpha1/types_swagger_doc_generated.go
@@ -46,7 +46,7 @@ func (PodPresetList) SwaggerDoc() map[string]string {
 }
 
 var map_PodPresetSpec = map[string]string{
-	"":             "PodPresetSpec is a description of a pod injection policy.",
+	"":             "PodPresetSpec is a description of a pod preset.",
 	"selector":     "Selector is a label query over a set of resources, in this case pods. Required.",
 	"env":          "Env defines the collection of EnvVar to inject into containers.",
 	"envFrom":      "EnvFrom defines the collection of EnvFromSource to inject into containers.",

--- a/pkg/registry/settings/podpreset/strategy.go
+++ b/pkg/registry/settings/podpreset/strategy.go
@@ -32,21 +32,21 @@ import (
 	"k8s.io/kubernetes/pkg/apis/settings/validation"
 )
 
-// podPresetStrategy implements verification logic for Pod Injection Policies.
+// podPresetStrategy implements verification logic for Pod Presets.
 type podPresetStrategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
 }
 
-// Strategy is the default logic that applies when creating and updating Pod Injection Policy objects.
+// Strategy is the default logic that applies when creating and updating Pod Preset objects.
 var Strategy = podPresetStrategy{api.Scheme, names.SimpleNameGenerator}
 
-// NamespaceScoped returns true because all Pod Injection Policies need to be within a namespace.
+// NamespaceScoped returns true because all Pod Presets need to be within a namespace.
 func (podPresetStrategy) NamespaceScoped() bool {
 	return true
 }
 
-// PrepareForCreate clears the status of a Pod Injection Policy before creation.
+// PrepareForCreate clears the status of a Pod Preset before creation.
 func (podPresetStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
 	pip := obj.(*settings.PodPreset)
 	pip.Generation = 1
@@ -82,7 +82,7 @@ func (podPresetStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old 
 	return append(validationErrorList, updateErrorList...)
 }
 
-// AllowUnconditionalUpdate is the default update policy for Pod Injection Policy objects.
+// AllowUnconditionalUpdate is the default update policy for Pod Preset objects.
 func (podPresetStrategy) AllowUnconditionalUpdate() bool {
 	return true
 }

--- a/staging/src/k8s.io/client-go/pkg/apis/settings/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/settings/types.go
@@ -34,7 +34,7 @@ type PodPreset struct {
 	Spec PodPresetSpec
 }
 
-// PodPresetSpec is a description of a pod injection policy.
+// PodPresetSpec is a description of a pod preset.
 type PodPresetSpec struct {
 	// Selector is a label query over a set of resources, in this case pods.
 	// Required.

--- a/staging/src/k8s.io/client-go/pkg/apis/settings/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/client-go/pkg/apis/settings/v1alpha1/generated.proto
@@ -51,7 +51,7 @@ message PodPresetList {
   repeated PodPreset items = 2;
 }
 
-// PodPresetSpec is a description of a pod injection policy.
+// PodPresetSpec is a description of a pod preset.
 message PodPresetSpec {
   // Selector is a label query over a set of resources, in this case pods.
   // Required.

--- a/staging/src/k8s.io/client-go/pkg/apis/settings/v1alpha1/types.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/settings/v1alpha1/types.go
@@ -34,7 +34,7 @@ type PodPreset struct {
 	Spec PodPresetSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
-// PodPresetSpec is a description of a pod injection policy.
+// PodPresetSpec is a description of a pod preset.
 type PodPresetSpec struct {
 	// Selector is a label query over a set of resources, in this case pods.
 	// Required.

--- a/staging/src/k8s.io/client-go/pkg/apis/settings/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/settings/v1alpha1/types_swagger_doc_generated.go
@@ -46,7 +46,7 @@ func (PodPresetList) SwaggerDoc() map[string]string {
 }
 
 var map_PodPresetSpec = map[string]string{
-	"":             "PodPresetSpec is a description of a pod injection policy.",
+	"":             "PodPresetSpec is a description of a pod preset.",
 	"selector":     "Selector is a label query over a set of resources, in this case pods. Required.",
 	"env":          "Env defines the collection of EnvVar to inject into containers.",
 	"envFrom":      "EnvFrom defines the collection of EnvFromSource to inject into containers.",


### PR DESCRIPTION
**What this PR does / why we need it**:
Replacing the leftovers of the old term "Pod Injection Policy" with "Pod Preset" in the code documentation.