### PR TITLE
Expose informer constructors

### DIFF
--- a/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion/externaladmissionhookconfiguration.go
+++ b/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion/externaladmissionhookconfiguration.go
@@ -41,8 +41,11 @@ type externalAdmissionHookConfigurationInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newExternalAdmissionHookConfigurationInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewExternalAdmissionHookConfigurationInformer constructs a new informer for ExternalAdmissionHookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewExternalAdmissionHookConfigurationInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Admissionregistration().ExternalAdmissionHookConfigurations().List(options)
@@ -53,14 +56,16 @@ func newExternalAdmissionHookConfigurationInformer(client internalclientset.Inte
 		},
 		&admissionregistration.ExternalAdmissionHookConfiguration{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultExternalAdmissionHookConfigurationInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewExternalAdmissionHookConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *externalAdmissionHookConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&admissionregistration.ExternalAdmissionHookConfiguration{}, newExternalAdmissionHookConfigurationInformer)
+	return f.factory.InformerFor(&admissionregistration.ExternalAdmissionHookConfiguration{}, defaultExternalAdmissionHookConfigurationInformer)
 }
 
 func (f *externalAdmissionHookConfigurationInformer) Lister() internalversion.ExternalAdmissionHookConfigurationLister {

--- a/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion/initializerconfiguration.go
+++ b/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion/initializerconfiguration.go
@@ -41,8 +41,11 @@ type initializerConfigurationInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newInitializerConfigurationInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewInitializerConfigurationInformer constructs a new informer for InitializerConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewInitializerConfigurationInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Admissionregistration().InitializerConfigurations().List(options)
@@ -53,14 +56,16 @@ func newInitializerConfigurationInformer(client internalclientset.Interface, res
 		},
 		&admissionregistration.InitializerConfiguration{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultInitializerConfigurationInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewInitializerConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *initializerConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&admissionregistration.InitializerConfiguration{}, newInitializerConfigurationInformer)
+	return f.factory.InformerFor(&admissionregistration.InitializerConfiguration{}, defaultInitializerConfigurationInformer)
 }
 
 func (f *initializerConfigurationInformer) Lister() internalversion.InitializerConfigurationLister {

--- a/pkg/client/informers/informers_generated/internalversion/batch/internalversion/cronjob.go
+++ b/pkg/client/informers/informers_generated/internalversion/batch/internalversion/cronjob.go
@@ -41,26 +41,31 @@ type cronJobInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newCronJobInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewCronJobInformer constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCronJobInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Batch().CronJobs(v1.NamespaceAll).List(options)
+				return client.Batch().CronJobs(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Batch().CronJobs(v1.NamespaceAll).Watch(options)
+				return client.Batch().CronJobs(namespace).Watch(options)
 			},
 		},
 		&batch.CronJob{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultCronJobInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewCronJobInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&batch.CronJob{}, newCronJobInformer)
+	return f.factory.InformerFor(&batch.CronJob{}, defaultCronJobInformer)
 }
 
 func (f *cronJobInformer) Lister() internalversion.CronJobLister {

--- a/pkg/client/informers/informers_generated/internalversion/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/informers/informers_generated/internalversion/certificates/internalversion/certificatesigningrequest.go
@@ -41,8 +41,11 @@ type certificateSigningRequestInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newCertificateSigningRequestInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCertificateSigningRequestInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Certificates().CertificateSigningRequests().List(options)
@@ -53,14 +56,16 @@ func newCertificateSigningRequestInformer(client internalclientset.Interface, re
 		},
 		&certificates.CertificateSigningRequest{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultCertificateSigningRequestInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewCertificateSigningRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *certificateSigningRequestInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&certificates.CertificateSigningRequest{}, newCertificateSigningRequestInformer)
+	return f.factory.InformerFor(&certificates.CertificateSigningRequest{}, defaultCertificateSigningRequestInformer)
 }
 
 func (f *certificateSigningRequestInformer) Lister() internalversion.CertificateSigningRequestLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/configmap.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/configmap.go
@@ -41,26 +41,31 @@ type configMapInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newConfigMapInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewConfigMapInformer constructs a new informer for ConfigMap type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewConfigMapInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Core().ConfigMaps(v1.NamespaceAll).List(options)
+				return client.Core().ConfigMaps(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Core().ConfigMaps(v1.NamespaceAll).Watch(options)
+				return client.Core().ConfigMaps(namespace).Watch(options)
 			},
 		},
 		&api.ConfigMap{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultConfigMapInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewConfigMapInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *configMapInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.ConfigMap{}, newConfigMapInformer)
+	return f.factory.InformerFor(&api.ConfigMap{}, defaultConfigMapInformer)
 }
 
 func (f *configMapInformer) Lister() internalversion.ConfigMapLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/endpoints.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/endpoints.go
@@ -41,26 +41,31 @@ type endpointsInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newEndpointsInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewEndpointsInformer constructs a new informer for Endpoints type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewEndpointsInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Core().Endpoints(v1.NamespaceAll).List(options)
+				return client.Core().Endpoints(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Core().Endpoints(v1.NamespaceAll).Watch(options)
+				return client.Core().Endpoints(namespace).Watch(options)
 			},
 		},
 		&api.Endpoints{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultEndpointsInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewEndpointsInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *endpointsInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.Endpoints{}, newEndpointsInformer)
+	return f.factory.InformerFor(&api.Endpoints{}, defaultEndpointsInformer)
 }
 
 func (f *endpointsInformer) Lister() internalversion.EndpointsLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/event.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/event.go
@@ -41,26 +41,31 @@ type eventInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newEventInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewEventInformer constructs a new informer for Event type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewEventInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Core().Events(v1.NamespaceAll).List(options)
+				return client.Core().Events(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Core().Events(v1.NamespaceAll).Watch(options)
+				return client.Core().Events(namespace).Watch(options)
 			},
 		},
 		&api.Event{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultEventInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewEventInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *eventInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.Event{}, newEventInformer)
+	return f.factory.InformerFor(&api.Event{}, defaultEventInformer)
 }
 
 func (f *eventInformer) Lister() internalversion.EventLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/limitrange.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/limitrange.go
@@ -41,26 +41,31 @@ type limitRangeInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newLimitRangeInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewLimitRangeInformer constructs a new informer for LimitRange type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewLimitRangeInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Core().LimitRanges(v1.NamespaceAll).List(options)
+				return client.Core().LimitRanges(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Core().LimitRanges(v1.NamespaceAll).Watch(options)
+				return client.Core().LimitRanges(namespace).Watch(options)
 			},
 		},
 		&api.LimitRange{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultLimitRangeInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewLimitRangeInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *limitRangeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.LimitRange{}, newLimitRangeInformer)
+	return f.factory.InformerFor(&api.LimitRange{}, defaultLimitRangeInformer)
 }
 
 func (f *limitRangeInformer) Lister() internalversion.LimitRangeLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/namespace.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/namespace.go
