### PR TITLE
Make SchedulerPredicates test more resiliant to recent Node restarts

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -39,6 +39,7 @@ import (
 
 const maxNumberOfPods int64 = 10
 const minPodCPURequest int64 = 500
+const imagePrePullingTimeout = 5 * time.Minute
 
 // variable set in BeforeEach, never modified afterwards
 var masterNodes sets.String
@@ -95,6 +96,9 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 		}
 
 		err = framework.WaitForPodsRunningReady(cs, metav1.NamespaceSystem, int32(systemPodsNo), 0, framework.PodReadyBeforeTimeout, ignoreLabels)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = framework.WaitForPodsSuccess(cs, metav1.NamespaceSystem, framework.ImagePullerLabels, imagePrePullingTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, node := range nodeList.Items {


### PR DESCRIPTION
cc @kubernetes/sig-scheduling-pr-reviews 