### PR TITLE
Detect ExternalTrafficPolicy and HealthCheckNodePort changes in needsUpdate()

### DIFF
--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -474,6 +474,16 @@ func (s *ServiceController) needsUpdate(oldService *v1.Service, newService *v1.S
 			oldService.UID, newService.UID)
 		return true
 	}
+	if oldService.Spec.ExternalTrafficPolicy != newService.Spec.ExternalTrafficPolicy {
+		s.eventRecorder.Eventf(newService, v1.EventTypeNormal, "ExternalTrafficPolicy", "%v -> %v",
+			oldService.Spec.ExternalTrafficPolicy, newService.Spec.ExternalTrafficPolicy)
+		return true
+	}
+	if oldService.Spec.HealthCheckNodePort != newService.Spec.HealthCheckNodePort {
+		s.eventRecorder.Eventf(newService, v1.EventTypeNormal, "HealthCheckNodePort", "%v -> %v",
+			oldService.Spec.HealthCheckNodePort, newService.Spec.HealthCheckNodePort)
+		return true
+	}
 
 	return false
 }

--- a/pkg/controller/service/servicecontroller_test.go
+++ b/pkg/controller/service/servicecontroller_test.go
@@ -673,6 +673,24 @@ func TestDoesExternalLoadBalancerNeedsUpdate(t *testing.T) {
 			},
 			expectedNeedsUpdate: true,
 		},
+		{
+			testName: "If ExternalTrafficPolicy is different",
+			updateFn: func() {
+				oldSvc = defaultExternalService()
+				newSvc = defaultExternalService()
+				newSvc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
+			},
+			expectedNeedsUpdate: true,
+		},
+		{
+			testName: "If HealthCheckNodePort is different",
+			updateFn: func() {
+				oldSvc = defaultExternalService()
+				newSvc = defaultExternalService()
+				newSvc.Spec.HealthCheckNodePort = 30123
+			},
+			expectedNeedsUpdate: true,
+		},
 	}
 
 	controller, _, _ := newController()


### PR DESCRIPTION
Fix a bug that editing ExternalTrafficPolicy doesn't trigger LoadBalancer update. I'm surprise that ESIPP e2e tests didn't catch this.

/assign @freehan @thockin 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