@@ -41,8 +41,11 @@ type namespaceInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newNamespaceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewNamespaceInformer constructs a new informer for Namespace type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNamespaceInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Core().Namespaces().List(options)
@@ -53,14 +56,16 @@ func newNamespaceInformer(client internalclientset.Interface, resyncPeriod time.
 		},
 		&api.Namespace{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultNamespaceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewNamespaceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *namespaceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.Namespace{}, newNamespaceInformer)
+	return f.factory.InformerFor(&api.Namespace{}, defaultNamespaceInformer)
 }
 
 func (f *namespaceInformer) Lister() internalversion.NamespaceLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/node.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/node.go
@@ -41,8 +41,11 @@ type nodeInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newNodeInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewNodeInformer constructs a new informer for Node type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNodeInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Core().Nodes().List(options)
@@ -53,14 +56,16 @@ func newNodeInformer(client internalclientset.Interface, resyncPeriod time.Durat
 		},
 		&api.Node{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultNodeInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewNodeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *nodeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.Node{}, newNodeInformer)
+	return f.factory.InformerFor(&api.Node{}, defaultNodeInformer)
 }
 
 func (f *nodeInformer) Lister() internalversion.NodeLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/persistentvolumeclaim.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/persistentvolumeclaim.go
@@ -41,26 +41,31 @@ type persistentVolumeClaimInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPersistentVolumeClaimInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPersistentVolumeClaimInformer constructs a new informer for PersistentVolumeClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPersistentVolumeClaimInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Core().PersistentVolumeClaims(v1.NamespaceAll).List(options)
+				return client.Core().PersistentVolumeClaims(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Core().PersistentVolumeClaims(v1.NamespaceAll).Watch(options)
+				return client.Core().PersistentVolumeClaims(namespace).Watch(options)
 			},
 		},
 		&api.PersistentVolumeClaim{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPersistentVolumeClaimInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPersistentVolumeClaimInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *persistentVolumeClaimInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.PersistentVolumeClaim{}, newPersistentVolumeClaimInformer)
+	return f.factory.InformerFor(&api.PersistentVolumeClaim{}, defaultPersistentVolumeClaimInformer)
 }
 
 func (f *persistentVolumeClaimInformer) Lister() internalversion.PersistentVolumeClaimLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/secret.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/secret.go
@@ -41,26 +41,31 @@ type secretInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newSecretInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewSecretInformer constructs a new informer for Secret type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewSecretInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Core().Secrets(v1.NamespaceAll).List(options)
+				return client.Core().Secrets(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Core().Secrets(v1.NamespaceAll).Watch(options)
+				return client.Core().Secrets(namespace).Watch(options)
 			},
 		},
 		&api.Secret{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultSecretInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewSecretInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *secretInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.Secret{}, newSecretInformer)
+	return f.factory.InformerFor(&api.Secret{}, defaultSecretInformer)
 }
 
 func (f *secretInformer) Lister() internalversion.SecretLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/service.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/service.go
@@ -41,26 +41,31 @@ type serviceInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newServiceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewServiceInformer constructs a new informer for Service type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewServiceInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Core().Services(v1.NamespaceAll).List(options)
+				return client.Core().Services(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Core().Services(v1.NamespaceAll).Watch(options)
+				return client.Core().Services(namespace).Watch(options)
 			},
 		},
 		&api.Service{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultServiceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewServiceInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *serviceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.Service{}, newServiceInformer)
+	return f.factory.InformerFor(&api.Service{}, defaultServiceInformer)
 }
 
 func (f *serviceInformer) Lister() internalversion.ServiceLister {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/serviceaccount.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/serviceaccount.go
@@ -41,26 +41,31 @@ type serviceAccountInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newServiceAccountInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewServiceAccountInformer constructs a new informer for ServiceAccount type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewServiceAccountInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Core().ServiceAccounts(v1.NamespaceAll).List(options)
+				return client.Core().ServiceAccounts(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Core().ServiceAccounts(v1.NamespaceAll).Watch(options)
+				return client.Core().ServiceAccounts(namespace).Watch(options)
 			},
 		},
 		&api.ServiceAccount{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultServiceAccountInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewServiceAccountInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *serviceAccountInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&api.ServiceAccount{}, newServiceAccountInformer)
+	return f.factory.InformerFor(&api.ServiceAccount{}, defaultServiceAccountInformer)
 }
 
 func (f *serviceAccountInformer) Lister() internalversion.ServiceAccountLister {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/deployment.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/deployment.go
@@ -41,26 +41,31 @@ type deploymentInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newDeploymentInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDeploymentInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Extensions().Deployments(v1.NamespaceAll).List(options)
+				return client.Extensions().Deployments(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Extensions().Deployments(v1.NamespaceAll).Watch(options)
+				return client.Extensions().Deployments(namespace).Watch(options)
 			},
 		},
 		&extensions.Deployment{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultDeploymentInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewDeploymentInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions.Deployment{}, newDeploymentInformer)
+	return f.factory.InformerFor(&extensions.Deployment{}, defaultDeploymentInformer)
 }
 
 func (f *deploymentInformer) Lister() internalversion.DeploymentLister {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/ingress.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/ingress.go
@@ -41,26 +41,31 @@ type ingressInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newIngressInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewIngressInformer constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewIngressInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Extensions().Ingresses(v1.NamespaceAll).List(options)
+				return client.Extensions().Ingresses(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Extensions().Ingresses(v1.NamespaceAll).Watch(options)
+				return client.Extensions().Ingresses(namespace).Watch(options)
 			},
 		},
 		&extensions.Ingress{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultIngressInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewIngressInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *ingressInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions.Ingress{}, newIngressInformer)
+	return f.factory.InformerFor(&extensions.Ingress{}, defaultIngressInformer)
 }
 
 func (f *ingressInformer) Lister() internalversion.IngressLister {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/networkpolicy.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/networkpolicy.go
@@ -41,26 +41,31 @@ type networkPolicyInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newNetworkPolicyInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNetworkPolicyInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Extensions().NetworkPolicies(v1.NamespaceAll).List(options)
+				return client.Extensions().NetworkPolicies(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Extensions().NetworkPolicies(v1.NamespaceAll).Watch(options)
+				return client.Extensions().NetworkPolicies(namespace).Watch(options)
 			},
 		},
 		&extensions.NetworkPolicy{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultNetworkPolicyInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewNetworkPolicyInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *networkPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions.NetworkPolicy{}, newNetworkPolicyInformer)
