### PR TITLE
Respect PDBs during node upgrades and add test coverage to the ServiceTest upgrade test.

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -53,6 +53,7 @@ go_library(
         "//pkg/apis/componentconfig:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//pkg/apis/policy/v1beta1:go_default_library",
         "//pkg/apis/rbac/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/client/clientset_generated/clientset/typed/authorization/v1beta1:go_default_library",

--- a/test/e2e/upgrades/services.go
+++ b/test/e2e/upgrades/services.go
@@ -36,6 +36,8 @@ type ServiceUpgradeTest struct {
 
 func (ServiceUpgradeTest) Name() string { return "service-upgrade" }
 
+func shouldTestPDBs() bool { return framework.ProviderIs("gce", "gke") }
+
 // Setup creates a service with a load balancer and makes sure it's reachable.
 func (t *ServiceUpgradeTest) Setup(f *framework.Framework) {
 	serviceName := "service-test"
@@ -55,7 +57,12 @@ func (t *ServiceUpgradeTest) Setup(f *framework.Framework) {
 	svcPort := int(tcpService.Spec.Ports[0].Port)
 
 	By("creating pod to be part of service " + serviceName)
-	jig.RunOrFail(ns.Name, nil)
+	rc := jig.RunOrFail(ns.Name, jig.AddRCAntiAffinity)
+
+	if shouldTestPDBs() {
+		By("creating a PodDisruptionBudget to cover the ReplicationController")
+		jig.CreatePDBOrFail(ns.Name, rc)
+	}
 
 	// Hit it once before considering ourselves ready
 	By("hitting the pod through the service's LoadBalancer")
@@ -72,6 +79,9 @@ func (t *ServiceUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, 
 	switch upgrade {
 	case MasterUpgrade:
 		t.test(f, done, true)
+	case NodeUpgrade:
+		// Node upgrades should test during disruption only on GCE/GKE for now.
+		t.test(f, done, shouldTestPDBs())
 	default:
 		t.test(f, done, false)
 	}
@@ -87,7 +97,7 @@ func (t *ServiceUpgradeTest) test(f *framework.Framework, done <-chan struct{}, 
 		// Continuous validation
 		By("continuously hitting the pod through the service's LoadBalancer")
 		wait.Until(func() {
-			t.jig.TestReachableHTTP(t.tcpIngressIP, t.svcPort, framework.Poll)
+			t.jig.TestReachableHTTP(t.tcpIngressIP, t.svcPort, framework.LoadBalancerLagTimeoutDefault)
 		}, framework.Poll, done)
 	} else {
 		// Block until upgrade is done


### PR DESCRIPTION
This is still a WIP... needs to be squashed at least, and I don't think it's currently passing until I increase the scale of the RC, but please have a look at the general outline.  Thanks!

Fixes #38336 

@kow3ns @bdbauer @krousey @erictune @maisem @davidopp 

```
On GCE, node upgrades will now respect PodDisruptionBudgets, if present.
```