### PR TITLE
Add generic NoExecute Toleration to NPD

### DIFF
--- a/cluster/addons/node-problem-detector/npd.yaml
+++ b/cluster/addons/node-problem-detector/npd.yaml
@@ -77,3 +77,6 @@ spec:
         hostPath:
           path: /etc/localtime
       serviceAccountName: node-problem-detector
+      tolerations:
+      - operator: "Exists"
+        effect: "NoExecute"


### PR DESCRIPTION
Ref. #44445

cc @davidopp 

```release-note
Add generic Toleration for NoExecute Taints to NodeProblemDetector
```