### PR TITLE
retry clientCA post start hook on transient failures

### DIFF
--- a/pkg/master/client_ca_hook_test.go
+++ b/pkg/master/client_ca_hook_test.go
@@ -190,7 +190,7 @@ func TestWriteClientCAs(t *testing.T) {
 
 	for _, test := range tests {
 		client := fake.NewSimpleClientset(test.preexistingObjs...)
-		test.hook.writeClientCAs(client.Core())
+		test.hook.tryToWriteClientCAs(client.Core())
 
 		actualConfigMaps, updated := getFinalConfiMaps(client)
 		if !reflect.DeepEqual(test.expectedConfigMaps, actualConfigMaps) {


### PR DESCRIPTION
@smarterclayton retries the poststarthook you saw failing.

Having looked through, it seems that I didn't kill the server on the failure.