+	return f.factory.InformerFor(&extensions.NetworkPolicy{}, defaultNetworkPolicyInformer)
 }
 
 func (f *networkPolicyInformer) Lister() internalversion.NetworkPolicyLister {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/podsecuritypolicy.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/podsecuritypolicy.go
@@ -41,8 +41,11 @@ type podSecurityPolicyInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPodSecurityPolicyInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPodSecurityPolicyInformer constructs a new informer for PodSecurityPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodSecurityPolicyInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Extensions().PodSecurityPolicies().List(options)
@@ -53,14 +56,16 @@ func newPodSecurityPolicyInformer(client internalclientset.Interface, resyncPeri
 		},
 		&extensions.PodSecurityPolicy{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPodSecurityPolicyInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPodSecurityPolicyInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podSecurityPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions.PodSecurityPolicy{}, newPodSecurityPolicyInformer)
+	return f.factory.InformerFor(&extensions.PodSecurityPolicy{}, defaultPodSecurityPolicyInformer)
 }
 
 func (f *podSecurityPolicyInformer) Lister() internalversion.PodSecurityPolicyLister {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/thirdpartyresource.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/thirdpartyresource.go
@@ -41,8 +41,11 @@ type thirdPartyResourceInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newThirdPartyResourceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewThirdPartyResourceInformer constructs a new informer for ThirdPartyResource type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewThirdPartyResourceInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Extensions().ThirdPartyResources().List(options)
@@ -53,14 +56,16 @@ func newThirdPartyResourceInformer(client internalclientset.Interface, resyncPer
 		},
 		&extensions.ThirdPartyResource{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultThirdPartyResourceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewThirdPartyResourceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *thirdPartyResourceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions.ThirdPartyResource{}, newThirdPartyResourceInformer)
+	return f.factory.InformerFor(&extensions.ThirdPartyResource{}, defaultThirdPartyResourceInformer)
 }
 
 func (f *thirdPartyResourceInformer) Lister() internalversion.ThirdPartyResourceLister {

--- a/pkg/client/informers/informers_generated/internalversion/policy/internalversion/poddisruptionbudget.go
+++ b/pkg/client/informers/informers_generated/internalversion/policy/internalversion/poddisruptionbudget.go
@@ -41,26 +41,31 @@ type podDisruptionBudgetInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPodDisruptionBudgetInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPodDisruptionBudgetInformer constructs a new informer for PodDisruptionBudget type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodDisruptionBudgetInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Policy().PodDisruptionBudgets(v1.NamespaceAll).List(options)
+				return client.Policy().PodDisruptionBudgets(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Policy().PodDisruptionBudgets(v1.NamespaceAll).Watch(options)
+				return client.Policy().PodDisruptionBudgets(namespace).Watch(options)
 			},
 		},
 		&policy.PodDisruptionBudget{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPodDisruptionBudgetInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPodDisruptionBudgetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podDisruptionBudgetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&policy.PodDisruptionBudget{}, newPodDisruptionBudgetInformer)
+	return f.factory.InformerFor(&policy.PodDisruptionBudget{}, defaultPodDisruptionBudgetInformer)
 }
 
 func (f *podDisruptionBudgetInformer) Lister() internalversion.PodDisruptionBudgetLister {

--- a/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/clusterrole.go
+++ b/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/clusterrole.go
@@ -41,8 +41,11 @@ type clusterRoleInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newClusterRoleInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Rbac().ClusterRoles().List(options)
@@ -53,14 +56,16 @@ func newClusterRoleInformer(client internalclientset.Interface, resyncPeriod tim
 		},
 		&rbac.ClusterRole{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultClusterRoleInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac.ClusterRole{}, newClusterRoleInformer)
+	return f.factory.InformerFor(&rbac.ClusterRole{}, defaultClusterRoleInformer)
 }
 
 func (f *clusterRoleInformer) Lister() internalversion.ClusterRoleLister {

--- a/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/clusterrolebinding.go
+++ b/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/clusterrolebinding.go
@@ -41,8 +41,11 @@ type clusterRoleBindingInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newClusterRoleBindingInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleBindingInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Rbac().ClusterRoleBindings().List(options)
@@ -53,14 +56,16 @@ func newClusterRoleBindingInformer(client internalclientset.Interface, resyncPer
 		},
 		&rbac.ClusterRoleBinding{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultClusterRoleBindingInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewClusterRoleBindingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac.ClusterRoleBinding{}, newClusterRoleBindingInformer)
+	return f.factory.InformerFor(&rbac.ClusterRoleBinding{}, defaultClusterRoleBindingInformer)
 }
 
 func (f *clusterRoleBindingInformer) Lister() internalversion.ClusterRoleBindingLister {

--- a/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/role.go
+++ b/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/role.go
@@ -41,26 +41,31 @@ type roleInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newRoleInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Rbac().Roles(v1.NamespaceAll).List(options)
+				return client.Rbac().Roles(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Rbac().Roles(v1.NamespaceAll).Watch(options)
+				return client.Rbac().Roles(namespace).Watch(options)
 			},
 		},
 		&rbac.Role{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultRoleInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewRoleInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac.Role{}, newRoleInformer)
+	return f.factory.InformerFor(&rbac.Role{}, defaultRoleInformer)
 }
 
 func (f *roleInformer) Lister() internalversion.RoleLister {

--- a/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/rolebinding.go
+++ b/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/rolebinding.go
@@ -41,26 +41,31 @@ type roleBindingInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newRoleBindingInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewRoleBindingInformer constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleBindingInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Rbac().RoleBindings(v1.NamespaceAll).List(options)
+				return client.Rbac().RoleBindings(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Rbac().RoleBindings(v1.NamespaceAll).Watch(options)
+				return client.Rbac().RoleBindings(namespace).Watch(options)
 			},
 		},
 		&rbac.RoleBinding{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultRoleBindingInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewRoleBindingInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac.RoleBinding{}, newRoleBindingInformer)
+	return f.factory.InformerFor(&rbac.RoleBinding{}, defaultRoleBindingInformer)
 }
 
 func (f *roleBindingInformer) Lister() internalversion.RoleBindingLister {

--- a/pkg/client/informers/informers_generated/internalversion/settings/internalversion/podpreset.go
+++ b/pkg/client/informers/informers_generated/internalversion/settings/internalversion/podpreset.go
@@ -41,26 +41,31 @@ type podPresetInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPodPresetInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPodPresetInformer constructs a new informer for PodPreset type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodPresetInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Settings().PodPresets(v1.NamespaceAll).List(options)
+				return client.Settings().PodPresets(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Settings().PodPresets(v1.NamespaceAll).Watch(options)
+				return client.Settings().PodPresets(namespace).Watch(options)
 			},
 		},
 		&settings.PodPreset{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPodPresetInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPodPresetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podPresetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&settings.PodPreset{}, newPodPresetInformer)
