### PR TITLE
add a new output format

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -808,6 +808,7 @@ func OutputsRawFormat(cmd *cobra.Command) bool {
 	output := GetFlagString(cmd, "output")
 	if output == "json" ||
 		output == "yaml" ||
+		output == "config" ||
 		output == "go-template" ||
 		output == "go-template-file" ||
 		output == "jsonpath" ||

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -63,7 +63,7 @@ func AddOutputVarFlagsForMutation(cmd *cobra.Command, output *string) {
 
 // AddOutputFlags adds output related flags to a command.
 func AddOutputFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
+	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|config|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
 	cmd.Flags().Bool("allow-missing-template-keys", true, "If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.")
 }
 

--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -37,6 +37,8 @@ func GetStandardPrinter(format, formatArgument string, noHeaders, allowMissingTe
 		printer = &JSONPrinter{}
 	case "yaml":
 		printer = &YAMLPrinter{}
+	case "config":
+		printer = &ConfigPrinter{}
 	case "name":
 		printer = &NamePrinter{
 			Typer:    typer,


### PR DESCRIPTION
support `kubectl get resource/name -o config | kubectl create -f - -n namespace`