### PR TITLE
Remove hardcode for blocksize, use stat(), fixes test failure on SLES

### DIFF
--- a/pkg/volume/metrics_du_test.go
+++ b/pkg/volume/metrics_du_test.go
@@ -23,13 +23,22 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"syscall"
 
 	utiltesting "k8s.io/client-go/util/testing"
 	. "k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
 
-const expectedBlockSize = 4096
+func getExpectedBlockSize(path string) (int64) {
+	statfs := &syscall.Statfs_t{}
+	err := syscall.Statfs(path, statfs)
+	if err != nil {
+		return 0
+	}
+
+	return int64(statfs.Bsize)
+}
 
 // TestMetricsDuGetCapacity tests that MetricsDu can read disk usage
 // for path
@@ -69,7 +78,7 @@ func TestMetricsDuGetCapacity(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error when calling GetMetrics %v", err)
 	}
-	if e, a := (expectedEmptyDirUsage.Value() + expectedBlockSize), actual.Used.Value(); e != a {
+	if e, a := (expectedEmptyDirUsage.Value() + getExpectedBlockSize(filepath.Join(tmpDir, "f1"))), actual.Used.Value(); e != a {
 		t.Errorf("Unexpected Used for directory with file.  Expected %v, got %d.", e, a)
 	}
 }

--- a/pkg/volume/metrics_du_test.go
+++ b/pkg/volume/metrics_du_test.go
@@ -22,15 +22,15 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"testing"
 	"syscall"
+	"testing"
 
 	utiltesting "k8s.io/client-go/util/testing"
 	. "k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
 )
 
-func getExpectedBlockSize(path string) (int64) {
+func getExpectedBlockSize(path string) int64 {
 	statfs := &syscall.Statfs_t{}
 	err := syscall.Statfs(path, statfs)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Removes hardcoding for blocksize, fixes test failure on SLES
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #44022

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
