### PR TITLE
Add ClusterSelector to Ingress Controller

### DIFF
--- a/federation/pkg/federation-controller/ingress/BUILD
+++ b/federation/pkg/federation-controller/ingress/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset:go_default_library",
         "//federation/pkg/federation-controller/util:go_default_library",
+        "//federation/pkg/federation-controller/util/clusterselector:go_default_library",
         "//federation/pkg/federation-controller/util/deletionhelper:go_default_library",
         "//federation/pkg/federation-controller/util/eventsink:go_default_library",
         "//pkg/api:go_default_library",

--- a/federation/pkg/federation-controller/ingress/ingress_controller_test.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller_test.go
@@ -233,6 +233,7 @@ func TestIngressController(t *testing.T) {
 		fedIngress.ObjectMeta.Annotations = make(map[string]string)
 	}
 	fedIngress.ObjectMeta.Annotations["A"] = "B"
+	fedIngress.ObjectMeta.Annotations[federationapi.FederationClusterSelectorAnnotation] = `[{"key": "cluster", "operator": "in", "values": ["cluster1","cluster2"]}]`
 	t.Log("Modifying Federated Ingress")
 	fedIngressWatch.Modify(&fedIngress)
 	t.Log("Checking that Ingress was correctly updated in cluster 1")

--- a/federation/pkg/federation-controller/util/test/test_helper.go
+++ b/federation/pkg/federation-controller/util/test/test_helper.go
@@ -366,6 +366,7 @@ func NewCluster(name string, readyStatus apiv1.ConditionStatus) *federationapi.C
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Annotations: map[string]string{},
+			Labels:      map[string]string{"cluster": name},
 		},
 		Status: federationapi.ClusterStatus{
 			Conditions: []federationapi.ClusterCondition{


### PR DESCRIPTION
This pull request adds ClusterSelector to the Federated Ingress Controller ref: design #29887 
This back ports the same functionality from the sync controller (merged pull #40234) in order to make this feature available across all Controllers for the 1.7 release.

cc: @kubernetes/sig-federation-pr-reviews @shashidharatd

**Release note**:
```
The annotation `federation.alpha.kubernetes.io/cluster-selector` can be used with Ingress objects to target federated clusters by label.
```
