### PR TITLE
Fix selfLinks of pods started from manifests

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -93,7 +93,7 @@ func getSelfLink(name, namespace string) string {
 	if len(namespace) == 0 {
 		namespace = metav1.NamespaceDefault
 	}
-	selfLink = fmt.Sprintf("/api/"+api.Registry.GroupOrDie(api.GroupName).GroupVersion.Version+"/pods/namespaces/%s/%s", name, namespace)
+	selfLink = fmt.Sprintf("/api/"+api.Registry.GroupOrDie(api.GroupName).GroupVersion.Version+"/namespaces/%s/pods/%s", namespace, name)
 	return selfLink
 }
 

--- a/pkg/kubelet/config/common_test.go
+++ b/pkg/kubelet/config/common_test.go
@@ -160,3 +160,31 @@ func TestDecodePodList(t *testing.T) {
 		}
 	}
 }
+
+func TestGetSelfLink(t *testing.T) {
+	var testCases = []struct {
+		desc             string
+		name             string
+		namespace        string
+		expectedSelfLink string
+	}{
+		{
+			desc:             "No namespace specified",
+			name:             "foo",
+			namespace:        "",
+			expectedSelfLink: "/api/v1/namespaces/default/pods/foo",
+		},
+		{
+			desc:             "Namespace specified",
+			name:             "foo",
+			namespace:        "bar",
+			expectedSelfLink: "/api/v1/namespaces/bar/pods/foo",
+		},
+	}
+	for _, testCase := range testCases {
+		selfLink := getSelfLink(testCase.name, testCase.namespace)
+		if testCase.expectedSelfLink != selfLink {
+			t.Errorf("%s: getSelfLink error, expected: %s, got: %s", testCase.desc, testCase.expectedSelfLink, selfLink)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
When running `curl http://localhost:10255/pods` the selfLink for pods started from manifests were incorrect. This PR fixes it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #46357

**Special notes for your reviewer**:

@number101010

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
