### PR TITLE
Write "kubectl options" help message to stdout, not stderr

### DIFF
--- a/federation/pkg/kubefed/kubefed.go
+++ b/federation/pkg/kubefed/kubefed.go
@@ -67,7 +67,7 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defa
 	templates.ActsAsRootCommand(cmds, filters, groups...)
 
 	cmds.AddCommand(kubectl.NewCmdVersion(f, out))
-	cmds.AddCommand(kubectl.NewCmdOptions())
+	cmds.AddCommand(kubectl.NewCmdOptions(out))
 
 	return cmds
 }

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -378,7 +378,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 	cmds.AddCommand(NewCmdVersion(f, out))
 	cmds.AddCommand(NewCmdApiVersions(f, out))
 	cmds.AddCommand(deprecatedAlias("apiversions", NewCmdApiVersions(f, out)))
-	cmds.AddCommand(NewCmdOptions())
+	cmds.AddCommand(NewCmdOptions(out))
 
 	return cmds
 }

--- a/pkg/kubectl/cmd/options.go
+++ b/pkg/kubectl/cmd/options.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cmd
 
 import (
+	"io"
+
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	"k8s.io/kubernetes/pkg/util/i18n"
 
@@ -30,7 +32,7 @@ var (
 )
 
 // NewCmdOptions implements the options command
-func NewCmdOptions() *cobra.Command {
+func NewCmdOptions(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "options",
 		Short:   i18n.T("Print the list of flags inherited by all commands"),
@@ -41,7 +43,13 @@ func NewCmdOptions() *cobra.Command {
 		},
 	}
 
-	templates.UseOptionsTemplates(cmd)
+	// The `options` command needs write its output to the `out` stream
+	// (typically stdout). Without calling SetOutput here, the Usage()
+	// function call will fall back to stderr.
+	//
+	// See https://github.com/kubernetes/kubernetes/pull/46394 for details.
+	cmd.SetOutput(out)
 
+	templates.UseOptionsTemplates(cmd)
 	return cmd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

Fix a very minor issue causing `kubectl` to write its help messages to `stderr` instead of `stdout`.

Try this:

`kubectl options | grep log`

It should print only the options related to logging, but right now it prints the entire help menu (since it's printing to stderr).

This patch brings us closer to unix convention and reduces user friction.

~~Another use case (if a user can't remember whether it's `-r` or `-R` for recursion):~~

~~`kubectl patch -h | grep recursive`~~

Update: this patch only affects `kubectl options`. The other commands are working as intended.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
