### PR TITLE
Use meta.v1 GroupVersionKind with json tags to generate OpenAPI spec

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -102,11 +102,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ComponentStatus"
+      "group": "",
+      "version": "v1",
+      "kind": "ComponentStatus"
      }
     },
     "parameters": [
@@ -190,11 +190,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ComponentStatus"
+      "group": "",
+      "version": "v1",
+      "kind": "ComponentStatus"
      }
     },
     "parameters": [
@@ -246,11 +246,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -336,11 +336,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "parameters": [
@@ -426,11 +426,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -516,11 +516,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "parameters": [
@@ -650,11 +650,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "post": {
@@ -695,11 +695,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -751,11 +751,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Binding"
+      "group": "",
+      "version": "v1",
+      "kind": "Binding"
      }
     },
     "parameters": [
@@ -851,11 +851,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "post": {
@@ -896,11 +896,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "delete": {
@@ -975,11 +975,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -1045,11 +1045,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "put": {
@@ -1090,11 +1090,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "delete": {
@@ -1156,11 +1156,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "patch": {
@@ -1203,11 +1203,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -1311,11 +1311,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "post": {
@@ -1356,11 +1356,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "delete": {
@@ -1435,11 +1435,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "parameters": [
@@ -1505,11 +1505,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "put": {
@@ -1550,11 +1550,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "delete": {
@@ -1616,11 +1616,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "patch": {
@@ -1663,11 +1663,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "parameters": [
@@ -1771,11 +1771,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "post": {
@@ -1816,11 +1816,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "delete": {
@@ -1895,11 +1895,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -1965,11 +1965,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "put": {
@@ -2010,11 +2010,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "delete": {
@@ -2076,11 +2076,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "patch": {
@@ -2123,11 +2123,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -2231,11 +2231,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "post": {
@@ -2276,11 +2276,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "delete": {
@@ -2355,11 +2355,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "parameters": [
@@ -2425,11 +2425,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "put": {
@@ -2470,11 +2470,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "delete": {
@@ -2536,11 +2536,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "patch": {
@@ -2583,11 +2583,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "parameters": [
@@ -2691,11 +2691,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "post": {
@@ -2736,11 +2736,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "delete": {
@@ -2815,11 +2815,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "parameters": [
@@ -2885,11 +2885,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "put": {
@@ -2930,11 +2930,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "delete": {
@@ -2996,11 +2996,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "patch": {
@@ -3043,11 +3043,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "parameters": [
@@ -3105,11 +3105,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "put": {
@@ -3150,11 +3150,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "patch": {
@@ -3197,11 +3197,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "parameters": [
@@ -3305,11 +3305,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "post": {
@@ -3350,11 +3350,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "delete": {
@@ -3429,11 +3429,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -3499,11 +3499,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "put": {
@@ -3544,11 +3544,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "delete": {
@@ -3610,11 +3610,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "patch": {
@@ -3657,11 +3657,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -3717,11 +3717,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "post": {
@@ -3750,11 +3750,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -3850,11 +3850,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Binding"
+      "group": "",
+      "version": "v1",
+      "kind": "Binding"
      }
     },
     "parameters": [
@@ -3922,11 +3922,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "Eviction"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "Eviction"
      }
     },
     "parameters": [
@@ -3982,11 +3982,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "post": {
@@ -4015,11 +4015,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -4113,11 +4113,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -4222,11 +4222,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "post": {
@@ -4255,11 +4255,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -4315,11 +4315,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "put": {
@@ -4348,11 +4348,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "post": {
@@ -4381,11 +4381,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "delete": {
@@ -4414,11 +4414,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "options": {
@@ -4447,11 +4447,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "head": {
@@ -4480,11 +4480,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "patch": {
@@ -4513,11 +4513,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -4573,11 +4573,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "put": {
@@ -4606,11 +4606,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "post": {
@@ -4639,11 +4639,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "delete": {
@@ -4672,11 +4672,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "options": {
@@ -4705,11 +4705,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "head": {
@@ -4738,11 +4738,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "patch": {
@@ -4771,11 +4771,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -4841,11 +4841,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "put": {
@@ -4886,11 +4886,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "patch": {
@@ -4933,11 +4933,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -5041,11 +5041,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "post": {
@@ -5086,11 +5086,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "delete": {
@@ -5165,11 +5165,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "parameters": [
@@ -5235,11 +5235,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "put": {
@@ -5280,11 +5280,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "delete": {
@@ -5346,11 +5346,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "patch": {
@@ -5393,11 +5393,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "parameters": [
@@ -5501,11 +5501,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "post": {
@@ -5546,11 +5546,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "delete": {
@@ -5625,11 +5625,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "parameters": [
@@ -5695,11 +5695,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "put": {
@@ -5740,11 +5740,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "delete": {
@@ -5806,11 +5806,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "patch": {
@@ -5853,11 +5853,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "parameters": [
@@ -5915,11 +5915,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "Scale"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "Scale"
      }
     },
     "put": {
@@ -5960,11 +5960,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "Scale"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "Scale"
      }
     },
     "patch": {
@@ -6007,11 +6007,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "Scale"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "Scale"
      }
     },
     "parameters": [
@@ -6069,11 +6069,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "put": {
@@ -6114,11 +6114,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "patch": {
@@ -6161,11 +6161,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "parameters": [
@@ -6269,11 +6269,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "post": {
@@ -6314,11 +6314,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "delete": {
@@ -6393,11 +6393,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "parameters": [
@@ -6463,11 +6463,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "put": {
@@ -6508,11 +6508,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "delete": {
@@ -6574,11 +6574,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "patch": {
@@ -6621,11 +6621,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "parameters": [
@@ -6683,11 +6683,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "put": {
@@ -6728,11 +6728,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "patch": {
@@ -6775,11 +6775,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "parameters": [
@@ -6883,11 +6883,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "post": {
@@ -6928,11 +6928,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "delete": {
@@ -7007,11 +7007,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -7077,11 +7077,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "put": {
@@ -7122,11 +7122,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "delete": {
@@ -7188,11 +7188,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "patch": {
@@ -7235,11 +7235,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -7343,11 +7343,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "post": {
@@ -7388,11 +7388,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "delete": {
@@ -7467,11 +7467,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "parameters": [
@@ -7537,11 +7537,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "put": {
@@ -7582,11 +7582,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "delete": {
@@ -7648,11 +7648,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "patch": {
@@ -7695,11 +7695,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "parameters": [
@@ -7803,11 +7803,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "post": {
@@ -7848,11 +7848,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -7918,11 +7918,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "put": {
@@ -7963,11 +7963,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "delete": {
@@ -7998,11 +7998,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "patch": {
@@ -8045,11 +8045,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -8105,11 +8105,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "put": {
@@ -8138,11 +8138,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "post": {
@@ -8171,11 +8171,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "delete": {
@@ -8204,11 +8204,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "options": {
@@ -8237,11 +8237,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "head": {
@@ -8270,11 +8270,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "patch": {
@@ -8303,11 +8303,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -8363,11 +8363,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "put": {
@@ -8396,11 +8396,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "post": {
@@ -8429,11 +8429,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "delete": {
@@ -8462,11 +8462,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "options": {
@@ -8495,11 +8495,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "head": {
@@ -8528,11 +8528,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "patch": {
@@ -8561,11 +8561,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -8631,11 +8631,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "put": {
@@ -8676,11 +8676,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "patch": {
@@ -8723,11 +8723,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -8801,11 +8801,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "put": {
@@ -8846,11 +8846,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "delete": {
@@ -8912,11 +8912,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "patch": {
@@ -8959,11 +8959,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -9023,11 +9023,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -9077,11 +9077,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "put": {
@@ -9122,11 +9122,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "patch": {
@@ -9169,11 +9169,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -9269,11 +9269,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "post": {
@@ -9314,11 +9314,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "delete": {
@@ -9393,11 +9393,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -9455,11 +9455,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "put": {
@@ -9500,11 +9500,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "delete": {
@@ -9566,11 +9566,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "patch": {
@@ -9613,11 +9613,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -9665,11 +9665,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "put": {
@@ -9698,11 +9698,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "post": {
@@ -9731,11 +9731,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "delete": {
@@ -9764,11 +9764,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "options": {
@@ -9797,11 +9797,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "head": {
@@ -9830,11 +9830,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "patch": {
@@ -9863,11 +9863,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -9915,11 +9915,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "put": {
@@ -9948,11 +9948,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "post": {
@@ -9981,11 +9981,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "delete": {
@@ -10014,11 +10014,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "options": {
@@ -10047,11 +10047,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "head": {
@@ -10080,11 +10080,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "patch": {
@@ -10113,11 +10113,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "CONNECT",
+     "x-kubernetes-action": "connect",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -10175,11 +10175,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "put": {
@@ -10220,11 +10220,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "patch": {
@@ -10267,11 +10267,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -10323,11 +10323,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "parameters": [
@@ -10457,11 +10457,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "post": {
@@ -10502,11 +10502,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "delete": {
@@ -10581,11 +10581,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "parameters": [
@@ -10643,11 +10643,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "put": {
@@ -10688,11 +10688,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "delete": {
@@ -10754,11 +10754,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "patch": {
@@ -10801,11 +10801,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "parameters": [
@@ -10855,11 +10855,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "put": {
@@ -10900,11 +10900,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "patch": {
@@ -10947,11 +10947,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "parameters": [
@@ -11003,11 +11003,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -11093,11 +11093,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "parameters": [
@@ -11179,11 +11179,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "put": {
@@ -11212,11 +11212,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "post": {
@@ -11245,11 +11245,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "delete": {
@@ -11278,11 +11278,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "options": {
@@ -11311,11 +11311,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "head": {
@@ -11344,11 +11344,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "patch": {
@@ -11377,11 +11377,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -11430,11 +11430,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "put": {
@@ -11463,11 +11463,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "post": {
@@ -11496,11 +11496,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "delete": {
@@ -11529,11 +11529,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "options": {
@@ -11562,11 +11562,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "head": {
@@ -11595,11 +11595,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "patch": {
@@ -11628,11 +11628,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -11689,11 +11689,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "put": {
@@ -11722,11 +11722,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "post": {
@@ -11755,11 +11755,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "delete": {
@@ -11788,11 +11788,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "options": {
@@ -11821,11 +11821,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "head": {
@@ -11854,11 +11854,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "patch": {
@@ -11887,11 +11887,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -11940,11 +11940,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "put": {
@@ -11973,11 +11973,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "post": {
@@ -12006,11 +12006,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "delete": {
@@ -12039,11 +12039,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "options": {
@@ -12072,11 +12072,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "head": {
@@ -12105,11 +12105,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "patch": {
@@ -12138,11 +12138,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -12199,11 +12199,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "put": {
@@ -12232,11 +12232,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "post": {
@@ -12265,11 +12265,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "delete": {
@@ -12298,11 +12298,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "options": {
@@ -12331,11 +12331,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "head": {
@@ -12364,11 +12364,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "patch": {
@@ -12397,11 +12397,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -12442,11 +12442,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "put": {
@@ -12475,11 +12475,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "post": {
@@ -12508,11 +12508,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "delete": {
@@ -12541,11 +12541,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "options": {
@@ -12574,11 +12574,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "head": {
@@ -12607,11 +12607,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "patch": {
@@ -12640,11 +12640,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PROXY",
+     "x-kubernetes-action": "proxy",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -12697,11 +12697,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "parameters": [
@@ -12787,11 +12787,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "parameters": [
@@ -12877,11 +12877,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -12967,11 +12967,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "parameters": [
@@ -13057,11 +13057,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -13147,11 +13147,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -13237,11 +13237,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "parameters": [
@@ -13327,11 +13327,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -13417,11 +13417,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "parameters": [
@@ -13507,11 +13507,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -13597,11 +13597,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -13695,11 +13695,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -13801,11 +13801,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "parameters": [
@@ -13899,11 +13899,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     },
     "parameters": [
@@ -14005,11 +14005,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -14103,11 +14103,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -14209,11 +14209,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "parameters": [
@@ -14307,11 +14307,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     },
     "parameters": [
@@ -14413,11 +14413,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "parameters": [
@@ -14511,11 +14511,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "parameters": [
@@ -14617,11 +14617,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -14715,11 +14715,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -14821,11 +14821,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "parameters": [
@@ -14919,11 +14919,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "parameters": [
@@ -15025,11 +15025,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "parameters": [
@@ -15123,11 +15123,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "parameters": [
@@ -15229,11 +15229,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "parameters": [
@@ -15327,11 +15327,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "parameters": [
@@ -15433,11 +15433,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -15531,11 +15531,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -15637,11 +15637,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "parameters": [
@@ -15735,11 +15735,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "parameters": [
@@ -15841,11 +15841,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -15939,11 +15939,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -16045,11 +16045,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -16143,11 +16143,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -16233,11 +16233,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     },
     "parameters": [
@@ -16331,11 +16331,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     },
     "parameters": [
@@ -16421,11 +16421,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "parameters": [
@@ -16511,11 +16511,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     },
     "parameters": [
@@ -16609,11 +16609,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     },
     "parameters": [
@@ -16699,11 +16699,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     },
     "parameters": [
@@ -16789,11 +16789,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     },
     "parameters": [
@@ -16879,11 +16879,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     },
     "parameters": [
@@ -16969,11 +16969,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -17059,11 +17059,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     },
     "parameters": [
@@ -17149,11 +17149,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -17382,11 +17382,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "post": {
@@ -17427,11 +17427,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "delete": {
@@ -17506,11 +17506,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "parameters": [
@@ -17568,11 +17568,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "put": {
@@ -17613,11 +17613,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "delete": {
@@ -17679,11 +17679,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "patch": {
@@ -17726,11 +17726,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "parameters": [
@@ -17826,11 +17826,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "post": {
@@ -17871,11 +17871,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "delete": {
@@ -17950,11 +17950,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "parameters": [
@@ -18012,11 +18012,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "put": {
@@ -18057,11 +18057,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "delete": {
@@ -18123,11 +18123,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "patch": {
@@ -18170,11 +18170,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "parameters": [
@@ -18226,11 +18226,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "parameters": [
@@ -18316,11 +18316,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     },
     "parameters": [
@@ -18414,11 +18414,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "parameters": [
@@ -18504,11 +18504,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     },
     "parameters": [
@@ -18668,11 +18668,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "parameters": [
@@ -18758,11 +18758,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -18892,11 +18892,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "post": {
@@ -18937,11 +18937,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "delete": {
@@ -19016,11 +19016,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "parameters": [
@@ -19086,11 +19086,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "put": {
@@ -19131,11 +19131,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "delete": {
@@ -19197,11 +19197,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "patch": {
@@ -19244,11 +19244,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "parameters": [
@@ -19352,11 +19352,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "post": {
@@ -19397,11 +19397,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "delete": {
@@ -19476,11 +19476,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -19546,11 +19546,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "put": {
@@ -19591,11 +19591,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "delete": {
@@ -19657,11 +19657,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "patch": {
@@ -19704,11 +19704,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -19776,11 +19776,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "DeploymentRollback"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "DeploymentRollback"
      }
     },
     "parameters": [
@@ -19838,11 +19838,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "put": {
@@ -19883,11 +19883,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "patch": {
@@ -19930,11 +19930,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "parameters": [
@@ -19992,11 +19992,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "put": {
@@ -20037,11 +20037,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "patch": {
@@ -20084,11 +20084,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -20192,11 +20192,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "post": {
@@ -20237,11 +20237,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "delete": {
@@ -20316,11 +20316,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "parameters": [
@@ -20386,11 +20386,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "put": {
@@ -20431,11 +20431,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "delete": {
@@ -20497,11 +20497,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "patch": {
@@ -20544,11 +20544,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "parameters": [
@@ -20606,11 +20606,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "put": {
@@ -20651,11 +20651,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "patch": {
@@ -20698,11 +20698,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "parameters": [
@@ -20762,11 +20762,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "parameters": [
@@ -20852,11 +20852,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "parameters": [
@@ -20942,11 +20942,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -21032,11 +21032,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "parameters": [
@@ -21130,11 +21130,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     },
     "parameters": [
@@ -21236,11 +21236,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -21334,11 +21334,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -21440,11 +21440,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "parameters": [
@@ -21538,11 +21538,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "parameters": [
@@ -21644,11 +21644,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     },
     "parameters": [
@@ -21808,11 +21808,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "authentication.k8s.io",
-      "Version": "v1",
-      "Kind": "TokenReview"
+      "group": "authentication.k8s.io",
+      "version": "v1",
+      "kind": "TokenReview"
      }
     },
     "parameters": [
@@ -21897,11 +21897,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "authentication.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "TokenReview"
+      "group": "authentication.k8s.io",
+      "version": "v1beta1",
+      "kind": "TokenReview"
      }
     },
     "parameters": [
@@ -22019,11 +22019,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "authorization.k8s.io",
-      "Version": "v1",
-      "Kind": "LocalSubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1",
+      "kind": "LocalSubjectAccessReview"
      }
     },
     "parameters": [
@@ -22083,11 +22083,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "authorization.k8s.io",
-      "Version": "v1",
-      "Kind": "SelfSubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1",
+      "kind": "SelfSubjectAccessReview"
      }
     },
     "parameters": [
@@ -22139,11 +22139,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "authorization.k8s.io",
-      "Version": "v1",
-      "Kind": "SubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1",
+      "kind": "SubjectAccessReview"
      }
     },
     "parameters": [
@@ -22228,11 +22228,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "LocalSubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "LocalSubjectAccessReview"
      }
     },
     "parameters": [
@@ -22292,11 +22292,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "SelfSubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "SelfSubjectAccessReview"
      }
     },
     "parameters": [
@@ -22348,11 +22348,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "SubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "SubjectAccessReview"
      }
     },
     "parameters": [
@@ -22462,11 +22462,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -22596,11 +22596,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "post": {
@@ -22641,11 +22641,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "delete": {
@@ -22720,11 +22720,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -22790,11 +22790,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "put": {
@@ -22835,11 +22835,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "delete": {
@@ -22901,11 +22901,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "patch": {
@@ -22948,11 +22948,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -23010,11 +23010,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "put": {
@@ -23055,11 +23055,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "patch": {
@@ -23102,11 +23102,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -23166,11 +23166,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -23256,11 +23256,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -23354,11 +23354,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -23493,11 +23493,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -23627,11 +23627,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "post": {
@@ -23672,11 +23672,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "delete": {
@@ -23751,11 +23751,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -23821,11 +23821,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "put": {
@@ -23866,11 +23866,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "delete": {
@@ -23932,11 +23932,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "patch": {
@@ -23979,11 +23979,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -24041,11 +24041,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "put": {
@@ -24086,11 +24086,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "patch": {
@@ -24133,11 +24133,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -24197,11 +24197,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -24287,11 +24287,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -24385,11 +24385,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     },
     "parameters": [
@@ -24557,11 +24557,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "parameters": [
@@ -24691,11 +24691,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "post": {
@@ -24736,11 +24736,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "delete": {
@@ -24815,11 +24815,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "parameters": [
@@ -24885,11 +24885,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "put": {
@@ -24930,11 +24930,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "delete": {
@@ -24996,11 +24996,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "patch": {
@@ -25043,11 +25043,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "parameters": [
@@ -25105,11 +25105,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "put": {
@@ -25150,11 +25150,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "patch": {
@@ -25197,11 +25197,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "parameters": [
@@ -25261,11 +25261,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "parameters": [
@@ -25351,11 +25351,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "parameters": [
@@ -25449,11 +25449,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     },
     "parameters": [
@@ -25588,11 +25588,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "parameters": [
@@ -25722,11 +25722,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "post": {
@@ -25767,11 +25767,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "delete": {
@@ -25846,11 +25846,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "parameters": [
@@ -25916,11 +25916,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "put": {
@@ -25961,11 +25961,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "delete": {
@@ -26027,11 +26027,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "patch": {
@@ -26074,11 +26074,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "parameters": [
@@ -26136,11 +26136,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "put": {
@@ -26181,11 +26181,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "patch": {
@@ -26228,11 +26228,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "parameters": [
@@ -26336,11 +26336,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "post": {
@@ -26381,11 +26381,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "delete": {
@@ -26460,11 +26460,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "parameters": [
@@ -26530,11 +26530,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "put": {
@@ -26575,11 +26575,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "delete": {
@@ -26641,11 +26641,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "patch": {
@@ -26688,11 +26688,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "parameters": [
@@ -26750,11 +26750,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "put": {
@@ -26795,11 +26795,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "patch": {
@@ -26842,11 +26842,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "parameters": [
@@ -26906,11 +26906,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "parameters": [
@@ -26996,11 +26996,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "parameters": [
@@ -27086,11 +27086,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "parameters": [
@@ -27184,11 +27184,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      }
     },
     "parameters": [
@@ -27290,11 +27290,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "parameters": [
@@ -27388,11 +27388,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "parameters": [
@@ -27494,11 +27494,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     },
     "parameters": [
@@ -27694,11 +27694,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "post": {
@@ -27739,11 +27739,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "delete": {
@@ -27818,11 +27818,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "parameters": [
@@ -27880,11 +27880,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "put": {
@@ -27925,11 +27925,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "delete": {
@@ -27991,11 +27991,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "patch": {
@@ -28038,11 +28038,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "parameters": [
@@ -28102,11 +28102,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "parameters": [
@@ -28166,11 +28166,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "parameters": [
@@ -28222,11 +28222,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "parameters": [
@@ -28312,11 +28312,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     },
     "parameters": [
@@ -28476,11 +28476,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -28566,11 +28566,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -28656,11 +28656,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -28790,11 +28790,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "post": {
@@ -28835,11 +28835,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "delete": {
@@ -28914,11 +28914,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -28984,11 +28984,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "put": {
@@ -29029,11 +29029,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "delete": {
@@ -29095,11 +29095,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "patch": {
@@ -29142,11 +29142,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -29204,11 +29204,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "put": {
@@ -29249,11 +29249,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "patch": {
@@ -29296,11 +29296,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -29404,11 +29404,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "post": {
@@ -29449,11 +29449,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "delete": {
@@ -29528,11 +29528,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -29598,11 +29598,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "put": {
@@ -29643,11 +29643,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "delete": {
@@ -29709,11 +29709,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "patch": {
@@ -29756,11 +29756,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -29828,11 +29828,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DeploymentRollback"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DeploymentRollback"
      }
     },
     "parameters": [
@@ -29890,11 +29890,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "put": {
@@ -29935,11 +29935,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "patch": {
@@ -29982,11 +29982,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "parameters": [
@@ -30044,11 +30044,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "put": {
@@ -30089,11 +30089,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "patch": {
@@ -30136,11 +30136,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -30244,11 +30244,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "post": {
@@ -30289,11 +30289,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "delete": {
@@ -30368,11 +30368,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -30438,11 +30438,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "put": {
@@ -30483,11 +30483,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "delete": {
@@ -30549,11 +30549,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "patch": {
@@ -30596,11 +30596,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -30658,11 +30658,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "put": {
@@ -30703,11 +30703,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "patch": {
@@ -30750,11 +30750,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -30858,11 +30858,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "post": {
@@ -30903,11 +30903,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "delete": {
@@ -30982,11 +30982,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -31052,11 +31052,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "put": {
@@ -31097,11 +31097,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "delete": {
@@ -31163,11 +31163,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "patch": {
@@ -31210,11 +31210,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -31318,11 +31318,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "post": {
@@ -31363,11 +31363,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "delete": {
@@ -31442,11 +31442,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -31512,11 +31512,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "put": {
@@ -31557,11 +31557,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "delete": {
@@ -31623,11 +31623,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "patch": {
@@ -31670,11 +31670,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -31732,11 +31732,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "put": {
@@ -31777,11 +31777,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "patch": {
@@ -31824,11 +31824,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "parameters": [
@@ -31886,11 +31886,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "put": {
@@ -31931,11 +31931,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "patch": {
@@ -31978,11 +31978,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -32040,11 +32040,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "put": {
@@ -32085,11 +32085,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "patch": {
@@ -32132,11 +32132,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "parameters": [
@@ -32196,11 +32196,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -32330,11 +32330,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "post": {
@@ -32375,11 +32375,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "delete": {
@@ -32454,11 +32454,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "parameters": [
@@ -32516,11 +32516,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "put": {
@@ -32561,11 +32561,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "delete": {
@@ -32627,11 +32627,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "patch": {
@@ -32674,11 +32674,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "parameters": [
@@ -32730,11 +32730,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -32864,11 +32864,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "post": {
@@ -32909,11 +32909,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "delete": {
@@ -32988,11 +32988,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "parameters": [
@@ -33050,11 +33050,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "put": {
@@ -33095,11 +33095,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "delete": {
@@ -33161,11 +33161,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "patch": {
@@ -33208,11 +33208,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "parameters": [
@@ -33264,11 +33264,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -33354,11 +33354,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -33444,11 +33444,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -33534,11 +33534,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -33632,11 +33632,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -33738,11 +33738,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -33836,11 +33836,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -33942,11 +33942,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -34040,11 +34040,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -34146,11 +34146,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -34244,11 +34244,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -34350,11 +34350,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -34448,11 +34448,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -34554,11 +34554,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -34644,11 +34644,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "parameters": [
@@ -34734,11 +34734,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     },
     "parameters": [
@@ -34832,11 +34832,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -34922,11 +34922,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "parameters": [
@@ -35012,11 +35012,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     },
     "parameters": [
@@ -35220,11 +35220,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "post": {
@@ -35265,11 +35265,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "delete": {
@@ -35344,11 +35344,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -35414,11 +35414,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "put": {
@@ -35459,11 +35459,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "delete": {
@@ -35525,11 +35525,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "patch": {
@@ -35572,11 +35572,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -35636,11 +35636,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -35726,11 +35726,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -35824,11 +35824,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -35930,11 +35930,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     },
     "parameters": [
@@ -36130,11 +36130,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "post": {
@@ -36175,11 +36175,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "delete": {
@@ -36254,11 +36254,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "parameters": [
@@ -36324,11 +36324,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "put": {
@@ -36369,11 +36369,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "delete": {
@@ -36435,11 +36435,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "patch": {
@@ -36482,11 +36482,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "parameters": [
@@ -36544,11 +36544,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "put": {
@@ -36589,11 +36589,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "patch": {
@@ -36636,11 +36636,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "parameters": [
@@ -36700,11 +36700,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "parameters": [
@@ -36790,11 +36790,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "parameters": [
@@ -36888,11 +36888,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "parameters": [
@@ -36994,11 +36994,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     },
     "parameters": [
@@ -37194,11 +37194,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "post": {
@@ -37239,11 +37239,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "delete": {
@@ -37318,11 +37318,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "parameters": [
@@ -37364,11 +37364,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "put": {
@@ -37409,11 +37409,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "delete": {
@@ -37475,11 +37475,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "patch": {
@@ -37522,11 +37522,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "parameters": [
@@ -37622,11 +37622,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "post": {
@@ -37667,11 +37667,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "delete": {
@@ -37746,11 +37746,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "parameters": [
@@ -37792,11 +37792,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "put": {
@@ -37837,11 +37837,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "delete": {
@@ -37903,11 +37903,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "patch": {
@@ -37950,11 +37950,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "parameters": [
@@ -38050,11 +38050,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "post": {
@@ -38095,11 +38095,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "delete": {
@@ -38174,11 +38174,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -38228,11 +38228,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "put": {
@@ -38273,11 +38273,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "delete": {
@@ -38339,11 +38339,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "patch": {
@@ -38386,11 +38386,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -38494,11 +38494,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "post": {
@@ -38539,11 +38539,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "delete": {
@@ -38618,11 +38618,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -38672,11 +38672,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "put": {
@@ -38717,11 +38717,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "delete": {
@@ -38783,11 +38783,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "patch": {
@@ -38830,11 +38830,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -38894,11 +38894,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -38984,11 +38984,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -39074,11 +39074,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "parameters": [
@@ -39164,11 +39164,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "parameters": [
@@ -39262,11 +39262,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "parameters": [
@@ -39352,11 +39352,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     },
     "parameters": [
@@ -39450,11 +39450,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -39548,11 +39548,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -39654,11 +39654,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -39752,11 +39752,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -39858,11 +39858,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -39948,11 +39948,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -40115,11 +40115,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "post": {
@@ -40160,11 +40160,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "delete": {
@@ -40239,11 +40239,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "parameters": [
@@ -40285,11 +40285,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "put": {
@@ -40330,11 +40330,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "delete": {
@@ -40396,11 +40396,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "patch": {
@@ -40443,11 +40443,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "parameters": [
@@ -40543,11 +40543,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "post": {
@@ -40588,11 +40588,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "delete": {
@@ -40667,11 +40667,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "parameters": [
@@ -40713,11 +40713,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "put": {
@@ -40758,11 +40758,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "delete": {
@@ -40824,11 +40824,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "patch": {
@@ -40871,11 +40871,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "parameters": [
@@ -40971,11 +40971,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "post": {
@@ -41016,11 +41016,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "delete": {
@@ -41095,11 +41095,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -41149,11 +41149,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "put": {
@@ -41194,11 +41194,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "delete": {
@@ -41260,11 +41260,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "patch": {
@@ -41307,11 +41307,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -41415,11 +41415,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "post": {
@@ -41460,11 +41460,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "delete": {
@@ -41539,11 +41539,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -41593,11 +41593,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "put": {
@@ -41638,11 +41638,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "delete": {
@@ -41704,11 +41704,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "patch": {
@@ -41751,11 +41751,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -41815,11 +41815,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -41905,11 +41905,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -41995,11 +41995,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "parameters": [
@@ -42085,11 +42085,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     },
     "parameters": [
@@ -42183,11 +42183,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "parameters": [
@@ -42273,11 +42273,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     },
     "parameters": [
@@ -42371,11 +42371,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -42469,11 +42469,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -42575,11 +42575,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -42673,11 +42673,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -42779,11 +42779,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     },
     "parameters": [
@@ -42869,11 +42869,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     },
     "parameters": [
@@ -43069,11 +43069,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "post": {
@@ -43114,11 +43114,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "delete": {
@@ -43193,11 +43193,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "parameters": [
@@ -43263,11 +43263,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "put": {
@@ -43308,11 +43308,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "delete": {
@@ -43374,11 +43374,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "patch": {
@@ -43421,11 +43421,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "parameters": [
@@ -43485,11 +43485,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "parameters": [
@@ -43575,11 +43575,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "parameters": [
@@ -43673,11 +43673,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "parameters": [
@@ -43779,11 +43779,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     },
     "parameters": [
@@ -43979,11 +43979,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "post": {
@@ -44024,11 +44024,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "delete": {
@@ -44103,11 +44103,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "parameters": [
@@ -44165,11 +44165,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "put": {
@@ -44210,11 +44210,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "delete": {
@@ -44276,11 +44276,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "patch": {
@@ -44323,11 +44323,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "parameters": [
@@ -44379,11 +44379,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "parameters": [
@@ -44469,11 +44469,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     },
     "parameters": [
@@ -44644,11 +44644,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "post": {
@@ -44689,11 +44689,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "delete": {
@@ -44768,11 +44768,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "parameters": [
@@ -44830,11 +44830,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "put": {
@@ -44875,11 +44875,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "delete": {
@@ -44941,11 +44941,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "patch": {
@@ -44988,11 +44988,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "parameters": [
@@ -45044,11 +45044,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "parameters": [
@@ -45134,11 +45134,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     },
     "parameters": [
@@ -46033,9 +46033,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Binding"
+      "group": "",
+      "version": "v1",
+      "kind": "Binding"
      }
     ]
    },
@@ -46165,9 +46165,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ComponentStatus"
+      "group": "",
+      "version": "v1",
+      "kind": "ComponentStatus"
      }
     ]
    },
@@ -46199,9 +46199,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ComponentStatusList"
+      "group": "",
+      "version": "v1",
+      "kind": "ComponentStatusList"
      }
     ]
    },
@@ -46230,9 +46230,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     ]
    },
@@ -46297,9 +46297,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMapList"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMapList"
      }
     ]
    },
@@ -46807,9 +46807,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Endpoints"
+      "group": "",
+      "version": "v1",
+      "kind": "Endpoints"
      }
     ]
    },
@@ -46841,9 +46841,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "EndpointsList"
+      "group": "",
+      "version": "v1",
+      "kind": "EndpointsList"
      }
     ]
    },
@@ -46960,9 +46960,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     ]
    },
@@ -46994,9 +46994,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "EventList"
+      "group": "",
+      "version": "v1",
+      "kind": "EventList"
      }
     ]
    },
@@ -47368,9 +47368,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRange"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRange"
      }
     ]
    },
@@ -47446,9 +47446,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "LimitRangeList"
+      "group": "",
+      "version": "v1",
+      "kind": "LimitRangeList"
      }
     ]
    },
@@ -47560,9 +47560,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     ]
    },
@@ -47594,9 +47594,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "NamespaceList"
+      "group": "",
+      "version": "v1",
+      "kind": "NamespaceList"
      }
     ]
    },
@@ -47647,9 +47647,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Node"
+      "group": "",
+      "version": "v1",
+      "kind": "Node"
      }
     ]
    },
@@ -47756,9 +47756,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "NodeList"
+      "group": "",
+      "version": "v1",
+      "kind": "NodeList"
      }
     ]
    },
@@ -48048,9 +48048,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolume"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolume"
      }
     ]
    },
@@ -48080,9 +48080,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaim"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaim"
      }
     ]
    },
@@ -48114,9 +48114,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeClaimList"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeClaimList"
      }
     ]
    },
@@ -48215,9 +48215,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PersistentVolumeList"
+      "group": "",
+      "version": "v1",
+      "kind": "PersistentVolumeList"
      }
     ]
    },
@@ -48391,9 +48391,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Pod"
+      "group": "",
+      "version": "v1",
+      "kind": "Pod"
      }
     ]
    },
@@ -48516,9 +48516,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodList"
+      "group": "",
+      "version": "v1",
+      "kind": "PodList"
      }
     ]
    },
@@ -48764,9 +48764,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplate"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplate"
      }
     ]
    },
@@ -48798,9 +48798,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "PodTemplateList"
+      "group": "",
+      "version": "v1",
+      "kind": "PodTemplateList"
      }
     ]
    },
@@ -49016,9 +49016,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationController"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationController"
      }
     ]
    },
@@ -49079,9 +49079,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ReplicationControllerList"
+      "group": "",
+      "version": "v1",
+      "kind": "ReplicationControllerList"
      }
     ]
    },
@@ -49199,9 +49199,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuota"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuota"
      }
     ]
    },
@@ -49233,9 +49233,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ResourceQuotaList"
+      "group": "",
+      "version": "v1",
+      "kind": "ResourceQuotaList"
      }
     ]
    },
@@ -49404,9 +49404,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     ]
    },
@@ -49471,9 +49471,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "SecretList"
+      "group": "",
+      "version": "v1",
+      "kind": "SecretList"
      }
     ]
    },
@@ -49578,9 +49578,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     ]
    },
@@ -49622,9 +49622,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccount"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccount"
      }
     ]
    },
@@ -49656,9 +49656,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceAccountList"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceAccountList"
      }
     ]
    },
@@ -49690,9 +49690,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceList"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceList"
      }
     ]
    },
@@ -50143,9 +50143,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfiguration"
      }
     ]
    },
@@ -50177,9 +50177,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ExternalAdmissionHookConfigurationList"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ExternalAdmissionHookConfigurationList"
      }
     ]
    },
@@ -50233,9 +50233,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfiguration"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfiguration"
      }
     ]
    },
@@ -50267,9 +50267,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "admissionregistration.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "InitializerConfigurationList"
+      "group": "admissionregistration.k8s.io",
+      "version": "v1alpha1",
+      "kind": "InitializerConfigurationList"
      }
     ]
    },
@@ -50379,9 +50379,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevision"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevision"
      }
     ]
    },
@@ -50413,9 +50413,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "ControllerRevisionList"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "ControllerRevisionList"
      }
     ]
    },
@@ -50445,9 +50445,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     ]
    },
@@ -50512,9 +50512,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "DeploymentList"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "DeploymentList"
      }
     ]
    },
@@ -50551,9 +50551,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "DeploymentRollback"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "DeploymentRollback"
      }
     ]
    },
@@ -50715,9 +50715,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     ]
    },
@@ -50780,9 +50780,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSet"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSet"
      }
     ]
    },
@@ -50812,9 +50812,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "apps",
-      "Version": "v1beta1",
-      "Kind": "StatefulSetList"
+      "group": "apps",
+      "version": "v1beta1",
+      "kind": "StatefulSetList"
      }
     ]
    },
@@ -50901,9 +50901,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "authentication.k8s.io",
-      "Version": "v1",
-      "Kind": "TokenReview"
+      "group": "authentication.k8s.io",
+      "version": "v1",
+      "kind": "TokenReview"
      }
     ]
    },
@@ -50991,9 +50991,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "authentication.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "TokenReview"
+      "group": "authentication.k8s.io",
+      "version": "v1beta1",
+      "kind": "TokenReview"
      }
     ]
    },
@@ -51081,9 +51081,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "authorization.k8s.io",
-      "Version": "v1",
-      "Kind": "LocalSubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1",
+      "kind": "LocalSubjectAccessReview"
      }
     ]
    },
@@ -51161,9 +51161,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "authorization.k8s.io",
-      "Version": "v1",
-      "Kind": "SelfSubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1",
+      "kind": "SelfSubjectAccessReview"
      }
     ]
    },
@@ -51208,9 +51208,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "authorization.k8s.io",
-      "Version": "v1",
-      "Kind": "SubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1",
+      "kind": "SubjectAccessReview"
      }
     ]
    },
@@ -51296,9 +51296,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "LocalSubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "LocalSubjectAccessReview"
      }
     ]
    },
@@ -51376,9 +51376,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "SelfSubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "SelfSubjectAccessReview"
      }
     ]
    },
@@ -51423,9 +51423,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "SubjectAccessReview"
+      "group": "authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "SubjectAccessReview"
      }
     ]
    },
@@ -51530,9 +51530,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscaler"
      }
     ]
    },
@@ -51564,9 +51564,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "HorizontalPodAutoscalerList"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "HorizontalPodAutoscalerList"
      }
     ]
    },
@@ -51657,9 +51657,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "autoscaling",
-      "Version": "v1",
-      "Kind": "Scale"
+      "group": "autoscaling",
+      "version": "v1",
+      "kind": "Scale"
      }
     ]
    },
@@ -51737,9 +51737,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscaler"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscaler"
      }
     ]
    },
@@ -51771,9 +51771,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "autoscaling",
-      "Version": "v2alpha1",
-      "Kind": "HorizontalPodAutoscalerList"
+      "group": "autoscaling",
+      "version": "v2alpha1",
+      "kind": "HorizontalPodAutoscalerList"
      }
     ]
    },
@@ -52038,9 +52038,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "Job"
+      "group": "batch",
+      "version": "v1",
+      "kind": "Job"
      }
     ]
    },
@@ -52105,9 +52105,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "batch",
-      "Version": "v1",
-      "Kind": "JobList"
+      "group": "batch",
+      "version": "v1",
+      "kind": "JobList"
      }
     ]
    },
@@ -52209,14 +52209,14 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJob"
      },
      {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJob"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJob"
      }
     ]
    },
@@ -52248,14 +52248,14 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "CronJobList"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "CronJobList"
      },
      {
-      "Group": "batch",
-      "Version": "v2alpha1",
-      "Kind": "ScheduledJobList"
+      "group": "batch",
+      "version": "v2alpha1",
+      "kind": "ScheduledJobList"
      }
     ]
    },
@@ -52353,9 +52353,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequest"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequest"
      }
     ]
    },
@@ -52407,9 +52407,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "certificates.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "CertificateSigningRequestList"
+      "group": "certificates.k8s.io",
+      "version": "v1beta1",
+      "kind": "CertificateSigningRequestList"
      }
     ]
    },
@@ -52509,9 +52509,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     ]
    },
@@ -52543,9 +52543,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSetList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSetList"
      }
     ]
    },
@@ -52668,9 +52668,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     ]
    },
@@ -52735,9 +52735,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DeploymentList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DeploymentList"
      }
     ]
    },
@@ -52774,9 +52774,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DeploymentRollback"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DeploymentRollback"
      }
     ]
    },
@@ -53001,9 +53001,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     ]
    },
@@ -53052,9 +53052,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "IngressList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "IngressList"
      }
     ]
    },
@@ -53140,9 +53140,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicy"
      }
     ]
    },
@@ -53193,9 +53193,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "NetworkPolicyList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "NetworkPolicyList"
      }
     ]
    },
@@ -53263,9 +53263,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicy"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicy"
      }
     ]
    },
@@ -53297,9 +53297,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "PodSecurityPolicyList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "PodSecurityPolicyList"
      }
     ]
    },
@@ -53418,9 +53418,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     ]
    },
@@ -53481,9 +53481,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSetList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSetList"
      }
     ]
    },
@@ -53644,9 +53644,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     ]
    },
@@ -53729,9 +53729,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResource"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResource"
      }
     ]
    },
@@ -53763,9 +53763,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ThirdPartyResourceList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ThirdPartyResourceList"
      }
     ]
    },
@@ -53791,9 +53791,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicy"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicy"
      }
     ]
    },
@@ -53844,9 +53844,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "networking.k8s.io",
-      "Version": "v1",
-      "Kind": "NetworkPolicyList"
+      "group": "networking.k8s.io",
+      "version": "v1",
+      "kind": "NetworkPolicyList"
      }
     ]
    },
@@ -53917,9 +53917,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "Eviction"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "Eviction"
      }
     ]
    },
@@ -53948,9 +53948,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudget"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudget"
      }
     ]
    },
@@ -53980,9 +53980,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "policy",
-      "Version": "v1beta1",
-      "Kind": "PodDisruptionBudgetList"
+      "group": "policy",
+      "version": "v1beta1",
+      "kind": "PodDisruptionBudgetList"
      }
     ]
    },
@@ -54075,9 +54075,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRole"
      }
     ]
    },
@@ -54114,9 +54114,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBinding"
      }
     ]
    },
@@ -54148,9 +54148,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleBindingList"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleBindingList"
      }
     ]
    },
@@ -54182,9 +54182,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "ClusterRoleList"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "ClusterRoleList"
      }
     ]
    },
@@ -54259,9 +54259,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "Role"
      }
     ]
    },
@@ -54298,9 +54298,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBinding"
      }
     ]
    },
@@ -54332,9 +54332,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleBindingList"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleBindingList"
      }
     ]
    },
@@ -54366,9 +54366,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "RoleList"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1alpha1",
+      "kind": "RoleList"
      }
     ]
    },
@@ -54447,9 +54447,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRole"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRole"
      }
     ]
    },
@@ -54486,9 +54486,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBinding"
      }
     ]
    },
@@ -54520,9 +54520,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleBindingList"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleBindingList"
      }
     ]
    },
@@ -54554,9 +54554,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "ClusterRoleList"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "ClusterRoleList"
      }
     ]
    },
@@ -54631,9 +54631,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "Role"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "Role"
      }
     ]
    },
@@ -54670,9 +54670,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBinding"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBinding"
      }
     ]
    },
@@ -54704,9 +54704,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleBindingList"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleBindingList"
      }
     ]
    },
@@ -54738,9 +54738,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "rbac.authorization.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "RoleList"
+      "group": "rbac.authorization.k8s.io",
+      "version": "v1beta1",
+      "kind": "RoleList"
      }
     ]
    },
@@ -54811,9 +54811,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPreset"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPreset"
      }
     ]
    },
@@ -54845,9 +54845,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "settings.k8s.io",
-      "Version": "v1alpha1",
-      "Kind": "PodPresetList"
+      "group": "settings.k8s.io",
+      "version": "v1alpha1",
+      "kind": "PodPresetList"
      }
     ]
    },
@@ -54920,9 +54920,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClass"
      }
     ]
    },
@@ -54954,9 +54954,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "storage.k8s.io",
-      "Version": "v1",
-      "Kind": "StorageClassList"
+      "group": "storage.k8s.io",
+      "version": "v1",
+      "kind": "StorageClassList"
      }
     ]
    },
@@ -54992,9 +54992,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClass"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClass"
      }
     ]
    },
@@ -55026,9 +55026,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "storage.k8s.io",
-      "Version": "v1beta1",
-      "Kind": "StorageClassList"
+      "group": "storage.k8s.io",
+      "version": "v1beta1",
+      "kind": "StorageClassList"
      }
     ]
    }

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -102,11 +102,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -192,11 +192,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -326,11 +326,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "post": {
@@ -371,11 +371,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -463,11 +463,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "post": {
@@ -508,11 +508,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "delete": {
@@ -587,11 +587,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -657,11 +657,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "put": {
@@ -702,11 +702,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "delete": {
@@ -768,11 +768,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "patch": {
@@ -815,11 +815,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -923,11 +923,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "post": {
@@ -968,11 +968,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "delete": {
@@ -1047,11 +1047,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -1117,11 +1117,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "put": {
@@ -1162,11 +1162,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "delete": {
@@ -1228,11 +1228,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "patch": {
@@ -1275,11 +1275,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -1383,11 +1383,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "post": {
@@ -1428,11 +1428,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "delete": {
@@ -1507,11 +1507,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -1577,11 +1577,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "put": {
@@ -1622,11 +1622,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "delete": {
@@ -1688,11 +1688,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "patch": {
@@ -1735,11 +1735,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -1843,11 +1843,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "post": {
@@ -1888,11 +1888,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "delete": {
@@ -1967,11 +1967,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -2037,11 +2037,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "put": {
@@ -2082,11 +2082,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "delete": {
@@ -2148,11 +2148,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "patch": {
@@ -2195,11 +2195,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -2257,11 +2257,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "put": {
@@ -2302,11 +2302,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "patch": {
@@ -2349,11 +2349,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -2427,11 +2427,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "put": {
@@ -2472,11 +2472,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "delete": {
@@ -2538,11 +2538,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "patch": {
@@ -2585,11 +2585,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -2649,11 +2649,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -2703,11 +2703,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "put": {
@@ -2748,11 +2748,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "patch": {
@@ -2795,11 +2795,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -2851,11 +2851,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -2941,11 +2941,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -3031,11 +3031,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -3121,11 +3121,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -3211,11 +3211,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -3301,11 +3301,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -3399,11 +3399,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     },
     "parameters": [
@@ -3505,11 +3505,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -3603,11 +3603,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     },
     "parameters": [
@@ -3709,11 +3709,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -3807,11 +3807,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -3913,11 +3913,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -4011,11 +4011,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -4117,11 +4117,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     },
     "parameters": [
@@ -4215,11 +4215,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     },
     "parameters": [
@@ -4305,11 +4305,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     },
     "parameters": [
@@ -4494,11 +4494,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -4584,11 +4584,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -4674,11 +4674,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -4808,11 +4808,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "post": {
@@ -4853,11 +4853,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "delete": {
@@ -4932,11 +4932,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -5002,11 +5002,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "put": {
@@ -5047,11 +5047,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "delete": {
@@ -5113,11 +5113,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "patch": {
@@ -5160,11 +5160,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -5222,11 +5222,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "put": {
@@ -5267,11 +5267,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "patch": {
@@ -5314,11 +5314,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -5422,11 +5422,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "post": {
@@ -5467,11 +5467,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "delete": {
@@ -5546,11 +5546,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -5616,11 +5616,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "put": {
@@ -5661,11 +5661,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "delete": {
@@ -5727,11 +5727,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "patch": {
@@ -5774,11 +5774,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -5846,11 +5846,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DeploymentRollback"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DeploymentRollback"
      }
     },
     "parameters": [
@@ -5908,11 +5908,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "put": {
@@ -5953,11 +5953,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "patch": {
@@ -6000,11 +6000,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "parameters": [
@@ -6062,11 +6062,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "put": {
@@ -6107,11 +6107,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "patch": {
@@ -6154,11 +6154,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -6262,11 +6262,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "post": {
@@ -6307,11 +6307,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "delete": {
@@ -6386,11 +6386,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -6456,11 +6456,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "put": {
@@ -6501,11 +6501,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "delete": {
@@ -6567,11 +6567,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "patch": {
@@ -6614,11 +6614,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -6676,11 +6676,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "put": {
@@ -6721,11 +6721,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "patch": {
@@ -6768,11 +6768,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -6876,11 +6876,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "post": {
@@ -6921,11 +6921,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "delete": {
@@ -7000,11 +7000,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -7070,11 +7070,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "put": {
@@ -7115,11 +7115,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "delete": {
@@ -7181,11 +7181,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "patch": {
@@ -7228,11 +7228,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -7290,11 +7290,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "put": {
@@ -7335,11 +7335,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "patch": {
@@ -7382,11 +7382,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     },
     "parameters": [
@@ -7444,11 +7444,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "put": {
@@ -7489,11 +7489,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "patch": {
@@ -7536,11 +7536,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -7600,11 +7600,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -7690,11 +7690,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -7780,11 +7780,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -7870,11 +7870,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -7960,11 +7960,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -8058,11 +8058,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     },
     "parameters": [
@@ -8164,11 +8164,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -8262,11 +8262,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     },
     "parameters": [
@@ -8368,11 +8368,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -8466,11 +8466,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     },
     "parameters": [
@@ -8572,11 +8572,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -8670,11 +8670,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -8776,11 +8776,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     },
     "parameters": [
@@ -8976,11 +8976,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "LIST",
+     "x-kubernetes-action": "list",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "post": {
@@ -9021,11 +9021,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "POST",
+     "x-kubernetes-action": "post",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "delete": {
@@ -9100,11 +9100,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETECOLLECTION",
+     "x-kubernetes-action": "deletecollection",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "parameters": [
@@ -9162,11 +9162,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "GET",
+     "x-kubernetes-action": "get",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "put": {
@@ -9207,11 +9207,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "delete": {
@@ -9273,11 +9273,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "DELETE",
+     "x-kubernetes-action": "delete",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "patch": {
@@ -9320,11 +9320,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PATCH",
+     "x-kubernetes-action": "patch",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "parameters": [
@@ -9384,11 +9384,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "PUT",
+     "x-kubernetes-action": "put",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "parameters": [
@@ -9440,11 +9440,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCHLIST",
+     "x-kubernetes-action": "watchlist",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "parameters": [
@@ -9530,11 +9530,11 @@
        "description": "Unauthorized"
       }
      },
-     "x-kubernetes-action": "WATCH",
+     "x-kubernetes-action": "watch",
      "x-kubernetes-group-version-kind": {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     },
     "parameters": [
@@ -10321,9 +10321,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "Cluster"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "Cluster"
      }
     ]
    },
@@ -10388,9 +10388,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "federation",
-      "Version": "v1beta1",
-      "Kind": "ClusterList"
+      "group": "federation",
+      "version": "v1beta1",
+      "kind": "ClusterList"
      }
     ]
    },
@@ -10650,9 +10650,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMap"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMap"
      }
     ]
    },
@@ -10717,9 +10717,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ConfigMapList"
+      "group": "",
+      "version": "v1",
+      "kind": "ConfigMapList"
      }
     ]
    },
@@ -11086,9 +11086,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Event"
+      "group": "",
+      "version": "v1",
+      "kind": "Event"
      }
     ]
    },
@@ -11120,9 +11120,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "EventList"
+      "group": "",
+      "version": "v1",
+      "kind": "EventList"
      }
     ]
    },
@@ -11553,9 +11553,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Namespace"
+      "group": "",
+      "version": "v1",
+      "kind": "Namespace"
      }
     ]
    },
@@ -11587,9 +11587,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "NamespaceList"
+      "group": "",
+      "version": "v1",
+      "kind": "NamespaceList"
      }
     ]
    },
@@ -12322,9 +12322,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Secret"
+      "group": "",
+      "version": "v1",
+      "kind": "Secret"
      }
     ]
    },
@@ -12389,9 +12389,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "SecretList"
+      "group": "",
+      "version": "v1",
+      "kind": "SecretList"
      }
     ]
    },
@@ -12496,9 +12496,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "Service"
+      "group": "",
+      "version": "v1",
+      "kind": "Service"
      }
     ]
    },
@@ -12530,9 +12530,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "",
-      "Version": "v1",
-      "Kind": "ServiceList"
+      "group": "",
+      "version": "v1",
+      "kind": "ServiceList"
      }
     ]
    },
@@ -12909,9 +12909,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSet"
      }
     ]
    },
@@ -12943,9 +12943,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DaemonSetList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DaemonSetList"
      }
     ]
    },
@@ -13068,9 +13068,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Deployment"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Deployment"
      }
     ]
    },
@@ -13135,9 +13135,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DeploymentList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DeploymentList"
      }
     ]
    },
@@ -13174,9 +13174,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "DeploymentRollback"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "DeploymentRollback"
      }
     ]
    },
@@ -13347,9 +13347,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Ingress"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Ingress"
      }
     ]
    },
@@ -13398,9 +13398,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "IngressList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "IngressList"
      }
     ]
    },
@@ -13490,9 +13490,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSet"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSet"
      }
     ]
    },
@@ -13553,9 +13553,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "ReplicaSetList"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "ReplicaSetList"
      }
     ]
    },
@@ -13681,9 +13681,9 @@
     },
     "x-kubernetes-group-version-kind": [
      {
-      "Group": "extensions",
-      "Version": "v1beta1",
-      "Kind": "Scale"
+      "group": "extensions",
+      "version": "v1beta1",
+      "kind": "Scale"
      }
     ]
    },

--- a/pkg/kubectl/cmd/util/openapi/openapi.go
+++ b/pkg/kubectl/cmd/util/openapi/openapi.go
@@ -370,15 +370,15 @@ func (o *Resources) getGroupVersionKind(s spec.Schema) (schema.GroupVersionKind,
 	if !ok {
 		return empty, fmt.Errorf("%s extension has unexpected type %T in %s", groupVersionKindExtensionKey, gvk, s.Extensions)
 	}
-	group, ok := gvkMap["Group"].(string)
+	group, ok := gvkMap["group"].(string)
 	if !ok {
 		return empty, fmt.Errorf("%s extension missing Group: %v", groupVersionKindExtensionKey, gvkMap)
 	}
-	version, ok := gvkMap["Version"].(string)
+	version, ok := gvkMap["version"].(string)
 	if !ok {
 		return empty, fmt.Errorf("%s extension missing Version: %v", groupVersionKindExtensionKey, gvkMap)
 	}
-	kind, ok := gvkMap["Kind"].(string)
+	kind, ok := gvkMap["kind"].(string)
 	if !ok {
 		return empty, fmt.Errorf("%s extension missing Kind: %v", groupVersionKindExtensionKey, gvkMap)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/group_version.go
@@ -75,9 +75,9 @@ func (gk *GroupKind) String() string {
 //
 // +protobuf.options.(gogoproto.goproto_stringer)=false
 type GroupVersionKind struct {
-	Group   string `protobuf:"bytes,1,opt,name=group"`
-	Version string `protobuf:"bytes,2,opt,name=version"`
-	Kind    string `protobuf:"bytes,3,opt,name=kind"`
+	Group   string `json:"group" protobuf:"bytes,1,opt,name=group"`
+	Version string `json:"version" protobuf:"bytes,2,opt,name=version"`
+	Kind    string `json:"kind" protobuf:"bytes,3,opt,name=kind"`
 }
 
 func (gvk GroupVersionKind) String() string {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -800,8 +800,12 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			return nil, fmt.Errorf("unrecognized action verb: %s", action.Verb)
 		}
 		for _, route := range routes {
-			route.Metadata(ROUTE_META_GVK, reqScope.Kind)
-			route.Metadata(ROUTE_META_ACTION, action.Verb)
+			route.Metadata(ROUTE_META_GVK, metav1.GroupVersionKind{
+				Group:   reqScope.Kind.Group,
+				Version: reqScope.Kind.Version,
+				Kind:    reqScope.Kind.Kind,
+			})
+			route.Metadata(ROUTE_META_ACTION, strings.ToLower(action.Verb))
 			ws.Route(route)
 		}
 		// Note: update GetAuthorizerAttributes() when adding a custom handler.


### PR DESCRIPTION
We are using two different GVK struct in generation of OpenAPI extensions. This PR unify that and also add json tags to meta.v1 GVK to comply with json naming system in other serializations. Also the value of Action extension is now lowercase.

ref: https://github.com/kubernetes/kubernetes/pull/46388
