### PR TITLE
fix pleg relist time

### DIFF
--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -186,8 +186,6 @@ func (g *GenericPLEG) relist() {
 	}
 
 	timestamp := g.clock.Now()
-	// Update the relist time.
-	g.updateRelisTime(timestamp)
 	defer func() {
 		metrics.PLEGRelistLatency.Observe(metrics.SinceInMicroseconds(timestamp))
 	}()
@@ -198,6 +196,10 @@ func (g *GenericPLEG) relist() {
 		glog.Errorf("GenericPLEG: Unable to retrieve pods: %v", err)
 		return
 	}
+
+	// Update the relist time.
+	g.updateRelisTime(timestamp)
+
 	pods := kubecontainer.Pods(podList)
 	g.podRecords.setCurrent(pods)
 


### PR DESCRIPTION
This PR fix pleg reslist time. According to current implementation, we have a `Healthy` method periodically check the relist time. If current timestamp subtracts latest relist time is longer than `relistThreshold`(default is 3 minutes), we should return an error to indicate the error of runtime.

`relist` method is also called periodically. If runtime(docker) hung, the relist method should return immediately without updating the latest relist time. If we update latest relist time no matter runtime(docker) hung(default timeout is 2 minutes), the `Healthy` method will never return an error.

```release-note
Kubelet PLEG updates the relist timestamp only after successfully relisting.
```

/cc @yujuhong @Random-Liu @dchen1107 