### PR TITLE
Print pod startup latency metric as perfdata

### DIFF
--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -159,7 +159,7 @@ func (l *PodStartupLatency) PrintHumanReadable() string {
 }
 
 func (l *PodStartupLatency) PrintJSON() string {
-	return PrettyPrintJSON(l)
+	return PrettyPrintJSON(PodStartupLatencyToPerfData(l))
 }
 
 type SchedulingLatency struct {

--- a/test/e2e/framework/perf_util.go
+++ b/test/e2e/framework/perf_util.go
@@ -51,6 +51,25 @@ func ApiCallToPerfData(apicalls *APIResponsiveness) *perftype.PerfData {
 	return perfData
 }
 
+// PodStartupLatencyToPerfData transforms PodStartupLatency to PerfData.
+func PodStartupLatencyToPerfData(latency *PodStartupLatency) *perftype.PerfData {
+	perfData := &perftype.PerfData{Version: currentApiCallMetricsVersion}
+	item := perftype.DataItem{
+		Data: map[string]float64{
+			"Perc50":  float64(latency.Latency.Perc50) / 1000000, // us -> ms
+			"Perc90":  float64(latency.Latency.Perc90) / 1000000,
+			"Perc99":  float64(latency.Latency.Perc99) / 1000000,
+			"Perc100": float64(latency.Latency.Perc100) / 1000000,
+		},
+		Unit: "ms",
+		Labels: map[string]string{
+			"Metric": "pod_startup",
+		},
+	}
+	perfData.DataItems = append(perfData.DataItems, item)
+	return perfData
+}
+
 // currentKubeletPerfMetricsVersion is the current kubelet performance metrics version. We should
 // bump up the version each time we make incompatible change to the metrics.
 const currentKubeletPerfMetricsVersion = "v2"


### PR DESCRIPTION
Follows #45657 
This should print pod startup latency in same format as api calls latencies.

cc @wojtek-t @gmarek 