### PR TITLE
let client-gen understand vendor

### DIFF
--- a/cmd/libs/go2idl/client-gen/BUILD
+++ b/cmd/libs/go2idl/client-gen/BUILD
@@ -41,6 +41,7 @@ filegroup(
         ":package-srcs",
         "//cmd/libs/go2idl/client-gen/args:all-srcs",
         "//cmd/libs/go2idl/client-gen/generators:all-srcs",
+        "//cmd/libs/go2idl/client-gen/path:all-srcs",
         "//cmd/libs/go2idl/client-gen/test_apis/testgroup:all-srcs",
         "//cmd/libs/go2idl/client-gen/testoutput/clientset_generated/test_internalclientset:all-srcs",
         "//cmd/libs/go2idl/client-gen/types:all-srcs",

--- a/cmd/libs/go2idl/client-gen/generators/BUILD
+++ b/cmd/libs/go2idl/client-gen/generators/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//cmd/libs/go2idl/client-gen/args:go_default_library",
         "//cmd/libs/go2idl/client-gen/generators/fake:go_default_library",
         "//cmd/libs/go2idl/client-gen/generators/scheme:go_default_library",
+        "//cmd/libs/go2idl/client-gen/path:go_default_library",
         "//cmd/libs/go2idl/client-gen/types:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",

--- a/cmd/libs/go2idl/client-gen/generators/client_generator.go
+++ b/cmd/libs/go2idl/client-gen/generators/client_generator.go
@@ -29,6 +29,7 @@ import (
 	clientgenargs "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/args"
 	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators/fake"
 	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/generators/scheme"
+	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/path"
 	clientgentypes "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types"
 
 	"github.com/golang/glog"
@@ -221,7 +222,8 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 	gvToTypes := map[clientgentypes.GroupVersion][]*types.Type{}
 	for gv, inputDir := range customArgs.GroupVersionToInputPath {
-		p := context.Universe.Package(inputDir)
+		// Package are indexed with the vendor prefix stripped
+		p := context.Universe.Package(path.Vendorless(inputDir))
 		for n, t := range p.Types {
 			// filter out types which are not included in user specified overrides.
 			typesOverride, ok := includedTypesOverrides[gv]

--- a/cmd/libs/go2idl/client-gen/generators/fake/BUILD
+++ b/cmd/libs/go2idl/client-gen/generators/fake/BUILD
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//cmd/libs/go2idl/client-gen/args:go_default_library",
         "//cmd/libs/go2idl/client-gen/generators/scheme:go_default_library",
+        "//cmd/libs/go2idl/client-gen/path:go_default_library",
         "//cmd/libs/go2idl/client-gen/types:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/gengo/generator:go_default_library",

--- a/cmd/libs/go2idl/client-gen/generators/fake/generator_fake_for_type.go
+++ b/cmd/libs/go2idl/client-gen/generators/fake/generator_fake_for_type.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
+	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/path"
 )
 
 // genFakeForType produces a file for each top-level type.
@@ -99,7 +100,7 @@ func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.
 	}
 
 	// allow user to define a group name that's different from the one parsed from the directory.
-	p := c.Universe.Package(g.inputPackage)
+	p := c.Universe.Package(path.Vendorless(g.inputPackage))
 	if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
 		groupName = override[0]
 	}

--- a/cmd/libs/go2idl/client-gen/generators/generator_for_group.go
+++ b/cmd/libs/go2idl/client-gen/generators/generator_for_group.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
+	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/path"
 )
 
 // genGroup produces a file for a group client, e.g. ExtensionsClient for the extension group.
@@ -76,7 +77,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		groupName = ""
 	}
 	// allow user to define a group name that's different from the one parsed from the directory.
-	p := c.Universe.Package(g.inputPackage)
+	p := c.Universe.Package(path.Vendorless(g.inputPackage))
 	if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
 		groupName = override[0]
 	}
@@ -95,7 +96,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 		"restDefaultKubernetesUserAgent": c.Universe.Function(types.Name{Package: "k8s.io/client-go/rest", Name: "DefaultKubernetesUserAgent"}),
 		"restRESTClientInterface":        c.Universe.Type(types.Name{Package: "k8s.io/client-go/rest", Name: "Interface"}),
 		"restRESTClientFor":              c.Universe.Function(types.Name{Package: "k8s.io/client-go/rest", Name: "RESTClientFor"}),
