### PR TITLE
Adding option to set the federation api server port if nodeport is set

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -84,6 +84,7 @@ const (
 
 	apiserverServiceTypeFlag      = "api-server-service-type"
 	apiserverAdvertiseAddressFlag = "api-server-advertise-address"
+	apiserverPortFlag             = "api-server-port"
 
 	dnsProviderSecretName = "federation-dns-provider.conf"
 
@@ -147,6 +148,7 @@ type initFederationOptions struct {
 	apiServerServiceTypeString       string
 	apiServerServiceType             v1.ServiceType
 	apiServerAdvertiseAddress        string
+	apiServerNodePortsPort           int32
 	apiServerEnableHTTPBasicAuth     bool
 	apiServerEnableTokenAuth         bool
 }
@@ -163,6 +165,7 @@ func (o *initFederationOptions) Bind(flags *pflag.FlagSet, defaultImage string) 
 	flags.StringVar(&o.controllerManagerOverridesString, "controllermanager-arg-overrides", "", "comma separated list of federation-controller-manager arguments to override: Example \"--arg1=value1,--arg2=value2...\"")
 	flags.StringVar(&o.apiServerServiceTypeString, apiserverServiceTypeFlag, string(v1.ServiceTypeLoadBalancer), "The type of service to create for federation API server. Options: 'LoadBalancer' (default), 'NodePort'.")
 	flags.StringVar(&o.apiServerAdvertiseAddress, apiserverAdvertiseAddressFlag, "", "Preferred address to advertise api server nodeport service. Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
+	flags.Int32Var(&o.apiServerNodePortsPort, apiserverPortFlag , 0, "Preferred port to use for api server nodeport service (0 for random port assignment). Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
 	flags.BoolVar(&o.apiServerEnableHTTPBasicAuth, "apiserver-enable-basic-auth", false, "Enables HTTP Basic authentication for the federation-apiserver. Defaults to false.")
 	flags.BoolVar(&o.apiServerEnableTokenAuth, "apiserver-enable-token-auth", false, "Enables token authentication for the federation-apiserver. Defaults to false.")
 }
@@ -229,6 +232,15 @@ func (i *initFederation) Complete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	if i.options.apiServerNodePortsPort != 0 {
+		if i.options.apiServerServiceType != v1.ServiceTypeNodePort {
+			return fmt.Errorf("%s should be passed only with '%s=NodePort'", apiserverPortFlag, apiserverServiceTypeFlag)
+		}
+	}
+	if i.options.apiServerNodePortsPort < 0 {
+		return fmt.Errorf("Please provide a valid port number for %s", apiserverPortFlag)
+	}
+
 	i.options.apiServerOverrides, err = marshallOverrides(i.options.apiServerOverridesString)
 	if err != nil {
 		return fmt.Errorf("error marshalling --apiserver-arg-overrides: %v", err)
@@ -292,7 +304,7 @@ func (i *initFederation) Run(cmdOut io.Writer, config util.AdminConfig) error {
 
 	fmt.Fprint(cmdOut, "Creating federation control plane service...")
 	glog.V(4).Info("Creating federation control plane service")
-	svc, ips, hostnames, err := createService(cmdOut, hostClientset, i.commonOptions.FederationSystemNamespace, serverName, i.commonOptions.Name, i.options.apiServerAdvertiseAddress, i.options.apiServerServiceType, i.options.dryRun)
+	svc, ips, hostnames, err := createService(cmdOut, hostClientset, i.commonOptions.FederationSystemNamespace, serverName, i.commonOptions.Name, i.options.apiServerAdvertiseAddress, i.options.apiServerNodePortsPort, i.options.apiServerServiceType, i.options.dryRun)
 	if err != nil {
 		return err
 	}
@@ -442,7 +454,16 @@ func createNamespace(clientset client.Interface, federationName, namespace strin
 	return clientset.Core().Namespaces().Create(ns)
 }
 
-func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcName, federationName, apiserverAdvertiseAddress string, apiserverServiceType v1.ServiceType, dryRun bool) (*api.Service, []string, []string, error) {
+func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcName, federationName, apiserverAdvertiseAddress string, apiserverPort int32, apiserverServiceType v1.ServiceType, dryRun bool) (*api.Service, []string, []string, error) {
+	port := api.ServicePort {
+			Name:       "https",
+			Protocol:   "TCP",
+			Port:       443,
+			TargetPort: intstr.FromString(apiServerSecurePortName),
+	}
+	if apiserverServiceType == v1.ServiceTypeNodePort {
+		port.NodePort = apiserverPort
+	}
 	svc := &api.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -453,14 +474,7 @@ func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcN
 		Spec: api.ServiceSpec{
 			Type:     api.ServiceType(apiserverServiceType),
 			Selector: apiserverSvcSelector,
-			Ports: []api.ServicePort{
-				{
-					Name:       "https",
-					Protocol:   "TCP",
-					Port:       443,
-					TargetPort: intstr.FromString(apiServerSecurePortName),
-				},
-			},
+			Ports: []api.ServicePort{port},
 		},
 	}
 
@@ -470,6 +484,9 @@ func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcN
 
 	var err error
 	svc, err = clientset.Core().Services(namespace).Create(svc)
+	if err != nil {
+		return svc, nil, nil, err
+	}
 
 	ips := []string{}
 	hostnames := []string{}

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -237,7 +237,7 @@ func (i *initFederation) Complete(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("%s should be passed only with '%s=NodePort'", apiserverPortFlag, apiserverServiceTypeFlag)
 		}
 	}
-	if i.options.apiServerNodePortsPort < 0 {
+	if i.options.apiServerNodePortsPort < 0 || i.options.apiServerNodePortsPort > 65535 {
 		return fmt.Errorf("Please provide a valid port number for %s", apiserverPortFlag)
 	}
 
@@ -461,7 +461,7 @@ func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcN
 			Port:       443,
 			TargetPort: intstr.FromString(apiServerSecurePortName),
 	}
-	if apiserverServiceType == v1.ServiceTypeNodePort {
+	if apiserverServiceType == v1.ServiceTypeNodePort && apiserverPort > 0 {
 		port.NodePort = apiserverPort
 	}
 	svc := &api.Service{

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -148,7 +148,7 @@ type initFederationOptions struct {
 	apiServerServiceTypeString       string
 	apiServerServiceType             v1.ServiceType
 	apiServerAdvertiseAddress        string
-	apiServerNodePortPort           int32
+	apiServerNodePortPort            int32
 	apiServerEnableHTTPBasicAuth     bool
 	apiServerEnableTokenAuth         bool
 }
@@ -165,7 +165,7 @@ func (o *initFederationOptions) Bind(flags *pflag.FlagSet, defaultImage string) 
 	flags.StringVar(&o.controllerManagerOverridesString, "controllermanager-arg-overrides", "", "comma separated list of federation-controller-manager arguments to override: Example \"--arg1=value1,--arg2=value2...\"")
 	flags.StringVar(&o.apiServerServiceTypeString, apiserverServiceTypeFlag, string(v1.ServiceTypeLoadBalancer), "The type of service to create for federation API server. Options: 'LoadBalancer' (default), 'NodePort'.")
 	flags.StringVar(&o.apiServerAdvertiseAddress, apiserverAdvertiseAddressFlag, "", "Preferred address to advertise api server nodeport service. Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
-	flags.Int32Var(&o.apiServerNodePortPort, apiserverPortFlag , 0, "Preferred port to use for api server nodeport service (0 for random port assignment). Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
+	flags.Int32Var(&o.apiServerNodePortPort, apiserverPortFlag, 0, "Preferred port to use for api server nodeport service (0 for random port assignment). Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
 	flags.BoolVar(&o.apiServerEnableHTTPBasicAuth, "apiserver-enable-basic-auth", false, "Enables HTTP Basic authentication for the federation-apiserver. Defaults to false.")
 	flags.BoolVar(&o.apiServerEnableTokenAuth, "apiserver-enable-token-auth", false, "Enables token authentication for the federation-apiserver. Defaults to false.")
 }
@@ -455,11 +455,11 @@ func createNamespace(clientset client.Interface, federationName, namespace strin
 }
 
 func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcName, federationName, apiserverAdvertiseAddress string, apiserverPort int32, apiserverServiceType v1.ServiceType, dryRun bool) (*api.Service, []string, []string, error) {
-	port := api.ServicePort {
-			Name:       "https",
-			Protocol:   "TCP",
-			Port:       443,
-			TargetPort: intstr.FromString(apiServerSecurePortName),
+	port := api.ServicePort{
+		Name:       "https",
+		Protocol:   "TCP",
+		Port:       443,
+		TargetPort: intstr.FromString(apiServerSecurePortName),
 	}
 	if apiserverServiceType == v1.ServiceTypeNodePort && apiserverPort > 0 {
 		port.NodePort = apiserverPort
@@ -474,7 +474,7 @@ func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcN
 		Spec: api.ServiceSpec{
 			Type:     api.ServiceType(apiserverServiceType),
 			Selector: apiserverSvcSelector,
-			Ports: []api.ServicePort{port},
+			Ports:    []api.ServicePort{port},
 		},
 	}
 

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -148,7 +148,7 @@ type initFederationOptions struct {
 	apiServerServiceTypeString       string
 	apiServerServiceType             v1.ServiceType
 	apiServerAdvertiseAddress        string
-	apiServerNodePortsPort           int32
+	apiServerNodePortPort           int32
 	apiServerEnableHTTPBasicAuth     bool
 	apiServerEnableTokenAuth         bool
 }
@@ -165,7 +165,7 @@ func (o *initFederationOptions) Bind(flags *pflag.FlagSet, defaultImage string) 
 	flags.StringVar(&o.controllerManagerOverridesString, "controllermanager-arg-overrides", "", "comma separated list of federation-controller-manager arguments to override: Example \"--arg1=value1,--arg2=value2...\"")
 	flags.StringVar(&o.apiServerServiceTypeString, apiserverServiceTypeFlag, string(v1.ServiceTypeLoadBalancer), "The type of service to create for federation API server. Options: 'LoadBalancer' (default), 'NodePort'.")
 	flags.StringVar(&o.apiServerAdvertiseAddress, apiserverAdvertiseAddressFlag, "", "Preferred address to advertise api server nodeport service. Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
-	flags.Int32Var(&o.apiServerNodePortsPort, apiserverPortFlag , 0, "Preferred port to use for api server nodeport service (0 for random port assignment). Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
+	flags.Int32Var(&o.apiServerNodePortPort, apiserverPortFlag , 0, "Preferred port to use for api server nodeport service (0 for random port assignment). Valid only if '"+apiserverServiceTypeFlag+"=NodePort'.")
 	flags.BoolVar(&o.apiServerEnableHTTPBasicAuth, "apiserver-enable-basic-auth", false, "Enables HTTP Basic authentication for the federation-apiserver. Defaults to false.")
 	flags.BoolVar(&o.apiServerEnableTokenAuth, "apiserver-enable-token-auth", false, "Enables token authentication for the federation-apiserver. Defaults to false.")
 }
@@ -232,12 +232,12 @@ func (i *initFederation) Complete(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if i.options.apiServerNodePortsPort != 0 {
+	if i.options.apiServerNodePortPort != 0 {
 		if i.options.apiServerServiceType != v1.ServiceTypeNodePort {
 			return fmt.Errorf("%s should be passed only with '%s=NodePort'", apiserverPortFlag, apiserverServiceTypeFlag)
 		}
 	}
-	if i.options.apiServerNodePortsPort < 0 || i.options.apiServerNodePortsPort > 65535 {
+	if i.options.apiServerNodePortPort < 0 || i.options.apiServerNodePortPort > 65535 {
 		return fmt.Errorf("Please provide a valid port number for %s", apiserverPortFlag)
 	}
 
@@ -304,7 +304,7 @@ func (i *initFederation) Run(cmdOut io.Writer, config util.AdminConfig) error {
 
 	fmt.Fprint(cmdOut, "Creating federation control plane service...")
 	glog.V(4).Info("Creating federation control plane service")
-	svc, ips, hostnames, err := createService(cmdOut, hostClientset, i.commonOptions.FederationSystemNamespace, serverName, i.commonOptions.Name, i.options.apiServerAdvertiseAddress, i.options.apiServerNodePortsPort, i.options.apiServerServiceType, i.options.dryRun)
+	svc, ips, hostnames, err := createService(cmdOut, hostClientset, i.commonOptions.FederationSystemNamespace, serverName, i.commonOptions.Name, i.options.apiServerAdvertiseAddress, i.options.apiServerNodePortPort, i.options.apiServerServiceType, i.options.dryRun)
 	if err != nil {
 		return err
 	}
@@ -485,7 +485,7 @@ func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcN
 	var err error
 	svc, err = clientset.Core().Services(namespace).Create(svc)
 	if err != nil {
-		return svc, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	ips := []string{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Kubefed will deploy the respected services and then it will do a health check. Prior to this patch if the user selects the nodeport a random port is opened. In environments where firewalls are in place this random port selection will cause the health check to fail. With this patch we enable users to designate a specific port, after for example opening it on their firewall.    

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #46021

**Special notes for your reviewer**:

**Release note**: 
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubefed init allows for setting port in Nodeport configuration
```
