### PR TITLE
Display <none> for "kubectl get pods -o wide" when node is empty.

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -345,6 +345,9 @@ func printPodBase(pod *api.Pod, w io.Writer, options printers.PrintOptions) erro
 		if podIP == "" {
 			podIP = "<none>"
 		}
+		if nodeName == "" {
+			nodeName = "<none>"
+		}
 		if _, err := fmt.Fprintf(w, "\t%s\t%s",
 			podIP,
 			nodeName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
If pods are pending due to no matched node to be scheduled, `Spec.NodeName` would be empty. In this case, "kubectl get pods -o wide" displays `<none>` instead of empty.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
