### PR TITLE
refactor and export openstack service clients

### DIFF
--- a/pkg/cloudprovider/providers/openstack/BUILD
+++ b/pkg/cloudprovider/providers/openstack/BUILD
@@ -13,6 +13,7 @@ go_library(
     srcs = [
         "metadata.go",
         "openstack.go",
+        "openstack_client.go",
         "openstack_instances.go",
         "openstack_loadbalancer.go",
         "openstack_metrics.go",

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -428,19 +428,13 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	glog.V(4).Info("openstack.LoadBalancer() called")
 
 	// TODO: Search for and support Rackspace loadbalancer API, and others.
-	network, err := openstack.NewNetworkV2(os.provider, gophercloud.EndpointOpts{
-		Region: os.region,
-	})
+	network, err := os.NewNetworkV2()
 	if err != nil {
-		glog.Warningf("Failed to find network endpoint: %v", err)
 		return nil, false
 	}
 
-	compute, err := openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
-		Region: os.region,
-	})
+	compute, err := os.NewComputeV2()
 	if err != nil {
-		glog.Warningf("Failed to find compute endpoint: %v", err)
 		return nil, false
 	}
 
@@ -504,11 +498,8 @@ func (os *OpenStack) GetZone() (cloudprovider.Zone, error) {
 func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 	glog.V(4).Info("openstack.Routes() called")
 
-	network, err := openstack.NewNetworkV2(os.provider, gophercloud.EndpointOpts{
-		Region: os.region,
-	})
+	network, err := os.NewNetworkV2()
 	if err != nil {
-		glog.Warningf("Failed to find network endpoint: %v", err)
 		return nil, false
 	}
 
@@ -523,11 +514,8 @@ func (os *OpenStack) Routes() (cloudprovider.Routes, bool) {
 		return nil, false
 	}
 
-	compute, err := openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
-		Region: os.region,
-	})
+	compute, err := os.NewComputeV2()
 	if err != nil {
-		glog.Warningf("Failed to find compute endpoint: %v", err)
 		return nil, false
 	}
 
@@ -595,29 +583,20 @@ func (os *OpenStack) volumeService(forceVersion string) (volumeService, error) {
 
 	switch bsVersion {
 	case "v1":
-		sClient, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
-			Region: os.region,
-		})
-		if err != nil || sClient == nil {
-			glog.Errorf("Unable to initialize cinder client for region: %s", os.region)
+		sClient, err := os.NewBlockStorageV1()
+		if err != nil {
 			return nil, err
 		}
 		return &VolumesV1{sClient, os.bsOpts}, nil
 	case "v2":
-		sClient, err := openstack.NewBlockStorageV2(os.provider, gophercloud.EndpointOpts{
-			Region: os.region,
-		})
-		if err != nil || sClient == nil {
-			glog.Errorf("Unable to initialize cinder v2 client for region: %s", os.region)
+		sClient, err := os.NewBlockStorageV2()
+		if err != nil {
 			return nil, err
 		}
 		return &VolumesV2{sClient, os.bsOpts}, nil
 	case "auto":
-		sClient, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
-			Region: os.region,
-		})
-		if err != nil || sClient == nil {
-			glog.Errorf("Unable to initialize cinder client for region: %s", os.region)
+		sClient, err := os.NewBlockStorageV1()
+		if err != nil {
 			return nil, err
 		}
 		availableApiVersions := []apiversions_v1.APIVersion{}

--- a/pkg/cloudprovider/providers/openstack/openstack_client.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_client.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack"
+
+	"github.com/golang/glog"
+)
+
+func (os *OpenStack) NewNetworkV2() (*gophercloud.ServiceClient, error) {
+	network, err := openstack.NewNetworkV2(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+	if err != nil {
+		glog.Warningf("Failed to find network v2 endpoint: %v", err)
+		return nil, err
+	}
+	return network, nil
+}
+
+func (os *OpenStack) NewComputeV2() (*gophercloud.ServiceClient, error) {
+	compute, err := openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+	if err != nil {
+		glog.Warningf("Failed to find compute v2 endpoint: %v", err)
+		return nil, err
+	}
+	return compute, nil
+}
+
+func (os *OpenStack) NewBlockStorageV1() (*gophercloud.ServiceClient, error) {
+	storage, err := openstack.NewBlockStorageV1(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+	if err != nil {
+		glog.Errorf("Unable to initialize cinder v1 client for region: %s", os.region)
+		return nil, err
+	}
+	return storage, nil
+}
+
+func (os *OpenStack) NewBlockStorageV2() (*gophercloud.ServiceClient, error) {
+	storage, err := openstack.NewBlockStorageV2(os.provider, gophercloud.EndpointOpts{
+		Region: os.region,
+	})
+	if err != nil {
+		glog.Errorf("Unable to initialize cinder v2 client for region: %s", os.region)
+		return nil, err
+	}
+	return storage, nil
+}

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/servers"
 	"github.com/gophercloud/gophercloud/pagination"
 
@@ -38,11 +37,8 @@ type Instances struct {
 func (os *OpenStack) Instances() (cloudprovider.Instances, bool) {
 	glog.V(4).Info("openstack.Instances() called")
 
-	compute, err := openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
-		Region: os.region,
-	})
+	compute, err := os.NewComputeV2()
 	if err != nil {
-		glog.Warningf("Failed to find compute endpoint: %v", err)
 		return nil, false
 	}
 

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -27,7 +27,6 @@ import (
 	k8s_volume "k8s.io/kubernetes/pkg/volume"
 
 	"github.com/gophercloud/gophercloud"
-	"github.com/gophercloud/gophercloud/openstack"
 	volumes_v1 "github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes"
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
@@ -221,11 +220,8 @@ func (os *OpenStack) AttachDisk(instanceID, volumeID string) (string, error) {
 		glog.Errorf(errmsg)
 		return "", errors.New(errmsg)
 	}
-	cClient, err := openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
-		Region: os.region,
-	})
-	if err != nil || cClient == nil {
-		glog.Errorf("Unable to initialize nova client for region: %s", os.region)
+	cClient, err := os.NewComputeV2()
+	if err != nil {
 		return "", err
 	}
 
@@ -267,11 +263,8 @@ func (os *OpenStack) DetachDisk(instanceID, volumeID string) error {
 		glog.Errorf(errmsg)
 		return errors.New(errmsg)
 	}
-	cClient, err := openstack.NewComputeV2(os.provider, gophercloud.EndpointOpts{
-		Region: os.region,
-	})
-	if err != nil || cClient == nil {
-		glog.Errorf("Unable to initialize nova client for region: %s", os.region)
+	cClient, err := os.NewComputeV2()
+	if err != nil {
 		return err
 	}
 	if volume.AttachedServerId != instanceID {


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactor and export openstack service client.
Exporting OpenStack client so other projects can use the them to call functions that are not implemented in openstack cloud providers yet.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
