### PR TITLE
Fix kubelet event recording

### DIFF
--- a/pkg/kubelet/container/container_reference_manager.go
+++ b/pkg/kubelet/container/container_reference_manager.go
@@ -38,6 +38,7 @@ func NewRefManager() *RefManager {
 }
 
 // SetRef stores a reference to a pod's container, associating it with the given container ID.
+// TODO: move this to client-go v1.ObjectReference
 func (c *RefManager) SetRef(id ContainerID, ref *v1.ObjectReference) {
 	c.Lock()
 	defer c.Unlock()
@@ -52,6 +53,7 @@ func (c *RefManager) ClearRef(id ContainerID) {
 }
 
 // GetRef returns the container reference of the given ID, or (nil, false) if none is stored.
+// TODO: move this to client-go v1.ObjectReference
 func (c *RefManager) GetRef(id ContainerID) (ref *v1.ObjectReference, ok bool) {
 	c.RLock()
 	defer c.RUnlock()

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -446,7 +446,7 @@ func (m *kubeGenericRuntimeManager) generateContainerEvent(containerID kubeconta
 		glog.Warningf("No ref for container %q", containerID)
 		return
 	}
-	m.recorder.Event(ref, eventType, reason, message)
+	m.recorder.Event(events.ToObjectReference(ref), eventType, reason, message)
 }
 
 // executePreStopHook runs the pre-stop lifecycle hooks if applicable and returns the duration it takes.

--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -100,12 +100,12 @@ func (pb *prober) probe(probeType probeType, pod *v1.Pod, status v1.PodStatus, c
 		if err != nil {
 			glog.V(1).Infof("%s probe for %q errored: %v", probeType, ctrName, err)
 			if hasRef {
-				pb.recorder.Eventf(ref, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored: %v", probeType, err)
+				pb.recorder.Eventf(events.ToObjectReference(ref), v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe errored: %v", probeType, err)
 			}
 		} else { // result != probe.Success
 			glog.V(1).Infof("%s probe for %q failed (%v): %s", probeType, ctrName, result, output)
 			if hasRef {
-				pb.recorder.Eventf(ref, v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
+				pb.recorder.Eventf(events.ToObjectReference(ref), v1.EventTypeWarning, events.ContainerUnhealthy, "%s probe failed: %s", probeType, output)
 			}
 		}
 		return results.Failure, err

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1271,13 +1271,13 @@ func (r *Runtime) generateEvents(runtimePod *kubecontainer.Pod, reason string, f
 		uuid := utilstrings.ShortenString(id.uuid, 8)
 		switch reason {
 		case "Created":
-			r.recorder.Eventf(ref, v1.EventTypeNormal, events.CreatedContainer, "Created with rkt id %v", uuid)
+			r.recorder.Eventf(events.ToObjectReference(ref), v1.EventTypeNormal, events.CreatedContainer, "Created with rkt id %v", uuid)
 		case "Started":
-			r.recorder.Eventf(ref, v1.EventTypeNormal, events.StartedContainer, "Started with rkt id %v", uuid)
+			r.recorder.Eventf(events.ToObjectReference(ref), v1.EventTypeNormal, events.StartedContainer, "Started with rkt id %v", uuid)
 		case "Failed":
-			r.recorder.Eventf(ref, v1.EventTypeWarning, events.FailedToStartContainer, "Failed to start with rkt id %v with error %v", uuid, failure)
+			r.recorder.Eventf(events.ToObjectReference(ref), v1.EventTypeWarning, events.FailedToStartContainer, "Failed to start with rkt id %v with error %v", uuid, failure)
 		case "Killing":
-			r.recorder.Eventf(ref, v1.EventTypeNormal, events.KillingContainer, "Killing with rkt id %v", uuid)
+			r.recorder.Eventf(events.ToObjectReference(ref), v1.EventTypeNormal, events.KillingContainer, "Killing with rkt id %v", uuid)
 		default:
 			glog.Errorf("rkt: Unexpected event %q", reason)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
There are numerous areas where the kubelet was not properly recording events due to an incorrect type.

To keep this small, I updated all references to `RefManager` that result in throwing an event to ensure it does a conversion.

**Which issue this PR fixes**
Fixes https://github.com/kubernetes/kubernetes/issues/46241
Fixes #44348
Fixes #44652

**Special notes for your reviewer**:
I updated all references I could find to the existing RefManager in kubelet.

**Release note**:
```release-note
Fix kubelet event recording for selected events.
```
