### PR TITLE
Fix doc about Verb for advanced audit feature

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/types.go
@@ -57,7 +57,7 @@ type Event struct {
 	// RequestURI is the request URI as sent by the client to a server.
 	RequestURI string `json:"requestURI"`
 	// Verb is the kubernetes verb associated with the request.
-	// For non-resource requests, this is identical to HttpMethod.
+	// For non-resource requests, this is the lower-cased HTTP method.
 	Verb string `json:"verb"`
 	// Authenticated user information.
 	User authnv1.UserInfo `json:"user"`


### PR DESCRIPTION
This patch is commited to address the following comment:
https://github.com/kubernetes/kubernetes/pull/45315#discussion_r117107507
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
