### PR TITLE
[Federation] Updates to enable hpa controllers test in integration and e2e

### DIFF
--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -114,10 +114,9 @@ function init() {
       --dns-zone-name="${DNS_ZONE_NAME}" \
       --dns-provider="${DNS_PROVIDER}" \
       --image="${kube_registry}/hyperkube-amd64:${kube_version}" \
-      --apiserver-arg-overrides="--storage-backend=etcd2" \
       --apiserver-enable-basic-auth=true \
       --apiserver-enable-token-auth=true \
-      --apiserver-arg-overrides="--v=4" \
+      --apiserver-arg-overrides="--runtime-config=api/all=true,--v=4" \
       --controllermanager-arg-overrides="--v=4" \
       --v=4
 }

--- a/test/integration/federation/framework/federation.go
+++ b/test/integration/federation/framework/federation.go
@@ -63,7 +63,10 @@ func (f *FederationFixture) SetUp(t *testing.T) {
 	t.Logf("Starting a federation of %d clusters", f.DesiredClusterCount)
 
 	f.APIFixture = &FederationAPIFixture{}
-	f.APIFixture.SetUp(t)
+	runOptions := GetRunOptions()
+	// Enable all apis features for test.
+	runOptions.APIEnablement.RuntimeConfig.Set("api/all=true")
+	f.APIFixture.SetUpWithRunOptions(t, runOptions)
 
 	f.stopChan = make(chan struct{})
 	monitorPeriod := 1 * time.Second


### PR DESCRIPTION
Enables the apis on api server in both scenario.
Additional logic to enable and run the crud portion of objects in integration, for controllers which implement additional logic in reconcile.

**Special notes for your reviewer**:
This on top of an existing PR https://github.com/kubernetes/kubernetes/pull/45497.
The last 2 commits are reviewable here
@kubernetes/sig-federation-pr-reviews 
cc @marun @perotinus 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
