### PR TITLE
kube-apiserver: wait for synched caches before /healthz returns OK

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -168,6 +168,7 @@ func CreateKubeAPIServer(kubeAPIServerConfig *master.Config, delegateAPIServer g
 	}
 	kubeAPIServer.GenericAPIServer.AddPostStartHook("start-kube-apiserver-informers", func(context genericapiserver.PostStartHookContext) error {
 		sharedInformers.Start(context.StopCh)
+		sharedInformers.WaitForCacheSync(context.StopCh)
 		return nil
 	})
 


### PR DESCRIPTION
(Might) fix https://github.com/kubernetes/kubernetes/issues/45786.