### PR TITLE
Set Kubelet Disk Defaults for the 1.7 release

### DIFF
--- a/cluster/vagrant/config-default.sh
+++ b/cluster/vagrant/config-default.sh
@@ -121,5 +121,3 @@ E2E_STORAGE_TEST_ENVIRONMENT=${KUBE_E2E_STORAGE_TEST_ENVIRONMENT:-false}
 # Default fallback NETWORK_IF_NAME, will be used in case when no 'VAGRANT-BEGIN' comments were defined in network-script
 export DEFAULT_NETWORK_IF_NAME="eth0"
 
-# Evict pods whenever compute resource availability on the nodes gets below a threshold.
-EVICTION_HARD="${EVICTION_HARD:-memory.available<100Mi,nodefs.available<10%}"

--- a/cluster/vagrant/config-test.sh
+++ b/cluster/vagrant/config-test.sh
@@ -27,5 +27,3 @@ REGISTER_MASTER_KUBELET=${REGISTER_MASTER:-false}
 # Optional: if set to true, kube-up will configure the cluster to run e2e tests.
 E2E_STORAGE_TEST_ENVIRONMENT=${KUBE_E2E_STORAGE_TEST_ENVIRONMENT:-false}
 
-# Evict pods whenever compute resource availability on the nodes gets below a threshold.
-EVICTION_HARD="${EVICTION_HARD:-memory.available<100Mi,nodefs.available<10%}"

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -45,7 +45,7 @@ CGROUP_DRIVER=${CGROUP_DRIVER:-""}
 USER=${USER:-$(whoami)}
 
 # enables testing eviction scenarios locally.
-EVICTION_HARD=${EVICTION_HARD:-"memory.available<100Mi"}
+EVICTION_HARD=${EVICTION_HARD:-"memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"}
 EVICTION_SOFT=${EVICTION_SOFT:-""}
 EVICTION_PRESSURE_TRANSITION_PERIOD=${EVICTION_PRESSURE_TRANSITION_PERIOD:-"1m"}
 

--- a/pkg/apis/componentconfig/v1alpha1/defaults.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults.go
@@ -301,9 +301,6 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 		temp := int32(80)
 		obj.ImageGCLowThresholdPercent = &temp
 	}
-	if obj.LowDiskSpaceThresholdMB == 0 {
-		obj.LowDiskSpaceThresholdMB = 256
-	}
 	if obj.MasterServiceNamespace == "" {
 		obj.MasterServiceNamespace = metav1.NamespaceDefault
 	}
@@ -396,7 +393,7 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 		obj.HairpinMode = PromiscuousBridge
 	}
 	if obj.EvictionHard == nil {
-		temp := "memory.available<100Mi"
+		temp := "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"
 		obj.EvictionHard = &temp
 	}
 	if obj.EvictionPressureTransitionPeriod == zeroDuration {


### PR DESCRIPTION
The `--low-diskspace-threshold-mb` flag has been depreciated since 1.6.
This PR sets the default to `0`, and sets defaults for disk eviction based on the values used for our [e2e tests](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/services/kubelet.go#L145).
This also removes the custom defaults for vagrant, as the new defaults should work for it as well.

/assign @derekwaynecarr 
cc @vishh 

```release-note
By default, --low-diskspace-threshold-mb is not set, and --eviction-hard includes "nodefs.available<10%,nodefs.inodesFree<5%"
```