### PR TITLE
[GCE] Removed duplicate CIDR

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
@@ -70,7 +70,7 @@ func newAddressMetricContext(request, region string) *metricContext {
 
 func init() {
 	var err error
-	lbSrcRngsFlag.ipn, err = netsets.ParseIPNets([]string{"130.211.0.0/22", "35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22", "35.191.0.0/16"}...)
+	lbSrcRngsFlag.ipn, err = netsets.ParseIPNets([]string{"130.211.0.0/22", "35.191.0.0/16", "209.85.152.0/22", "209.85.204.0/22"}...)
 	if err != nil {
 		panic("Incorrect default GCE L7 source ranges")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#release-notes
-->

**What this PR does / why we need it**:
Removes a duplicate CIDR in the list of LB source CIDRs.
https://cloud.google.com/compute/docs/load-balancing/network/ and https://cloud.google.com/compute/docs/load-balancing/http/ both list `35.191.0.0/16`.  Only one is needed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access) 
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`. 
-->
```release-note
NONE
```
