### PR TITLE
Check volume's status before detaching volume

### DIFF
--- a/pkg/volume/cinder/BUILD
+++ b/pkg/volume/cinder/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
 )
 


### PR DESCRIPTION
When volume's status is 'detaching', controllermanager will detach
it again and return err. It is necessary to check volume's status
before detaching volume.

same issue: #44536