### PR TITLE
Temporarily remove coreos image to unblock the submit queue.

### DIFF
--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -69,24 +69,3 @@ images:
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
-  coreos-resource1:
-    image: coreos-alpha-1122-0-0-v20160727
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 0 pods per node \[Benchmark\]'
-  coreos-resource2:
-    image: coreos-alpha-1122-0-0-v20160727
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 35 pods per node \[Benchmark\]'
-  coreos-resource3:
-    image: coreos-alpha-1122-0-0-v20160727
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'

--- a/test/e2e_node/jenkins/image-config-serial.yaml
+++ b/test/e2e_node/jenkins/image-config-serial.yaml
@@ -8,10 +8,6 @@ images:
   ubuntu-docker12:
     image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
     project: kubernetes-node-e2e-images
-  coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   containervm:
     image: e2e-node-containervm-v20161208-image # docker 1.11.2
     project: kubernetes-node-e2e-images

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -8,10 +8,6 @@ images:
   ubuntu-docker12:
     image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
     project: kubernetes-node-e2e-images
-  coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
-    project: coreos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   containervm:
     image: e2e-node-containervm-v20161208-image # docker 1.11.2
     project: kubernetes-node-e2e-images


### PR DESCRIPTION
The previous alpha coreos image was removed today, and all node e2e tests are failing because it could not find coreos image.

Discussed with @ericchiang @yujuhong, and we think it would be better to temporarily remove the image to unblock the submit queue.

@ericchiang Please send a new PR to add the new image version, and please make sure the new version pass the node e2e test.

@dchen1107 @ericchiang @mtaufen @krzyzacy 
/cc @kubernetes/sig-node-bugs 