### PR TITLE
Make Stackdriver Logging e2e tests less restrictive

### DIFF
--- a/test/e2e/cluster-logging/sd_load.go
+++ b/test/e2e/cluster-logging/sd_load.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	loadTestMaxAllowedLostFraction    = 0.001
+	loadTestMaxAllowedLostFraction    = 0.01
 	loadTestMaxAllowedFluentdRestarts = 1
 )
 


### PR DESCRIPTION
To reduce flakiness, as described in https://github.com/kubernetes/kubernetes/issues/45998, until further investigation

/cc @fgrzadkowski 