### PR TITLE
Make FakeExec easier / less-boilerplatey / better

### DIFF
--- a/pkg/util/ebtables/ebtables_test.go
+++ b/pkg/util/ebtables/ebtables_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/exec"
 )
 
-func testEnsureChain(t *testing.T) {
+func TestEnsureChain(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// Does not Exists
@@ -75,7 +75,7 @@ func testEnsureChain(t *testing.T) {
 	}
 }
 
-func testEnsureRule(t *testing.T) {
+func TestEnsureRule(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// Exists
@@ -118,7 +118,7 @@ Bridge chain: TEST, entries: 0, policy: ACCEPT`), nil
 	if exists {
 		t.Errorf("expected exists = false")
 	}
-	errStr := "Failed to ensure rule: exist 2, output: "
+	errStr := "Failed to ensure rule: exit 2, output: "
 	if err == nil || err.Error() != errStr {
 		t.Errorf("expected error: %q", errStr)
 	}

--- a/pkg/util/exec/fake_exec.go
+++ b/pkg/util/exec/fake_exec.go
@@ -19,6 +19,11 @@ package exec
 import (
 	"fmt"
 	"io"
+	osexec "os/exec"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
 )
 
 // A simple scripted Interface type.
@@ -26,13 +31,34 @@ type FakeExec struct {
 	CommandScript []FakeCommandAction
 	CommandCalls  int
 	LookPathFunc  func(string) (string, error)
+
+	T *testing.T
+}
+
+// NewFakeExec creates a FakeExec. You can pass nil for t if you are not running from a
+// test program. (This will cause certain failures to result in a panic rather than a
+// t.Fatal.) cmdsInPath is a list of command names for which LookPath will return a match
+// ("/fake-bin/commandname"); if your code does not use LookPath you can pass nil. (If you
+// need more complex behavior, you can override LookPathFunc on the returned FakeExec.)
+func NewFakeExec(t *testing.T, cmdsInPath []string) *FakeExec {
+	return &FakeExec{
+		T: t,
+		LookPathFunc: func(cmd string) (string, error) {
+			for _, pathCmd := range cmdsInPath {
+				if pathCmd == cmd {
+					return "/fake-bin/" + cmd, nil
+				}
+			}
+			return "", &osexec.Error{cmd, osexec.ErrNotFound}
+		},
+	}
 }
 
 type FakeCommandAction func(cmd string, args ...string) Cmd
 
 func (fake *FakeExec) Command(cmd string, args ...string) Cmd {
 	if fake.CommandCalls > len(fake.CommandScript)-1 {
-		panic(fmt.Sprintf("ran out of Command() actions. Could not handle command [%d]: %s args: %v", fake.CommandCalls, cmd, args))
+		fake.fail("ran out of Command() actions at %s executing %v", getCaller(1), append([]string{cmd}, args...))
 	}
 	i := fake.CommandCalls
 	fake.CommandCalls++
@@ -41,6 +67,82 @@ func (fake *FakeExec) Command(cmd string, args ...string) Cmd {
 
 func (fake *FakeExec) LookPath(file string) (string, error) {
 	return fake.LookPathFunc(file)
+}
+
+func getCaller(n int) string {
+	_, file, line, ok := runtime.Caller(n + 1)
+	if !ok {
+		return "???"
+	}
+	if i := strings.LastIndexAny(file, "/\\"); i >= 0 {
+		file = file[i+1:]
+	}
+	return fmt.Sprintf("%s:%d", file, line)
+}
+
+func (fake *FakeExec) fail(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if fake.T == nil {
+		panic(msg)
+	}
+
+	// Don't re-fail from a "defer fexec.AssertExpectedCommands()" if we already failed once
+	if fake.T.Failed() {
+		return
+	}
+	fake.T.Fatal(msg)
+}
+
+// AddCommand adds a Cmd to be returned by a future fake.Command(...) call. Call
+// SetCombinedOutput or SetRunOutput on the result to specify its result.
+func (fake *FakeExec) AddCommand(cmd string, args ...string) *FakeCmd {
+	expectCaller := getCaller(1)
+	expectedArgv := append([]string{cmd}, args...)
+	fcmd := &FakeCmd{}
+	fake.CommandScript = append(fake.CommandScript,
+		func(cmd string, args ...string) Cmd {
+			InitFakeCmd(fcmd, cmd, args...)
+			if !reflect.DeepEqual(expectedArgv, fcmd.Argv) {
+				fake.fail("Wrong command: expected\n%v (at %s)\ngot\n%v (at %s)", expectedArgv, expectCaller, fcmd.Argv, getCaller(2))
+			}
+			return fcmd
+		},
+	)
+	return fcmd
+}
+
+func outputAsBytes(output interface{}) []byte {
+	if outputBytes, ok := output.([]byte); ok {
+		return outputBytes
+	} else if outputStr, ok := output.(string); ok {
+		return []byte(outputStr)
+	} else if output == nil {
+		return nil
+	}
+	panic("output must be []byte or string")
+}
+
+// SetRunOutput provides the result of calling Run() on a FakeCmd.
+// stdout and stderr can be either []byte or string (which will be converted to []byte).
+func (fcmd *FakeCmd) SetRunOutput(stdout, stderr interface{}, err error) {
+	fcmd.RunScript = []FakeRunAction{
+		func() ([]byte, []byte, error) { return outputAsBytes(stdout), outputAsBytes(stderr), err },
+	}
+}
+
+// SetCombinedOutput provides the result of calling CombinedOutput() on a FakeCmd.
+// output can be either a []byte or a string (which will be converted to a []byte).
+func (fcmd *FakeCmd) SetCombinedOutput(output interface{}, err error) {
+	fcmd.CombinedOutputScript = []FakeCombinedOutputAction{
+		func() ([]byte, error) { return outputAsBytes(output), err },
+	}
+}
+
+// AssertExpectedCommands ensures that all of the commands added to fake via AddCommand were actually executed
+func (fake *FakeExec) AssertExpectedCommands() {
+	if fake.CommandCalls != len(fake.CommandScript) {
+		fake.fail("Only used %d of %d expected commands (at %s)", fake.CommandCalls, len(fake.CommandScript), getCaller(1))
+	}
 }
 
 // A simple scripted Cmd type.

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -333,7 +333,7 @@ func TestEnsureRuleErrorCreating(t *testing.T) {
 	}
 }
 
-func TestDeleteRuleAlreadyExists(t *testing.T) {
+func TestDeleteRuleDoesNotExist(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// iptables version check
@@ -368,7 +368,7 @@ func TestDeleteRuleAlreadyExists(t *testing.T) {
 	}
 }
 
-func TestDeleteRuleNew(t *testing.T) {
+func TestDeleteRuleExists(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// iptables version check
@@ -438,7 +438,7 @@ func TestDeleteRuleErrorChecking(t *testing.T) {
 	}
 }
 
-func TestDeleteRuleErrorCreating(t *testing.T) {
+func TestDeleteRuleErrorDeleting(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// iptables version check


### PR DESCRIPTION
The fake implementation of pkg/util/exec for test programs is kind of really annoying to use. This PR adds some wrapper functions to make it easier, AND to automatically check that the passed-in command was what you expected (which some tests were doing but most weren't).

So:

    fcmd := exec.FakeCmd{
            CombinedOutputScript: []exec.FakeCombinedOutputAction{
                    // iptables version check
                    func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
                    // iptables-restore version check
                    func() ([]byte, error) { return []byte("iptables-restore v1.9.22"), nil },
                    // Success.
                    func() ([]byte, error) { return []byte{}, nil },
            },
    }
    fexec := exec.FakeExec{
            CommandScript: []exec.FakeCommandAction{
                    func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
                    func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
                    func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
            },
    }

becomes

    fexec := exec.FakeExec{}
    fexec.ExpectCombinedOutput("iptables --version", "iptables v1.9.22", nil)
    fexec.ExpectCombinedOutput("iptables-restore --version", "iptables-restore v1.9.22", nil)
    fexec.ExpectCombinedOutput("iptables -w2 -N FOOBAR -t nat", "", nil)

In the interest of being useful, the first argument to ExpectCombinedOutput() and ExpectRun() can be either a string (as above) or a []string (if some of the args have spaces in them, or if you're building up the expected command line from a bunch of variables and don't want to sprintf them together). And the output arg(s) can be either a []byte or a string (since most of the time you're not dealing with binary output).

The fact that it always checks that the command line is as expected is mostly a win, I think, although it may also be annoying at times; if you change the code so that the args end up in a different order, or decide that you should be passing some additional arg you weren't using before, you'll have to change the tests to match.

I ported all the tests in pkg/util/ to use the new functions as a proof of concept. I could do the rest if this was going to be accepted.

**Release note**:
```release-note
NONE
```
