### PR TITLE
Chaosmonkey - Signal stop to tests and wait for done when disruption fails

### DIFF
--- a/test/e2e/chaosmonkey/chaosmonkey.go
+++ b/test/e2e/chaosmonkey/chaosmonkey.go
@@ -98,14 +98,17 @@ func (cm *chaosmonkey) Do() {
 		sem.waitForReadyOrDone()
 	}
 
+	defer func() {
+		close(stopCh)
+		By("Waiting for async validations to complete")
+		for _, sem := range sems {
+			sem.waitForDone()
+		}
+	}()
+
 	By("Starting disruption")
 	cm.disruption()
 	By("Disruption complete; stopping async validations")
-	close(stopCh)
-	By("Waiting for async validations to complete")
-	for _, sem := range sems {
-		sem.waitForDone()
-	}
 }
 
 // Semaphore is taken by a Test and provides: Ready(), for the Test to call when it's ready for the


### PR DESCRIPTION
**What this PR does / why we need it**:
Prevents tests from leaking resources because their Teardown was never called when test disruption fails.   

**Which issue this PR fixes**
First problem of #45842 

**Release note**:
```release-note
NONE
```
