### PR TITLE
Add configuration for encryption providers

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -87,6 +87,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/server/filters:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/options/encryptionconfig:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -50,6 +50,7 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/filters"
+	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
@@ -494,6 +495,16 @@ func BuildStorageFactory(s *options.ServerRunOptions) (*serverstorage.DefaultSto
 
 		servers := strings.Split(tokens[1], ";")
 		storageFactory.SetEtcdLocation(groupResource, servers)
+	}
+
+	if s.Etcd.EncryptionProviderConfigFilepath != "" {
+		transformerOverrides, err := encryptionconfig.GetTransformerOverrides(s.Etcd.EncryptionProviderConfigFilepath)
+		if err != nil {
+			return nil, err
+		}
+		for groupResource, transformer := range transformerOverrides {
+			storageFactory.SetTransformer(groupResource, transformer)
+		}
 	}
 
 	return storageFactory, nil

--- a/hack/.linted_packages
+++ b/hack/.linted_packages
@@ -357,6 +357,7 @@ staging/src/k8s.io/apiserver/pkg/storage/names
 staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory
 staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory
 staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes
+staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/identity
 staging/src/k8s.io/apiserver/pkg/util/flushwriter
 staging/src/k8s.io/apiserver/pkg/util/logs
 staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/BUILD
