### PR TITLE
avoid concrete examples for missingResourceError

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -84,8 +84,8 @@ var missingResourceError = fmt.Errorf(`You must provide one or more resources by
 Example resource specifications include:
    '-f rsrc.yaml'
    '--filename=rsrc.json'
-   'pods my-pod'
-   'services'`)
+   '<resource> <name>'
+   '<resource>'`)
 
 // TODO: expand this to include other errors.
 func IsUsageError(err error) bool {


### PR DESCRIPTION
missingResourceError uses pod and services as an example in error message. However some sub-commands doesn't support pod/service, this change use `<resource> <name>` instead of concrete examples.
Before this change:
```console
$ kubectl set subject
error: You must provide one or more resources by argument or filename.
Example resource specifications include:
   '-f rsrc.yaml'
   '--filename=rsrc.json'
   'pods my-pod'
   'services'
```

After this change:
```console
$ kubectl set subject
error: You must provide one or more resources by argument or filename.
Example resource specifications include:
   '-f rsrc.yaml'
   '--filename=rsrc.json'
   '<resource> <name>'
   '<resource>'
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
avoid concrete examples for missingResourceError
```
