### PR TITLE
embed kube-apiextensions inside of kube-apiserver

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -93,6 +93,7 @@ go_library(
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/controllers/autoregister:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/apiserver:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/client/informers/internalversion:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/cmd/server:go_default_library",
     ],
 )

--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -11,6 +11,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "aggregator.go",
+        "apiextensions.go",
         "plugins.go",
         "server.go",
     ],
@@ -91,6 +92,8 @@ go_library(
         "//vendor/k8s.io/kube-aggregator/pkg/apiserver:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/controllers/autoregister:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/apiserver:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/cmd/server:go_default_library",
     ],
 )
 

--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package app does all of the work necessary to create a Kubernetes
+// APIServer by binding together the API, master and APIServer infrastructure.
+// It can be configured and called directly or via the hyperkube framework.
+package app
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	genericoptions "k8s.io/apiserver/pkg/server/options"
+	apiextensionsapiserver "k8s.io/kube-apiextensions-server/pkg/apiserver"
+	apiextensionscmd "k8s.io/kube-apiextensions-server/pkg/cmd/server"
+	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
+)
+
+func createAPIExtensionsConfig(kubeAPIServerConfig genericapiserver.Config, commandOptions *options.ServerRunOptions) (*apiextensionsapiserver.Config, error) {
+	// make a shallow copy to let us twiddle a few things
+	// most of the config actually remains the same.  We only need to mess with a couple items related to the particulars of the apiextensions
+	genericConfig := kubeAPIServerConfig
+
+	// the apiextensions doesn't wire these up.  It just delegates them to the kubeapiserver
+	genericConfig.EnableSwaggerUI = false
+
+	// TODO these need to be sorted out.  There's an issue open
+	genericConfig.OpenAPIConfig = nil
+	genericConfig.SwaggerConfig = nil
+
+	// copy the loopbackclientconfig.  We're going to change the contenttype back to json until we get protobuf serializations for it
+	t := *kubeAPIServerConfig.LoopbackClientConfig
+	genericConfig.LoopbackClientConfig = &t
+	genericConfig.LoopbackClientConfig.ContentConfig.ContentType = ""
+
+	// copy the etcd options so we don't mutate originals.
+	etcdOptions := *commandOptions.Etcd
+	etcdOptions.StorageConfig.Codec = apiextensionsapiserver.Codecs.LegacyCodec(schema.GroupVersion{Group: "apiextensions.k8s.io", Version: "v1alpha1"})
+	etcdOptions.StorageConfig.Copier = apiextensionsapiserver.Scheme
+	genericConfig.RESTOptionsGetter = &genericoptions.SimpleRestOptionsFactory{Options: etcdOptions}
+
+	apiextensionsConfig := &apiextensionsapiserver.Config{
+		GenericConfig:        &genericConfig,
+		CRDRESTOptionsGetter: apiextensionscmd.NewCRDRESTOptionsGetter(etcdOptions),
+	}
+
+	return apiextensionsConfig, nil
+
+}
+
+func createAPIExtensionsServer(apiextensionsConfig *apiextensionsapiserver.Config, delegateAPIServer genericapiserver.DelegationTarget) (*apiextensionsapiserver.CustomResourceDefinitions, error) {
+	apiextensionsServer, err := apiextensionsConfig.Complete().New(delegateAPIServer)
+	if err != nil {
+		return nil, err
+	}
+
+	return apiextensionsServer, nil
+}

--- a/pkg/master/thirdparty/BUILD
+++ b/pkg/master/thirdparty/BUILD
@@ -43,6 +43,9 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/client/listers/apiextensions/internalversion:go_default_library",
     ],
 )
 
@@ -72,5 +75,7 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions:go_default_library",
+        "//vendor/k8s.io/kube-apiextensions-server/pkg/client/listers/apiextensions/internalversion:go_default_library",
     ],
 )

--- a/pkg/master/thirdparty/tprregistration_controller_test.go
+++ b/pkg/master/thirdparty/tprregistration_controller_test.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
+	"k8s.io/kube-apiextensions-server/pkg/apis/apiextensions"
+	crdlisters "k8s.io/kube-apiextensions-server/pkg/client/listers/apiextensions/internalversion"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	listers "k8s.io/kubernetes/pkg/client/listers/extensions/internalversion"
 )
@@ -56,17 +58,18 @@ func TestEnqueue(t *testing.T) {
 	}
 }
 
