### PR TITLE
Return MethodNotSupported when accessing unwatcheable resource with ?watch=true

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -292,7 +292,11 @@ func ListResource(r rest.Lister, rw rest.Watcher, scope RequestScope, forceWatch
 			opts.FieldSelector = nameSelector
 		}
 
-		if (opts.Watch || forceWatch) && rw != nil {
+		if opts.Watch || forceWatch {
+			if rw == nil {
+				scope.err(errors.NewMethodNotSupported(scope.Resource.GroupResource(), "watch"), w, req)
+				return
+			}
 			// TODO: Currently we explicitly ignore ?timeout= and use only ?timeoutSeconds=.
 			timeout := time.Duration(0)
 			if opts.TimeoutSeconds != nil {


### PR DESCRIPTION
Currently, if a RESTStorage does not implement Watch(), accessing the list endpoint with ?watch=true will call List, with ListOptions.Watch=true. It should return a MethodNotSupported error.