### PR TITLE
apimachinery: move unversioned registration to metav1

### DIFF
--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -50,10 +50,6 @@ const GroupName = ""
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
 
-// Unversioned is group version for unversioned API objects
-// TODO: this should be v1 probably
-var Unversioned = schema.GroupVersion{Group: "", Version: "v1"}
-
 // ParameterCodec handles versioning of objects that are converted to query parameters.
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
@@ -123,13 +119,5 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ConfigMapList{},
 	)
 
-	// Register Unversioned types under their own special group
-	scheme.AddUnversionedTypes(Unversioned,
-		&metav1.Status{},
-		&metav1.APIVersions{},
-		&metav1.APIGroupList{},
-		&metav1.APIGroup{},
-		&metav1.APIResourceList{},
-	)
 	return nil
 }

--- a/pkg/controller/garbagecollector/metaonly/metaonly.go
+++ b/pkg/controller/garbagecollector/metaonly/metaonly.go
@@ -52,14 +52,14 @@ func NewMetadataCodecFactory() serializer.CodecFactory {
 		if kind.Version == runtime.APIVersionInternal {
 			continue
 		}
-		if kind == api.Unversioned.WithKind("Status") {
+		if kind == metav1.Unversioned.WithKind("Status") {
 			// this is added below as unversioned
 			continue
 		}
 		metaOnlyObject := gvkToMetadataOnlyObject(kind)
 		scheme.AddKnownTypeWithName(kind, metaOnlyObject)
 	}
-	scheme.AddUnversionedTypes(api.Unversioned, &metav1.Status{})
+	scheme.AddUnversionedTypes(metav1.Unversioned, &metav1.Status{})
 	return serializer.NewCodecFactory(scheme)
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/register.go
@@ -27,6 +27,10 @@ const GroupName = "meta.k8s.io"
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
 
+// Unversioned is group version for unversioned API objects
+// TODO: this should be v1 probably
+var Unversioned = schema.GroupVersion{Group: "", Version: "v1"}
+
 // WatchEventKind is name reserved for serializing watch events.
 const WatchEventKind = "WatchEvent"
 
@@ -54,6 +58,15 @@ func AddToGroupVersion(scheme *runtime.Scheme, groupVersion schema.GroupVersion)
 		Convert_versioned_InternalEvent_to_versioned_Event,
 		Convert_watch_Event_to_versioned_Event,
 		Convert_versioned_Event_to_versioned_InternalEvent,
+	)
+
+	// Register Unversioned types under their own special group
+	scheme.AddUnversionedTypes(Unversioned,
+		&Status{},
+		&APIVersions{},
+		&APIGroupList{},
+		&APIGroup{},
+		&APIResourceList{},
 	)
 
 	// register manually. This usually goes through the SchemeBuilder, which we cannot use here.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme.go
@@ -151,8 +151,8 @@ func (s *Scheme) AddUnversionedTypes(version schema.GroupVersion, types ...Objec
 		t := reflect.TypeOf(obj).Elem()
 		gvk := version.WithKind(t.Name())
 		s.unversionedTypes[t] = gvk
-		if _, ok := s.unversionedKinds[gvk.Kind]; ok {
-			panic(fmt.Sprintf("%v has already been registered as unversioned kind %q - kind name must be unique", reflect.TypeOf(t), gvk.Kind))
+		if old, ok := s.unversionedKinds[gvk.Kind]; ok && t != old {
+			panic(fmt.Sprintf("%v.%v has already been registered as unversioned kind %q - kind name must be unique", old.PkgPath(), old.Name(), gvk))
 		}
 		s.unversionedKinds[gvk.Kind] = t
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -571,6 +571,7 @@ func TestAddKnownTypesIdemPotent(t *testing.T) {
 	}
 
 	s.AddUnversionedTypes(gv, &InternalSimple{})
+	s.AddUnversionedTypes(gv, &InternalSimple{})
 	if len(s.KnownTypes(gv)) != 1 {
 		t.Errorf("expected only one %v type after double registration with custom name", gv)
 	}
@@ -586,6 +587,11 @@ func TestAddKnownTypesIdemPotent(t *testing.T) {
 		t.Errorf("expected only one kind for InternalSimple after double registration", gv)
 	}
 }
+
+// EmbeddableTypeMeta passes GetObjectKind to the type which embeds it.
+type EmbeddableTypeMeta runtime.TypeMeta
+
+func (tm *EmbeddableTypeMeta) GetObjectKind() schema.ObjectKind { return (*runtime.TypeMeta)(tm) }
 
 func TestConflictingAddKnownTypes(t *testing.T) {
 	s := runtime.NewScheme()
@@ -612,7 +618,14 @@ func TestConflictingAddKnownTypes(t *testing.T) {
 				panicked <- true
 			}
 		}()
+
 		s.AddUnversionedTypes(gv, &InternalSimple{})
+
+		// redefine InternalSimple with the same name, but obviously as a different type
+		type InternalSimple struct {
+			EmbeddableTypeMeta `json:",inline"`
+			TestString         string `json:"testString"`
+		}
 		s.AddUnversionedTypes(gv, &InternalSimple{})
 		panicked <- false
 	}()

--- a/staging/src/k8s.io/client-go/pkg/api/register.go
+++ b/staging/src/k8s.io/client-go/pkg/api/register.go
@@ -50,10 +50,6 @@ const GroupName = ""
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}
 
-// Unversioned is group version for unversioned API objects
-// TODO: this should be v1 probably
-var Unversioned = schema.GroupVersion{Group: "", Version: "v1"}
-
 // ParameterCodec handles versioning of objects that are converted to query parameters.
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 
@@ -123,13 +119,5 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&ConfigMapList{},
 	)
 
-	// Register Unversioned types under their own special group
-	scheme.AddUnversionedTypes(Unversioned,
-		&metav1.Status{},
-		&metav1.APIVersions{},
-		&metav1.APIGroupList{},
-		&metav1.APIGroup{},
-		&metav1.APIResourceList{},
-	)
 	return nil
 }


### PR DESCRIPTION
Follow-up from the discussions in https://github.com/kubernetes/kubernetes/pull/43027:

We need `Status` as unversioned type which is hardcoded to `GroupVersion{Group: "", Version: "v1"}`. If the core group is not in the scheme, we miss `Status`.

Fixing https://github.com/kubernetes/kubernetes/issues/47030.