### PR TITLE
[WIP] Don't filter cloud provider nodes. #45118

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -3295,7 +3295,6 @@ func (c *Cloud) findInstanceByNodeName(nodeName types.NodeName) (*ec2.Instance, 
 	privateDNSName := mapNodeNameToPrivateDNSName(nodeName)
 	filters := []*ec2.Filter{
 		newEc2Filter("private-dns-name", privateDNSName),
-		newEc2Filter("instance-state-name", "running"),
 	}
 
 	instances, err := c.describeInstances(filters)

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -300,8 +300,7 @@ func foreachServer(client *gophercloud.ServiceClient, opts servers.ListOptsBuild
 
 func getServerByName(client *gophercloud.ServiceClient, name types.NodeName) (*servers.Server, error) {
 	opts := servers.ListOpts{
-		Name:   fmt.Sprintf("^%s$", regexp.QuoteMeta(mapNodeNameToServerName(name))),
-		Status: "ACTIVE",
+		Name: fmt.Sprintf("^%s$", regexp.QuoteMeta(mapNodeNameToServerName(name))),
 	}
 	pager := servers.List(client, opts)
 

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -27,7 +27,6 @@ import (
 	"net/url"
 	"path"
 	"sort"
-	"strings"
 
 	"gopkg.in/gcfg.v1"
 
@@ -245,8 +244,7 @@ func getInstancesFromXml(body io.Reader) (OVirtInstanceMap, error) {
 	instances := make(OVirtInstanceMap)
 
 	for _, vm := range vmlist.Vm {
-		// Always return only vms that are up and running
-		if vm.Hostname != "" && strings.ToLower(vm.State) == "up" {
+		if vm.Hostname != "" {
 			address := ""
 			if len(vm.Addresses) > 0 {
 				address = vm.Addresses[0].Address

--- a/pkg/cloudprovider/providers/ovirt/ovirt_test.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt_test.go
@@ -115,12 +115,12 @@ func TestOVirtCloudXmlParsing(t *testing.T) {
 	if err4 != nil {
 		t.Fatalf("Unexpected error listing instances: %s", err4)
 	}
-	if len(instances4) != 2 {
+	if len(instances4) != 3 {
 		t.Fatalf("Unexpected number of instance(s): %d", len(instances4))
 	}
 
 	names := instances4.ListSortedNames()
-	if names[0] != "host1" || names[1] != "host3" {
+	if names[0] != "host1" || names[1] != "host2" || names[2] != "host3" {
 		t.Fatalf("Unexpected instance(s): %s", instances4)
 	}
 }

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -287,8 +287,7 @@ func getServerByName(client *gophercloud.ServiceClient, name string) (*osservers
 		return getServerByAddress(client, name)
 	}
 	opts := osservers.ListOpts{
-		Name:   fmt.Sprintf("^%s$", regexp.QuoteMeta(name)),
-		Status: "ACTIVE",
+		Name: fmt.Sprintf("^%s$", regexp.QuoteMeta(name)),
 	}
 	pager := servers.List(client, opts)
 

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -608,17 +608,12 @@ func (vs *VSphere) ExternalID(nodeName k8stypes.NodeName) (string, error) {
 		return "", err
 	}
 
-	if mvm.Summary.Runtime.PowerState == ActivePowerState {
-		return vm.InventoryPath, nil
-	}
-
-	if mvm.Summary.Config.Template == false {
-		glog.Warningf("VM %s, is not in %s state", nodeName, ActivePowerState)
-	} else {
+	if mvm.Summary.Config.Template == true {
 		glog.Warningf("VM %s, is a template", nodeName)
+		return "", cloudprovider.InstanceNotFound
 	}
 
-	return "", cloudprovider.InstanceNotFound
+	return vm.InventoryPath, nil
 }
 
 // InstanceID returns the cloud provider ID of the node with the specified Name.


### PR DESCRIPTION
fixes #45118

WIP.  Only fixed for aws and to be used as a point of discussion and help identify any potential issues with the change.

**Release note**:
If a cloud provider node moved to any state other than available/running then it would be removed from the list of nodes in kubernetes.  That is no longer the case.  The node will not be removed from the list of nodes in kubernetes now but will instead end up marked as any other node that can't be contacted.