+	return f.factory.InformerFor(&settings.PodPreset{}, defaultPodPresetInformer)
 }
 
 func (f *podPresetInformer) Lister() internalversion.PodPresetLister {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1/customresourcedefinition.go
@@ -41,8 +41,11 @@ type customResourceDefinitionInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.ApiextensionsV1beta1().CustomResourceDefinitions().List(options)
@@ -53,14 +56,16 @@ func newCustomResourceDefinitionInformer(client clientset.Interface, resyncPerio
 		},
 		&apiextensions_v1beta1.CustomResourceDefinition{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultCustomResourceDefinitionInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewCustomResourceDefinitionInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *customResourceDefinitionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiextensions_v1beta1.CustomResourceDefinition{}, newCustomResourceDefinitionInformer)
+	return f.factory.InformerFor(&apiextensions_v1beta1.CustomResourceDefinition{}, defaultCustomResourceDefinitionInformer)
 }
 
 func (f *customResourceDefinitionInformer) Lister() v1beta1.CustomResourceDefinitionLister {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion/customresourcedefinition.go
@@ -41,8 +41,11 @@ type customResourceDefinitionInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newCustomResourceDefinitionInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewCustomResourceDefinitionInformer constructs a new informer for CustomResourceDefinition type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCustomResourceDefinitionInformer(client internalclientset.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.Apiextensions().CustomResourceDefinitions().List(options)
@@ -53,14 +56,16 @@ func newCustomResourceDefinitionInformer(client internalclientset.Interface, res
 		},
 		&apiextensions.CustomResourceDefinition{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultCustomResourceDefinitionInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewCustomResourceDefinitionInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *customResourceDefinitionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apiextensions.CustomResourceDefinition{}, newCustomResourceDefinitionInformer)
+	return f.factory.InformerFor(&apiextensions.CustomResourceDefinition{}, defaultCustomResourceDefinitionInformer)
 }
 
 func (f *customResourceDefinitionInformer) Lister() internalversion.CustomResourceDefinitionLister {

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
@@ -41,8 +41,11 @@ type externalAdmissionHookConfigurationInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newExternalAdmissionHookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewExternalAdmissionHookConfigurationInformer constructs a new informer for ExternalAdmissionHookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewExternalAdmissionHookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.AdmissionregistrationV1alpha1().ExternalAdmissionHookConfigurations().List(options)
@@ -53,14 +56,16 @@ func newExternalAdmissionHookConfigurationInformer(client kubernetes.Interface, 
 		},
 		&admissionregistration_v1alpha1.ExternalAdmissionHookConfiguration{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultExternalAdmissionHookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewExternalAdmissionHookConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *externalAdmissionHookConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&admissionregistration_v1alpha1.ExternalAdmissionHookConfiguration{}, newExternalAdmissionHookConfigurationInformer)
+	return f.factory.InformerFor(&admissionregistration_v1alpha1.ExternalAdmissionHookConfiguration{}, defaultExternalAdmissionHookConfigurationInformer)
 }
 
 func (f *externalAdmissionHookConfigurationInformer) Lister() v1alpha1.ExternalAdmissionHookConfigurationLister {

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/initializerconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/initializerconfiguration.go
@@ -41,8 +41,11 @@ type initializerConfigurationInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newInitializerConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewInitializerConfigurationInformer constructs a new informer for InitializerConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewInitializerConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.AdmissionregistrationV1alpha1().InitializerConfigurations().List(options)
@@ -53,14 +56,16 @@ func newInitializerConfigurationInformer(client kubernetes.Interface, resyncPeri
 		},
 		&admissionregistration_v1alpha1.InitializerConfiguration{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultInitializerConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewInitializerConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *initializerConfigurationInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&admissionregistration_v1alpha1.InitializerConfiguration{}, newInitializerConfigurationInformer)
+	return f.factory.InformerFor(&admissionregistration_v1alpha1.InitializerConfiguration{}, defaultInitializerConfigurationInformer)
 }
 
 func (f *initializerConfigurationInformer) Lister() v1alpha1.InitializerConfigurationLister {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
@@ -41,26 +41,31 @@ type controllerRevisionInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newControllerRevisionInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewControllerRevisionInformer constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewControllerRevisionInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.AppsV1beta1().ControllerRevisions(v1.NamespaceAll).List(options)
+				return client.AppsV1beta1().ControllerRevisions(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.AppsV1beta1().ControllerRevisions(v1.NamespaceAll).Watch(options)
+				return client.AppsV1beta1().ControllerRevisions(namespace).Watch(options)
 			},
 		},
 		&apps_v1beta1.ControllerRevision{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultControllerRevisionInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewControllerRevisionInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apps_v1beta1.ControllerRevision{}, newControllerRevisionInformer)
+	return f.factory.InformerFor(&apps_v1beta1.ControllerRevision{}, defaultControllerRevisionInformer)
 }
 
 func (f *controllerRevisionInformer) Lister() v1beta1.ControllerRevisionLister {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
@@ -41,26 +41,31 @@ type deploymentInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.AppsV1beta1().Deployments(v1.NamespaceAll).List(options)
+				return client.AppsV1beta1().Deployments(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.AppsV1beta1().Deployments(v1.NamespaceAll).Watch(options)
+				return client.AppsV1beta1().Deployments(namespace).Watch(options)
 			},
 		},
 		&apps_v1beta1.Deployment{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewDeploymentInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apps_v1beta1.Deployment{}, newDeploymentInformer)
+	return f.factory.InformerFor(&apps_v1beta1.Deployment{}, defaultDeploymentInformer)
 }
 
 func (f *deploymentInformer) Lister() v1beta1.DeploymentLister {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
@@ -41,26 +41,31 @@ type statefulSetInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newStatefulSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewStatefulSetInformer constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.AppsV1beta1().StatefulSets(v1.NamespaceAll).List(options)
+				return client.AppsV1beta1().StatefulSets(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.AppsV1beta1().StatefulSets(v1.NamespaceAll).Watch(options)
+				return client.AppsV1beta1().StatefulSets(namespace).Watch(options)
 			},
 		},
 		&apps_v1beta1.StatefulSet{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultStatefulSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewStatefulSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apps_v1beta1.StatefulSet{}, newStatefulSetInformer)
+	return f.factory.InformerFor(&apps_v1beta1.StatefulSet{}, defaultStatefulSetInformer)
 }
 
 func (f *statefulSetInformer) Lister() v1beta1.StatefulSetLister {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
@@ -41,26 +41,31 @@ type deploymentInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.AppsV1beta2().Deployments(v1.NamespaceAll).List(options)
+				return client.AppsV1beta2().Deployments(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.AppsV1beta2().Deployments(v1.NamespaceAll).Watch(options)
+				return client.AppsV1beta2().Deployments(namespace).Watch(options)
 			},
 		},
 		&apps_v1beta2.Deployment{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewDeploymentInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apps_v1beta2.Deployment{}, newDeploymentInformer)
+	return f.factory.InformerFor(&apps_v1beta2.Deployment{}, defaultDeploymentInformer)
 }
 
 func (f *deploymentInformer) Lister() v1beta2.DeploymentLister {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
@@ -41,26 +41,31 @@ type statefulSetInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newStatefulSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewStatefulSetInformer constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.AppsV1beta2().StatefulSets(v1.NamespaceAll).List(options)
+				return client.AppsV1beta2().StatefulSets(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.AppsV1beta2().StatefulSets(v1.NamespaceAll).Watch(options)
+				return client.AppsV1beta2().StatefulSets(namespace).Watch(options)
 			},
 		},
 		&apps_v1beta2.StatefulSet{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultStatefulSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewStatefulSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&apps_v1beta2.StatefulSet{}, newStatefulSetInformer)
