### PR TITLE
Integration test for kube-apiextensions-server: integers

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/BUILD
@@ -23,6 +23,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/resources.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/resources.go
@@ -59,6 +59,10 @@ func NewNoxuInstance(namespace, name string) *unstructured.Unstructured {
 			"content": map[string]interface{}{
 				"key": "value",
 			},
+			"num": map[string]interface{}{
+				"num1": 9223372036854775807,
+				"num2": 1000000,
+			},
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Check if integers are present after decoding.
Originally an issue for TPRs: #30213

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: for #45511 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
@sttts 
