### PR TITLE
Log out digest when digest is invalid

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/helpers.go
+++ b/pkg/kubelet/dockershim/libdocker/helpers.go
@@ -112,7 +112,7 @@ func matchImageIDOnly(inspected dockertypes.ImageInspect, image string) bool {
 
 	digest, isDigested := ref.(dockerref.Digested)
 	if !isDigested {
-		glog.V(4).Infof("the image reference %q was not a digest reference")
+		glog.V(4).Infof("the image reference %q was not a digest reference", image)
 		return false
 	}
 


### PR DESCRIPTION
Notice this in frakti: missing image ref when logging it out.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
