### PR TITLE
kubectl proxy -h should show appropriate description on top

### DIFF
--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -35,21 +35,10 @@ import (
 var (
 	defaultPort = 8001
 	proxyLong   = templates.LongDesc(i18n.T(`
-		To proxy all of the kubernetes api and nothing else, use:
-
-		    $ kubectl proxy --api-prefix=/
-
-		To proxy only part of the kubernetes api and also some static files:
-
-		    $ kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
-
-		The above lets you 'curl localhost:8001/api/v1/pods'.
-
-		To proxy the entire kubernetes api at a different root, use:
-
-		    $ kubectl proxy --api-prefix=/custom/
-
-		The above lets you 'curl localhost:8001/custom/api/v1/pods'`))
+		Creates a proxy server or application-level gateway between local host and 
+		Kubernetes API Server. It also allows serving static content over specified 
+		http path. All incoming data enters through one port and gets forwarded to 
+		remote kubernetes API Server port, except for path matching static content.`))
 
 	proxyExample = templates.Examples(i18n.T(`
 		# Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
@@ -61,7 +50,21 @@ var (
 
 		# Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api
 		# This makes e.g. the pods api available at localhost:8001/k8s-api/v1/pods/
-		kubectl proxy --api-prefix=/k8s-api`))
+		kubectl proxy --api-prefix=/k8s-api
+		
+		# To proxy all of the kubernetes api and nothing else, use:
+		kubectl proxy --api-prefix=/
+		
+		#To proxy only part of the kubernetes api and also some static files:
+		kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
+		The above lets you 'curl localhost:8001/api/v1/pods'.
+		
+		#To proxy the entire kubernetes api at a different root, use:
+		kubectl proxy --api-prefix=/custom/
+		The above lets you 'curl localhost:8001/custom/api/v1/pods'
+
+		# Run a proxy to kubernetes apiserver, allowing access only to http GET method
+		kubectl proxy --reject-methods='POST,PUT,PATCH'`))
 )
 
 func NewCmdProxy(f cmdutil.Factory, out io.Writer) *cobra.Command {


### PR DESCRIPTION
Changes to show appropriate description for kubectl proxy -h

fixes #45736 
fixes #45737
(possibly) #45689

**Special notes for your reviewer**:
Change is limited to long description and example in help section