### PR TITLE
Ignored mirror pods in PodPreset admission plugin

### DIFF
--- a/plugin/pkg/admission/podpreset/admission.go
+++ b/plugin/pkg/admission/podpreset/admission.go
@@ -97,6 +97,11 @@ func (c *podPresetPlugin) Admit(a admission.Attributes) error {
 	if !ok {
 		return errors.NewBadRequest("Resource was marked with kind Pod but was unable to be converted")
 	}
+
+	if _, isMirrorPod := pod.Annotations[api.MirrorPodAnnotationKey]; isMirrorPod {
+		return nil
+	}
+
 	list, err := c.lister.PodPresets(pod.GetNamespace()).List(labels.Everything())
 	if err != nil {
 		return fmt.Errorf("listing pod presets failed: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Ignored mirror pods in PodPreset admission plugin.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #45925 

**Release note**:

```release-note
Ignored mirror pods in PodPreset admission plugin.
```
