### PR TITLE
Updated test/test_owners.csv for federation test cases

### DIFF
--- a/test/test_owners.csv
+++ b/test/test_owners.csv
@@ -145,50 +145,48 @@ EmptyDir wrapper volumes should not conflict,deads2k,1,node
 Etcd failure should recover from SIGKILL,pmorie,1,api-machinery
 Etcd failure should recover from network partition with master,justinsb,1,api-machinery
 Events should be sent by kubelets and the scheduler about pods scheduling and running,zmerlynn,1,node
-Federated Services Without Clusters should succeed when a service is created,rmmh,1,federation
-Federated Services with clusters DNS non-local federated service missing local service should never find DNS entries for a missing local service,mml,0,federation
-Federated Services with clusters DNS non-local federated service should be able to discover a non-local federated service,jlowdermilk,1,federation
-Federated Services with clusters DNS should be able to discover a federated service,derekwaynecarr,1,federation
-Federated Services with clusters Federated Service should be deleted from underlying clusters when OrphanDependents is false,zmerlynn,1,
-Federated Services with clusters Federated Service should create matching services in underlying clusters,thockin,1,
-Federated Services with clusters Federated Service should not be deleted from underlying clusters when OrphanDependents is nil,yifan-gu,1,
-Federated Services with clusters Federated Service should not be deleted from underlying clusters when OrphanDependents is true,davidopp,1,
-Federated ingresses Federated Ingresses Ingress connectivity and DNS should be able to connect to a federated ingress via its load balancer,rmmh,1,federation
-Federated ingresses Federated Ingresses should be created and deleted successfully,dchen1107,1,federation
-Federated ingresses Federated Ingresses should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0,federation
-Federated ingresses Federated Ingresses should create and update matching ingresses in underlying clusters,rrati,0,federation
-Federated ingresses Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0,federation
-Federated ingresses Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0,federation
-Federation API server authentication should accept cluster resources when the client has right authentication credentials,davidopp,1,federation
-Federation API server authentication should not accept cluster resources when the client has invalid authentication credentials,yujuhong,1,federation
-Federation API server authentication should not accept cluster resources when the client has no authentication credentials,nikhiljindal,1,federation
-Federation apiserver Admission control should not be able to create resources if namespace does not exist,alex-mohr,1,federation
-Federation apiserver Cluster objects should be created and deleted successfully,rrati,0,federation
-Federation daemonsets DaemonSet objects should be created and deleted successfully,nikhiljindal,0,federation
-Federation daemonsets DaemonSet objects should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0,federation
-Federation daemonsets DaemonSet objects should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0,federation
-Federation daemonsets DaemonSet objects should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0,federation
-Federation deployments Deployment objects should be created and deleted successfully,soltysh,1,federation
+Federated ReplicaSet Features CRUD should be deleted from underlying clusters when OrphanDependents is false,perotinus,0,federation
+Federated ReplicaSet Features CRUD should create and update matching replicasets in underlying clusters,perotinus,0,federation
+Federated ReplicaSet Features CRUD should not be deleted from underlying clusters when OrphanDependents is nil,perotinus,0,federation
+Federated ReplicaSet Features CRUD should not be deleted from underlying clusters when OrphanDependents is true,perotinus,0,federation
+Federated ReplicaSet Features Preferences should create replicasets with max replicas preference,perotinus,0,federation
+Federated ReplicaSet Features Preferences should create replicasets with min replicas preference,perotinus,0,federation
+Federated ReplicaSet Features Preferences should create replicasets with weight preference,perotinus,0,federation
+Federated ReplicaSet ReplicaSet objects should be created and deleted successfully,perotinus,0,federation
+Federated Services Without Clusters should succeed when a service is created,shashidharatd,0,federation
+Federated Services with clusters DNS non-local federated service missing local service should never find DNS entries for a missing local service,shashidharatd,0,federation
+Federated Services with clusters DNS should be able to discover a federated service,shashidharatd,0,federation
+Federated Services with clusters Federated Service should be deleted from underlying clusters when OrphanDependents is false,shashidharatd,0,federation
+Federated Services with clusters Federated Service should create and update matching services in underlying clusters,shashidharatd,0,federation
+Federated Services with clusters Federated Service should not be deleted from underlying clusters when OrphanDependents is nil,shashidharatd,0,federation
+Federated Services with clusters Federated Service should not be deleted from underlying clusters when OrphanDependents is true,shashidharatd,0,federation
+Federated Services with clusters Federated Service should recreate service shard in underlying clusters when service shard is deleted,shashidharatd,0,federation
+Federated ingresses Federated Ingresses should be created and deleted successfully,madhusudancs,0,federation
+Federated ingresses Federated Ingresses should be deleted from underlying clusters when OrphanDependents is false,madhusudancs,0,federation
+Federated ingresses Federated Ingresses should create and update matching ingresses in underlying clusters,madhusudancs,0,federation
+Federated ingresses Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is nil,madhusudancs,0,federation
+Federated ingresses Federated Ingresses should not be deleted from underlying clusters when OrphanDependents is true,madhusudancs,0,federation
+"Federated types Federated %q resources should be created, read, updated and deleted successfully",marun,0,federation
+Federation API server authentication should accept cluster resources when the client has HTTP Basic authentication credentials,nikhiljindal,0,federation
+Federation API server authentication should accept cluster resources when the client has certificate authentication credentials,nikhiljindal,0,federation
+Federation API server authentication should accept cluster resources when the client has token authentication credentials,nikhiljindal,0,federation
+Federation API server authentication should not accept cluster resources when the client has invalid HTTP Basic authentication credentials,nikhiljindal,0,federation
+Federation API server authentication should not accept cluster resources when the client has invalid token authentication credentials,nikhiljindal,0,federation
+Federation API server authentication should not accept cluster resources when the client has no authentication credentials,nikhiljindal,0,federation
+Federation apiserver Admission control should not be able to create resources if namespace does not exist,nikhiljindal,0,federation
+Federation apiserver Cluster objects should be created and deleted successfully,nikhiljindal,0,federation
+Federation deployments Deployment objects should be created and deleted successfully,nikhiljindal,0,federation
 Federation deployments Federated Deployment should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0,federation