-func TestHandleTPR(t *testing.T) {
+func TestHandleVersionUpdate(t *testing.T) {
 	tests := []struct {
 		name         string
 		startingTPRs []*extensions.ThirdPartyResource
+		startingCRDs []*apiextensions.CustomResourceDefinition
 		version      schema.GroupVersion
 
 		expectedAdded   []*apiregistration.APIService
 		expectedRemoved []string
 	}{
 		{
-			name: "simple add",
+			name: "simple add tpr",
 			startingTPRs: []*extensions.ThirdPartyResource{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "resource.group.com"},
@@ -89,12 +92,49 @@ func TestHandleTPR(t *testing.T) {
 			},
 		},
 		{
-			name: "simple remove",
+			name: "simple remove tpr",
 			startingTPRs: []*extensions.ThirdPartyResource{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "resource.group.com"},
 					Versions: []extensions.APIVersion{
 						{Name: "v1"},
+					},
+				},
+			},
+			version: schema.GroupVersion{Group: "group.com", Version: "v2"},
+
+			expectedRemoved: []string{"v2.group.com"},
+		},
+		{
+			name: "simple add crd",
+			startingCRDs: []*apiextensions.CustomResourceDefinition{
+				{
+					Spec: apiextensions.CustomResourceDefinitionSpec{
+						Group:   "group.com",
+						Version: "v1",
+					},
+				},
+			},
+			version: schema.GroupVersion{Group: "group.com", Version: "v1"},
+
+			expectedAdded: []*apiregistration.APIService{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "v1.group.com"},
+					Spec: apiregistration.APIServiceSpec{
+						Group:    "group.com",
+						Version:  "v1",
+						Priority: 500,
+					},
+				},
+			},
+		},
+		{
+			name: "simple remove crd",
+			startingCRDs: []*apiextensions.CustomResourceDefinition{
+				{
+					Spec: apiextensions.CustomResourceDefinitionSpec{
+						Group:   "group.com",
+						Version: "v1",
 					},
 				},
 			},
@@ -108,15 +148,21 @@ func TestHandleTPR(t *testing.T) {
 		registration := &fakeAPIServiceRegistration{}
 		tprCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		tprLister := listers.NewThirdPartyResourceLister(tprCache)
+		crdCache := cache.NewIndexer(cache.DeletionHandlingMetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+		crdLister := crdlisters.NewCustomResourceDefinitionLister(crdCache)
 		c := tprRegistrationController{
 			tprLister:              tprLister,
+			crdLister:              crdLister,
 			apiServiceRegistration: registration,
 		}
 		for i := range test.startingTPRs {
 			tprCache.Add(test.startingTPRs[i])
 		}
+		for i := range test.startingCRDs {
+			crdCache.Add(test.startingCRDs[i])
+		}
 
-		c.handleTPR(test.version)
+		c.handleVersionUpdate(test.version)
 
 		if !reflect.DeepEqual(test.expectedAdded, registration.added) {
 			t.Errorf("%s expected %v, got %v", test.name, test.expectedAdded, registration.added)

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/apiserver.go
@@ -79,6 +79,9 @@ type Config struct {
 
 type CustomResourceDefinitions struct {
 	GenericAPIServer *genericapiserver.GenericAPIServer
+
+	// provided for easier embedding
+	Informers internalinformers.SharedInformerFactory
 }
 
 type completedConfig struct {
@@ -126,11 +129,11 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		return nil, err
 	}
 
-	customResourceDefinitionClient, err := internalclientset.NewForConfig(s.GenericAPIServer.LoopbackClientConfig)
+	crdClient, err := internalclientset.NewForConfig(s.GenericAPIServer.LoopbackClientConfig)
 	if err != nil {
 		return nil, err
 	}
-	customResourceDefinitionInformers := internalinformers.NewSharedInformerFactory(customResourceDefinitionClient, 5*time.Minute)
+	s.Informers = internalinformers.NewSharedInformerFactory(crdClient, 5*time.Minute)
 
 	delegateHandler := delegationTarget.UnprotectedHandler()
 	if delegateHandler == nil {
@@ -145,31 +148,31 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		discovery: map[string]*discovery.APIGroupHandler{},
 		delegate:  delegateHandler,
 	}
-	customResourceDefinitionHandler := NewCustomResourceDefinitionHandler(
+	crdHandler := NewCustomResourceDefinitionHandler(
 		versionDiscoveryHandler,
 		groupDiscoveryHandler,
 		s.GenericAPIServer.RequestContextMapper(),
-		customResourceDefinitionInformers.Apiextensions().InternalVersion().CustomResourceDefinitions().Lister(),
+		s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions().Lister(),
 		delegateHandler,
 		c.CRDRESTOptionsGetter,
 		c.GenericConfig.AdmissionControl,
 	)
-	s.GenericAPIServer.Handler.PostGoRestfulMux.Handle("/apis", customResourceDefinitionHandler)
-	s.GenericAPIServer.Handler.PostGoRestfulMux.HandlePrefix("/apis/", customResourceDefinitionHandler)
+	s.GenericAPIServer.Handler.PostGoRestfulMux.Handle("/apis", crdHandler)
+	s.GenericAPIServer.Handler.PostGoRestfulMux.HandlePrefix("/apis/", crdHandler)
 
-	customResourceDefinitionController := NewDiscoveryController(customResourceDefinitionInformers.Apiextensions().InternalVersion().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler)
-	namingController := status.NewNamingConditionController(customResourceDefinitionInformers.Apiextensions().InternalVersion().CustomResourceDefinitions(), customResourceDefinitionClient)
+	crdController := NewDiscoveryController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler)
+	namingController := status.NewNamingConditionController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), crdClient)
 	finalizingController := finalizer.NewCRDFinalizer(
-		customResourceDefinitionInformers.Apiextensions().InternalVersion().CustomResourceDefinitions(),
-		customResourceDefinitionClient,
+		s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(),
+		crdClient,
 		dynamic.NewDynamicClientPool(s.GenericAPIServer.LoopbackClientConfig))
 
 	s.GenericAPIServer.AddPostStartHook("start-apiextensions-informers", func(context genericapiserver.PostStartHookContext) error {
-		customResourceDefinitionInformers.Start(context.StopCh)
+		s.Informers.Start(context.StopCh)
 		return nil
 	})
 	s.GenericAPIServer.AddPostStartHook("start-apiextensions-controllers", func(context genericapiserver.PostStartHookContext) error {
-		go customResourceDefinitionController.Run(context.StopCh)
+		go crdController.Run(context.StopCh)
 		go namingController.Run(context.StopCh)
 		go finalizingController.Run(5, context.StopCh)
 		return nil

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/apiserver.go
@@ -74,7 +74,7 @@ func init() {
 type Config struct {
 	GenericConfig *genericapiserver.Config
 
-	CustomResourceDefinitionRESTOptionsGetter genericregistry.RESTOptionsGetter
+	CRDRESTOptionsGetter genericregistry.RESTOptionsGetter
 }
 
 type CustomResourceDefinitions struct {
@@ -105,7 +105,7 @@ func (c *Config) SkipComplete() completedConfig {
 
 // New returns a new instance of CustomResourceDefinitions from the given config.
 func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget) (*CustomResourceDefinitions, error) {
-	genericServer, err := c.Config.GenericConfig.SkipComplete().New(genericapiserver.EmptyDelegate) // completion is done in Complete, no need for a second time
+	genericServer, err := c.Config.GenericConfig.SkipComplete().New(delegationTarget) // completion is done in Complete, no need for a second time
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		s.GenericAPIServer.RequestContextMapper(),
 		customResourceDefinitionInformers.Apiextensions().InternalVersion().CustomResourceDefinitions().Lister(),
 		delegateHandler,
-		c.CustomResourceDefinitionRESTOptionsGetter,
+		c.CRDRESTOptionsGetter,
 		c.GenericConfig.AdmissionControl,
 	)
 	s.GenericAPIServer.Handler.PostGoRestfulMux.Handle("/apis", customResourceDefinitionHandler)

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
@@ -127,10 +127,6 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		r.delegate.ServeHTTP(w, req)
 		return
 	}
-	if len(requestInfo.Subresource) > 0 {
-		http.NotFound(w, req)
-		return
-	}
 
 	crdName := requestInfo.Resource + "." + requestInfo.APIGroup
 	crd, err := r.crdLister.Get(crdName)
@@ -149,6 +145,10 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// if we can't definitively determine that our names are good, delegate
 	if !apiextensions.IsCRDConditionFalse(crd, apiextensions.NameConflict) {
 		r.delegate.ServeHTTP(w, req)
+	}
+	if len(requestInfo.Subresource) > 0 {
+		http.NotFound(w, req)
+		return
 	}
 
 	terminating := apiextensions.IsCRDConditionTrue(crd, apiextensions.Terminating)

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
@@ -379,7 +379,7 @@ type UnstructuredDefaulter struct{}
 
 func (UnstructuredDefaulter) Default(in runtime.Object) {}
 
-type CustomResourceDefinitionRESTOptionsGetter struct {
+type CRDRESTOptionsGetter struct {
 	StorageConfig           storagebackend.Config
 	StoragePrefix           string
 	EnableWatchCache        bool
@@ -388,7 +388,7 @@ type CustomResourceDefinitionRESTOptionsGetter struct {
 	DeleteCollectionWorkers int
 }
 
-func (t CustomResourceDefinitionRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
+func (t CRDRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (generic.RESTOptions, error) {
 	ret := generic.RESTOptions{
 		StorageConfig:           &t.StorageConfig,
 		Decorator:               generic.UndecoratedStorage,

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/cmd/server/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/cmd/server/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/registration_test.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/registration_test.go
@@ -457,9 +457,9 @@ func TestEtcdStorage(t *testing.T) {
 }
 
 func getPrefixFromConfig(t *testing.T, config *extensionsapiserver.Config) string {
-	extensionsOptionsGetter, ok := config.CustomResourceDefinitionRESTOptionsGetter.(extensionsapiserver.CustomResourceDefinitionRESTOptionsGetter)
+	extensionsOptionsGetter, ok := config.CRDRESTOptionsGetter.(extensionsapiserver.CRDRESTOptionsGetter)
 	if !ok {
-		t.Fatal("can't obtain etcd prefix: unable to cast config.CustomResourceDefinitionRESTOptionsGetter to extensionsapiserver.CustomResourceDefinitionRESTOptionsGetter")
+		t.Fatal("can't obtain etcd prefix: unable to cast config.CRDRESTOptionsGetter to extensionsapiserver.CRDRESTOptionsGetter")
 	}
 	return extensionsOptionsGetter.StoragePrefix
 }

--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/start.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/start.go
@@ -76,7 +76,7 @@ func DefaultServerConfig() (*extensionsapiserver.Config, error) {
 		return nil, err
 	}
 
-	customResourceDefinitionRESTOptionsGetter := extensionsapiserver.CustomResourceDefinitionRESTOptionsGetter{
+	customResourceDefinitionRESTOptionsGetter := extensionsapiserver.CRDRESTOptionsGetter{
 		StorageConfig:           options.RecommendedOptions.Etcd.StorageConfig,
 		StoragePrefix:           options.RecommendedOptions.Etcd.StorageConfig.Prefix,
 		EnableWatchCache:        options.RecommendedOptions.Etcd.EnableWatchCache,
@@ -88,8 +88,8 @@ func DefaultServerConfig() (*extensionsapiserver.Config, error) {
 	customResourceDefinitionRESTOptionsGetter.StorageConfig.Copier = extensionsapiserver.UnstructuredCopier{}
 
 	config := &extensionsapiserver.Config{
-		GenericConfig:                             genericConfig,
-		CustomResourceDefinitionRESTOptionsGetter: customResourceDefinitionRESTOptionsGetter,
+		GenericConfig:        genericConfig,
+		CRDRESTOptionsGetter: customResourceDefinitionRESTOptionsGetter,
 	}
 
 	return config, nil

--- a/test/integration/etcd/BUILD
+++ b/test/integration/etcd/BUILD
@@ -34,6 +34,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
 	kclient "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
@@ -559,7 +560,7 @@ func startRealMasterOrDie(t *testing.T, certDir string) (*allClient, clientv3.KV
 
 			kubeAPIServerConfig.APIResourceConfigSource = &allResourceSource{} // force enable all resources
 
-			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, sharedInformers)
+			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.EmptyDelegate, sharedInformers)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/examples/BUILD
+++ b/test/integration/examples/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -33,6 +33,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	genericapiserver "k8s.io/apiserver/pkg/server"
 	client "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -117,7 +118,7 @@ func TestAggregatedAPIServer(t *testing.T) {
 			}
 			kubeClientConfigValue.Store(kubeAPIServerConfig.GenericConfig.LoopbackClientConfig)
 
-			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, sharedInformers)
+			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.EmptyDelegate, sharedInformers)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
To reduce operation complexity, we decided to include the kube-apiextensions-server inside of kube-apiserver (https://github.com/kubernetes/community/blob/master/sig-api-machinery/api-extensions-position-statement.md#q-should-kube-aggregator-be-a-separate-binaryprocess-than-kube-apiserver).  With the API reasonably well established and a finalizer about merge, I think its time to add ourselves.

This pull wires kube-apiextensions-server ahead of the TPRs so that one will replace the other if both are added by accident (CRDs should have priority) and wires a controller for automatic aggregation.

WIP because I still need tests: unit test for controller, test-cmd test to mirror the TPR test.


```release-note
Adds the `CustomResourceDefinition` (crd) types to the `kube-apiserver`.  These are the successors to `ThirdPartyResource`.  See https://github.com/kubernetes/community/blob/master/contributors/design-proposals/thirdpartyresources.md for more details.
```