### PR TITLE
IPv6 support for getting IP from default route

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -29,6 +29,13 @@ import (
 	"github.com/golang/glog"
 )
 
+type AddressFamily uint
+
+const (
+	familyIPv4 AddressFamily = 4
+	familyIPv6 AddressFamily = 6
+)
+
 type Route struct {
 	Interface   string
 	Destination net.IP
@@ -36,6 +43,7 @@ type Route struct {
 	// TODO: add more fields here if needed
 }
 
+// getRoutes obtains the IPv4 routes, and filters out non-default routes.
 func getRoutes(input io.Reader) ([]Route, error) {
 	routes := []Route{}
 	if input == nil {
@@ -52,19 +60,22 @@ func getRoutes(input io.Reader) ([]Route, error) {
 			continue
 		}
 		fields := strings.Fields(line)
+		dest, err := parseIP(fields[1])
+		if err != nil {
+			return nil, err
+		}
+		gw, err := parseIP(fields[2])
+		if err != nil {
+			return nil, err
+		}
+		if !dest.Equal(net.IPv4zero) {
+			continue
+		}
 		routes = append(routes, Route{})
 		route := &routes[len(routes)-1]
 		route.Interface = fields[0]
-		ip, err := parseIP(fields[1])
-		if err != nil {
-			return nil, err
-		}
-		route.Destination = ip
-		ip, err = parseIP(fields[2])
-		if err != nil {
-			return nil, err
-		}
-		route.Gateway = ip
+		route.Destination = dest
+		route.Gateway = gw
 	}
 	return routes, nil
 }
@@ -77,9 +88,8 @@ func parseIP(str string) (net.IP, error) {
 	if err != nil {
 		return nil, err
 	}
-	//TODO add ipv6 support
 	if len(bytes) != net.IPv4len {
-		return nil, fmt.Errorf("only IPv4 is supported")
+		return nil, fmt.Errorf("invalid IPv4 address in route")
 	}
 	bytes[0], bytes[1], bytes[2], bytes[3] = bytes[3], bytes[2], bytes[1], bytes[0]
 	return net.IP(bytes), nil
@@ -96,10 +106,17 @@ func isInterfaceUp(intf *net.Interface) bool {
 	return false
 }
 
-//getFinalIP method receives all the IP addrs of a Interface
-//and returns a nil if the address is Loopback, Ipv6, link-local or nil.
-//It returns a valid IPv4 if an Ipv4 address is found in the array.
-func getFinalIP(addrs []net.Addr) (net.IP, error) {
+func inFamily(ip net.IP, expectedFamily AddressFamily) bool {
+	ipFamily := familyIPv4
+	if ip.To4() == nil {
+		ipFamily = familyIPv6
+	}
+	return ipFamily == expectedFamily
+}
+
+// getFinalIP method checks all the IP addresses of a Interface looking
+// for a valid non-loopback/link-local address of the requested family.
+func getFinalIP(addrs []net.Addr, family AddressFamily) (net.IP, error) {
 	if len(addrs) > 0 {
 		for i := range addrs {
 			glog.V(4).Infof("Checking addr  %s.", addrs[i].String())
@@ -107,17 +124,15 @@ func getFinalIP(addrs []net.Addr) (net.IP, error) {
 			if err != nil {
 				return nil, err
 			}
-			//Only IPv4
-			//TODO : add IPv6 support
-			if ip.To4() != nil {
-				if !ip.IsLoopback() && !ip.IsLinkLocalMulticast() && !ip.IsLinkLocalUnicast() {
+			if inFamily(ip, family) {
+				if ip.IsGlobalUnicast() {
 					glog.V(4).Infof("IP found %v", ip)
 					return ip, nil
 				} else {
-					glog.V(4).Infof("Loopback/link-local found %v", ip)
+					glog.V(4).Infof("non-global IP found %v", ip)
 				}
 			} else {
-				glog.V(4).Infof("%v is not a valid IPv4 address", ip)
+				glog.V(4).Infof("%v is not an IPv%d address", ip, int(family))
 			}
 
 		}
@@ -125,7 +140,7 @@ func getFinalIP(addrs []net.Addr) (net.IP, error) {
 	return nil, nil
 }
 
-func getIPFromInterface(intfName string, nw networkInterfacer) (net.IP, error) {
+func getIPFromInterface(intfName string, forFamily AddressFamily, nw networkInterfacer) (net.IP, error) {
 	intf, err := nw.InterfaceByName(intfName)
 	if err != nil {
 		return nil, err
@@ -136,12 +151,12 @@ func getIPFromInterface(intfName string, nw networkInterfacer) (net.IP, error) {
 			return nil, err
 		}
 		glog.V(4).Infof("Interface %q has %d addresses :%v.", intfName, len(addrs), addrs)
-		finalIP, err := getFinalIP(addrs)
+		finalIP, err := getFinalIP(addrs, forFamily)
 		if err != nil {
 			return nil, err
 		}
 		if finalIP != nil {
-			glog.V(4).Infof("valid IPv4 address for interface %q found as %v.", intfName, finalIP)
+			glog.V(4).Infof("valid IPv%d address for interface %q found as %v.", int(forFamily), intfName, finalIP)
 			return finalIP, nil
 		}
 	}
@@ -240,27 +255,30 @@ func chooseHostInterfaceFromRoute(inFile io.Reader, nw networkInterfacer) (net.I
 	if err != nil {
 		return nil, err
 	}
-	zero := net.IP{0, 0, 0, 0}
-	var finalIP net.IP
-	for i := range routes {
-		//find interface with gateway
-		if routes[i].Destination.Equal(zero) {
-			glog.V(4).Infof("Default route transits interface %q", routes[i].Interface)
-			finalIP, err := getIPFromInterface(routes[i].Interface, nw)
+	if len(routes) == 0 {
+		return nil, fmt.Errorf("No default routes.")
+	}
+	// TODO: append IPv6 routes for processing - currently only have IPv4 routes
+	for _, family := range []AddressFamily{familyIPv4, familyIPv6} {
+		glog.V(4).Infof("Looking for default routes with IPv%d addresses", uint(family))
+		for _, route := range routes {
+			// TODO: When have IPv6 routes, filter here to speed up processing
+			// if route.Family != family {
+			// 	continue
+			// }
+			glog.V(4).Infof("Default route transits interface %q", route.Interface)
+			finalIP, err := getIPFromInterface(route.Interface, family, nw)
 			if err != nil {
 				return nil, err
 			}
 			if finalIP != nil {
-				glog.V(4).Infof("Choosing IP %v ", finalIP)
+				glog.V(4).Infof("Found active IP %v ", finalIP)
 				return finalIP, nil
 			}
 		}
 	}
-	glog.V(4).Infof("No valid IP found")
-	if finalIP == nil {
-		return nil, fmt.Errorf("Unable to select an IP.")
-	}
-	return nil, nil
+	glog.V(4).Infof("No active IP found by looking at default routes")
+	return nil, fmt.Errorf("unable to select an IP from default routes.")
 }
 
 // If bind-address is usable, return it directly

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface_test.go
@@ -48,19 +48,19 @@ virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
 `
 const nothing = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                            
 `
-const gatewayfirstIpv6_1 = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+const badDestination = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
 eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0                                                                   
 eth3	0000FE0AA1	00000000	0001	0	0	0	0080FFFF	0	0	0                                                                      
 docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
 virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
 `
-const gatewayfirstIpv6_2 = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+const badGateway = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
 eth3	00000000	0100FE0AA1	0003	0	0	1024	00000000	0	0	0                                                                   
 eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0                                                                      
 docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
 virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
 `
-const route_Invalidhex = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+const route_Invalidhex = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
 eth3	00000000	0100FE0AA	0003	0	0	1024	00000000	0	0	0                                                                   
 eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0                                                                      
 docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
@@ -73,25 +73,42 @@ eth0    00000000        0120372D        0001    0       0       0       00000000
 eth0    00000000        00000000        0001    0       0       2048    00000000        0       0       0                                                                            
 `
 
+var (
+	ipv4Route = Route{Interface: "eth3", Gateway: net.ParseIP("10.254.0.1")}
+)
+
 func TestGetRoutes(t *testing.T) {
 	testCases := []struct {
-		tcase    string
-		route    string
-		expected int
+		tcase      string
+		route      string
+		count      int
+		expected   *Route
+		errStrFrag string
 	}{
-		{"gatewayfirst", gatewayfirst, 4},
-		{"gatewaymiddle", gatewaymiddle, 4},
-		{"gatewaylast", gatewaylast, 4},
-		{"nothing", nothing, 0},
-		{"gatewayfirstIpv6_1", gatewayfirstIpv6_1, 0},
-		{"gatewayfirstIpv6_2", gatewayfirstIpv6_2, 0},
-		{"route_Invalidhex", route_Invalidhex, 0},
+		{"gatewayfirst", gatewayfirst, 1, &ipv4Route, ""},
+		{"gatewaymiddle", gatewaymiddle, 1, &ipv4Route, ""},
+		{"gatewaylast", gatewaylast, 1, &ipv4Route, ""},
+		{"no routes", nothing, 0, nil, ""},
+		{"badDestination", badDestination, 0, nil, "invalid IPv4"},
+		{"badGateway", badGateway, 0, nil, "invalid IPv4"},
+		{"route_Invalidhex", route_Invalidhex, 0, nil, "odd length hex string"},
+		{"no default routes", noInternetConnection, 0, nil, ""},
 	}
 	for _, tc := range testCases {
 		r := strings.NewReader(tc.route)
 		routes, err := getRoutes(r)
-		if len(routes) != tc.expected {
-			t.Errorf("case[%v]: expected %v, got %v .err : %v", tc.tcase, tc.expected, len(routes), err)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.errStrFrag) {
+				t.Errorf("case[%s]: Error string %q does not contain %q", tc.tcase, err, tc.errStrFrag)
+			}
+		} else if tc.errStrFrag != "" {
+			t.Errorf("case[%s]: Error %q expected, but not seen", tc.tcase, tc.errStrFrag)
+		} else {
+			if tc.count != len(routes) {
+				t.Errorf("case[%s]: expected %d routes, have %v", tc.tcase, tc.count, routes)
+			} else if tc.count == 1 && !tc.expected.Gateway.Equal(routes[0].Gateway) {
+				t.Errorf("case[%s]: expected %v, got %v .err : %v", tc.tcase, tc.expected, routes, err)
+			}
 		}
 	}
 }
@@ -122,15 +139,15 @@ func TestParseIP(t *testing.T) {
 func TestIsInterfaceUp(t *testing.T) {
 	testCases := []struct {
 		tcase    string
-		intf     net.Interface
+		intf     *net.Interface
 		expected bool
 	}{
-		{"up", net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}, true},
-		{"down", net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: 0}, false},
-		{"nothing", net.Interface{}, false},
+		{"up", &net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}, true},
+		{"down", &net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: 0}, false},
+		{"no interface", nil, false},
 	}
 	for _, tc := range testCases {
-		it := isInterfaceUp(&tc.intf)
+		it := isInterfaceUp(tc.intf)
 		if it != tc.expected {
 			t.Errorf("case[%v]: expected %v, got %v .", tc.tcase, tc.expected, it)
 		}
@@ -150,17 +167,24 @@ func TestFinalIP(t *testing.T) {
 	testCases := []struct {
 		tcase    string
 		addr     []net.Addr
+		family   AddressFamily
 		expected net.IP
 	}{
-		{"ipv6", []net.Addr{addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}, nil},
-		{"invalidCIDR", []net.Addr{addrStruct{val: "fe80::2f7:67fff:fe6e:2956/64"}}, nil},
-		{"loopback", []net.Addr{addrStruct{val: "127.0.0.1/24"}}, nil},
-		{"ip4", []net.Addr{addrStruct{val: "10.254.12.132/17"}}, net.ParseIP("10.254.12.132")},
+		{"no ipv4", []net.Addr{addrStruct{val: "2001::5/64"}}, familyIPv4, nil},
+		{"no ipv6", []net.Addr{addrStruct{val: "10.128.0.4/32"}}, familyIPv6, nil},
+		{"invalidV4CIDR", []net.Addr{addrStruct{val: "10.20.30.40.50/24"}}, familyIPv4, nil},
+		{"invalidV6CIDR", []net.Addr{addrStruct{val: "fe80::2f7:67fff:fe6e:2956/64"}}, familyIPv6, nil},
+		{"loopback", []net.Addr{addrStruct{val: "127.0.0.1/24"}}, familyIPv4, nil},
+		{"loopbackv6", []net.Addr{addrStruct{val: "::1/128"}}, familyIPv6, nil},
+		{"link local v4", []net.Addr{addrStruct{val: "169.254.1.10/16"}}, familyIPv4, nil},
+		{"link local v6", []net.Addr{addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}, familyIPv6, nil},
+		{"ip4", []net.Addr{addrStruct{val: "10.254.12.132/17"}}, familyIPv4, net.ParseIP("10.254.12.132")},
+		{"ip6", []net.Addr{addrStruct{val: "2001::5/64"}}, familyIPv6, net.ParseIP("2001::5")},
 
-		{"nothing", []net.Addr{}, nil},
+		{"no addresses", []net.Addr{}, familyIPv4, nil},
 	}
 	for _, tc := range testCases {
-		ip, err := getFinalIP(tc.addr)
+		ip, err := getFinalIP(tc.addr, tc.family)
 		if !ip.Equal(tc.expected) {
 			t.Errorf("case[%v]: expected %v, got %v .err : %v", tc.tcase, tc.expected, ip, err)
 		}
@@ -193,29 +217,30 @@ func (_ validNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
 	return ifat, nil
 }
 
-type validNetworkInterfaceWithLinkLocal struct {
+// Interface with only IPv6 address
+type ipv6NetworkInterface struct {
 }
 
-func (_ validNetworkInterfaceWithLinkLocal) InterfaceByName(intfName string) (*net.Interface, error) {
-	c := net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: net.FlagUp}
-	return &c, nil
-}
-func (_ validNetworkInterfaceWithLinkLocal) Addrs(intf *net.Interface) ([]net.Addr, error) {
-	var ifat []net.Addr
-	ifat = []net.Addr{addrStruct{val: "169.254.162.166/16"}, addrStruct{val: "45.55.47.146/19"}}
-	return ifat, nil
-}
-
-type validNetworkInterfacewithIpv6Only struct {
-}
-
-func (_ validNetworkInterfacewithIpv6Only) InterfaceByName(intfName string) (*net.Interface, error) {
+func (_ ipv6NetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
 	c := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}
 	return &c, nil
 }
-func (_ validNetworkInterfacewithIpv6Only) Addrs(intf *net.Interface) ([]net.Addr, error) {
+func (_ ipv6NetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
 	var ifat []net.Addr
-	ifat = []net.Addr{addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}
+	ifat = []net.Addr{addrStruct{val: "2001::200/64"}}
+	return ifat, nil
+}
+
+type validNetworkInterfaceWithOnlyLinkLocals struct {
+}
+
+func (_ validNetworkInterfaceWithOnlyLinkLocals) InterfaceByName(intfName string) (*net.Interface, error) {
+	c := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}
+	return &c, nil
+}
+func (_ validNetworkInterfaceWithOnlyLinkLocals) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr
+	ifat = []net.Addr{addrStruct{val: "169.254.162.166/16"}, addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}
 	return ifat, nil
 }
 
@@ -223,10 +248,25 @@ type noNetworkInterface struct {
 }
 
 func (_ noNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
-	return nil, fmt.Errorf("unable get Interface")
+	return nil, fmt.Errorf("no such network interface")
 }
 func (_ noNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
 	return nil, nil
+}
+
+// Interface is down
+type downNetworkInterface struct {
+}
+
+func (_ downNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	c := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: 0}
+	return &c, nil
+}
+func (_ downNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr
+	ifat = []net.Addr{
+		addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}, addrStruct{val: "10.254.71.145/17"}}
+	return ifat, nil
 }
 
 type networkInterfacewithNoAddrs struct {
@@ -240,33 +280,46 @@ func (_ networkInterfacewithNoAddrs) Addrs(intf *net.Interface) ([]net.Addr, err
 	return nil, fmt.Errorf("unable get Addrs")
 }
 
-type networkInterfacewithIpv6addrs struct {
+// Invalid addresses for interface
+type networkInterfaceWithInvalidAddr struct {
 }
 
-func (_ networkInterfacewithIpv6addrs) InterfaceByName(intfName string) (*net.Interface, error) {
+func (_ networkInterfaceWithInvalidAddr) InterfaceByName(intfName string) (*net.Interface, error) {
 	c := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}
 	return &c, nil
 }
-func (_ networkInterfacewithIpv6addrs) Addrs(intf *net.Interface) ([]net.Addr, error) {
+func (_ networkInterfaceWithInvalidAddr) Addrs(intf *net.Interface) ([]net.Addr, error) {
 	var ifat []net.Addr
-	ifat = []net.Addr{addrStruct{val: "fe80::2f7:6ffff:fe6e:2956/64"}}
+	ifat = []net.Addr{addrStruct{val: "10.20.30.40.50/24"}}
 	return ifat, nil
 }
 
 func TestGetIPFromInterface(t *testing.T) {
 	testCases := []struct {
-		tcase    string
-		nwname   string
-		nw       networkInterfacer
-		expected net.IP
+		tcase      string
+		nwname     string
+		family     AddressFamily
+		nw         networkInterfacer
+		expected   net.IP
+		errStrFrag string
 	}{
-		{"valid", "eth3", validNetworkInterface{}, net.ParseIP("10.254.71.145")},
-		{"ipv6", "eth3", validNetworkInterfacewithIpv6Only{}, nil},
-		{"nothing", "eth3", noNetworkInterface{}, nil},
+		{"ipv4", "eth3", familyIPv4, validNetworkInterface{}, net.ParseIP("10.254.71.145"), ""},
+		{"ipv6", "eth3", familyIPv6, ipv6NetworkInterface{}, net.ParseIP("2001::200"), ""},
+		{"no ipv4", "eth3", familyIPv4, ipv6NetworkInterface{}, nil, ""},
+		{"no ipv6", "eth3", familyIPv6, validNetworkInterface{}, nil, ""},
+		{"I/F down", "eth3", familyIPv4, downNetworkInterface{}, nil, ""},
+		{"get addrs fail", "eth3", familyIPv4, noNetworkInterface{}, nil, "no such network interface"},
+		{"fail to get IP", "eth3", familyIPv4, networkInterfaceWithInvalidAddr{}, nil, "invalid CIDR"},
 	}
 	for _, tc := range testCases {
-		ip, err := getIPFromInterface(tc.nwname, tc.nw)
-		if !ip.Equal(tc.expected) {
+		ip, err := getIPFromInterface(tc.nwname, tc.family, tc.nw)
+		if err != nil {
+			if !strings.Contains(err.Error(), tc.errStrFrag) {
+				t.Errorf("case[%s]: Error string %q does not contain %q", tc.tcase, err, tc.errStrFrag)
+			}
+		} else if tc.errStrFrag != "" {
+			t.Errorf("case[%s]: Error %q expected, but not seen", tc.tcase, tc.errStrFrag)
+		} else if !ip.Equal(tc.expected) {
 			t.Errorf("case[%v]: expected %v, got %+v .err : %v", tc.tcase, tc.expected, ip, err)
 		}
 	}
@@ -279,17 +332,13 @@ func TestChooseHostInterfaceFromRoute(t *testing.T) {
 		nw       networkInterfacer
 		expected net.IP
 	}{
-		{"valid_routefirst", strings.NewReader(gatewayfirst), validNetworkInterface{}, net.ParseIP("10.254.71.145")},
-		{"valid_routelast", strings.NewReader(gatewaylast), validNetworkInterface{}, net.ParseIP("10.254.71.145")},
-		{"valid_routemiddle", strings.NewReader(gatewaymiddle), validNetworkInterface{}, net.ParseIP("10.254.71.145")},
-		{"valid_routemiddle_ipv6", strings.NewReader(gatewaymiddle), validNetworkInterfacewithIpv6Only{}, nil},
-		{"no internet connection", strings.NewReader(noInternetConnection), validNetworkInterface{}, nil},
-		{"no non-link-local ip", strings.NewReader(gatewayfirstLinkLocal), validNetworkInterfaceWithLinkLocal{}, net.ParseIP("45.55.47.146")},
-		{"no route", strings.NewReader(nothing), validNetworkInterface{}, nil},
+		{"ipv4", strings.NewReader(gatewayfirst), validNetworkInterface{}, net.ParseIP("10.254.71.145")},
+		{"ipv6", strings.NewReader(gatewaymiddle), ipv6NetworkInterface{}, net.ParseIP("2001::200")},
+		{"no non-link-local ip", strings.NewReader(gatewaymiddle), validNetworkInterfaceWithOnlyLinkLocals{}, nil},
+		{"no routes", strings.NewReader(nothing), validNetworkInterface{}, nil},
 		{"no route file", nil, validNetworkInterface{}, nil},
 		{"no interfaces", nil, noNetworkInterface{}, nil},
-		{"no interface Addrs", strings.NewReader(gatewaymiddle), networkInterfacewithNoAddrs{}, nil},
-		{"Invalid Addrs", strings.NewReader(gatewaymiddle), networkInterfacewithIpv6addrs{}, nil},
+		{"no interface addrs", strings.NewReader(gatewaymiddle), networkInterfacewithNoAddrs{}, nil},
 	}
 	for _, tc := range testCases {
 		ip, err := chooseHostInterfaceFromRoute(tc.inFile, tc.nw)


### PR DESCRIPTION
This is part 2 of the effort to update ChoseHostInterface() to support IPv6
addresses (as part of issue 44848). This changeset includes:

- Supports finding IPv6 host addresses from default routes (but currently only
  provided with IPv4 default routes).
- getRoutes() filters for default routes.
- getFinalIP() checks that IP is in requested family. Uses IsGlobalUnicast(),
  instead of explicit tests for loopback, multicast, and link-local IPs.
- getIPFromInterace() checks for family requested.
- chooseHostInterfaceFromRoute()
    * Quickly exits, if no default routes.
    * Since only getting default routes, no check here.
    * Searches all default routes for IPv4 addresses, and then searches all
      default routes for IPv6 addresses (for backwards compatibility).
- More coverage in Uts (65.4% vs 62.6%).
- Better testing of error conditions/results.
- Tests for IPv6 IPs, throughout functions.
- Reduced duplicate testing for items tested at lower levels.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Part of multiple PRs to allow selection of IPv6 host IPs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: xref #44848 

**Special notes for your reviewer**:
This is the second PR (see PR 46044 for the first). Another PR will follow to collect IPv6 default routes that can then be fed into this code (so it will be dependent upon this change).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-noteNONE
```
