### PR TITLE
Display same fields of Status.Conditions of different resources in 'kubectl describe'

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -892,7 +892,7 @@ metadata:
 				{"Annotations:"},
 				{"CreationTimestamp:"},
 				{"Conditions:"},
-				{"Type", "Status", "LastHeartbeatTime", "LastTransitionTime", "Reason", "Message"},
+				{"Type", "Status", "Reason"},
 				{"Addresses:"},
 				{"Capacity:"},
 				{"Version:"},

--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -892,7 +892,7 @@ metadata:
 				{"Annotations:"},
 				{"CreationTimestamp:"},
 				{"Conditions:"},
-				{"Type", "Status", "Reason"},
+				{"Type", "Status", "LastHeartbeatTime", "LastTransitionTime", "Reason", "Message"},
 				{"Addresses:"},
 				{"Capacity:"},
 				{"Version:"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Display same fields of Status.Conditions of different resources in 'kubectl describe'

EDIT: Status.Conditions of node and cluster are left as are as per @soltysh comments.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #44948

**Special notes for your reviewer**:
@kargakis @smarterclayton @soltysh 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