+	return f.factory.InformerFor(&apps_v1beta2.StatefulSet{}, defaultStatefulSetInformer)
 }
 
 func (f *statefulSetInformer) Lister() v1beta2.StatefulSetLister {

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2alpha1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2alpha1/horizontalpodautoscaler.go
@@ -41,26 +41,31 @@ type horizontalPodAutoscalerInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newHorizontalPodAutoscalerInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewHorizontalPodAutoscalerInformer constructs a new informer for HorizontalPodAutoscaler type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.AutoscalingV2alpha1().HorizontalPodAutoscalers(v1.NamespaceAll).List(options)
+				return client.AutoscalingV2alpha1().HorizontalPodAutoscalers(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.AutoscalingV2alpha1().HorizontalPodAutoscalers(v1.NamespaceAll).Watch(options)
+				return client.AutoscalingV2alpha1().HorizontalPodAutoscalers(namespace).Watch(options)
 			},
 		},
 		&autoscaling_v2alpha1.HorizontalPodAutoscaler{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultHorizontalPodAutoscalerInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewHorizontalPodAutoscalerInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *horizontalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&autoscaling_v2alpha1.HorizontalPodAutoscaler{}, newHorizontalPodAutoscalerInformer)
+	return f.factory.InformerFor(&autoscaling_v2alpha1.HorizontalPodAutoscaler{}, defaultHorizontalPodAutoscalerInformer)
 }
 
 func (f *horizontalPodAutoscalerInformer) Lister() v2alpha1.HorizontalPodAutoscalerLister {

--- a/staging/src/k8s.io/client-go/informers/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v2alpha1/cronjob.go
@@ -41,26 +41,31 @@ type cronJobInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newCronJobInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewCronJobInformer constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCronJobInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.BatchV2alpha1().CronJobs(v1.NamespaceAll).List(options)
+				return client.BatchV2alpha1().CronJobs(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.BatchV2alpha1().CronJobs(v1.NamespaceAll).Watch(options)
+				return client.BatchV2alpha1().CronJobs(namespace).Watch(options)
 			},
 		},
 		&batch_v2alpha1.CronJob{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultCronJobInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewCronJobInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&batch_v2alpha1.CronJob{}, newCronJobInformer)
+	return f.factory.InformerFor(&batch_v2alpha1.CronJob{}, defaultCronJobInformer)
 }
 
 func (f *cronJobInformer) Lister() v2alpha1.CronJobLister {

--- a/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/informers/certificates/v1beta1/certificatesigningrequest.go
@@ -41,8 +41,11 @@ type certificateSigningRequestInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewCertificateSigningRequestInformer constructs a new informer for CertificateSigningRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.CertificatesV1beta1().CertificateSigningRequests().List(options)
@@ -53,14 +56,16 @@ func newCertificateSigningRequestInformer(client kubernetes.Interface, resyncPer
 		},
 		&certificates_v1beta1.CertificateSigningRequest{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultCertificateSigningRequestInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewCertificateSigningRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *certificateSigningRequestInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&certificates_v1beta1.CertificateSigningRequest{}, newCertificateSigningRequestInformer)
+	return f.factory.InformerFor(&certificates_v1beta1.CertificateSigningRequest{}, defaultCertificateSigningRequestInformer)
 }
 
 func (f *certificateSigningRequestInformer) Lister() v1beta1.CertificateSigningRequestLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
@@ -41,26 +41,31 @@ type configMapInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newConfigMapInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewConfigMapInformer constructs a new informer for ConfigMap type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewConfigMapInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().ConfigMaps(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().ConfigMaps(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().ConfigMaps(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().ConfigMaps(namespace).Watch(options)
 			},
 		},
 		&core_v1.ConfigMap{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultConfigMapInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewConfigMapInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *configMapInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.ConfigMap{}, newConfigMapInformer)
+	return f.factory.InformerFor(&core_v1.ConfigMap{}, defaultConfigMapInformer)
 }
 
 func (f *configMapInformer) Lister() v1.ConfigMapLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
@@ -41,26 +41,31 @@ type endpointsInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newEndpointsInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewEndpointsInformer constructs a new informer for Endpoints type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewEndpointsInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().Endpoints(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().Endpoints(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().Endpoints(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().Endpoints(namespace).Watch(options)
 			},
 		},
 		&core_v1.Endpoints{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultEndpointsInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewEndpointsInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *endpointsInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.Endpoints{}, newEndpointsInformer)
+	return f.factory.InformerFor(&core_v1.Endpoints{}, defaultEndpointsInformer)
 }
 
 func (f *endpointsInformer) Lister() v1.EndpointsLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/event.go
@@ -41,26 +41,31 @@ type eventInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newEventInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewEventInformer constructs a new informer for Event type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewEventInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().Events(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().Events(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().Events(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().Events(namespace).Watch(options)
 			},
 		},
 		&core_v1.Event{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultEventInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewEventInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *eventInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.Event{}, newEventInformer)
+	return f.factory.InformerFor(&core_v1.Event{}, defaultEventInformer)
 }
 
 func (f *eventInformer) Lister() v1.EventLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
@@ -41,26 +41,31 @@ type limitRangeInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newLimitRangeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewLimitRangeInformer constructs a new informer for LimitRange type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewLimitRangeInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().LimitRanges(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().LimitRanges(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().LimitRanges(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().LimitRanges(namespace).Watch(options)
 			},
 		},
 		&core_v1.LimitRange{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultLimitRangeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewLimitRangeInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *limitRangeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.LimitRange{}, newLimitRangeInformer)
+	return f.factory.InformerFor(&core_v1.LimitRange{}, defaultLimitRangeInformer)
 }
 
 func (f *limitRangeInformer) Lister() v1.LimitRangeLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/node.go
@@ -41,8 +41,11 @@ type nodeInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewNodeInformer constructs a new informer for Node type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
 				return client.CoreV1().Nodes().List(options)
@@ -53,14 +56,16 @@ func newNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration) ca
 		},
 		&core_v1.Node{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewNodeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *nodeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.Node{}, newNodeInformer)
+	return f.factory.InformerFor(&core_v1.Node{}, defaultNodeInformer)
 }
 
 func (f *nodeInformer) Lister() v1.NodeLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
@@ -41,8 +41,11 @@ type persistentVolumeInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPersistentVolumeInformer constructs a new informer for PersistentVolume type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
 				return client.CoreV1().PersistentVolumes().List(options)
@@ -53,14 +56,16 @@ func newPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.
 		},
 		&core_v1.PersistentVolume{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPersistentVolumeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *persistentVolumeInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.PersistentVolume{}, newPersistentVolumeInformer)
+	return f.factory.InformerFor(&core_v1.PersistentVolume{}, defaultPersistentVolumeInformer)
 }
 
 func (f *persistentVolumeInformer) Lister() v1.PersistentVolumeLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
