### PR TITLE
fix self link error of generic resources in describe command

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -224,7 +224,7 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 			if slice.ContainsString(skip, skipExpr, nil) {
 				continue
 			}
-			w.Write(level, fmt.Sprintf("%s:\n", smartLabelFor(field)))
+			w.Write(level, "%s:\n", smartLabelFor(field))
 			printUnstructuredContent(w, level+1, typedValue, skipExpr, skip...)
 
 		case []interface{}:
@@ -232,13 +232,13 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 			if slice.ContainsString(skip, skipExpr, nil) {
 				continue
 			}
-			w.Write(level, fmt.Sprintf("%s:\n", smartLabelFor(field)))
+			w.Write(level, "%s:\n", smartLabelFor(field))
 			for _, child := range typedValue {
 				switch typedChild := child.(type) {
 				case map[string]interface{}:
 					printUnstructuredContent(w, level+1, typedChild, skipExpr, skip...)
 				default:
-					w.Write(level+1, fmt.Sprintf("%v\n", typedChild))
+					w.Write(level+1, "%v\n", typedChild)
 				}
 			}
 
@@ -247,7 +247,7 @@ func printUnstructuredContent(w PrefixWriter, level int, content map[string]inte
 			if slice.ContainsString(skip, skipExpr, nil) {
 				continue
 			}
-			w.Write(level, fmt.Sprintf("%s:\t%v\n", smartLabelFor(field), typedValue))
+			w.Write(level, "%s:\t%v\n", smartLabelFor(field), typedValue)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
fix Self Link error
```
./cluster/kubectl.sh describe clusterrole system:controller:ttl-controller
Name:		system:controller:ttl-controller
Namespace:	
Labels:		kubernetes.io/bootstrapping=rbac-defaults
Annotations:	rbac.authorization.kubernetes.io/autoupdate=true
API Version:	rbac.authorization.k8s.io/v1alpha1
Kind:		ClusterRole
Metadata:
  Creation Timestamp:	2017-05-18T06:42:02Z
  Resource Version:	80
  Self Link:		/apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/system%!A(MISSING)controller%!A(MISSING)ttl-controller
  UID:			19a705a4-3b95-11e7-9d55-7427ea6f0fe3
Rules:
  API Groups:
    
  Resources:
    nodes
  Verbs:
    list
    patch
    update
    watch
  API Groups:
    
  Resources:
    events
  Verbs:
    create
    patch
    update
Events:	<none>
```

**Which issue this PR fixes**: fixes #48743

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
