### PR TITLE
apiserver: no Status in body for http 204

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -103,6 +103,12 @@ func ErrorNegotiated(err error, s runtime.NegotiatedSerializer, gv schema.GroupV
 		delay := strconv.Itoa(int(status.Details.RetryAfterSeconds))
 		w.Header().Set("Retry-After", delay)
 	}
+
+	if code == http.StatusNoContent {
+		w.WriteHeader(code)
+		return code
+	}
+
 	WriteObjectNegotiated(s, gv, w, req, code, status)
 	return code
 }


### PR DESCRIPTION
Fixes http writer errors as with 204 we must not send any body.

Needed downstream for https://github.com/openshift/origin/issues/14213.