### PR TITLE
Correct client-go TPR example type registration

### DIFF
--- a/staging/src/k8s.io/client-go/examples/third-party-resources/apis/tpr/v1/register.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/apis/tpr/v1/register.go
@@ -38,13 +38,6 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-func init() {
-	// We only register manually-written functions here. The registration of the
-	// generated functions takes place in the generated files. The separation
-	// makes the code compile even when the generated files are missing.
-	SchemeBuilder.Register(addKnownTypes)
-}
-
 // addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,

--- a/staging/src/k8s.io/client-go/examples/third-party-resources/apis/tpr/v1/register.go
+++ b/staging/src/k8s.io/client-go/examples/third-party-resources/apis/tpr/v1/register.go
@@ -27,25 +27,25 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// GroupName is the group name use in this package
+// GroupName is the group name use in this package.
 const GroupName = "tpr.client-go.k8s.io"
 
-// SchemeGroupVersion is group version used to register these objects
+// SchemeGroupVersion is the group version used to register these objects.
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
 
-// Resource takes an unqualified resource and returns a Group qualified GroupResource
+// Resource takes an unqualified resource and returns a Group-qualified GroupResource.
 func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
 func init() {
-	// We only register manually written functions here. The registration of the
+	// We only register manually-written functions here. The registration of the
 	// generated functions takes place in the generated files. The separation
 	// makes the code compile even when the generated files are missing.
 	SchemeBuilder.Register(addKnownTypes)
 }
 
-// Adds the list of known types to api.Scheme.
+// addKnownTypes adds the set of types defined in this package to the supplied scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Example{},


### PR DESCRIPTION
**What this PR does / why we need it**:

Eliminate duplicate registration of third-party resource types in the _client-go_ example, precluding any number of readers from copying the mistake into their own applications as they adapt the example to their own needs.

**Special notes for your reviewer**:

See [the preceding discussion](https://github.com/kubernetes/kubernetes/commit/a6c97715ed7e24581dd9a02a256d57e56b70ac44#commitcomment-22146536) about a6c97715ed7e24581dd9a02a256d57e56b70ac44, committed as part of #45463 but only noticed after the merge.

It's possible that we could take a few of the changes proposed here and apply them more broadly throughout the rest of the code, such as not exporting the `AddToScheme` var in favor of an actual function declaration. Given the flux in #44784, I'd prefer that we don't hold up these small touch-ups on a broader unification.

People I expect will want to weigh in: @sttts, @caesarxuchao, and @nilebox.