### PR TITLE
remove useless flags from hack/verify-flags/known-flags.txt

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -86,7 +86,6 @@ cgroups-per-qos
 chaos-chance
 cidr-allocator-type
 clean-start
-cleanup
 cleanup-iptables
 client-ca-file
 client-certificate
@@ -274,7 +273,6 @@ federation-name
 federation-system-namespace
 federation-upgrade-target
 file-check-frequency
-file_content_in_loop
 file-suffix
 flex-volume-plugin-dir
 forward-services
@@ -303,7 +301,6 @@ google-json-key
 grace-period
 ha-domain
 hairpin-mode
-hard
 hard-pod-affinity-symmetric-weight
 healthz-bind-address
 healthz-port
@@ -564,7 +561,6 @@ pv-recycler-minimum-timeout-nfs
 pv-recycler-pod-template-filepath-hostpath
 pv-recycler-pod-template-filepath-nfs
 pv-recycler-timeout-increment-hostpath
-quiet
 read-only-port
 really-crash-for-testing
 reconcile-cidr
@@ -593,13 +589,11 @@ requestheader-username-headers
 required-contexts
 require-kubeconfig
 resolv-conf
-resource
 resource-container
 resource-name
 resource-quota-sync-period
 resource-version
 results-dir
-retry_time
 rkt-api-endpoint
 rkt-path
 rkt-stage1-image
@@ -618,7 +612,6 @@ schedule-pods-here
 scheduler-config
 scheduler-name
 schema-cache-dir
-scopes
 scrape-timeout
 seccomp-profile-root
 secondary-node-eviction-rate
@@ -669,7 +662,6 @@ storage-media-type
 storage-version
 storage-versions
 streaming-connection-idle-timeout
-subresource
 suicide-timeout
 sync-frequency
 system-cgroups
@@ -712,7 +704,6 @@ use-service-account-credentials
 user-whitelist
 use-service-account-credentials
 use-taint-based-evictions
-verb
 verify-only
 versioned-clientset-package
 viper-config


### PR DESCRIPTION
Flags in known-flags.txt is used to check misspelling from "-" to "_" in
workspace, so a flag with out "-" should not show up in this file.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
