### PR TITLE
fix missing argument for Errorf(%v): format reads arg 1, have only 0 args

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/client.go
@@ -216,7 +216,7 @@ func (m *namespacedMetrics) GetForObject(groupKind schema.GroupKind, name string
 	}
 
 	if len(res.Items) != 1 {
-		return nil, fmt.Errorf("the custom metrics API server returned %v results when we asked for exactly one")
+		return nil, fmt.Errorf("the custom metrics API server returned %v results when we asked for exactly one", len(res.Items))
 	}
 
 	return &res.Items[0], nil


### PR DESCRIPTION
Signed-off-by: yupengzte <yu.peng36@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
add the missing code of "len(res.Items)"
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
```
