### PR TITLE
Add eparis to approval for OWNERS

### DIFF
--- a/build/OWNERS
+++ b/build/OWNERS
@@ -5,9 +5,10 @@ reviewers:
   - zmerlynn
   - spxtr
 approvers:
+  - eparis
   - ixdy
   - jbeda
   - lavalamp
-  - zmerlynn
   - mikedanese
   - spxtr
+  - zmerlynn

--- a/cmd/OWNERS
+++ b/cmd/OWNERS
@@ -5,6 +5,7 @@ reviewers:
   - thockin
 approvers:
   - dchen1107
+  - eparis
   - lavalamp
   - mikedanese
   - thockin

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -4,6 +4,7 @@ reviewers:
   - thockin
 approvers:
   - brendandburns
+  - eparis
   - smarterclayton
   - thockin
   - pwittrock

--- a/federation/OWNERS
+++ b/federation/OWNERS
@@ -10,6 +10,7 @@ reviewers:
   - shashidharatd
 approvers:
   - csbell
+  - eparis
   - madhusudancs
   - mwielgus
   - nikhiljindal

--- a/pkg/OWNERS
+++ b/pkg/OWNERS
@@ -7,6 +7,7 @@ reviewers:
 approvers:
   - brendandburns
   - dchen1107
+  - eparis
   - lavalamp
   - smarterclayton
   - thockin

--- a/plugin/OWNERS
+++ b/plugin/OWNERS
@@ -8,5 +8,6 @@ approvers:
   - brendandburns
   - davidopp
   - dchen1107
+  - eparis
   - lavalamp
   - thockin

--- a/staging/OWNERS
+++ b/staging/OWNERS
@@ -1,14 +1,15 @@
-approvers:
-- lavalamp
-- smarterclayton
 reviewers:
-- lavalamp
-- smarterclayton
-- wojtek-t
-- deads2k
-- caesarxuchao
-- mikedanese
-- liggitt
-- nikhiljindal
-- sttts
-- krousey
+  - lavalamp
+  - smarterclayton
+  - wojtek-t
+  - deads2k
+  - caesarxuchao
+  - mikedanese
+  - liggitt
+  - nikhiljindal
+  - sttts
+  - krousey
+approvers:
+  - eparis
+  - lavalamp
+  - smarterclayton


### PR DESCRIPTION
We regularly run into issues where a very minor easy to approve
PR crosses functional boundaries. Today we have a limited number
of (very busy) people who can approve it or we need to get approval
from a large number of people across subsystems.

Almost everyone who works on kube at Red Hat reports to me and I can
only help them with simple clear PRs with approve privs. I agree
to be very conservative and only approve things I know to be safe. I
will gladly defer and find help for anything assigned to me that I am
not 100% confident in my approval.

I agree to be a good approver. To only approve things I know how to
approve and to make sure someone smarter than me approves things I am
not "smrt" enough to approve.

**Release note**:
```release-note
NONE
```
