### PR TITLE
Add plural name for CustomResources example

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/artifacts/customresource-01/noxu-resource-definition.yaml
+++ b/staging/src/k8s.io/kube-apiextensions-server/artifacts/customresource-01/noxu-resource-definition.yaml
@@ -7,7 +7,7 @@ spec:
   version: v1alpha1
   scope: Namespaced
   names:
-    name: noxus
+    plural: noxus
     singular: noxu
     kind: Noxu
     listKind: NoxuList


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: Adds plural name for CustomResources example.

There is no field called `name` for CustomResources. Instead it is `plural`. This will also fail validation (https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/validation/validation.go#L33) while executing the instructions mentioned here: https://github.com/kubernetes/kubernetes/issues/45510.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```
NONE
```
@sttts 