### PR TITLE
Fix XDG-based kubectl plugin dirs

### DIFF
--- a/pkg/kubectl/plugins/loader.go
+++ b/pkg/kubectl/plugins/loader.go
@@ -145,10 +145,10 @@ func XDGDataPluginLoader() PluginLoader {
 	}
 	return TolerantMultiPluginLoader{
 		&DirectoryPluginLoader{
-			Directory: "/usr/local/share",
+			Directory: "/usr/local/share/kubectl/plugins",
 		},
 		&DirectoryPluginLoader{
-			Directory: "/usr/share",
+			Directory: "/usr/share/kubectl/plugins",
 		},
 	}
 }


### PR DESCRIPTION
XDGDataPluginLoader messed up its default-value handling for `XDG_DATA_DIRS` and ends up scanning *all of /usr/share* looking for plugins if you don't have that set :-O

/release-note-none
/assign @fabianofranz 
