### PR TITLE
[CRI] Continue remove image when can't find image id with ImageRef

### DIFF
--- a/pkg/kubelet/dockershim/docker_image.go
+++ b/pkg/kubelet/dockershim/docker_image.go
@@ -101,8 +101,11 @@ func (ds *dockerService) RemoveImage(image *runtimeapi.ImageSpec) error {
 			}
 		}
 		return nil
-	} else if err != nil && libdocker.IsImageNotFoundError(err) {
-		return nil
+	}
+	// dockerclient.InspectImageByID doesn't work with digest and repoTags,
+	// it is safe to continue removing it since there is another check below.
+	if err != nil && !libdocker.IsImageNotFoundError(err) {
+		return err
 	}
 
 	_, err = ds.client.RemoveImage(image.Image, dockertypes.ImageRemoveOptions{PruneChildren: true})

--- a/pkg/kubelet/dockershim/libdocker/helpers.go
+++ b/pkg/kubelet/dockershim/libdocker/helpers.go
@@ -133,5 +133,8 @@ func matchImageIDOnly(inspected dockertypes.ImageInspect, image string) bool {
 // isImageNotFoundError returns whether the err is caused by image not found in docker
 // TODO: Use native error tester once ImageNotFoundError is supported in docker-engine client(eg. ImageRemove())
 func isImageNotFoundError(err error) bool {
-	return strings.Contains(err.Error(), "No such image:")
+	if err != nil {
+		return strings.Contains(err.Error(), "No such image:")
+	}
+	return false
 }


### PR DESCRIPTION
Signed-off-by: Crazykev <crazykev@zju.edu.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**: 
Should try to remove imageRef as repo:tag when can't find it as imageID.
/cc @feiskyer @Random-Liu  PTAL
also /cc @xlgao-zju @heartlock

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
None
```
