### PR TITLE
orphan when kubectl delete --cascade=false

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -294,7 +294,10 @@ func DeleteResult(r *resource.Result, out io.Writer, ignoreNotFound bool, shortO
 			return err
 		}
 		found++
-		return deleteResource(info, out, shortOutput, mapper, nil)
+
+		// if we're here, it means that cascade=false (not the default), so we should orphan as requested
+		orphan := true
+		return deleteResource(info, out, shortOutput, mapper, &metav1.DeleteOptions{OrphanDependents: &orphan})
 	})
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -140,8 +140,9 @@ func TestOrphanDependentsInDeleteObject(t *testing.T) {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
-	// Test that delete options should be nil when cascade is false.
-	expectedOrphanDependents = nil
+	// Test that delete options should be set to orphan when cascade is false.
+	trueVar := true
+	expectedOrphanDependents = &trueVar
 	buf, errBuf = bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 	cmd = NewCmdDelete(f, buf, errBuf)
 	cmd.Flags().Set("namespace", "test")


### PR DESCRIPTION
The default for new objects is to propagate deletes (use GC) when no deleteoptions are passed.  In addition, the vast majority of kube objects use this default.  Only a few controllers resources (sts, rc, deploy, jobs, rs) orphan by default.  This means that when you do `kubectl delete sa/foo --cascade=false` you do *not* orphan.  That doesn't fulfill the intent of the command.  This explicitly orphans when `--cascade=false` so we don't use GC.

@fabianofranz 
@jwforres I liked this easter egg :)

@kubernetes/sig-cli-bugs we should backport this to 1.6