### PR TITLE
Move govet verify into rest of verify*-.sh scripts

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -54,7 +54,7 @@ KUBE_GOLDFLAGS := $(GOLDFLAGS)
 KUBE_GOGCFLAGS = $(GOGCFLAGS)
 
 # Extra options for the release or quick-release options:
-KUBE_RELEASE_RUN_TESTS := $(KUBE_RELEASE_RUN_TESTS) 
+KUBE_RELEASE_RUN_TESTS := $(KUBE_RELEASE_RUN_TESTS)
 KUBE_FASTBUILD := $(KUBE_FASTBUILD)
 
 # This controls the verbosity of the build.  Higher numbers mean more output.
@@ -121,7 +121,6 @@ verify:
 else
 verify: verify_generated_files
 	KUBE_VERIFY_GIT_BRANCH=$(BRANCH) hack/make-rules/verify.sh -v
-	hack/make-rules/vet.sh
 endif
 
 define UPDATE_HELP_INFO
@@ -340,8 +339,8 @@ ifeq ($(PRINT_HELP),y)
 vet:
 	@echo "$$VET_HELP_INFO"
 else
-vet:
-	hack/make-rules/vet.sh $(WHAT)
+vet: generated_files
+	CALLED_FROM_MAIN_MAKEFILE=1 hack/make-rules/vet.sh $(WHAT)
 endif
 
 define RELEASE_HELP_INFO
@@ -361,7 +360,7 @@ endif
 
 define RELEASE_SKIP_TESTS_HELP_INFO
 # Build a release, but skip tests
-# 
+#
 # Args:
 #   KUBE_RELEASE_RUN_TESTS: Whether to run tests. Set to 'y' to run tests anyways.
 #   KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'true' to do so.

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -25,7 +25,6 @@ source "${KUBE_ROOT}/hack/lib/util.sh"
 EXCLUDED_PATTERNS=(
   "verify-all.sh"                # this script calls the make rule and would cause a loop
   "verify-linkcheck.sh"          # runs in separate Jenkins job once per day due to high network usage
-  "verify-govet.sh"              # it has a separate make vet target
   "verify-test-owners.sh"        # TODO(rmmh): figure out how to avoid endless conflicts
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
   )

--- a/hack/make-rules/vet.sh
+++ b/hack/make-rules/vet.sh
@@ -23,9 +23,16 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 
 cd "${KUBE_ROOT}"
 
+# If called directly, exit.
+if [[ "${CALLED_FROM_MAIN_MAKEFILE:-""}" == "" ]]; then
+    echo "ERROR: $0 should not be run directly." >&2
+    echo >&2
+    echo "Please run this command using \"make vet\""
+    exit 1
+fi
+
 # This is required before we run govet for the results to be correct.
 # See https://github.com/golang/go/issues/16086 for details.
-make generated_files
 go install ./cmd/...
 
 # Use eval to preserve embedded quoted strings.
@@ -46,5 +53,4 @@ if [[ ${#targets[@]} -eq 0 ]]; then
   targets=$(go list -e ./... | egrep -v "/(third_party|vendor|staging|clientset_generated)/")
 fi
 
-set -x
 go vet "${goflags[@]:+${goflags[@]}}" ${targets[@]}

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -28,10 +28,4 @@ if [[ "$#" -gt 0 ]]; then
     ARGHELP="WHAT='$@'"
 fi
 
-echo "NOTE: $0 has been replaced by 'make vet'"
-echo
-echo "The equivalent of this invocation is: "
-echo "    make vet ${ARGHELP}"
-echo
-echo
 make --no-print-directory -C "${KUBE_ROOT}" vet WHAT="$@"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Instead of having two govet scripts, consolidate them to into one and have both the Makefile and verify.sh scripts target the same script. This also will allow proper syntax highlighting and timing when the vet script is run as part of `make verify`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/test-infra/issues/2725

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @fejta @rmmh 