### PR TITLE
Update cluster startup scripts to use gcloud beta for alias IP support

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -188,7 +188,7 @@ ENABLE_RESCHEDULER="${KUBE_ENABLE_RESCHEDULER:-true}"
 
 # Optional: Enable allocation of pod IPs using IP aliases.
 #
-# ALPHA FEATURE.
+# BETA FEATURE.
 #
 # IP_ALIAS_SIZE is the size of the podCIDR allocated to a node.
 # IP_ALIAS_SUBNETWORK is the subnetwork to allocate from. If empty, a

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -221,14 +221,14 @@ ENABLE_RESCHEDULER="${KUBE_ENABLE_RESCHEDULER:-true}"
 
 # Optional: Enable allocation of pod IPs using IP aliases.
 #
-# ALPHA FEATURE.
+# BETA FEATURE.
 #
 # IP_ALIAS_SIZE is the size of the podCIDR allocated to a node.
 # IP_ALIAS_SUBNETWORK is the subnetwork to allocate from. If empty, a
 #   new subnetwork will be created for the cluster.
 ENABLE_IP_ALIASES=${KUBE_GCE_ENABLE_IP_ALIASES:-false}
 if [ ${ENABLE_IP_ALIASES} = true ]; then
-  # Size of ranges allocated to each node. gcloud alpha supports only /32 and /24.
+  # Size of ranges allocated to each node. gcloud current supports only /32 and /24.
   IP_ALIAS_SIZE=${KUBE_GCE_IP_ALIAS_SIZE:-/24}
   IP_ALIAS_SUBNETWORK=${KUBE_GCE_IP_ALIAS_SUBNETWORK:-${INSTANCE_PREFIX}-subnet-default}
   # NODE_IP_RANGE is used when ENABLE_IP_ALIASES=true. It is the primary range in

--- a/cluster/gce/container-linux/master-helper.sh
+++ b/cluster/gce/container-linux/master-helper.sh
@@ -67,7 +67,7 @@ function replicate-master-instance() {
 function create-master-instance-internal() {
   local gcloud="gcloud"
   if [[ "${ENABLE_IP_ALIASES:-}" == 'true' ]]; then
-    gcloud="gcloud alpha"
+    gcloud="gcloud beta"
   fi
 
   local -r master_name="${1}"

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -515,7 +515,7 @@ function create-node-template() {
   fi
 
   if [[ "${ENABLE_IP_ALIASES:-}" == 'true' ]]; then
-    gcloud="gcloud alpha"
+    gcloud="gcloud beta"
   fi
 
   local preemptible_minions=""
@@ -745,7 +745,7 @@ function create-subnetwork() {
 
   # Look for the subnet, it must exist and have a secondary range
   # configured.
-  local subnet=$(gcloud alpha compute networks subnets describe \
+  local subnet=$(gcloud beta compute networks subnets describe \
     --project "${PROJECT}" \
     --region ${REGION} \
     ${IP_ALIAS_SUBNETWORK} 2>/dev/null)
@@ -762,7 +762,7 @@ function create-subnetwork() {
     fi
 
     echo "Creating subnet ${NETWORK}:${IP_ALIAS_SUBNETWORK}"
-    gcloud alpha compute networks subnets create \
+    gcloud beta compute networks subnets create \
       ${IP_ALIAS_SUBNETWORK} \
       --description "Automatically generated subnet for ${INSTANCE_PREFIX} cluster. This will be removed on cluster teardown." \
       --project "${PROJECT}" \
@@ -812,11 +812,11 @@ function delete-subnetwork() {
   fi
 
   echo "Removing auto-created subnet ${NETWORK}:${IP_ALIAS_SUBNETWORK}"
-  if [[ -n $(gcloud alpha compute networks subnets describe \
+  if [[ -n $(gcloud beta compute networks subnets describe \
         --project "${PROJECT}" \
         --region ${REGION} \
         ${IP_ALIAS_SUBNETWORK} 2>/dev/null) ]]; then
-    gcloud alpha --quiet compute networks subnets delete \
+    gcloud beta --quiet compute networks subnets delete \
       --project "${PROJECT}" \
       --region ${REGION} \
       ${IP_ALIAS_SUBNETWORK}


### PR DESCRIPTION
The feature has gone from alpha to beta.

```release-note
NONE
```
