### PR TITLE
Cherrypick of #45990

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -995,13 +995,10 @@ func deleteImages(imageGC ImageGC, reportBytesFreed bool) nodeReclaimFunc {
 	return func() (*resource.Quantity, error) {
 		glog.Infof("eviction manager: attempting to delete unused images")
 		bytesFreed, err := imageGC.DeleteUnusedImages()
-		if err != nil {
-			return nil, err
-		}
 		reclaimed := int64(0)
 		if reportBytesFreed {
 			reclaimed = bytesFreed
 		}
-		return resource.NewQuantity(reclaimed, resource.BinarySI), nil
+		return resource.NewQuantity(reclaimed, resource.BinarySI), err
 	}
 }


### PR DESCRIPTION
Fixes disk eviction for the 1.6 branch.  This has been manually verified to pass the inode eviction test.

Cherrypick of #45990

cc @dchen1107 
/assign @enisoc 

```release-note
Fix kubelet panic during disk eviction introduced in 1.6.3.
```