### PR TITLE
restrict visibility of client-go/pkg/api

### DIFF
--- a/staging/src/k8s.io/client-go/pkg/api/BUILD
+++ b/staging/src/k8s.io/client-go/pkg/api/BUILD
@@ -26,7 +26,6 @@ go_library(
     visibility = [
         "//vendor/k8s.io/client-go/pkg/api:__subpackages__",
         "//vendor/k8s.io/client-go/pkg/apis:__subpackages__",
-        "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/install:__subpackages__",
         "//vendor/k8s.io/metrics/pkg/client/clientset_generated/clientset/fake:__subpackages__",
     ],
     deps = [


### PR DESCRIPTION
The dependency was removed in a previous PR.