### PR TITLE
Fix hardcoded tmp dir path in kubectl test.

### DIFF
--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -281,8 +281,11 @@ func TestRefetchSchemaWhenValidationFails(t *testing.T) {
 			}
 		}),
 	}
-	dir := os.TempDir() + "/schemaCache"
-	os.RemoveAll(dir)
+	dir, err := ioutil.TempDir("", "schemaCache")
+	if err != nil {
+		t.Fatalf("Error getting tempDir: %v", err)
+	}
+	defer os.RemoveAll(dir)
 
 	fullDir, err := substituteUserHome(dir)
 	if err != nil {
@@ -339,8 +342,11 @@ func TestValidateCachesSchema(t *testing.T) {
 			}
 		}),
 	}
-	dir := os.TempDir() + "/schemaCache"
-	os.RemoveAll(dir)
+	dir, err := ioutil.TempDir("", "schemaCache")
+	if err != nil {
+		t.Fatalf("Error getting tempDir: %v", err)
+	}
+	defer os.RemoveAll(dir)
 
 	obj := &api.Pod{}
 	data, err := runtime.Encode(testapi.Default.Codec(), obj)


### PR DESCRIPTION
**What this PR does / why we need it**:
Current case uses hardcoded tmp dir path, and it does not delete tmp dir after test run.

Which means 1. The case could not be run by different users (no permission) 2. /tmp dir keeps growing.

**Which issue this PR fixes** 

**Special notes for your reviewer**:

**Release note**:
