### PR TITLE
clientgo/examples/out-of-cluster: add instructions

### DIFF
--- a/staging/src/k8s.io/client-go/examples/out-of-cluster/README.md
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster/README.md
@@ -1,0 +1,34 @@
+# Authenticating outside the cluster
+
+This example shows you how to authenticate to the Kubernetes API from an
+application running outside the Kubernetes cluster with client-go.
+
+You can use your kubeconfig file that contains the context information
+of your cluster to initialize a client. The kubeconfig file is also used
+by the `kubectl` command to authenticate to the clusters.
+
+## Running this example
+
+Make sure your `kubectl` is configured and pointed to a cluster. Run
+`kubectl get nodes` to confirm.
+
+Run this application with:
+
+    cd out-of-cluster
+    go build -o app .
+    ./app
+
+Running this application will use the kubeconfig file and then authenticate to the
+cluster, and print the number of nodes in the cluster every 10 seconds:
+
+    $ ./app
+    There are 3 pods in the cluster
+    There are 3 pods in the cluster
+    There are 3 pods in the cluster
+    ...
+
+Press <kbd>Ctrl</kbd>+<kbd>C</kbd> to quit this application.
+
+> **Note:** You can use the `-kubeconfig` option to use a different config file. By default
+this program picks up the default file used by kubectl (when `KUBECONFIG`
+environment variable is not set).

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster/main.go
@@ -20,6 +20,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,14 +32,21 @@ import (
 )
 
 func main() {
-	kubeconfig := flag.String("kubeconfig", "./config", "absolute path to the kubeconfig file")
+	var kubeconfig *string
+	if home := homeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
 	flag.Parse()
-	// uses the current context in kubeconfig
+
+	// use the current context in kubeconfig
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	if err != nil {
 		panic(err.Error())
 	}
-	// creates the clientset
+
+	// create the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		panic(err.Error())
@@ -50,4 +59,11 @@ func main() {
 		fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
 		time.Sleep(10 * time.Second)
 	}
+}
+
+func homeDir() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
 }


### PR DESCRIPTION
Adding instructions for out-of-cluster example and making it work without
specifying the -kubeconfig argument if the home directory can be inferred.

This is part of the body of work improving the client library samples.

Signed-off-by: Ahmet Alp Balkan <ahmetb@google.com>