### PR TITLE
servicecontroller: use consistent node criteria

### DIFF
--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//pkg/util/metrics:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",


### PR DESCRIPTION
We have two node selection functions: includeNodeFromNodeList and
getNodeConditionPredicate, and the logic is different.

The logic should be the same, so remove includeNodeFromNodeList and just
use getNodeConditionPredicate everywhere.

Fix #45772

```release-note
servicecontroller: Fix node selection logic on initial LB creation
```
