### PR TITLE
Automated cherry pick of #44104

### DIFF
--- a/test/e2e/cluster_upgrade.go
+++ b/test/e2e/cluster_upgrade.go
@@ -209,8 +209,8 @@ func (cma *chaosMonkeyAdapter) Test(sem *chaosmonkey.Semaphore) {
 		return
 	}
 
-	cma.test.Setup(cma.framework)
 	defer cma.test.Teardown(cma.framework)
+	cma.test.Setup(cma.framework)
 	sem.Ready()
 	cma.test.Test(cma.framework, sem.StopCh, cma.upgradeType)
 }

--- a/test/e2e/upgrades/upgrade.go
+++ b/test/e2e/upgrades/upgrade.go
@@ -56,8 +56,9 @@ type Test interface {
 	// begin.
 	Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType)
 
-	// TearDown should clean up any objects that are created that
-	// aren't already cleaned up by the framework.
+	// Teardown should clean up any objects that are created that
+	// aren't already cleaned up by the framework. This will
+	// always be called, even if Setup failed.
 	Teardown(f *framework.Framework)
 }
 


### PR DESCRIPTION
Cherry pick of #44104 on release-1.6.

#44104: Make sure Teardown is called.

**Release note**:
```release-note
NONE
```