### PR TITLE
deduplicate endpoints before DNS registration

### DIFF
--- a/federation/pkg/federation-controller/service/BUILD
+++ b/federation/pkg/federation-controller/service/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",

--- a/federation/pkg/federation-controller/service/dns.go
+++ b/federation/pkg/federation-controller/service/dns.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
@@ -346,14 +347,14 @@ func getResolvedEndpoints(endpoints []string) ([]string, error) {
 			resolvedEndpoints = append(resolvedEndpoints, endpoint)
 		}
 	}
-	deduped := []string{}
+	deduped := sets.String{}
 
-	for _, value := range resolvedEndpoints {
-		if !dedupeEndpoints(value, deduped) {
-			deduped = append(deduped, value)
+	for _, endpoint := range resolvedEndpoints {
+		if !deduped.Has(endpoint) {
+			deduped.Insert(endpoint)
 		}
 	}
-	return deduped, nil
+	return deduped.List(), nil
 }
 
 /* ensureDNSRrsets ensures (idempotently, and with minimum mutations) that all of the DNS resource record sets for dnsName are consistent with endpoints.

--- a/federation/pkg/federation-controller/service/dns.go
+++ b/federation/pkg/federation-controller/service/dns.go
@@ -342,12 +342,18 @@ func getResolvedEndpoints(endpoints []string) ([]string, error) {
 				return resolvedEndpoints, err
 			}
 			resolvedEndpoints = append(resolvedEndpoints, ipAddrs...)
-
 		} else {
 			resolvedEndpoints = append(resolvedEndpoints, endpoint)
 		}
 	}
-	return resolvedEndpoints, nil
+	deduped := []string{}
+
+	for _, value := range resolvedEndpoints {
+		if !dedupeEndpoints(value, deduped) {
+			deduped = append(deduped, value)
+		}
+	}
+	return deduped, nil
 }
 
 /* ensureDNSRrsets ensures (idempotently, and with minimum mutations) that all of the DNS resource record sets for dnsName are consistent with endpoints.


### PR DESCRIPTION
**What this PR does / why we need it**: Multizone clusters will return duplicated endpoints to the federation controller manager. The FCM will then attempt to create an A record with duplicate entries, which will fail. As a result, federated services on multi-AZ clusters don't work right now. This PR deduplicates the endpoint IPs before attempting the DNS record registration. 

**Which issue this PR fixes**: fixes #35997

**Special notes for your reviewer**:
I believe there is a lot of refactoring required with multizone federated clusters, most notably with regard to AWS and optimising for ALIAS records rather than A, but this PR will at least allow basic functionality to work.

```release-note NONE
```