### PR TITLE
Require DeleteStrategy for all registry.Store

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -143,8 +143,7 @@ type Store struct {
 	// AfterUpdate implements a further operation to run after a resource is
 	// updated and before it is decorated, optional.
 	AfterUpdate ObjectFunc
-	// DeleteStrategy implements resource-specific behavior during deletion,
-	// optional.
+	// DeleteStrategy implements resource-specific behavior during deletion.
 	DeleteStrategy rest.RESTDeleteStrategy
 	// AfterDelete implements a further operation to run after a resource is
 	// deleted and before it is decorated, optional.
@@ -1136,6 +1135,10 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 		isNamespaced = e.UpdateStrategy.NamespaceScoped()
 	default:
 		return fmt.Errorf("store for %s must have CreateStrategy or UpdateStrategy set", e.QualifiedResource.String())
+	}
+
+	if e.DeleteStrategy == nil {
+		return fmt.Errorf("store for %s must have DeleteStrategy set", e.QualifiedResource.String())
 	}
 
 	if options.RESTOptions == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

All `registry.Store` objects already set a non-nil `DeleteStrategy`.  This change ensures that all future objects do so as well.

Signed-off-by: Monis Khan <mkhan@redhat.com>

xref: #24153 openshift/origin/issues/14198

cc @deads2k @liggitt @caesarxuchao @lavalamp @smarterclayton @derekmahar 

In regards to this, why is the `RESTDeleteStrategy` a useless interface (as far as deletion goes)?  We cast it to `GarbageCollectionDeleteStrategy` or `RESTGracefulDeleteStrategy` in an attempt to do operations related to deletion, but we have "default" behavior for both of those cases.  It should be possible to make `DeleteStrategy` optional by using the other strategies as the `runtime.ObjectTyper` and then defaulting a `nil` `DeleteStrategy` with the expected behavior.

```go
// RESTDeleteStrategy defines deletion behavior on an object that follows Kubernetes
// API conventions.
type RESTDeleteStrategy interface {
	runtime.ObjectTyper
}

type GarbageCollectionPolicy string

const (
	DeleteDependents GarbageCollectionPolicy = "DeleteDependents"
	OrphanDependents GarbageCollectionPolicy = "OrphanDependents"
)

// GarbageCollectionDeleteStrategy must be implemented by the registry that wants to
// orphan dependents by default.
type GarbageCollectionDeleteStrategy interface {
	// DefaultGarbageCollectionPolicy returns the default garbage collection behavior.
	DefaultGarbageCollectionPolicy() GarbageCollectionPolicy
}

// RESTGracefulDeleteStrategy must be implemented by the registry that supports
// graceful deletion.
type RESTGracefulDeleteStrategy interface {
	// CheckGracefulDelete should return true if the object can be gracefully deleted and set
	// any default values on the DeleteOptions.
	CheckGracefulDelete(ctx genericapirequest.Context, obj runtime.Object, options *metav1.DeleteOptions) bool
}
```

**Release note**:

```
NONE
```
