### PR TITLE
ParsePodFullName():code robustness

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -608,7 +608,7 @@ func BuildPodFullName(name, namespace string) string {
 // Parse the pod full name.
 func ParsePodFullName(podFullName string) (string, string, error) {
 	parts := strings.Split(podFullName, "_")
-	if len(parts) != 2 {
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf("failed to parse the pod full name %q", podFullName)
 	}
 	return parts[0], parts[1], nil

--- a/pkg/kubelet/pod/mirror_client_test.go
+++ b/pkg/kubelet/pod/mirror_client_test.go
@@ -32,7 +32,7 @@ func TestParsePodFullName(t *testing.T) {
 		"bar.org_foo.com": {Name: "bar.org", Namespace: "foo.com"},
 		"bar-bar_foo":     {Name: "bar-bar", Namespace: "foo"},
 	}
-	failedCases := []string{"barfoo", "bar_foo_foo", ""}
+	failedCases := []string{"barfoo", "bar_foo_foo", "", "bar_", "_foo"}
 
 	for podFullName, expected := range successfulCases {
 		name, namespace, err := kubecontainer.ParsePodFullName(podFullName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

ParsePodFullName():code robustness

if pod name or namespace name is null, the function can handle it.
Meanwhile update unit test 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
