### PR TITLE
oidc auth plugin not to override the Auth header if it's already exits

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
@@ -216,6 +216,9 @@ type roundTripper struct {
 }
 
 func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if len(req.Header.Get("Authorization")) != 0 {
+		return r.wrapped.RoundTrip(req)
+	}
 	token, err := r.provider.idToken()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
oidc auth client plugin should not override the `Authorization` header if it's already exits.
**Which issue this PR fixes** : 
fix oidc auth plugin override the` Authorization` header
**Special notes for your reviewer**:

**Release note**: