### PR TITLE
kubectl: fixes issues #45736 and #45737

### DIFF
--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -35,23 +35,28 @@ import (
 var (
 	defaultPort = 8001
 	proxyLong   = templates.LongDesc(i18n.T(`
-		To proxy all of the kubernetes api and nothing else, use:
+		Creates a proxy server or application-level gateway between localhost and 
+		the Kubernetes API Server. It also allows serving static content over specified 
+		HTTP path. All incoming data enters through one port and gets forwarded to 
+		the remote kubernetes API Server port, except for the path matching the static content path.`))
+
+	proxyExample = templates.Examples(i18n.T(`
+		# To proxy all of the kubernetes api and nothing else, use:
 
 		    $ kubectl proxy --api-prefix=/
 
-		To proxy only part of the kubernetes api and also some static files:
+		# To proxy only part of the kubernetes api and also some static files:
 
 		    $ kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
 
-		The above lets you 'curl localhost:8001/api/v1/pods'.
+		# The above lets you 'curl localhost:8001/api/v1/pods'.
 
-		To proxy the entire kubernetes api at a different root, use:
+		# To proxy the entire kubernetes api at a different root, use:
 
 		    $ kubectl proxy --api-prefix=/custom/
 
-		The above lets you 'curl localhost:8001/custom/api/v1/pods'`))
+		# The above lets you 'curl localhost:8001/custom/api/v1/pods'
 
-	proxyExample = templates.Examples(i18n.T(`
 		# Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
 		kubectl proxy --port=8011 --www=./local/www/
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the help displayed by the `kubectl proxy` command.

**Which issue this PR fixes**: 
fixes #45736, fixes #45737 

**Special notes for your reviewer**:
NONE

**Release note**:
NONE
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```