### PR TITLE
[Federation] Reconcile hooks for federated type adapters

### DIFF
--- a/federation/pkg/federatedtypes/adapter.go
+++ b/federation/pkg/federatedtypes/adapter.go
@@ -54,6 +54,15 @@ type FederatedTypeAdapter interface {
 	ClusterWatch(client kubeclientset.Interface, namespace string, options metav1.ListOptions) (watch.Interface, error)
 
 	NewTestObject(namespace string) pkgruntime.Object
+
+	// ImplementsReconcileHook is used to explicitly state, if the adapter implements ReconcilePlugin interface also.
+	ImplementsReconcilePlugin() bool
+}
+
+// ReconcilePlugin defines additional reconcile operations for those controllers which need
+// additional reconcile logic.
+type ReconcilePlugin interface {
+	ReconcileHook(pkgruntime.Object, map[string]pkgruntime.Object) (map[string]pkgruntime.Object, error)
 }
 
 // AdapterFactory defines the function signature for factory methods

--- a/federation/pkg/federatedtypes/configmap.go
+++ b/federation/pkg/federatedtypes/configmap.go
@@ -144,3 +144,7 @@ func (a *ConfigMapAdapter) NewTestObject(namespace string) pkgruntime.Object {
 		},
 	}
 }
+
+func (a *ConfigMapAdapter) ImplementsReconcilePlugin() bool {
+	return false
+}

--- a/federation/pkg/federatedtypes/daemonset.go
+++ b/federation/pkg/federatedtypes/daemonset.go
@@ -161,3 +161,7 @@ func (a *DaemonSetAdapter) NewTestObject(namespace string) pkgruntime.Object {
 		},
 	}
 }
+
+func (a *DaemonSetAdapter) ImplementsReconcilePlugin() bool {
+	return false
+}

--- a/federation/pkg/federatedtypes/secret.go
+++ b/federation/pkg/federatedtypes/secret.go
@@ -146,3 +146,7 @@ func (a *SecretAdapter) NewTestObject(namespace string) pkgruntime.Object {
 		Type: apiv1.SecretTypeOpaque,
 	}
 }
+
+func (a *SecretAdapter) ImplementsReconcilePlugin() bool {
+	return false
+}

--- a/federation/pkg/federation-controller/sync/BUILD
+++ b/federation/pkg/federation-controller/sync/BUILD
@@ -10,7 +10,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["controller.go"],
+    srcs = [
+        "adapter_fake.go",
+        "controller.go",
+    ],
     tags = ["automanaged"],
     deps = [
         "//federation/apis/federation/v1beta1:go_default_library",

--- a/federation/pkg/federation-controller/sync/adapter_fake.go
+++ b/federation/pkg/federation-controller/sync/adapter_fake.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sync
+
+import (
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/federation/pkg/federatedtypes"
+)
+
+// Used to invoke the reconcile plugin type path.
+// When real implementers get merged, they can be used instead.
+type fakeReconcilePluginAdapter struct {
+	federatedtypes.SecretAdapter
+}
+
+func (f *fakeReconcilePluginAdapter) ImplementsReconcilePlugin() bool {
+	return true
+}
+
+func (f *fakeReconcilePluginAdapter) ReconcileHook(fedObj pkgruntime.Object, currentObjs map[string]pkgruntime.Object) (map[string]pkgruntime.Object, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This PR is done on top of @marun's PR https://github.com/kubernetes/kubernetes/pull/45374.
This commit needs to be reviewed here 
https://github.com/irfanurrehman/kubernetes/commit/92f40d285650596020daa8fac4f8f083d67d66f6 
@kubernetes/sig-federation-misc 
@kubernetes/sig-federation-pr-reviews 
Completely open for better name suggestions for methods.. !

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```NONE
```
