### PR TITLE
Change all the existing admission init blocks to call a Register function

### DIFF
--- a/plugin/pkg/admission/admit/admission.go
+++ b/plugin/pkg/admission/admit/admission.go
@@ -24,7 +24,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("AlwaysAdmit", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("AlwaysAdmit", func(config io.Reader) (admission.Interface, error) {
 		return NewAlwaysAdmit(), nil
 	})
 }

--- a/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/plugin/pkg/admission/alwayspullimages/admission.go
@@ -34,7 +34,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("AlwaysPullImages", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("AlwaysPullImages", func(config io.Reader) (admission.Interface, error) {
 		return NewAlwaysPullImages(), nil
 	})
 }

--- a/plugin/pkg/admission/antiaffinity/admission.go
+++ b/plugin/pkg/admission/antiaffinity/admission.go
@@ -28,7 +28,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("LimitPodHardAntiAffinityTopology", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("LimitPodHardAntiAffinityTopology", func(config io.Reader) (admission.Interface, error) {
 		return NewInterPodAntiAffinity(), nil
 	})
 }

--- a/plugin/pkg/admission/defaulttolerationseconds/admission.go
+++ b/plugin/pkg/admission/defaulttolerationseconds/admission.go
@@ -40,7 +40,12 @@ var (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("DefaultTolerationSeconds", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("DefaultTolerationSeconds", func(config io.Reader) (admission.Interface, error) {
 		return NewDefaultTolerationSeconds(), nil
 	})
 }

--- a/plugin/pkg/admission/deny/admission.go
+++ b/plugin/pkg/admission/deny/admission.go
@@ -25,7 +25,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("AlwaysDeny", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("AlwaysDeny", func(config io.Reader) (admission.Interface, error) {
 		return NewAlwaysDeny(), nil
 	})
 }

--- a/plugin/pkg/admission/exec/admission.go
+++ b/plugin/pkg/admission/exec/admission.go
@@ -30,13 +30,18 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("DenyEscalatingExec", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("DenyEscalatingExec", func(config io.Reader) (admission.Interface, error) {
 		return NewDenyEscalatingExec(), nil
 	})
 
 	// This is for legacy support of the DenyExecOnPrivileged admission controller.  Most
 	// of the time DenyEscalatingExec should be preferred.
-	kubeapiserveradmission.Plugins.Register("DenyExecOnPrivileged", func(config io.Reader) (admission.Interface, error) {
+	plugins.Register("DenyExecOnPrivileged", func(config io.Reader) (admission.Interface, error) {
 		return NewDenyExecOnPrivileged(), nil
 	})
 }

--- a/plugin/pkg/admission/gc/gc_admission.go
+++ b/plugin/pkg/admission/gc/gc_admission.go
@@ -32,7 +32,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("OwnerReferencesPermissionEnforcement", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("OwnerReferencesPermissionEnforcement", func(config io.Reader) (admission.Interface, error) {
 		// the pods/status endpoint is ignored by this plugin since old kubelets
 		// corrupt them.  the pod status strategy ensures status updates cannot mutate
 		// ownerRef.

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -50,7 +50,12 @@ var (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("ImagePolicyWebhook", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("ImagePolicyWebhook", func(config io.Reader) (admission.Interface, error) {
 		newImagePolicyWebhook, err := NewImagePolicyWebhook(config)
 		if err != nil {
 			return nil, err

--- a/plugin/pkg/admission/initialresources/admission.go
+++ b/plugin/pkg/admission/initialresources/admission.go
@@ -47,7 +47,12 @@ const (
 
 // WARNING: this feature is experimental and will definitely change.
 func init() {
-	kubeapiserveradmission.Plugins.Register("InitialResources", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("InitialResources", func(config io.Reader) (admission.Interface, error) {
 		// TODO: remove the usage of flags in favor of reading versioned configuration
 		s, err := newDataSource(*source)
 		if err != nil {

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -44,7 +44,12 @@ const (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("LimitRanger", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("LimitRanger", func(config io.Reader) (admission.Interface, error) {
 		return NewLimitRanger(&DefaultLimitRangerActions{})
 	})
 }

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -31,7 +31,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("NamespaceAutoProvision", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("NamespaceAutoProvision", func(config io.Reader) (admission.Interface, error) {
 		return NewProvision(), nil
 	})
 }

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -31,7 +31,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("NamespaceExists", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("NamespaceExists", func(config io.Reader) (admission.Interface, error) {
 		return NewExists(), nil
 	})
 }

--- a/plugin/pkg/admission/namespace/lifecycle/admission.go
+++ b/plugin/pkg/admission/namespace/lifecycle/admission.go
@@ -51,7 +51,12 @@ const (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic))
 	})
 }

--- a/plugin/pkg/admission/persistentvolume/label/admission.go
+++ b/plugin/pkg/admission/persistentvolume/label/admission.go
@@ -33,7 +33,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("PersistentVolumeLabel", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("PersistentVolumeLabel", func(config io.Reader) (admission.Interface, error) {
 		persistentVolumeLabelAdmission := NewPersistentVolumeLabel()
 		return persistentVolumeLabelAdmission, nil
 	})

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -40,7 +40,12 @@ import (
 var NamespaceNodeSelectors = []string{"scheduler.alpha.kubernetes.io/node-selector"}
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("PodNodeSelector", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("PodNodeSelector", func(config io.Reader) (admission.Interface, error) {
 		// TODO move this to a versioned configuration file format.
 		pluginConfig := readConfig(config)
 		plugin := NewPodNodeSelector(pluginConfig.PodNodeSelectorPluginConfig)

--- a/plugin/pkg/admission/podpreset/admission.go
+++ b/plugin/pkg/admission/podpreset/admission.go
@@ -42,7 +42,12 @@ const (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register(pluginName, func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(pluginName, func(config io.Reader) (admission.Interface, error) {
 		return NewPlugin(), nil
 	})
 }

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -37,6 +37,11 @@ import (
 )
 
 func init() {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
 	kubeapiserveradmission.Plugins.Register("PodTolerationRestriction", func(config io.Reader) (admission.Interface, error) {
 		pluginConfig, err := loadConfiguration(config)
 		if err != nil {

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -33,7 +33,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("ResourceQuota",
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("ResourceQuota",
 		func(config io.Reader) (admission.Interface, error) {
 			// load the configuration provided (if any)
 			configuration, err := LoadConfiguration(config)

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -45,7 +45,12 @@ const (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		plugin := NewPlugin(psp.NewSimpleStrategyFactory(), getMatchingPolicies, true)
 		return plugin, nil
 	})

--- a/plugin/pkg/admission/securitycontext/scdeny/admission.go
+++ b/plugin/pkg/admission/securitycontext/scdeny/admission.go
@@ -27,7 +27,12 @@ import (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register("SecurityContextDeny", func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register("SecurityContextDeny", func(config io.Reader) (admission.Interface, error) {
 		return NewSecurityContextDeny(), nil
 	})
 }

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -54,7 +54,12 @@ const DefaultAPITokenMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 const PluginName = "ServiceAccount"
 
 func init() {
-	kubeapiserveradmission.Plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		serviceAccountAdmission := NewServiceAccount()
 		return serviceAccountAdmission, nil
 	})

--- a/plugin/pkg/admission/storageclass/default/admission.go
+++ b/plugin/pkg/admission/storageclass/default/admission.go
@@ -39,7 +39,12 @@ const (
 )
 
 func init() {
-	kubeapiserveradmission.Plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+	Register(&kubeapiserveradmission.Plugins)
+}
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
 		plugin := newPlugin()
 		return plugin, nil
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide

2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
this is a two stage refactor when done there will be no init block in admission plugins.
Instead all plugins expose Register function which accept admission.Plugins instance.
The registration to global plugin registry happens inside Register function

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```