### PR TITLE
making updateCIDRAllocation use patch instead of update

### DIFF
--- a/pkg/controller/node/range_allocator.go
+++ b/pkg/controller/node/range_allocator.go
@@ -244,18 +244,18 @@ func (r *rangeAllocator) updateCIDRAllocation(data nodeAndCIDR) error {
 		}
 		oldData, err := json.Marshal(node)
 		if err != nil {
-			return fmt.Errorf("failed to marshal old node %#v for node %q: %v", node, data.nodeName, err)
+			return fmt.Errorf("Failed to json.Marshal(%#v) for node %q: %v", node, data.nodeName, err)
 		}
 
 		node.Spec.PodCIDR = data.cidr.String()
 
 		newData, err := json.Marshal(node)
 		if err != nil {
-			return fmt.Errorf("failed to marshal modified node %#v for node %q: %v", node, data.nodeName, err)
+			return fmt.Errorf("Failed to json.Marshal(%#v) for updated node %q: %v", node, data.nodeName, err)
 		}
 
 		if err := patchNode(r.client, oldData, newData, data.nodeName); err != nil {
-			glog.Errorf("Failed while patching Node.Spec.PodCIDR (%d retries left): %v", podCIDRUpdateRetry-rep-1, err)
+			glog.Errorf("Failed while patching Node.Spec.PodCIDR for node %v (%d retries): %v", node, rep+1, err)
 		} else {
 			break
 		}
@@ -278,7 +278,7 @@ func (r *rangeAllocator) updateCIDRAllocation(data nodeAndCIDR) error {
 func patchNode(c clientset.Interface, oldData, newData []byte, nodeName string) error {
 	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
 	if err != nil {
-		return fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
+		return fmt.Errorf("Error creating patch for node %q: %v", nodeName, err)
 	}
 
 	_, err = c.Core().Nodes().Patch(string(nodeName), types.StrategicMergePatchType, patchBytes)

--- a/pkg/controller/node/range_allocator.go
+++ b/pkg/controller/node/range_allocator.go
@@ -255,7 +255,7 @@ func (r *rangeAllocator) updateCIDRAllocation(data nodeAndCIDR) error {
 		}
 
 		if err := patchNode(r.client, oldData, newData, data.nodeName); err != nil {
-			glog.Errorf("Failed while patching Node.Spec.PodCIDR for node %v (%d retries): %v", node, rep+1, err)
+			glog.Errorf("Failed to patch Node.Spec.PodCIDR for node %v (%d retries): %v", node, rep+1, err)
 		} else {
 			break
 		}

--- a/pkg/controller/node/range_allocator.go
+++ b/pkg/controller/node/range_allocator.go
@@ -25,7 +25,10 @@ import (
 	clientv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -224,7 +227,7 @@ func (r *rangeAllocator) updateCIDRAllocation(data nodeAndCIDR) error {
 	var node *v1.Node
 	defer r.removeNodeFromProcessing(data.nodeName)
 	for rep := 0; rep < podCIDRUpdateRetry; rep++ {
-		// TODO: change it to using PATCH instead of full Node updates.
+
 		node, err = r.client.Core().Nodes().Get(data.nodeName, metav1.GetOptions{})
 		if err != nil {
 			glog.Errorf("Failed while getting node %v to retry updating Node.Spec.PodCIDR: %v", data.nodeName, err)
@@ -239,9 +242,20 @@ func (r *rangeAllocator) updateCIDRAllocation(data nodeAndCIDR) error {
 			}
 			return nil
 		}
+		oldData, err := json.Marshal(node)
+		if err != nil {
+			return fmt.Errorf("failed to marshal old node %#v for node %q: %v", node, data.nodeName, err)
+		}
+
 		node.Spec.PodCIDR = data.cidr.String()
-		if _, err := r.client.Core().Nodes().Update(node); err != nil {
-			glog.Errorf("Failed while updating Node.Spec.PodCIDR (%d retries left): %v", podCIDRUpdateRetry-rep-1, err)
+
+		newData, err := json.Marshal(node)
+		if err != nil {
+			return fmt.Errorf("failed to marshal modified node %#v for node %q: %v", node, data.nodeName, err)
+		}
+
+		if err := patchNode(r.client, oldData, newData, data.nodeName); err != nil {
+			glog.Errorf("Failed while patching Node.Spec.PodCIDR (%d retries left): %v", podCIDRUpdateRetry-rep-1, err)
 		} else {
 			break
 		}
@@ -258,5 +272,15 @@ func (r *rangeAllocator) updateCIDRAllocation(data nodeAndCIDR) error {
 			}
 		}
 	}
+	return err
+}
+
+func patchNode(c clientset.Interface, oldData, newData []byte, nodeName string) error {
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+	if err != nil {
+		return fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
+	}
+
+	_, err = c.Core().Nodes().Patch(string(nodeName), types.StrategicMergePatchType, patchBytes)
 	return err
 }


### PR DESCRIPTION
**What this PR does / why we need it**: makes the CIDRAllocation update function use patch instead of update.

**Which issue this PR fixes** : fixes #46215

**Special notes for your reviewer**:

**Release note**:

```release-note
```
