### PR TITLE
Display <none> for kubectl describe secret when type is empty.

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -1709,7 +1709,11 @@ func describeSecret(secret *api.Secret) (string, error) {
 		skipAnnotations := sets.NewString(api.LastAppliedConfigAnnotation)
 		printAnnotationsMultilineWithFilter(w, "Annotations", secret.Annotations, skipAnnotations)
 
-		w.Write(LEVEL_0, "\nType:\t%s\n", secret.Type)
+		if secret.Type == "" {
+			w.Write(LEVEL_0, "\nType:\t<none>\n")
+		} else {
+			w.Write(LEVEL_0, "\nType:\t%s\n", secret.Type)
+		}
 
 		w.Write(LEVEL_0, "\nData\n====\n")
 		for k, v := range secret.Data {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
when describe secret, if its type is null, it is better to show <none>

**Special notes for your reviewer**:
Refer to #45788
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
