### PR TITLE
Matches single without selector

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/fields/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/fields/selector_test.go
@@ -325,3 +325,73 @@ func TestRequiresExactMatch(t *testing.T) {
 		}
 	}
 }
+
+func TestTransform(t *testing.T) {
+	testCases := []struct {
+		name      string
+		selector  string
+		transform func(field, value string) (string, string, error)
+		result    string
+		isEmpty   bool
+	}{
+		{
+			name:      "empty selector",
+			selector:  "",
+			transform: func(field, value string) (string, string, error) { return field, value, nil },
+			result:    "",
+			isEmpty:   true,
+		},
+		{
+			name:      "no-op transform",
+			selector:  "a=b,c=d",
+			transform: func(field, value string) (string, string, error) { return field, value, nil },
+			result:    "a=b,c=d",
+			isEmpty:   false,
+		},
+		{
+			name:     "transform one field",
+			selector: "a=b,c=d",
+			transform: func(field, value string) (string, string, error) {
+				if field == "a" {
+					return "e", "f", nil
+				}
+				return field, value, nil
+			},
+			result:  "e=f,c=d",
+			isEmpty: false,
+		},
+		{
+			name:      "remove field to make empty",
+			selector:  "a=b",
+			transform: func(field, value string) (string, string, error) { return "", "", nil },
+			result:    "",
+			isEmpty:   true,
+		},
+		{
+			name:     "remove only one field",
+			selector: "a=b,c=d,e=f",
+			transform: func(field, value string) (string, string, error) {
+				if field == "c" {
+					return "", "", nil
+				}
+				return field, value, nil
+			},
+			result:  "a=b,e=f",
+			isEmpty: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := ParseAndTransformSelector(tc.selector, tc.transform)
+		if err != nil {
+			t.Errorf("[%d] unexpected error during Transform: %v", i, err)
+		}
+		if result.Empty() != tc.isEmpty {
+			t.Errorf("[%d] expected empty: %t, got: %t", i, tc.isEmpty, result.Empty)
+		}
+		if result.String() != tc.result {
+			t.Errorf("[%d] unexpected result: %s", i, result.String())
+		}
+	}
+
+}

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1032,7 +1032,16 @@ func (e *Store) Watch(ctx genericapirequest.Context, options *metainternalversio
 func (e *Store) WatchPredicate(ctx genericapirequest.Context, p storage.SelectionPredicate, resourceVersion string) (watch.Interface, error) {
 	if name, ok := p.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
-			w, err := e.Storage.Watch(ctx, key, resourceVersion, p)
+			// For performance reasons, we can optimize the further computations of
+			// selector, by removing then "matches-single" fields, because they are
+			// already satisfied by choosing appropriate key.
+			sp, err := p.RemoveMatchesSingleRequirements()
+			if err != nil {
+				glog.Warningf("Couldn't remove matches-single requirements: %v", err)
+				// Since we couldn't optimize selector, reset to the original one.
+				sp = p
+			}
+			w, err := e.Storage.Watch(ctx, key, resourceVersion, sp)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This is reducing cpu-usage of apiserver by ~5% in 5000-node clusters.