### PR TITLE
Allow the /logs handler on the apiserver to be toggled.

### DIFF
--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -848,6 +848,10 @@ function start-kube-apiserver {
     params+=" --audit-log-maxsize=2000000000"
   fi
 
+  if [[ "${ENABLE_APISERVER_LOGS_HANDLER:-}" == "false" ]]; then
+    params+=" --enable-logs-handler=false"
+  fi
+
   local admission_controller_config_mount=""
   local admission_controller_config_volume=""
   local image_policy_webhook_config_mount=""

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1055,6 +1055,10 @@ function start-kube-apiserver {
     params+=" --audit-log-maxsize=2000000000"
   fi
 
+  if [[ "${ENABLE_APISERVER_LOGS_HANDLER:-}" == "false" ]]; then
+    params+=" --enable-logs-handler=false"
+  fi
+
   local admission_controller_config_mount=""
   local admission_controller_config_volume=""
   local image_policy_webhook_config_mount=""

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -56,6 +56,7 @@ type ServerRunOptions struct {
 	APIEnablement           *kubeoptions.APIEnablementOptions
 
 	AllowPrivileged           bool
+	EnableLogsHandler         bool
 	EventTTL                  time.Duration
 	KubeletConfig             kubeletclient.KubeletClientConfig
 	KubernetesServiceNodePort int
@@ -86,8 +87,9 @@ func NewServerRunOptions() *ServerRunOptions {
 		StorageSerialization: kubeoptions.NewStorageSerializationOptions(),
 		APIEnablement:        kubeoptions.NewAPIEnablementOptions(),
 
-		EventTTL:    1 * time.Hour,
-		MasterCount: 1,
+		EnableLogsHandler: true,
+		EventTTL:          1 * time.Hour,
+		MasterCount:       1,
 		KubeletConfig: kubeletclient.KubeletClientConfig{
 			Port:         ports.KubeletPort,
 			ReadOnlyPort: ports.KubeletReadOnlyPort,
@@ -141,6 +143,9 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&s.AllowPrivileged, "allow-privileged", s.AllowPrivileged,
 		"If true, allow privileged containers.")
+
+	fs.BoolVar(&s.EnableLogsHandler, "enable-logs-handler", s.EnableLogsHandler,
+		"If true, install a /logs handler for the apiserver logs.")
 
 	fs.StringVar(&s.SSHUser, "ssh-user", s.SSHUser,
 		"If non-empty, use secure SSH proxy to the nodes, using this user name")

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -263,7 +263,7 @@ func CreateKubeAPIServerConfig(s *options.ServerRunOptions) (*master.Config, inf
 		EventTTL:                s.EventTTL,
 		KubeletClientConfig:     s.KubeletConfig,
 		EnableUISupport:         true,
-		EnableLogsSupport:       true,
+		EnableLogsSupport:       s.EnableLogsHandler,
 		ProxyTransport:          proxyTransport,
 
 		Tunneler: nodeTunneler,

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -198,6 +198,7 @@ enable-garbage-collector
 enable-garbage-collector
 enable-garbage-collector
 enable-hostpath-provisioner
+enable-logs-handler
 enable-server
 enable-swagger-ui
 enable-taint-manager


### PR DESCRIPTION
Adds a flag to kube-apiserver, and plumbs through en environment variable in configure-helper.sh