### PR TITLE
Abstract BearerTokenSource interface from auth provider

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc_test.go
@@ -270,7 +270,7 @@ func TestNewOIDCAuthProvider(t *testing.T) {
 		provider.client = tt.client
 		provider.now = func() time.Time { return t0 }
 
-		if _, err := provider.idToken(); err != nil {
+		if _, err := provider.Token(); err != nil {
 			if !tt.wantTokenErr {
 				t.Errorf("%s: failed to get id token: %v", tt.name, err)
 			}

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -113,6 +113,24 @@ type Config struct {
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?
 	// Version string
+
+	// BearerTokenSource for managing the token, if it's not nil, will use this to wrap the http request,
+	// if it's nil, and "AuthProvider" is not nil, we will generate one by "AuthProvider" configuration, so
+	// you can use this to manage and dynamic refresh the token.
+	BearerTokenSource BearerTokenSource
+}
+
+// BearerTokenSource for managing the token
+type BearerTokenSource interface {
+
+	// Token returns a bearer token for HTTP requests. Implementations may rotate the token
+	// returned by this method, for example, refreshing expired tokens.
+	Token() (string, error)
+
+	// Refresh is called when the REST client experiences a 401, which implies that the token is invalid
+	// or has expired. Implementations that do rotation automatically should return (false, nil) indicating
+	// the request should not be retried.
+	Refresh() (retry bool, err error)
 }
 
 // ImpersonationConfig has all the available impersonation options

--- a/staging/src/k8s.io/client-go/rest/plugin.go
+++ b/staging/src/k8s.io/client-go/rest/plugin.go
@@ -18,7 +18,6 @@ package rest
 
 import (
 	"fmt"
-	"net/http"
 	"sync"
 
 	"github.com/golang/glog"
@@ -27,12 +26,11 @@ import (
 )
 
 type AuthProvider interface {
-	// WrapTransport allows the plugin to create a modified RoundTripper that
-	// attaches authorization headers (or other info) to requests.
-	WrapTransport(http.RoundTripper) http.RoundTripper
 	// Login allows the plugin to initialize its configuration. It must not
 	// require direct user interaction.
 	Login() error
+	//used to manage the tokens
+	BearerTokenSource() BearerTokenSource
 }
 
 // Factory generates an AuthProvider plugin.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -165,6 +165,9 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 			authInfoName, _ := config.getAuthInfoName()
 			persister = PersisterForUser(config.configAccess, authInfoName)
 		}
+		if err != nil {
+			return nil, err
+		}
 		userAuthPartialConfig, err := config.getUserIdentificationPartialConfig(configAuthInfo, config.fallbackReader, persister)
 		if err != nil {
 			return nil, err

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -48,6 +48,16 @@ type Config struct {
 	// config may layer other RoundTrippers on top of the returned
 	// RoundTripper.
 	WrapTransport func(rt http.RoundTripper) http.RoundTripper
+
+	//TokenSource is used to mange the tokens
+	TokenSource BearerTokenSource
+}
+
+// BearerTokenSource is used to generate a token
+type BearerTokenSource interface {
+
+	// Token returns a bearer token for HTTP requests. Implementations may rotate the token
+	Token() (string, error)
 }
 
 // ImpersonationConfig has all the available impersonation options
@@ -68,6 +78,11 @@ func (c *Config) HasCA() bool {
 // HasBasicAuth returns whether the configuration has basic authentication or not.
 func (c *Config) HasBasicAuth() bool {
 	return len(c.Username) != 0
+}
+
+//
+func (c *Config) HasTokenSource() bool {
+	return c.TokenSource != nil
 }
 
 // HasTokenAuth returns whether the configuration has token authentication or not.


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Abstract BearerTokenSource interface, so that client side can refresh tokens dynamiclly.
// BearerTokenSource is used to generate
```
package rest

type Config struct {
    // ...

    BearerTokenSource BearerTokenSource

    // ...
}

type BearerTokenSource interface {
    // Token returns a bearer token to add to all requests sent by the REST client.
    Token() (string, error)
    // Refresh is triggered when the client experiences a 401, indicating the current
    // bearer token is invalid and should be renewed.
    //
    // Implementations that can determine expirey from inspecting the current token
    // may do their own rotation on calls to Token, and should return (false, nil) to
    // indicate they don't require refreshing.
    Refresh() (ok bool, err error)
}
```
When the BearerTokenSource and AuthProvider coexits, we should use the BearerTokenSource first, and if only AuthProvider exits, the BearerTokenSource are generated from the AuthProvider plugin.

2. We can define the priority when more than one auth type enable in the transport layer, and a new TokenSourceRoundTripper is added.
in  transport/round_trippers.go:
```
    switch {
	case config.HasBasicAuth() && config.HasTokenAuth():
		return nil, fmt.Errorf("username/password or bearer token may be set, but not both")
	case config.HasTokenAuth():
		rt = NewBearerAuthRoundTripper(config.BearerToken, rt)
	case config.HasBasicAuth():
		rt = NewBasicAuthRoundTripper(config.Username, config.Password, rt)
	case config.HasTokenSource():
		rt = NewTokenSourceRoundTripper(config.TokenSource, rt)
	}
```

3. Remove `WrapTransport` func from the AuthProvider plugin interface, instead, return an BearerTokenSrouce
```
type AuthProvider interface {
	// Login allows the plugin to initialize its configuration. It must not
	// require direct user interaction.
	Login() error
	//used to manage the tokens
	BearerTokenSource() BearerTokenSource
}
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This is still WIP, based on the thoughts here: https://github.com/kubernetes/kubernetes/pull/39587#issuecomment-291961912 , @ericchiang Please let me know if I understood you correctly.
/cc @liggitt @deads2k 
**Release note**:
```None
```
