### PR TITLE
Fix flag formatting errors in the node tests

### DIFF
--- a/test/e2e_node/jenkins/jenkins-memcg-serial.properties
+++ b/test/e2e_node/jenkins/jenkins-memcg-serial.properties
@@ -13,7 +13,7 @@ CLEANUP=true
 # gci-docker-version specifies docker version in GCI image.
 GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION},gci-update-strategy=update_disabled"
 GINKGO_FLAGS='--focus="MemoryEviction" --skip=""'
-TEST_ARGS='--kubelet-flags=--feature-gates=DynamicKubeletConfig=true'
+TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
 KUBELET_ARGS='--cgroups-per-qos=true --cgroup-root=/'
 PARALLELISM=1
 TIMEOUT=1h

--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -145,7 +145,8 @@ func updateCOSKubeletFlags(args, host, workspace string) (string, error) {
 		return args, fmt.Errorf("unabled to chmod 544 GCI/COS mounter script. Err: %v, Output:\n%s", err, output)
 	}
 	// Insert args at beginning of test args, so any values from command line take precedence
-	args = fmt.Sprintf("--kubelet-flags='--experimental-kernel-memcg-notification=true --experimental-mounter-path=%s'", mounterPath) + args
+	args = "--kubelet-flags=--experimental-kernel-memcg-notification=true " + args
+	args = fmt.Sprintf("--kubelet-flags=--experimental-mounter-path=%s ", mounterPath) + args
 	return args, nil
 }
 


### PR DESCRIPTION
There were three problems:
- Lack of a trailing space after prepending flags.
- Passing multiple flags in a string to --kubelet-flags seems to confuse
the flag parser; it stops parsing ALL flags as soon as it sees the
second kubelet flag. Fortunately, all instances of --kubelet-flags are
combined together, so we can just pass two of those.
- --feature-gates should be passed to the test framework, which then
forwards it to the kubelet, instead of using --kubelet-flags.

This hopefully fixes the dynamic config test failures on COS, which
started after #45602. (See: https://k8s-testgrid.appspot.com/google-node#kubelet-serial-gce-e2e)
