### PR TITLE
Automated cherry pick of #45715

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -93,6 +93,8 @@ spec:
       tolerations:
       - key: "node.alpha.kubernetes.io/ismaster"
         effect: "NoSchedule"
+      - operator: "Exists"
+        effect: "NoExecute"
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
Cherry pick of #45715 on release-1.6.

#45715: Add general NoExecute Toleration to fluentd in gcp