### PR TITLE
fix: required openstack heat version for conditions is 2016-10-14 / newton

### DIFF
--- a/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubecluster.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   Kubernetes cluster with one master and one or more worker nodes

--- a/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
+++ b/cluster/openstack-heat/kubernetes-heat/kubeminion.yaml
@@ -1,4 +1,4 @@
-heat_template_version: 2014-10-16
+heat_template_version: 2016-10-14
 
 description: >
   This is a nested stack that defines a single Kubernetes minion, This stack is


### PR DESCRIPTION
This fix sets the required heat version to 2016-10-14.

In OpenStack heat the conditions statement was introduced in version 2016-10-14 | newton, accourding to: 
https://docs.openstack.org/releasenotes/heat/newton.html
and more specific:
https://docs.openstack.org/developer/heat/template_guide/hot_spec.html

The conditions are used to make the assignment of public ips / floating ips optional (added in commit https://github.com/kubernetes/kubernetes/commit/4eef540876aecdb9fd954020b5569afccffea682). However this template is not compatible with OpenStack heat releases prior newton and produces the following error:

```
ERROR: Failed to validate: : resources.kube_minions: : "condition" is not a valid keyword inside a output definition
```

PR without a release note:
```release-note
NONE
```