### PR TITLE
Automated cherry pick of #44612

### DIFF
--- a/pkg/master/thirdparty/thirdparty.go
+++ b/pkg/master/thirdparty/thirdparty.go
@@ -315,11 +315,12 @@ func (m *ThirdPartyResourceServer) thirdpartyapi(group, kind, version, pluralRes
 		Root:         apiRoot,
 		GroupVersion: externalVersion,
 
-		Creater:   thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
-		Convertor: api.Scheme,
-		Copier:    api.Scheme,
-		Defaulter: api.Scheme,
-		Typer:     api.Scheme,
+		Creater:         thirdpartyresourcedata.NewObjectCreator(group, version, api.Scheme),
+		Convertor:       api.Scheme,
+		Copier:          api.Scheme,
+		Defaulter:       api.Scheme,
+		Typer:           api.Scheme,
+		UnsafeConvertor: api.Scheme,
 
 		Mapper:                 thirdpartyresourcedata.NewMapper(api.Registry.GroupOrDie(extensions.GroupName).RESTMapper, kind, version, group),
 		Linker:                 api.Registry.GroupOrDie(extensions.GroupName).SelfLinker,


### PR DESCRIPTION
Cherry pick of #44612 on release-1.6.

#44612: Fix kube-apiserver crash when patching TPR data