### PR TITLE
kubectl plugin: Expand environment variables in the command of plugin.yaml

### DIFF
--- a/pkg/kubectl/plugins/runner.go
+++ b/pkg/kubectl/plugins/runner.go
@@ -18,6 +18,7 @@ package plugins
 
 import (
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -47,7 +48,7 @@ type ExecPluginRunner struct{}
 // Run takes a given plugin and runs it in a given context using os/exec, returning
 // any error found while running.
 func (r *ExecPluginRunner) Run(plugin *Plugin, ctx RunningContext) error {
-	command := strings.Split(plugin.Command, " ")
+	command := strings.Split(os.ExpandEnv(plugin.Command), " ")
 	base := command[0]
 	args := []string{}
 	if len(command) > 1 {

--- a/pkg/kubectl/plugins/runner_test.go
+++ b/pkg/kubectl/plugins/runner_test.go
@@ -18,6 +18,7 @@ package plugins
 
 import (
 	"bytes"
+	"os"
 	"testing"
 )
 
@@ -38,7 +39,15 @@ func TestExecRunner(t *testing.T) {
 			command:     "false",
 			expectedErr: "exit status 1",
 		},
+		{
+			name:        "env",
+			command:     "echo $KUBECTL_PLUGINS_TEST",
+			expectedMsg: "ok\n",
+		},
 	}
+
+	os.Setenv("KUBECTL_PLUGINS_TEST", "ok")
+	defer os.Unsetenv("KUBECTL_PLUGINS_TEST")
 
 	for _, test := range tests {
 		outBuf := bytes.NewBuffer([]byte{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:

This commit improves kubectl plugins to expand environment variables in the command of plugin.yaml.
I'd like to use environment variables in the command of plugin.yaml as follows:
```yaml
name: hello
shortDesc: "The hello plugin"
longDesc: >
  The hello plugin is a new
  plugin used by test-cmd
  to test multiple plugin locations.
command: $HOME/path/to/plugins/hello.sh
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
