### PR TITLE
prevent pods/status from touching ownerreferences

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -153,6 +153,10 @@ func (podStatusStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, ol
 	oldPod := old.(*api.Pod)
 	newPod.Spec = oldPod.Spec
 	newPod.DeletionTimestamp = nil
+
+	// don't allow the pods/status endpoint to touch owner references since old kubelets corrupt them in a way
+	// that breaks garbage collection
+	newPod.OwnerReferences = oldPod.OwnerReferences
 }
 
 func (podStatusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {


### PR DESCRIPTION
pods/status updates touching ownerreferences causes new fields to be dropped.

I think we really want to protect our metatdata by default with something like https://github.com/kubernetes/kubernetes/pull/45552 .  This fixes the immediate problem.

```release-note
prevent pods/status from touching ownerreferences
```

@derekwaynecarr @eparis 