### PR TITLE
Fix Cross-Build, and reduce test to 1 restart to reduce flakyness

### DIFF
--- a/test/e2e_node/garbage_collector_test.go
+++ b/test/e2e_node/garbage_collector_test.go
@@ -151,19 +151,9 @@ func containerGCTest(f *framework.Framework, test testRun) {
 			By("Making sure all containers restart the specified number of times")
 			Eventually(func() error {
 				for _, podSpec := range test.testPods {
-					updatedPod, err := f.ClientSet.Core().Pods(f.Namespace.Name).Get(podSpec.podName, metav1.GetOptions{})
+					err := verifyPodRestartCount(f, podSpec.podName, podSpec.numContainers, podSpec.restartCount)
 					if err != nil {
 						return err
-					}
-					if len(updatedPod.Status.ContainerStatuses) != podSpec.numContainers {
-						return fmt.Errorf("expected pod %s to have %d containers, actual: %d",
-							updatedPod.Name, podSpec.numContainers, len(updatedPod.Status.ContainerStatuses))
-					}
-					for _, containerStatus := range updatedPod.Status.ContainerStatuses {
-						if containerStatus.RestartCount != podSpec.restartCount {
-							return fmt.Errorf("pod %s had container with restartcount %d.  Should have been at least %d",
-								updatedPod.Name, containerStatus.RestartCount, podSpec.restartCount)
-						}
 					}
 				}
 				return nil
@@ -292,7 +282,7 @@ func getPods(specs []*testPodSpec) (pods []*v1.Pod) {
 			containers = append(containers, v1.Container{
 				Image:   "gcr.io/google_containers/busybox:1.24",
 				Name:    spec.getContainerName(i),
-				Command: getRestartingContainerCommand("/test-empty-dir-mnt", i, int(spec.restartCount), ""),
+				Command: getRestartingContainerCommand("/test-empty-dir-mnt", i, spec.restartCount, ""),
 				VolumeMounts: []v1.VolumeMount{
 					{MountPath: "/test-empty-dir-mnt", Name: "test-empty-dir"},
 				},
@@ -312,7 +302,7 @@ func getPods(specs []*testPodSpec) (pods []*v1.Pod) {
 	return
 }
 
-func getRestartingContainerCommand(path string, containerNum, restarts int, loopingCommand string) []string {
+func getRestartingContainerCommand(path string, containerNum int, restarts int32, loopingCommand string) []string {
 	return []string{
 		"sh",
 		"-c",
@@ -325,4 +315,22 @@ func getRestartingContainerCommand(path string, containerNum, restarts int, loop
 			while true; do %s sleep 10; done`,
 			path, strconv.Itoa(containerNum), restarts+1, loopingCommand),
 	}
+}
+
+func verifyPodRestartCount(f *framework.Framework, podName string, expectedNumContainers int, expectedRestartCount int32) error {
+	updatedPod, err := f.ClientSet.Core().Pods(f.Namespace.Name).Get(podName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if len(updatedPod.Status.ContainerStatuses) != expectedNumContainers {
+		return fmt.Errorf("expected pod %s to have %d containers, actual: %d",
+			updatedPod.Name, expectedNumContainers, len(updatedPod.Status.ContainerStatuses))
+	}
+	for _, containerStatus := range updatedPod.Status.ContainerStatuses {
+		if containerStatus.RestartCount != expectedRestartCount {
+			return fmt.Errorf("pod %s had container with restartcount %d.  Should have been at least %d",
+				updatedPod.Name, containerStatus.RestartCount, expectedRestartCount)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
In response to https://github.com/kubernetes/kubernetes/pull/46308#issuecomment-304248450

This fixes the error: `test/e2e_node/summary_test.go:138: constant 100000000000 overflows int` from the cross build.

This [recent flake](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet/4179) was because the container restarted during the period where the test expected to Continually see the container in the Summary API.

/assign @dchen1107 
cc @gmarek @luxas 

/release-note-none