### PR TITLE
[do not merge] NS controller: replace estimate with 2 seconds

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -60,7 +60,7 @@ func NewCMServer() *CMServer {
 			ConcurrentJobSyncs:                              5,
 			ConcurrentResourceQuotaSyncs:                    5,
 			ConcurrentDeploymentSyncs:                       5,
-			ConcurrentNamespaceSyncs:                        2,
+			ConcurrentNamespaceSyncs:                        5,
 			ConcurrentSATokenSyncs:                          5,
 			LookupCacheSizeForRC:                            4096,
 			LookupCacheSizeForRS:                            4096,

--- a/pkg/controller/namespace/deletion/BUILD
+++ b/pkg/controller/namespace/deletion/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -131,10 +131,10 @@ func (nm *NamespaceController) worker() {
 			return false
 		}
 
-		if estimate, ok := err.(*deletion.ResourcesRemainingError); ok {
-			t := estimate.Estimate/2 + 1
-			glog.V(4).Infof("Content remaining in namespace %s, waiting %d seconds", key, t)
-			nm.queue.AddAfter(key, time.Duration(t)*time.Second)
+		if _, ok := err.(*deletion.ResourcesRemainingError); ok {
+			//t := estimate.Estimate/2 + 1
+			//glog.V(4).Infof("Content remaining in namespace %s, waiting %d seconds", key, t)
+			nm.queue.AddAfter(key, 2*time.Second)
 		} else {
 			// rather than wait for a full resync, re-add the namespace to the queue to be processed
 			nm.queue.AddRateLimited(key)


### PR DESCRIPTION
First commit is #46037 

Thought experiment - what happens to namespace deletion if we ignore the estimate and instead just retry deleting everything every 2 seconds? In one test on my laptop (Kubectl client Simple pod should support inline execution and attach), it reduces the deletion time from 22s to 8s.

cc @smarterclayton @derekwaynecarr 