### PR TITLE
Remove duplicate error message output in hyperkube.

### DIFF
--- a/cmd/hyperkube/hyperkube.go
+++ b/cmd/hyperkube/hyperkube.go
@@ -186,7 +186,6 @@ func (hk *HyperKube) Run(args []string) error {
 func (hk *HyperKube) RunToExit(args []string) {
 	err := hk.Run(args)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err.Error())
 		os.Exit(1)
 	}
 	os.Exit(0)


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently hyperkube binary will always print duplicate messages if fatal error occurs:
```
$ ./kubelet # run without permission
I0523 08:38:02.642638   25701 feature_gate.go:144] feature gates: map[]
W0523 08:38:02.642827   25701 server.go:472] No API client: no api servers specified
Error: failed to run Kubelet: error reading /var/run/kubernetes/kubelet.key, certificate and key must be supplied as a pair
Error: failed to run Kubelet: error reading /var/run/kubernetes/kubelet.key, certificate and key must be supplied as a pair
```

This is due to RunToExit will print out the error which Run has just printed. https://github.com/kubernetes/kubernetes/blob/8bee44b/cmd/hyperkube/hyperkube.go#L178-L189

This was introduced in following commit for adding GOMAXPROCS calls.
https://github.com/kubernetes/kubernetes/commit/1e679f0069f629d76fcab6f9f39ef0efc1814cc4

The following commit removes GOMAXPROCS calls, but did not remove the corresponding error output line.
https://github.com/kubernetes/kubernetes/commit/88ea80b5728fe4adb5c0f43f0283302ab3b9eb22


**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:

