### PR TITLE
hyperkube_test should not depend on number of spaces.

### DIFF
--- a/cmd/hyperkube/hyperkube_test.go
+++ b/cmd/hyperkube/hyperkube_test.go
@@ -175,7 +175,8 @@ func TestServerHelp(t *testing.T) {
 	x := runFull(t, "hyperkube test1 --help")
 	assert.NoError(t, x.err)
 	assert.Contains(t, x.output, "A simple server named test1")
-	assert.Contains(t, x.output, "-h, --help                                         help for hyperkube")
+	assert.Contains(t, x.output, "-h, --help")
+	assert.Contains(t, x.output, "help for hyperkube")
 	assert.NotContains(t, x.output, "test1 Run")
 }
 
@@ -183,7 +184,8 @@ func TestServerFlagsBad(t *testing.T) {
 	x := runFull(t, "hyperkube test1 --bad-flag")
 	assert.EqualError(t, x.err, "unknown flag: --bad-flag")
 	assert.Contains(t, x.output, "A simple server named test1")
-	assert.Contains(t, x.output, "-h, --help                                         help for hyperkube")
+	assert.Contains(t, x.output, "-h, --help")
+	assert.Contains(t, x.output, "help for hyperkube")
 	assert.NotContains(t, x.output, "test1 Run")
 }
 


### PR DESCRIPTION
From #45524.

Apparently adding a long flag to kube-controller-manager breaks the hyperkube unit tests, because they depend on number of spaces :)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
