### PR TITLE
[Federation] ClusterSelector for Service Controller

### DIFF
--- a/federation/pkg/federation-controller/service/BUILD
+++ b/federation/pkg/federation-controller/service/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//federation/pkg/dnsprovider:go_default_library",
         "//federation/pkg/dnsprovider/rrstype:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
+        "//federation/pkg/federation-controller/util/clusterselector:go_default_library",
         "//federation/pkg/federation-controller/util/deletionhelper:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",


### PR DESCRIPTION
This pull request adds ClusterSelector to the Federated Service Controller ref: design #29887 This back ports the same functionality from the sync controller (merged pull #40234).

cc: @nikhiljindal @marun

**Release note**:
```
The annotation `federation.alpha.kubernetes.io/cluster-selector` can be used with Service objects to target federated clusters by label.
```