### PR TITLE
Make fake iptables' Save operation more realistic

### DIFF
--- a/pkg/util/iptables/testing/fake.go
+++ b/pkg/util/iptables/testing/fake.go
@@ -72,8 +72,10 @@ func (*FakeIPTables) IsIpv6() bool {
 	return false
 }
 
-func (*FakeIPTables) Save(table iptables.Table) ([]byte, error) {
-	return make([]byte, 0), nil
+func (f *FakeIPTables) Save(table iptables.Table) ([]byte, error) {
+	lines := make([]byte, len(f.Lines))
+	copy(lines, f.Lines)
+	return lines, nil
 }
 
 func (*FakeIPTables) SaveAll() ([]byte, error) {


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/45622#issuecomment-301624384 (2nd point)

This would make fake IPtables actually return the iptable contents it stores.

cc @kubernetes/sig-scalability-misc @wojtek-t