### PR TITLE
add owners file for strategic merge patch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/mergepatch/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/util/mergepatch/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- pwittrock
+reviewers:
+- mengqiy
+- apelisse

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- pwittrock
+reviewers:
+- mengqiy
+- apelisse

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/OWNERS
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- pwittrock
+reviewers:
+- mengqiy
+- apelisse


### PR DESCRIPTION
`staging/src/k8s.io/apimachinery/pkg/util/strategicpatch` is the strategic merge patch pkg
`staging/src/k8s.io/apimachinery/pkg/util/mergepatch` is the util pkg for strategic merge patch and json merge patch
`staging/src/k8s.io/apimachinery/third_party/forked/golang/json/OWNERS` is another util pkg used by strategic merge patch

cc: @pwittrock @grodrigues3 @apelisse 