### PR TITLE
Remove  Annotaions: volume.alpha.kubernetes.io/storage-class

### DIFF
--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -530,12 +530,10 @@ func IsStatefulSetPodInitialized(pod v1.Pod) bool {
 
 // NewStatefulSetPVC returns a PersistentVolumeClaim named name, for testing StatefulSets.
 func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
+    classAnything := "anything" 
 	return v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
-			Annotations: map[string]string{
-				"volume.alpha.kubernetes.io/storage-class": "anything",
-			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{
@@ -546,6 +544,7 @@ func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 					v1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
 				},
 			},
+			StorageClassName: &classAnything,
 		},
 	}
 }

--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -530,7 +530,6 @@ func IsStatefulSetPodInitialized(pod v1.Pod) bool {
 
 // NewStatefulSetPVC returns a PersistentVolumeClaim named name, for testing StatefulSets.
 func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
-    classAnything := "anything" 
 	return v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
@@ -544,7 +543,6 @@ func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 					v1.ResourceStorage: *resource.NewQuantity(1, resource.BinarySI),
 				},
 			},
-			StorageClassName: &classAnything,
 		},
 	}
 }


### PR DESCRIPTION
Replace  statefulset_utils.go  NewStatefulSetPVC function ,Annotaions: volume.alpha.kubernetes.io/storage-class with Spec StorageClassName,since k8s 1.6.x,StorageClassName attribute has been added to PersistentVolume and PersistentVolumeClaim objects and should be used instead of annotation volume.beta.kubernetes.io/storage-class. 