### PR TITLE
Let kubemark exit if it fails to start

### DIFF
--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -89,7 +89,9 @@ func NewHollowKubelet(
 
 // Starts this HollowKubelet and blocks.
 func (hk *HollowKubelet) Run() {
-	kubeletapp.RunKubelet(hk.KubeletFlags, hk.KubeletConfiguration, hk.KubeletDeps, false, false)
+	if err := kubeletapp.RunKubelet(hk.KubeletFlags, hk.KubeletConfiguration, hk.KubeletDeps, false, false); err != nil {
+		glog.Fatalf("Failed to run HollowKubelet: %v. Exiting.", err)
+	}
 	select {}
 }
 


### PR DESCRIPTION
Fix the bug: If there is sth wrong to run hollow kubelet, kubemark will just hang instead of exiting. 

I came across the problem when I tried to start kubemark with no-root user.

```
I0523 15:27:39.721447   16855 docker_service.go:223] Setting cgroupDriver to cgroupfs
I0523 15:27:39.721634   16855 docker_legacy.go:151] No legacy containers found, stop performing legacy cleanup.
I0523 15:27:39.722208   16855 kubelet.go:559] Starting the GRPC server for the docker CRI shim.
I0523 15:27:39.722228   16855 docker_server.go:60] Start dockershim grpc server
I0523 15:27:39.722265   16855 server.go:819] failed to unlink socket file "/var/run/dockershim.sock": permission denied
E0523 15:27:39.722327   16855 container_manager_linux.go:98] Unable to ensure the docker processes run in the desired containers
``` 