### PR TITLE
Add node e2e tests for runAsUser

### DIFF
--- a/test/e2e_node/security_context_test.go
+++ b/test/e2e_node/security_context_test.go
@@ -274,4 +274,45 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		})
 	})
 
+	Context("When creating a container with runAsUser", func() {
+		makeUserPod := func(podName, image string, command []string, userid int64) *v1.Pod {
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						{
+							Image:   image,
+							Name:    podName,
+							Command: command,
+							SecurityContext: &v1.SecurityContext{
+								RunAsUser: &userid,
+							},
+						},
+					},
+				},
+			}
+		}
+		createAndWaitUserPod := func(userid int64) {
+			podName := fmt.Sprintf("busybox-user-%d-%s", userid, uuid.NewUUID())
+			podClient.Create(makeUserPod(podName,
+				"gcr.io/google_containers/busybox:1.24",
+				[]string{"sh", "-c", fmt.Sprintf("test $(id -u) -eq %d", userid)},
+				userid,
+			))
+
+			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+		}
+
+		It("should run the container with uid 65534", func() {
+			createAndWaitUserPod(65534)
+		})
+
+		It("should run the container with uid 0", func() {
+			createAndWaitUserPod(0)
+		})
+
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This PR adds node e2e tests for runAsUser.

**Which issue this PR fixes** 

Part of #44118.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
