### PR TITLE
Add version for fluentd-gcp config

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -415,7 +415,7 @@ data:
       </store>
     </match>
 metadata:
-  name: fluentd-gcp-config
+  name: fluentd-gcp-config-v1.0
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -118,7 +118,7 @@ spec:
           path: /usr/lib64
       - name: config-volume
         configMap:
-          name: fluentd-gcp-config
+          name: fluentd-gcp-config-v1.0
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs


### PR DESCRIPTION
Fluentd-gcp config should be versioned, because otherwise during the update race can happen and the new pod can mount the old config