@@ -41,26 +41,31 @@ type persistentVolumeClaimInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPersistentVolumeClaimInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPersistentVolumeClaimInformer constructs a new informer for PersistentVolumeClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPersistentVolumeClaimInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().PersistentVolumeClaims(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().PersistentVolumeClaims(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().PersistentVolumeClaims(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().PersistentVolumeClaims(namespace).Watch(options)
 			},
 		},
 		&core_v1.PersistentVolumeClaim{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPersistentVolumeClaimInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPersistentVolumeClaimInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *persistentVolumeClaimInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.PersistentVolumeClaim{}, newPersistentVolumeClaimInformer)
+	return f.factory.InformerFor(&core_v1.PersistentVolumeClaim{}, defaultPersistentVolumeClaimInformer)
 }
 
 func (f *persistentVolumeClaimInformer) Lister() v1.PersistentVolumeClaimLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/pod.go
@@ -41,26 +41,31 @@ type podInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPodInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPodInformer constructs a new informer for Pod type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().Pods(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().Pods(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().Pods(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().Pods(namespace).Watch(options)
 			},
 		},
 		&core_v1.Pod{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPodInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPodInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.Pod{}, newPodInformer)
+	return f.factory.InformerFor(&core_v1.Pod{}, defaultPodInformer)
 }
 
 func (f *podInformer) Lister() v1.PodLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
@@ -41,26 +41,31 @@ type podTemplateInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPodTemplateInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPodTemplateInformer constructs a new informer for PodTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodTemplateInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().PodTemplates(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().PodTemplates(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().PodTemplates(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().PodTemplates(namespace).Watch(options)
 			},
 		},
 		&core_v1.PodTemplate{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPodTemplateInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPodTemplateInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podTemplateInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.PodTemplate{}, newPodTemplateInformer)
+	return f.factory.InformerFor(&core_v1.PodTemplate{}, defaultPodTemplateInformer)
 }
 
 func (f *podTemplateInformer) Lister() v1.PodTemplateLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
@@ -41,26 +41,31 @@ type resourceQuotaInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newResourceQuotaInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewResourceQuotaInformer constructs a new informer for ResourceQuota type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewResourceQuotaInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().ResourceQuotas(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().ResourceQuotas(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().ResourceQuotas(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().ResourceQuotas(namespace).Watch(options)
 			},
 		},
 		&core_v1.ResourceQuota{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultResourceQuotaInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewResourceQuotaInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *resourceQuotaInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.ResourceQuota{}, newResourceQuotaInformer)
+	return f.factory.InformerFor(&core_v1.ResourceQuota{}, defaultResourceQuotaInformer)
 }
 
 func (f *resourceQuotaInformer) Lister() v1.ResourceQuotaLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/secret.go
@@ -41,26 +41,31 @@ type secretInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newSecretInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewSecretInformer constructs a new informer for Secret type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewSecretInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().Secrets(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().Secrets(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().Secrets(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().Secrets(namespace).Watch(options)
 			},
 		},
 		&core_v1.Secret{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultSecretInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewSecretInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *secretInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.Secret{}, newSecretInformer)
+	return f.factory.InformerFor(&core_v1.Secret{}, defaultSecretInformer)
 }
 
 func (f *secretInformer) Lister() v1.SecretLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/service.go
@@ -41,26 +41,31 @@ type serviceInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newServiceInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewServiceInformer constructs a new informer for Service type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewServiceInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().Services(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().Services(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().Services(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().Services(namespace).Watch(options)
 			},
 		},
 		&core_v1.Service{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultServiceInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewServiceInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *serviceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.Service{}, newServiceInformer)
+	return f.factory.InformerFor(&core_v1.Service{}, defaultServiceInformer)
 }
 
 func (f *serviceInformer) Lister() v1.ServiceLister {

--- a/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
@@ -41,26 +41,31 @@ type serviceAccountInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newServiceAccountInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewServiceAccountInformer constructs a new informer for ServiceAccount type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewServiceAccountInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.CoreV1().ServiceAccounts(meta_v1.NamespaceAll).List(options)
+				return client.CoreV1().ServiceAccounts(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.CoreV1().ServiceAccounts(meta_v1.NamespaceAll).Watch(options)
+				return client.CoreV1().ServiceAccounts(namespace).Watch(options)
 			},
 		},
 		&core_v1.ServiceAccount{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultServiceAccountInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewServiceAccountInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *serviceAccountInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&core_v1.ServiceAccount{}, newServiceAccountInformer)
+	return f.factory.InformerFor(&core_v1.ServiceAccount{}, defaultServiceAccountInformer)
 }
 
 func (f *serviceAccountInformer) Lister() v1.ServiceAccountLister {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
@@ -41,26 +41,31 @@ type daemonSetInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newDaemonSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewDaemonSetInformer constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDaemonSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.ExtensionsV1beta1().DaemonSets(v1.NamespaceAll).List(options)
+				return client.ExtensionsV1beta1().DaemonSets(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.ExtensionsV1beta1().DaemonSets(v1.NamespaceAll).Watch(options)
+				return client.ExtensionsV1beta1().DaemonSets(namespace).Watch(options)
 			},
 		},
 		&extensions_v1beta1.DaemonSet{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultDaemonSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewDaemonSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions_v1beta1.DaemonSet{}, newDaemonSetInformer)
+	return f.factory.InformerFor(&extensions_v1beta1.DaemonSet{}, defaultDaemonSetInformer)
 }
 
 func (f *daemonSetInformer) Lister() v1beta1.DaemonSetLister {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
@@ -41,26 +41,31 @@ type deploymentInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewDeploymentInformer constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDeploymentInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.ExtensionsV1beta1().Deployments(v1.NamespaceAll).List(options)
+				return client.ExtensionsV1beta1().Deployments(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.ExtensionsV1beta1().Deployments(v1.NamespaceAll).Watch(options)
+				return client.ExtensionsV1beta1().Deployments(namespace).Watch(options)
 			},
 		},
 		&extensions_v1beta1.Deployment{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewDeploymentInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions_v1beta1.Deployment{}, newDeploymentInformer)
+	return f.factory.InformerFor(&extensions_v1beta1.Deployment{}, defaultDeploymentInformer)
 }
 
 func (f *deploymentInformer) Lister() v1beta1.DeploymentLister {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
@@ -41,26 +41,31 @@ type ingressInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newIngressInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewIngressInformer constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewIngressInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.ExtensionsV1beta1().Ingresses(v1.NamespaceAll).List(options)
+				return client.ExtensionsV1beta1().Ingresses(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.ExtensionsV1beta1().Ingresses(v1.NamespaceAll).Watch(options)
+				return client.ExtensionsV1beta1().Ingresses(namespace).Watch(options)
 			},
 		},
 		&extensions_v1beta1.Ingress{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultIngressInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewIngressInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *ingressInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions_v1beta1.Ingress{}, newIngressInformer)
