### PR TITLE
[1.6] orphan when kubectl delete --cascade=false

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -294,7 +294,10 @@ func DeleteResult(r *resource.Result, out io.Writer, ignoreNotFound bool, shortO
 			return err
 		}
 		found++
-		return deleteResource(info, out, shortOutput, mapper, nil)
+
+		// if we're here, it means that cascade=false (not the default), so we should orphan as requested
+		orphan := true
+		return deleteResource(info, out, shortOutput, mapper, &metav1.DeleteOptions{OrphanDependents: &orphan})
 	})
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/delete_test.go
+++ b/pkg/kubectl/cmd/delete_test.go
@@ -140,8 +140,9 @@ func TestOrphanDependentsInDeleteObject(t *testing.T) {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
 
-	// Test that delete options should be nil when cascade is false.
-	expectedOrphanDependents = nil
+	// Test that delete options should be set to orphan when cascade is false.
+	trueVar := true
+	expectedOrphanDependents = &trueVar
 	buf, errBuf = bytes.NewBuffer([]byte{}), bytes.NewBuffer([]byte{})
 	cmd = NewCmdDelete(f, buf, errBuf)
 	cmd.Flags().Set("namespace", "test")


### PR DESCRIPTION
Cherry-pick of https://github.com/kubernetes/kubernetes/pull/45661

```release-note
Fix `kubectl delete --cascade=false` for resources that don't have legacy overrides to orphan by default.
```