### PR TITLE
Copy static variable 'verb' before instrumenting APIserver call to prevent overwriting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -103,10 +103,11 @@ func InstrumentRouteFunc(verb, resource string, routeFunc restful.RouteFunction)
 
 		routeFunc(request, response)
 
+		reportedVerb := verb
 		if verb == "LIST" && strings.ToLower(request.QueryParameter("watch")) == "true" {
-			verb = "WATCH"
+			reportedVerb = "WATCH"
 		}
-		Monitor(&verb, &resource, cleanUserAgent(utilnet.GetHTTPClient(request.Request)), rw.Header().Get("Content-Type"), delegate.status, now)
+		Monitor(&reportedVerb, &resource, cleanUserAgent(utilnet.GetHTTPClient(request.Request)), rw.Header().Get("Content-Type"), delegate.status, now)
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/45566

cc @wojtek-t @gmarek 