+	return f.factory.InformerFor(&extensions_v1beta1.Ingress{}, defaultIngressInformer)
 }
 
 func (f *ingressInformer) Lister() v1beta1.IngressLister {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
@@ -41,26 +41,31 @@ type replicaSetInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newReplicaSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewReplicaSetInformer constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.ExtensionsV1beta1().ReplicaSets(v1.NamespaceAll).List(options)
+				return client.ExtensionsV1beta1().ReplicaSets(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.ExtensionsV1beta1().ReplicaSets(v1.NamespaceAll).Watch(options)
+				return client.ExtensionsV1beta1().ReplicaSets(namespace).Watch(options)
 			},
 		},
 		&extensions_v1beta1.ReplicaSet{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultReplicaSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewReplicaSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions_v1beta1.ReplicaSet{}, newReplicaSetInformer)
+	return f.factory.InformerFor(&extensions_v1beta1.ReplicaSet{}, defaultReplicaSetInformer)
 }
 
 func (f *replicaSetInformer) Lister() v1beta1.ReplicaSetLister {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/thirdpartyresource.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/thirdpartyresource.go
@@ -41,8 +41,11 @@ type thirdPartyResourceInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newThirdPartyResourceInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewThirdPartyResourceInformer constructs a new informer for ThirdPartyResource type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewThirdPartyResourceInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.ExtensionsV1beta1().ThirdPartyResources().List(options)
@@ -53,14 +56,16 @@ func newThirdPartyResourceInformer(client kubernetes.Interface, resyncPeriod tim
 		},
 		&extensions_v1beta1.ThirdPartyResource{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultThirdPartyResourceInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewThirdPartyResourceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *thirdPartyResourceInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&extensions_v1beta1.ThirdPartyResource{}, newThirdPartyResourceInformer)
+	return f.factory.InformerFor(&extensions_v1beta1.ThirdPartyResource{}, defaultThirdPartyResourceInformer)
 }
 
 func (f *thirdPartyResourceInformer) Lister() v1beta1.ThirdPartyResourceLister {

--- a/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
@@ -41,26 +41,31 @@ type networkPolicyInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newNetworkPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewNetworkPolicyInformer constructs a new informer for NetworkPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNetworkPolicyInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
-				return client.NetworkingV1().NetworkPolicies(meta_v1.NamespaceAll).List(options)
+				return client.NetworkingV1().NetworkPolicies(namespace).List(options)
 			},
 			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
-				return client.NetworkingV1().NetworkPolicies(meta_v1.NamespaceAll).Watch(options)
+				return client.NetworkingV1().NetworkPolicies(namespace).Watch(options)
 			},
 		},
 		&networking_v1.NetworkPolicy{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultNetworkPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewNetworkPolicyInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *networkPolicyInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&networking_v1.NetworkPolicy{}, newNetworkPolicyInformer)
+	return f.factory.InformerFor(&networking_v1.NetworkPolicy{}, defaultNetworkPolicyInformer)
 }
 
 func (f *networkPolicyInformer) Lister() v1.NetworkPolicyLister {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
@@ -41,8 +41,11 @@ type clusterRoleInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.RbacV1alpha1().ClusterRoles().List(options)
@@ -53,14 +56,16 @@ func newClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Durat
 		},
 		&rbac_v1alpha1.ClusterRole{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac_v1alpha1.ClusterRole{}, newClusterRoleInformer)
+	return f.factory.InformerFor(&rbac_v1alpha1.ClusterRole{}, defaultClusterRoleInformer)
 }
 
 func (f *clusterRoleInformer) Lister() v1alpha1.ClusterRoleLister {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
@@ -41,26 +41,31 @@ type roleInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.RbacV1alpha1().Roles(v1.NamespaceAll).List(options)
+				return client.RbacV1alpha1().Roles(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.RbacV1alpha1().Roles(v1.NamespaceAll).Watch(options)
+				return client.RbacV1alpha1().Roles(namespace).Watch(options)
 			},
 		},
 		&rbac_v1alpha1.Role{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewRoleInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac_v1alpha1.Role{}, newRoleInformer)
+	return f.factory.InformerFor(&rbac_v1alpha1.Role{}, defaultRoleInformer)
 }
 
 func (f *roleInformer) Lister() v1alpha1.RoleLister {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
@@ -41,8 +41,11 @@ type clusterRoleInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewClusterRoleInformer constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.RbacV1beta1().ClusterRoles().List(options)
@@ -53,14 +56,16 @@ func newClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Durat
 		},
 		&rbac_v1beta1.ClusterRole{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac_v1beta1.ClusterRole{}, newClusterRoleInformer)
+	return f.factory.InformerFor(&rbac_v1beta1.ClusterRole{}, defaultClusterRoleInformer)
 }
 
 func (f *clusterRoleInformer) Lister() v1beta1.ClusterRoleLister {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrolebinding.go
@@ -41,8 +41,11 @@ type clusterRoleBindingInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewClusterRoleBindingInformer constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.RbacV1beta1().ClusterRoleBindings().List(options)
@@ -53,14 +56,16 @@ func newClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod tim
 		},
 		&rbac_v1beta1.ClusterRoleBinding{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewClusterRoleBindingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac_v1beta1.ClusterRoleBinding{}, newClusterRoleBindingInformer)
+	return f.factory.InformerFor(&rbac_v1beta1.ClusterRoleBinding{}, defaultClusterRoleBindingInformer)
 }
 
 func (f *clusterRoleBindingInformer) Lister() v1beta1.ClusterRoleBindingLister {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
@@ -41,26 +41,31 @@ type roleInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewRoleInformer constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.RbacV1beta1().Roles(v1.NamespaceAll).List(options)
+				return client.RbacV1beta1().Roles(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.RbacV1beta1().Roles(v1.NamespaceAll).Watch(options)
+				return client.RbacV1beta1().Roles(namespace).Watch(options)
 			},
 		},
 		&rbac_v1beta1.Role{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewRoleInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac_v1beta1.Role{}, newRoleInformer)
+	return f.factory.InformerFor(&rbac_v1beta1.Role{}, defaultRoleInformer)
 }
 
 func (f *roleInformer) Lister() v1beta1.RoleLister {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
@@ -41,26 +41,31 @@ type roleBindingInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewRoleBindingInformer constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.RbacV1beta1().RoleBindings(v1.NamespaceAll).List(options)
+				return client.RbacV1beta1().RoleBindings(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.RbacV1beta1().RoleBindings(v1.NamespaceAll).Watch(options)
+				return client.RbacV1beta1().RoleBindings(namespace).Watch(options)
 			},
 		},
 		&rbac_v1beta1.RoleBinding{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewRoleBindingInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&rbac_v1beta1.RoleBinding{}, newRoleBindingInformer)
