### PR TITLE
set LANG to 'C' in Makefile

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -20,6 +20,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Set locale to ensure english responses from kubectl commands
+export LANG=C
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 # Expects the following has already been done by whatever sources this script
 # source "${KUBE_ROOT}/hack/lib/init.sh"


### PR DESCRIPTION
Now we support multi-languages:
https://github.com/kubernetes/kubernetes/tree/master/translations

But some tests support only English. This test fails when LANG is set to zh_CN.UTF-8:
https://github.com/kubernetes/kubernetes/blob/master/hack/make-rules/test-cmd-util.sh#L2838
The expected err string is translated to Chinese:
https://github.com/kubernetes/kubernetes/blob/master/translations/kubectl/zh_CN/LC_MESSAGES/k8s.po#L82

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
