### PR TITLE
Tune Cinder approvers

### DIFF
--- a/pkg/volume/cinder/OWNERS
+++ b/pkg/volume/cinder/OWNERS
@@ -1,5 +1,6 @@
 approvers:
 - jsafrane
+- anguslees
 reviewers:
 - anguslees
 - justinsb
@@ -13,7 +14,6 @@ reviewers:
 - bprashanth
 - pmorie
 - saad-ali
-- justinsb
 - jsafrane
 - rootfs
 - jingxu97


### PR DESCRIPTION
I don't want to be single approver for cinder PRs, @anguslees is OpenStack maintainer and should be able to help with Cinder.

Any other volunteers from @kubernetes/sig-storage-pr-reviews or @k8s-sig-openstack-pr-reviews?

Note: @justinsb **is** still reviewer, he was just listed twice.

```release-note
NONE
```
