### PR TITLE
More owners from SIG-CLI

### DIFF
--- a/cmd/clicheck/OWNERS
+++ b/cmd/clicheck/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- sig-cli-maintainers
+reviewers:
+- sig-cli

--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -9,11 +9,13 @@ reviewers:
 approvers:
   - deads2k
   - eparis
+  - fabianofranz
   - fejta
   - ixdy
   - jbeda
   - lavalamp
   - madhusudancs
+  - pwittrock
   - shashidharatd
   - spxtr
   - zmerlynn


### PR DESCRIPTION
Adds SIG-CLI as reviewers and approvers of `cmd/clicheck/` and adds me + @pwittrock as approvers in `hack/` (mostly for `test-cmd` and some `hack/verify*.sh` and `hack/update*.sh` scripts).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
