### PR TITLE
Remove ObjectNameFunc from custom resources

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/registry/customresource/etcd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package customresource
 
 import (
-	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,13 +39,6 @@ func NewREST(resource schema.GroupResource, listKind schema.GroupVersionKind, co
 			ret := &unstructured.UnstructuredList{}
 			ret.SetGroupVersionKind(listKind)
 			return ret
-		},
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			accessor, err := meta.Accessor(obj)
-			if err != nil {
-				return "", err
-			}
-			return accessor.GetName(), nil
 		},
 		PredicateFunc:     strategy.MatchCustomResourceDefinitionStorage,
 		QualifiedResource: resource,

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/registry/customresourcedefinition/etcd.go
@@ -35,12 +35,9 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST
 	strategy := NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		Copier:      scheme,
-		NewFunc:     func() runtime.Object { return &apiextensions.CustomResourceDefinition{} },
-		NewListFunc: func() runtime.Object { return &apiextensions.CustomResourceDefinitionList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*apiextensions.CustomResourceDefinition).Name, nil
-		},
+		Copier:            scheme,
+		NewFunc:           func() runtime.Object { return &apiextensions.CustomResourceDefinition{} },
+		NewListFunc:       func() runtime.Object { return &apiextensions.CustomResourceDefinitionList{} },
 		PredicateFunc:     MatchCustomResourceDefinition,
 		QualifiedResource: apiextensions.Resource("customresourcedefinitions"),
 


### PR DESCRIPTION
@deads2k as far as I can tell these `ObjectNameFunc`s are unnecessary.

Signed-off-by: Monis Khan <mkhan@redhat.com>

**Release note**:

```
NONE
```