### PR TITLE
Stream output of run-gcloud-compute-with-retries to stdout in realtime

### DIFF
--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -20,8 +20,10 @@
 function run-gcloud-compute-with-retries {
   RETRIES="${RETRIES:-3}"
   for attempt in $(seq 1 ${RETRIES}); do
+    exec 5>&1  # Duplicate &1 to &5 for use below.
     # We don't use 'local' to declare gcloud_result as then ret_val always gets value 0.
-    gcloud_result=$(gcloud compute "$@" 2>&1) || local ret_val="$?"
+    # We use tee to output to &5 (redirected to stdout) while also storing it in the variable.
+    gcloud_result=$(gcloud compute "$@" |& tee >(cat - >&5)) || local ret_val="$?"
     echo "${gcloud_result}"
     if [[ "${ret_val:-0}" -ne "0" ]]; then
       if [[ $(echo "${gcloud_result}" | grep -c "already exists") -gt 0 ]]; then


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/40139#issuecomment-299894222 (3rd point)
This should help us get more info about timeouts during start-kubemark-master.sh.

cc @wojtek-t @gmarek 