### PR TITLE
Fix zone in node e2e serial tests

### DIFF
--- a/test/e2e_node/jenkins/jenkins-serial.properties
+++ b/test/e2e_node/jenkins/jenkins-serial.properties
@@ -1,6 +1,6 @@
 GCE_HOSTS=
 GCE_IMAGE_CONFIG_PATH=test/e2e_node/jenkins/image-config-serial.yaml
-GCE_ZONE=us-west1-d
+GCE_ZONE=us-west1-b
 GCE_PROJECT=k8s-jkns-ci-node-e2e
 CLEANUP=true
 GINKGO_FLAGS='--focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]"'


### PR DESCRIPTION
```shell
$ gcloud compute regions describe us-west1 --project k8s-jkns-ci-node-e2e
creationTimestamp: '2016-06-14T17:29:18.761-07:00'
description: us-west1
id: '1210'
kind: compute#region
name: us-west1
quotas:
- limit: 100.0
  metric: CPUS
  usage: 0.0
- limit: 10240.0
  metric: DISKS_TOTAL_GB
  usage: 0.0
- limit: 7.0
  metric: STATIC_ADDRESSES
  usage: 0.0
- limit: 100.0
  metric: IN_USE_ADDRESSES
  usage: 0.0
- limit: 2048.0
  metric: SSD_TOTAL_GB
  usage: 0.0
- limit: 10240.0
  metric: LOCAL_SSD_TOTAL_GB
  usage: 0.0
- limit: 100.0
  metric: INSTANCE_GROUPS
  usage: 0.0
- limit: 50.0
  metric: INSTANCE_GROUP_MANAGERS
  usage: 0.0
- limit: 1000.0
  metric: INSTANCES
  usage: 0.0
- limit: 50.0
  metric: AUTOSCALERS
  usage: 0.0
- limit: 20.0
  metric: REGIONAL_AUTOSCALERS
  usage: 0.0
- limit: 20.0
  metric: REGIONAL_INSTANCE_GROUP_MANAGERS
  usage: 0.0
selfLink: https://www.googleapis.com/compute/v1/projects/k8s-jkns-ci-node-e2e/regions/us-west1
status: UP
zones:
- https://www.googleapis.com/compute/v1/projects/k8s-jkns-ci-node-e2e/zones/us-west1-a
- https://www.googleapis.com/compute/v1/projects/k8s-jkns-ci-node-e2e/zones/us-west1-b
```