### PR TITLE
Do not set old defaults for configs in clientcache

### DIFF
--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -252,7 +252,7 @@ func GetVersionedClientForRBACOrFail(hostFactory cmdutil.Factory) (client.Interf
 				if err != nil {
 					return nil, err
 				}
-				return hostFactory.ClientSetForVersion(&gv)
+				return hostFactory.ClientSetForVersion(gv)
 			}
 			for _, version := range g.Versions {
 				if version.GroupVersion != "" {
@@ -260,7 +260,7 @@ func GetVersionedClientForRBACOrFail(hostFactory cmdutil.Factory) (client.Interf
 					if err != nil {
 						return nil, err
 					}
-					return hostFactory.ClientSetForVersion(&gv)
+					return hostFactory.ClientSetForVersion(gv)
 				}
 			}
 		}

--- a/pkg/client/unversioned/helper.go
+++ b/pkg/client/unversioned/helper.go
@@ -48,22 +48,3 @@ func SetKubernetesDefaults(config *restclient.Config) error {
 	}
 	return restclient.SetKubernetesDefaults(config)
 }
-
-func setGroupDefaults(groupName string, config *restclient.Config) error {
-	config.APIPath = defaultAPIPath
-	if config.UserAgent == "" {
-		config.UserAgent = restclient.DefaultKubernetesUserAgent()
-	}
-	if config.GroupVersion == nil || config.GroupVersion.Group != groupName {
-		g, err := api.Registry.Group(groupName)
-		if err != nil {
-			return err
-		}
-		copyGroupVersion := g.GroupVersion
-		config.GroupVersion = &copyGroupVersion
-	}
-	if config.NegotiatedSerializer == nil {
-		config.NegotiatedSerializer = api.Codecs
-	}
-	return nil
-}

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -314,16 +314,16 @@ func (f *FakeFactory) ClientForMapping(mapping *meta.RESTMapping) (resource.REST
 	return f.tf.Client, f.tf.Err
 }
 
