### PR TITLE
examples/podsecuritypolicy/rbac: allow to use projected volumes in restricted PSP

### DIFF
--- a/examples/podsecuritypolicy/rbac/policies.yaml
+++ b/examples/podsecuritypolicy/rbac/policies.yaml
@@ -35,4 +35,5 @@ spec:
   - 'downwardAPI'
   - 'configMap'
   - 'persistentVolumeClaim'
+  - 'projected'
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies `restricted` PSP to allow `projected` volume type. No need to modify `privileged` PSP because it already allows all volume types.

It should not add any harm because `projected` uses configmaps, downward API, and secrets that are already permitted.

**Special notes for your reviewer**:
This was inspired by similar change in the OpenShift: https://github.com/openshift/origin/pull/14147

**Release note**:
```release-note
NONE
```

PTAL @pweil- @derekwaynecarr 
CC @mfojtik 