### PR TITLE
Fix waitForNPods in restart.go

### DIFF
--- a/test/e2e/restart.go
+++ b/test/e2e/restart.go
@@ -133,7 +133,7 @@ func waitForNPods(ps *testutils.PodStore, expect int, timeout time.Duration) ([]
 	var errLast error
 	found := wait.Poll(framework.Poll, timeout, func() (bool, error) {
 		allPods := ps.List()
-		pods := filterIrrelevantPods(allPods)
+		pods = filterIrrelevantPods(allPods)
 		if len(pods) != expect {
 			errLast = fmt.Errorf("expected to find %d pods but found only %d", expect, len(pods))
 			framework.Logf("Error getting pods: %v", errLast)


### PR DESCRIPTION
From https://github.com/kubernetes/kubernetes/issues/45991#issuecomment-302292404.

Don't redefine `pods` so we can return real pod names instead of empty array.

/assign @dchen1107 @bowei 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