+	return f.factory.InformerFor(&rbac_v1beta1.RoleBinding{}, defaultRoleBindingInformer)
 }
 
 func (f *roleBindingInformer) Lister() v1beta1.RoleBindingLister {

--- a/staging/src/k8s.io/client-go/informers/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/informers/settings/v1alpha1/podpreset.go
@@ -41,26 +41,31 @@ type podPresetInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newPodPresetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewPodPresetInformer constructs a new informer for PodPreset type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodPresetInformer(client kubernetes.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.SettingsV1alpha1().PodPresets(v1.NamespaceAll).List(options)
+				return client.SettingsV1alpha1().PodPresets(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.SettingsV1alpha1().PodPresets(v1.NamespaceAll).Watch(options)
+				return client.SettingsV1alpha1().PodPresets(namespace).Watch(options)
 			},
 		},
 		&settings_v1alpha1.PodPreset{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultPodPresetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewPodPresetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podPresetInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&settings_v1alpha1.PodPreset{}, newPodPresetInformer)
+	return f.factory.InformerFor(&settings_v1alpha1.PodPreset{}, defaultPodPresetInformer)
 }
 
 func (f *podPresetInformer) Lister() v1alpha1.PodPresetLister {

--- a/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1/storageclass.go
@@ -41,8 +41,11 @@ type storageClassInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewStorageClassInformer constructs a new informer for StorageClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
 				return client.StorageV1().StorageClasses().List(options)
@@ -53,14 +56,16 @@ func newStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 		},
 		&storage_v1.StorageClass{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewStorageClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *storageClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&storage_v1.StorageClass{}, newStorageClassInformer)
+	return f.factory.InformerFor(&storage_v1.StorageClass{}, defaultStorageClassInformer)
 }
 
 func (f *storageClassInformer) Lister() v1.StorageClassLister {

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
@@ -41,8 +41,11 @@ type storageClassInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewStorageClassInformer constructs a new informer for StorageClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
 				return client.StorageV1beta1().StorageClasses().List(options)
@@ -53,14 +56,16 @@ func newStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 		},
 		&storage_v1beta1.StorageClass{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewStorageClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *storageClassInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&storage_v1beta1.StorageClass{}, newStorageClassInformer)
+	return f.factory.InformerFor(&storage_v1beta1.StorageClass{}, defaultStorageClassInformer)
 }
 
 func (f *storageClassInformer) Lister() v1beta1.StorageClassLister {

--- a/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/informer.go
@@ -96,11 +96,8 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 
 	sw.Do(typeInformerInterface, m)
 	sw.Do(typeInformerStruct, m)
-	if len(g.groupVersion.Version) == 0 {
-		sw.Do(typeInformerConstructorInternal, m)
-	} else {
-		sw.Do(typeInformerConstructorVersioned, m)
-	}
+	sw.Do(typeInformerPublicConstructor, m)
+	sw.Do(typeInformerConstructor, m)
 	sw.Do(typeInformerInformer, m)
 	sw.Do(typeInformerLister, m)
 
@@ -122,49 +119,36 @@ type $.type|private$Informer struct {
 }
 `
 
-var typeInformerConstructorInternal = `
-func new$.type|public$Informer(client $.clientSetInterface|raw$, resyncPeriod $.timeDuration|raw$) $.cacheSharedIndexInformer|raw$ {
-	sharedIndexInformer := $.cacheNewSharedIndexInformer|raw$(
+var typeInformerPublicConstructor = `
+// New$.type|public$Informer constructs a new informer for $.type|public$ type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func New$.type|public$Informer(client $.clientSetInterface|raw$$if .namespaced$, namespace string$end$, resyncPeriod $.timeDuration|raw$, indexers $.cacheIndexers|raw$) $.cacheSharedIndexInformer|raw$ {
+	return $.cacheNewSharedIndexInformer|raw$(
 		&$.cacheListWatch|raw${
 			ListFunc: func(options $.v1ListOptions|raw$) ($.runtimeObject|raw$, error) {
-				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$$.namespaceAll|raw$$end$).List(options)
+				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).List(options)
 			},
 			WatchFunc: func(options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
-				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$$.namespaceAll|raw$$end$).Watch(options)
+				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).Watch(options)
 			},
 		},
 		&$.type|raw${},
 		resyncPeriod,
-		$.cacheIndexers|raw${$.cacheNamespaceIndex|raw$: $.cacheMetaNamespaceIndexFunc|raw$},
+		indexers,
 	)
-
-	return sharedIndexInformer
 }
 `
 
-var typeInformerConstructorVersioned = `
-func new$.type|public$Informer(client $.clientSetInterface|raw$, resyncPeriod $.timeDuration|raw$) $.cacheSharedIndexInformer|raw$ {
-	sharedIndexInformer := $.cacheNewSharedIndexInformer|raw$(
-		&$.cacheListWatch|raw${
-			ListFunc: func(options $.v1ListOptions|raw$) ($.runtimeObject|raw$, error) {
-				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$$.namespaceAll|raw$$end$).List(options)
-			},
-			WatchFunc: func(options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
-				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$$.namespaceAll|raw$$end$).Watch(options)
-			},
-		},
-		&$.type|raw${},
-		resyncPeriod,
-		$.cacheIndexers|raw${$.cacheNamespaceIndex|raw$: $.cacheMetaNamespaceIndexFunc|raw$},
-	)
-
-	return sharedIndexInformer
+var typeInformerConstructor = `
+func default$.type|public$Informer(client $.clientSetInterface|raw$, resyncPeriod $.timeDuration|raw$) $.cacheSharedIndexInformer|raw$ {
+	return New$.type|public$Informer(client, $if .namespaced$$.namespaceAll|raw$, $end$resyncPeriod, $.cacheIndexers|raw${$.cacheNamespaceIndex|raw$: $.cacheMetaNamespaceIndexFunc|raw$})
 }
 `
 
 var typeInformerInformer = `
 func (f *$.type|private$Informer) Informer() $.cacheSharedIndexInformer|raw$ {
-	return f.factory.$.informerFor$(&$.type|raw${}, new$.type|public$Informer)
+	return f.factory.$.informerFor$(&$.type|raw${}, default$.type|public$Informer)
 }
 `
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/wardle/internalversion/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/wardle/internalversion/flunder.go
@@ -41,26 +41,31 @@ type flunderInformer struct {
 	factory internalinterfaces.SharedInformerFactory
 }
 
-func newFlunderInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	sharedIndexInformer := cache.NewSharedIndexInformer(
+// NewFlunderInformer constructs a new informer for Flunder type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewFlunderInformer(client internalclientset.Interface, namespace string, resyncPeriod time.Duration, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformer(
 		&cache.ListWatch{
 			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
-				return client.Wardle().Flunders(v1.NamespaceAll).List(options)
+				return client.Wardle().Flunders(namespace).List(options)
 			},
 			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
-				return client.Wardle().Flunders(v1.NamespaceAll).Watch(options)
+				return client.Wardle().Flunders(namespace).Watch(options)
 			},
 		},
 		&wardle.Flunder{},
 		resyncPeriod,
-		cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		indexers,
 	)
+}
 
-	return sharedIndexInformer
+func defaultFlunderInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+	return NewFlunderInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *flunderInformer) Informer() cache.SharedIndexInformer {
-	return f.factory.InformerFor(&wardle.Flunder{}, newFlunderInformer)
+	return f.factory.InformerFor(&wardle.Flunder{}, defaultFlunderInformer)
 }
 
 func (f *flunderInformer) Lister() internalversion.FlunderLister {


### PR DESCRIPTION
**What this PR does / why we need it**:
See #45939

**Which issue this PR fixes**
Fixes #45939

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
