### PR TITLE
[WIP] Dynamic registration prototype

### DIFF
--- a/pkg/apis/admission/types.go
+++ b/pkg/apis/admission/types.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// AdmissionControlConfiguration is the cluster-wide configuration of default
+// initializers and external admission webhooks that are applied to each
+// resource.
+type AdmissionControlConfiguration struct {
+	metav1.TypeMeta
+
+	// ResourceInitializers is a list of resources and their default initializers
+	ResourceInitializers []ResouceInitializer
+
+	// ExternalAdmissionHooks is a list of external admission webhooks and the
+	// affected resources and operations.
+	ExternalAdmissionHooks []ExternalAdmissionHook
+}
+
+// ResouceInitializer describes the default initializers that will be
+// applied to a resource. The order of initializers is sensitive.
+type ResouceInitializer struct {
+	// APIGroup is the API group of the resource
+	APIGroup string
+
+	// APIVersions is the API Versions of the resource
+	// '*' means all API Versions.
+	// If '*' is present, the length of the slice must be one.
+	// Defaults to '*'.
+	APIVersions []string
+
+	// Resource is resource to be initialized
+	Resource string
+
+	// Initializers is a list of initializers that will be applied to the
+	// resource by default. It is order-sensitive.
+	Initializers []Initializer
+}
+
+// Initializer describes the name and the failure policy of an initializer.
+type Initializer struct {
+	// Name is the identifier of the initializer. It will be added to the
+	// object that needs to be initialized.
+	Name string
+
+	// FailurePolicy defines what happens if the responsible initializer controller
+	// fails to takes action. Allowed values are Ignore, or Fail. If "Ignore" is
+	// set, initializer is removed from the initializers list of an object if
+	// the timeout is reached; If "Fail" is set, apiserver returns timeout error
+	// if the timeout is reached.
+	FailurePolicy *FailurePolicyType
+}
+
+type FailurePolicyType string
+
+const (
+	// Ignore means the initilizer is removed from the initializers list of an
+	// object if the initializer is timed out.
+	Ignore FailurePolicyType = "Ignore"
+	// For 1.7, only "Ignore" is allowed. "Fail" will be allowed when the
+	// extensible admission feature is beta.
+	Fail FailurePolicyType = "Fail"
+)
+
+// ExternalAdmissionHook describes an external admission webhook and the
+// resources and operations it applies to.
+type ExternalAdmissionHook struct {
+	// The name of the external admission webhook.
+	Name string
+
+	// ClientConfig defines how to communicate with the hook.
+	ClientConfig AdmissionHookClientConfig
+
+	// Rules describes what operations on what resources/subresources the webhook cares about.
+	// The webhook cares about an operation if it matches _any_ Rule.
+	Rules []Rule
+
+	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
+	// allowed values are Ignore or Fail. Defaults to Ignore.
+	FailurePolicy FailurePolicyType
+}
+
+// Rule describes the Verbs and Resources an admission hook cares about. Each
+// Rule is a tuple of Verbs and Resources.It is recommended to make sure all
+// the tuple expansions are valid.
+type Rule struct {
+	// Verbs is the verbs the admission hook cares about - CREATE, UPDATE, or *
+	// for all verbs.
+	// If '*' is present, the length of the slice must be one.
+	// Required.
+	Verbs []OperationType
+
+	// APIGroups is the API groups the resources belong to. '*' is all groups.
+	// If '*' is present, the length of the slice must be one.
+	// Required.
+	APIGroups []string
+
+	// APIVersions is the API versions the resources belong to. '*' is all versions.
+	// If '*' is present, the length of the slice must be one.
+	// Required.
+	APIVersions []string
+
+	// Resources is a list of resources this rule applies to.
+	//
+	// For example:
+	// 'pods' means pods.
+	// 'pods/log' means the log subresource of pods.
+	// '*' means all resources, but not subresources.
+	// 'pods/*' means all subresources of pods.
+	// '*/scale' means all scale subresources.
+	// '*/*' means all resources and their subresources.
+	//
+	// If '*' or '*/*' is present, the length of the slice must be one.
+	// Required.
+	Resources []string
+}
+
+type OperationType string
+
+const (
+	VerbAll OperationType = "*"
+	Create  OperationType = "CREATE"
+	Update  OperationType = "UPDATE"
+)
+
+// AdmissionHookClientConfig contains the information to make a TLS
+// connection with the webhook
+type AdmissionHookClientConfig struct {
+	// Service is a reference to the service for this webhook. If there is only
+	// one port open for the service, that port will be used. If there are multiple
+	// ports open, port 443 will be used if it is open, otherwise it is an error.
+	Service ServiceReference
+	// CABundle is a PEM encoded CA bundle which will be used to validate webhook's server certificate.
+	CABundle []byte
+}
+
+// ServiceReference holds a reference to Service.legacy.k8s.io
+type ServiceReference struct {
+	// Namespace is the namespace of the service
+	Namespace string
+	// Name is the name of the service
+	Name string
+}

