### PR TITLE
Fix comment typo in kube-apiserver and cachesize

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -536,7 +536,7 @@ func defaultOptions(s *options.ServerRunOptions) error {
 		// This is the heuristics that from memory capacity is trying to infer
 		// the maximum number of nodes in the cluster and set cache sizes based
 		// on that value.
-		// From our documentation, we officially recomment 120GB machines for
+		// From our documentation, we officially recommend 120GB machines for
 		// 2000 nodes, and we scale from that point. Thus we assume ~60MB of
 		// capacity per node.
 		// TODO: We may consider deciding that some percentage of memory will

--- a/pkg/registry/cachesize/cachesize.go
+++ b/pkg/registry/cachesize/cachesize.go
@@ -73,7 +73,7 @@ func InitializeWatchCacheSizes(expectedRAMCapacityMB int) {
 	// This is the heuristics that from memory capacity is trying to infer
 	// the maximum number of nodes in the cluster and set cache sizes based
 	// on that value.
-	// From our documentation, we officially recomment 120GB machines for
+	// From our documentation, we officially recommend 120GB machines for
 	// 2000 nodes, and we scale from that point. Thus we assume ~60MB of
 	// capacity per node.
 	// TODO: Revisit this heuristics


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Fix comment typo in files cmd/kube-apiserver/app/server.go and pkg/registry/cachesize/cachesize.go
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Not a major issue, just a minor improvement.
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
