### PR TITLE
Make /var/lib/kubelet as shared during startup

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -75,6 +75,10 @@ func (mi *fakeMountInterface) PathIsDevice(pathname string) (bool, error) {
 	return true, nil
 }
 
+func (mi *fakeMountInterface) MakeRShared(path string) error {
+	return nil
+}
+
 func fakeContainerMgrMountInt() mount.Interface {
 	return &fakeMountInterface{
 		[]mount.MountPoint{

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1157,6 +1157,9 @@ func (kl *Kubelet) setupDataDirs() error {
 	if err := os.MkdirAll(kl.getRootDir(), 0750); err != nil {
 		return fmt.Errorf("error creating root directory: %v", err)
 	}
+	if err := kl.mounter.MakeRShared(kl.getRootDir()); err != nil {
+		return fmt.Errorf("error configuring root directory: %v", err)
+	}
 	if err := os.MkdirAll(kl.getPodsDir(), 0750); err != nil {
 		return fmt.Errorf("error creating pods directory: %v", err)
 	}

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -160,6 +160,7 @@ func newTestKubeletWithImageList(
 	kubelet.recorder = fakeRecorder
 	kubelet.kubeClient = fakeKubeClient
 	kubelet.os = &containertest.FakeOS{}
+	kubelet.mounter = &mount.FakeMounter{}
 
 	kubelet.hostname = testKubeletHostname
 	kubelet.nodeName = types.NodeName(testKubeletHostname)

--- a/pkg/kubelet/runonce_test.go
+++ b/pkg/kubelet/runonce_test.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	statustest "k8s.io/kubernetes/pkg/kubelet/status/testing"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager"
+	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
@@ -127,6 +128,7 @@ func TestRunOnce(t *testing.T) {
 
 	kb.evictionManager = evictionManager
 	kb.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)
+	kb.mounter = &mount.FakeMounter{}
 	if err := kb.setupDataDirs(); err != nil {
 		t.Errorf("Failed to init data dirs: %v", err)
 	}

--- a/pkg/util/io/BUILD
+++ b/pkg/util/io/BUILD
@@ -7,7 +7,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["writer.go"],
+    srcs = [
+        "consistentread.go",
+        "writer.go",
+    ],
     deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )
 

--- a/pkg/util/io/consistentread.go
+++ b/pkg/util/io/consistentread.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+)
+
+// ConsistentRead repeatedly reads a file until it gets the same content twice.
+// This is useful when reading files in /proc that are larger than page size
+// and kernel may modify them between individual read() syscalls.
+func ConsistentRead(filename string, attempts int) ([]byte, error) {
+	oldContent, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < attempts; i++ {
+		newContent, err := ioutil.ReadFile(filename)
+		if err != nil {
+			return nil, err
+		}
+		if bytes.Compare(oldContent, newContent) == 0 {
+			return newContent, nil
+		}
+		// Files are different, continue reading
+		oldContent = newContent
+	}
+	return nil, fmt.Errorf("could not get consistent content of %s after %d attempts", filename, attempts)
+}

--- a/pkg/util/mount/BUILD
+++ b/pkg/util/mount/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/utils/exec:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "//pkg/util/io:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         ],

--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -171,3 +171,7 @@ func (f *FakeMounter) PathIsDevice(pathname string) (bool, error) {
 func (f *FakeMounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
 	return getDeviceNameFromMount(f, mountPath, pluginDir)
 }
+
+func (f *FakeMounter) MakeRShared(path string) error {
+	return nil
+}

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -67,6 +67,9 @@ type Interface interface {
 	// GetDeviceNameFromMount finds the device name by checking the mount path
 	// to get the global mount path which matches its plugin directory
 	GetDeviceNameFromMount(mountPath, pluginDir string) (string, error)
+	// MakeRShared checks that given path is on a mount with 'rshared' mount
+	// propagation. If not, it bind-mounts the path as rshared.
+	MakeRShared(path string) error
 }
 
 // Exec executes command where mount utilities are. This can be either the host,

--- a/pkg/util/mount/mount_linux_test.go
+++ b/pkg/util/mount/mount_linux_test.go
@@ -19,32 +19,23 @@ limitations under the License.
 package mount
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"reflect"
-	"strings"
 	"testing"
 )
 
 func TestReadProcMountsFrom(t *testing.T) {
 	successCase :=
 		`/dev/0 /path/to/0 type0 flags 0 0
-		/dev/1    /path/to/1   type1	flags 1 1
-		/dev/2 /path/to/2 type2 flags,1,2=3 2 2
-		`
+/dev/1    /path/to/1   type1	flags 1 1
+/dev/2 /path/to/2 type2 flags,1,2=3 2 2
+`
 	// NOTE: readProcMountsFrom has been updated to using fnv.New32a()
-	hash, err := readProcMountsFrom(strings.NewReader(successCase), nil)
+	mounts, err := parseProcMounts([]byte(successCase))
 	if err != nil {
-		t.Errorf("expected success")
-	}
-	if hash != 0xa290ff0b {
-		t.Errorf("expected 0xa290ff0b, got %#x", hash)
-	}
-	mounts := []MountPoint{}
-	hash, err = readProcMountsFrom(strings.NewReader(successCase), &mounts)
-	if err != nil {
-		t.Errorf("expected success")
-	}
-	if hash != 0xa290ff0b {
-		t.Errorf("expected 0xa290ff0b, got %#x", hash)
+		t.Errorf("expected success, got %v", err)
 	}
 	if len(mounts) != 3 {
 		t.Fatalf("expected 3 mounts, got %d", len(mounts))
@@ -68,7 +59,7 @@ func TestReadProcMountsFrom(t *testing.T) {
 		"/dev/2 /path/to/mount type flags 0 b\n",
 	}
 	for _, ec := range errorCases {
-		_, err := readProcMountsFrom(strings.NewReader(ec), &mounts)
+		_, err := parseProcMounts([]byte(ec))
 		if err == nil {
 			t.Errorf("expected error")
 		}
@@ -205,6 +196,129 @@ func TestGetMountRefsByDev(t *testing.T) {
 
 		if refs, err := GetMountRefsByDev(fm, test.mountPath); err != nil || !setEquivalent(test.expectedRefs, refs) {
 			t.Errorf("%d. getMountRefsByDev(%q) = %v, %v; expected %v, nil", i, test.mountPath, refs, err, test.expectedRefs)
+		}
+	}
+}
+
+func writeFile(content string) (string, string, error) {
+	tempDir, err := ioutil.TempDir("", "mounter_shared_test")
+	if err != nil {
+		return "", "", err
+	}
+	filename := filepath.Join(tempDir, "mountinfo")
+	err = ioutil.WriteFile(filename, []byte(content), 0600)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return "", "", err
+	}
+	return tempDir, filename, nil
+}
+
+func TestIsSharedSuccess(t *testing.T) {
+	successMountInfo :=
+		`62 0 253:0 / / rw,relatime shared:1 - ext4 /dev/mapper/ssd-root rw,seclabel,data=ordered
+76 62 8:1 / /boot rw,relatime shared:29 - ext4 /dev/sda1 rw,seclabel,data=ordered
+78 62 0:41 / /tmp rw,nosuid,nodev shared:30 - tmpfs tmpfs rw,seclabel
+80 62 0:42 / /var/lib/nfs/rpc_pipefs rw,relatime shared:31 - rpc_pipefs sunrpc rw
+82 62 0:43 / /var/lib/foo rw,relatime shared:32 - tmpfs tmpfs rw
+83 63 0:44 / /var/lib/bar rw,relatime - tmpfs tmpfs rw
+227 62 253:0 /var/lib/docker/devicemapper /var/lib/docker/devicemapper rw,relatime - ext4 /dev/mapper/ssd-root rw,seclabel,data=ordered
+224 62 253:0 /var/lib/docker/devicemapper/test/shared /var/lib/docker/devicemapper/test/shared rw,relatime master:1 shared:44 - ext4 /dev/mapper/ssd-root rw,seclabel,data=ordered
+`
+	tempDir, filename, err := writeFile(successMountInfo)
+	if err != nil {
+		t.Fatalf("cannot create temporary file: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	tests := []struct {
+		name           string
+		path           string
+		expectedResult bool
+	}{
+		{
+			// /var/lib/kubelet is a directory on mount '/' that is shared
+			// This is the most common case.
+			"shared",
+			"/var/lib/kubelet",
+			true,
+		},
+		{
+			// 8a2a... is a directory on mount /var/lib/docker/devicemapper
+			// that is private.
+			"private",
+			"/var/lib/docker/devicemapper/mnt/8a2a5c19eefb06d6f851dfcb240f8c113427f5b49b19658b5c60168e88267693/",
+			false,
+		},
+		{
+			// 'directory' is a directory on mount
+			// /var/lib/docker/devicemapper/test/shared that is shared, but one
+			// of its parent is private.
+			"nested-shared",
+			"/var/lib/docker/devicemapper/test/shared/my/test/directory",
+			true,
+		},
+		{
+			// /var/lib/foo is a mount point and it's shared
+			"shared-mount",
+			"/var/lib/foo",
+			true,
+		},
+		{
+			// /var/lib/bar is a mount point and it's private
+			"private-mount",
+			"/var/lib/bar",
+			false,
+		},
+	}
+	for _, test := range tests {
+		ret, err := isShared(test.path, filename)
+		if err != nil {
+			t.Errorf("test %s got unexpected error: %v", test.name, err)
+		}
+		if ret != test.expectedResult {
+			t.Errorf("test %s expected %v, got %v", test.name, test.expectedResult, ret)
+		}
+	}
+}
+
+func TestIsSharedFailure(t *testing.T) {
+	errorTests := []struct {
+		name    string
+		content string
+	}{
+		{
+			// the first line is too short
+			name: "too-short-line",
+			content: `62 0 253:0 / / rw,relatime
+76 62 8:1 / /boot rw,relatime shared:29 - ext4 /dev/sda1 rw,seclabel,data=ordered
+78 62 0:41 / /tmp rw,nosuid,nodev shared:30 - tmpfs tmpfs rw,seclabel
+80 62 0:42 / /var/lib/nfs/rpc_pipefs rw,relatime shared:31 - rpc_pipefs sunrpc rw
+227 62 253:0 /var/lib/docker/devicemapper /var/lib/docker/devicemapper rw,relatime - ext4 /dev/mapper/ssd-root rw,seclabel,data=ordered
+224 62 253:0 /var/lib/docker/devicemapper/test/shared /var/lib/docker/devicemapper/test/shared rw,relatime master:1 shared:44 - ext4 /dev/mapper/ssd-root rw,seclabel,data=ordered
+`,
+		},
+		{
+			// there is no root mount
+			name: "no-root-mount",
+			content: `76 62 8:1 / /boot rw,relatime shared:29 - ext4 /dev/sda1 rw,seclabel,data=ordered
+78 62 0:41 / /tmp rw,nosuid,nodev shared:30 - tmpfs tmpfs rw,seclabel
+80 62 0:42 / /var/lib/nfs/rpc_pipefs rw,relatime shared:31 - rpc_pipefs sunrpc rw
+227 62 253:0 /var/lib/docker/devicemapper /var/lib/docker/devicemapper rw,relatime - ext4 /dev/mapper/ssd-root rw,seclabel,data=ordered
+224 62 253:0 /var/lib/docker/devicemapper/test/shared /var/lib/docker/devicemapper/test/shared rw,relatime master:1 shared:44 - ext4 /dev/mapper/ssd-root rw,seclabel,data=ordered
+`,
+		},
+	}
+	for _, test := range errorTests {
+		tempDir, filename, err := writeFile(test.content)
+		if err != nil {
+			t.Fatalf("cannot create temporary file: %v", err)
+		}
+		defer os.RemoveAll(tempDir)
+
+		_, err = isShared("/", filename)
+		if err == nil {
+			t.Errorf("test %q: expected error, got none", test.name)
 		}
 	}
 }

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -67,6 +67,10 @@ func (mounter *Mounter) PathIsDevice(pathname string) (bool, error) {
 	return true, nil
 }
 
+func (mounter *Mounter) MakeRShared(path string) error {
+	return nil
+}
+
 func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, fstype string, options []string) error {
 	return nil
 }

--- a/pkg/util/mount/nsenter_mount_unsupported.go
+++ b/pkg/util/mount/nsenter_mount_unsupported.go
@@ -61,3 +61,7 @@ func (*NsenterMounter) PathIsDevice(pathname string) (bool, error) {
 func (*NsenterMounter) GetDeviceNameFromMount(mountPath, pluginDir string) (string, error) {
 	return "", nil
 }
+
+func (*NsenterMounter) MakeRShared(path string) error {
+	return nil
+}

--- a/pkg/util/removeall/removeall_test.go
+++ b/pkg/util/removeall/removeall_test.go
@@ -66,6 +66,10 @@ func (mounter *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
+func (mounter *fakeMounter) MakeRShared(path string) error {
+	return nil
+}
+
 func TestRemoveAllOneFilesystem(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
This is part of ~~https://github.com/kubernetes/community/pull/589~~ https://github.com/kubernetes/community/pull/659

We'd like kubelet to be able to consume mounts from containers in the future, therefore kubelet should make sure that `/var/lib/kubelet` has shared mount propagation to be able to see these mounts. 

On most distros, root directory is already mounted with shared mount propagation and this code will not do anything. On older distros such as Debian Wheezy, this code detects that `/var/lib/kubelet` is a directory on `/` which has private mount propagation and kubelet bind-mounts `/var/lib/kubelet` as rshared.

Both "regular" linux mounter and `NsenterMounter` are updated here.

@kubernetes/sig-storage-pr-reviews @kubernetes/sig-node-pr-reviews 
@vishh 

Release note:
```release-note
Kubelet re-binds /var/lib/kubelet directory with rshared mount propagation during startup if it is not shared yet.
```