### PR TITLE
Remove broken getvolumename and pass PV or volume name to attach call

### DIFF
--- a/examples/volumes/flexvolume/lvm
+++ b/examples/volumes/flexvolume/lvm
@@ -24,7 +24,6 @@ usage() {
 	err "\t$0 waitforattach <mount device> <json params>"
 	err "\t$0 mountdevice <mount dir> <mount device> <json params>"
 	err "\t$0 unmountdevice <mount dir>"
-	err "\t$0 getvolumename <json params>"
 	err "\t$0 isattached <json params> <nodename>"
 	exit 1
 }
@@ -138,17 +137,6 @@ unmountdevice() {
 	exit 0
 }
 
-getvolumename() {
-	JSON_PARAMS=$1
-	DMDEV=$(getdevice)
-
-	# get lvm device UUID
-	UUID=`lvs -o lv_uuid --noheadings ${DMDEV} 2>/dev/null|tr -d " "`
-
-	log "{\"status\": \"Success\", \"volumeName\":\"${UUID}\"}"
-	exit 0
-}
-
 isattached() {
 	log "{\"status\": \"Success\", \"attached\":true}"
 	exit 0
@@ -182,9 +170,6 @@ case "$op" in
 		;;
 	unmountdevice)
 		unmountdevice $*
-		;;
-	getvolumename)
-		getvolumename $*
 		;;
 	isattached)
                 isattached $*

--- a/examples/volumes/flexvolume/nfs
+++ b/examples/volumes/flexvolume/nfs
@@ -21,7 +21,6 @@ usage() {
 	err "\t$0 init"
 	err "\t$0 mount <mount dir> <json params>"
 	err "\t$0 unmount <mount dir>"
-	err "\t$0 getvolumename <json params>"
 	exit 1
 }
 
@@ -78,14 +77,6 @@ unmount() {
 	fi
 
 	log "{\"status\": \"Success\"}"
-	exit 0
-}
-
-getvolumename() {
-	NFS_SERVER=$(echo $1 | jq -r '.server')
-	SHARE=$(echo $1 | jq -r '.share')
-
-	log "{\"status\": \"Success\", \"volumeName\": \"${NFS_SERVER}/${SHARE}\"}"
 	exit 0
 }
 

--- a/pkg/volume/flexvolume/attacher.go
+++ b/pkg/volume/flexvolume/attacher.go
@@ -33,8 +33,13 @@ var _ volume.Attacher = &flexVolumeAttacher{}
 
 // Attach is part of the volume.Attacher interface
 func (a *flexVolumeAttacher) Attach(spec *volume.Spec, hostName types.NodeName) (string, error) {
+
+	extraOptions := make(map[string]string)
+	// Implicit parameters
+	extraOptions[optionPVorVolumeName] = spec.Name()
+
 	call := a.plugin.NewDriverCall(attachCmd)
-	call.AppendSpec(spec, a.plugin.host, nil)
+	call.AppendSpec(spec, a.plugin.host, extraOptions)
 	call.Append(string(hostName))
 
 	status, err := call.Run()

--- a/pkg/volume/flexvolume/attacher.go
+++ b/pkg/volume/flexvolume/attacher.go
@@ -34,12 +34,8 @@ var _ volume.Attacher = &flexVolumeAttacher{}
 // Attach is part of the volume.Attacher interface
 func (a *flexVolumeAttacher) Attach(spec *volume.Spec, hostName types.NodeName) (string, error) {
 
-	extraOptions := make(map[string]string)
-	// Implicit parameters
-	extraOptions[optionPVorVolumeName] = spec.Name()
-
 	call := a.plugin.NewDriverCall(attachCmd)
-	call.AppendSpec(spec, a.plugin.host, extraOptions)
+	call.AppendSpec(spec, a.plugin.host, nil)
 	call.Append(string(hostName))
 
 	status, err := call.Run()

--- a/pkg/volume/flexvolume/detacher.go
+++ b/pkg/volume/flexvolume/detacher.go
@@ -34,14 +34,15 @@ type flexVolumeDetacher struct {
 var _ volume.Detacher = &flexVolumeDetacher{}
 
 // Detach is part of the volume.Detacher interface.
-func (d *flexVolumeDetacher) Detach(deviceName string, hostName types.NodeName) error {
+func (d *flexVolumeDetacher) Detach(pvOrVolumeName string, hostName types.NodeName) error {
+
 	call := d.plugin.NewDriverCall(detachCmd)
-	call.Append(deviceName)
+	call.Append(pvOrVolumeName)
 	call.Append(string(hostName))
 
 	_, err := call.Run()
 	if isCmdNotSupportedErr(err) {
-		return (*detacherDefaults)(d).Detach(deviceName, hostName)
+		return (*detacherDefaults)(d).Detach(pvOrVolumeName, hostName)
 	}
 	return err
 }

--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -169,6 +169,8 @@ func NewOptionsForDriver(spec *volume.Spec, host volume.VolumeHost, extraOptions
 		options[optionReadWrite] = "rw"
 	}
 
+	options[optionPVorVolumeName] = spec.Name()
+
 	for key, value := range extraOptions {
 		options[key] = value
 	}

--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -51,6 +51,7 @@ const (
 	optionKeySecret = "kubernetes.io/secret"
 	optionFSGroup   = "kubernetes.io/fsGroup"
 	optionMountsDir = "kubernetes.io/mountsDir"
+	optionPVorVolumeName = "kubernetes.io/pvOrVolumeName"
 )
 
 const (

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -25,7 +25,6 @@ import (
 	api "k8s.io/kubernetes/pkg/api/v1"
 	"k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/mount"
-	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
 )
 
@@ -67,16 +66,7 @@ func (plugin *flexVolumePlugin) GetPluginName() string {
 
 // GetVolumeName is part of the volume.VolumePlugin interface.
 func (plugin *flexVolumePlugin) GetVolumeName(spec *volume.Spec) (string, error) {
-	call := plugin.NewDriverCall(getVolumeNameCmd)
-	call.AppendSpec(spec, plugin.host, nil)
-
-	status, err := call.Run()
-	if isCmdNotSupportedErr(err) {
-		return (*pluginDefaults)(plugin).GetVolumeName(spec)
-	} else if err != nil {
-		return "", err
-	}
-	return utilstrings.EscapeQualifiedNameForDisk(status.VolumeName), nil
+	return (*pluginDefaults)(plugin).GetVolumeName(spec)
 }
 
 // CanSupport is part of the volume.VolumePlugin interface.


### PR DESCRIPTION
**What this PR does / why we need it**:
Flex getvolumename is broken in 1.6. It needs to be fixed comprehensively in 1.7 release. Removing the api in 1.6. Also pass PV or volume name to the driver during attach call. Detach uses PV or volume name, so plugin can use that information to map to PV.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes - #44737
