### PR TITLE
Minor fix in run-gcloud-compute-with-retries output piping

### DIFF
--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -23,7 +23,7 @@ function run-gcloud-compute-with-retries {
     exec 5>&1  # Duplicate &1 to &5 for use below.
     # We don't use 'local' to declare gcloud_result as then ret_val always gets value 0.
     # We use tee to output to &5 (redirected to stdout) while also storing it in the variable.
-    gcloud_result=$(gcloud compute "$@" |& tee >(cat - >&5)) || local ret_val="$?"
+    gcloud_result=$(gcloud compute "$@" 2>&1 | tee >(cat - >&5)) || local ret_val="$?"
     echo "${gcloud_result}"
     if [[ "${ret_val:-0}" -ne "0" ]]; then
       if [[ $(echo "${gcloud_result}" | grep -c "already exists") -gt 0 ]]; then


### PR DESCRIPTION
To work with older versions of bash.

cc @wojtek-t @gmarek