### PR TITLE
start serving customresourcedefinition based on status

### DIFF
--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -435,6 +435,14 @@
 			"Rev": "84398b94e188ee336f307779b57b3aa91af7063c"
 		},
 		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru/simplelru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
 			"ImportPath": "github.com/howeyc/gopass",
 			"Rev": "3ca23474a7c7203e0a0a070fd33508f6efdb9b3d"
 		},

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/client-go",
-	"GoVersion": "go1.7",
+	"GoVersion": "go1.8",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./..."
@@ -137,6 +137,14 @@
 		{
 			"ImportPath": "github.com/google/gofuzz",
 			"Rev": "44d81051d367757e1c7c6a5a86423ece9afcf63c"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru/simplelru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
 		},
 		{
 			"ImportPath": "github.com/howeyc/gopass",

--- a/staging/src/k8s.io/client-go/tools/cache/BUILD
+++ b/staging/src/k8s.io/client-go/tools/cache/BUILD
@@ -53,6 +53,7 @@ go_library(
         "index.go",
         "listers.go",
         "listwatch.go",
+        "mutation_cache.go",
         "mutation_detector.go",
         "reflector.go",
         "shared_informer.go",
@@ -63,6 +64,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/hashicorp/golang-lru:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/client-go/tools/cache/index.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index.go
@@ -28,6 +28,8 @@ type Indexer interface {
 	Store
 	// Retrieve list of objects that match on the named indexing function
 	Index(indexName string, obj interface{}) ([]interface{}, error)
+	// IndexKeys returns the set of keys that match on the named indexing function.
+	IndexKeys(indexName, indexKey string) ([]string, error)
 	// ListIndexFuncValues returns the list of generated values of an Index func
 	ListIndexFuncValues(indexName string) []string
 	// ByIndex lists object that match on the named indexing function with the exact key

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+
+	lru "github.com/hashicorp/golang-lru"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// MutationCache is able to take the result of update operations and stores them in an LRU
+// that can be used to provide a more current view of a requested object.  It requires interpretting
+// resourceVersions for comparisons.
+// Implementations must be thread-safe.
+// TODO find a way to layer this into an informer/lister
+type MutationCache interface {
+	GetByKey(key string) (interface{}, bool, error)
+	ByIndex(indexName, indexKey string) ([]interface{}, error)
+	Mutation(interface{})
+}
+
+type ResourceVersionComparator interface {
+	CompareResourceVersion(lhs, rhs runtime.Object) int
+}
+
+// NewIntegerResourceVersionMutationCache returns a MutationCache that understands how to
+// deal with objects that have a resource version that:
+//
+//   - is an integer
+//   - increases when updated
+//   - is comparable across the same resource in a namespace
+//
+// Most backends will have these semantics. Indexer may be nil.
+func NewIntegerResourceVersionMutationCache(backingCache Store, indexer Indexer) MutationCache {
+	lru, err := lru.New(100)
+	if err != nil {
+		// errors only happen on invalid sizes, this would be programmer error
+		panic(err)
+	}
+
+	return &mutationCache{
+		backingCache:  backingCache,
+		indexer:       indexer,
+		mutationCache: lru,
+		comparator:    etcdObjectVersioner{},
+	}
+}
+
+// mutationCache doesn't guarantee that it returns values added via Mutation since they can page out and
+// since you can't distinguish between, "didn't observe create" and "was deleted after create",
+// if the key is missing from the backing cache, we always return it as missing
+type mutationCache struct {
+	lock          sync.Mutex
+	backingCache  Store
+	indexer       Indexer
+	mutationCache *lru.Cache
+
+	comparator ResourceVersionComparator
+}
+
+// GetByKey is never guaranteed to return back the value set in Mutation.  It could be paged out, it could
+// be older than another copy, the backingCache may be more recent or, you might have written twice into the same key.
+// You get a value that was valid at some snapshot of time and will always return the newer of backingCache and mutationCache.
+func (c *mutationCache) GetByKey(key string) (interface{}, bool, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	obj, exists, err := c.backingCache.GetByKey(key)
+	if err != nil {
+		return nil, false, err
+	}
+	if !exists {
+		// we can't distinguish between, "didn't observe create" and "was deleted after create", so
+		// if the key is missing, we always return it as missing
+		return nil, false, nil
+	}
+	objRuntime, ok := obj.(runtime.Object)
+	if !ok {
+		return obj, true, nil
+	}
+	return c.newerObject(key, objRuntime), true, nil
+}
+
+// ByIndex returns the newer objects that match the provided index and indexer key.
+// Will return an error if no indexer was provided.
+func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.indexer == nil {
+		return nil, fmt.Errorf("no indexer has been provided to the mutation cache")
+	}
+	keys, err := c.indexer.IndexKeys(name, indexKey)
+	if err != nil {
+		return nil, err
+	}
+	var items []interface{}
+	for _, key := range keys {
+		obj, exists, err := c.indexer.GetByKey(key)
+		if err != nil {
+			return nil, err
+		}
+		if !exists {
+			continue
+		}
+		if objRuntime, ok := obj.(runtime.Object); ok {
+			items = append(items, c.newerObject(key, objRuntime))
+		} else {
+			items = append(items, obj)
+		}
+	}
+	return items, nil
+}
+
+// newerObject checks the mutation cache for a newer object and returns one if found. If the
+// mutated object is older than the backing object, it is removed from the  Must be
+// called while the lock is held.
+func (c *mutationCache) newerObject(key string, backing runtime.Object) runtime.Object {
+	mutatedObj, exists := c.mutationCache.Get(key)
+	if !exists {
+		return backing
+	}
+	mutatedObjRuntime, ok := mutatedObj.(runtime.Object)
+	if !ok {
+		return backing
+	}
+	if c.comparator.CompareResourceVersion(backing, mutatedObjRuntime) >= 0 {
+		c.mutationCache.Remove(key)
+		return backing
+	}
+	return mutatedObjRuntime
+}
+
+// Mutation adds a change to the cache that can be returned in GetByKey if it is newer than the backingCache
+// copy.  If you call Mutation twice with the same object on different threads, one will win, but its not defined
+// which one.  This doesn't affect correctness, since the GetByKey guaranteed of "later of these two caches" is
+// preserved, but you may not get the version of the object you want.  The object you get is only guaranteed to
+// "one that was valid at some point in time", not "the one that I want".
+func (c *mutationCache) Mutation(obj interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	key, err := DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		// this is a "nice to have", so failures shouldn't do anything weird
+		utilruntime.HandleError(err)
+		return
+	}
+
+	if objRuntime, ok := obj.(runtime.Object); ok {
+		if mutatedObj, exists := c.mutationCache.Get(key); exists {
+			if mutatedObjRuntime, ok := mutatedObj.(runtime.Object); ok {
+				if c.comparator.CompareResourceVersion(objRuntime, mutatedObjRuntime) < 0 {
+					return
+				}
+			}
+		}
+	}
+	c.mutationCache.Add(key, obj)
+}
+
+// etcdObjectVersioner implements versioning and extracting etcd node information
+// for objects that have an embedded ObjectMeta or ListMeta field.
+type etcdObjectVersioner struct{}
+
+// ObjectResourceVersion implements Versioner
+func (a etcdObjectVersioner) ObjectResourceVersion(obj runtime.Object) (uint64, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return 0, err
+	}
+	version := accessor.GetResourceVersion()
+	if len(version) == 0 {
+		return 0, nil
+	}
+	return strconv.ParseUint(version, 10, 64)
+}
+
+// CompareResourceVersion compares etcd resource versions.  Outside this API they are all strings,
+// but etcd resource versions are special, they're actually ints, so we can easily compare them.
+func (a etcdObjectVersioner) CompareResourceVersion(lhs, rhs runtime.Object) int {
+	lhsVersion, err := a.ObjectResourceVersion(lhs)
+	if err != nil {
+		// coder error
+		panic(err)
+	}
+	rhsVersion, err := a.ObjectResourceVersion(rhs)
+	if err != nil {
+		// coder error
+		panic(err)
+	}
+
+	if lhsVersion == rhsVersion {
+		return 0
+	}
+	if lhsVersion < rhsVersion {
+		return -1
+	}
+
+	return 1
+}

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -172,6 +172,10 @@ func (c *cache) Index(indexName string, obj interface{}) ([]interface{}, error) 
 	return c.cacheStorage.Index(indexName, obj)
 }
 
