### PR TITLE
Fix node e2e panic when not using image config file.

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -132,7 +132,7 @@ type internalImageConfig struct {
 type internalGCEImage struct {
 	image     string
 	project   string
-	resources *Resources
+	resources Resources
 	metadata  *compute.Metadata
 	machine   string
 	tests     []string
@@ -209,7 +209,7 @@ func main() {
 					metadata:  getImageMetadata(imageConfig.Metadata),
 					machine:   imageConfig.Machine,
 					tests:     imageConfig.Tests,
-					resources: &imageConfig.Resources,
+					resources: imageConfig.Resources,
 				}
 				if isRegex && len(images) > 1 {
 					// Use image name when shortName is not unique.


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/pull/45430, `resources` field in image config is a pointer, and we only initialize it when using image config file.

However, we still have test specifying images directly without image config file, this will cause those test to panic. See:
* https://k8s-testgrid.appspot.com/google-docker#kubelet
* https://k8s-testgrid.appspot.com/google-docker#e2e-cos

This PR fixes this.

@vishh @mtaufen @kewu1992 