### PR TITLE
move CRD behind TPR

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -42196,6 +42196,33 @@
      }
     ]
    },
+   "/apis/{var}": {
+    "get": {
+     "description": "ignored endpoint registered for infrastructure handling",
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "Var"
+     ],
+     "operationId": "getVarIgnored",
+     "responses": {
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "ignored variable for infrastructure handling",
+      "name": "var",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
    "/logs/": {
     "get": {
      "schemes": [

--- a/api/swagger-spec/apis.json
+++ b/api/swagger-spec/apis.json
@@ -30,6 +30,28 @@
       ]
      }
     ]
+   },
+   {
+    "path": "/apis/{var}",
+    "description": "get available API versions",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "ignored endpoint registered for infrastructure handling",
+      "nickname": "getIgnored",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "var",
+        "description": "ignored variable for infrastructure handling",
+        "required": true,
+        "allowMultiple": false
+       }
+      ]
+     }
+    ]
    }
   ],
   "models": {

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -9676,6 +9676,33 @@
      }
     ]
    },
+   "/apis/{var}": {
+    "get": {
+     "description": "ignored endpoint registered for infrastructure handling",
+     "schemes": [
+      "https"
+     ],
+     "tags": [
+      "Var"
+     ],
+     "operationId": "getVarIgnored",
+     "responses": {
+      "401": {
+       "description": "Unauthorized"
+      }
+     }
+    },
+    "parameters": [
+     {
+      "uniqueItems": true,
+      "type": "string",
+      "description": "ignored variable for infrastructure handling",
+      "name": "var",
+      "in": "path",
+      "required": true
+     }
+    ]
+   },
    "/logs/": {
     "get": {
      "schemes": [

--- a/federation/apis/swagger-spec/apis.json
+++ b/federation/apis/swagger-spec/apis.json
@@ -30,6 +30,28 @@
       ]
      }
     ]
+   },
+   {
+    "path": "/apis/{var}",
+    "description": "get available API versions",
+    "operations": [
+     {
+      "type": "void",
+      "method": "GET",
+      "summary": "ignored endpoint registered for infrastructure handling",
+      "nickname": "getIgnored",
+      "parameters": [
+       {
+        "type": "string",
+        "paramType": "path",
+        "name": "var",
+        "description": "ignored variable for infrastructure handling",
+        "required": true,
+        "allowMultiple": false
+       }
+      ]
+     }
+    ]
    }
   ],
   "models": {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/root_test.go
@@ -69,7 +69,7 @@ func decodeResponse(t *testing.T, resp *http.Response, obj interface{}) error {
 }
 
 func getGroupList(t *testing.T, server *httptest.Server) (*metav1.APIGroupList, error) {
-	resp, err := http.Get(server.URL)
+	resp, err := http.Get(server.URL + "/apis")
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +85,7 @@ func getGroupList(t *testing.T, server *httptest.Server) (*metav1.APIGroupList, 
 
 func TestDiscoveryAtAPIS(t *testing.T) {
 	mapper := request.NewRequestContextMapper()
-	handler := NewRootAPIsHandler(DefaultAddresses{DefaultAddress: "192.168.1.1"}, codecs, mapper)
+	handler := NewRootAPIsHandler(http.NotFoundHandler(), DefaultAddresses{DefaultAddress: "192.168.1.1"}, codecs, mapper)
 
 	server := httptest.NewServer(request.WithRequestContext(handler, mapper))
 	groupList, err := getGroupList(t, server)
@@ -136,7 +136,7 @@ func TestDiscoveryAtAPIS(t *testing.T) {
 
 func TestDiscoveryOrdering(t *testing.T) {
 	mapper := request.NewRequestContextMapper()
-	handler := NewRootAPIsHandler(DefaultAddresses{DefaultAddress: "192.168.1.1"}, codecs, mapper)
+	handler := NewRootAPIsHandler(http.NotFoundHandler(), DefaultAddresses{DefaultAddress: "192.168.1.1"}, codecs, mapper)
 
 	server := httptest.NewServer(request.WithRequestContext(handler, mapper))
 	groupList, err := getGroupList(t, server)

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -406,7 +406,7 @@ func (c completedConfig) New(delegationTarget DelegationTarget) (*GenericAPIServ
 
 		healthzChecks: c.HealthzChecks,
 
-		DiscoveryGroupManager: discovery.NewRootAPIsHandler(c.DiscoveryAddresses, c.Serializer, c.RequestContextMapper),
+		DiscoveryGroupManager: discovery.NewRootAPIsHandler(apiServerHandler.PostGoRestfulMux, c.DiscoveryAddresses, c.Serializer, c.RequestContextMapper),
 	}
 
 	for k, v := range delegationTarget.PostStartHooks() {


### PR DESCRIPTION
This moves the CRD handler behind the main kube-apiserver handler chain to ease the migration plan that @enisoc came up with.

@sttts ptal