### PR TITLE
[Bug Fix] Return quantity freed even when an error exists

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -1001,13 +1001,10 @@ func deleteImages(imageGC ImageGC, reportBytesFreed bool) nodeReclaimFunc {
 	return func() (*resource.Quantity, error) {
 		glog.Infof("eviction manager: attempting to delete unused images")
 		bytesFreed, err := imageGC.DeleteUnusedImages()
-		if err != nil {
-			return nil, err
-		}
 		reclaimed := int64(0)
 		if reportBytesFreed {
 			reclaimed = bytesFreed
 		}
-		return resource.NewQuantity(reclaimed, resource.BinarySI), nil
+		return resource.NewQuantity(reclaimed, resource.BinarySI), err
 	}
 }


### PR DESCRIPTION
bug was added by #44986.  If we get an error from deleteImages, we try and use the bytes freed in a calculation.
That PR changed the behavior from evicting a pod upon error, to panicking because of the nil pointer.

This should fix inode eviction tests

/assign @dchen1107 