### PR TITLE
Get the uuid from the node spec first and then from cloud (For cinder)

### DIFF
--- a/pkg/volume/cinder/BUILD
+++ b/pkg/volume/cinder/BUILD
@@ -47,12 +47,16 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
+        "//pkg/client/clientset_generated/clientset/fake:go_default_library",
         "//pkg/cloudprovider:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/util/testing:go_default_library",
     ],
 )


### PR DESCRIPTION
List action will have a big load to cloud, so get the node UUID from node spec first.