--- a/pkg/apis/admission/v1alpha1/types.go
+++ b/pkg/apis/admission/v1alpha1/types.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	CanonicalName = "AdmissionControlConfiguration"
+)
+
+// +genclient=true
+
+// AdmissionControlConfiguration is the cluster-wide configuration of default
+// initializers and external admission webhooks that are applied to each
+// resource.
+type AdmissionControlConfiguration struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// ResourceInitializers is a list of resources and their default initializers
+	// +optional
+	ResourceInitializers []ResouceInitializer `json:"resourceInitializers,omitempty" protobuf:"bytes,1,rep,name=resourceInitializers"`
+
+	// ExternalAdmissionHooks is a list of external admission webhooks and the
+	// affected resources and operations.
+	// +optional
+	ExternalAdmissionHooks []ExternalAdmissionHook `json:"externalAdmissionHooks,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=externalAdmissionHooks"`
+}
+
+// ResouceInitializer describes the default initializers that will be
+// applied to a resource. The order of initializers is sensitive.
+type ResouceInitializer struct {
+	// APIGroup is the API group of the resource
+	// Required
+	APIGroup string `json:"apiGroup" protobuf:"bytes,1,opt,name=apiGroup"`
+
+	// APIVersions is the API Versions of the resource
+	// '*' means all API Versions.
+	// If '*' is present, the length of the slice must be one.
+	// Defaults to '*'.
+	APIVersions []string `json:"apiVersions,omitempty" protobuf:"bytes,2,rep,name=apiVersions"`
+
+	// Resource is resource to be initialized
+	// Required
+	Resource string `json:"resource" protobuf:"bytes,3,opt,name=resource"`
+
+	// Initializers is a list of initializers that will be applied to the
+	// resource by default. It is order-sensitive.
+	Initializers []Initializer `json:"initializers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,3,rep,name=initializers"`
+}
+
+// Initializer describes the name and the failure policy of an initializer.
+type Initializer struct {
+	// Name is the identifier of the initializer. It will be added to the
+	// object that needs to be initialized.
+	// Required
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
+
+	// FailurePolicy defines what happens if the responsible initializer controller
+	// fails to takes action. Allowed values are Ignore, or Fail. If "Ignore" is
+	// set, initializer is removed from the initializers list of an object if
+	// the timeout is reached; If "Fail" is set, apiserver returns timeout error
+	// if the timeout is reached.
+	FailurePolicy *FailurePolicyType `json:"failurePolicy,omitempty" protobuf:"bytes,2,opt,name=failurePolicy"`
+}
+
+type FailurePolicyType string
+
+const (
+	// Ignore means the initilizer is removed from the initializers list of an
+	// object if the initializer is timed out.
+	Ignore FailurePolicyType = "Ignore"
+	// For 1.7, only "Ignore" is allowed. "Fail" will be allowed when the
+	// extensible admission feature is beta.
+	Fail FailurePolicyType = "Fail"
+)
+
+// ExternalAdmissionHook describes an external admission webhook and the
+// resources and operations it applies to.
+type ExternalAdmissionHook struct {
+	// The name of the external admission webhook.
+	// Required.
+	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
+
+	// ClientConfig defines how to communicate with the hook.
+	// Required
+	ClientConfig AdmissionHookClientConfig `json:"clientConfig" protobuf:"bytes,2,opt,name=clientConfig"`
+
+	// Rules describes what operations on what resources/subresources the webhook cares about.
+	// The webhook cares about an operation if it matches _any_ Rule.
+	Rules []Rule `json:"rules,omitempty" protobuf:"bytes,3,rep,name=rules"`
+
+	// FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
+	// allowed values are Ignore or Fail. Defaults to Ignore.
+	// +optional
+	FailurePolicy FailurePolicyType
+}
+
+// Rule describes the Verbs and Resources an admission hook cares about. Each
+// Rule is a tuple of Verbs and Resources.It is recommended to make sure all
+// the tuple expansions are valid.
+type Rule struct {
+	// Verbs is the verbs the admission hook cares about - CREATE, UPDATE, or *
+	// for all verbs.
+	// If '*' is present, the length of the slice must be one.
+	// Required.
+	Verbs []OperationType `json:"verbs,omitempty" protobuf:"bytes,1,rep,name=verbs"`
+
+	// APIGroups is the API groups the resources belong to. '*' is all groups.
+	// If '*' is present, the length of the slice must be one.
+	// Required.
+	APIGroups []string `json:"apiGroups,omitempty" protobuf:"bytes,2,rep,name=apiGroups"`
+
+	// APIVersions is the API versions the resources belong to. '*' is all versions.
+	// If '*' is present, the length of the slice must be one.
+	// Required.
+	APIVersions []string `json:"apiVersions,omitempty" protobuf:"bytes,3,rep,name=apiVersions"`
+
+	// Resources is a list of resources this rule applies to.
+	//
+	// For example:
+	// 'pods' means pods.
+	// 'pods/log' means the log subresource of pods.
+	// '*' means all resources, but not subresources.
+	// 'pods/*' means all subresources of pods.
+	// '*/scale' means all scale subresources.
+	// '*/*' means all resources and their subresources.
+	//
+	// If '*' or '*/*' is present, the length of the slice must be one.
+	// Required.
+	Resources []string `json:"resources,omitempty" protobuf:"bytes,4,rep,name=resources"`
+}
+
+type OperationType string
+
+const (
+	VerbAll OperationType = "*"
+	Create  OperationType = "CREATE"
+	Update  OperationType = "UPDATE"
+)
+
+// AdmissionHookClientConfig contains the information to make a TLS
+// connection with the webhook
+type AdmissionHookClientConfig struct {
+	// Service is a reference to the service for this webhook. If there is only
+	// one port open for the service, that port will be used. If there are multiple
+	// ports open, port 443 will be used if it is open, otherwise it is an error.
+	// Required
+	Service ServiceReference `json:"service" protobuf:"bytes,1,opt,name=service"`
+	// CABundle is a PEM encoded CA bundle which will be used to validate webhook's server certificate.
+	// Required
+	CABundle []byte `json:"caBundle" protobuf:"bytes,2,rep,name=caBundle"`
+}
+
+// ServiceReference holds a reference to Service.legacy.k8s.io
+type ServiceReference struct {
+	// Namespace is the namespace of the service
+	// Required
+	Namespace string `json:"namespace" protobuf:"bytes,1,opt,name=namespace"`
+	// Name is the name of the service
+	// Required
+	Name string `json:"name" protobuf:"bytes,2,opt,name=name"`
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/acc_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/acc_manager.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/apis/admission/v1alpha1"
+)
+
+const (
+	interval  = 1 * time.Second
+	threshold = 5
+)
+
+type configurationGetter interface {
+	Get(name string, options metav1.GetOptions) (*v1alpha1.AdmissionControlConfiguration, error)
+}
+
+type AdmissionControlConfigurationManager struct {
+	// The client to get the latest configuration from the server.
+	client configurationGetter
+	// consistent read interval
+	interval time.Duration
+	// if the number consecutive read failure equals or exceeds the threshold, the
+	// configuration is regarded as not ready.
+	threshold uint
+	// if the configuration is regarded as ready.
+	ready     bool
+	readyLock sync.RWMutex
+
+	configuration     *v1alpha1.AdmissionControlConfiguration
+	configurationLock sync.RWMutex
+}
+
+func NewAdmissionControlConfigurationManager(c configurationGetter) *AdmissionControlConfigurationManager {
+	return &AdmissionControlConfigurationManager{
+		client:    c,
+		interval:  interval,
+		threshold: threshold,
+	}
+}
+
+func (a *AdmissionControlConfigurationManager) Ready() bool {
+	a.readyLock.RLock()
+	defer a.readyLock.RUnlock()
+	return a.ready
+}
+
+func (a *AdmissionControlConfigurationManager) setReady(value bool) {
+	a.readyLock.Lock()
+	defer a.readyLock.Unlock()
+	a.ready = value
+}
+
+func (a *AdmissionControlConfigurationManager) Configuration() (v1alpha1.AdmissionControlConfiguration, error) {
+	var ret v1alpha1.AdmissionControlConfiguration
+	if !a.Ready() {
+		return ret, fmt.Errorf("configuration is not ready")
+	}
+	a.configurationLock.RLock()
+	defer a.configurationLock.RUnlock()
+	if a.configuration == nil {
+		return ret, fmt.Errorf("configuration is nil")
+	}
+	return *a.configuration, nil
+}
+
+func (a *AdmissionControlConfigurationManager) setConfiguration(value *v1alpha1.AdmissionControlConfiguration) {
+	a.configurationLock.Lock()
+	defer a.configurationLock.Unlock()
+	a.configuration = value
+}
+
+func (a *AdmissionControlConfigurationManager) Run(stopCh <-chan struct{}) {
+	var failure uint
+	go wait.Until(func() {
+		// TODO: need to be a consistent read
+		configuration, err := a.client.Get(v1alpha1.CanonicalName, metav1.GetOptions{})
+		if err != nil {
+			failure++
+			if failure >= a.threshold {
+				a.setReady(false)
+			}
+			return
+		}
+		failure = 0
+		a.setConfiguration(configuration)
+		a.setReady(true)
+	}, a.interval, stopCh)
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/acc_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/acc_manager_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/apis/admission/v1alpha1"
+)
+
+type mockGetter struct {
+	invoked       uint
+	successes     uint
+	failures      uint
+	stopCh        chan struct{}
+	configuration v1alpha1.AdmissionControlConfiguration
+	t             *testing.T
+}
+
+func newMockGetter(successes, failures uint, configuration v1alpha1.AdmissionControlConfiguration, t *testing.T) *mockGetter {
+	return &mockGetter{
+		failures:      failures,
+		successes:     successes,
+		configuration: configuration,
+		stopCh:        make(chan struct{}),
+		t:             t,
+	}
+}
+
+// The first m.successes Get will be successful; the next m.failures Get will
+// fail; the next m.successes Get will be successful; the stopCh is closed at
+// the 1+m.failures+m.successes call.
+func (m *mockGetter) Get(name string, options metav1.GetOptions) (*v1alpha1.AdmissionControlConfiguration, error) {
+	m.invoked++
+	if m.invoked == 1+m.successes+m.failures {
+		close(m.stopCh)
+	}
+	if m.invoked == 1 {
+		return &m.configuration, nil
+	}
+	if m.invoked <= 1+m.failures {
+		return nil, fmt.Errorf("some error")
+	}
+	if m.invoked <= 1+m.failures+m.successes {
+		return &m.configuration, nil
+	}
+	m.t.Fatalf("unexpected call to Get, stopCh has been closed at the %d time call", 1+m.successes+m.failures)
+	return nil, nil
+}
+
+func TestConfiguration(t *testing.T) {
+	cases := []struct {
+		name     string
+		failures uint
+		// note that the first call to mockGetter is always a success.
+		successes   uint
+		expectReady bool
+	}{
+		{
+			name:        "number of failures hasn't reached threshold",
+			failures:    threshold - 1,
+			expectReady: true,
+		},
+		{
+			name:        "number of failures just reaches threshold",
+			failures:    threshold,
+			expectReady: false,
+		},
+		{
+			name:        "number of failures exceeds threshold",
+			failures:    threshold + 1,
+			expectReady: false,
+		},
+		{
+			name:        "number of failures exceeds threshold, but then get another success",
+			failures:    threshold + 1,
+			successes:   1,
+			expectReady: true,
+		},
+	}
+	for _, c := range cases {
+		mock := newMockGetter(c.successes, c.failures, v1alpha1.AdmissionControlConfiguration{}, t)
+		manager := NewAdmissionControlConfigurationManager(mock)
+		manager.interval = 1 * time.Millisecond
+		manager.Run(mock.stopCh)
+		<-mock.stopCh
+		_, err := manager.Configuration()
+		if err != nil && c.expectReady {
+			t.Errorf("case %s, expect ready, got: %v", c.name, err)
+		}
+		if err == nil && !c.expectReady {
+			t.Errorf("case %s, expect not ready", c.name)
+		}
+	}
+}


### PR DESCRIPTION
Design: https://github.com/kubernetes/community/pull/611

Apparently it's a WIP since the proposal is not approved yet, just want to avoid duplicating efforts.

What's done:
* Added the types.go.
* Added an AdmissionControlConfigurationManager which does periodic consistent read of the ACC and reports not error if the read failures exceeds the threshold.

AIs:
- [ ] rebase on https://github.com/kubernetes/kubernetes/pull/45564, or need to create another API group
- [ ] implement the fail open intializers on top of @smarterclayton's PR for initializers prototype 

cc @lavalamp @smarterclayton @whitlockjc 