### PR TITLE
fix missing argument

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -652,7 +652,7 @@ func TestFinishRequest(t *testing.T) {
 			t.Errorf("%d: unexpected err. expected: %v, got: %v", i, tc.expectedErr, err)
 		}
 		if !apiequality.Semantic.DeepEqual(obj, tc.expectedObj) {
-			t.Errorf("%d: unexpected obj. expected %#v, got %#v", tc.expectedObj, obj)
+			t.Errorf("%d: unexpected obj. expected %#v, got %#v", i, tc.expectedObj, obj)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

**What this PR does / why we need it**:
format reads arg 3, have only 2 args

```release-note
```