-func (f *FakeFactory) FederationClientSetForVersion(version *schema.GroupVersion) (fedclientset.Interface, error) {
+func (f *FakeFactory) FederationClientSetForVersion(version schema.GroupVersion) (fedclientset.Interface, error) {
 	return nil, nil
 }
-func (f *FakeFactory) FederationClientForVersion(version *schema.GroupVersion) (*restclient.RESTClient, error) {
+func (f *FakeFactory) FederationClientForVersion(version schema.GroupVersion) (*restclient.RESTClient, error) {
 	return nil, nil
 }
-func (f *FakeFactory) ClientSetForVersion(requiredVersion *schema.GroupVersion) (internalclientset.Interface, error) {
+func (f *FakeFactory) ClientSetForVersion(requiredVersion schema.GroupVersion) (internalclientset.Interface, error) {
 	return nil, nil
 }
-func (f *FakeFactory) ClientConfigForVersion(requiredVersion *schema.GroupVersion) (*restclient.Config, error) {
+func (f *FakeFactory) ClientConfigForVersion(requiredVersion schema.GroupVersion) (*restclient.Config, error) {
 	return nil, nil
 }
 
@@ -597,7 +597,7 @@ func (f *fakeAPIFactory) DiscoveryClient() (discovery.CachedDiscoveryInterface, 
 	return cmdutil.NewCachedDiscoveryClient(discoveryClient, cacheDir, time.Duration(10*time.Minute)), nil
 }
 
-func (f *fakeAPIFactory) ClientSetForVersion(requiredVersion *schema.GroupVersion) (internalclientset.Interface, error) {
+func (f *fakeAPIFactory) ClientSetForVersion(requiredVersion schema.GroupVersion) (internalclientset.Interface, error) {
 	return f.ClientSet()
 }
 

--- a/pkg/kubectl/cmd/util/clientcache.go
+++ b/pkg/kubectl/cmd/util/clientcache.go
@@ -48,9 +48,6 @@ type ClientCache struct {
 	fedClientSets map[schema.GroupVersion]fedclientset.Interface
 	configs       map[schema.GroupVersion]*restclient.Config
 
-	// noVersionConfig provides a cached config for the case of no required version specified
-	noVersionConfig *restclient.Config
-
 	matchVersion bool
 
 	lock          sync.Mutex
@@ -89,7 +86,7 @@ func (c *ClientCache) getDefaultConfig() (restclient.Config, discovery.Discovery
 }
 
 // ClientConfigForVersion returns the correct config for a server
-func (c *ClientCache) ClientConfigForVersion(requiredVersion *schema.GroupVersion) (*restclient.Config, error) {
+func (c *ClientCache) ClientConfigForVersion(requiredVersion schema.GroupVersion) (*restclient.Config, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -97,42 +94,30 @@ func (c *ClientCache) ClientConfigForVersion(requiredVersion *schema.GroupVersio
 }
 
 // clientConfigForVersion returns the correct config for a server
-func (c *ClientCache) clientConfigForVersion(requiredVersion *schema.GroupVersion) (*restclient.Config, error) {
+func (c *ClientCache) clientConfigForVersion(requiredVersion schema.GroupVersion) (*restclient.Config, error) {
 	// TODO: have a better config copy method
 	config, discoveryClient, err := c.getDefaultConfig()
 	if err != nil {
 		return nil, err
 	}
-	if requiredVersion == nil && config.GroupVersion != nil {
+	if config.GroupVersion != nil {
 		// if someone has set the values via flags, our config will have the groupVersion set
 		// that means it is required.
-		requiredVersion = config.GroupVersion
+		requiredVersion = *config.GroupVersion
 	}
 
-	// required version may still be nil, since config.GroupVersion may have been nil.  Do the check
-	// before looking up from the cache
-	if requiredVersion != nil {
-		if config, ok := c.configs[*requiredVersion]; ok {
-			return copyConfig(config), nil
-		}
-	} else if c.noVersionConfig != nil {
-		return copyConfig(c.noVersionConfig), nil
+	if config, ok := c.configs[requiredVersion]; ok {
+		return copyConfig(config), nil
 	}
-
-	negotiatedVersion, err := discovery.NegotiateVersion(discoveryClient, requiredVersion, api.Registry.EnabledVersions())
-	if err != nil {
-		return nil, err
-	}
-	config.GroupVersion = negotiatedVersion
 
 	// TODO this isn't what we want.  Each clientset should be setting defaults as it sees fit.
 	oldclient.SetKubernetesDefaults(&config)
 
-	if requiredVersion != nil {
-		c.configs[*requiredVersion] = copyConfig(&config)
-	} else {
-		c.noVersionConfig = copyConfig(&config)
+	negotiatedVersion, err := discovery.NegotiateVersion(discoveryClient, &requiredVersion, api.Registry.EnabledVersions())
+	if err != nil {
+		return nil, err
 	}
+	config.GroupVersion = negotiatedVersion
 
 	// `version` does not necessarily equal `config.Version`.  However, we know that we call this method again with
 	// `config.Version`, we should get the config we've just built.
@@ -150,14 +135,12 @@ func copyConfig(in *restclient.Config) *restclient.Config {
 
 // ClientSetForVersion initializes or reuses a clientset for the specified version, or returns an
 // error if that is not possible
-func (c *ClientCache) ClientSetForVersion(requiredVersion *schema.GroupVersion) (internalclientset.Interface, error) {
+func (c *ClientCache) ClientSetForVersion(requiredVersion schema.GroupVersion) (internalclientset.Interface, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	if requiredVersion != nil {
-		if clientset, ok := c.clientsets[*requiredVersion]; ok {
-			return clientset, nil
-		}
+	if clientset, ok := c.clientsets[requiredVersion]; ok {
+		return clientset, nil
 	}
 	config, err := c.clientConfigForVersion(requiredVersion)
 	if err != nil {
@@ -170,33 +153,19 @@ func (c *ClientCache) ClientSetForVersion(requiredVersion *schema.GroupVersion) 
 	}
 	c.clientsets[*config.GroupVersion] = clientset
 
-	// `version` does not necessarily equal `config.Version`.  However, we know that if we call this method again with
-	// `version`, we should get a client based on the same config we just found.  There's no guarantee that a client
-	// is copiable, so create a new client and save it in the cache.
-	if requiredVersion != nil {
-		configCopy := *config
-		clientset, err := internalclientset.NewForConfig(&configCopy)
-		if err != nil {
-			return nil, err
-		}
-		c.clientsets[*requiredVersion] = clientset
-	}
-
 	return clientset, nil
 }
 
-func (c *ClientCache) FederationClientSetForVersion(version *schema.GroupVersion) (fedclientset.Interface, error) {
+func (c *ClientCache) FederationClientSetForVersion(version schema.GroupVersion) (fedclientset.Interface, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
 	return c.federationClientSetForVersion(version)
 }
 
-func (c *ClientCache) federationClientSetForVersion(version *schema.GroupVersion) (fedclientset.Interface, error) {
-	if version != nil {
-		if clientSet, found := c.fedClientSets[*version]; found {
-			return clientSet, nil
-		}
+func (c *ClientCache) federationClientSetForVersion(version schema.GroupVersion) (fedclientset.Interface, error) {
+	if clientSet, found := c.fedClientSets[version]; found {
+		return clientSet, nil
 	}
 	config, err := c.clientConfigForVersion(version)
 	if err != nil {
@@ -210,19 +179,10 @@ func (c *ClientCache) federationClientSetForVersion(version *schema.GroupVersion
 	}
 	c.fedClientSets[*config.GroupVersion] = clientSet
 
-	if version != nil {
-		configCopy := *config
-		clientSet, err := fedclientset.NewForConfig(&configCopy)
-		if err != nil {
-			return nil, err
-		}
-		c.fedClientSets[*version] = clientSet
-	}
-
 	return clientSet, nil
 }
 
-func (c *ClientCache) FederationClientForVersion(version *schema.GroupVersion) (*restclient.RESTClient, error) {
+func (c *ClientCache) FederationClientForVersion(version schema.GroupVersion) (*restclient.RESTClient, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -100,13 +100,13 @@ type ClientAccessFactory interface {
 
 	// TODO this should probably be removed and collapsed into whatever we want to use long term
 	// probably returning a restclient for a version and leaving contruction up to someone else
-	FederationClientSetForVersion(version *schema.GroupVersion) (fedclientset.Interface, error)
+	FederationClientSetForVersion(version schema.GroupVersion) (fedclientset.Interface, error)
 	// TODO remove this should be rolled into restclient with the right version
-	FederationClientForVersion(version *schema.GroupVersion) (*restclient.RESTClient, error)
+	FederationClientForVersion(version schema.GroupVersion) (*restclient.RESTClient, error)
 	// TODO remove.  This should be rolled into `ClientSet`
-	ClientSetForVersion(requiredVersion *schema.GroupVersion) (internalclientset.Interface, error)
+	ClientSetForVersion(requiredVersion schema.GroupVersion) (internalclientset.Interface, error)
 	// TODO remove.  This should be rolled into `ClientConfig`
-	ClientConfigForVersion(requiredVersion *schema.GroupVersion) (*restclient.Config, error)
+	ClientConfigForVersion(requiredVersion schema.GroupVersion) (*restclient.Config, error)
 
 	// Returns interfaces for decoding objects - if toInternal is set, decoded objects will be converted
 	// into their internal form (if possible). Eventually the internal form will be removed as an option,

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -43,6 +43,7 @@ import (
 	fedclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_internalclientset"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/service"
+	"k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -169,37 +170,37 @@ func (f *ring0Factory) DiscoveryClient() (discovery.CachedDiscoveryInterface, er
 }
 
 func (f *ring0Factory) ClientSet() (internalclientset.Interface, error) {
-	return f.clientCache.ClientSetForVersion(nil)
+	return f.clientCache.ClientSetForVersion(v1.SchemeGroupVersion)
 }
 
-func (f *ring0Factory) ClientSetForVersion(requiredVersion *schema.GroupVersion) (internalclientset.Interface, error) {
+func (f *ring0Factory) ClientSetForVersion(requiredVersion schema.GroupVersion) (internalclientset.Interface, error) {
 	return f.clientCache.ClientSetForVersion(requiredVersion)
 }
 
 func (f *ring0Factory) ClientConfig() (*restclient.Config, error) {
-	return f.clientCache.ClientConfigForVersion(nil)
+	return f.clientCache.ClientConfigForVersion(v1.SchemeGroupVersion)
 }
 func (f *ring0Factory) BareClientConfig() (*restclient.Config, error) {
 	return f.clientConfig.ClientConfig()
 }
 
-func (f *ring0Factory) ClientConfigForVersion(requiredVersion *schema.GroupVersion) (*restclient.Config, error) {
-	return f.clientCache.ClientConfigForVersion(nil)
+func (f *ring0Factory) ClientConfigForVersion(requiredVersion schema.GroupVersion) (*restclient.Config, error) {
+	return f.clientCache.ClientConfigForVersion(v1.SchemeGroupVersion)
 }
 
 func (f *ring0Factory) RESTClient() (*restclient.RESTClient, error) {
-	clientConfig, err := f.clientCache.ClientConfigForVersion(nil)
+	clientConfig, err := f.clientCache.ClientConfigForVersion(v1.SchemeGroupVersion)
 	if err != nil {
 		return nil, err
 	}
 	return restclient.RESTClientFor(clientConfig)
 }
 
-func (f *ring0Factory) FederationClientSetForVersion(version *schema.GroupVersion) (fedclientset.Interface, error) {
+func (f *ring0Factory) FederationClientSetForVersion(version schema.GroupVersion) (fedclientset.Interface, error) {
 	return f.clientCache.FederationClientSetForVersion(version)
 }
 
-func (f *ring0Factory) FederationClientForVersion(version *schema.GroupVersion) (*restclient.RESTClient, error) {
+func (f *ring0Factory) FederationClientForVersion(version schema.GroupVersion) (*restclient.RESTClient, error) {
 	return f.clientCache.FederationClientForVersion(version)
 }
 

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -141,7 +141,7 @@ func (f *ring1Factory) ClientForMapping(mapping *meta.RESTMapping) (resource.RES
 	switch gvk.Group {
 	case federation.GroupName:
 		mappingVersion := mapping.GroupVersionKind.GroupVersion()
-		return f.clientAccessFactory.FederationClientForVersion(&mappingVersion)
+		return f.clientAccessFactory.FederationClientForVersion(mappingVersion)
 	case api.GroupName:
 		cfg.APIPath = "/api"
 	default:
@@ -173,7 +173,7 @@ func (f *ring1Factory) UnstructuredClientForMapping(mapping *meta.RESTMapping) (
 func (f *ring1Factory) Describer(mapping *meta.RESTMapping) (printers.Describer, error) {
 	mappingVersion := mapping.GroupVersionKind.GroupVersion()
 	if mapping.GroupVersionKind.Group == federation.GroupName {
-		fedClientSet, err := f.clientAccessFactory.FederationClientSetForVersion(&mappingVersion)
+		fedClientSet, err := f.clientAccessFactory.FederationClientSetForVersion(mappingVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -182,7 +182,7 @@ func (f *ring1Factory) Describer(mapping *meta.RESTMapping) (printers.Describer,
 		}
 	}
 
-	clientset, err := f.clientAccessFactory.ClientSetForVersion(&mappingVersion)
+	clientset, err := f.clientAccessFactory.ClientSetForVersion(mappingVersion)
 	if err != nil {
 		// if we can't make a client for this group/version, go generic if possible
 		if genericDescriber, genericErr := genericDescriber(f.clientAccessFactory, mapping); genericErr == nil {
@@ -233,7 +233,7 @@ func genericDescriber(clientAccessFactory ClientAccessFactory, mapping *meta.RES
 }
 
 func (f *ring1Factory) LogsForObject(object, options runtime.Object, timeout time.Duration) (*restclient.Request, error) {
-	clientset, err := f.clientAccessFactory.ClientSetForVersion(nil)
+	clientset, err := f.clientAccessFactory.ClientSetForVersion(v1.SchemeGroupVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func (f *ring1Factory) LogsForObject(object, options runtime.Object, timeout tim
 
 func (f *ring1Factory) Scaler(mapping *meta.RESTMapping) (kubectl.Scaler, error) {
 	mappingVersion := mapping.GroupVersionKind.GroupVersion()
-	clientset, err := f.clientAccessFactory.ClientSetForVersion(&mappingVersion)
+	clientset, err := f.clientAccessFactory.ClientSetForVersion(mappingVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ func (f *ring1Factory) Scaler(mapping *meta.RESTMapping) (kubectl.Scaler, error)
 
 func (f *ring1Factory) Reaper(mapping *meta.RESTMapping) (kubectl.Reaper, error) {
 	mappingVersion := mapping.GroupVersionKind.GroupVersion()
-	clientset, clientsetErr := f.clientAccessFactory.ClientSetForVersion(&mappingVersion)
+	clientset, clientsetErr := f.clientAccessFactory.ClientSetForVersion(mappingVersion)
 	reaper, reaperErr := kubectl.ReaperFor(mapping.GroupVersionKind.GroupKind(), clientset)
 
 	if kubectl.IsNoSuchReaperError(reaperErr) {
@@ -324,7 +324,7 @@ func (f *ring1Factory) Reaper(mapping *meta.RESTMapping) (kubectl.Reaper, error)
 
 func (f *ring1Factory) HistoryViewer(mapping *meta.RESTMapping) (kubectl.HistoryViewer, error) {
 	mappingVersion := mapping.GroupVersionKind.GroupVersion()
-	clientset, err := f.clientAccessFactory.ClientSetForVersion(&mappingVersion)
+	clientset, err := f.clientAccessFactory.ClientSetForVersion(mappingVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -333,7 +333,7 @@ func (f *ring1Factory) HistoryViewer(mapping *meta.RESTMapping) (kubectl.History
 
 func (f *ring1Factory) Rollbacker(mapping *meta.RESTMapping) (kubectl.Rollbacker, error) {
 	mappingVersion := mapping.GroupVersionKind.GroupVersion()
-	clientset, err := f.clientAccessFactory.ClientSetForVersion(&mappingVersion)
+	clientset, err := f.clientAccessFactory.ClientSetForVersion(mappingVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +342,7 @@ func (f *ring1Factory) Rollbacker(mapping *meta.RESTMapping) (kubectl.Rollbacker
 
 func (f *ring1Factory) StatusViewer(mapping *meta.RESTMapping) (kubectl.StatusViewer, error) {
 	mappingVersion := mapping.GroupVersionKind.GroupVersion()
-	clientset, err := f.clientAccessFactory.ClientSetForVersion(&mappingVersion)
+	clientset, err := f.clientAccessFactory.ClientSetForVersion(mappingVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -350,7 +350,7 @@ func (f *ring1Factory) StatusViewer(mapping *meta.RESTMapping) (kubectl.StatusVi
 }
 
 func (f *ring1Factory) AttachablePodForObject(object runtime.Object, timeout time.Duration) (*api.Pod, error) {
-	clientset, err := f.clientAccessFactory.ClientSetForVersion(nil)
+	clientset, err := f.clientAccessFactory.ClientSetForVersion(v1.SchemeGroupVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubectl/cmd/util/factory_object_mapping_test.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping_test.go
@@ -40,7 +40,7 @@ type fakeClientAccessFactory struct {
 	fakeClientset *fake.Clientset
 }
 
-func (f *fakeClientAccessFactory) ClientSetForVersion(requiredVersion *schema.GroupVersion) (internalclientset.Interface, error) {
+func (f *fakeClientAccessFactory) ClientSetForVersion(requiredVersion schema.GroupVersion) (internalclientset.Interface, error) {
 	return f.fakeClientset, nil
 }
 


### PR DESCRIPTION
Fixes #45418.

@deads2k ptal, since you've added that line which is causing to reset the requested GroupVersion from `batch/v2alpha1` into `/v1` which further prevents `kubectl describe cronjob` from working properly.


