### PR TITLE
Denote if a printer is generic.

### DIFF
--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -456,8 +456,7 @@ func TestApplyObjectOutput(t *testing.T) {
 	}
 
 	f, tf, _, _ := cmdtesting.NewAPIFactory()
-	tf.CommandPrinter = &printers.YAMLPrinter{}
-	tf.GenericPrinter = true
+	tf.Printer = &printers.YAMLPrinter{}
 	tf.UnstructuredClient = &fake.RESTClient{
 		APIRegistry:          api.Registry,
 		NegotiatedSerializer: unstructuredSerializer,

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -80,8 +80,9 @@ func defaultClientConfigForVersion(version *schema.GroupVersion) *restclient.Con
 }
 
 type testPrinter struct {
-	Objects []runtime.Object
-	Err     error
+	Objects        []runtime.Object
+	Err            error
+	GenericPrinter bool
 }
 
 func (t *testPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
@@ -97,6 +98,10 @@ func (t *testPrinter) HandledResources() []string {
 
 func (t *testPrinter) AfterPrint(output io.Writer, res string) error {
 	return nil
+}
+
+func (t *testPrinter) IsGeneric() bool {
+	return t.GenericPrinter
 }
 
 type testDescriber struct {

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -81,7 +81,7 @@ func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess
 				cmd.Flags().Set("output", defaultOutputFormat)
 			}
 
-			printer, _, err := cmdutil.PrinterForCommand(cmd, meta.NewDefaultRESTMapper(nil, nil), latest.Scheme, []runtime.Decoder{latest.Codec})
+			printer, err := cmdutil.PrinterForCommand(cmd, meta.NewDefaultRESTMapper(nil, nil), latest.Scheme, nil, []runtime.Decoder{latest.Codec}, printers.PrintOptions{})
 			cmdutil.CheckErr(err)
 			printer = printers.NewVersionedPrinter(printer, latest.Scheme, latest.ExternalVersion)
 

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -164,7 +164,7 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.C
 		cmd.Flags().Set("output", outputFormat)
 	}
 	o.encoder = f.JSONEncoder()
-	o.printer, _, err = f.PrinterForCommand(cmd)
+	o.printer, err = f.PrinterForCommand(cmd, printers.PrintOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/create_clusterrole_test.go
+++ b/pkg/kubectl/cmd/create_clusterrole_test.go
@@ -46,6 +46,10 @@ func (t *testClusterRolePrinter) HandledResources() []string {
 	return []string{}
 }
 
+func (t *testClusterRolePrinter) IsGeneric() bool {
+	return true
+}
+
 func TestCreateClusterRole(t *testing.T) {
 	clusterRoleName := "my-cluster-role"
 

--- a/pkg/kubectl/cmd/create_role_test.go
+++ b/pkg/kubectl/cmd/create_role_test.go
@@ -46,6 +46,10 @@ func (t *testRolePrinter) HandledResources() []string {
 	return []string{}
 }
 
+func (t *testRolePrinter) IsGeneric() bool {
+	return true
+}
+
 func TestCreateRole(t *testing.T) {
 	roleName := "my-role"
 

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -302,7 +302,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 		return err
 	}
 
-	printer, generic, err := f.PrinterForCommand(cmd)
+	printer, err := f.PrinterForCommand(cmd, printers.PrintOptions{})
 	if err != nil {
 		return err
 	}
@@ -313,7 +313,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 		r.IgnoreErrors(kapierrors.IsNotFound)
 	}
 
-	if generic {
+	if printer.IsGeneric() {
 		// we flattened the data from the builder, so we have individual items, but now we'd like to either:
 		// 1. if there is more than one item, combine them all into a single list
 		// 2. if there is a single item and that item is a list, leave it as its specific list
@@ -436,7 +436,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 			mapping = infos[ix].Mapping
 			original = infos[ix].Object
 		}
-		if printer == nil || lastMapping == nil || mapping == nil || mapping.Resource != lastMapping.Resource {
+		if shouldGetNewPrinterForMapping(printer, lastMapping, mapping) {
 			if printer != nil {
 				w.Flush()
 			}
@@ -512,4 +512,8 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 	w.Flush()
 	cmdutil.PrintFilterCount(errOut, len(objs), filteredResourceCount, len(allErrs), filterOpts, options.IgnoreNotFound)
 	return utilerrors.NewAggregate(allErrs)
+}
+
+func shouldGetNewPrinterForMapping(printer printers.ResourcePrinter, lastMapping, mapping *meta.RESTMapping) bool {
+	return printer == nil || lastMapping == nil || mapping == nil || mapping.Resource != lastMapping.Resource
 }

--- a/pkg/kubectl/cmd/patch_test.go
+++ b/pkg/kubectl/cmd/patch_test.go
@@ -161,8 +161,7 @@ func TestPatchObjectFromFileOutput(t *testing.T) {
 	svcCopy.Labels["post-patch"] = "post-patch-value"
 
 	f, tf, codec, _ := cmdtesting.NewAPIFactory()
-	tf.CommandPrinter = &printers.YAMLPrinter{}
-	tf.GenericPrinter = true
+	tf.Printer = &printers.YAMLPrinter{}
 	tf.UnstructuredClient = &fake.RESTClient{
 		APIRegistry:          api.Registry,
 		NegotiatedSerializer: unstructuredSerializer,

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -221,13 +221,11 @@ type TestFactory struct {
 	UnstructuredClient kubectl.RESTClient
 	Describer          printers.Describer
 	Printer            printers.ResourcePrinter
-	CommandPrinter     printers.ResourcePrinter
 	Validator          validation.Schema
 	Namespace          string
 	ClientConfig       *restclient.Config
 	Err                error
 	Command            string
-	GenericPrinter     bool
 	TmpDir             string
 
 	ClientForMappingFunc             func(mapping *meta.RESTMapping) (resource.RESTClient, error)
@@ -338,8 +336,8 @@ func (f *FakeFactory) Describer(*meta.RESTMapping) (printers.Describer, error) {
 	return f.tf.Describer, f.tf.Err
 }
 
-func (f *FakeFactory) PrinterForCommand(cmd *cobra.Command) (printers.ResourcePrinter, bool, error) {
-	return f.tf.CommandPrinter, f.tf.GenericPrinter, f.tf.Err
+func (f *FakeFactory) PrinterForCommand(cmd *cobra.Command, options printers.PrintOptions) (printers.ResourcePrinter, error) {
+	return f.tf.Printer, f.tf.Err
 }
 
 func (f *FakeFactory) Printer(mapping *meta.RESTMapping, options printers.PrintOptions) (printers.ResourcePrinter, error) {
@@ -619,8 +617,8 @@ func (f *fakeAPIFactory) UnstructuredClientForMapping(m *meta.RESTMapping) (reso
 	return f.tf.UnstructuredClient, f.tf.Err
 }
 
-func (f *fakeAPIFactory) PrinterForCommand(cmd *cobra.Command) (printers.ResourcePrinter, bool, error) {
-	return f.tf.CommandPrinter, f.tf.GenericPrinter, f.tf.Err
+func (f *fakeAPIFactory) PrinterForCommand(cmd *cobra.Command, options printers.PrintOptions) (printers.ResourcePrinter, error) {
+	return f.tf.Printer, f.tf.Err
 }
 
 func (f *fakeAPIFactory) Describer(*meta.RESTMapping) (printers.Describer, error) {

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -230,10 +230,10 @@ type ObjectMappingFactory interface {
 // Generally they depend upon client mapper functions
 type BuilderFactory interface {
 	// PrinterForCommand returns the default printer for the command. It requires that certain options
-	// are declared on the command (see AddPrinterFlags). Returns a printer, true if the printer is
-	// generic (is not internal), or an error if a printer could not be found.
+	// are declared on the command (see AddPrinterFlags). Returns a printer, or an error if a printer
+	// could not be found.
 	// TODO: Break the dependency on cmd here.
-	PrinterForCommand(cmd *cobra.Command) (printers.ResourcePrinter, bool, error)
+	PrinterForCommand(cmd *cobra.Command, options printers.PrintOptions) (printers.ResourcePrinter, error)
 	// PrinterForMapping returns a printer suitable for displaying the provided resource type.
 	// Requires that printer flags have been added to cmd (see AddPrinterFlags).
 	PrinterForMapping(cmd *cobra.Command, mapping *meta.RESTMapping, withNamespace bool) (printers.ResourcePrinter, error)

--- a/pkg/kubectl/sorting_printer.go
+++ b/pkg/kubectl/sorting_printer.go
@@ -60,8 +60,12 @@ func (s *SortingPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
 }
 
 // TODO: implement HandledResources()
-func (p *SortingPrinter) HandledResources() []string {
+func (s *SortingPrinter) HandledResources() []string {
 	return []string{}
+}
+
+func (s *SortingPrinter) IsGeneric() bool {
+	return s.Delegate.IsGeneric()
 }
 
 func (s *SortingPrinter) sortObj(obj runtime.Object) error {

--- a/pkg/printers/customcolumn.go
+++ b/pkg/printers/customcolumn.go
@@ -239,3 +239,7 @@ func (s *CustomColumnsPrinter) printOneObject(obj runtime.Object, parsers []*jso
 func (s *CustomColumnsPrinter) HandledResources() []string {
 	return []string{}
 }
+
+func (s *CustomColumnsPrinter) IsGeneric() bool {
+	return true
+}

--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -152,6 +152,10 @@ func (h *HumanReadablePrinter) AfterPrint(output io.Writer, res string) error {
 	return nil
 }
 
+func (h *HumanReadablePrinter) IsGeneric() bool {
+	return false
+}
+
 func (h *HumanReadablePrinter) unknown(data []byte, w io.Writer) error {
 	_, err := fmt.Fprintf(w, "Unknown object: %s", string(data))
 	return err

--- a/pkg/printers/interface.go
+++ b/pkg/printers/interface.go
@@ -31,6 +31,8 @@ type ResourcePrinter interface {
 	//Can be used to print out warning/clarifications if needed
 	//after all objects were printed
 	AfterPrint(io.Writer, string) error
+	// Identify if it is a generic printer
+	IsGeneric() bool
 }
 
 // ResourcePrinterFunc is a function that can print objects
@@ -48,6 +50,10 @@ func (fn ResourcePrinterFunc) HandledResources() []string {
 
 func (fn ResourcePrinterFunc) AfterPrint(io.Writer, string) error {
 	return nil
+}
+
+func (fn ResourcePrinterFunc) IsGeneric() bool {
+	return true
 }
 
 type PrintOptions struct {

--- a/pkg/printers/json.go
+++ b/pkg/printers/json.go
@@ -63,6 +63,10 @@ func (p *JSONPrinter) HandledResources() []string {
 	return []string{}
 }
 
+func (p *JSONPrinter) IsGeneric() bool {
+	return true
+}
+
 // YAMLPrinter is an implementation of ResourcePrinter which outputs an object as YAML.
 // The input object is assumed to be in the internal version of an API and is converted
 // to the given version first.
@@ -98,4 +102,8 @@ func (p *YAMLPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 // TODO: implement HandledResources()
 func (p *YAMLPrinter) HandledResources() []string {
 	return []string{}
+}
+
+func (p *YAMLPrinter) IsGeneric() bool {
+	return true
 }

--- a/pkg/printers/jsonpath.go
+++ b/pkg/printers/jsonpath.go
@@ -155,3 +155,7 @@ func (j *JSONPathPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 func (p *JSONPathPrinter) HandledResources() []string {
 	return []string{}
 }
+
+func (p *JSONPathPrinter) IsGeneric() bool {
+	return true
+}

--- a/pkg/printers/name.go
+++ b/pkg/printers/name.go
@@ -87,3 +87,7 @@ func (p *NamePrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 func (p *NamePrinter) HandledResources() []string {
 	return []string{}
 }
+
+func (p *NamePrinter) IsGeneric() bool {
+	return true
+}

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -25,92 +25,102 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// GetStandardPrinter takes a format type, an optional format argument. It will return true
-// if the format is generic (untyped), otherwise it will return false. The printer
-// is agnostic to schema versions, so you must send arguments to PrintObj in the
-// version you wish them to be shown using a VersionedPrinter (typically when
-// generic is true).
-func GetStandardPrinter(format, formatArgument string, noHeaders, allowMissingTemplateKeys bool, mapper meta.RESTMapper, typer runtime.ObjectTyper, decoders []runtime.Decoder) (ResourcePrinter, bool, error) {
+// GetStandardPrinter takes a format type, an optional format argument. It will return
+// a printer or an error. The printer is agnostic to schema versions, so you must
+// send arguments to PrintObj in the version you wish them to be shown using a
+// VersionedPrinter (typically when generic is true).
+func GetStandardPrinter(format, formatArgument string, noHeaders, allowMissingTemplateKeys bool, mapper meta.RESTMapper, typer runtime.ObjectTyper, encoder runtime.Encoder, decoders []runtime.Decoder, options PrintOptions) (ResourcePrinter, error) {
 	var printer ResourcePrinter
 	switch format {
+
 	case "json":
 		printer = &JSONPrinter{}
+
 	case "yaml":
 		printer = &YAMLPrinter{}
+
 	case "name":
 		printer = &NamePrinter{
 			Typer:    typer,
 			Decoders: decoders,
 			Mapper:   mapper,
 		}
+
 	case "template", "go-template":
 		if len(formatArgument) == 0 {
-			return nil, false, fmt.Errorf("template format specified but no template given")
+			return nil, fmt.Errorf("template format specified but no template given")
 		}
 		templatePrinter, err := NewTemplatePrinter([]byte(formatArgument))
 		if err != nil {
-			return nil, false, fmt.Errorf("error parsing template %s, %v\n", formatArgument, err)
+			return nil, fmt.Errorf("error parsing template %s, %v\n", formatArgument, err)
 		}
 		templatePrinter.AllowMissingKeys(allowMissingTemplateKeys)
 		printer = templatePrinter
+
 	case "templatefile", "go-template-file":
 		if len(formatArgument) == 0 {
-			return nil, false, fmt.Errorf("templatefile format specified but no template file given")
+			return nil, fmt.Errorf("templatefile format specified but no template file given")
 		}
 		data, err := ioutil.ReadFile(formatArgument)
 		if err != nil {
-			return nil, false, fmt.Errorf("error reading template %s, %v\n", formatArgument, err)
+			return nil, fmt.Errorf("error reading template %s, %v\n", formatArgument, err)
 		}
 		templatePrinter, err := NewTemplatePrinter(data)
 		if err != nil {
-			return nil, false, fmt.Errorf("error parsing template %s, %v\n", string(data), err)
+			return nil, fmt.Errorf("error parsing template %s, %v\n", string(data), err)
 		}
 		templatePrinter.AllowMissingKeys(allowMissingTemplateKeys)
 		printer = templatePrinter
+
 	case "jsonpath":
 		if len(formatArgument) == 0 {
-			return nil, false, fmt.Errorf("jsonpath template format specified but no template given")
+			return nil, fmt.Errorf("jsonpath template format specified but no template given")
 		}
 		jsonpathPrinter, err := NewJSONPathPrinter(formatArgument)
 		if err != nil {
-			return nil, false, fmt.Errorf("error parsing jsonpath %s, %v\n", formatArgument, err)
+			return nil, fmt.Errorf("error parsing jsonpath %s, %v\n", formatArgument, err)
 		}
 		jsonpathPrinter.AllowMissingKeys(allowMissingTemplateKeys)
 		printer = jsonpathPrinter
+
 	case "jsonpath-file":
 		if len(formatArgument) == 0 {
-			return nil, false, fmt.Errorf("jsonpath file format specified but no template file file given")
+			return nil, fmt.Errorf("jsonpath file format specified but no template file file given")
 		}
 		data, err := ioutil.ReadFile(formatArgument)
 		if err != nil {
-			return nil, false, fmt.Errorf("error reading template %s, %v\n", formatArgument, err)
+			return nil, fmt.Errorf("error reading template %s, %v\n", formatArgument, err)
 		}
 		jsonpathPrinter, err := NewJSONPathPrinter(string(data))
 		if err != nil {
-			return nil, false, fmt.Errorf("error parsing template %s, %v\n", string(data), err)
+			return nil, fmt.Errorf("error parsing template %s, %v\n", string(data), err)
 		}
 		jsonpathPrinter.AllowMissingKeys(allowMissingTemplateKeys)
 		printer = jsonpathPrinter
+
 	case "custom-columns":
 		var err error
 		if printer, err = NewCustomColumnsPrinterFromSpec(formatArgument, decoders[0], noHeaders); err != nil {
-			return nil, false, err
+			return nil, err
 		}
+
 	case "custom-columns-file":
 		file, err := os.Open(formatArgument)
 		if err != nil {
-			return nil, false, fmt.Errorf("error reading template %s, %v\n", formatArgument, err)
+			return nil, fmt.Errorf("error reading template %s, %v\n", formatArgument, err)
 		}
 		defer file.Close()
 		if printer, err = NewCustomColumnsPrinterFromTemplate(file, decoders[0]); err != nil {
-			return nil, false, err
+			return nil, err
 		}
+
 	case "wide":
 		fallthrough
 	case "":
-		return nil, false, nil
+
+		printer = NewHumanReadablePrinter(encoder, decoders[0], options)
 	default:
-		return nil, false, fmt.Errorf("output format %q not recognized", format)
+		return nil, fmt.Errorf("output format %q not recognized", format)
 	}
-	return printer, true, nil
+	return printer, nil
 }

--- a/pkg/printers/template.go
+++ b/pkg/printers/template.go
@@ -88,6 +88,10 @@ func (p *TemplatePrinter) HandledResources() []string {
 	return []string{}
 }
 
+func (p *TemplatePrinter) IsGeneric() bool {
+	return true
+}
+
 // safeExecute tries to execute the template, but catches panics and returns an error
 // should the template engine panic.
 func (p *TemplatePrinter) safeExecute(w io.Writer, obj interface{}) error {

--- a/pkg/printers/versioned.go
+++ b/pkg/printers/versioned.go
@@ -61,3 +61,7 @@ func (p *VersionedPrinter) PrintObj(obj runtime.Object, w io.Writer) error {
 func (p *VersionedPrinter) HandledResources() []string {
 	return []string{}
 }
+
+func (p *VersionedPrinter) IsGeneric() bool {
+	return p.printer.IsGeneric()
+}


### PR DESCRIPTION
This fixes #38779.

This allows us to avoid case in which printers.GetStandardPrinter
returns nil for both printer and err removing any potential panics that
may arise throughout kubectl commands.

Please see #38779 and #38112 for complete context.