### PR TITLE
kube-apiextensions-server: Fix potential SEGV with null delegate handler

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/apiserver.go
@@ -145,7 +145,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		groupDiscoveryHandler,
 		s.GenericAPIServer.RequestContextMapper(),
 		customResourceInformers.Apiextensions().InternalVersion().CustomResources().Lister(),
-		delegationTarget.UnprotectedHandler(),
+		delegateHandler,
 		c.CustomResourceRESTOptionsGetter,
 		c.GenericConfig.AdmissionControl,
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
In the kube-apiextensions-server there is a fallback value for `null` delegate to `http.NotFoundHandler()` in handling group and versions discovery, but no fallback for custom resources endpoint.
It leads to SEGV when running with `genericapiserver.EmptyDelegate`.