### PR TITLE
Fix potential nil pointer dereference for kube-proxy healthcheck

### DIFF
--- a/pkg/proxy/healthcheck/healthcheck.go
+++ b/pkg/proxy/healthcheck/healthcheck.go
@@ -197,7 +197,13 @@ var _ http.Handler = hcHandler{}
 
 func (h hcHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	h.hcs.lock.Lock()
-	count := h.hcs.services[h.name].endpoints
+	svc, ok := h.hcs.services[h.name]
+	if !ok || svc == nil {
+		h.hcs.lock.Unlock()
+		glog.Errorf("Received request for closed healthcheck %q", h.name.String())
+		return
+	}
+	count := svc.endpoints
 	h.hcs.lock.Unlock()
 
 	resp.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
Found error log from https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-slow/5222:
```
I0524 20:22:35.554156       7 healthcheck.go:226] Not saving endpoints for unknown healthcheck "kube-system/kubernetes-dashboard"
I0524 20:22:35.554172       7 proxier.go:923] syncProxyRules took 40.047209ms
I0524 20:22:35.554218       7 healthcheck.go:175] Healthcheck "e2e-tests-esipp-f7djn/external-local" closed: accept tcp [::]:32027: use of closed network connection
I0524 20:22:37.416133       7 logs.go:41] http: panic serving 169.254.169.254:49216: runtime error: invalid memory address or nil pointer dereference
goroutine 1623 [running]:
net/http.(*conn).serve.func1(0xc420b27220)
	/usr/local/go_k8s_patched/src/net/http/server.go:1721 +0xd0
panic(0x1c07e40, 0x2b11ee0)
	/usr/local/go_k8s_patched/src/runtime/panic.go:489 +0x2cf
k8s.io/kubernetes/pkg/proxy/healthcheck.hcHandler.ServeHTTP(0xc4201aea60, 0x15, 0xc4203233a0, 0xe, 0xc4203aa280, 0x2ab51a0, 0xc420ae4d20, 0xc4202e7a00)
	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/proxy/healthcheck/healthcheck.go:200 +0x86
k8s.io/kubernetes/pkg/proxy/healthcheck.(*hcHandler).ServeHTTP(0xc420798390, 0x2ab51a0, 0xc420ae4d20, 0xc4202e7a00)
	<autogenerated>:8 +0x87
net/http.serverHandler.ServeHTTP(0xc4208d0210, 0x2ab51a0, 0xc420ae4d20, 0xc4202e7a00)
	/usr/local/go_k8s_patched/src/net/http/server.go:2568 +0x92
net/http.(*conn).serve(0xc420b27220, 0x2ab66e0, 0xc420945380)
	/usr/local/go_k8s_patched/src/net/http/server.go:1825 +0x612
created by net/http.(*Server).Serve
	/usr/local/go_k8s_patched/src/net/http/server.go:2668 +0x2ce
```

So seems like it's possible healthcheck server is still serving traffic after service entry is removed.

/assign @freehan 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix kube-proxy hang due to panic when requesting a closed healthcheck.
```
