### PR TITLE
[Federation] Add a SchedulingAdapter that can extend the FederatedTypeAdapter and that provides hooks for scheduling objects into clusters.

### DIFF
--- a/federation/pkg/federatedtypes/BUILD
+++ b/federation/pkg/federatedtypes/BUILD
@@ -14,10 +14,12 @@ go_library(
         "configmap.go",
         "daemonset.go",
         "registry.go",
+        "scheduling.go",
         "secret.go",
     ],
     tags = ["automanaged"],
     deps = [
+        "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
         "//pkg/api/v1:go_default_library",

--- a/federation/pkg/federatedtypes/adapter.go
+++ b/federation/pkg/federatedtypes/adapter.go
@@ -53,6 +53,8 @@ type FederatedTypeAdapter interface {
 	ClusterUpdate(client kubeclientset.Interface, obj pkgruntime.Object) (pkgruntime.Object, error)
 	ClusterWatch(client kubeclientset.Interface, namespace string, options metav1.ListOptions) (watch.Interface, error)
 
+	IsSchedulingAdapter() bool
+
 	NewTestObject(namespace string) pkgruntime.Object
 }
 

--- a/federation/pkg/federatedtypes/configmap.go
+++ b/federation/pkg/federatedtypes/configmap.go
@@ -133,6 +133,10 @@ func (a *ConfigMapAdapter) ClusterWatch(client kubeclientset.Interface, namespac
 	return client.CoreV1().ConfigMaps(namespace).Watch(options)
 }
 
+func (a *ConfigMapAdapter) IsSchedulingAdapter() bool {
+	return false
+}
+
 func (a *ConfigMapAdapter) NewTestObject(namespace string) pkgruntime.Object {
 	return &apiv1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/federation/pkg/federatedtypes/daemonset.go
+++ b/federation/pkg/federatedtypes/daemonset.go
@@ -136,6 +136,10 @@ func (a *DaemonSetAdapter) ClusterWatch(client kubeclientset.Interface, namespac
 	return client.Extensions().DaemonSets(namespace).Watch(options)
 }
 
+func (a *DaemonSetAdapter) IsSchedulingAdapter() bool {
+	return false
+}
+
 func (a *DaemonSetAdapter) NewTestObject(namespace string) pkgruntime.Object {
 	return &extensionsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/federation/pkg/federatedtypes/scheduling.go
+++ b/federation/pkg/federatedtypes/scheduling.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package federatedtypes
+
+import (
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	federationapi "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
+)
+
+// SchedulingStatus contains the status of the objects that are being
+// scheduled into joined clusters.
+type SchedulingStatus struct {
+	Replicas             int32
+	FullyLabeledReplicas int32
+	ReadyReplicas        int32
+	AvailableReplicas    int32
+}
+
+// SchedulingInfo wraps the information that a SchedulingAdapter needs
+// to update objects per a schedule.
+type SchedulingInfo struct {
+	Schedule map[string]int64
+	Status   SchedulingStatus
+}
+
+// SchedulingAdapter defines operations for interacting with a
+// federated type that requires more complex synchronization logic.
+type SchedulingAdapter interface {
+	GetSchedule(obj pkgruntime.Object, key string, clusters []*federationapi.Cluster, informer fedutil.FederatedInformer) (*SchedulingInfo, error)
+	ScheduleObject(cluster *federationapi.Cluster, clusterObj pkgruntime.Object, federationObjCopy pkgruntime.Object, schedulingInfo *SchedulingInfo) (pkgruntime.Object, bool, error)
+	UpdateFederatedStatus(obj pkgruntime.Object, status SchedulingStatus) error
+}

--- a/federation/pkg/federatedtypes/secret.go
+++ b/federation/pkg/federatedtypes/secret.go
@@ -134,6 +134,10 @@ func (a *SecretAdapter) ClusterWatch(client kubeclientset.Interface, namespace s
 	return client.CoreV1().Secrets(namespace).Watch(options)
 }
 
+func (a *SecretAdapter) IsSchedulingAdapter() bool {
+	return false
+}
+
 func (a *SecretAdapter) NewTestObject(namespace string) pkgruntime.Object {
 	return &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/federation/pkg/federation-controller/sync/controller_test.go
+++ b/federation/pkg/federation-controller/sync/controller_test.go
@@ -75,7 +75,7 @@ func TestSyncToClusters(t *testing.T) {
 					}
 					return nil, nil
 				},
-				func(federatedtypes.FederatedTypeAdapter, []*federationapi.Cluster, []*federationapi.Cluster, pkgruntime.Object) ([]util.FederatedOperation, error) {
+				func(federatedtypes.FederatedTypeAdapter, []*federationapi.Cluster, []*federationapi.Cluster, pkgruntime.Object, *federatedtypes.SchedulingInfo) ([]util.FederatedOperation, error) {
 					if testCase.operationsError {
 						return nil, awfulError
 					}
@@ -91,6 +91,7 @@ func TestSyncToClusters(t *testing.T) {
 					return nil
 				},
 				adapter,
+				nil,
 				obj,
 			)
 			require.Equal(t, testCase.status, status, "Unexpected status!")
@@ -207,7 +208,8 @@ func TestClusterOperations(t *testing.T) {
 				selectedClusters = []*federationapi.Cluster{}
 				unselectedClusters = clusters
 			}
-			operations, err := clusterOperations(adapter, selectedClusters, unselectedClusters, obj, key, func(string) (interface{}, bool, error) {
+			// TODO: Tests for ScheduleObject on type adapter
+			operations, err := clusterOperations(adapter, selectedClusters, unselectedClusters, obj, key, nil, func(string) (interface{}, bool, error) {
 				if testCase.expectedErr {
 					return nil, false, awfulError
 				}


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```
