### PR TITLE
Revert "[Federation] Fix federated service reconcilation issue due to addition of External…"

### DIFF
--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -575,11 +575,6 @@ func (s *ServiceController) getOperationsToPerformOnCluster(cluster *v1beta1.Clu
 				}
 			}
 		}
-		// If ExternalTrafficPolicy is not set in federated service, use the ExternalTrafficPolicy
-		// defaulted to in federated cluster.
-		if desiredService.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyType("") {
-			desiredService.Spec.ExternalTrafficPolicy = clusterService.Spec.ExternalTrafficPolicy
-		}
 
 		// Update existing service, if needed.
 		if !Equivalent(desiredService, clusterService) {

--- a/test/e2e_federation/service.go
+++ b/test/e2e_federation/service.go
@@ -379,13 +379,10 @@ func deleteServiceShard(c *fedframework.Cluster, namespace, service string) erro
 
 // equivalent returns true if the two services are equivalent.  Fields which are expected to differ between
 // federated services and the underlying cluster services (e.g. ClusterIP, NodePort) are ignored.
-func equivalent(clusterService, federationService v1.Service) bool {
-	federationService.Spec.ClusterIP = clusterService.Spec.ClusterIP
-	for i := range federationService.Spec.Ports {
-		federationService.Spec.Ports[i].NodePort = clusterService.Spec.Ports[i].NodePort
-	}
-	if federationService.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyType("") {
-		federationService.Spec.ExternalTrafficPolicy = clusterService.Spec.ExternalTrafficPolicy
+func equivalent(federationService, clusterService v1.Service) bool {
+	clusterService.Spec.ClusterIP = federationService.Spec.ClusterIP
+	for i := range clusterService.Spec.Ports {
+		clusterService.Spec.Ports[i].NodePort = federationService.Spec.Ports[i].NodePort
 	}
 
 	if federationService.Name != clusterService.Name || federationService.Namespace != clusterService.Namespace {


### PR DESCRIPTION
Reverts kubernetes/kubernetes#45798

Reverting the temporary fix as the problem is fixed in #45869.
with that fix federation also can default ExternalTrafficLocalOnly if not set.

Issue: #45812

cc @MrHohn @madhusudancs @kubernetes/sig-federation-bugs 