### PR TITLE
apiextensions: add integration test for name conflicts

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/helpers.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/helpers.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/helpers_test.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/helpers_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/BUILD
@@ -24,6 +24,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
         "//vendor/k8s.io/kube-apiextensions-server/pkg/apis/apiextensions/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/resources.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/resources.go
@@ -67,6 +67,24 @@ func NewNoxuInstance(namespace, name string) *unstructured.Unstructured {
 	}
 }
 
+func NewNoxu2CustomResourceDefinition(scope apiextensionsv1alpha1.ResourceScope) *apiextensionsv1alpha1.CustomResourceDefinition {
+	return &apiextensionsv1alpha1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: "noxus2.mygroup.example.com"},
+		Spec: apiextensionsv1alpha1.CustomResourceDefinitionSpec{
+			Group:   "mygroup.example.com",
+			Version: "v1alpha1",
+			Names: apiextensionsv1alpha1.CustomResourceDefinitionNames{
+				Plural:     "noxus2",
+				Singular:   "nonenglishnoxu2",
+				Kind:       "WishIHadChosenNoxu2",
+				ShortNames: []string{"foo", "bar", "abc", "def"},
+				ListKind:   "Noxu2ItemList",
+			},
+			Scope: scope,
+		},
+	}
+}
+
 func NewCurletCustomResourceDefinition(scope apiextensionsv1alpha1.ResourceScope) *apiextensionsv1alpha1.CustomResourceDefinition {
 	return &apiextensionsv1alpha1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: "curlets.mygroup.example.com"},
@@ -100,20 +118,20 @@ func NewCurletInstance(namespace, name string) *unstructured.Unstructured {
 	}
 }
 
-func CreateNewCustomResourceDefinition(customResourceDefinition *apiextensionsv1alpha1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, clientPool dynamic.ClientPool) (*dynamic.Client, error) {
-	_, err := apiExtensionsClient.Apiextensions().CustomResourceDefinitions().Create(customResourceDefinition)
+func CreateNewCustomResourceDefinition(crd *apiextensionsv1alpha1.CustomResourceDefinition, apiExtensionsClient clientset.Interface, clientPool dynamic.ClientPool) (*dynamic.Client, error) {
+	_, err := apiExtensionsClient.Apiextensions().CustomResourceDefinitions().Create(crd)
 	if err != nil {
 		return nil, err
 	}
 
 	// wait until the resource appears in discovery
-	err = wait.PollImmediate(30*time.Millisecond, 30*time.Second, func() (bool, error) {
-		resourceList, err := apiExtensionsClient.Discovery().ServerResourcesForGroupVersion(customResourceDefinition.Spec.Group + "/" + customResourceDefinition.Spec.Version)
+	err = wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
+		resourceList, err := apiExtensionsClient.Discovery().ServerResourcesForGroupVersion(crd.Spec.Group + "/" + crd.Spec.Version)
 		if err != nil {
 			return false, nil
 		}
 		for _, resource := range resourceList.APIResources {
-			if resource.Name == customResourceDefinition.Spec.Names.Plural {
+			if resource.Name == crd.Spec.Names.Plural {
 				return true, nil
 			}
 		}
@@ -123,29 +141,36 @@ func CreateNewCustomResourceDefinition(customResourceDefinition *apiextensionsv1
 		return nil, err
 	}
 
-	dynamicClient, err := clientPool.ClientForGroupVersionResource(schema.GroupVersionResource{Group: customResourceDefinition.Spec.Group, Version: customResourceDefinition.Spec.Version, Resource: customResourceDefinition.Spec.Names.Plural})
+	dynamicClient, err := clientPool.ClientForGroupVersionResource(schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Version, Resource: crd.Spec.Names.Plural})
 	if err != nil {
 		return nil, err
 	}
 	return dynamicClient, nil
 }
 
-func DeleteCustomResourceDefinition(customResource *apiextensionsv1alpha1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) error {
-	if err := apiExtensionsClient.Apiextensions().CustomResourceDefinitions().Delete(customResource.Name, nil); err != nil {
+func DeleteCustomResourceDefinition(crd *apiextensionsv1alpha1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) error {
+	if err := apiExtensionsClient.Apiextensions().CustomResourceDefinitions().Delete(crd.Name, nil); err != nil {
 		return err
 	}
-	err := wait.PollImmediate(30*time.Millisecond, 30*time.Second, func() (bool, error) {
-		if _, err := apiExtensionsClient.Discovery().ServerResourcesForGroupVersion(customResource.Spec.Group + "/" + customResource.Spec.Version); err != nil {
+	err := wait.PollImmediate(500*time.Millisecond, 30*time.Second, func() (bool, error) {
+		groupResource, err := apiExtensionsClient.Discovery().ServerResourcesForGroupVersion(crd.Spec.Group + "/" + crd.Spec.Version)
+		if err != nil {
 			if errors.IsNotFound(err) {
 				return true, nil
+
 			}
 			return false, err
 		}
-		return false, nil
+		for _, g := range groupResource.APIResources {
+			if g.Name == crd.Spec.Names.Plural {
+				return false, nil
+			}
+		}
+		return true, nil
 	})
 	return err
 }
 
-func GetCustomResourceDefinition(customResource *apiextensionsv1alpha1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1alpha1.CustomResourceDefinition, error) {
-	return apiExtensionsClient.Apiextensions().CustomResourceDefinitions().Get(customResource.Name, metav1.GetOptions{})
+func GetCustomResourceDefinition(crd *apiextensionsv1alpha1.CustomResourceDefinition, apiExtensionsClient clientset.Interface) (*apiextensionsv1alpha1.CustomResourceDefinition, error) {
+	return apiExtensionsClient.Apiextensions().CustomResourceDefinitions().Get(crd.Name, metav1.GetOptions{})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Add integration test for name conflicts.
Create 2 CRDs with name conflict. The controller sets the NameConflict condition on the second one. Delete the first one. The second CRD should now get accepted.

Update:
- [x] Add integration test for name conflicts
- [x] Fix naming controller so that when a resource is deleted, other resources in the same group are added to the queue
- [x]  Add integration test for self link (cluster scoped resources)
- [x] Add bigger poll interval
- [x] Fix DeleteCustomResourceDefinition poll condition


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: for #45511 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
@sttts 
