### PR TITLE
Log kubefed operations at log level 4 in our test environments.

### DIFF
--- a/federation/cluster/federation-down.sh
+++ b/federation/cluster/federation-down.sh
@@ -52,7 +52,8 @@ function unjoin_clusters() {
         "${context}" \
         --federation-system-namespace=${FEDERATION_NAMESPACE} \
         --context="${FEDERATION_KUBE_CONTEXT}" \
-        --host-cluster-context="${HOST_CLUSTER_CONTEXT}"
+        --host-cluster-context="${HOST_CLUSTER_CONTEXT}" \
+        --v=4
   done
 }
 

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -94,7 +94,8 @@ function init() {
       --apiserver-enable-basic-auth=true \
       --apiserver-enable-token-auth=true \
       --apiserver-arg-overrides="--v=4" \
-      --controllermanager-arg-overrides="--v=4"
+      --controllermanager-arg-overrides="--v=4" \
+      --v=4
 }
 
 # join_clusters joins the clusters in the local kubeconfig to federation. The clusters
@@ -107,7 +108,8 @@ function join_clusters() {
         "${context}" \
         --federation-system-namespace=${FEDERATION_NAMESPACE} \
         --host-cluster-context="${HOST_CLUSTER_CONTEXT}" \
-        --context="${FEDERATION_KUBE_CONTEXT}"
+        --context="${FEDERATION_KUBE_CONTEXT}" \
+        --v=4
   done
 }
 


### PR DESCRIPTION
This is useful for debugging test failures that involve federation control plane turn up/down.


**Release note**:
```release-note
NONE
```

/assign @perotinus @csbell 
/sig federation

cc @kubernetes/sig-federation-pr-reviews 
