### PR TITLE
prevent illegal verb/name combinations in default policy rules

### DIFF
--- a/pkg/apis/rbac/helpers.go
+++ b/pkg/apis/rbac/helpers.go
@@ -190,6 +190,22 @@ func (r *PolicyRuleBuilder) Rule() (PolicyRule, error) {
 			// this a common bug
 			return PolicyRule{}, fmt.Errorf("resource rule must have apiGroups: %#v", r.PolicyRule)
 		}
+		// if resource names are set, then the verb must not be list, watch, create, or deletecollection
+		// since verbs are largely opaque, we don't want to accidentally prevent things like "impersonate", so
+		// we will backlist common mistakes, not whitelist acceptable options.
+		if len(r.PolicyRule.ResourceNames) != 0 {
+			illegalVerbs := []string{}
+			for _, verb := range r.PolicyRule.Verbs {
+				switch verb {
+				case "list", "watch", "create", "deletecollection":
+					illegalVerbs = append(illegalVerbs, verb)
+				}
+			}
+			if len(illegalVerbs) > 0 {
+				return PolicyRule{}, fmt.Errorf("verbs %v do not have names available: %#v", illegalVerbs, r.PolicyRule)
+			}
+		}
+
 	default:
 		return PolicyRule{}, fmt.Errorf("a rule must have either nonResourceURLs or resources: %#v", r.PolicyRule)
 	}

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/client-go",
-	"GoVersion": "go1.7",
+	"GoVersion": "go1.8",
 	"GodepVersion": "v79",
 	"Packages": [
 		"./..."

--- a/staging/src/k8s.io/client-go/pkg/apis/rbac/helpers.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/rbac/helpers.go
@@ -189,6 +189,22 @@ func (r *PolicyRuleBuilder) Rule() (PolicyRule, error) {
 			// this a common bug
 			return PolicyRule{}, fmt.Errorf("resource rule must have apiGroups: %#v", r.PolicyRule)
 		}
+		// if resource names are set, then the verb must not be list, watch, create, or deletecollection
+		// since verbs are largely opaque, we don't want to accidentally prevent things like "impersonate", so
+		// we will backlist common mistakes, not whitelist acceptable options.
+		if len(r.PolicyRule.ResourceNames) != 0 {
+			illegalVerbs := []string{}
+			for _, verb := range r.PolicyRule.Verbs {
+				switch verb {
+				case "list", "watch", "create", "deletecollection":
+					illegalVerbs = append(illegalVerbs, verb)
+				}
+			}
+			if len(illegalVerbs) > 0 {
+				return PolicyRule{}, fmt.Errorf("verbs %v do not have names available: %#v", illegalVerbs, r.PolicyRule)
+			}
+		}
+
 	default:
 		return PolicyRule{}, fmt.Errorf("a rule must have either nonResourceURLs or resources: %#v", r.PolicyRule)
 	}


### PR DESCRIPTION
Names aren't presented with some kinds of "normal" verbs.  This prevents people from making common mistakes.

@timothysc as I noted in your pull.  This will prevent some classes of errors.