### PR TITLE
Remove --dns-provider as mandatory flag to kubefed

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -209,7 +209,13 @@ type credentials struct {
 // Complete ensures that options are valid and marshals them if necessary.
 func (i *initFederation) Complete(cmd *cobra.Command, args []string) error {
 	if len(i.options.dnsProvider) == 0 {
-		return fmt.Errorf("--dns-provider is mandatory")
+		return fmt.Errorf("--dns-provider is mandatory. pass '--dns-provider=none', if you need to disable dns controller")
+	}
+	if i.options.dnsProvider == "none" {
+		if len(i.options.controllerManagerOverridesString) != 0 {
+			i.options.controllerManagerOverridesString += ","
+		}
+		i.options.controllerManagerOverridesString += "--controllers=service-dns=false"
 	}
 
 	err := i.commonOptions.SetName(cmd, args)


### PR DESCRIPTION
**What this PR does / why we need it**:
`--dns-provider` flag is no longer a mandatory parameter for controller-manager.
We can disable DNS controller optionally and there could be scenarios where we wish to disable DNS-controller. (one of them is in development environment).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
/cc @marun @madhusudancs 

**Release note**:
```release-note
NONE
```
