### PR TITLE
e2e node: update coreos tag used

### DIFF
--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -70,21 +70,21 @@ images:
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
   coreos-resource1:
-    image: coreos-alpha-1122-0-0-v20160727
+    image: coreos-stable-1353-7-0-v20170427
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   coreos-resource2:
-    image: coreos-alpha-1122-0-0-v20160727
+    image: coreos-stable-1353-7-0-v20170427
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   coreos-resource3:
-    image: coreos-alpha-1122-0-0-v20160727
+    image: coreos-stable-1353-7-0-v20170427
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
     machine: n1-standard-1

--- a/test/e2e_node/jenkins/image-config-serial.yaml
+++ b/test/e2e_node/jenkins/image-config-serial.yaml
@@ -8,8 +8,8 @@ images:
   ubuntu-docker12:
     image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
     project: kubernetes-node-e2e-images
-  coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+  coreos-stable:
+    image: coreos-stable-1353-7-0-v20170427 # docker 1.12.6
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   containervm:

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -8,8 +8,8 @@ images:
   ubuntu-docker12:
     image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
     project: kubernetes-node-e2e-images
-  coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+  coreos-stable:
+    image: coreos-stable-1353-7-0-v20170427 # docker 1.12.6
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   containervm:


### PR DESCRIPTION
The alpha image was deleted. Update to a newer tag.

@euank noted that `coreos-stable` might be an okay tag to use as well, but for now, update to the lastest stable image https://stable.release.core-os.net/amd64-usr/current/coreos_production_gce.txt.

cc @euank @yifan-gu 