### PR TITLE
kubectl: 'apply view-last-applied' must not use printf() semantics

### DIFF
--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -143,13 +143,13 @@ func (o *ViewLastAppliedOptions) RunApplyViewLastApplied() error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(o.Out, string(jsonBuffer.Bytes()))
+			fmt.Fprint(o.Out, string(jsonBuffer.Bytes()))
 		case "yaml":
 			yamlOutput, err := yaml.JSONToYAML([]byte(str))
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(o.Out, string(yamlOutput))
+			fmt.Fprint(o.Out, string(yamlOutput))
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
This fixes `kubectl apply view-last-applied` to not use `fmt.Fprintf()`, as this will cause format codes in the YAML/JSON to be interpreted. For example, if a resource manifest contains `%r`, this would cause `view-last-applied` so print `%!r(MISSING)`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #45608.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
Fixes an edge case where "kubectl apply view-last-applied" would emit garbage if the data contained Go format codes.
```