### PR TITLE
Double `StopContainer` request timeout.

### DIFF
--- a/pkg/kubelet/remote/remote_runtime.go
+++ b/pkg/kubelet/remote/remote_runtime.go
@@ -209,11 +209,10 @@ func (r *RemoteRuntimeService) StartContainer(containerID string) error {
 
 // StopContainer stops a running container with a grace period (i.e., timeout).
 func (r *RemoteRuntimeService) StopContainer(containerID string, timeout int64) error {
-	ctx, cancel := getContextWithTimeout(time.Duration(timeout) * time.Second)
-	if timeout == 0 {
-		// Use default timeout if stop timeout is 0.
-		ctx, cancel = getContextWithTimeout(r.timeout)
-	}
+	// Use timeout + default timeout (2 minutes) as timeout to leave extra time
+	// for SIGKILL container and request latency.
+	t := r.timeout + time.Duration(timeout)*time.Second
+	ctx, cancel := getContextWithTimeout(t)
 	defer cancel()
 
 	_, err := r.runtimeClient.StopContainer(ctx, &runtimeapi.StopContainerRequest{


### PR DESCRIPTION
Doubled `StopContainer` request timeout to leave some time for `SIGKILL` container.

@yujuhong @feiskyer 

```release-note
Fix kubelet request timeout when stopping a container.
```