### PR TITLE
clientgo/examples/in-cluster: add instructions to run the example

### DIFF
--- a/staging/src/k8s.io/client-go/examples/in-cluster/Dockerfile
+++ b/staging/src/k8s.io/client-go/examples/in-cluster/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM debian
+COPY ./app /app
+ENTRYPOINT /app

--- a/staging/src/k8s.io/client-go/examples/in-cluster/README.md
+++ b/staging/src/k8s.io/client-go/examples/in-cluster/README.md
@@ -1,0 +1,50 @@
+# Authenticating inside the cluster
+
+This example shows you how you can write an application that authenticates to
+the Kubernetes API while it is running on a Kubernetes cluster.
+
+client-go uses the [Service Account token][sa] mounted inside the Pod at the
+`/var/run/secrets/kubernetes.io/serviceaccount` path when the
+`rest.InClusterConfig()` is used.
+
+## Running this example
+
+First compile the application for Linux:
+
+    cd in-cluster
+    GOOS=linux go build -o ./app .
+
+Then package it to a docker image using the provided Dockerfile to run it on
+Kubernetes.
+
+If you are running a [Minikube][mk] cluster, you can build this image directly
+on the Docker engine of the Minikube node without pushing it to a registry. To
+build the image on Minikube:
+
+    eval $(minikube docker-env)
+    docker build -t in-cluster .
+
+If you are not using Minikube, you should build this image and push it to a registry
+that your Kubernetes cluster can pull from.
+
+Then, run the image in a Pod with a single instance Deployment:
+
+    $ kubectl run --rm -i demo --image=in-cluster --image-pull-policy=Never
+
+    There are 4 pods in the cluster
+    There are 4 pods in the cluster
+    There are 4 pods in the cluster
+    ...
+
+The example now runs on Kubernetes API and successfully queries the number of
+pods in the cluster every 10 seconds.
+
+### Clean up
+
+To stop this example and clean up the pod, press <kbd>Ctrl</kbd>+<kbd>C</kbd> on
+the `kubectl run` command and then run:
+
+    kubectl delete deployment demo
+
+[sa]: https://kubernetes.io/docs/admin/authentication/#service-account-tokens
+[mk]: https://kubernetes.io/docs/getting-started-guides/minikube/


### PR DESCRIPTION
This patch adds instructions for how to run the in-cluster client-go example.
To make this example executable, providing a Dockerfile and build steps so
that it can directly be run on minikube.

This is part of the body of work improving the client library samples.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>