### PR TITLE
mark --network-plugin-dir deprecated for kubelet

### DIFF
--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -535,11 +535,7 @@ function start-kubelet {
   fi
   # Network plugin
   if [[ -n "${NETWORK_PROVIDER:-}" ]]; then
-    if [[ "${NETWORK_PROVIDER:-}" == "cni" ]]; then
-      flags+=" --cni-bin-dir=/opt/kubernetes/bin"
-    else
-      flags+=" --network-plugin-dir=/opt/kubernetes/bin"
-    fi
+    flags+=" --cni-bin-dir=/opt/kubernetes/bin"
     flags+=" --network-plugin=${NETWORK_PROVIDER}"
   fi
   if [[ -n "${NON_MASQUERADE_CIDR:-}" ]]; then

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -708,11 +708,7 @@ function start-kubelet {
   fi
   # Network plugin
   if [[ -n "${NETWORK_PROVIDER:-}" || -n "${NETWORK_POLICY_PROVIDER:-}" ]]; then
-    if [[ "${NETWORK_PROVIDER:-}" == "cni" || "${NETWORK_POLICY_PROVIDER:-}" == "calico" ]]; then
-      flags+=" --cni-bin-dir=/home/kubernetes/bin"
-    else
-      flags+=" --network-plugin-dir=/home/kubernetes/bin"
-    fi
+    flags+=" --cni-bin-dir=/home/kubernetes/bin"
     if [[ "${NETWORK_POLICY_PROVIDER:-}" == "calico" ]]; then
       # Calico uses CNI always.
       flags+=" --network-plugin=cni"

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -131,9 +131,9 @@
 {% if pillar.get('network_provider', '').lower() == 'opencontrail' %}
   {% set network_plugin = "--network-plugin=opencontrail" %}
 {% elif pillar.get('network_provider', '').lower() == 'cni' %}
-  {% set network_plugin = "--network-plugin=cni --network-plugin-dir=/etc/cni/net.d/" %}
+  {% set network_plugin = "--network-plugin=cni --cni-bin-dir=/etc/cni/net.d/" %}
 {%elif pillar.get('network_policy_provider', '').lower() == 'calico' and grains['roles'][0] != 'kubernetes-master' -%}
-  {% set network_plugin = "--network-plugin=cni --network-plugin-dir=/etc/cni/net.d/ --cni-bin-dir=/home/kubernetes/bin/" %}
+  {% set network_plugin = "--network-plugin=cni --cni-conf-dir=/etc/cni/net.d/ --cni-bin-dir=/home/kubernetes/bin/" %}
 {% elif pillar.get('network_provider', '').lower() == 'kubenet' %}
   {% set network_plugin = "--network-plugin=kubenet" -%}
 {% endif -%}

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -131,7 +131,9 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 
 	// Network plugin settings. Shared by both docker and rkt.
 	fs.StringVar(&s.NetworkPluginName, "network-plugin", s.NetworkPluginName, "<Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle")
+	//TODO(#46410): Remove the network-plugin-dir flag.
 	fs.StringVar(&s.NetworkPluginDir, "network-plugin-dir", s.NetworkPluginDir, "<Warning: Alpha feature> The full path of the directory in which to search for network plugins or CNI config")
+	fs.MarkDeprecated("network-plugin-dir", "Use --cni-bin-dir instead. This flag will be removed in a future version.")
 	fs.StringVar(&s.CNIConfDir, "cni-conf-dir", s.CNIConfDir, "<Warning: Alpha feature> The full path of the directory in which to search for CNI config files. Default: /etc/cni/net.d")
 	fs.StringVar(&s.CNIBinDir, "cni-bin-dir", s.CNIBinDir, "<Warning: Alpha feature> The full path of the directory in which to search for CNI plugin binaries. Default: /opt/cni/bin")
 	fs.Int32Var(&s.NetworkPluginMTU, "network-plugin-mtu", s.NetworkPluginMTU, "<Warning: Alpha feature> The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU.")

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -33,8 +33,10 @@ POD_MANIFEST_PATH=${POD_MANIFEST_PATH:-"/var/run/kubernetes/static-pods"}
 KUBELET_FLAGS=${KUBELET_FLAGS:-""}
 # Name of the network plugin, eg: "kubenet"
 NET_PLUGIN=${NET_PLUGIN:-""}
-# Place the binaries required by NET_PLUGIN in this directory, eg: "/home/kubernetes/bin".
-NET_PLUGIN_DIR=${NET_PLUGIN_DIR:-""}
+# Place the config files and binaries required by NET_PLUGIN in these directory,
+# eg: "/etc/cni/net.d" for config files, and "/opt/cni/bin" for binaries.
+CNI_CONF_DIR=${CNI_CONF_DIR:-""}
+CNI_BIN_DIR=${CNI_BIN_DIR:-""}
 SERVICE_CLUSTER_IP_RANGE=${SERVICE_CLUSTER_IP_RANGE:-10.0.0.0/24}
 FIRST_SERVICE_CLUSTER_IP=${FIRST_SERVICE_CLUSTER_IP:-10.0.0.1}
 # if enabled, must set CGROUP_ROOT
@@ -625,9 +627,14 @@ function start_kubelet {
         auth_args="${auth_args} --client-ca-file=${CLIENT_CA_FILE}"
       fi
 
-      net_plugin_dir_args=""
-      if [[ -n "${NET_PLUGIN_DIR}" ]]; then
-        net_plugin_dir_args="--network-plugin-dir=${NET_PLUGIN_DIR}"
+      cni_conf_dir_args=""
+      if [[ -n "${CNI_CONF_DIR}" ]]; then
+        cni_conf_dir_args="--cni-conf-dir=${CNI_CONF_DIR}"
+      fi
+
+      cni_bin_dir_args=""
+      if [[ -n "${CNI_BIN_DIR}" ]]; then
+        cni_bin_dir_args="--cni-bin-dir=${CNI_BIN_DIR}"
       fi
 
       container_runtime_endpoint_args=""
@@ -664,7 +671,8 @@ function start_kubelet {
         --pod-manifest-path="${POD_MANIFEST_PATH}" \
         ${auth_args} \
         ${dns_args} \
-        ${net_plugin_dir_args} \
+        ${cni_conf_dir_args} \
+        ${cni_bin_dir_args} \
         ${net_plugin_args} \
         ${container_runtime_endpoint_args} \
         ${image_service_endpoint_args} \

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -148,7 +148,7 @@ else
 
   # Do not use any network plugin by default. User could override the flags with
   # test_args.
-  test_args='--kubelet-flags="--network-plugin= --network-plugin-dir=" '$test_args
+  test_args='--kubelet-flags="--network-plugin= --cni-bin-dir=" '$test_args
 
   # Runtime flags
   test_args='--kubelet-flags="--container-runtime='$runtime'" '$test_args

--- a/test/e2e_node/conformance/run_test.sh
+++ b/test/e2e_node/conformance/run_test.sh
@@ -70,8 +70,11 @@ mkdir -p $LOG_DIR
 # plugin by default.
 NETWORK_PLUGIN=${NETWORK_PLUGIN:-""}
 
-# NETWORK_PLUGIN_PATH is the path to network plugin binary.
-NETWORK_PLUGIN_PATH=${NETWORK_PLUGIN_PATH:-""}
+# CNI_CONF_DIR is the path to network plugin binaries.
+CNI_CONF_DIR=${CNI_CONF_DIR:-""}
+
+# CNI_BIN_DIR is the path to network plugin config files.
+CNI_BIN_DIR=${CNI_BIN_DIR:-""}
 
 # start_kubelet starts kubelet and redirect kubelet log to $LOG_DIR/kubelet.log.
 kubelet_log=kubelet.log
@@ -164,7 +167,8 @@ start_kubelet --api-servers $apiserver \
   --system-cgroups=/system \
   --cgroup-root=/ \
   --network-plugin=$NETWORK_PLUGIN \
-  --network-plugin-dir=$NETWORK_PLUGIN_PATH \
+  --cni-conf-dir=$CNI_CONF_DIR \
+  --cni-bin-dir=$CNI_BIN_DIR \
   --v=$log_level \
   --logtostderr
 


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes** : fixes #43967

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
