### PR TITLE
Introduce human readable String() to resource.Quantity.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -602,15 +602,21 @@ func (q *Quantity) Neg() {
 // of most Quantity values.
 const int64QuantityExpectedBytes = 18
 
-// String formats the Quantity as a string, caching the result if not calculated.
+// String formats the Quantity as a string. The unbuffered version exists to provide human readable
+// log format for structs/maps that contain nested Quantity field.
+func (q Quantity) String() string {
+	result := make([]byte, 0, int64QuantityExpectedBytes)
+	number, suffix := q.CanonicalizeBytes(result)
+	number = append(number, suffix...)
+	return string(number)
+}
+
+// StringBuffered formats the Quantity as a string, caching the result if not calculated.
 // String is an expensive operation and caching this result significantly reduces the cost of
 // normal parse / marshal operations on Quantity.
-func (q *Quantity) String() string {
+func (q *Quantity) StringBuffered() string {
 	if len(q.s) == 0 {
-		result := make([]byte, 0, int64QuantityExpectedBytes)
-		number, suffix := q.CanonicalizeBytes(result)
-		number = append(number, suffix...)
-		q.s = string(number)
+		q.s = q.String()
 	}
 	return q.s
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_example_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_example_test.go
@@ -32,10 +32,16 @@ func ExampleFormat() {
 	cores := resource.NewMilliQuantity(5300, resource.DecimalSI)
 	fmt.Printf("cores = %v\n", cores)
 
+	sampleMap := map[string]resource.Quantity{
+		"test": *memorySize,
+	}
+	fmt.Printf("sampleMap = %v\n", sampleMap)
+
 	// Output:
 	// memorySize = 5Gi
 	// diskSize = 5G
 	// cores = 5300m
+	// sampleMap = map[test:5Gi]
 }
 
 func ExampleMustParse() {

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto.go
@@ -46,7 +46,7 @@ func (m *Quantity) MarshalTo(data []byte) (int, error) {
 	data[i] = 0xa
 	i++
 	// BEGIN CUSTOM MARSHAL
-	out := m.String()
+	out := m.StringBuffered()
 	i = encodeVarintGenerated(data, i, uint64(len(out)))
 	i += copy(data[i:], out)
 	// END CUSTOM MARSHAL
@@ -69,7 +69,7 @@ func (m *Quantity) Size() (n int) {
 	_ = l
 
 	// BEGIN CUSTOM SIZE
-	l = len(m.String())
+	l = len(m.StringBuffered())
 	// END CUSTOM SIZE
 
 	n += 1 + l + sovGenerated(uint64(l))

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -638,7 +638,7 @@ func TestQuantityNeg(t *testing.T) {
 	}
 }
 
-func TestQuantityString(t *testing.T) {
+func TestQuantityStringBuffered(t *testing.T) {
 	table := []struct {
 		in        Quantity
 		expect    string
@@ -688,7 +688,7 @@ func TestQuantityString(t *testing.T) {
 		{decQuantity(1080, -6, DecimalSI), "1080u", ""},
 	}
 	for _, item := range table {
-		got := item.in.String()
+		got := item.in.StringBuffered()
 		if e, a := item.expect, got; e != a {
 			t.Errorf("%#v: expected %v, got %v", item.in, e, a)
 		}
@@ -710,11 +710,11 @@ func TestQuantityString(t *testing.T) {
 		if len(q.s) != 0 {
 			t.Errorf("%#v: unexpected nested string: %v", item.expect, q.s)
 		}
-		if q.String() != item.expect {
+		if q.StringBuffered() != item.expect {
 			t.Errorf("%#v: unexpected alternate canonical: %v", item.expect, q.String())
 		}
 		if len(q.s) == 0 || q.s != item.expect {
-			t.Errorf("%#v: did not set canonical string on ToString: %s", item.expect, q.s)
+			t.Errorf("%#v: did not set canonical string on StringBuffered: %s", item.expect, q.s)
 		}
 	}
 	desired := &inf.Dec{} // Avoid modifying the values in the table.
@@ -1221,7 +1221,6 @@ func BenchmarkQuantityString(b *testing.B) {
 	var s string
 	for i := 0; i < b.N; i++ {
 		q := values[i%len(values)]
-		q.s = ""
 		s = q.String()
 	}
 	b.StopTimer()
@@ -1233,13 +1232,13 @@ func BenchmarkQuantityString(b *testing.B) {
 func BenchmarkQuantityStringPrecalc(b *testing.B) {
 	values := benchmarkQuantities()
 	for i := range values {
-		_ = values[i].String()
+		_ = values[i].StringBuffered()
 	}
 	b.ResetTimer()
 	var s string
 	for i := 0; i < b.N; i++ {
 		q := values[i%len(values)]
-		s = q.String()
+		s = q.StringBuffered()
 	}
 	b.StopTimer()
 	if len(s) == 0 {
@@ -1256,7 +1255,6 @@ func BenchmarkQuantityStringBinarySI(b *testing.B) {
 	var s string
 	for i := 0; i < b.N; i++ {
 		q := values[i%len(values)]
-		q.s = ""
 		s = q.String()
 	}
 	b.StopTimer()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
When resource.Quantity is a value in map (or field in struct), call to String() on map/struct returns hard to understand representation of the field:
```
{i:{value:88 scale:-3} d:{Dec:<nil>} s:88m Format:DecimalSI}
```
This is because, String() was defined only for *resource.Quantity.

Two changes were made:
1. String() receiver type is migrated to value to be visible for both calls on value (as e.g. in struct/maps) and pointer.
2. New StringBuffered() is introduced (works only on a pointer receiver type) to be used in performance critical places (e.g. protobuf marshal operation).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/contrib/issues/2351
**Special notes for your reviewer**:
An assumption is made that only calls from quantity_proto.go are performance critical and other calls to String() can be unbuffered.
Could you please validate this assumption or provide the information how to validate it?

**Release note**:
```release-note
NONE
```
