### PR TITLE
IPv6 support for hexCIDR()

### DIFF
--- a/pkg/util/bandwidth/linux.go
+++ b/pkg/util/bandwidth/linux.go
@@ -101,7 +101,7 @@ func hexCIDR(cidr string) (string, error) {
 		return "", err
 	}
 	ip = ip.Mask(ipnet.Mask)
-	hexIP := hex.EncodeToString([]byte(ip.To4()))
+	hexIP := hex.EncodeToString([]byte(ip))
 	hexMask := ipnet.Mask.String()
 	return hexIP + "/" + hexMask, nil
 }
@@ -119,6 +119,9 @@ func asciiCIDR(cidr string) (string, error) {
 	ip := net.IP(ipData)
 
 	maskData, err := hex.DecodeString(parts[1])
+	if err != nil {
+		return "", err
+	}
 	mask := net.IPMask(maskData)
 	size, _ := mask.Size()
 


### PR DESCRIPTION
Includes these changes:
- Modified so that IPv6 CIDRs can be converted correctly.
- Added test cases for IPv6 addresses.
- Split UTs for hexCIDR() and asciiCIDR() so that masking can be tested.
- Add UTs for failure cases.

Note: Some code that calls hexCIDR() builds a CIDR from the pod IP string
and the concatenation of "/32". These should, in the future, use "128",
if/when the pod IP is IPv6. Not addressed as part of this commit.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #45906

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-noteNONE
```
