### PR TITLE
If pod reason is "NodeLost", set the count of ready containers as 0.

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -341,6 +341,11 @@ func printPod(pod *api.Pod, options printers.PrintOptions) ([]metav1alpha1.Table
 		reason = "Terminating"
 	}
 
+	// if the reason is "NodeLost", set the count of ready containers as 0.
+	if pod.Status.Reason == node.NodeUnreachablePodReason {
+		readyContainers = 0
+	}
+
 	row.Cells = append(row.Cells, pod.Name, fmt.Sprintf("%d/%d", readyContainers, totalContainers), reason, restarts, translateTimestamp(pod.CreationTimestamp))
 
 	if options.Wide {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
If pod reason is "NodeLost", we don't know the real state of containers. Setting the count of ready containers as 0 would be better user friendly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #45016

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
