### PR TITLE
1.6 backport: Recreate deployments dont wait for pod termination

### DIFF
--- a/pkg/controller/deployment/BUILD
+++ b/pkg/controller/deployment/BUILD
@@ -71,6 +71,7 @@ go_test(
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
+        "//vendor:k8s.io/apimachinery/pkg/types",
         "//vendor:k8s.io/apimachinery/pkg/util/intstr",
         "//vendor:k8s.io/apimachinery/pkg/util/uuid",
         "//vendor:k8s.io/client-go/testing",

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -560,18 +560,21 @@ func TestGetPodMapForReplicaSets(t *testing.T) {
 	for _, podList := range podMap {
 		podCount += len(podList.Items)
 	}
-	if got, want := podCount, 2; got != want {
+	if got, want := podCount, 3; got != want {
 		t.Errorf("podCount = %v, want %v", got, want)
 	}
 
 	if got, want := len(podMap), 2; got != want {
 		t.Errorf("len(podMap) = %v, want %v", got, want)
 	}
-	if got, want := len(podMap[rs1.UID].Items), 1; got != want {
+	if got, want := len(podMap[rs1.UID].Items), 2; got != want {
 		t.Errorf("len(podMap[rs1]) = %v, want %v", got, want)
 	}
-	if got, want := podMap[rs1.UID].Items[0].Name, "rs1-pod"; got != want {
-		t.Errorf("podMap[rs1] = [%v], want [%v]", got, want)
+	expect := map[string]struct{}{"rs1-pod": {}, "pod4": {}}
+	for _, pod := range podMap[rs1.UID].Items {
+		if _, ok := expect[pod.Name]; !ok {
+			t.Errorf("unexpected pod name for rs1: %s", pod.Name)
+		}
 	}
 	if got, want := len(podMap[rs2.UID].Items), 1; got != want {
 		t.Errorf("len(podMap[rs2]) = %v, want %v", got, want)

--- a/pkg/controller/deployment/recreate.go
+++ b/pkg/controller/deployment/recreate.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/deployment/util"
 )
 
 // rolloutRecreate implements the logic for recreating a replica set.
@@ -43,18 +44,12 @@ func (dc *DeploymentController) rolloutRecreate(d *extensions.Deployment, rsList
 		return dc.syncRolloutStatus(allRSs, newRS, d)
 	}
 
-	newStatus := calculateStatus(allRSs, newRS, d)
 	// Do not process a deployment when it has old pods running.
-	if newStatus.UpdatedReplicas == 0 {
-		for _, podList := range podMap {
-			if len(podList.Items) > 0 {
-				return dc.syncRolloutStatus(allRSs, newRS, d)
-			}
-		}
+	if oldPodsRunning(newRS, oldRSs, podMap) {
+		return dc.syncRolloutStatus(allRSs, newRS, d)
 	}
 
 	// If we need to create a new RS, create it now
-	// TODO: Create a new RS without re-listing all RSs.
 	if newRS == nil {
 		newRS, oldRSs, err = dc.getAllReplicaSetsAndSyncRevision(d, rsList, podMap, true)
 		if err != nil {
@@ -63,14 +58,9 @@ func (dc *DeploymentController) rolloutRecreate(d *extensions.Deployment, rsList
 		allRSs = append(oldRSs, newRS)
 	}
 
-	// scale up new replica set
-	scaledUp, err := dc.scaleUpNewReplicaSetForRecreate(newRS, d)
-	if err != nil {
+	// scale up new replica set.
+	if _, err := dc.scaleUpNewReplicaSetForRecreate(newRS, d); err != nil {
 		return err
-	}
-	if scaledUp {
-		// Update DeploymentStatus
-		return dc.syncRolloutStatus(allRSs, newRS, d)
 	}
 
 	// Sync deployment status
@@ -96,6 +86,23 @@ func (dc *DeploymentController) scaleDownOldReplicaSetsForRecreate(oldRSs []*ext
 		}
 	}
 	return scaled, nil
+}
+
+// oldPodsRunning returns whether there are old pods running or any of the old ReplicaSets thinks that it runs pods.
+func oldPodsRunning(newRS *extensions.ReplicaSet, oldRSs []*extensions.ReplicaSet, podMap map[types.UID]*v1.PodList) bool {
+	if oldPods := util.GetActualReplicaCountForReplicaSets(oldRSs); oldPods > 0 {
+		return true
+	}
+	for rsUID, podList := range podMap {
+		// If the pods belong to the new ReplicaSet, ignore.
+		if newRS != nil && newRS.UID == rsUID {
+			continue
+		}
+		if len(podList.Items) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // scaleUpNewReplicaSetForRecreate scales up new replica set when deployment strategy is "Recreate"

--- a/pkg/controller/deployment/recreate_test.go
+++ b/pkg/controller/deployment/recreate_test.go
@@ -21,8 +21,10 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/v1"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset/fake"
 	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/externalversions"
@@ -81,4 +83,63 @@ func TestScaleDownOldReplicaSets(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestOldPodsRunning(t *testing.T) {
+	tests := []struct {
+		name string
+
+		newRS  *extensions.ReplicaSet
+		oldRSs []*extensions.ReplicaSet
+		podMap map[types.UID]*v1.PodList
+
+		expected bool
+	}{
+		{
+			name:     "no old RSs",
+			expected: false,
+		},
+		{
+			name:     "old RSs with running pods",
+			oldRSs:   []*extensions.ReplicaSet{rsWithUID("some-uid"), rsWithUID("other-uid")},
+			podMap:   podMapWithUIDs([]string{"some-uid", "other-uid"}),
+			expected: true,
+		},
+		{
+			name:     "old RSs without pods but with non-zero status replicas",
+			oldRSs:   []*extensions.ReplicaSet{newRSWithStatus("rs-blabla", 0, 1, nil)},
+			expected: true,
+		},
+		{
+			name:     "old RSs without pods or non-zero status replicas",
+			oldRSs:   []*extensions.ReplicaSet{newRSWithStatus("rs-blabla", 0, 0, nil)},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		if expected, got := test.expected, oldPodsRunning(test.newRS, test.oldRSs, test.podMap); expected != got {
+			t.Errorf("%s: expected %t, got %t", test.name, expected, got)
+		}
+	}
+}
+
+func rsWithUID(uid string) *extensions.ReplicaSet {
+	d := newDeployment("foo", 1, nil, nil, nil, map[string]string{"foo": "bar"})
+	rs := newReplicaSet(d, fmt.Sprintf("foo-%s", uid), 0)
+	rs.UID = types.UID(uid)
+	return rs
+}
+
+func podMapWithUIDs(uids []string) map[types.UID]*v1.PodList {
+	podMap := make(map[types.UID]*v1.PodList)
+	for _, uid := range uids {
+		podMap[types.UID(uid)] = &v1.PodList{
+			Items: []v1.Pod{
+				{ /* supposedly a pod */ },
+				{ /* supposedly another pod pod */ },
+			},
+		}
+	}
+	return podMap
 }

--- a/pkg/controller/deployment/sync.go
+++ b/pkg/controller/deployment/sync.go
@@ -135,7 +135,7 @@ func (dc *DeploymentController) getAllReplicaSetsAndSyncRevision(d *extensions.D
 // rsList should come from getReplicaSetsForDeployment(d).
 // podMap should come from getPodMapForDeployment(d, rsList).
 func (dc *DeploymentController) rsAndPodsWithHashKeySynced(d *extensions.Deployment, rsList []*extensions.ReplicaSet, podMap map[types.UID]*v1.PodList) ([]*extensions.ReplicaSet, *v1.PodList, error) {
-	syncedRSList := []*extensions.ReplicaSet{}
+	var syncedRSList []*extensions.ReplicaSet
 	for _, rs := range rsList {
 		// Add pod-template-hash information if it's not in the RS.
 		// Otherwise, new RS produced by Deployment will overlap with pre-existing ones
@@ -520,7 +520,6 @@ func (dc *DeploymentController) cleanupDeployment(oldRSs []*extensions.ReplicaSe
 	glog.V(4).Infof("Looking to cleanup old replica sets for deployment %q", deployment.Name)
 
 	var errList []error
-	// TODO: This should be parallelized.
 	for i := int32(0); i < diff; i++ {
 		rs := cleanableRSes[i]
 		// Avoid delete replica set with non-zero replica counts


### PR DESCRIPTION
The #27362 was fixed in #43963. Wasn't applying cleanly mostly because of added periods in the comments.

Haven't tested it. Maybe there are automated tests on PRs?

edit: looks like there aren't.

```release-note
Fix [Deployments with Recreate strategy not waiting for Pod termination](https://github.com/kubernetes/kubernetes/issues/27362).
```