### PR TITLE
ConfigMap of cluster info for identifying clusters

### DIFF
--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -288,7 +288,7 @@ func (m *Master) InstallLegacyAPI(c *Config, restOptionsGetter generic.RESTOptio
 
 	if c.EnableCoreControllers {
 		coreClient := coreclient.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
-		bootstrapController := c.NewBootstrapController(legacyRESTStorage, coreClient, coreClient)
+		bootstrapController := c.NewBootstrapController(legacyRESTStorage, coreClient, coreClient, coreClient)
 		if err := m.GenericAPIServer.AddPostStartHook("bootstrap-controller", bootstrapController.PostStartHook); err != nil {
 			glog.Fatalf("Error registering PostStartHook %q: %v", "bootstrap-controller", err)
 		}

--- a/test/integration/master/master_test.go
+++ b/test/integration/master/master_test.go
@@ -542,6 +542,31 @@ func TestMasterService(t *testing.T) {
 	}
 }
 
+func TestClusterInfoConfigMap(t *testing.T) {
+	_, s, closeFn := framework.RunAMaster(framework.NewIntegrationTestMasterConfig())
+	defer closeFn()
+
+	client := clientset.NewForConfigOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(api.GroupName).GroupVersion}})
+
+	err := wait.Poll(time.Second, time.Minute, func() (bool, error) {
+		info, err := client.Core().ConfigMaps(metav1.NamespaceDefault).Get("cluster-info", metav1.GetOptions{})
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+			return false, nil
+		}
+
+		if _, ok := info.Data["cluster-id"]; !ok {
+			t.Errorf("unexpected error: %v", err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestServiceAlloc(t *testing.T) {
 	cfg := framework.NewIntegrationTestMasterConfig()
 	_, cidr, err := net.ParseCIDR("192.168.0.0/29")


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR creates a configmap of cluster info, the map contains a "cluster-id" for identification purpose.

Third party api server such as service catalog has a specific need for this feature. Different clusters access our service brokers but currently we have no way to identify clusters. 

**Which issue this PR fixes**
This PR addresses at least part of #19831, and we can revisit the rest of it at another time if the need is still there.

**Special notes for your reviewer**:
We are keeping the changes to minimum for service catalog's need, and we purposely did not expose this change in the kubectl UX for the same reason. However, we can consider exposing this map through UX later if there is a need.

