### PR TITLE
Enforce flag consistency: etcd2 is the default

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -87,7 +87,7 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 		"Enable watch caching in the apiserver")
 
 	fs.StringVar(&s.StorageConfig.Type, "storage-backend", s.StorageConfig.Type,
-		"The storage backend for persistence. Options: 'etcd3' (default), 'etcd2'.")
+		"The storage backend for persistence. Options: 'etcd2' (default), 'etcd3'.")
 
 	fs.IntVar(&s.StorageConfig.DeserializationCacheSize, "deserialization-cache-size", s.StorageConfig.DeserializationCacheSize,
 		"Number of deserialized json objects to cache in memory.")

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -29,7 +29,7 @@ const (
 
 // Config is configuration for creating a storage backend.
 type Config struct {
-	// Type defines the type of storage backend, e.g. "etcd2", etcd3". Default ("") is "etcd3".
+	// Type defines the type of storage backend, e.g. "etcd2", etcd3". Default ("") is "etcd2".
 	Type string
 	// Prefix is the prefix to all keys passed to storage.Interface methods.
 	Prefix string

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
@@ -29,9 +29,14 @@ type DestroyFunc func()
 // Create creates a storage backend based on given config.
 func Create(c storagebackend.Config) (storage.Interface, DestroyFunc, error) {
 	switch c.Type {
-	case storagebackend.StorageTypeETCD2:
+	// Warning: changing the interpretation of the default (StorageTypeUnset)
+	// is a breaking change for users, and is subject to the kubernetes
+	// deprecation policy.  Also note that it's probably a bad idea, because
+	// then we end up with API servers whose default varies depending on when
+	// they were built.  More details in #45457.
+	case storagebackend.StorageTypeUnset, storagebackend.StorageTypeETCD2:
 		return newETCD2Storage(c)
-	case storagebackend.StorageTypeUnset, storagebackend.StorageTypeETCD3:
+	case storagebackend.StorageTypeETCD3:
 		// TODO: We have the following features to implement:
 		// - Support secure connection by using key, cert, and CA files.
 		// - Honor "https" scheme to support secure connection in gRPC.


### PR DESCRIPTION
Per #45457, we can't change the default storage engine every time
there's a new version of etcd, or we end up with a situation where the
default flag for each component depends on the time it was released.

A good option might be to require that the flag be set, but in the
meantime, this enforces etcd2 everywhere.

Fix #45457

```release-note
storage-backend flag defaults to etcd2 in apiservers, for consistency of operation
```
