### PR TITLE
Add unittest for describe secret

### DIFF
--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -118,6 +118,31 @@ func TestDescribePodTolerations(t *testing.T) {
 	}
 }
 
+func TestDescribeSecret(t *testing.T) {
+	fake := fake.NewSimpleClientset(&api.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "foo",
+		},
+		Data: map[string][]byte{
+			"username": []byte("YWRtaW4="),
+			"password": []byte("MWYyZDFlMmU2N2Rm"),
+		},
+	})
+	c := &describeClient{T: t, Namespace: "foo", Interface: fake}
+	d := SecretDescriber{c}
+	out, err := d.Describe("foo", "bar", printers.DescriberSettings{})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "bar") || !strings.Contains(out, "foo") || !strings.Contains(out, "username") || !strings.Contains(out, "8 bytes") || !strings.Contains(out, "password") || !strings.Contains(out, "16 bytes") {
+		t.Errorf("unexpected out: %s", out)
+	}
+	if strings.Contains(out, "YWRtaW4=") || strings.Contains(out, "MWYyZDFlMmU2N2Rm") {
+		t.Errorf("sensitive data should not be shown, unexpected out: %s", out)
+	}
+}
+
 func TestDescribeNamespace(t *testing.T) {
 	fake := fake.NewSimpleClientset(&api.Namespace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
add unittest for describe secret


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
