### PR TITLE
Provide LoadBalancers to list all cached services on demand

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -79,8 +79,14 @@ func GetInstanceProviderID(cloud Interface, nodeName types.NodeName) (string, er
 	return cloud.ProviderName() + "://" + instanceID, nil
 }
 
+type ServiceLister interface {
+	List() []*v1.Service
+}
+
 // LoadBalancer is an abstract, pluggable interface for load balancers.
 type LoadBalancer interface {
+	// InitializeLoadBalancer provides the load balancer with an interface which lists all services
+	InitializeLoadBalancer(lister ServiceLister)
 	// TODO: Break this up into different interfaces (LB, etc) when we have more than one type of service
 	// GetLoadBalancer returns whether the specified load balancer exists, and
 	// if so, what its status is.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2540,6 +2540,9 @@ func nodeNames(nodes []*v1.Node) sets.String {
 	return ret
 }
 
+// InitializeLoadBalancer provides the load balancer with an interface which lists all cached services
+func (c *Cloud) InitializeLoadBalancer(lister cloudprovider.ServiceLister) {}
+
 // EnsureLoadBalancer implements LoadBalancer.EnsureLoadBalancer
 func (c *Cloud) EnsureLoadBalancer(clusterName string, apiService *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	annotations := apiService.Annotations

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -35,6 +35,9 @@ import (
 // ServiceAnnotationLoadBalancerInternal is the annotation used on the service
 const ServiceAnnotationLoadBalancerInternal = "service.beta.kubernetes.io/azure-load-balancer-internal"
 
+// InitializeLoadBalancer provides the load balancer with an interface which lists all cached services
+func (az *Cloud) InitializeLoadBalancer(lister cloudprovider.ServiceLister) {}
+
 // GetLoadBalancer returns whether the specified load balancer exists, and
 // if so, what its status is.
 func (az *Cloud) GetLoadBalancer(clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack_loadbalancer.go
@@ -39,6 +39,9 @@ type loadBalancer struct {
 	rules     map[string]*cloudstack.LoadBalancerRule
 }
 
+// InitializeLoadBalancer provides the load balancer with an interface which lists all cached services
+func (cs *CSCloud) InitializeLoadBalancer(lister cloudprovider.ServiceLister) {}
+
 // GetLoadBalancer returns whether the specified load balancer exists, and if so, what its status is.
 func (cs *CSCloud) GetLoadBalancer(clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
 	glog.V(4).Infof("GetLoadBalancer(%v, %v, %v)", clusterName, service.Namespace, service.Name)

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -132,6 +132,9 @@ func (f *FakeCloud) Routes() (cloudprovider.Routes, bool) {
 	return f, true
 }
 
+// InitializeLoadBalancer provides the load balancer with an interface which lists all cached services
+func (f *FakeCloud) InitializeLoadBalancer(lister cloudprovider.ServiceLister) {}
+
 // GetLoadBalancer is a stub implementation of LoadBalancer.GetLoadBalancer.
 func (f *FakeCloud) GetLoadBalancer(clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
 	status := &v1.LoadBalancerStatus{}

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
@@ -78,6 +78,9 @@ func init() {
 	flag.Var(&lbSrcRngsFlag, "cloud-provider-gce-lb-src-cidrs", "CIDRS opened in GCE firewall for LB traffic proxy & health checks")
 }
 
+// InitializeLoadBalancer provides the load balancer with an interface which lists all cached services
+func (gce *GCECloud) InitializeLoadBalancer(lister cloudprovider.ServiceLister) {}
+
 // String is the method to format the flag's value, part of the flag.Value interface.
 func (c *cidrs) String() string {
 	return strings.Join(c.ipn.StringSlice(), ",")

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -555,6 +555,9 @@ func stringInArray(x string, list []string) bool {
 	return false
 }
 
+// InitializeLoadBalancer provides the load balancer with an interface which lists all cached services
+func (lbaas *LbaasV2) InitializeLoadBalancer(lister cloudprovider.ServiceLister) {}
+
 func (lbaas *LbaasV2) GetLoadBalancer(clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
 	loadBalancerName := cloudprovider.GetLoadBalancerName(service)
 	loadbalancer, err := getLoadbalancerByName(lbaas.network, loadBalancerName)
@@ -1202,6 +1205,9 @@ func (lbaas *LbaasV2) EnsureLoadBalancerDeleted(clusterName string, service *v1.
 
 	return nil
 }
+
+// InitializeLoadBalancer provides the load balancer with an interface which lists all cached services
+func (lb *LbaasV1) InitializeLoadBalancer(lister cloudprovider.ServiceLister) {}
 
 func (lb *LbaasV1) GetLoadBalancer(clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {
 	loadBalancerName := cloudprovider.GetLoadBalancerName(service)

--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -216,6 +216,9 @@ func (s *ServiceController) init() error {
 	if !ok {
 		return fmt.Errorf("the cloud provider does not support external load balancers.")
 	}
+
+	balancer.InitializeLoadBalancer(s.cache)
+
 	s.balancer = balancer
 
 	return nil
@@ -376,6 +379,11 @@ func (s *serviceCache) ListKeys() []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// List implements the interface cloudprovider.ServiceLister and returns the list of cached services
+func (s *serviceCache) List() []*v1.Service {
+	return s.allServices()
 }
 
 // GetByKey returns the value stored in the serviceMap under the given key


### PR DESCRIPTION
**What this PR does / why we need it**:
`cloudprovider.LoadBalancer` implementations could need to see all services when implementing or deleting LB resources for a specific service.  For instance, several loadbalancers could be sharing a resource in a third-party system. The following PR allows the providers to call a `List()` func to return a list of cached service objects.

**Release note**:
```release-note
NONE
```
