### PR TITLE
Check endpoint subsets length before asserting addresses.

### DIFF
--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -325,6 +325,10 @@ func (j *ServiceTestJig) WaitForEndpointOnNode(namespace, serviceName, nodeName 
 			Logf("Get endpoints for service %s/%s failed (%s)", namespace, serviceName, err)
 			return false, nil
 		}
+		if len(endpoints.Subsets) == 0 {
+			Logf("Expect endpoints with subsets, got none.")
+			return false, nil
+		}
 		// TODO: Handle multiple endpoints
 		if len(endpoints.Subsets[0].Addresses) == 0 {
 			Logf("Expected Ready endpoints - found none")


### PR DESCRIPTION
Fix #45824.

Panics were caused by [WaitForEndpointOnNode()](https://github.com/kubernetes/kubernetes/blob/3227f441577ff18e3dbb75db36bfd61a6aa69876/test/e2e/framework/service_util.go#L329). Check subsets length ahead to prevent panicing.

/assign @freehan

cc @wojtek-t 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
