### PR TITLE
Remove leaked tmp file in unit tests

### DIFF
--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -1042,6 +1042,7 @@ func TestRestoreAll(t *testing.T) {
 		},
 	}
 	runner := newInternal(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4, TestLockfilePath)
+	defer os.Remove(TestLockfilePath)
 	defer runner.Destroy()
 
 	err := runner.RestoreAll([]byte{}, NoFlushTables, RestoreCounters)
@@ -1086,6 +1087,7 @@ func TestRestoreAllWait(t *testing.T) {
 		},
 	}
 	runner := newInternal(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4, TestLockfilePath)
+	defer os.Remove(TestLockfilePath)
 	defer runner.Destroy()
 
 	err := runner.RestoreAll([]byte{}, NoFlushTables, RestoreCounters)
@@ -1131,6 +1133,7 @@ func TestRestoreAllWaitOldIptablesRestore(t *testing.T) {
 		},
 	}
 	runner := newInternal(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4, TestLockfilePath)
+	defer os.Remove(TestLockfilePath)
 	defer runner.Destroy()
 
 	err := runner.RestoreAll([]byte{}, NoFlushTables, RestoreCounters)
@@ -1177,6 +1180,7 @@ func TestRestoreAllGrabNewLock(t *testing.T) {
 	}
 
 	runner := newInternal(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4, TestLockfilePath)
+	defer os.Remove(TestLockfilePath)
 	defer runner.Destroy()
 
 	// Grab the /run lock and ensure the RestoreAll fails
@@ -1219,6 +1223,7 @@ func TestRestoreAllGrabOldLock(t *testing.T) {
 	}
 
 	runner := newInternal(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4, TestLockfilePath)
+	defer os.Remove(TestLockfilePath)
 	defer runner.Destroy()
 
 	// Grab the abstract @xtables socket


### PR DESCRIPTION
Some unit tests leave a temp file in work space:
pkg/util/iptables/xtables.lock
This patch remove that file
@dcbw 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
