### PR TITLE
Use beta GCP API instead of alpha in CloudCIDR controller

### DIFF
--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -45,7 +45,7 @@ go_library(
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
-        "//vendor/google.golang.org/api/compute/v0.alpha:go_default_library",
+        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/container/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -35,7 +35,7 @@ import (
 	"github.com/golang/glog"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
-	computealpha "google.golang.org/api/compute/v0.alpha"
+	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 	container "google.golang.org/api/container/v1"
 )
@@ -76,7 +76,7 @@ const (
 // GCECloud is an implementation of Interface, LoadBalancer and Instances for Google Compute Engine.
 type GCECloud struct {
 	service                  *compute.Service
-	serviceAlpha             *computealpha.Service
+	serviceBeta              *computebeta.Service
 	containerService         *container.Service
 	projectID                string
 	region                   string
@@ -187,7 +187,7 @@ func CreateGCECloud(projectID, region, zone string, managedZones []string, netwo
 	}
 
 	client, err = newOauthClient(tokenSource)
-	serviceAlpha, err := computealpha.New(client)
+	serviceBeta, err := computebeta.New(client)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,7 @@ func CreateGCECloud(projectID, region, zone string, managedZones []string, netwo
 
 	return &GCECloud{
 		service:                  service,
-		serviceAlpha:             serviceAlpha,
+		serviceBeta:              serviceBeta,
 		containerService:         containerService,
 		projectID:                projectID,
 		region:                   region,

--- a/pkg/cloudprovider/providers/gce/gce_instances.go
+++ b/pkg/cloudprovider/providers/gce/gce_instances.go
@@ -26,7 +26,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/golang/glog"
-	computealpha "google.golang.org/api/compute/v0.alpha"
+	computealpha "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -244,7 +244,7 @@ func (gce *GCECloud) AliasRanges(nodeName types.NodeName) (cidrs []string, err e
 	}
 
 	var res *computealpha.Instance
-	res, err = gce.serviceAlpha.Instances.Get(
+	res, err = gce.serviceBeta.Instances.Get(
 		gce.projectID, instance.Zone, instance.Name).Do()
 	if err != nil {
 		return


### PR DESCRIPTION
The feature we are using has been promoted to beta.

```release-note
NONE
```
