### PR TITLE
Fix invalid bash script in unit test.

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -84,7 +84,7 @@ kube::test::find_dirs() {
 
     find ./staging/src/k8s.io/kube-apiextensions-server -not \( \
         \( \
-          -o -path './test/integration/*' \
+          -path '*/test/integration/*' \
         \) -prune \
       \) -name '*_test.go' \
       -name '*_test.go' -print0 | xargs -0n1 dirname | sed 's|^\./staging/src/|./vendor/|' | LC_ALL=C sort -u


### PR DESCRIPTION
This change fix such error when we run "make test":
    "find: invalid expression; you have used a binary operator '-o' with
     nothing before it."

@deads2k 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
