### PR TITLE
Update generated protos

### DIFF
--- a/pkg/api/v1/generated.proto
+++ b/pkg/api/v1/generated.proto
@@ -3697,20 +3697,6 @@ message ServiceSpec {
   // Must be a valid DNS name and requires Type to be ExternalName.
   // +optional
   optional string externalName = 10;
-
-  // externalTrafficPolicy denotes if this Service desires to route external traffic to
-  // local endpoints only. This preserves Source IP and avoids a second hop for
-  // LoadBalancer and Nodeport type services.
-  // +optional
-  optional string externalTrafficPolicy = 11;
-
-  // healthCheckNodePort specifies the healthcheck nodePort for the service.
-  // If not specified, HealthCheckNodePort is created by the service api
-  // backend with the allocated nodePort. Will use user-specified nodePort value
-  // if specified by the client. Only effects when Type is set to LoadBalancer
-  // and ExternalTrafficPolicy is set to Local.
-  // +optional
-  optional int32 healthCheckNodePort = 12;
 }
 
 // ServiceStatus represents the current status of a service.

--- a/pkg/apis/settings/v1alpha1/generated.proto
+++ b/pkg/apis/settings/v1alpha1/generated.proto
@@ -51,7 +51,7 @@ message PodPresetList {
   repeated PodPreset items = 2;
 }
 
-// PodPresetSpec is a description of a pod preset.
+// PodPresetSpec is a description of a pod injection policy.
 message PodPresetSpec {
   // Selector is a label query over a set of resources, in this case pods.
   // Required.


### PR DESCRIPTION
Protos aren't staying up to date.
These get generated when you run make quick-release, but not when you run make.
See: https://github.com/kubernetes/kubernetes/issues/45783

