### PR TITLE
Make hollow-proxy a privileged container to prevent OOM'ing

### DIFF
--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -90,6 +90,8 @@ spec:
           requests:
             cpu: {{HOLLOW_PROXY_CPU}}m
             memory: {{HOLLOW_PROXY_MEM}}Ki
+        securityContext:
+          privileged: true
       - name: hollow-node-problem-detector
         image: gcr.io/google_containers/node-problem-detector:v0.3.0
         env:


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/45622#issuecomment-301624384 (1st point)

This would enable hollow-proxy to write to `/proc/<pid>/oom_score_abj` file with a value of 0 (replacing default of 987), thus making it harder to get oom-killed.

cc @kubernetes/sig-scalability-misc @wojtek-t