### PR TITLE
Disabling service-dns controller for federation kubectl tests

### DIFF
--- a/hack/make-rules/test-federation-cmd.sh
+++ b/hack/make-rules/test-federation-cmd.sh
@@ -60,28 +60,17 @@ function run_federation_controller_manager() {
   kubectl config set-context "context" --cluster="apiserver" --kubeconfig="${kubeconfig}"
   kubectl config use-context "context" --kubeconfig="${kubeconfig}"
 
-  cat << EOF > /tmp/dns-provider.conf
-[Global]
-etcd-endpoints = http://127.0.0.1:2379
-zones = f8n.io
-EOF
-
   # Start controller manager
   kube::log::status "Starting federation-controller-manager"
   "${KUBE_OUTPUT_HOSTBIN}/federation-controller-manager" \
     --port="${CTLRMGR_PORT}" \
     --kubeconfig="${kubeconfig}" \
     --kube-api-content-type="${KUBE_TEST_API_TYPE-}" \
-    --federation-name=federation \
-    --dns-provider=coredns \
-    --dns-provider-config=/tmp/dns-provider.conf \
-    --zone-name=f8n.io \
+    --controllers="service-dns=false" \
     --master="127.0.0.1:${API_PORT}" 1>&2 &
   CTLRMGR_PID=$!
 
   kube::util::wait_for_url "http://127.0.0.1:${CTLRMGR_PORT}/healthz" "controller-manager"
-
-  rm -rf /tmp/dns-provider.conf
 }
 
 kube::log::status "Running kubectl tests for federation-apiserver"


### PR DESCRIPTION
**What this PR does / why we need it**:

DNS was unnecessary to do kubectl tests against federation, but it was required earlier as service-controller would not start without initializing dns-provider. Now since we have the capability to disable service-dns controller, we no longer need to initialize federation-controller-manger with DNS specific stuff. So removing it.

Ref: https://github.com/kubernetes/kubernetes/pull/43136#issuecomment-287242198

**Release note**:
```
NONE
```
/cc @nikhiljindal @marun 
@kubernetes/sig-federation-pr-reviews 