### PR TITLE
apiextensions: add Established condition

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/types.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/types.go
@@ -70,6 +70,10 @@ const (
 type CustomResourceDefinitionConditionType string
 
 const (
+	// Established means that the resource has become active. A resource is established when all names are
+	// accepted without a conflict for the first time. A resource stays established until deleted, even during
+	// a later NameConflict due to changed names. Note that not all names can be changed.
+	Established CustomResourceDefinitionConditionType = "Established"
 	// NameConflict means the names chosen for this CustomResourceDefinition conflict with others in the group.
 	NameConflict CustomResourceDefinitionConditionType = "NameConflict"
 	// Terminating means that the CustomResourceDefinition has been deleted and is cleaning up.

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/types.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/types.go
@@ -72,10 +72,11 @@ type CustomResourceDefinitionConditionType string
 const (
 	// Established means that the resource has become active. A resource is established when all names are
 	// accepted without a conflict for the first time. A resource stays established until deleted, even during
-	// a later NameConflict due to changed names. Note that not all names can be changed.
+	// a later NamesAccepted due to changed names. Note that not all names can be changed.
 	Established CustomResourceDefinitionConditionType = "Established"
-	// NameConflict means the names chosen for this CustomResourceDefinition conflict with others in the group.
-	NameConflict CustomResourceDefinitionConditionType = "NameConflict"
+	// NamesAccepted means the names chosen for this CustomResourceDefinition do not conflict with others in
+	// the group and are therefore accepted.
+	NamesAccepted CustomResourceDefinitionConditionType = "NamesAccepted"
 	// Terminating means that the CustomResourceDefinition has been deleted and is cleaning up.
 	Terminating CustomResourceDefinitionConditionType = "Terminating"
 )

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/v1alpha1/types.go
@@ -70,6 +70,10 @@ const (
 type CustomResourceDefinitionConditionType string
 
 const (
+	// Established means that the resource has become active. A resource is established when all names are
+	// accepted without a conflict for the first time. A resource stays established until deleted, even during
+	// a later NameConflict due to changed names. Note that not all names can be changed.
+	Established CustomResourceDefinitionConditionType = "Established"
 	// NameConflict means the names chosen for this CustomResourceDefinition conflict with others in the group.
 	NameConflict CustomResourceDefinitionConditionType = "NameConflict"
 	// Terminating means that the CustomResourceDefinition has been deleted and is cleaning up.

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/v1alpha1/types.go
@@ -72,10 +72,11 @@ type CustomResourceDefinitionConditionType string
 const (
 	// Established means that the resource has become active. A resource is established when all names are
 	// accepted without a conflict for the first time. A resource stays established until deleted, even during
-	// a later NameConflict due to changed names. Note that not all names can be changed.
+	// a later NamesAccepted due to changed names. Note that not all names can be changed.
 	Established CustomResourceDefinitionConditionType = "Established"
-	// NameConflict means the names chosen for this CustomResourceDefinition conflict with others in the group.
-	NameConflict CustomResourceDefinitionConditionType = "NameConflict"
+	// NamesAccepted means the names chosen for this CustomResourceDefinition do not conflict with others in
+	// the group and are therefore accepted.
+	NamesAccepted CustomResourceDefinitionConditionType = "NamesAccepted"
 	// Terminating means that the CustomResourceDefinition has been deleted and is cleaning up.
 	Terminating CustomResourceDefinitionConditionType = "Terminating"
 )

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_discovery_controller.go
@@ -85,8 +85,7 @@ func (c *DiscoveryController) sync(version schema.GroupVersion) error {
 	foundVersion := false
 	foundGroup := false
 	for _, crd := range crds {
-		// if we can't definitively determine that our names are good, don't serve it
-		if !apiextensions.IsCRDConditionFalse(crd, apiextensions.NameConflict) {
+		if !apiextensions.IsCRDConditionTrue(crd, apiextensions.Established) {
 			continue
 		}
 

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
@@ -143,8 +143,7 @@ func (r *crdHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		r.delegate.ServeHTTP(w, req)
 		return
 	}
-	// if we can't definitively determine that our names are good, delegate
-	if !apiextensions.IsCRDConditionFalse(crd, apiextensions.NameConflict) {
+	if !apiextensions.IsCRDConditionTrue(crd, apiextensions.Established) {
 		r.delegate.ServeHTTP(w, req)
 	}
 	if len(requestInfo.Subresource) > 0 {

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/BUILD
@@ -28,6 +28,7 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/golang/glog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -118,11 +119,11 @@ func (c *NamingConditionController) getAcceptedNamesForGroup(group string) (allR
 	return allResources, allKinds
 }
 
-func (c *NamingConditionController) calculateNames(in *apiextensions.CustomResourceDefinition) (apiextensions.CustomResourceDefinitionNames, apiextensions.CustomResourceDefinitionCondition) {
+func (c *NamingConditionController) calculateNamesAndConditions(in *apiextensions.CustomResourceDefinition) (apiextensions.CustomResourceDefinitionNames, apiextensions.CustomResourceDefinitionCondition, apiextensions.CustomResourceDefinitionCondition) {
 	// Get the names that have already been claimed
 	allResources, allKinds := c.getAcceptedNamesForGroup(in.Spec.Group)
 
-	condition := apiextensions.CustomResourceDefinitionCondition{
+	nameConflictCondition := apiextensions.CustomResourceDefinitionCondition{
 		Type:   apiextensions.NameConflict,
 		Status: apiextensions.ConditionUnknown,
 	}
@@ -134,16 +135,16 @@ func (c *NamingConditionController) calculateNames(in *apiextensions.CustomResou
 	// Check each name for mismatches.  If there's a mismatch between spec and status, then try to deconflict.
 	// Continue on errors so that the status is the best match possible
 	if err := equalToAcceptedOrFresh(requestedNames.Plural, acceptedNames.Plural, allResources); err != nil {
-		condition.Status = apiextensions.ConditionTrue
-		condition.Reason = "Plural"
-		condition.Message = err.Error()
+		nameConflictCondition.Status = apiextensions.ConditionTrue
+		nameConflictCondition.Reason = "Plural"
+		nameConflictCondition.Message = err.Error()
 	} else {
 		newNames.Plural = requestedNames.Plural
 	}
 	if err := equalToAcceptedOrFresh(requestedNames.Singular, acceptedNames.Singular, allResources); err != nil {
-		condition.Status = apiextensions.ConditionTrue
-		condition.Reason = "Singular"
-		condition.Message = err.Error()
+		nameConflictCondition.Status = apiextensions.ConditionTrue
+		nameConflictCondition.Reason = "Singular"
+		nameConflictCondition.Message = err.Error()
 	} else {
 		newNames.Singular = requestedNames.Singular
 	}
@@ -161,37 +162,58 @@ func (c *NamingConditionController) calculateNames(in *apiextensions.CustomResou
 
 		}
 		if err := utilerrors.NewAggregate(errs); err != nil {
-			condition.Status = apiextensions.ConditionTrue
-			condition.Reason = "ShortNames"
-			condition.Message = err.Error()
+			nameConflictCondition.Status = apiextensions.ConditionTrue
+			nameConflictCondition.Reason = "ShortNames"
+			nameConflictCondition.Message = err.Error()
 		} else {
 			newNames.ShortNames = requestedNames.ShortNames
 		}
 	}
 
 	if err := equalToAcceptedOrFresh(requestedNames.Kind, acceptedNames.Kind, allKinds); err != nil {
-		condition.Status = apiextensions.ConditionTrue
-		condition.Reason = "Kind"
-		condition.Message = err.Error()
+		nameConflictCondition.Status = apiextensions.ConditionTrue
+		nameConflictCondition.Reason = "Kind"
+		nameConflictCondition.Message = err.Error()
 	} else {
 		newNames.Kind = requestedNames.Kind
 	}
 	if err := equalToAcceptedOrFresh(requestedNames.ListKind, acceptedNames.ListKind, allKinds); err != nil {
-		condition.Status = apiextensions.ConditionTrue
-		condition.Reason = "ListKind"
-		condition.Message = err.Error()
+		nameConflictCondition.Status = apiextensions.ConditionTrue
+		nameConflictCondition.Reason = "ListKind"
+		nameConflictCondition.Message = err.Error()
 	} else {
 		newNames.ListKind = requestedNames.ListKind
 	}
 
 	// if we haven't changed the condition, then our names must be good.
-	if condition.Status == apiextensions.ConditionUnknown {
-		condition.Status = apiextensions.ConditionFalse
-		condition.Reason = "NoConflicts"
-		condition.Message = "no conflicts found"
+	if nameConflictCondition.Status == apiextensions.ConditionUnknown {
+		nameConflictCondition.Status = apiextensions.ConditionFalse
+		nameConflictCondition.Reason = "NoConflicts"
+		nameConflictCondition.Message = "no conflicts found"
 	}
 
-	return newNames, condition
+	// set EstablishedCondition to true if all names are accepted. Never set it back to false.
+	establishedCondition := apiextensions.CustomResourceDefinitionCondition{
+		Type:               apiextensions.Established,
+		Status:             apiextensions.ConditionFalse,
+		Reason:             "NotAccepted",
+		Message:            "not all names are accepted",
+		LastTransitionTime: metav1.NewTime(time.Now()),
+	}
+	if old := apiextensions.FindCRDCondition(in, apiextensions.Established); old != nil {
+		establishedCondition = *old
+	}
+	if establishedCondition.Status != apiextensions.ConditionTrue && nameConflictCondition.Status == apiextensions.ConditionFalse {
+		establishedCondition = apiextensions.CustomResourceDefinitionCondition{
+			Type:               apiextensions.Established,
+			Status:             apiextensions.ConditionTrue,
+			Reason:             "InitialNamesAccepted",
+			Message:            "the initial names have been accepted",
+			LastTransitionTime: metav1.NewTime(time.Now()),
+		}
+	}
+
+	return newNames, nameConflictCondition, establishedCondition
 }
 
 func equalToAcceptedOrFresh(requestedName, acceptedName string, usedNames sets.String) error {
@@ -214,12 +236,12 @@ func (c *NamingConditionController) sync(key string) error {
 		return err
 	}
 
-	acceptedNames, namingCondition := c.calculateNames(inCustomResourceDefinition)
+	acceptedNames, namingCondition, establishedCondition := c.calculateNamesAndConditions(inCustomResourceDefinition)
+
 	// nothing to do if accepted names and NameConflict condition didn't change
 	if reflect.DeepEqual(inCustomResourceDefinition.Status.AcceptedNames, acceptedNames) &&
-		apiextensions.IsCRDConditionEquivalent(
-			&namingCondition,
-			apiextensions.FindCRDCondition(inCustomResourceDefinition, apiextensions.NameConflict)) {
+		apiextensions.IsCRDConditionEquivalent(&namingCondition, apiextensions.FindCRDCondition(inCustomResourceDefinition, apiextensions.NameConflict)) &&
+		apiextensions.IsCRDConditionEquivalent(&establishedCondition, apiextensions.FindCRDCondition(inCustomResourceDefinition, apiextensions.Established)) {
 		return nil
 	}
 
@@ -230,6 +252,7 @@ func (c *NamingConditionController) sync(key string) error {
 
 	crd.Status.AcceptedNames = acceptedNames
 	apiextensions.SetCRDCondition(crd, namingCondition)
+	apiextensions.SetCRDCondition(crd, establishedCondition)
 
 	updatedObj, err := c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
 	if err != nil {

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller_test.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller_test.go
@@ -89,16 +89,16 @@ func (b *crdBuilder) NewOrDie() *apiextensions.CustomResourceDefinition {
 }
 
 var acceptedCondition = apiextensions.CustomResourceDefinitionCondition{
-	Type:    apiextensions.NameConflict,
-	Status:  apiextensions.ConditionFalse,
+	Type:    apiextensions.NamesAccepted,
+	Status:  apiextensions.ConditionTrue,
 	Reason:  "NoConflicts",
 	Message: "no conflicts found",
 }
 
 func nameConflictCondition(reason, message string) apiextensions.CustomResourceDefinitionCondition {
 	return apiextensions.CustomResourceDefinitionCondition{
-		Type:    apiextensions.NameConflict,
-		Status:  apiextensions.ConditionTrue,
+		Type:    apiextensions.NamesAccepted,
+		Status:  apiextensions.ConditionFalse,
 		Reason:  reason,
 		Message: message,
 	}
@@ -155,7 +155,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
 			},
 			expectedNames:                 names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedNameConflictCondition: nameConflictCondition("Plural", `"alfa" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("PluralConflict", `"alfa" is already in use`),
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
@@ -165,7 +165,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "indias", "", "", "delta-singular").NewOrDie(),
 			},
 			expectedNames:                 names("alfa", "", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedNameConflictCondition: nameConflictCondition("Singular", `"delta-singular" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("SingularConflict", `"delta-singular" is already in use`),
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
@@ -175,7 +175,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "indias", "", "", "hotel-shortname-2").NewOrDie(),
 			},
 			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind"),
-			expectedNameConflictCondition: nameConflictCondition("ShortNames", `"hotel-shortname-2" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("ShortNamesConflict", `"hotel-shortname-2" is already in use`),
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
@@ -185,7 +185,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "indias", "", "echo-kind").NewOrDie(),
 			},
 			expectedNames:                 names("alfa", "delta-singular", "", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedNameConflictCondition: nameConflictCondition("Kind", `"echo-kind" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("KindConflict", `"echo-kind" is already in use`),
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
@@ -195,7 +195,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "").NewOrDie(),
 			},
 			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "", "golf-shortname-1", "hotel-shortname-2"),
-			expectedNameConflictCondition: nameConflictCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("ListKindConflict", `"foxtrot-listkind" is already in use`),
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
@@ -218,7 +218,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "", "delta-singular").NewOrDie(),
 			},
 			expectedNames:                 names("alfa", "yankee-singular", "echo-kind", "whiskey-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedNameConflictCondition: nameConflictCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("ListKindConflict", `"foxtrot-listkind" is already in use`),
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
@@ -231,7 +231,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "", "delta-singular", "golf-shortname-1").NewOrDie(),
 			},
 			expectedNames:                 names("alfa", "yankee-singular", "echo-kind", "whiskey-listkind", "victor-shortname-1", "uniform-shortname-2"),
-			expectedNameConflictCondition: nameConflictCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("ListKindConflict", `"foxtrot-listkind" is already in use`),
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
@@ -295,7 +295,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
 			},
 			expectedNames:                 names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedNameConflictCondition: nameConflictCondition("Plural", `"alfa" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("PluralConflict", `"alfa" is already in use`),
 			expectedEstablishedCondition:  establishedCondition,
 		},
 		{
@@ -307,7 +307,7 @@ func TestSync(t *testing.T) {
 				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
 			},
 			expectedNames:                 names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedNameConflictCondition: nameConflictCondition("Plural", `"alfa" is already in use`),
+			expectedNameConflictCondition: nameConflictCondition("PluralConflict", `"alfa" is already in use`),
 			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 	}

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller_test.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/status/naming_controller_test.go
@@ -67,6 +67,12 @@ func (b *crdBuilder) StatusNames(plural, singular, kind, listKind string, shortN
 	return b
 }
 
+func (b *crdBuilder) Condition(c apiextensions.CustomResourceDefinitionCondition) *crdBuilder {
+	b.curr.Status.Conditions = append(b.curr.Status.Conditions, c)
+
+	return b
+}
+
 func names(plural, singular, kind, listKind string, shortNames ...string) apiextensions.CustomResourceDefinitionNames {
 	ret := apiextensions.CustomResourceDefinitionNames{
 		Plural:     plural,
@@ -82,14 +88,14 @@ func (b *crdBuilder) NewOrDie() *apiextensions.CustomResourceDefinition {
 	return &b.curr
 }
 
-var goodCondition = apiextensions.CustomResourceDefinitionCondition{
+var acceptedCondition = apiextensions.CustomResourceDefinitionCondition{
 	Type:    apiextensions.NameConflict,
 	Status:  apiextensions.ConditionFalse,
 	Reason:  "NoConflicts",
 	Message: "no conflicts found",
 }
 
-func badCondition(reason, message string) apiextensions.CustomResourceDefinitionCondition {
+func nameConflictCondition(reason, message string) apiextensions.CustomResourceDefinitionCondition {
 	return apiextensions.CustomResourceDefinitionCondition{
 		Type:    apiextensions.NameConflict,
 		Status:  apiextensions.ConditionTrue,
@@ -98,14 +104,29 @@ func badCondition(reason, message string) apiextensions.CustomResourceDefinition
 	}
 }
 
+var establishedCondition = apiextensions.CustomResourceDefinitionCondition{
+	Type:    apiextensions.Established,
+	Status:  apiextensions.ConditionTrue,
+	Reason:  "InitialNamesAccepted",
+	Message: "the initial names have been accepted",
+}
+
+var notEstablishedCondition = apiextensions.CustomResourceDefinitionCondition{
+	Type:    apiextensions.Established,
+	Status:  apiextensions.ConditionFalse,
+	Reason:  "NotAccepted",
+	Message: "not all names are accepted",
+}
+
 func TestSync(t *testing.T) {
 	tests := []struct {
 		name string
 
-		in                *apiextensions.CustomResourceDefinition
-		existing          []*apiextensions.CustomResourceDefinition
-		expectedNames     apiextensions.CustomResourceDefinitionNames
-		expectedCondition apiextensions.CustomResourceDefinitionCondition
+		in                            *apiextensions.CustomResourceDefinition
+		existing                      []*apiextensions.CustomResourceDefinition
+		expectedNames                 apiextensions.CustomResourceDefinitionNames
+		expectedNameConflictCondition apiextensions.CustomResourceDefinitionCondition
+		expectedEstablishedCondition  apiextensions.CustomResourceDefinitionCondition
 	}{
 		{
 			name:     "first resource",
@@ -114,7 +135,8 @@ func TestSync(t *testing.T) {
 			expectedNames: apiextensions.CustomResourceDefinitionNames{
 				Plural: "alfa",
 			},
-			expectedCondition: goodCondition,
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  establishedCondition,
 		},
 		{
 			name: "different groups",
@@ -122,8 +144,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("alfa.charlie.com").StatusNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").NewOrDie(),
 			},
-			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedCondition: goodCondition,
+			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  establishedCondition,
 		},
 		{
 			name: "conflict plural to singular",
@@ -131,8 +154,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
 			},
-			expectedNames:     names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedCondition: badCondition("Plural", `"alfa" is already in use`),
+			expectedNames:                 names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: nameConflictCondition("Plural", `"alfa" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
 			name: "conflict singular to shortName",
@@ -140,8 +164,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "indias", "", "", "delta-singular").NewOrDie(),
 			},
-			expectedNames:     names("alfa", "", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedCondition: badCondition("Singular", `"delta-singular" is already in use`),
+			expectedNames:                 names("alfa", "", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: nameConflictCondition("Singular", `"delta-singular" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
 			name: "conflict on shortName to shortName",
@@ -149,8 +174,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "indias", "", "", "hotel-shortname-2").NewOrDie(),
 			},
-			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind"),
-			expectedCondition: badCondition("ShortNames", `"hotel-shortname-2" is already in use`),
+			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind"),
+			expectedNameConflictCondition: nameConflictCondition("ShortNames", `"hotel-shortname-2" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
 			name: "conflict on kind to listkind",
@@ -158,8 +184,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "indias", "", "echo-kind").NewOrDie(),
 			},
-			expectedNames:     names("alfa", "delta-singular", "", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedCondition: badCondition("Kind", `"echo-kind" is already in use`),
+			expectedNames:                 names("alfa", "delta-singular", "", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: nameConflictCondition("Kind", `"echo-kind" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
 			name: "conflict on listkind to kind",
@@ -167,8 +194,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "").NewOrDie(),
 			},
-			expectedNames:     names("alfa", "delta-singular", "echo-kind", "", "golf-shortname-1", "hotel-shortname-2"),
-			expectedCondition: badCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: nameConflictCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
 			name: "no conflict on resource and kind",
@@ -176,8 +204,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "echo-kind", "", "").NewOrDie(),
 			},
-			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedCondition: goodCondition,
+			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  establishedCondition,
 		},
 		{
 			name: "merge on conflicts",
@@ -188,8 +217,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "", "delta-singular").NewOrDie(),
 			},
-			expectedNames:     names("alfa", "yankee-singular", "echo-kind", "whiskey-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedCondition: badCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedNames:                 names("alfa", "yankee-singular", "echo-kind", "whiskey-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: nameConflictCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
 			name: "merge on conflicts shortNames as one",
@@ -200,8 +230,9 @@ func TestSync(t *testing.T) {
 			existing: []*apiextensions.CustomResourceDefinition{
 				newCRD("india.bravo.com").StatusNames("india", "indias", "foxtrot-listkind", "", "delta-singular", "golf-shortname-1").NewOrDie(),
 			},
-			expectedNames:     names("alfa", "yankee-singular", "echo-kind", "whiskey-listkind", "victor-shortname-1", "uniform-shortname-2"),
-			expectedCondition: badCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedNames:                 names("alfa", "yankee-singular", "echo-kind", "whiskey-listkind", "victor-shortname-1", "uniform-shortname-2"),
+			expectedNameConflictCondition: nameConflictCondition("ListKind", `"foxtrot-listkind" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 		{
 			name: "no conflicts on self",
@@ -215,8 +246,9 @@ func TestSync(t *testing.T) {
 					StatusNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
 					NewOrDie(),
 			},
-			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
-			expectedCondition: goodCondition,
+			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  establishedCondition,
 		},
 		{
 			name: "no conflicts on self, remove shortname",
@@ -230,8 +262,53 @@ func TestSync(t *testing.T) {
 					StatusNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
 					NewOrDie(),
 			},
-			expectedNames:     names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1"),
-			expectedCondition: goodCondition,
+			expectedNames:                 names("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1"),
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  establishedCondition,
+		},
+		{
+			name:     "established before with true condition",
+			in:       newCRD("alfa.bravo.com").Condition(establishedCondition).NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{},
+			expectedNames: apiextensions.CustomResourceDefinitionNames{
+				Plural: "alfa",
+			},
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  establishedCondition,
+		},
+		{
+			name:     "not established before with false condition",
+			in:       newCRD("alfa.bravo.com").Condition(notEstablishedCondition).NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{},
+			expectedNames: apiextensions.CustomResourceDefinitionNames{
+				Plural: "alfa",
+			},
+			expectedNameConflictCondition: acceptedCondition,
+			expectedEstablishedCondition:  establishedCondition,
+		},
+		{
+			name: "conflicting, established before with true condition",
+			in: newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+				Condition(establishedCondition).
+				NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
+			},
+			expectedNames:                 names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: nameConflictCondition("Plural", `"alfa" is already in use`),
+			expectedEstablishedCondition:  establishedCondition,
+		},
+		{
+			name: "conflicting, not established before with false condition",
+			in: newCRD("alfa.bravo.com").SpecNames("alfa", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2").
+				Condition(notEstablishedCondition).
+				NewOrDie(),
+			existing: []*apiextensions.CustomResourceDefinition{
+				newCRD("india.bravo.com").StatusNames("india", "alfa", "", "").NewOrDie(),
+			},
+			expectedNames:                 names("", "delta-singular", "echo-kind", "foxtrot-listkind", "golf-shortname-1", "hotel-shortname-2"),
+			expectedNameConflictCondition: nameConflictCondition("Plural", `"alfa" is already in use`),
+			expectedEstablishedCondition:  notEstablishedCondition,
 		},
 	}
 
@@ -245,12 +322,15 @@ func TestSync(t *testing.T) {
 			crdLister:        listers.NewCustomResourceDefinitionLister(crdIndexer),
 			crdMutationCache: cache.NewIntegerResourceVersionMutationCache(crdIndexer, crdIndexer, 60*time.Second, false),
 		}
-		actualNames, actualCondition := c.calculateNames(tc.in)
+		actualNames, actualNameConflictCondition, actualEstablishedCondition := c.calculateNamesAndConditions(tc.in)
 
 		if e, a := tc.expectedNames, actualNames; !reflect.DeepEqual(e, a) {
 			t.Errorf("%v expected %v, got %#v", tc.name, e, a)
 		}
-		if e, a := tc.expectedCondition, actualCondition; !apiextensions.IsCRDConditionEquivalent(&e, &a) {
+		if e, a := tc.expectedNameConflictCondition, actualNameConflictCondition; !apiextensions.IsCRDConditionEquivalent(&e, &a) {
+			t.Errorf("%v expected %v, got %v", tc.name, e, a)
+		}
+		if e, a := tc.expectedEstablishedCondition, actualEstablishedCondition; !apiextensions.IsCRDConditionEquivalent(&e, &a) {
 			t.Errorf("%v expected %v, got %v", tc.name, e, a)
 		}
 	}


### PR DESCRIPTION
This introduces a `Established` condition on `CustomResourceDefinition`s. `Established` means that the resource has become active. A resource is established when all names are accepted initially without a conflict. A resource stays established until deleted, even during a later NameConflict due to changed names. Note that not all names can be changed.

This change is necessary to allow deletion of once-active CRDs which might have still instances, but  have NameConflicts now. Before this PR the REST endpoint was not active anymore in this case, making deletion of the instances impossible.