@@ -1,0 +1,36 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "config.go",
+        "types.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/value:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/aes:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/value/encrypt/identity:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["encryptionconfig_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/value:go_default_library",
+    ],
+)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package encryptionconfig
+
+import (
+	"crypto/aes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	yaml "github.com/ghodss/yaml"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/storage/value"
+	aestransformer "k8s.io/apiserver/pkg/storage/value/encrypt/aes"
+	"k8s.io/apiserver/pkg/storage/value/encrypt/identity"
+)
+
+const (
+	aesTransformerPrefixV1 = "k8s:enc:aes:v1:"
+)
+
+// GetTransformerOverrides returns the transformer overrides by reading and parsing the encryption provider configuration file
+func GetTransformerOverrides(filepath string) (map[schema.GroupResource]value.Transformer, error) {
+	f, err := os.Open(filepath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening encryption provider configuration file %q: %v", filepath, err)
+	}
+	defer f.Close()
+
+	result, err := ParseEncryptionConfiguration(f)
+	if err != nil {
+		return nil, fmt.Errorf("error while parsing encryption provider configuration file %q: %v", filepath, err)
+	}
+	return result, nil
+}
+
+// ParseEncryptionConfiguration parses configuration data and returns the transformer overrides
+func ParseEncryptionConfiguration(f io.Reader) (map[schema.GroupResource]value.Transformer, error) {
+	configFileContents, err := ioutil.ReadAll(f)
+	if err != nil {
+		return nil, fmt.Errorf("could not read contents: %v", err)
+	}
+
+	var config EncryptionConfig
+	err = yaml.Unmarshal(configFileContents, &config)
+	if err != nil {
+		return nil, fmt.Errorf("error while parsing file: %v", err)
+	}
+
+	if config.Kind != "EncryptionConfig" && config.Kind != "" {
+		return nil, fmt.Errorf("invalid configuration kind %q provided", config.Kind)
+	}
+	if config.Kind == "" {
+		return nil, fmt.Errorf("invalid configuration file, missing Kind")
+	}
+	// TODO config.APIVersion is unchecked
+
+	resourceToPrefixTransformer := map[schema.GroupResource][]value.PrefixTransformer{}
+
+	// For each entry in the configuration
+	for _, resourceConfig := range config.Resources {
+		transformers, err := GetPrefixTransformers(&resourceConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		// For each resource, create a list of providers to use
+		for _, resource := range resourceConfig.Resources {
+			gr := schema.ParseGroupResource(resource)
+			resourceToPrefixTransformer[gr] = append(
+				resourceToPrefixTransformer[gr], transformers...)
+		}
+	}
+
+	result := map[schema.GroupResource]value.Transformer{}
+	for gr, transList := range resourceToPrefixTransformer {
+		result[gr] = value.NewMutableTransformer(value.NewPrefixTransformers(fmt.Errorf("no matching prefix found"), transList...))
+	}
+	return result, nil
+}
+
+// GetPrefixTransformer constructs and returns the appropriate prefix transformers for the passed resource using its configuration
+func GetPrefixTransformers(config *ResourceConfig) ([]value.PrefixTransformer, error) {
+	var result []value.PrefixTransformer
+	for _, provider := range config.Providers {
+		found := false
+
+		if provider.AES != nil {
+			transformer, err := GetAESPrefixTransformer(provider.AES)
+			found = true
+			if err != nil {
+				return result, err
+			}
+			result = append(result, transformer)
+		}
+
+		if provider.Identity != nil {
+			if found == true {
+				return result, fmt.Errorf("more than one provider specified in a single element, should split into different list elements")
+			}
+			found = true
+			result = append(result, value.PrefixTransformer{
+				Transformer: identity.NewEncryptCheckTransformer(),
+				Prefix:      []byte{},
+			})
+		}
+
+		if found == false {
+			return result, fmt.Errorf("invalid provider configuration provided")
+		}
+	}
+	return result, nil
+}
+
+// GetAESPrefixTransformer returns a prefix transformer from the provided configuration
+func GetAESPrefixTransformer(config *AESConfig) (value.PrefixTransformer, error) {
+	var result value.PrefixTransformer
+
+	if len(config.Keys) == 0 {
+		return result, fmt.Errorf("aes provider has no valid keys")
+	}
+	for _, key := range config.Keys {
+		if key.Name == "" {
+			return result, fmt.Errorf("key with invalid name provided")
+		}
+		if key.Secret == "" {
+			return result, fmt.Errorf("key %v has no provided secret", key.Name)
+		}
+	}
+
+	keyTransformers := []value.PrefixTransformer{}
+
+	for _, keyData := range config.Keys {
+		key, err := base64.StdEncoding.DecodeString(keyData.Secret)
+		if err != nil {
+			return result, fmt.Errorf("could not obtain secret for named key %s: %s", keyData.Name, err)
+		}
+		block, err := aes.NewCipher(key)
+		if err != nil {
+			return result, fmt.Errorf("error while creating cipher for named key %s: %s", keyData.Name, err)
+		}
+
+		// Create a new PrefixTransformer for this key
+		keyTransformers = append(keyTransformers,
+			value.PrefixTransformer{
+				Transformer: aestransformer.NewGCMTransformer(block),
+				Prefix:      []byte(keyData.Name + ":"),
+			})
+	}
+
+	// Create a prefixTransformer which can choose between these keys
+	keyTransformer := value.NewPrefixTransformers(
+		fmt.Errorf("no matching key was found for the provided AES transformer"), keyTransformers...)
+
+	// Create a PrefixTransformer which shall later be put in a list with other providers
+	result = value.PrefixTransformer{
+		Transformer: keyTransformer,
+		Prefix:      []byte(aesTransformerPrefixV1),
+	}
+	return result, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/encryptionconfig_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/encryptionconfig_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package encryptionconfig
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/storage/value"
+)
+
+const (
+	sampleText = "abcdefghijklmnopqrstuvwxyz"
+
+	sampleContextText = "0123456789"
+
+	correctConfigWithIdentityFirst = `
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    - namespaces
+    providers:
+    - identity: {}
+    - aes:
+        keys:
+        - name: key1
+          secret: c2VjcmV0IGlzIHNlY3VyZQ==
+        - name: key2
+          secret: dGhpcyBpcyBwYXNzd29yZA==
+`
+
+	correctConfigWithAesFirst = `
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - secrets
+    providers:
+    - aes:
+        keys:
+        - name: key1
+          secret: c2VjcmV0IGlzIHNlY3VyZQ==
+        - name: key2
+          secret: dGhpcyBpcyBwYXNzd29yZA==
+    - identity: {}
+`
+
+	incorrectConfigNoSecretForKey = `
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - namespaces
+    - secrets
+    providers:
+    - aes:
+        keys:
+        - name: key1
+`
+
+	incorrectConfigInvalidKey = `
+kind: EncryptionConfig
+apiVersion: v1
+resources:
+  - resources:
+    - namespaces
+    - secrets
+    providers:
+    - aes:
+        keys:
+        - name: key1
+          secret: c2VjcmV0IGlzIHNlY3VyZQ==
+        - name: key2
+          secret: YSBzZWNyZXQgYSBzZWNyZXQ=
+`
+)
+
+func TestEncryptionProviderConfigCorrect(t *testing.T) {
+	// Creates two transformers with different ordering of identity and AES transformers.
+	// Transforms data using one of them, and tries to untransform using both of them.
+	// Repeats this for both the possible combinations.
+
+	identityFirstTransformerOverrides, err := ParseEncryptionConfiguration(strings.NewReader(correctConfigWithIdentityFirst))
+	if err != nil {
+		t.Fatalf("error while parsing configuration file: %s.\nThe file was:\n%s", err, correctConfigWithIdentityFirst)
+	}
+
+	aesFirstTransformerOverrides, err := ParseEncryptionConfiguration(strings.NewReader(correctConfigWithAesFirst))
+	if err != nil {
+		t.Fatalf("error while parsing configuration file: %s.\nThe file was:\n%s", err, correctConfigWithAesFirst)
+	}
+
+	// Pick the transformer for any of the returned resources.
+	identityFirstTransformer := identityFirstTransformerOverrides[schema.ParseGroupResource("secrets")]
+	aesFirstTransformer := aesFirstTransformerOverrides[schema.ParseGroupResource("secrets")]
+
+	context := value.DefaultContext([]byte(sampleContextText))
+	originalText := []byte(sampleText)
+
+	testCases := []struct {
+		WritingTransformer value.Transformer
+		Name               string
+		AesStale           bool
+		IdentityStale      bool
+	}{
+		{aesFirstTransformer, "aesFirst", false, true},
+		{identityFirstTransformer, "identityFirst", true, false},
+	}
+
+	for _, testCase := range testCases {
+		transformedData, err := testCase.WritingTransformer.TransformToStorage(originalText, context)
+		if err != nil {
+			t.Fatalf("%s: error while transforming data to storage: %s", testCase.Name, err)
+		}
+
+		aesUntransformedData, stale, err := aesFirstTransformer.TransformFromStorage(transformedData, context)
+		if err != nil {
+			t.Fatalf("%s: error while reading using aesFirst transformer: %s", testCase.Name, err)
+		}
+		if stale != testCase.AesStale {
+			t.Fatalf("%s: wrong stale information on reading using aesFirst transformer, should be %v", testCase.Name, testCase.AesStale)
+		}
+
+		identityUntransformedData, stale, err := identityFirstTransformer.TransformFromStorage(transformedData, context)
+		if err != nil {
+			t.Fatalf("%s: error while reading using identityFirst transformer: %s", testCase.Name, err)
+		}
+		if stale != testCase.IdentityStale {
+			t.Fatalf("%s: wrong stale information on reading using identityFirst transformer, should be %v", testCase.Name, testCase.IdentityStale)
+		}
+
+		if bytes.Compare(aesUntransformedData, originalText) != 0 {
+			t.Fatalf("%s: aesFirst transformer transformed data incorrectly. Expected: %v, got %v", testCase.Name, originalText, aesUntransformedData)
+		}
+
+		if bytes.Compare(identityUntransformedData, originalText) != 0 {
+			t.Fatalf("%s: identityFirst transformer transformed data incorrectly. Expected: %v, got %v", testCase.Name, originalText, aesUntransformedData)
+		}
+	}
+}
+
+// Throw error if key has no secret
+func TestEncryptionProviderConfigNoSecretForKey(t *testing.T) {
+	if _, err := ParseEncryptionConfiguration(strings.NewReader(incorrectConfigNoSecretForKey)); err == nil {
+		t.Fatalf("invalid configuration file (one key has no secret) got parsed:\n%s", incorrectConfigNoSecretForKey)
+	}
+}
+
+// Throw error if invalid key for AES
+func TestEncryptionProviderConfigInvalidKey(t *testing.T) {
+	if _, err := ParseEncryptionConfiguration(strings.NewReader(incorrectConfigInvalidKey)); err == nil {
+		t.Fatalf("invalid configuration file (bad AES key) got parsed:\n%s", incorrectConfigInvalidKey)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/types.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package encryptionconfig
+
+// EncryptionConfig stores the complete configuration for encryption providers.
+type EncryptionConfig struct {
+	// kind is the type of configuration file.
+	Kind string `json:"kind"`
+	// apiVersion is the API version this file has to be parsed as.
+	APIVersion string `json:"apiVersion"`
+	// resources is a list containing resources, and their corresponding encryption providers.
+	Resources []ResourceConfig `json:"resources"`
+}
+
+// ResourceConfig stores per resource configuration.
+type ResourceConfig struct {
+	// resources is a list of kubernetes resources which have to be encrypted.
+	Resources []string `json:"resources"`
+	// providers is a list of transformers to be used for reading and writing the resources to disk.
+	// eg: aes, identity.
+	Providers []ProviderConfig `json:"providers"`
+}
+
+// ProviderConfig stores the provided configuration for an encryption provider.
+type ProviderConfig struct {
+	// aes is the configuration for the AEAD-GCM transformer.
+	AES *AESConfig `json:"aes,omitempty"`
+	// identity is the (empty) configuration for the identity transformer.
+	Identity *IdentityConfig `json:"identity,omitempty"`
+}
+
+// AESConfig contains the API configuration for an AES transformer.
+type AESConfig struct {
+	// keys is a list of keys to be used for creating the AES transformer.
+	Keys []Key `json:"keys"`
+}
+
+// Key contains name and secret of the provided key for AES transformer.
+type Key struct {
+	// name is the name of the key to be used while storing data to disk.
+	Name string `json:"name"`
+	// secret is the actual AES key, encoded in base64. It has to be 16, 24 or 32 bytes long.
+	Secret string `json:"secret"`
+}
+
+// IdentityConfig is an empty struct to allow identity transformer in provider configuration.
+type IdentityConfig struct{}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -30,7 +30,8 @@ import (
 )
 
 type EtcdOptions struct {
-	StorageConfig storagebackend.Config
+	StorageConfig                    storagebackend.Config
+	EncryptionProviderConfigFilepath string
 
 	EtcdServersOverrides []string
 
@@ -109,6 +110,9 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&s.StorageConfig.Quorum, "etcd-quorum-read", s.StorageConfig.Quorum,
 		"If true, enable quorum read.")
+
+	fs.StringVar(&s.EncryptionProviderConfigFilepath, "experimental-encryption-provider-config", s.EncryptionProviderConfigFilepath,
+		"The file containing configuration for encryption providers to be used for storing secrets in etcd")
 }
 
 func (s *EtcdOptions) ApplyTo(c *server.Config) error {

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/BUILD
@@ -48,5 +48,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/recognizer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/value:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -388,7 +388,7 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, pred stor
 
 	elems := make([]*elemForDecode, 0, len(getResp.Kvs))
 	for _, kv := range getResp.Kvs {
-		data, _, err := s.transformer.TransformFromStorage(kv.Value, authenticatedDataString(key))
+		data, _, err := s.transformer.TransformFromStorage(kv.Value, authenticatedDataString(kv.Key))
 		if err != nil {
 			utilruntime.HandleError(fmt.Errorf("unable to transform key %q: %v", key, err))
 			continue

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -58,7 +58,7 @@ func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, e
 	}
 	transformer := c.Transformer
 	if transformer == nil {
-		transformer = value.IdentityTransformer
+		transformer = value.NewMutableTransformer(value.IdentityTransformer)
 	}
 	if c.Quorum {
 		return etcd3.New(client, c.Codec, c.Prefix, transformer), destroyFunc, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/identity/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/identity/BUILD
@@ -1,0 +1,15 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["identity.go"],
+    tags = ["automanaged"],
+    deps = ["//vendor/k8s.io/apiserver/pkg/storage/value:go_default_library"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/identity/identity.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/identity/identity.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package identity
+
+import (
+	"bytes"
+	"fmt"
+
+	"k8s.io/apiserver/pkg/storage/value"
+)
+
+// encryptIdentityTransformer performs no transformation on provided data, but validates
+// that the data is not encrypted data during TransformFromStorage
+type identityTransformer struct{}
+
+// NewEncryptCheckTransformer returns an identityTransformer which returns an error
+// on attempts to read encrypted data
+func NewEncryptCheckTransformer() value.Transformer {
+	return identityTransformer{}
+}
+
+// TransformFromStorage returns the input bytes if the data is not encrypted
+func (identityTransformer) TransformFromStorage(b []byte, context value.Context) ([]byte, bool, error) {
+	// EncryptIdentityTransformer has to return an error if the data is encoded using another transformer.
+	// JSON data starts with '{'. Protobuf data has a prefix 'k8s[\x00-\xFF]'.
+	// Prefix 'k8s:enc:' is reserved for encrypted data on disk.
+	if bytes.HasPrefix(b, []byte("k8s:enc:")) {
+		return []byte{}, false, fmt.Errorf("identity transformer tried to read encrypted data")
+	}
+	return b, false, nil
+}
+
+// TransformToStorage implements the Transformer interface for encryptIdentityTransformer
+func (identityTransformer) TransformToStorage(b []byte, context value.Context) ([]byte, error) {
+	return b, nil
+}


### PR DESCRIPTION
## Additions

Allows providing a configuration file (using flag `--experimental-encryption-provider-config`) to use the existing AEAD transformer (with multiple keys) by composing mutable transformer, prefix transformer (for parsing providerId), another prefix transformer (for parsing keyId), and AES-GCM transformers (one for each key). Multiple providers can be configured using the configuration file.

Example configuration:
```
kind: EncryptionConfig
apiVersion: v1
resources:
  - resources:
    - namespaces
    providers:
    - aes:
        keys:
        - name: key1
          secret: c2vjcmv0iglzihnly3vyzq==
        - name: key2
          secret: dghpcybpcybwyxnzd29yza==
    - identity: {}
```

Need for configuration discussed in:
#41939
[Encryption](https://github.com/destijl/community/blob/3418b4e4c6358f5dc747a37b90a97bc792f159ee/contributors/design-proposals/encryption.md)

**Pathway of a read/write request**:
1. MutableTransformer
2. PrefixTransformer reads the provider-id, and passes the request further if that matches.
3. PrefixTransformer reads the key-id, and passes the request further if that matches.
4. GCMTransformer tries decrypting and authenticating the cipher text in case of reads. Similarly for writes.

## Caveats
1. To keep the command line parameter parsing independent of the individual transformer's configuration, we need to convert the configuration to an `interface{}` and manually parse it in the transformer. Suggestions on better ways to do this are welcome.

2. Flags `--encryption-provider` and `--encrypt-resource` (both mentioned in [this document](https://github.com/destijl/community/blob/3418b4e4c6358f5dc747a37b90a97bc792f159ee/contributors/design-proposals/encryption.md) ) are not supported in this because they do not allow more than one provider, and the current format for the configuration file possibly supersedes their functionality.

3. Currently, it can be tested by adding `--experimental-encryption-provider-config=config.yml` to `hack/local-up-cluster.sh` on line 511, and placing the above configuration in `config.yml` in the root project directory.

Previous discussion on these changes:
https://github.com/sakshamsharma/kubernetes/pull/1

@jcbsmpsn @destijl @smarterclayton

## TODO
1. Investigate if we need to store keys on disk (per [encryption.md](https://github.com/destijl/community/blob/3418b4e4c6358f5dc747a37b90a97bc792f159ee/contributors/design-proposals/encryption.md#option-1-simple-list-of-keys-on-disk))
2. Look at [alpha flag conventions](https://github.com/kubernetes/kubernetes/blob/master/pkg/features/kube_features.go)
3. Need to reserve `k8s:enc` prefix formally for encrypted data. Else find a better way to detect transformed data.