### PR TITLE
Adds Support for Node Resource IPv6 Addressing

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -359,8 +359,13 @@ func (kl *Kubelet) GetClusterDNS(pod *v1.Pod) ([]string, []string, []string, boo
 		// local machine". A nameserver setting of localhost is equivalent to
 		// this documented behavior.
 		if kl.resolverConfig == "" {
-			hostDNS = []string{"127.0.0.1"}
 			hostSearch = []string{"."}
+			switch {
+			case kl.nodeIP == nil || kl.nodeIP.To4() != nil:
+				hostDNS = []string{"127.0.0.1"}
+			case kl.nodeIP.To16() != nil:
+				hostDNS = []string{"::1"}
+			}
 		} else {
 			hostSearch = kl.formDNSSearchForDNSDefault(hostSearch, pod)
 		}

--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -99,28 +99,56 @@ func TestNoOpHostSupportsLegacyFeatures(t *testing.T) {
 }
 
 func TestNodeIPParam(t *testing.T) {
-	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
-	tests := []struct {
+	type test struct {
 		nodeIP   string
 		success  bool
 		testName string
-	}{
+	}
+	tests := []test{
 		{
 			nodeIP:   "",
-			success:  true,
+			success:  false,
 			testName: "IP not set",
 		},
 		{
 			nodeIP:   "127.0.0.1",
 			success:  false,
-			testName: "loopback address",
+			testName: "IPv4 loopback address",
 		},
 		{
-			nodeIP:   "FE80::0202:B3FF:FE1E:8329",
+			nodeIP:   "::1",
 			success:  false,
-			testName: "IPv6 address",
+			testName: "IPv6 loopback address",
+		},
+		{
+			nodeIP:   "224.0.0.1",
+			success:  false,
+			testName: "multicast IPv4 address",
+		},
+		{
+			nodeIP:   "ff00::1",
+			success:  false,
+			testName: "multicast IPv6 address",
+		},
+		{
+			nodeIP:   "169.254.0.1",
+			success:  false,
+			testName: "IPv4 link-local unicast address",
+		},
+		{
+			nodeIP:   "fe80::0202:b3ff:fe1e:8329",
+			success:  false,
+			testName: "IPv6 link-local unicast address",
+		},
+		{
+			nodeIP:   "0.0.0.0",
+			success:  false,
+			testName: "Unspecified IPv4 address",
+		},
+		{
+			nodeIP:   "::",
+			success:  false,
+			testName: "Unspecified IPv6 address",
 		},
 		{
 			nodeIP:   "1.2.3.4",
@@ -128,9 +156,31 @@ func TestNodeIPParam(t *testing.T) {
 			testName: "IPv4 address that doesn't belong to host",
 		},
 	}
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		assert.Error(t, err, fmt.Sprintf(
+			"Unable to obtain a list of the node's unicast interface addresses."))
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+			break
+		}
+		successTest := test{
+			nodeIP:   ip.String(),
+			success:  true,
+			testName: fmt.Sprintf("Success test case for address %s", ip.String()),
+		}
+		tests = append(tests, successTest)
+	}
 	for _, test := range tests {
-		kubelet.nodeIP = net.ParseIP(test.nodeIP)
-		err := kubelet.validateNodeIP()
+		err := validateNodeIP(net.ParseIP(test.nodeIP))
 		if test.success {
 			assert.NoError(t, err, "test %s", test.testName)
 		} else {

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -144,7 +144,7 @@ func TestNodeStatusWithCloudProviderNodeIP(t *testing.T) {
 		Spec:       v1.NodeSpec{},
 	}
 
-	// TODO : is it possible to mock kubelet.validateNodeIP() to avoid relying on the host interface addresses ?
+	// TODO : is it possible to mock validateNodeIP() to avoid relying on the host interface addresses ?
 	addrs, err := net.InterfaceAddrs()
 	assert.NoError(t, err)
 	for _, addr := range addrs {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for the following:

1. A node resource to be assigned an IPv6 address.
2. Expands IPv4/v6 address validation checks.

**Which issue this PR fixes**:
Fixes Issue #44848 (in combination with PR #45116).

**Special notes for your reviewer**:
This PR is part of a larger effort, Issue #1443 to add IPv6 support to k8s.

**Release note**:
```
NONE
```
