### PR TITLE
Update fluentd-gcp version

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -26,7 +26,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.2
+        image: gcr.io/google-containers/fluentd-gcp:2.0.4
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
         # tries to send this message to the server => fails to send a chunk and so on.


### PR DESCRIPTION
Updates the `fluent-plugin-google-cloud` version to `0.6.3`. This patch containes bug fixes