### PR TITLE
[Federation] Fix federated service reconcilation issue due to addition of External…

### DIFF
--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -664,6 +664,11 @@ func (s *ServiceController) getOperationsToPerformOnCluster(cluster *v1beta1.Clu
 				}
 			}
 		}
+		// If ExternalTrafficPolicy is not set in federated service, use the ExternalTrafficPolicy
+		// defaulted to in federated cluster.
+		if desiredService.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyType("") {
+			desiredService.Spec.ExternalTrafficPolicy = clusterService.Spec.ExternalTrafficPolicy
+		}
 
 		// Update existing service, if needed.
 		if !Equivalent(desiredService, clusterService) {

--- a/test/e2e_federation/service.go
+++ b/test/e2e_federation/service.go
@@ -379,10 +379,13 @@ func deleteServiceShard(c *fedframework.Cluster, namespace, service string) erro
 
 // equivalent returns true if the two services are equivalent.  Fields which are expected to differ between
 // federated services and the underlying cluster services (e.g. ClusterIP, NodePort) are ignored.
-func equivalent(federationService, clusterService v1.Service) bool {
-	clusterService.Spec.ClusterIP = federationService.Spec.ClusterIP
-	for i := range clusterService.Spec.Ports {
-		clusterService.Spec.Ports[i].NodePort = federationService.Spec.Ports[i].NodePort
+func equivalent(clusterService, federationService v1.Service) bool {
+	federationService.Spec.ClusterIP = clusterService.Spec.ClusterIP
+	for i := range federationService.Spec.Ports {
+		federationService.Spec.Ports[i].NodePort = clusterService.Spec.Ports[i].NodePort
+	}
+	if federationService.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyType("") {
+		federationService.Spec.ExternalTrafficPolicy = clusterService.Spec.ExternalTrafficPolicy
 	}
 
 	if federationService.Name != clusterService.Name || federationService.Namespace != clusterService.Namespace {


### PR DESCRIPTION
…TrafficPolicy field to v1.Service

**What this PR does / why we need it**:
New fields (ExternalTrafficPolicy) are introduced to v1.Service by this PR #41162. If this field is not specified in service spec, the service controller will assign default and updates the service spec.
In federation, the service spec is not updated and we continuously try to reconcile as the federated service and the service in federated cluster do not match.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #45795


**Special notes for your reviewer**:

**Release note**:
```
NONE
```

cc @kubernetes/sig-federation-bugs @madhusudancs 
