### PR TITLE
Updates hostport pkg for IPv6

### DIFF
--- a/pkg/kubelet/network/hostport/fake_iptables.go
+++ b/pkg/kubelet/network/hostport/fake_iptables.go
@@ -25,6 +25,13 @@ import (
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 )
 
+type fakeProtocol byte
+
+const (
+	ProtocolIpv4 fakeProtocol = iota + 1
+	ProtocolIpv6
+)
+
 type fakeChain struct {
 	name  utiliptables.Chain
 	rules []string
@@ -36,12 +43,14 @@ type fakeTable struct {
 }
 
 type fakeIPTables struct {
-	tables map[string]*fakeTable
+	protocol fakeProtocol
+	tables   map[string]*fakeTable
 }
 
-func NewFakeIPTables() *fakeIPTables {
+func NewFakeIPTables(protocol fakeProtocol) *fakeIPTables {
 	return &fakeIPTables{
-		tables: make(map[string]*fakeTable, 0),
+		protocol: protocol,
+		tables:   make(map[string]*fakeTable, 0),
 	}
 }
 
@@ -176,10 +185,13 @@ func normalizeRule(rule string) (string, error) {
 		arg := remaining[:end]
 
 		// Normalize un-prefixed IP addresses like iptables does
-		if net.ParseIP(arg) != nil {
-			arg = arg + "/32"
+		if addr := net.ParseIP(arg); addr != nil {
+			if addr.To4() != nil {
+				arg += "/32"
+			} else {
+				arg += "/128"
+			}
 		}
-
 		if len(normalized) > 0 {
 			normalized += " "
 		}
@@ -218,7 +230,7 @@ func (f *fakeIPTables) DeleteRule(tableName utiliptables.Table, chainName utilip
 }
 
 func (f *fakeIPTables) IsIpv6() bool {
-	return false
+	return f.protocol == ProtocolIpv6
 }
 
 func saveChain(chain *fakeChain, data *bytes.Buffer) {

--- a/pkg/kubelet/network/hostport/hostport_manager.go
+++ b/pkg/kubelet/network/hostport/hostport_manager.go
@@ -51,8 +51,8 @@ type hostportManager struct {
 	mu          sync.Mutex
 }
 
-func NewHostportManager() HostPortManager {
-	iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), utiliptables.ProtocolIpv4)
+func NewHostportManager(protocol utiliptables.Protocol) HostPortManager {
+	iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), protocol)
 	return &hostportManager{
 		hostPortMap: make(map[hostport]closeable),
 		iptables:    iptInterface,
@@ -72,7 +72,7 @@ func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping, natInt
 		return nil
 	}
 
-	if podPortMapping.IP.To4() == nil {
+	if podPortMapping.IP.To4() == nil && podPortMapping.IP.To16() == nil {
 		return fmt.Errorf("invalid or missing IP of pod %s", podFullName)
 	}
 	podIP := podPortMapping.IP.String()

--- a/pkg/kubelet/network/hostport/hostport_manager_test.go
+++ b/pkg/kubelet/network/hostport/hostport_manager_test.go
@@ -30,13 +30,21 @@ import (
 func NewFakeHostportManager() HostPortManager {
 	return &hostportManager{
 		hostPortMap: make(map[hostport]closeable),
-		iptables:    NewFakeIPTables(),
+		iptables:    NewFakeIPTables(ProtocolIpv4),
+		portOpener:  NewFakeSocketManager().openFakeSocket,
+	}
+}
+
+func NewIPv6FakeHostportManager() HostPortManager {
+	return &hostportManager{
+		hostPortMap: make(map[hostport]closeable),
+		iptables:    NewFakeIPTables(ProtocolIpv6),
 		portOpener:  NewFakeSocketManager().openFakeSocket,
 	}
 }
 
 func TestHostportManager(t *testing.T) {
-	iptables := NewFakeIPTables()
+	iptables := NewFakeIPTables(ProtocolIpv4)
 	portOpener := NewFakeSocketManager()
 	manager := &hostportManager{
 		hostPortMap: make(map[hostport]closeable),
@@ -159,6 +167,170 @@ func TestHostportManager(t *testing.T) {
 		"-A KUBE-HP-7THKRFSEH4GIIXK7 -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination 10.1.1.2:81":  true,
 		"-A KUBE-HP-5N7UH5JAXCVP5UJR -m comment --comment \"pod3_ns1 hostport 8443\" -s 10.1.1.4/32 -j KUBE-MARK-MASQ":                    true,
 		"-A KUBE-HP-5N7UH5JAXCVP5UJR -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination 10.1.1.4:443": true,
+		`COMMIT`: true,
+	}
+	for _, line := range lines {
+		if len(strings.TrimSpace(line)) > 0 {
+			_, ok := expectedLines[strings.TrimSpace(line)]
+			assert.EqualValues(t, true, ok)
+		}
+	}
+
+	// Remove all added hostports
+	for _, tc := range testCases {
+		if !tc.expectError {
+			err := manager.Remove("id", tc.mapping)
+			assert.NoError(t, err)
+		}
+	}
+
+	// Check Iptables-save result after deleting hostports
+	raw.Reset()
+	err = iptables.SaveInto(utiliptables.TableNAT, raw)
+	assert.NoError(t, err)
+	lines = strings.Split(string(raw.Bytes()), "\n")
+	remainingChains := make(map[string]bool)
+	for _, line := range lines {
+		if strings.HasPrefix(line, ":") {
+			remainingChains[strings.TrimSpace(line)] = true
+		}
+	}
+	expectDeletedChains := []string{"KUBE-HP-4YVONL46AKYWSKS3", "KUBE-HP-7THKRFSEH4GIIXK7", "KUBE-HP-5N7UH5JAXCVP5UJR"}
+	for _, chain := range expectDeletedChains {
+		_, ok := remainingChains[chain]
+		assert.EqualValues(t, false, ok)
+	}
+
+	// check if all ports are closed
+	for _, port := range portOpener.mem {
+		assert.EqualValues(t, true, port.closed)
+	}
+}
+
+func TestIPv6HostportManager(t *testing.T) {
+	iptables := NewFakeIPTables(ProtocolIpv6)
+	portOpener := NewFakeSocketManager()
+	manager := &hostportManager{
+		hostPortMap: make(map[hostport]closeable),
+		iptables:    iptables,
+		portOpener:  portOpener.openFakeSocket,
+	}
+
+	testCases := []struct {
+		mapping     *PodPortMapping
+		expectError bool
+	}{
+		{
+			mapping: &PodPortMapping{
+				Name:        "pod1",
+				Namespace:   "ns1",
+				IP:          net.ParseIP("2001:db8::2"),
+				HostNetwork: false,
+				PortMappings: []*PortMapping{
+					{
+						HostPort:      8080,
+						ContainerPort: 80,
+						Protocol:      v1.ProtocolTCP,
+					},
+					{
+						HostPort:      8081,
+						ContainerPort: 81,
+						Protocol:      v1.ProtocolUDP,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			mapping: &PodPortMapping{
+				Name:        "pod2",
+				Namespace:   "ns1",
+				IP:          net.ParseIP("2001:db8::3"),
+				HostNetwork: false,
+				PortMappings: []*PortMapping{
+					{
+						HostPort:      8082,
+						ContainerPort: 80,
+						Protocol:      v1.ProtocolTCP,
+					},
+					{
+						HostPort:      8081,
+						ContainerPort: 81,
+						Protocol:      v1.ProtocolUDP,
+					},
+				},
+			},
+			expectError: true,
+		},
+		{
+			mapping: &PodPortMapping{
+				Name:        "pod3",
+				Namespace:   "ns1",
+				IP:          net.ParseIP("2001:db8::4"),
+				HostNetwork: false,
+				PortMappings: []*PortMapping{
+					{
+						HostPort:      8443,
+						ContainerPort: 443,
+						Protocol:      v1.ProtocolTCP,
+					},
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	// Add Hostports
+	for _, tc := range testCases {
+		err := manager.Add("id", tc.mapping, "cbr0")
+		if tc.expectError {
+			assert.Error(t, err)
+			continue
+		}
+		assert.NoError(t, err)
+	}
+
+	// Check port opened
+	expectedPorts := []hostport{{8080, "tcp"}, {8081, "udp"}, {8443, "tcp"}}
+	openedPorts := make(map[hostport]bool)
+	for hp, port := range portOpener.mem {
+		if !port.closed {
+			openedPorts[hp] = true
+		}
+	}
+	assert.EqualValues(t, len(openedPorts), len(expectedPorts))
+	for _, hp := range expectedPorts {
+		_, ok := openedPorts[hp]
+		assert.EqualValues(t, true, ok)
+	}
+
+	// Check Iptables-save result after adding hostports
+	raw := bytes.NewBuffer(nil)
+	err := iptables.SaveInto(utiliptables.TableNAT, raw)
+	assert.NoError(t, err)
+
+	lines := strings.Split(string(raw.Bytes()), "\n")
+	expectedLines := map[string]bool{
+		`*nat`: true,
+		`:KUBE-HOSTPORTS - [0:0]`:                                                                                                                true,
+		`:OUTPUT - [0:0]`:                                                                                                                        true,
+		`:PREROUTING - [0:0]`:                                                                                                                    true,
+		`:POSTROUTING - [0:0]`:                                                                                                                   true,
+		`:KUBE-HP-4YVONL46AKYWSKS3 - [0:0]`:                                                                                                      true,
+		`:KUBE-HP-7THKRFSEH4GIIXK7 - [0:0]`:                                                                                                      true,
+		`:KUBE-HP-5N7UH5JAXCVP5UJR - [0:0]`:                                                                                                      true,
+		"-A KUBE-HOSTPORTS -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp --dport 8443 -j KUBE-HP-5N7UH5JAXCVP5UJR":               true,
+		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp --dport 8081 -j KUBE-HP-7THKRFSEH4GIIXK7":               true,
+		"-A KUBE-HOSTPORTS -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp --dport 8080 -j KUBE-HP-4YVONL46AKYWSKS3":               true,
+		"-A OUTPUT -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                                true,
+		"-A PREROUTING -m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS":                            true,
+		"-A POSTROUTING -m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s ::1/128 -j MASQUERADE":                        true,
+		"-A KUBE-HP-4YVONL46AKYWSKS3 -m comment --comment \"pod1_ns1 hostport 8080\" -s 2001:db8::2/128 -j KUBE-MARK-MASQ":                       true,
+		"-A KUBE-HP-4YVONL46AKYWSKS3 -m comment --comment \"pod1_ns1 hostport 8080\" -m tcp -p tcp -j DNAT --to-destination 2001:db8::2:80/128":  true,
+		"-A KUBE-HP-7THKRFSEH4GIIXK7 -m comment --comment \"pod1_ns1 hostport 8081\" -s 2001:db8::2/128 -j KUBE-MARK-MASQ":                       true,
+		"-A KUBE-HP-7THKRFSEH4GIIXK7 -m comment --comment \"pod1_ns1 hostport 8081\" -m udp -p udp -j DNAT --to-destination 2001:db8::2:81/128":  true,
+		"-A KUBE-HP-5N7UH5JAXCVP5UJR -m comment --comment \"pod3_ns1 hostport 8443\" -s 2001:db8::4/128 -j KUBE-MARK-MASQ":                       true,
+		"-A KUBE-HP-5N7UH5JAXCVP5UJR -m comment --comment \"pod3_ns1 hostport 8443\" -m tcp -p tcp -j DNAT --to-destination 2001:db8::4:443/128": true,
 		`COMMIT`: true,
 	}
 	for _, line := range lines {

--- a/pkg/kubelet/network/hostport/hostport_syncer.go
+++ b/pkg/kubelet/network/hostport/hostport_syncer.go
@@ -49,8 +49,8 @@ type hostportSyncer struct {
 	portOpener  hostportOpener
 }
 
-func NewHostportSyncer() HostportSyncer {
-	iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), utiliptables.ProtocolIpv4)
+func NewHostportSyncer(protocol utiliptables.Protocol) HostportSyncer {
+	iptInterface := utiliptables.New(utilexec.New(), utildbus.New(), protocol)
 	return &hostportSyncer{
 		hostPortMap: make(map[hostport]closeable),
 		iptables:    iptInterface,
@@ -117,7 +117,7 @@ func getPodFullName(pod *PodPortMapping) string {
 func gatherAllHostports(activePodPortMappings []*PodPortMapping) (map[*PortMapping]targetPod, error) {
 	podHostportMap := make(map[*PortMapping]targetPod)
 	for _, pm := range activePodPortMappings {
-		if pm.IP.To4() == nil {
+		if pm.IP.To4() == nil && pm.IP.To16() == nil {
 			return nil, fmt.Errorf("Invalid or missing pod %s IP", getPodFullName(pm))
 		}
 		// should not handle hostports for hostnetwork pods

--- a/pkg/kubelet/network/hostport/hostport_syncer_test.go
+++ b/pkg/kubelet/network/hostport/hostport_syncer_test.go
@@ -33,7 +33,7 @@ type ruleMatch struct {
 }
 
 func TestOpenPodHostports(t *testing.T) {
-	fakeIPTables := NewFakeIPTables()
+	fakeIPTables := NewFakeIPTables(ProtocolIpv4)
 	fakeOpener := NewFakeSocketManager()
 
 	h := &hostportSyncer{
@@ -176,6 +176,189 @@ func TestOpenPodHostports(t *testing.T) {
 	// Generic rules
 	genericRules := []*ruleMatch{
 		{-1, "POSTROUTING", "-m comment --comment \"SNAT for localhost access to hostports\" -o br0 -s 127.0.0.0/8 -j MASQUERADE"},
+		{-1, "PREROUTING", "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"},
+		{-1, "OUTPUT", "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"},
+	}
+
+	for _, rule := range genericRules {
+		_, chain, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain(rule.chain))
+		if err != nil {
+			t.Fatalf("Expected NAT chain %s did not exist", rule.chain)
+		}
+		if !matchRule(chain, rule.match) {
+			t.Fatalf("Expected %s chain rule match '%s' not found", rule.chain, rule.match)
+		}
+	}
+
+	// Pod rules
+	for _, test := range tests {
+		for _, match := range test.matches {
+			// Ensure chain exists
+			_, chain, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain(match.chain))
+			if err != nil {
+				t.Fatalf("Expected NAT chain %s did not exist", match.chain)
+			}
+			if !matchRule(chain, match.match) {
+				t.Fatalf("Expected NAT chain %s rule containing '%s' not found", match.chain, match.match)
+			}
+		}
+	}
+
+	// Socket
+	hostPortMap := map[hostport]closeable{
+		{123, "tcp"}:  &fakeSocket{123, "tcp", false},
+		{4567, "tcp"}: &fakeSocket{4567, "tcp", false},
+		{5678, "udp"}: &fakeSocket{5678, "udp", false},
+	}
+	if !reflect.DeepEqual(hostPortMap, h.hostPortMap) {
+		t.Fatalf("Mismatch in expected hostPortMap. Expected '%v', got '%v'", hostPortMap, h.hostPortMap)
+	}
+}
+
+func TestOpenIPv6PodHostports(t *testing.T) {
+	fakeIPTables := NewFakeIPTables(ProtocolIpv6)
+	fakeOpener := NewFakeSocketManager()
+
+	h := &hostportSyncer{
+		hostPortMap: make(map[hostport]closeable),
+		iptables:    fakeIPTables,
+		portOpener:  fakeOpener.openFakeSocket,
+	}
+
+	tests := []struct {
+		mapping *PodPortMapping
+		matches []*ruleMatch
+	}{
+		// New pod that we are going to add
+		{
+			&PodPortMapping{
+				Name:        "test-pod",
+				Namespace:   v1.NamespaceDefault,
+				IP:          net.ParseIP("2001:db8::2"),
+				HostNetwork: false,
+				PortMappings: []*PortMapping{
+					{
+						HostPort:      4567,
+						ContainerPort: 80,
+						Protocol:      v1.ProtocolTCP,
+					},
+					{
+						HostPort:      5678,
+						ContainerPort: 81,
+						Protocol:      v1.ProtocolUDP,
+					},
+				},
+			},
+			[]*ruleMatch{
+				{
+					-1,
+					"KUBE-HOSTPORTS",
+					"-m comment --comment \"test-pod_default hostport 4567\" -m tcp -p tcp --dport 4567",
+				},
+				{
+					4567,
+					"",
+					"-m comment --comment \"test-pod_default hostport 4567\" -s 2001:db8::2/128 -j KUBE-MARK-MASQ",
+				},
+				{
+					4567,
+					"",
+					"-m comment --comment \"test-pod_default hostport 4567\" -m tcp -p tcp -j DNAT --to-destination 2001:db8::2:80",
+				},
+				{
+					-1,
+					"KUBE-HOSTPORTS",
+					"-m comment --comment \"test-pod_default hostport 5678\" -m udp -p udp --dport 5678",
+				},
+				{
+					5678,
+					"",
+					"-m comment --comment \"test-pod_default hostport 5678\" -s 2001:db8::2/128 -j KUBE-MARK-MASQ",
+				},
+				{
+					5678,
+					"",
+					"-m comment --comment \"test-pod_default hostport 5678\" -m udp -p udp -j DNAT --to-destination 2001:db8::2:81",
+				},
+			},
+		},
+		// Already running pod
+		{
+			&PodPortMapping{
+				Name:        "another-test-pod",
+				Namespace:   v1.NamespaceDefault,
+				IP:          net.ParseIP("2001:db8::5"),
+				HostNetwork: false,
+				PortMappings: []*PortMapping{
+					{
+						HostPort:      123,
+						ContainerPort: 654,
+						Protocol:      v1.ProtocolTCP,
+					},
+				},
+			},
+			[]*ruleMatch{
+				{
+					-1,
+					"KUBE-HOSTPORTS",
+					"-m comment --comment \"another-test-pod_default hostport 123\" -m tcp -p tcp --dport 123",
+				},
+				{
+					123,
+					"",
+					"-m comment --comment \"another-test-pod_default hostport 123\" -s 2001:db8::5/128 -j KUBE-MARK-MASQ",
+				},
+				{
+					123,
+					"",
+					"-m comment --comment \"another-test-pod_default hostport 123\" -m tcp -p tcp -j DNAT --to-destination 2001:db8::5:654",
+				},
+			},
+		},
+	}
+
+	activePodPortMapping := make([]*PodPortMapping, 0)
+
+	// Fill in any match rules missing chain names
+	for _, test := range tests {
+		for _, match := range test.matches {
+			if match.hostport >= 0 {
+				found := false
+				for _, pm := range test.mapping.PortMappings {
+					if int(pm.HostPort) == match.hostport {
+						match.chain = string(hostportChainName(pm, getPodFullName(test.mapping)))
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("Failed to find ContainerPort for match %d/'%s'", match.hostport, match.match)
+				}
+			}
+		}
+		activePodPortMapping = append(activePodPortMapping, test.mapping)
+
+	}
+
+	// Already running pod's host port
+	hp := hostport{
+		tests[1].mapping.PortMappings[0].HostPort,
+		strings.ToLower(string(tests[1].mapping.PortMappings[0].Protocol)),
+	}
+	h.hostPortMap[hp] = &fakeSocket{
+		tests[1].mapping.PortMappings[0].HostPort,
+		strings.ToLower(string(tests[1].mapping.PortMappings[0].Protocol)),
+		false,
+	}
+
+	err := h.OpenPodHostportsAndSync(tests[0].mapping, "br0", activePodPortMapping)
+	if err != nil {
+		t.Fatalf("Failed to OpenPodHostportsAndSync: %v", err)
+	}
+
+	// Generic rules
+	genericRules := []*ruleMatch{
+		{-1, "POSTROUTING", "-m comment --comment \"SNAT for localhost access to hostports\" -o br0 -s ::1/128 -j MASQUERADE"},
 		{-1, "PREROUTING", "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"},
 		{-1, "OUTPUT", "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"},
 	}

--- a/pkg/kubelet/network/hostport/hostport_test.go
+++ b/pkg/kubelet/network/hostport/hostport_test.go
@@ -131,7 +131,33 @@ func TestEnsureKubeHostportChains(t *testing.T) {
 	jumpRule := "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"
 	masqRule := "-m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s 127.0.0.0/8 -j MASQUERADE"
 
-	fakeIPTables := NewFakeIPTables()
+	fakeIPTables := NewFakeIPTables(ProtocolIpv4)
+	assert.NoError(t, ensureKubeHostportChains(fakeIPTables, interfaceName))
+
+	_, _, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain("KUBE-HOSTPORTS"))
+	assert.NoError(t, err)
+
+	_, chain, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.ChainPostrouting)
+	assert.NoError(t, err)
+	assert.EqualValues(t, len(chain.rules), 1)
+	assert.Contains(t, chain.rules[0], masqRule)
+
+	for _, chainName := range builtinChains {
+		_, chain, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain(chainName))
+		assert.NoError(t, err)
+		assert.EqualValues(t, len(chain.rules), 1)
+		assert.Contains(t, chain.rules[0], jumpRule)
+	}
+
+}
+
+func TestEnsureIPv6KubeHostportChains(t *testing.T) {
+	interfaceName := "cbr0"
+	builtinChains := []string{"PREROUTING", "OUTPUT"}
+	jumpRule := "-m comment --comment \"kube hostport portals\" -m addrtype --dst-type LOCAL -j KUBE-HOSTPORTS"
+	masqRule := "-m comment --comment \"SNAT for localhost access to hostports\" -o cbr0 -s ::1/128 -j MASQUERADE"
+
+	fakeIPTables := NewFakeIPTables(ProtocolIpv6)
 	assert.NoError(t, ensureKubeHostportChains(fakeIPTables, interfaceName))
 
 	_, _, err := fakeIPTables.getChain(utiliptables.TableNAT, utiliptables.Chain("KUBE-HOSTPORTS"))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Previously, the hostport pkg hardcoded the IPv4 version of
iptables. This PR adds support for the hostport pkg to select
either iptables or ip6tables based on the kubelet bind address
for the kubenet plugin.

**Which issue this PR fixes**: fixes #46291

**Special notes for your reviewer**:
This PR is part of a larger effort, Issue #1443 to add IPv6 support to k8s.

**Release note**:
`NONE`
