### PR TITLE
clear init container status annotations when cleared in status

### DIFF
--- a/pkg/api/v1/pod/util.go
+++ b/pkg/api/v1/pod/util.go
@@ -103,6 +103,9 @@ func SetInitContainersStatusesAnnotations(pod *v1.Pod) error {
 		}
 		pod.Annotations[v1.PodInitContainerStatusesAnnotationKey] = string(value)
 		pod.Annotations[v1.PodInitContainerStatusesBetaAnnotationKey] = string(value)
+	} else {
+		delete(pod.Annotations, v1.PodInitContainerStatusesAnnotationKey)
+		delete(pod.Annotations, v1.PodInitContainerStatusesBetaAnnotationKey)
 	}
 	return nil
 }

--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package pod
 
 import (
+	"encoding/json"
 	"reflect"
 	"strings"
 	"testing"
@@ -396,6 +397,55 @@ func TestIsPodAvailable(t *testing.T) {
 		isAvailable := IsPodAvailable(test.pod, test.minReadySeconds, now)
 		if isAvailable != test.expected {
 			t.Errorf("[tc #%d] expected available pod: %t, got: %t", i, test.expected, isAvailable)
+		}
+	}
+}
+
+func TestSetInitContainersStatusesAnnotations(t *testing.T) {
+	testStatuses := []v1.ContainerStatus{
+		{
+			Name: "test",
+		},
+	}
+	value, _ := json.Marshal(testStatuses)
+	testAnnotation := string(value)
+	tests := []struct {
+		name        string
+		pod         *v1.Pod
+		annotations map[string]string
+	}{
+		{
+			name: "Populate annotations from status",
+			pod: &v1.Pod{
+				Status: v1.PodStatus{
+					InitContainerStatuses: testStatuses,
+				},
+			},
+			annotations: map[string]string{
+				v1.PodInitContainerStatusesAnnotationKey:     testAnnotation,
+				v1.PodInitContainerStatusesBetaAnnotationKey: testAnnotation,
+			},
+		},
+		{
+			name: "Clear annotations if no status",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1.PodInitContainerStatusesAnnotationKey:     testAnnotation,
+						v1.PodInitContainerStatusesBetaAnnotationKey: testAnnotation,
+					},
+				},
+				Status: v1.PodStatus{
+					InitContainerStatuses: []v1.ContainerStatus{},
+				},
+			},
+			annotations: map[string]string{},
+		},
+	}
+	for _, test := range tests {
+		SetInitContainersStatusesAnnotations(test.pod)
+		if !reflect.DeepEqual(test.pod.Annotations, test.annotations) {
+			t.Errorf("%v, actual = %v, expected = %v", test.name, test.pod.Annotations, test.annotations)
 		}
 	}
 }


### PR DESCRIPTION
When I pod with an init container is terminated due to exceeding its active deadline, the pod status is phase `Failed` with reason `DeadlineExceeded`.  All container statuses are cleared from the pod status.

With init containers, however, the status is being regenerated from the status annotations.  This is causing kubectl to report the pod state as `Init:0/1` instead of `DeadlineExceeded` because the kubectl printer observes a running init container, which in reality is not running.

This PR clears out the init container status annotations when they have been removed from the pod status so they are not regenerated on the apiserver.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1453180

@derekwaynecarr 

```release-note
Fix init container status reporting when active deadline is exceeded.
```