### PR TITLE
Bazel: mount tmpfs on /tmp

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -4,3 +4,6 @@ test --test_output=errors
 
 # Include git version info
 build --workspace_status_command hack/print-workspace-status.sh
+
+# Make /tmp hermetic
+build --sandbox_tmpfs_path=/tmp


### PR DESCRIPTION
**What this PR does / why we need it**: our custom `go_genrule` assumes a hermetic `/tmp/` directory, but Bazel 0.5.0 just mounts the host `/tmp` read-write by default.

As a result, we can run into build failures like:
```
W0526 23:53:12.504] ERROR: /workspace/k8s.io/kubernetes/pkg/generated/openapi/BUILD:7:1: error executing shell command: 'set -e
W0526 23:53:12.504] export GOROOT=$(pwd)/external/io_bazel_rules_go_toolchain/bin/..
W0526 23:53:12.504] export GOPATH=/tmp/gopath
W0526 23:53:12.505] export GO_WORKSPACE=${GOPATH}/src/k8s.io/kubernetes
W0526 23:53:12.505] mkdir -p ${GO_WORKSPACE%/*}
W0526 23:53:12.505] ln -s $(pwd) ${GO_W...' failed: bash failed: error executing command 
W0526 23:53:12.506]   (exec env - \
W0526 23:53:12.506]   /bin/bash -c 'set -e
W0526 23:53:12.506] export GOROOT=$(pwd)/external/io_bazel_rules_go_toolchain/bin/..
W0526 23:53:12.506] export GOPATH=/tmp/gopath
W0526 23:53:12.506] export GO_WORKSPACE=${GOPATH}/src/k8s.io/kubernetes
W0526 23:53:12.507] mkdir -p ${GO_WORKSPACE%/*}
W0526 23:53:12.507] ln -s $(pwd) ${GO_WORKSPACE}
W0526 23:53:12.507] export GENGOPATH=/tmp/gengopath
W0526 23:53:12.508] export GENGO_WORKSPACE=${GENGOPATH}/src/k8s.io/kubernetes
W0526 23:53:12.508] mkdir -p ${GENGO_WORKSPACE%/*}
W0526 23:53:12.508] ln -s $(pwd)/bazel-out/local-fastbuild/genfiles ${GENGO_WORKSPACE}
W0526 23:53:12.508] export GOPATH=${GOPATH}:${GENGOPATH}
W0526 23:53:12.508] cd ${GO_WORKSPACE}
W0526 23:53:12.510] bazel-out/host/bin/cmd/libs/go2idl/openapi-gen/openapi-gen --v 1 --logtostderr --go-header-file hack/boilerplate/boilerplate.go.txt --output-file-base zz_generated.openapi --output-package k8s.io/kubernetes/pkg/generated/openapi --input-dirs k8s.io/kubernetes/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1,k8s.io/kubernetes/federation/apis/federation/v1beta1,k8s.io/kubernetes/pkg/api/v1,k8s.io/kubernetes/pkg/apis/abac/v0,k8s.io/kubernetes/pkg/apis/abac/v1beta1,k8s.io/kubernetes/pkg/apis/admission/v1alpha1,k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1,k8s.io/kubernetes/pkg/apis/apps/v1beta1,k8s.io/kubernetes/pkg/apis/authentication/v1,k8s.io/kubernetes/pkg/apis/authentication/v1beta1,k8s.io/kubernetes/pkg/apis/authorization/v1,k8s.io/kubernetes/pkg/apis/authorization/v1beta1,k8s.io/kubernetes/pkg/apis/autoscaling/v1,k8s.io/kubernetes/pkg/apis/autoscaling/v2alpha1,k8s.io/kubernetes/pkg/apis/batch/v1,k8s.io/kubernetes/pkg/apis/batch/v2alpha1,k8s.io/kubernetes/pkg/apis/certificates/v1beta1,k8s.io/kubernetes/pkg/apis/componentconfig/v1alpha1,k8s.io/kubernetes/pkg/apis/extensions/v1beta1,k8s.io/kubernetes/pkg/apis/imagepolicy/v1alpha1,k8s.io/kubernetes/pkg/apis/policy/v1beta1,k8s.io/kubernetes/pkg/apis/rbac/v1alpha1,k8s.io/kubernetes/pkg/apis/rbac/v1beta1,k8s.io/kubernetes/pkg/apis/settings/v1alpha1,k8s.io/kubernetes/pkg/apis/storage/v1,k8s.io/kubernetes/pkg/apis/storage/v1beta1,k8s.io/kubernetes/pkg/version,k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource,k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1,k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1alpha1,k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/runtime,k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/intstr,k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/version,k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/apis/audit/v1alpha1,k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/apis/example/v1,k8s.io/kubernetes/vendor/k8s.io/client-go/pkg/api/v1,k8s.io/kubernetes/vendor/k8s.io/metrics/pkg/apis/custom_metrics/v1alpha1,k8s.io/kubernetes/vendor/k8s.io/metrics/pkg/apis/metrics/v1alpha1 && cp pkg/generated/openapi/zz_generated.openapi.go bazel-out/local-fastbuild/genfiles/pkg/generated/openapi')
```

By specifying this flag, we can restore the old behavior.
/assign @mikedanese @spxtr 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```