+func (c *cache) IndexKeys(indexName, indexKey string) ([]string, error) {
+	return c.cacheStorage.IndexKeys(indexName, indexKey)
+}
+
 // ListIndexFuncValues returns the list of generated values of an Index func
 func (c *cache) ListIndexFuncValues(indexName string) []string {
 	return c.cacheStorage.ListIndexFuncValues(indexName)

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -191,6 +191,14 @@
 			"Rev": "84398b94e188ee336f307779b57b3aa91af7063c"
 		},
 		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru/simplelru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
 			"ImportPath": "github.com/howeyc/gopass",
 			"Rev": "3ca23474a7c7203e0a0a070fd33508f6efdb9b3d"
 		},

--- a/staging/src/k8s.io/kube-apiextensions-server/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-apiextensions-server/Godeps/Godeps.json
@@ -183,6 +183,14 @@
 			"Rev": "84398b94e188ee336f307779b57b3aa91af7063c"
 		},
 		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru/simplelru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
 			"ImportPath": "github.com/howeyc/gopass",
 			"Rev": "3ca23474a7c7203e0a0a070fd33508f6efdb9b3d"
 		},

--- a/staging/src/k8s.io/kube-apiextensions-server/artifacts/customresource-01/noxu-resource-definition.yaml
+++ b/staging/src/k8s.io/kube-apiextensions-server/artifacts/customresource-01/noxu-resource-definition.yaml
@@ -1,5 +1,5 @@
 apiVersion: apiextensions.k8s.io/v1alpha1
