### PR TITLE
Make fluentd-gcp run with host network

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -24,6 +24,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       dnsPolicy: Default
+      hostNetwork: true
       containers:
       - name: fluentd-gcp
         image: gcr.io/google-containers/fluentd-gcp:2.0.2


### PR DESCRIPTION
Fluentd-gcp should have access to instance's platform-dependent service account in order to work.

/cc @piosz 