### PR TITLE
Dont attach a GPU to ubuntu test machines for node e2e serial tests

### DIFF
--- a/test/e2e_node/jenkins/image-config-serial.yaml
+++ b/test/e2e_node/jenkins/image-config-serial.yaml
@@ -8,13 +8,6 @@ images:
   ubuntu-docker12:
     image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
     project: kubernetes-node-e2e-images
-    # Using `n1-standard-2` because GPU driver installation takes up significant amount of CPU.
-    machine: n1-standard-2
-    metadata: 'startup-script<test/e2e_node/jenkins/ubuntu-14.04-nvidia-install.sh'
-    resources:
-      accelerators:
-        - type: nvidia-tesla-k80
-          count: 2
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
     project: coreos-cloud


### PR DESCRIPTION
This should fix flakes in the e2e_node serial suite.

@vishh I think this is what you were asking for...

/assign @vishh 