### PR TITLE
[Federation] Uniquify the ClusterRole and ClusterRoleBinding names created by `kubefed join`

### DIFF
--- a/federation/pkg/kubefed/join.go
+++ b/federation/pkg/kubefed/join.go
@@ -593,7 +593,7 @@ func createServiceAccount(clusterClientset internalclientset.Interface, namespac
 // service account identified by saName to access all resources in all namespaces
 // in the cluster associated with clusterClientset.
 func createClusterRoleBinding(clusterClientset internalclientset.Interface, saName, namespace, federationName, joiningClusterName string, dryRun bool) (*rbac.ClusterRoleBinding, error) {
-	roleName := util.ClusterRoleName(saName)
+	roleName := util.ClusterRoleName(federationName, saName)
 	role := &rbac.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleName,

--- a/federation/pkg/kubefed/join_test.go
+++ b/federation/pkg/kubefed/join_test.go
@@ -475,7 +475,7 @@ func fakeJoinTargetClusterFactory(clusterName, clusterCtx, dnsProvider, tmpDirPa
 		},
 	}
 
-	roleName := util.ClusterRoleName(saName)
+	roleName := util.ClusterRoleName(testFederationName, saName)
 	clusterRole := rbacv1beta1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      roleName,
@@ -595,7 +595,7 @@ func fakeCluster(clusterName, secretName, server string, isRBACAPIAvailable bool
 		saName := serviceAccountName(clusterName)
 		annotations := map[string]string{
 			kubectl.ServiceAccountNameAnnotation: saName,
-			kubectl.ClusterRoleNameAnnotation:    util.ClusterRoleName(saName),
+			kubectl.ClusterRoleNameAnnotation:    util.ClusterRoleName(testFederationName, saName),
 		}
 		cluster.ObjectMeta.SetAnnotations(annotations)
 	}

--- a/federation/pkg/kubefed/unjoin_test.go
+++ b/federation/pkg/kubefed/unjoin_test.go
@@ -275,7 +275,7 @@ func fakeUnjoinHostFactory(clusterName string) cmdutil.Factory {
 				return &http.Response{StatusCode: http.StatusOK, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(codec, &status)}, nil
 			case strings.HasPrefix(p, clusterRoleBindingPrefix) && m == http.MethodDelete:
 				got := strings.TrimPrefix(p, clusterRoleBindingPrefix)
-				want := util.ClusterRoleName(serviceAccountName(clusterName))
+				want := util.ClusterRoleName(testFederationName, serviceAccountName(clusterName))
 				if got != want {
 					return nil, errors.NewNotFound(api.Resource("clusterrolebindings"), got)
 				}
@@ -286,7 +286,7 @@ func fakeUnjoinHostFactory(clusterName string) cmdutil.Factory {
 				return &http.Response{StatusCode: http.StatusOK, Header: kubefedtesting.DefaultHeader(), Body: kubefedtesting.ObjBody(codec, &status)}, nil
 			case strings.HasPrefix(p, clusterRolePrefix) && m == http.MethodDelete:
 				got := strings.TrimPrefix(p, clusterRolePrefix)
-				want := util.ClusterRoleName(serviceAccountName(clusterName))
+				want := util.ClusterRoleName(testFederationName, serviceAccountName(clusterName))
 				if got != want {
 					return nil, errors.NewNotFound(api.Resource("clusterroles"), got)
 				}

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -302,6 +302,6 @@ func ClusterServiceAccountName(joiningClusterName, hostContext string) string {
 // ClusterRoleName returns the name of a ClusterRole and its associated
 // ClusterRoleBinding that are used to allow the service account to
 // access necessary resources on the cluster.
-func ClusterRoleName(serviceAccountName string) string {
-	return fmt.Sprintf("federation-controller-manager:%s", serviceAccountName)
+func ClusterRoleName(federationName, serviceAccountName string) string {
+	return fmt.Sprintf("federation-controller-manager:%s-%s", federationName, serviceAccountName)
 }


### PR DESCRIPTION
This allows a cluster to be in multiple federations.

**Release note**:
```release-note
NONE
```
