### PR TITLE
Update url information to prevent http 304 redirection

### DIFF
--- a/hack/gen-swagger-doc/Dockerfile
+++ b/hack/gen-swagger-doc/Dockerfile
@@ -35,7 +35,7 @@ COPY gen-swagger-docs.sh build/
 # Run the script once to download the dependent java libraries into the image
 RUN mkdir -p /output /swagger-source \
 	&& wget https://raw.githubusercontent.com/kubernetes/kubernetes/master/api/swagger-spec/v1.json -O /swagger-source/v1.json \
-	&& wget https://raw.githubusercontent.com/GoogleCloudPlatform/kubernetes/master/pkg/api/v1/register.go -O /register.go \
+	&& wget https://raw.githubusercontent.com/kubernetes/kubernetes/master/pkg/api/v1/register.go -O /register.go \
 	&& build/gen-swagger-docs.sh v1 \
 	&& rm -rf /output/* /swagger-source/* /register.go
 

--- a/hack/lookup_pull.py
+++ b/hack/lookup_pull.py
@@ -21,7 +21,7 @@ import sys
 import urllib2
 
 PULLQUERY=("https://api.github.com/repos/"
-           "GoogleCloudPlatform/kubernetes/pulls/{pull}")
+           "kubernetes/kubernetes/pulls/{pull}")
 LOGIN="login"
 TITLE="title"
 USER="user"


### PR DESCRIPTION
Although repo [https://github.com/GoogleCloudPlatform/kubernetes](https://github.com/GoogleCloudPlatform/kubernetes) still can be access, but I think one more 304 redirection is no needed

```release-note
NONE
```
