### PR TITLE
[Federation][kubefed]: Use StorageClassName for etcd pvc

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -215,6 +215,7 @@ etcd-mutation-timeout
 etcd-persistent-storage
 etcd-prefix
 etcd-pv-capacity
+etcd-pv-storage-class
 etcd-quorum-read
 etcd-server
 etcd-servers


### PR DESCRIPTION
This PR updates kubefed to use the StorageClassName field [added in 1.6](http://blog.kubernetes.io/2017/03/dynamic-provisioning-and-storage-classes-kubernetes.html
) for etcd's pvc to allow the user to specify which storage class they want to use.  If no value is provided to ``kubefed init``, the field will not be set, and initialization of the pvc may fail on a cluster without a default storage class configured.

The alpha annotation that was previously used (``volume.alpha.kubernetes.io/storage-class``) was deprecated as of 1.4 according to the following blog post:

http://blog.kubernetes.io/2016/10/dynamic-provisioning-and-storage-in-kubernetes.html

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
'kubefed init' has been updated to support specification of the storage class (via --etcd-pv-storage-class) for the Persistent Volume Claim (PVC) used for etcd storage.  If --etcd-pv-storage-class is not specified, the default storage class configured for the cluster will be used.
```

cc: @kubernetes/sig-federation-pr-reviews


