### PR TITLE
Add iptables lock mount to kube-proxy salt manifest

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/init.sls
+++ b/cluster/saltbase/salt/kube-proxy/init.sls
@@ -30,7 +30,7 @@
     - user: root
     - group: root
     - mode: 644
-
+    
 #stop legacy kube-proxy service
 stop_kube-proxy:
   service.dead:

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -108,7 +108,6 @@ spec:
     name: varlog
   - hostPath:
       path: /run
-    name: run
-  - hostPath:
-      path: /run/xtables.lock
+      subPath: xtables.lock
     name: iptableslock
+    


### PR DESCRIPTION
Related to #44895 #46103

The new mount is necessary to support iptables -w operations.
This works fine when kube-proxy works out of the box and
should now work in containerized instances as well.

**Release note**:
```
support iptables -w in salt kube-proxy
```
