### PR TITLE
Up namespace controller workers to 5

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -66,7 +66,7 @@ func NewCMServer() *CMServer {
 			ConcurrentJobSyncs:                              5,
 			ConcurrentResourceQuotaSyncs:                    5,
 			ConcurrentDeploymentSyncs:                       5,
-			ConcurrentNamespaceSyncs:                        2,
+			ConcurrentNamespaceSyncs:                        5,
 			ConcurrentSATokenSyncs:                          5,
 			LookupCacheSizeForRC:                            4096,
 			LookupCacheSizeForRS:                            4096,


### PR DESCRIPTION
Increase the number of namespace controller workers from 2 to 5 in an
effort to speed up namespace deletions.

xref #20051