-Federation deployments Federated Deployment should create and update matching deployments in underlying clusters,lavalamp,1,federation
+Federation deployments Federated Deployment should create and update matching deployments in underlying clusters,nikhiljindal,0,federation
 Federation deployments Federated Deployment should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0,federation
 Federation deployments Federated Deployment should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0,federation
-Federation events Event objects should be created and deleted successfully,rrati,0,federation
+Federation events Event objects should be created and deleted successfully,shashidharatd,0,federation
 Federation namespace Namespace objects all resources in the namespace should be deleted when namespace is deleted,nikhiljindal,0,federation
 Federation namespace Namespace objects deletes replicasets in the namespace when the namespace is deleted,nikhiljindal,0,federation
-Federation namespace Namespace objects should be created and deleted successfully,xiang90,1,federation
+Federation namespace Namespace objects should be created and deleted successfully,nikhiljindal,0,federation
 Federation namespace Namespace objects should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0,federation
 Federation namespace Namespace objects should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0,federation
 Federation namespace Namespace objects should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0,federation
-Federation replicasets Federated ReplicaSet should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0,federation
-Federation replicasets Federated ReplicaSet should create and update matching replicasets in underling clusters,childsb,1,federation
-Federation replicasets Federated ReplicaSet should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0,federation
-Federation replicasets Federated ReplicaSet should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0,federation
-Federation replicasets ReplicaSet objects should be created and deleted successfully,apelisse,1,federation
-Federation secrets Secret objects should be created and deleted successfully,pmorie,1,federation
-Federation secrets Secret objects should be deleted from underlying clusters when OrphanDependents is false,nikhiljindal,0,federation
-Federation secrets Secret objects should not be deleted from underlying clusters when OrphanDependents is nil,nikhiljindal,0,federation
-Federation secrets Secret objects should not be deleted from underlying clusters when OrphanDependents is true,nikhiljindal,0,federation
 Firewall rule should create valid firewall rules for LoadBalancer type service,MrHohn,0,network
 Firewall rule should have correct firewall rules for e2e cluster,MrHohn,0,network
 GCP Volumes GlusterFS should be mountable,nikhiljindal,0,storage


### PR DESCRIPTION
To the best of my knowledge have updated the test owners for federation e2e test cases. PTAL and comment if any concern.

**Release note**:
```release-note
NONE
```
cc @kubernetes/sig-federation-pr-reviews @fejta 
/assign @madhusudancs 
