### PR TITLE
apiextensions: fix missing storage on CRD delete without previous CR access

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
@@ -247,13 +247,9 @@ func (r *crdHandler) removeDeadStorage() {
 
 // GetCustomResourceListerCollectionDeleter returns the ListerCollectionDeleter for
 // the given uid, or nil if one does not exist.
-func (r *crdHandler) GetCustomResourceListerCollectionDeleter(uid types.UID) finalizer.ListerCollectionDeleter {
-	storageMap := r.customStorage.Load().(crdStorageMap)
-	ret, ok := storageMap[uid]
-	if !ok {
-		return nil
-	}
-	return ret.storage
+func (r *crdHandler) GetCustomResourceListerCollectionDeleter(crd *apiextensions.CustomResourceDefinition) finalizer.ListerCollectionDeleter {
+	info := r.getServingInfoFor(crd)
+	return info.storage
 }
 
 func (r *crdHandler) getServingInfoFor(crd *apiextensions.CustomResourceDefinition) *crdInfo {

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/finalizer/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/finalizer/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/controller/finalizer/crd_finalizer.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/conversion"
-	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -69,7 +68,7 @@ type ListerCollectionDeleter interface {
 type CRClientGetter interface {
 	// GetCustomResourceListerCollectionDeleter gets the ListerCollectionDeleter for the given CRD
 	// UID.
-	GetCustomResourceListerCollectionDeleter(uid types.UID) ListerCollectionDeleter
+	GetCustomResourceListerCollectionDeleter(crd *apiextensions.CustomResourceDefinition) ListerCollectionDeleter
 }
 
 // NewCRDFinalizer creates a new CRDFinalizer.
@@ -162,7 +161,7 @@ func (c *CRDFinalizer) deleteInstances(crd *apiextensions.CustomResourceDefiniti
 	// Now we can start deleting items. While it would be ideal to use a REST API client, doing so
 	// could incorrectly delete a ThirdPartyResource with the same URL as the CustomResource, so we go
 	// directly to the storage instead. Since we control the storage, we know that delete collection works.
-	crClient := c.crClientGetter.GetCustomResourceListerCollectionDeleter(crd.UID)
+	crClient := c.crClientGetter.GetCustomResourceListerCollectionDeleter(crd)
 	if crClient == nil {
 		err := fmt.Errorf("unable to find a custom resource client for %s.%s", crd.Status.AcceptedNames.Plural, crd.Spec.Group)
 		return apiextensions.CustomResourceDefinitionCondition{


### PR DESCRIPTION
Create CR storage on demand when needed from CRD finalizer controller.

/cc @nikhita 