### PR TITLE
Updating kubectl to wait for the resource to be deleted when doing cascading deletion

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
@@ -91,13 +92,20 @@ var (
 type DeleteOptions struct {
 	resource.FilenameOptions
 
-	Selector        string
-	DeleteAll       bool
-	IgnoreNotFound  bool
-	Cascade         bool
-	DeleteNow       bool
-	ForceDeletion   bool
-	WaitForDeletion bool
+	Selector       string
+	DeleteAll      bool
+	IgnoreNotFound bool
+	Cascade        bool
+	DeleteNow      bool
+	ForceDeletion  bool
+	// Whether we should wait for resource deletion.
+	// Tied to `--wait` flag.
+	// Nil if the user did not explicitly set it.
+	WaitForDeletion *bool
+	// Whether we should wait for deletion when the resource is deleted gracefully.
+	// This is to support backwards compatibility when graceful deletion was introduced.
+	// This option is not exposed to the user.
+	WaitForGracefulDeletion bool
 
 	GracePeriod int
 	Timeout     time.Duration
@@ -157,6 +165,7 @@ func NewCmdDelete(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	cmd.Flags().IntVar(&options.GracePeriod, "grace-period", -1, "Period of time in seconds given to the resource to terminate gracefully. Ignored if negative.")
 	cmd.Flags().BoolVar(&options.DeleteNow, "now", false, "If true, resources are signaled for immediate shutdown (same as --grace-period=1).")
 	cmd.Flags().BoolVar(&options.ForceDeletion, "force", false, "Immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
+	options.WaitForDeletion = cmd.Flags().Bool("wait", true, "If true, waits for the resource to be deleted before returning. True by default, expect for namespace deletion and pod graceful deletion")
 	cmd.Flags().DurationVar(&options.Timeout, "timeout", 0, "The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object")
 	cmdutil.AddOutputVarFlagsForMutation(cmd, &options.Output)
 	cmdutil.AddInclude3rdPartyVarFlags(cmd, &options.Include3rdParty)
@@ -210,6 +219,10 @@ func (o *DeleteOptions) Validate(cmd *cobra.Command) error {
 			o.IgnoreNotFound = true
 		}
 	}
+	// Set WaitForDeletion to nil, unless it was explicitly specified by the user.
+	if !cmd.Flags().Changed("wait") {
+		o.WaitForDeletion = nil
+	}
 	if o.DeleteNow {
 		if o.GracePeriod != -1 {
 			return fmt.Errorf("--now and --grace-period cannot be specified together")
@@ -223,7 +236,7 @@ func (o *DeleteOptions) Validate(cmd *cobra.Command) error {
 			// To preserve backwards compatibility, but prevent accidental data loss, we convert --grace-period=0
 			// into --grace-period=1 and wait until the object is successfully deleted. Users may provide --force
 			// to bypass this wait.
-			o.WaitForDeletion = true
+			o.WaitForGracefulDeletion = true
 			o.GracePeriod = 1
 		}
 	}
@@ -234,12 +247,17 @@ func (o *DeleteOptions) RunDelete() error {
 	shortOutput := o.Output == "name"
 	// By default use a reaper to delete all related resources.
 	if o.Cascade {
-		return ReapResult(o.Result, o.f, o.Out, true, o.IgnoreNotFound, o.Timeout, o.GracePeriod, o.WaitForDeletion, shortOutput, o.Mapper, false)
+		return reapResultWithWaitingOptions(o.Result, o.f, o.Out, true, o.IgnoreNotFound, o.Timeout, o.GracePeriod, o.WaitForGracefulDeletion, shortOutput, o.Mapper, false, o.WaitForDeletion)
 	}
-	return DeleteResult(o.Result, o.Out, o.IgnoreNotFound, shortOutput, o.Mapper)
+	return DeleteResult(o.Result, o.Out, o.IgnoreNotFound, shortOutput, o.Mapper, o.WaitForDeletion, o.Timeout)
 }
 
-func ReapResult(r *resource.Result, f cmdutil.Factory, out io.Writer, isDefaultDelete, ignoreNotFound bool, timeout time.Duration, gracePeriod int, waitForDeletion, shortOutput bool, mapper meta.RESTMapper, quiet bool) error {
+func ReapResult(r *resource.Result, f cmdutil.Factory, out io.Writer, isDefaultDelete, ignoreNotFound bool, timeout time.Duration, gracePeriod int, waitForGracefulDeletion, shortOutput bool, mapper meta.RESTMapper, quiet bool) error {
+	waitForDeletion := false
+	return reapResultWithWaitingOptions(r, f, out, isDefaultDelete, ignoreNotFound, timeout, gracePeriod, waitForGracefulDeletion, shortOutput, mapper, quiet, &waitForDeletion)
+}
+
+func reapResultWithWaitingOptions(r *resource.Result, f cmdutil.Factory, out io.Writer, isDefaultDelete, ignoreNotFound bool, timeout time.Duration, gracePeriod int, waitForGracefulDeletion, shortOutput bool, mapper meta.RESTMapper, quiet bool, waitForDeletion *bool) error {
 	found := 0
 	if ignoreNotFound {
 		r = r.IgnoreErrors(errors.IsNotFound)
@@ -254,7 +272,10 @@ func ReapResult(r *resource.Result, f cmdutil.Factory, out io.Writer, isDefaultD
 			// If there is no reaper for this resources and the user didn't explicitly ask for stop.
 			if kubectl.IsNoSuchReaperError(err) && isDefaultDelete {
 				// No client side reaper found. Let the server do cascading deletion.
-				return cascadingDeleteResource(info, out, shortOutput, mapper)
+				if err := deleteResourceAndWait(info, out, shortOutput, mapper, false, waitForDeletion, timeout); err != nil {
+					return cmdutil.AddSourceToErr("deleting", info.Source, err)
+				}
+				return nil
 			}
 			return cmdutil.AddSourceToErr("reaping", info.Source, err)
 		}
@@ -265,7 +286,7 @@ func ReapResult(r *resource.Result, f cmdutil.Factory, out io.Writer, isDefaultD
 		if err := reaper.Stop(info.Namespace, info.Name, timeout, options); err != nil {
 			return cmdutil.AddSourceToErr("stopping", info.Source, err)
 		}
-		if waitForDeletion {
+		if waitForGracefulDeletion {
 			if err := waitForObjectDeletion(info, timeout); err != nil {
 				return cmdutil.AddSourceToErr("stopping", info.Source, err)
 			}
@@ -284,7 +305,7 @@ func ReapResult(r *resource.Result, f cmdutil.Factory, out io.Writer, isDefaultD
 	return nil
 }
 
-func DeleteResult(r *resource.Result, out io.Writer, ignoreNotFound bool, shortOutput bool, mapper meta.RESTMapper) error {
+func DeleteResult(r *resource.Result, out io.Writer, ignoreNotFound bool, shortOutput bool, mapper meta.RESTMapper, waitForDeletion *bool, timeout time.Duration) error {
 	found := 0
 	if ignoreNotFound {
 		r = r.IgnoreErrors(errors.IsNotFound)
@@ -296,8 +317,7 @@ func DeleteResult(r *resource.Result, out io.Writer, ignoreNotFound bool, shortO
 		found++
 
 		// if we're here, it means that cascade=false (not the default), so we should orphan as requested
-		orphan := true
-		return deleteResource(info, out, shortOutput, mapper, &metav1.DeleteOptions{OrphanDependents: &orphan})
+		return deleteResourceAndWait(info, out, shortOutput, mapper, true, waitForDeletion, timeout)
 	})
 	if err != nil {
 		return err
@@ -308,18 +328,86 @@ func DeleteResult(r *resource.Result, out io.Writer, ignoreNotFound bool, shortO
 	return nil
 }
 
-func cascadingDeleteResource(info *resource.Info, out io.Writer, shortOutput bool, mapper meta.RESTMapper) error {
-	falseVar := false
-	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return deleteResource(info, out, shortOutput, mapper, deleteOptions)
-}
+// Deletes the given resource and then waits to confirm that the resource is deleted.
+func deleteResourceAndWait(info *resource.Info, out io.Writer, shortOutput bool, mapper meta.RESTMapper, orphanDependents bool, waitForDeletion *bool, timeout time.Duration) error {
+	// TODO: Use PropagationPolicy instead of OrphanDependents as per https://github.com/kubernetes/kubernetes/issues/46659.
+	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &orphanDependents}
+	obj, err := deleteResource(info, out, shortOutput, mapper, deleteOptions)
+	if err != nil {
+		return err
+	}
+	// WaitForDeletion is true by default except for namespace deletion.
+	if waitForDeletion == nil {
+		if info.Mapping.Resource == "namespaces" {
+			falseVar := false
+			waitForDeletion = &falseVar
+		} else {
+			trueVar := true
+			waitForDeletion = &trueVar
+		}
+	}
 
-func deleteResource(info *resource.Info, out io.Writer, shortOutput bool, mapper meta.RESTMapper, deleteOptions *metav1.DeleteOptions) error {
-	if err := resource.NewHelper(info.Client, info.Mapping).DeleteWithOptions(info.Namespace, info.Name, deleteOptions); err != nil {
-		return cmdutil.AddSourceToErr("deleting", info.Source, err)
+	if *waitForDeletion == false {
+		cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, false, "deleted")
+		return nil
+	}
+	// Keep deleting the resource with uid precondition until we get a
+	// resource not found error.
+	// We use DELETE here instead of using GET to ensure that DELETE
+	// works without requiring GET permissions.
+	uid, err := getUID(obj)
+	if err != nil {
+		return fmt.Errorf("unexpected error in extracting uid: %s", err)
+	}
+	if uid == "" {
+		// For backwards compatibility, we just return when we are unable to get the UID.
+		// TODO: Remove this in 1.8.
+		return nil
+	}
+	deleteOptions = &metav1.DeleteOptions{OrphanDependents: &orphanDependents, Preconditions: metav1.NewUIDPreconditions(uid)}
+	err = wait.PollImmediate(objectDeletionWaitInterval, timeout, func() (bool, error) {
+		_, err := deleteResource(info, out, shortOutput, mapper, deleteOptions)
+		if errors.IsNotFound(err) || errors.IsConflict(err) {
+			// Resource successfully deleted.
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		return err
 	}
 	cmdutil.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, false, "deleted")
 	return nil
+}
+
+func getUID(obj runtime.Object) (string, error) {
+	// Check if the object is of type Status.
+	status, isStatus := obj.(*metav1.Status)
+	if isStatus {
+		if status.Details == nil || status.Details.UID == "" {
+			// This can happen for an older apiserver (before 1.7)
+			// which does not set Details.
+			// For now, we do not generate an error in this case to ensure
+			// kubectl can work with 1.6 apiserver.
+			// TODO: In 1.8, update this to generate an error.
+			return "", nil
+		}
+		return string(status.Details.UID), nil
+	}
+	// The resource is itself returned.
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+	return string(accessor.GetUID()), nil
+}
+
+func deleteResource(info *resource.Info, out io.Writer, shortOutput bool, mapper meta.RESTMapper, deleteOptions *metav1.DeleteOptions) (runtime.Object, error) {
+	obj, err := resource.NewHelper(info.Client, info.Mapping).DeleteWithOptions(info.Namespace, info.Name, deleteOptions)
+	if err != nil {
+		return obj, cmdutil.AddSourceToErr("deleting", info.Source, err)
+	}
+	return obj, nil
 }
 
 // objectDeletionWaitInterval is the interval to wait between checks for deletion. Exposed for testing.
@@ -327,6 +415,7 @@ var objectDeletionWaitInterval = time.Second
 
 // waitForObjectDeletion refreshes the object, waiting until it is deleted, a timeout is reached, or
 // an error is encountered. It checks once a second.
+// TODO: Update this to use DELETE with precondition instead of using GET to wait.
 func waitForObjectDeletion(info *resource.Info, timeout time.Duration) error {
 	copied := *info
 	info = &copied

--- a/pkg/kubectl/cmd/get_test.go
+++ b/pkg/kubectl/cmd/get_test.go
@@ -51,11 +51,11 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 		},
 		Items: []api.Pod{
 			{
-				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "test", ResourceVersion: "10"},
+				ObjectMeta: metav1.ObjectMeta{UID: "random-uid-pod1", Name: "foo", Namespace: "test", ResourceVersion: "10"},
 				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 			{
-				ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "test", ResourceVersion: "11"},
+				ObjectMeta: metav1.ObjectMeta{UID: "random-uid-pod2", Name: "bar", Namespace: "test", ResourceVersion: "11"},
 				Spec:       apitesting.DeepEqualSafePodSpec(),
 			},
 		},
@@ -66,7 +66,7 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 		},
 		Items: []api.Service{
 			{
-				ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "12"},
+				ObjectMeta: metav1.ObjectMeta{UID: "random-uid-svc1", Name: "baz", Namespace: "test", ResourceVersion: "12"},
 				Spec: api.ServiceSpec{
 					SessionAffinity: "None",
 					Type:            api.ServiceTypeClusterIP,
@@ -80,7 +80,7 @@ func testData() (*api.PodList, *api.ServiceList, *api.ReplicationControllerList)
 		},
 		Items: []api.ReplicationController{
 			{
-				ObjectMeta: metav1.ObjectMeta{Name: "rc1", Namespace: "test", ResourceVersion: "18"},
+				ObjectMeta: metav1.ObjectMeta{UID: "random-uid-rc1", Name: "rc1", Namespace: "test", ResourceVersion: "18"},
 				Spec: api.ReplicationControllerSpec{
 					Replicas: 1,
 				},

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -227,7 +227,8 @@ func forceReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		glog.Warningf("\"cascade\" is set, kubectl will delete and re-create all resources managed by this resource (e.g. Pods created by a ReplicationController). Consider using \"kubectl rolling-update\" if you want to update a ReplicationController together with its Pods.")
 		err = ReapResult(r, f, out, cmdutil.GetFlagBool(cmd, "cascade"), ignoreNotFound, timeout, gracePeriod, waitForDeletion, shortOutput, mapper, false)
 	} else {
-		err = DeleteResult(r, out, ignoreNotFound, shortOutput, mapper)
+		waitForDelete := false
+		err = DeleteResult(r, out, ignoreNotFound, shortOutput, mapper, &waitForDelete, timeout)
 	}
 	if err != nil {
 		return err

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -745,6 +745,7 @@ func testDynamicResources() []*discovery.APIGroupResources {
 					{Name: "configmaps", Namespaced: true, Kind: "ConfigMap"},
 					{Name: "type", Namespaced: false, Kind: "Type"},
 					{Name: "namespacedtype", Namespaced: true, Kind: "NamespacedType"},
+					{Name: "namespaces", Namespaced: false, Kind: "Namespace"},
 				},
 			},
 		},

--- a/pkg/kubectl/delete.go
+++ b/pkg/kubectl/delete.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+type deleteFunc func(options *metav1.DeleteOptions) (runtime.Object, error)
+
+// Sends a request to DELETE the object and waits till the object is deleted.
+// deleteFn should return the deleted object or a metav1.Status object.
+func WaitForDeletion(deleteFn deleteFunc, options *metav1.DeleteOptions, timeout time.Duration) error {
+	obj, err := deleteFn(options)
+	if err != nil {
+		return err
+	}
+	// Keep deleting the resource with uid precondition until we get a
+	// resource not found error.
+	// We use DELETE here instead of using GET to ensure that DELETE
+	// works without requiring GET permissions.
+	uid, err := getUID(obj)
+	if err != nil {
+		return fmt.Errorf("unexpected error in extracting uid: %s", err)
+	}
+	if uid == "" {
+		// For backwards compatibility, we just return when we are unable to get the UID.
+		// TODO: Remove this in 1.8.
+		return nil
+	}
+	options.Preconditions = metav1.NewUIDPreconditions(uid)
+	err = wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		_, err := deleteFn(options)
+		if errors.IsNotFound(err) || errors.IsConflict(err) {
+			// Resource successfully deleted.
+			return true, nil
+		}
+		return false, err
+	})
+	return err
+}
+
+func getUID(obj runtime.Object) (string, error) {
+	// Check if the object is of type Status.
+	status, isStatus := obj.(*metav1.Status)
+	if isStatus {
+		if status.Details == nil || status.Details.UID == "" {
+			// This can happen for an older apiserver (before 1.7)
+			// which does not set Details.
+			// For now, we do not generate an error in this case to ensure
+			// kubectl can work with 1.6 apiserver.
+			// TODO: In 1.8, update this to generate an error.
+			return "", nil
+		}
+		return string(status.Details.UID), nil
+	}
+	// The resource is itself returned.
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+	return string(accessor.GetUID()), nil
+}
+
+// TODO: Update the generated clientset to return the deleted object and then update the callers to use that.
+func DeleteWithRestClient(client RESTClient, name, namespace, resource string, isNamespaced bool, options *metav1.DeleteOptions) (runtime.Object, error) {
+	return client.Delete().
+		NamespaceIfScoped(namespace, isNamespaced).
+		Resource(resource).
+		Name(name).
+		Body(options).
+		Do().
+		Get()
+}

--- a/pkg/kubectl/resource/helper.go
+++ b/pkg/kubectl/resource/helper.go
@@ -96,17 +96,18 @@ func (m *Helper) WatchSingle(namespace, name, resourceVersion string) (watch.Int
 }
 
 func (m *Helper) Delete(namespace, name string) error {
-	return m.DeleteWithOptions(namespace, name, nil)
+	_, err := m.DeleteWithOptions(namespace, name, nil)
+	return err
 }
 
-func (m *Helper) DeleteWithOptions(namespace, name string, options *metav1.DeleteOptions) error {
+func (m *Helper) DeleteWithOptions(namespace, name string, options *metav1.DeleteOptions) (runtime.Object, error) {
 	return m.RESTClient.Delete().
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
 		Name(name).
 		Body(options).
 		Do().
-		Error()
+		Get()
 }
 
 func (m *Helper) Create(namespace string, modify bool, obj runtime.Object) (runtime.Object, error) {

--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -24,10 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
+	rest "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/batch"
@@ -71,68 +73,72 @@ func IsNoSuchReaperError(err error) bool {
 func ReaperFor(kind schema.GroupKind, c internalclientset.Interface) (Reaper, error) {
 	switch kind {
 	case api.Kind("ReplicationController"):
-		return &ReplicationControllerReaper{c.Core(), Interval, Timeout}, nil
+		return &ReplicationControllerReaper{c.Core(), c.Core().RESTClient(), Interval, Timeout}, nil
 
 	case extensions.Kind("ReplicaSet"):
-		return &ReplicaSetReaper{c.Extensions(), Interval, Timeout}, nil
+		return &ReplicaSetReaper{c.Extensions(), c.Extensions().RESTClient(), Interval, Timeout}, nil
 
 	case extensions.Kind("DaemonSet"):
-		return &DaemonSetReaper{c.Extensions(), Interval, Timeout}, nil
+		return &DaemonSetReaper{c.Extensions(), c.Extensions().RESTClient(), Interval, Timeout}, nil
 
 	case api.Kind("Pod"):
-		return &PodReaper{c.Core()}, nil
+		return &PodReaper{c.Core(), c.Core().RESTClient()}, nil
 
 	case api.Kind("Service"):
-		return &ServiceReaper{c.Core()}, nil
+		return &ServiceReaper{c.Core(), c.Core().RESTClient()}, nil
 
 	case batch.Kind("Job"):
-		return &JobReaper{c.Batch(), c.Core(), Interval, Timeout}, nil
+		return &JobReaper{c.Batch(), c.Core(), c.Batch().RESTClient(), Interval, Timeout}, nil
 
 	case apps.Kind("StatefulSet"):
-		return &StatefulSetReaper{c.Apps(), c.Core(), Interval, Timeout}, nil
+		return &StatefulSetReaper{c.Apps(), c.Core(), c.Apps().RESTClient(), Interval, Timeout}, nil
 
 	case extensions.Kind("Deployment"), apps.Kind("Deployment"):
-		return &DeploymentReaper{c.Extensions(), c.Extensions(), Interval, Timeout}, nil
+		return &DeploymentReaper{c.Extensions(), c.Extensions(), c.Extensions().RESTClient(), Interval, Timeout}, nil
 
 	}
 	return nil, &NoSuchReaperError{kind}
 }
 
-func ReaperForReplicationController(rcClient coreclient.ReplicationControllersGetter, timeout time.Duration) (Reaper, error) {
-	return &ReplicationControllerReaper{rcClient, Interval, timeout}, nil
-}
-
 type ReplicationControllerReaper struct {
 	client                coreclient.ReplicationControllersGetter
+	RESTClient            rest.Interface
 	pollInterval, timeout time.Duration
 }
 type ReplicaSetReaper struct {
 	client                extensionsclient.ReplicaSetsGetter
+	RESTClient            rest.Interface
 	pollInterval, timeout time.Duration
 }
 type DaemonSetReaper struct {
 	client                extensionsclient.DaemonSetsGetter
+	RESTClient            rest.Interface
 	pollInterval, timeout time.Duration
 }
 type JobReaper struct {
 	client                batchclient.JobsGetter
 	podClient             coreclient.PodsGetter
+	RESTClient            rest.Interface
 	pollInterval, timeout time.Duration
 }
 type DeploymentReaper struct {
 	dClient               extensionsclient.DeploymentsGetter
 	rsClient              extensionsclient.ReplicaSetsGetter
+	RESTClient            rest.Interface
 	pollInterval, timeout time.Duration
 }
 type PodReaper struct {
-	client coreclient.PodsGetter
+	client     coreclient.PodsGetter
+	RESTClient rest.Interface
 }
 type ServiceReaper struct {
-	client coreclient.ServicesGetter
+	client     coreclient.ServicesGetter
+	RESTClient rest.Interface
 }
 type StatefulSetReaper struct {
 	client                appsclient.StatefulSetsGetter
 	podClient             coreclient.PodsGetter
+	RESTClient            rest.Interface
 	pollInterval, timeout time.Duration
 }
 
@@ -217,7 +223,11 @@ func (reaper *ReplicationControllerReaper) Stop(namespace, name string, timeout 
 	}
 	falseVar := false
 	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return rc.Delete(name, deleteOptions)
+	deleteFunc := func(options *metav1.DeleteOptions) (runtime.Object, error) {
+		// TODO: Update the generated clientset to return the deleted object and then use that instead of using the rest client.
+		return DeleteWithRestClient(reaper.RESTClient, name, namespace, "replictioncontrollers", true, options)
+	}
+	return WaitForDeletion(deleteFunc, deleteOptions, timeout)
 }
 
 // TODO(madhusudancs): Implement it when controllerRef is implemented - https://github.com/kubernetes/kubernetes/issues/2210
@@ -288,7 +298,11 @@ func (reaper *ReplicaSetReaper) Stop(namespace, name string, timeout time.Durati
 
 	falseVar := false
 	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return rsc.Delete(name, deleteOptions)
+	deleteFunc := func(options *metav1.DeleteOptions) (runtime.Object, error) {
+		// TODO: Update the generated clientset to return the deleted object and then use that instead of using the rest client.
+		return DeleteWithRestClient(reaper.RESTClient, name, namespace, "replicasets", true, options)
+	}
+	return WaitForDeletion(deleteFunc, deleteOptions, timeout)
 }
 
 func (reaper *DaemonSetReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
@@ -325,7 +339,11 @@ func (reaper *DaemonSetReaper) Stop(namespace, name string, timeout time.Duratio
 
 	falseVar := false
 	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return reaper.client.DaemonSets(namespace).Delete(name, deleteOptions)
+	deleteFunc := func(options *metav1.DeleteOptions) (runtime.Object, error) {
+		// TODO: Update the generated clientset to return the deleted object and then use that instead of using the rest client.
+		return DeleteWithRestClient(reaper.RESTClient, name, namespace, "daemonsets", true, options)
+	}
+	return WaitForDeletion(deleteFunc, deleteOptions, timeout)
 }
 
 func (reaper *StatefulSetReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
@@ -377,7 +395,11 @@ func (reaper *StatefulSetReaper) Stop(namespace, name string, timeout time.Durat
 	// stop, so just leave this up to the statefulset.
 	falseVar := false
 	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return statefulsets.Delete(name, deleteOptions)
+	deleteFunc := func(options *metav1.DeleteOptions) (runtime.Object, error) {
+		// TODO: Update the generated clientset to return the deleted object and then use that instead of using the rest client.
+		return DeleteWithRestClient(reaper.RESTClient, name, namespace, "statefulsets", true, options)
+	}
+	return WaitForDeletion(deleteFunc, deleteOptions, timeout)
 }
 
 func (reaper *JobReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
@@ -422,12 +444,16 @@ func (reaper *JobReaper) Stop(namespace, name string, timeout time.Duration, gra
 	// once we have all the pods removed we can safely remove the job itself.
 	falseVar := false
 	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return jobs.Delete(name, deleteOptions)
+	deleteFunc := func(options *metav1.DeleteOptions) (runtime.Object, error) {
+		// TODO: Update the generated clientset to return the deleted object and then use that instead of using the rest client.
+		return DeleteWithRestClient(reaper.RESTClient, name, namespace, "jobs", true, options)
+	}
+	return WaitForDeletion(deleteFunc, deleteOptions, timeout)
 }
 
 func (reaper *DeploymentReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
 	deployments := reaper.dClient.Deployments(namespace)
-	rsReaper := &ReplicaSetReaper{reaper.rsClient, reaper.pollInterval, reaper.timeout}
+	rsReaper := &ReplicaSetReaper{reaper.rsClient, reaper.RESTClient, reaper.pollInterval, reaper.timeout}
 
 	deployment, err := reaper.updateDeploymentWithRetries(namespace, name, func(d *extensions.Deployment) {
 		// set deployment's history and scale to 0
@@ -488,8 +514,12 @@ func (reaper *DeploymentReaper) Stop(namespace, name string, timeout time.Durati
 	// Delete deployment at the end.
 	// Note: We delete deployment at the end so that if removing RSs fails, we at least have the deployment to retry.
 	var falseVar = false
-	nonOrphanOption := metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return deployments.Delete(name, &nonOrphanOption)
+	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
+	deleteFunc := func(options *metav1.DeleteOptions) (runtime.Object, error) {
+		// TODO: Update the generated clientset to return the deleted object and then use that instead of using the rest client.
+		return DeleteWithRestClient(reaper.RESTClient, name, namespace, "deployments", true, options)
+	}
+	return WaitForDeletion(deleteFunc, deleteOptions, timeout)
 }
 
 type updateDeploymentFunc func(d *extensions.Deployment)
@@ -520,7 +550,11 @@ func (reaper *PodReaper) Stop(namespace, name string, timeout time.Duration, gra
 	if err != nil {
 		return err
 	}
-	return pods.Delete(name, gracePeriod)
+	deleteFunc := func(options *metav1.DeleteOptions) (runtime.Object, error) {
+		// TODO: Update the generated clientset to return the deleted object and then use that instead of using the rest client.
+		return DeleteWithRestClient(reaper.RESTClient, name, namespace, "pods", true, options)
+	}
+	return WaitForDeletion(deleteFunc, gracePeriod, timeout)
 }
 
 func (reaper *ServiceReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
@@ -531,5 +565,9 @@ func (reaper *ServiceReaper) Stop(namespace, name string, timeout time.Duration,
 	}
 	falseVar := false
 	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return services.Delete(name, deleteOptions)
+	deleteFunc := func(options *metav1.DeleteOptions) (runtime.Object, error) {
+		// TODO: Update the generated clientset to return the deleted object and then use that instead of using the rest client.
+		return DeleteWithRestClient(reaper.RESTClient, name, namespace, "services", true, options)
+	}
+	return WaitForDeletion(deleteFunc, deleteOptions, timeout)
 }


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/42594

Added a `--wait` flag to kubectl that is true by default, expect for namespace deletion and graceful pod deletion.
When the flag is set to true and kubectl is doing cascading deletion, then it waits to ensure that the resource has been deleted before returning.

cc @kubernetes/sig-cli-pr-reviews 


```release-note
Adding a -wait flag to kubectl that users can set to false if they do not want kubectl to wait for the resource to be deleted before returning.
```