### PR TITLE
Differentiate update/create message on set-context

### DIFF
--- a/pkg/kubectl/cmd/config/create_context.go
+++ b/pkg/kubectl/cmd/config/create_context.go
@@ -60,8 +60,13 @@ func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 		Example: create_context_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
-			cmdutil.CheckErr(options.run())
-			fmt.Fprintf(out, "Context %q set.\n", options.name)
+			exists, err := options.run()
+			cmdutil.CheckErr(err)
+			if exists {
+				fmt.Fprintf(out, "Context %q modified.\n", options.name)
+			} else {
+				fmt.Fprintf(out, "Context %q created.\n", options.name)
+			}
 		},
 	}
 
@@ -72,15 +77,15 @@ func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 	return cmd
 }
 
-func (o createContextOptions) run() error {
+func (o createContextOptions) run() (bool, error) {
 	err := o.validate()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	startingStanza, exists := config.Contexts[o.name]
@@ -91,10 +96,10 @@ func (o createContextOptions) run() error {
 	config.Contexts[o.name] = &context
 
 	if err := clientcmd.ModifyConfig(o.configAccess, *config, true); err != nil {
-		return err
+		return exists, err
 	}
 
-	return nil
+	return exists, nil
 }
 
 func (o *createContextOptions) modifyContext(existingContext clientcmdapi.Context) clientcmdapi.Context {

--- a/pkg/kubectl/cmd/config/create_context_test.go
+++ b/pkg/kubectl/cmd/config/create_context_test.go
@@ -46,7 +46,7 @@ func TestCreateContext(t *testing.T) {
 			"--user=user_nickname",
 			"--namespace=namespace",
 		},
-		expected: `Context "shaker-context" set.` + "\n",
+		expected: `Context "shaker-context" created.` + "\n",
 		expectedConfig: clientcmdapi.Config{
 			Contexts: map[string]*clientcmdapi.Context{
 				"shaker-context": {AuthInfo: "user_nickname", Cluster: "cluster_nickname", Namespace: "namespace"}},
@@ -68,7 +68,7 @@ func TestModifyContext(t *testing.T) {
 			"--user=user_nickname",
 			"--namespace=namespace",
 		},
-		expected: `Context "shaker-context" set.` + "\n",
+		expected: `Context "shaker-context" modified.` + "\n",
 		expectedConfig: clientcmdapi.Config{
 			Contexts: map[string]*clientcmdapi.Context{
 				"shaker-context": {AuthInfo: "user_nickname", Cluster: "cluster_nickname", Namespace: "namespace"},


### PR DESCRIPTION
kubectl config set-context prints the same message (Context %q set) for both
new and existing contexts. This patch helps differentiate whether an existing
context is modified or a new context is created.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>