### PR TITLE
Allow setting service account with kubectl run

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -117,6 +117,7 @@ func addRunFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("rm", false, "If true, delete resources created in this command for attached containers.")
 	cmd.Flags().String("overrides", "", i18n.T("An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field."))
 	cmd.Flags().StringArray("env", []string{}, "Environment variables to set in the container")
+	cmd.Flags().String("serviceaccount", "", "Service account to set in the pod spec")
 	cmd.Flags().String("port", "", i18n.T("The port that this container exposes.  If --expose is true, this is also the port used by the service that is created."))
 	cmd.Flags().Int("hostport", -1, "The host port mapping for the container port. To demonstrate a single-machine container.")
 	cmd.Flags().StringP("labels", "l", "", "Labels to apply to the pod(s).")

--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -52,6 +52,7 @@ func (DeploymentV1Beta1) ParamNames() []GeneratorParam {
 		{"env", false},
 		{"requests", false},
 		{"limits", false},
+		{"serviceaccount", false},
 	}
 }
 
@@ -141,6 +142,7 @@ func (DeploymentAppsV1Beta1) ParamNames() []GeneratorParam {
 		{"env", false},
 		{"requests", false},
 		{"limits", false},
+		{"serviceaccount", false},
 	}
 }
 
@@ -306,6 +308,7 @@ func (JobV1) ParamNames() []GeneratorParam {
 		{"requests", false},
 		{"limits", false},
 		{"restart", false},
+		{"serviceaccount", false},
 	}
 }
 
@@ -400,6 +403,7 @@ func (CronJobV2Alpha1) ParamNames() []GeneratorParam {
 		{"limits", false},
 		{"restart", false},
 		{"schedule", true},
+		{"serviceaccount", false},
 	}
 }
 
@@ -498,6 +502,7 @@ func (BasicReplicationController) ParamNames() []GeneratorParam {
 		{"env", false},
 		{"requests", false},
 		{"limits", false},
+		{"serviceaccount", false},
 	}
 }
 
@@ -603,6 +608,7 @@ func makePodSpec(params map[string]string, name string) (*v1.PodSpec, error) {
 	}
 
 	spec := v1.PodSpec{
+		ServiceAccountName: params["serviceaccount"],
 		Containers: []v1.Container{
 			{
 				Name:      name,
@@ -761,6 +767,7 @@ func (BasicPod) ParamNames() []GeneratorParam {
 		{"env", false},
 		{"requests", false},
 		{"limits", false},
+		{"serviceaccount", false},
 	}
 }
 
@@ -821,6 +828,7 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 			Labels: labels,
 		},
 		Spec: v1.PodSpec{
+			ServiceAccountName: params["serviceaccount"],
 			Containers: []v1.Container{
 				{
 					Name:            name,


### PR DESCRIPTION
As more containers need to make use of the API, and more clusters are RBAC-enabled, which service account is used to run a particular container becomes more important.

This adds support to existing generators for setting the service account name in the pod spec.

```release-note
`kubectl run` learned how to set a service account name in the generated pod spec with the `--serviceaccount` flag.
```

related to #45147