### PR TITLE
[Federation] Fix bad logic of deletion error handling for federated updater

### DIFF
--- a/federation/pkg/federation-controller/util/federated_updater.go
+++ b/federation/pkg/federation-controller/util/federated_updater.go
@@ -122,7 +122,7 @@ func (fu *federatedUpdaterImpl) Update(ops []FederatedOperation) error {
 				fu.recordEvent(op.Obj, eventType, "Deleting", eventArgs...)
 				err = fu.deleteFunction(clientset, op.Obj)
 				// IsNotFound error is fine since that means the object is deleted already.
-				if err != nil && !errors.IsNotFound(err) {
+				if errors.IsNotFound(err) {
 					err = nil
 				}
 			}


### PR DESCRIPTION
Reverts a change accidentally added in #45364.

cc: @kubernetes/sig-federation-pr-reviews 