-		"SchemeGroupVersion":             c.Universe.Variable(types.Name{Package: g.inputPackage, Name: "SchemeGroupVersion"}),
+		"SchemeGroupVersion":             c.Universe.Variable(types.Name{Package: path.Vendorless(g.inputPackage), Name: "SchemeGroupVersion"}),
 	}
 	sw.Do(groupInterfaceTemplate, m)
 	sw.Do(groupClientTemplate, m)

--- a/cmd/libs/go2idl/client-gen/generators/scheme/generator_for_scheme.go
+++ b/cmd/libs/go2idl/client-gen/generators/scheme/generator_for_scheme.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
+	"k8s.io/kubernetes/cmd/libs/go2idl/client-gen/path"
 	clientgentypes "k8s.io/kubernetes/cmd/libs/go2idl/client-gen/types"
 )
 
@@ -66,10 +67,10 @@ func (g *GenScheme) Imports(c *generator.Context) (imports []string) {
 					packagePath = filepath.Dir(packagePath)
 				}
 				packagePath = filepath.Join(packagePath, "install")
-				imports = append(imports, strings.ToLower(fmt.Sprintf("%s \"%s\"", group.Group.NonEmpty(), packagePath)))
+				imports = append(imports, strings.ToLower(fmt.Sprintf("%s \"%s\"", group.Group.NonEmpty(), path.Vendorless(packagePath))))
 				break
 			} else {
-				imports = append(imports, strings.ToLower(fmt.Sprintf("%s%s \"%s\"", group.Group.NonEmpty(), version.NonEmpty(), packagePath)))
+				imports = append(imports, strings.ToLower(fmt.Sprintf("%s%s \"%s\"", group.Group.NonEmpty(), version.NonEmpty(), path.Vendorless(packagePath))))
 			}
 		}
 	}

--- a/cmd/libs/go2idl/client-gen/path/BUILD
+++ b/cmd/libs/go2idl/client-gen/path/BUILD
@@ -9,15 +9,8 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["generator_for_scheme.go"],
+    srcs = ["path.go"],
     tags = ["automanaged"],
-    deps = [
-        "//cmd/libs/go2idl/client-gen/path:go_default_library",
-        "//cmd/libs/go2idl/client-gen/types:go_default_library",
-        "//vendor/k8s.io/gengo/generator:go_default_library",
-        "//vendor/k8s.io/gengo/namer:go_default_library",
-        "//vendor/k8s.io/gengo/types:go_default_library",
-    ],
 )
 
 filegroup(

--- a/cmd/libs/go2idl/client-gen/path/path.go
+++ b/cmd/libs/go2idl/client-gen/path/path.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package path
+
+import "strings"
+
+// Vendorless removes the longest match of "*/vendor/" from the front of p.
+// It is useful if a package locates in vendor/, e.g.,
+// k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1, because gengo
+// indexes the package with its import path, e.g.,
+// k8s.io/apimachinery/pkg/apis/meta/v1,
+func Vendorless(p string) string {
+	if pos := strings.LastIndex(p, "/vendor/"); pos != -1 {
+		return p[pos+len("/vendor/"):]
+	}
+	return p
+}

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -26,6 +26,7 @@ cmd/kubectl
 cmd/kubelet
 cmd/libs/go2idl/client-gen
 cmd/libs/go2idl/client-gen/generators
+cmd/libs/go2idl/client-gen/path
 cmd/libs/go2idl/client-gen/test_apis/testgroup/install
 cmd/libs/go2idl/conversion-gen
 cmd/libs/go2idl/deepcopy-gen


### PR DESCRIPTION
This is extracted from #44784, where we move external api types to k8s.io/api. After the move, the types will locate at vendor/k8s.io/api/xxx. However, gengo index the parsed package using the import path, which is stripped of  the vendor/ prefix, so we'll need to strip the vendor/ prefix as necessary in client-gen.

This PR doesn't produce any change to the generated clientset yet since all types are still in the kubernetes repo.
