### PR TITLE
Enable the ip-masq-agent on GCE installs

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -234,6 +234,9 @@ OPENCONTRAIL_PUBLIC_SUBNET="${OPENCONTRAIL_PUBLIC_SUBNET:-10.1.0.0/16}"
 # Network Policy plugin specific settings.
 NETWORK_POLICY_PROVIDER="${NETWORK_POLICY_PROVIDER:-none}" # calico
 
+# Should the kubelet configure egress masquerade (old way) or let a daemonset do it?
+NON_MASQUERADE_CIDR="0.0.0.0/0"
+
 # How should the kubelet configure hairpin mode?
 HAIRPIN_MODE="${HAIRPIN_MODE:-promiscuous-bridge}" # promiscuous-bridge, hairpin-veth, none
 # Optional: if set to true, kube-up will configure the cluster to run e2e tests.


### PR DESCRIPTION
Setting this will trigger cluster/addons/ip-masq-agent/ip-masq-agent.yaml to be installed as an addon, which disable configure IP masquerade for all of RFC1918, rather
than just 10.0/8.

Because the flag defaulted to 10.0/8 we can't just change the default.  I think anyone who needs IP masquerade set up should probably use this instead.

@justinsb @kubernetes/sig-cluster-lifecycle-misc 

Fixes #11204

@dnardo - any reason not to do this?

Release Note:
```release-note

GCE installs will now avoid IP masquerade for all RFC-1918 IP blocks, rather than just 10.0.0.0/8.  This means that clusters can
be created in 192.168.0.0./16 and 172.16.0.0/12 while preserving the container IPs (which would be lost before).
``` 