### PR TITLE
Fix TestCertificateController index out of range panic

### DIFF
--- a/pkg/controller/certificates/certificate_controller_test.go
+++ b/pkg/controller/certificates/certificate_controller_test.go
@@ -29,7 +29,6 @@ import (
 // TODO flesh this out to cover things like not being able to find the csr in the cache, not
 // auto-approving, etc.
 func TestCertificateController(t *testing.T) {
-
 	csr := &certificates.CertificateSigningRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test-csr",
@@ -69,8 +68,8 @@ func TestCertificateController(t *testing.T) {
 	controller.processNextWorkItem()
 
 	actions := client.Actions()
-	if len(actions) != 3 {
-		t.Errorf("expected 3 actions")
+	if l := len(actions); l != 3 {
+		t.Fatalf("expected 3 actions, got %d", l)
 	}
 	if a := actions[0]; !a.Matches("list", "certificatesigningrequests") {
 		t.Errorf("unexpected action: %#v", a)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #46477  

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
