### PR TITLE
[Federation] Move service dns controller to its own package

### DIFF
--- a/federation/cmd/federation-controller-manager/app/BUILD
+++ b/federation/cmd/federation-controller-manager/app/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//federation/pkg/federation-controller/namespace:go_default_library",
         "//federation/pkg/federation-controller/replicaset:go_default_library",
         "//federation/pkg/federation-controller/service:go_default_library",
+        "//federation/pkg/federation-controller/service/dns:go_default_library",
         "//federation/pkg/federation-controller/sync:go_default_library",
         "//pkg/util/configz:go_default_library",
         "//pkg/version:go_default_library",

--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -42,6 +42,7 @@ import (
 	namespacecontroller "k8s.io/kubernetes/federation/pkg/federation-controller/namespace"
 	replicasetcontroller "k8s.io/kubernetes/federation/pkg/federation-controller/replicaset"
 	servicecontroller "k8s.io/kubernetes/federation/pkg/federation-controller/service"
+	servicednscontroller "k8s.io/kubernetes/federation/pkg/federation-controller/service/dns"
 	synccontroller "k8s.io/kubernetes/federation/pkg/federation-controller/sync"
 	"k8s.io/kubernetes/pkg/util/configz"
 	"k8s.io/kubernetes/pkg/version"
@@ -136,9 +137,9 @@ func StartControllers(s *options.CMServer, restClientCfg *restclient.Config) err
 	clustercontroller.StartClusterController(restClientCfg, stopChan, s.ClusterMonitorPeriod.Duration)
 
 	if controllerEnabled(s.Controllers, serverResources, servicecontroller.ControllerName, servicecontroller.RequiredResources, true) {
-		if controllerEnabled(s.Controllers, serverResources, servicecontroller.DNSControllerName, servicecontroller.RequiredResources, true) {
-			serviceDNScontrollerClientset := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, servicecontroller.DNSUserAgentName))
-			serviceDNSController, err := servicecontroller.NewServiceDNSController(serviceDNScontrollerClientset, s.DnsProvider, s.DnsConfigFile, s.FederationName, s.ServiceDnsSuffix, s.ZoneName, s.ZoneID)
+		if controllerEnabled(s.Controllers, serverResources, servicednscontroller.ControllerName, servicecontroller.RequiredResources, true) {
+			serviceDNScontrollerClientset := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, servicednscontroller.UserAgentName))
+			serviceDNSController, err := servicednscontroller.NewServiceDNSController(serviceDNScontrollerClientset, s.DnsProvider, s.DnsConfigFile, s.FederationName, s.ServiceDnsSuffix, s.ZoneName, s.ZoneID)
 			if err != nil {
 				glog.Fatalf("Failed to start service dns controller: %v", err)
 			} else {

--- a/federation/pkg/federation-controller/service/BUILD
+++ b/federation/pkg/federation-controller/service/BUILD
@@ -10,18 +10,13 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "dns.go",
-        "ingress.go",
-        "servicecontroller.go",
-    ],
+    srcs = ["servicecontroller.go"],
     tags = ["automanaged"],
     deps = [
         "//federation/apis/federation:go_default_library",
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset:go_default_library",
-        "//federation/pkg/dnsprovider:go_default_library",
-        "//federation/pkg/dnsprovider/rrstype:go_default_library",
+        "//federation/pkg/federation-controller/service/ingress:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
         "//federation/pkg/federation-controller/util/clusterselector:go_default_library",
         "//federation/pkg/federation-controller/util/deletionhelper:go_default_library",
@@ -38,7 +33,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/pkg/api/v1:go_default_library",
@@ -51,16 +45,13 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = [
-        "dns_test.go",
-        "servicecontroller_test.go",
-    ],
+    srcs = ["servicecontroller_test.go"],
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset/fake:go_default_library",
-        "//federation/pkg/dnsprovider/providers/google/clouddns:go_default_library",
+        "//federation/pkg/federation-controller/service/ingress:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
         "//federation/pkg/federation-controller/util/test:go_default_library",
         "//pkg/api/v1:go_default_library",
@@ -86,6 +77,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//federation/pkg/federation-controller/service/dns:all-srcs",
+        "//federation/pkg/federation-controller/service/ingress:all-srcs",
+    ],
     tags = ["automanaged"],
 )

--- a/federation/pkg/federation-controller/service/dns/BUILD
+++ b/federation/pkg/federation-controller/service/dns/BUILD
@@ -1,0 +1,62 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["dns_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//federation/apis/federation/v1beta1:go_default_library",
+        "//federation/client/clientset_generated/federation_clientset/fake:go_default_library",
+        "//federation/pkg/dnsprovider/providers/google/clouddns:go_default_library",
+        "//federation/pkg/federation-controller/service/ingress:go_default_library",
+        "//federation/pkg/federation-controller/util/test:go_default_library",
+        "//pkg/api/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["dns.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//federation/client/clientset_generated/federation_clientset:go_default_library",
+        "//federation/pkg/dnsprovider:go_default_library",
+        "//federation/pkg/dnsprovider/rrstype:go_default_library",
+        "//federation/pkg/federation-controller/service/ingress:go_default_library",
+        "//federation/pkg/federation-controller/util:go_default_library",
+        "//pkg/api/v1:go_default_library",
+        "//pkg/client/listers/core/v1:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/federation/pkg/federation-controller/service/ingress/BUILD
+++ b/federation/pkg/federation-controller/service/ingress/BUILD
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ingress.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//federation/apis/federation:go_default_library",
+        "//pkg/api/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/federation/pkg/federation-controller/service/ingress/ingress.go
+++ b/federation/pkg/federation-controller/service/ingress/ingress.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package service
+package ingress
 
 import (
 	"encoding/json"


### PR DESCRIPTION
This PR does nothing but just moves service dns controller code to its own package.

**Release note**:
```release-note
NONE
```
cc @kubernetes/sig-federation-pr-reviews 
/assign @marun 
