### PR TITLE
add safe way to prevent status from touching objectmeta

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
@@ -22,8 +22,11 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/ugorji/go/codec:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers.go
@@ -232,3 +232,14 @@ func HasObjectMetaSystemFieldValues(meta Object) bool {
 	return !meta.GetCreationTimestamp().Time.IsZero() ||
 		len(meta.GetUID()) != 0
 }
+
+// ResetObjectMetaForStatus forces the meta fields for a status update to match the meta fields
+// for a pre-existing object.  Status updates are for updating status, not annotations
+func ResetObjectMetaForStatus(meta, existingMeta Object) {
+	meta.SetGeneration(existingMeta.GetGeneration())
+	meta.SetSelfLink(existingMeta.GetSelfLink())
+	meta.SetLabels(existingMeta.GetLabels())
+	meta.SetAnnotations(existingMeta.GetAnnotations())
+	meta.SetFinalizers(existingMeta.GetFinalizers())
+	meta.SetOwnerReferences(existingMeta.GetOwnerReferences())
+}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/helpers_test.go
@@ -21,7 +21,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/gofuzz"
+
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func TestLabelSelectorAsSelector(t *testing.T) {
@@ -150,5 +154,38 @@ func TestLabelSelectorAsMap(t *testing.T) {
 		if !reflect.DeepEqual(out, tc.out) {
 			t.Errorf("[%v]expected:\n\t%+v\nbut got:\n\t%+v", i, tc.out, out)
 		}
+	}
+}
+
+func TestResetObjectMetaForStatus(t *testing.T) {
+	meta := &ObjectMeta{}
+	existingMeta := &ObjectMeta{}
+
+	// fuzz the existingMeta to set every field, no nils
+	f := fuzz.New().NilChance(0).NumElements(1, 1)
+	f.Fuzz(existingMeta)
+
+	ResetObjectMetaForStatus(meta, existingMeta)
+
+	// not all fields are stomped during the reset.  These fields should not have been set.false
+	// set them all to their zero values.  Before you add anything to this list, consider whether or not
+	// you're enforcing immutability (those are fine) and whether /status should be able to update
+	// these values (these are usually not fine).
+
+	// generateName doesn't do anything after create
+	existingMeta.SetGenerateName("")
+	// resourceVersion is enforced in validation and used during the storage update
+	existingMeta.SetResourceVersion("")
+	// fields made immutable in validation
+	existingMeta.SetUID(types.UID(""))
+	existingMeta.SetName("")
+	existingMeta.SetNamespace("")
+	existingMeta.SetClusterName("")
+	existingMeta.SetCreationTimestamp(Time{})
+	existingMeta.SetDeletionTimestamp(nil)
+	existingMeta.SetDeletionGracePeriodSeconds(nil)
+
+	if !reflect.DeepEqual(meta, existingMeta) {
+		t.Error(diff.ObjectDiff(meta, existingMeta))
 	}
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["strategy.go"],
     tags = ["automanaged"],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/strategy.go
@@ -19,6 +19,7 @@ package apiservice
 import (
 	"fmt"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -92,10 +93,8 @@ func (apiServerStatusStrategy) PrepareForUpdate(ctx genericapirequest.Context, o
 	newAPIService := obj.(*apiregistration.APIService)
 	oldAPIService := old.(*apiregistration.APIService)
 	newAPIService.Spec = oldAPIService.Spec
-	newAPIService.Labels = oldAPIService.Labels
-	newAPIService.Annotations = oldAPIService.Annotations
-	newAPIService.Finalizers = oldAPIService.Finalizers
-	newAPIService.OwnerReferences = oldAPIService.OwnerReferences
+
+	metav1.ResetObjectMetaForStatus(newAPIService, oldAPIService)
 }
 
 func (apiServerStatusStrategy) AllowCreateOnUpdate() bool {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/45539

This provides a way for `/status` endpoints to prevent objectmeta mutation moving forward.

@kubernetes/sig-api-machinery-pr-reviews 
@sttts as promised