### PR TITLE
add crd shortname

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/registry/customresourcedefinition/etcd.go
@@ -58,6 +58,14 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST
 	return &REST{store}
 }
 
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"crd"}
+}
+
 // Delete adds the CRD finalizer to the list
 func (r *REST) Delete(ctx genericapirequest.Context, name string, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
 	obj, err := r.Get(ctx, name, &metav1.GetOptions{})


### PR DESCRIPTION
Adds a shortname, `crd`, for `CustomResourceDefinition`.

