### PR TITLE
Move docker validation test to separate project.

### DIFF
--- a/test/e2e_node/jenkins/docker_validation/jenkins-perf.properties
+++ b/test/e2e_node/jenkins/docker_validation/jenkins-perf.properties
@@ -15,7 +15,7 @@ sed -i -e "s@{{METADATA}}@user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKE
 
 GCE_HOSTS=
 GCE_ZONE=us-central1-f
-GCE_PROJECT=k8s-jkns-ci-node-e2e
+GCE_PROJECT=node-cos-docker-validation-ci
 CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]"'
 PARALLELISM=1

--- a/test/e2e_node/jenkins/docker_validation/jenkins-validation.properties
+++ b/test/e2e_node/jenkins/docker_validation/jenkins-validation.properties
@@ -8,7 +8,7 @@ GCE_HOSTS=
 GCE_IMAGES=${GCI_IMAGE}
 GCE_IMAGE_PROJECT=${GCI_IMAGE_PROJECT}
 GCE_ZONE=us-central1-f
-GCE_PROJECT=k8s-jkns-ci-node-e2e
+GCE_PROJECT=node-cos-docker-validation-ci
 # user-data is the GCI cloud init config file.
 # gci-docker-version specifies docker version in GCI image.
 GCE_INSTANCE_METADATA="user-data<${GCI_CLOUD_INIT},gci-docker-version=${DOCKER_VERSION},gci-update-strategy=update_disabled"


### PR DESCRIPTION
Docker validation test is leaking VMs because new docker version `DOCKER_VERSION=17.05.0-c` totally breaks the new gci image `GCE_IMAGES=gci-test-60-9579-0-0` with the `gci-docker-version` metadata specified.

The test successfully created the instance, but timed out when checking VM aliveness, and leaked the VM.

I've cleaned up all leaked VMs. This PR moves docker validation node e2e test into a separate project to not influencing other node e2e test.

@kewu1992 We should fix the docker automated validation test.

/cc @dchen1107 @yujuhong @abgworrall