### PR TITLE
custom resource De-Registration testcase

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/BUILD
@@ -18,6 +18,7 @@ go_test(
         "integration",
     ],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/BUILD
@@ -16,6 +16,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//vendor/github.com/pborman/uuid:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",


### PR DESCRIPTION
@deads2k  as discussed via IRC

Built on top of #45732
To reproduce #45767

Uncomment code in `TestDeRegistrationAndReRegistration` to reproduce `panic` 