-kind: CustomResource
+kind: CustomResourceDefinition
 metadata:
   name: noxus.mygroup.example.com
 spec:

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/BUILD
@@ -11,6 +11,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "doc.go",
+        "helpers.go",
         "register.go",
         "types.go",
         "zz_generated.deepcopy.go",

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/helpers.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/helpers.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiextensions
+
+// SetCRDCondition sets the status condition.  It either overwrites the existing one or
+// creates a new one
+func SetCRDCondition(customResourceDefinition *CustomResourceDefinition, newCondition CustomResourceDefinitionCondition) {
+	existingCondition := FindCRDCondition(customResourceDefinition, newCondition.Type)
+	if existingCondition == nil {
+		customResourceDefinition.Status.Conditions = append(customResourceDefinition.Status.Conditions, newCondition)
+		return
+	}
+
+	if existingCondition.Status != newCondition.Status {
+		existingCondition.Status = newCondition.Status
+		existingCondition.LastTransitionTime = newCondition.LastTransitionTime
+	}
+
+	existingCondition.Reason = newCondition.Reason
+	existingCondition.Message = newCondition.Message
+}
+
+// FindCRDCondition returns the condition you're looking for or nil
+func FindCRDCondition(customResourceDefinition *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType) *CustomResourceDefinitionCondition {
+	for i := range customResourceDefinition.Status.Conditions {
+		if customResourceDefinition.Status.Conditions[i].Type == conditionType {
+			return &customResourceDefinition.Status.Conditions[i]
+		}
+	}
+
+	return nil
+}
+
+// IsCRDConditionTrue indicates if the condition is present and strictly true
+func IsCRDConditionTrue(customResourceDefinition *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType) bool {
+	return IsCRDConditionPresentAndEqual(customResourceDefinition, conditionType, ConditionTrue)
+}
+
+// IsCRDConditionFalse indicates if the condition is present and false true
+func IsCRDConditionFalse(customResourceDefinition *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType) bool {
+	return IsCRDConditionPresentAndEqual(customResourceDefinition, conditionType, ConditionFalse)
+}
+
+// IsCRDConditionPresentAndEqual indicates if the condition is present and equal to the arg
+func IsCRDConditionPresentAndEqual(customResourceDefinition *CustomResourceDefinition, conditionType CustomResourceDefinitionConditionType, status ConditionStatus) bool {
+	for _, condition := range customResourceDefinition.Status.Conditions {
+		if condition.Type == conditionType {
+			return condition.Status == status
+		}
+	}
+	return false
+}
+
+// IsCRDConditionEquivalent returns true if the lhs and rhs are equivalent except for times
+func IsCRDConditionEquivalent(lhs, rhs *CustomResourceDefinitionCondition) bool {
+	if lhs == nil && rhs == nil {
+		return true
+	}
+	if lhs == nil || rhs == nil {
+		return false
+	}
+
+	return lhs.Message == rhs.Message && lhs.Reason == rhs.Reason && lhs.Status == rhs.Status && lhs.Type == rhs.Type
+}

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/BUILD
@@ -54,6 +54,7 @@ go_library(
         "//vendor/k8s.io/kube-apiextensions-server/pkg/client/informers/internalversion:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/client/listers/apiextensions/internalversion:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/controller/status:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/registry/customresource:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/registry/customresourcedefinition:go_default_library",
     ],

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/BUILD
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["naming_controller_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/client/listers/apiextensions/internalversion:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["naming_controller.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/client/listers/apiextensions/internalversion:go_default_library",
+    ],
+)

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/golang/glog"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"k8s.io/kube-apiextensions-server/pkg/apis/apiextensions"
+	client "k8s.io/kube-apiextensions-server/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion"
+	informers "k8s.io/kube-apiextensions-server/pkg/client/informers/internalversion/apiextensions/internalversion"
+	listers "k8s.io/kube-apiextensions-server/pkg/client/listers/apiextensions/internalversion"
+)
+
+var cloner = conversion.NewCloner()
+
+// This controller is reserving names. To avoid conflicts, be sure to run only one instance of the worker at a time.
+// This could eventually be lifted, but starting simple.
+type NamingConditionController struct {
+	crdClient client.CustomResourceDefinitionsGetter
+
+	crdLister listers.CustomResourceDefinitionLister
+	crdSynced cache.InformerSynced
+	// crdMutationCache backs our lister and keeps track of committed updates to avoid racy
+	// write/lookup cycles.  It's got 100 slots by default, so it unlikely to overrun
+	// TODO to revisit this if naming conflicts are found to occur in the wild
+	crdMutationCache cache.MutationCache
+
+	// To allow injection for testing.
+	syncFn func(key string) error
+
+	queue workqueue.RateLimitingInterface
+}
+
+func NewNamingConditionController(
+	crdInformer informers.CustomResourceDefinitionInformer,
+	crdClient client.CustomResourceDefinitionsGetter,
+) *NamingConditionController {
+	c := &NamingConditionController{
+		crdClient: crdClient,
+		crdLister: crdInformer.Lister(),
+		crdSynced: crdInformer.Informer().HasSynced,
+		queue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CustomResourceDefinition-NamingConditionController"),
+	}
+
+	informerIndexer := crdInformer.Informer().GetIndexer()
+	c.crdMutationCache = cache.NewIntegerResourceVersionMutationCache(informerIndexer, informerIndexer)
+
+	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addCustomResourceDefinition,
+		UpdateFunc: c.updateCustomResourceDefinition,
+		DeleteFunc: c.deleteCustomResourceDefinition,
+	})
+
+	c.syncFn = c.sync
+
+	return c
+}
+
+func (c *NamingConditionController) getAcceptedNamesForGroup(group string) (allResources sets.String, allKinds sets.String) {
+	allResources = sets.String{}
+	allKinds = sets.String{}
+
+	list, err := c.crdLister.List(labels.Everything())
+	if err != nil {
+		panic(err)
+	}
+
+	for _, curr := range list {
+		if curr.Spec.Group != group {
+			continue
+		}
+
+		// for each item here, see if we have a mutation cache entry that is more recent
+		// this makes sure that if we tight loop on update and run, our mutation cache will show
+		// us the version of the objects we just updated to.
+		item := curr
+		obj, exists, err := c.crdMutationCache.GetByKey(curr.Name)
+		if exists && err == nil {
+			item = obj.(*apiextensions.CustomResourceDefinition)
+		}
+
+		allResources.Insert(item.Status.AcceptedNames.Plural)
+		allResources.Insert(item.Status.AcceptedNames.Singular)
+		allResources.Insert(item.Status.AcceptedNames.ShortNames...)
+
+		allKinds.Insert(item.Status.AcceptedNames.Kind)
+		allKinds.Insert(item.Status.AcceptedNames.ListKind)
+	}
+
+	return allResources, allKinds
+}
+
+func (c *NamingConditionController) calculateNames(in *apiextensions.CustomResourceDefinition) (apiextensions.CustomResourceDefinitionNames, apiextensions.CustomResourceDefinitionCondition) {
+	// Get the names that have already been claimed
+	allResources, allKinds := c.getAcceptedNamesForGroup(in.Spec.Group)
+
+	condition := apiextensions.CustomResourceDefinitionCondition{
+		Type:   apiextensions.NameConflict,
+		Status: apiextensions.ConditionUnknown,
+	}
+
+	requestedNames := in.Spec.Names
+	acceptedNames := in.Status.AcceptedNames
+	newNames := in.Status.AcceptedNames
+
+	// Check each name for mismatches.  If there's a mismatch between spec and status, then try to deconflict.
+	// Continue on errors so that the status is the best match possible
+	if err := equalToAcceptedOrFresh(requestedNames.Plural, acceptedNames.Plural, allResources); err != nil {
+		condition.Status = apiextensions.ConditionTrue
+		condition.Reason = "Plural"
+		condition.Message = err.Error()
+	} else {
+		newNames.Plural = requestedNames.Plural
+	}
+	if err := equalToAcceptedOrFresh(requestedNames.Singular, acceptedNames.Singular, allResources); err != nil {
+		condition.Status = apiextensions.ConditionTrue
+		condition.Reason = "Singular"
+		condition.Message = err.Error()
+	} else {
+		newNames.Singular = requestedNames.Singular
+	}
+	if !reflect.DeepEqual(requestedNames.ShortNames, acceptedNames.ShortNames) {
+		errs := []error{}
+		existingShortNames := sets.NewString(acceptedNames.ShortNames...)
+		for _, shortName := range requestedNames.ShortNames {
+			// if the shortname is already ours, then we're fine
+			if existingShortNames.Has(shortName) {
+				continue
+			}
+			if err := equalToAcceptedOrFresh(shortName, "", allResources); err != nil {
+				errs = append(errs, err)
+			}
+
+		}
+		if err := utilerrors.NewAggregate(errs); err != nil {
+			condition.Status = apiextensions.ConditionTrue
+			condition.Reason = "ShortNames"
+			condition.Message = err.Error()
+		} else {
+			newNames.ShortNames = requestedNames.ShortNames
+		}
+	}
+
+	if err := equalToAcceptedOrFresh(requestedNames.Kind, acceptedNames.Kind, allKinds); err != nil {
+		condition.Status = apiextensions.ConditionTrue
+		condition.Reason = "Kind"
+		condition.Message = err.Error()
+	} else {
+		newNames.Kind = requestedNames.Kind
+	}
+	if err := equalToAcceptedOrFresh(requestedNames.ListKind, acceptedNames.ListKind, allKinds); err != nil {
+		condition.Status = apiextensions.ConditionTrue
+		condition.Reason = "ListKind"
+		condition.Message = err.Error()
+	} else {
+		newNames.ListKind = requestedNames.ListKind
+	}
+
+	// if we haven't changed the condition, then our names must be good.
+	if condition.Status == apiextensions.ConditionUnknown {
+		condition.Status = apiextensions.ConditionFalse
+		condition.Reason = "NoConflicts"
+		condition.Message = "no conflicts found"
+	}
+
+	return newNames, condition
+}
+
+func equalToAcceptedOrFresh(requestedName, acceptedName string, usedNames sets.String) error {
+	if requestedName == acceptedName {
+		return nil
+	}
+	if !usedNames.Has(requestedName) {
+		return nil
+	}
+
+	return fmt.Errorf("%q is already in use", requestedName)
+}
+
+func (c *NamingConditionController) sync(key string) error {
+	inCustomResourceDefinition, err := c.crdLister.Get(key)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	acceptedNames, namingCondition := c.calculateNames(inCustomResourceDefinition)
+	// nothing to do if accepted names and NameConflict condition didn't change
+	if reflect.DeepEqual(inCustomResourceDefinition.Status.AcceptedNames, acceptedNames) &&
+		apiextensions.IsCRDConditionEquivalent(
+			&namingCondition,
+			apiextensions.FindCRDCondition(inCustomResourceDefinition, apiextensions.NameConflict)) {
+		return nil
+	}
+
+	crd := &apiextensions.CustomResourceDefinition{}
+	if err := apiextensions.DeepCopy_apiextensions_CustomResourceDefinition(inCustomResourceDefinition, crd, cloner); err != nil {
+		return err
+	}
+
+	crd.Status.AcceptedNames = acceptedNames
+	apiextensions.SetCRDCondition(crd, namingCondition)
+
+	updatedObj, err := c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	if err != nil {
+		return err
+	}
+
+	// if the update was successful, go ahead and add the entry to the mutation cache
+	c.crdMutationCache.Mutation(updatedObj)
+
+	// we updated our status, so we may be releasing a name.  When this happens, we need to rekick everything in our group
+	// if we fail to rekick, just return as normal.  We'll get everything on a resync
+	list, err := c.crdLister.List(labels.Everything())
+	if err != nil {
+		return nil
+	}
+	for _, curr := range list {
+		if curr.Spec.Group == crd.Spec.Group {
+			c.queue.Add(curr.Name)
+		}
+	}
+
+	return nil
+}
+
+func (c *NamingConditionController) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer c.queue.ShutDown()
+
+	glog.Infof("Starting NamingConditionController")
+	defer glog.Infof("Shutting down NamingConditionController")
+
+	if !cache.WaitForCacheSync(stopCh, c.crdSynced) {
+		return
+	}
+
+	// only start one worker thread since its a slow moving API and the naming conflict resolution bits aren't thread-safe
+	go wait.Until(c.runWorker, time.Second, stopCh)
+
+	<-stopCh
+}
+
+func (c *NamingConditionController) runWorker() {
+	for c.processNextWorkItem() {
+	}
+}
+
+// processNextWorkItem deals with one key off the queue.  It returns false when it's time to quit.
+func (c *NamingConditionController) processNextWorkItem() bool {
+	key, quit := c.queue.Get()
+	if quit {
+		return false
+	}
+	defer c.queue.Done(key)
+
+	err := c.syncFn(key.(string))
+	if err == nil {
+		c.queue.Forget(key)
+		return true
+	}
+
+	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", key, err))
+	c.queue.AddRateLimited(key)
+
+	return true
+}
+
+func (c *NamingConditionController) enqueue(obj *apiextensions.CustomResourceDefinition) {
+	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", obj, err))
+		return
+	}
+
+	c.queue.Add(key)
+}
+
+func (c *NamingConditionController) addCustomResourceDefinition(obj interface{}) {
+	castObj := obj.(*apiextensions.CustomResourceDefinition)
+	glog.V(4).Infof("Adding %s", castObj.Name)
+	c.enqueue(castObj)
+}
+
+func (c *NamingConditionController) updateCustomResourceDefinition(obj, _ interface{}) {
+	castObj := obj.(*apiextensions.CustomResourceDefinition)
+	glog.V(4).Infof("Updating %s", castObj.Name)
+	c.enqueue(castObj)
+}
+
+func (c *NamingConditionController) deleteCustomResourceDefinition(obj interface{}) {
+	castObj, ok := obj.(*apiextensions.CustomResourceDefinition)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			glog.Errorf("Couldn't get object from tombstone %#v", obj)
+			return
+		}
+		castObj, ok = tombstone.Obj.(*apiextensions.CustomResourceDefinition)
+		if !ok {
+			glog.Errorf("Tombstone contained object that is not expected %#v", obj)
+			return
+		}
+	}
+	glog.V(4).Infof("Deleting %q", castObj.Name)
+	c.enqueue(castObj)
+}

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller_test.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/kube-apiextensions-server/pkg/apis/apiextensions"
+	listers "k8s.io/kube-apiextensions-server/pkg/client/listers/apiextensions/internalversion"
+)
+
+type crdBuilder struct {
+	curr apiextensions.CustomResourceDefinition
+}
+
+func newCRD(name string) *crdBuilder {
+	tokens := strings.SplitN(name, ".", 2)
+	return &crdBuilder{
+		curr: apiextensions.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: apiextensions.CustomResourceDefinitionSpec{
+				Group: tokens[1],
+				Names: apiextensions.CustomResourceDefinitionNames{
+					Plural: tokens[0],
+				},
+			},
+		},
+	}
+}
+
+func (b *crdBuilder) SpecNames(plural, singular, kind, listKind string, shortNames ...string) *crdBuilder {
+	b.curr.Spec.Names.Plural = plural
+	b.curr.Spec.Names.Singular = singular
+	b.curr.Spec.Names.Kind = kind
+	b.curr.Spec.Names.ListKind = listKind
+	b.curr.Spec.Names.ShortNames = shortNames
+
+	return b
+}
+
+func (b *crdBuilder) StatusNames(plural, singular, kind, listKind string, shortNames ...string) *crdBuilder {
+	b.curr.Status.AcceptedNames.Plural = plural
+	b.curr.Status.AcceptedNames.Singular = singular
+	b.curr.Status.AcceptedNames.Kind = kind
+	b.curr.Status.AcceptedNames.ListKind = listKind
+	b.curr.Status.AcceptedNames.ShortNames = shortNames
+
+	return b
+}
+
+func names(plural, singular, kind, listKind string, shortNames ...string) apiextensions.CustomResourceDefinitionNames {
+	ret := apiextensions.CustomResourceDefinitionNames{
+		Plural:     plural,
+		Singular:   singular,
+		Kind:       kind,
+		ListKind:   listKind,
+		ShortNames: shortNames,
+	}
+	return ret
+}
+
+func (b *crdBuilder) NewOrDie() *apiextensions.CustomResourceDefinition {
+	return &b.curr
+}
+
+var goodCondition = apiextensions.CustomResourceDefinitionCondition{
+	Type:    apiextensions.NameConflict,
+	Status:  apiextensions.ConditionFalse,
+	Reason:  "NoConflicts",
+	Message: "no conflicts found",
+}
+
+func badCondition(reason, message string) apiextensions.CustomResourceDefinitionCondition {
+	return apiextensions.CustomResourceDefinitionCondition{
+		Type:    apiextensions.NameConflict,
+		Status:  apiextensions.ConditionTrue,
+		Reason:  reason,
+		Message: message,
+	}
+}
+
+func TestSync(t *testing.T) {
+	tests := []struct {
+		name string
+
+		in                *apiextensions.CustomResourceDefinition
+		existing          []*apiextensions.CustomResourceDefinition
+		expectedNames     apiextensions.CustomResourceDefinitionNames
+		expectedCondition apiextensions.CustomResourceDefinitionCondition
+	}{
+		{
+			name:     "first resource",
+			in:       newCRD("alfa.bravo.com").NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{},
+			expectedNames: apiextensions.CustomResourceDefinitionNames{
+				Plural: "alfa",
+			},
+			expectedCondition: goodCondition,
+		},
+		{
+			name: "different groups",
+			in:   newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("alfa.charlie.com").StatusNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
+			},
+			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedCondition: goodCondition,
+		},
+		{
+			name: "conflict plural to singular",
+			in:   newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
+			},
+			expectedNames:     names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedCondition: badCondition("Plural", `"alfa" is already in use`),
+		},
+		{
+			name: "conflict singular to shortName",
+			in:   newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "indias", "", "", "delta-singular").NewOrDie(),
+			},
+			expectedNames:     names("alfa", "", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedCondition: badCondition("Singular", `"delta-singular" is already in use`),
+		},
+		{
+			name: "conflict on shortName to shortName",
+			in:   newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "indias", "", "", "hotel-shortname-2").NewOrDie(),
+			},
+			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind"),
+			expectedCondition: badCondition("ShortNames", `"hotel-shortname-2" is already in use`),
+		},
+		{
+			name: "conflict on kind to listkind",
+			in:   newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "indias", "", "echo-kind").NewOrDie(),
+			},
+			expectedNames:     names("alfa", "delta-singular", "", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedCondition: badCondition("Kind", `"echo-kind" is already in use`),
+		},
+		{
+			name: "conflict on listkind to kind",
+			in:   newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "").NewOrDie(),
+			},
+			expectedNames:     names("alfa", "delta-singular", "echo-kind", "", "golf-shortname-1", "hotel-shortname-2"),
+			expectedCondition: badCondition("ListKind", `"foxtrot-listkind" is already in use`),
+		},
+		{
+			name: "no conflict on resource and kind",
+			in:   newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "echo-kind", "", "").NewOrDie(),
+			},
+			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedCondition: goodCondition,
+		},
+		{
+			name: "merge on conflicts",
+			in: newCRD("alfa.bravo.com").
+				SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+				StatusNames("zulu", "yankee-singular", "xray-kind", "whiskey-listkind", "victor-shortname-1", "uniform-shortname-2").
+				NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "", "delta-singular").NewOrDie(),
+			},
+			expectedNames:     names("alfa", "yankee-singular", "echo-kind", "whiskey-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedCondition: badCondition("ListKind", `"foxtrot-listkind" is already in use`),
+		},
+		{
+			name: "merge on conflicts shortNames as one",
+			in: newCRD("alfa.bravo.com").
+				SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+				StatusNames("zulu", "yankee-singular", "xray-kind", "whiskey-listkind", "victor-shortname-1", "uniform-shortname-2").
+				NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "", "delta-singular", "golf-shortname-1").NewOrDie(),
+			},
+			expectedNames:     names("alfa", "yankee-singular", "echo-kind", "whiskey-listkind", "victor-shortname-1", "uniform-shortname-2"),
+			expectedCondition: badCondition("ListKind", `"foxtrot-listkind" is already in use`),
+		},
+		{
+			name: "no conflicts on self",
+			in: newCRD("alfa.bravo.com").
+				SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+				StatusNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+				NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("alfa.bravo.com").
+					SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+					StatusNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+					NewOrDie(),
+			},
+			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedCondition: goodCondition,
+		},
+		{
+			name: "no conflicts on self, remove shortname",
+			in: newCRD("alfa.bravo.com").
+				SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1").
+				StatusNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+				NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("alfa.bravo.com").
+					SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+					StatusNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+					NewOrDie(),
+			},
+			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1"),
+			expectedCondition: goodCondition,
+		},
+	}
+
+	for _, tc := range tests {
+		crdIndexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		for _, obj := range tc.existing {
+			crdIndexer.Add(obj)
+		}
+
+		c := NamingConditionController{
+			crdLister:        listers.NewCustomResourceDefinitionLister(crdIndexer),
+			crdMutationCache: cache.NewIntegerResourceVersionMutationCache(crdIndexer, crdIndexer),
+		}
+		actualNames, actualCondition := c.calculateNames(tc.in)
+
+		if e, a := tc.expectedNames, actualNames; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v expected %v, got %#v", tc.name, e, a)
+		}
+		if e, a := tc.expectedCondition, actualCondition; !apiextensions.IsCRDConditionEquivalent(&e, &a) {
+			t.Errorf("%v expected %v, got %v", tc.name, e, a)
+		}
+	}
+}

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/registry/customresourcedefinition/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/registry/customresourcedefinition/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -175,6 +175,14 @@
 			"Rev": "84398b94e188ee336f307779b57b3aa91af7063c"
 		},
 		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru/simplelru",
+			"Rev": "a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4"
+		},
+		{
 			"ImportPath": "github.com/howeyc/gopass",
 			"Rev": "3ca23474a7c7203e0a0a070fd33508f6efdb9b3d"
 		},


### PR DESCRIPTION
This exposes the `customresourcedefinition/status` endpoint, wires a controller to drive `NameConflict` conditions, and serves discovery from status, not spec.

Next steps after this include wiring the conditions into handling and reswizzling the handling chain to be cleaner now that we have a custom mux.
 