### PR TITLE
Use variadic nature of *cobra.Command.AddCommand to add group of commands to a parent command

### DIFF
--- a/pkg/kubectl/cmd/templates/command_groups.go
+++ b/pkg/kubectl/cmd/templates/command_groups.go
@@ -29,9 +29,7 @@ type CommandGroups []CommandGroup
 
 func (g CommandGroups) Add(c *cobra.Command) {
 	for _, group := range g {
-		for _, command := range group.Commands {
-			c.AddCommand(command)
-		}
+		c.AddCommand(group.Commands...)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Rather than looping over commands in a group and add it one by one to a
parent command, use variadic nature of *cobra.Command.AddCommand to add
the group of commands to the parent.