### PR TITLE
Added more information when authenticating failed.

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -225,7 +225,8 @@ func (s *Server) InstallAuthFilter() {
 		// Authenticate
 		u, ok, err := s.auth.AuthenticateRequest(req.Request)
 		if err != nil {
-			glog.Errorf("Unable to authenticate the request due to an error: %v", err)
+			glog.Errorf("Unable to authenticate the request, from %v for %v, due to an error: %v",
+				req.Request.UserAgent(), req.Request.URL, err)
 			resp.WriteErrorString(http.StatusUnauthorized, "Unauthorized")
 			return
 		}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/authentication.go
@@ -55,7 +55,8 @@ func WithAuthentication(handler http.Handler, mapper genericapirequest.RequestCo
 			user, ok, err := auth.AuthenticateRequest(req)
 			if err != nil || !ok {
 				if err != nil {
-					glog.Errorf("Unable to authenticate the request due to an error: %v", err)
+					glog.Errorf("Unable to authenticate the request, from %v for %v, due to an error: %v",
+						req.UserAgent(), req.URL, err)
 				}
 				failed.ServeHTTP(w, req)
 				return


### PR DESCRIPTION
**What this PR does / why we need it**:
Add more information when authenticating failed, e.g. where the request came from, which resource is requesting.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # N/A

**Release note**:

```release-note
Add more information when authenticating failed, e.g. where the request cames from, which resource is requesting.
```
