### PR TITLE
Adds a helper to convert componentconfig into a configmap

### DIFF
--- a/pkg/apis/componentconfig/BUILD
+++ b/pkg/apis/componentconfig/BUILD
@@ -20,6 +20,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/apis/componentconfig/helpers.go
+++ b/pkg/apis/componentconfig/helpers.go
@@ -17,10 +17,14 @@ limitations under the License.
 package componentconfig
 
 import (
+	"encoding/json"
 	"fmt"
 	"net"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/kubernetes/pkg/api/v1"
 )
 
 // used for validating command line opts
@@ -94,4 +98,22 @@ func (v PortRangeVar) String() string {
 
 func (v PortRangeVar) Type() string {
 	return "port-range"
+}
+
+// ConvertObjToConfigMap converts an object to a ConfigMap.
+// This is specifically meant for ComponentConfigs.
+func ConvertObjToConfigMap(name string, obj runtime.Object) (*v1.ConfigMap, error) {
+	eJSONBytes, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	cm := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Data: map[string]string{
+			name: string(eJSONBytes[:]),
+		},
+	}
+	return cm, nil
 }

--- a/pkg/apis/componentconfig/v1alpha1/BUILD
+++ b/pkg/apis/componentconfig/v1alpha1/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -44,4 +45,12 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["defaults_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = ["//pkg/apis/componentconfig:go_default_library"],
 )

--- a/pkg/apis/componentconfig/v1alpha1/defaults_test.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	componentconfig "k8s.io/kubernetes/pkg/apis/componentconfig"
+)
+
+func TestSchedulerDefaults(t *testing.T) {
+	ks1 := &KubeSchedulerConfiguration{}
+	SetDefaults_KubeSchedulerConfiguration(ks1)
+	cm, err := componentconfig.ConvertObjToConfigMap("KubeSchedulerConfiguration", ks1)
+	if err != nil {
+		t.Errorf("unexpected ConvertObjToConfigMap error %v", err)
+	}
+
+	ks2 := &KubeSchedulerConfiguration{}
+	if err = json.Unmarshal([]byte(cm.Data["KubeSchedulerConfiguration"]), ks2); err != nil {
+		t.Errorf("unexpected error unserializing scheduler config %v", err)
+	}
+
+	if !reflect.DeepEqual(ks2, ks1) {
+		t.Errorf("Expected:\n%#v\n\nGot:\n%#v", ks1, ks2)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a utility function that will be used by self-hosted components such as `kubeadm` but is also a step towards https://github.com/kubernetes/kubernetes/issues/44857 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
NONE
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews  @bsalamat 
