### PR TITLE
Fix kuberuntime GetPods.

### DIFF
--- a/pkg/kubelet/kuberuntime/helpers.go
+++ b/pkg/kubelet/kuberuntime/helpers.go
@@ -105,14 +105,14 @@ func (m *kubeGenericRuntimeManager) toKubeContainer(c *runtimeapi.Container) (*k
 		return nil, fmt.Errorf("unable to convert a nil pointer to a runtime container")
 	}
 
-	labeledInfo := getContainerInfoFromLabels(c.Labels)
 	annotatedInfo := getContainerInfoFromAnnotations(c.Annotations)
 	return &kubecontainer.Container{
-		ID:    kubecontainer.ContainerID{Type: m.runtimeName, ID: c.Id},
-		Name:  labeledInfo.ContainerName,
-		Image: c.Image.Image,
-		Hash:  annotatedInfo.Hash,
-		State: toKubeContainerState(c.State),
+		ID:      kubecontainer.ContainerID{Type: m.runtimeName, ID: c.Id},
+		Name:    c.GetMetadata().GetName(),
+		ImageID: c.ImageRef,
+		Image:   c.Image.Image,
+		Hash:    annotatedInfo.Hash,
+		State:   toKubeContainerState(c.State),
 	}, nil
 }
 

--- a/pkg/kubelet/kuberuntime/helpers_test.go
+++ b/pkg/kubelet/kuberuntime/helpers_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/api/v1"
+	runtimetesting "k8s.io/kubernetes/pkg/kubelet/apis/cri/testing"
+	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1"
+	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 func TestStableKey(t *testing.T) {
@@ -85,4 +88,37 @@ func TestGetSystclsFromAnnotations(t *testing.T) {
 		assert.Len(t, actualSysctls, len(test.expectedSysctls), "TestCase[%d]", i)
 		assert.Equal(t, test.expectedSysctls, actualSysctls, "TestCase[%d]", i)
 	}
+}
+
+func TestToKubeContainer(t *testing.T) {
+	c := &runtimeapi.Container{
+		Id: "test-id",
+		Metadata: &runtimeapi.ContainerMetadata{
+			Name:    "test-name",
+			Attempt: 1,
+		},
+		Image:    &runtimeapi.ImageSpec{Image: "test-image"},
+		ImageRef: "test-image-ref",
+		State:    runtimeapi.ContainerState_CONTAINER_RUNNING,
+		Annotations: map[string]string{
+			containerHashLabel: "1234",
+		},
+	}
+	expect := &kubecontainer.Container{
+		ID: kubecontainer.ContainerID{
+			Type: runtimetesting.FakeRuntimeName,
+			ID:   "test-id",
+		},
+		Name:    "test-name",
+		ImageID: "test-image-ref",
+		Image:   "test-image",
+		Hash:    uint64(0x1234),
+		State:   kubecontainer.ContainerStateRunning,
+	}
+
+	_, _, m, err := createTestRuntimeManager()
+	assert.NoError(t, err)
+	got, err := m.toKubeContainer(c)
+	assert.NoError(t, err)
+	assert.Equal(t, expect, got)
 }


### PR DESCRIPTION
The `ImageID` is not populated from `GetPods` in kuberuntime.

Image garbage collector is using this field, https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/images/image_gc_manager.go#L204.

Without this fix, image garbage collector will try to garbage collect all images every time. Because docker will not allow that, it should be fine. However, I'm not sure whether the unnecessary remove will cause any problem, e.g. overload docker image management system and make docker hang.

@dchen1107 @yujuhong @feiskyer Do you think we should cherry-pick this?

```release-note
Kubelet: Fix image garbage collector attempting to remove in-use images.
```