### PR TITLE
Fix the outdated link to the Helm Charts repo

### DIFF
--- a/examples/guidelines.md
+++ b/examples/guidelines.md
@@ -8,7 +8,7 @@ Kubernetes in a meaningful way. It is educational and informative.
 Examples are not:
 
 * Full app deployments, ready to use, with no explanation. These
-  belong to [Helm charts](https://github.com/helm/charts).
+  belong to [Helm charts](https://github.com/kubernetes/charts).
 * Simple toys to show how to use a Kubernetes feature. These belong in
   the [user guide](../docs/user-guide/).
 * Demos that follow a script to show a Kubernetes feature in


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

It is only a link fix, the repo URL has changed

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
