### PR TITLE
audit: no RequestReceived events for read-only requests

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/BUILD
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
     ],
 )
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -21,12 +21,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
 )
 
 var (
-	ReadWrite = []string{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"}
-	Read      = []string{"get", "list", "watch"}
+	ReadWrite = request.ReadWriteVerbs
+	Read      = request.ReadVerbs
 
 	Label      = map[string]string{"kubernetes.io/bootstrapping": "rbac-defaults"}
 	Annotation = map[string]string{rbac.AutoUpdateAnnotationKey: "true"}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/audit_test.go
@@ -127,7 +127,7 @@ func TestAudit(t *testing.T) {
 			},
 			selfLinker,
 			200,
-			2,
+			1,
 			[]eventCheck{
 				noRequestBody(0),
 				responseBodyMatches(0, `{.*"name":"c".*}`),
@@ -144,7 +144,7 @@ func TestAudit(t *testing.T) {
 				namespace:   "other",
 			},
 			200,
-			2,
+			1,
 			[]eventCheck{
 				noRequestBody(0),
 				responseBodyMatches(0, `{.*"name":"a".*"name":"b".*}`),
@@ -259,7 +259,7 @@ func TestAudit(t *testing.T) {
 				namespace:   "other",
 			},
 			200,
-			3,
+			2,
 			[]eventCheck{
 				noRequestBody(0),
 				noResponseBody(0),

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -88,8 +88,12 @@ func WithAudit(handler http.Handler, requestContextMapper request.RequestContext
 			return
 		}
 
-		ev.Stage = auditinternal.StageRequestReceived
-		sink.ProcessEvents(ev)
+		// send first event for non-read-only requests
+		ri, _ := request.RequestInfoFrom(ctx)
+		if !(ri != nil && ri.ReadOnly) {
+			ev.Stage = auditinternal.StageRequestReceived
+			sink.ProcessEvents(ev)
+		}
 
 		// intercept the status code
 		var longRunningSink audit.Sink

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -207,7 +207,6 @@ func TestAudit(t *testing.T) {
 			"GET",
 			func(http.ResponseWriter, *http.Request) {},
 			[]string{
-				readOnlyShortRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				readOnlyShortRunningPrefix(auditinternal.StageResponseComplete) + ` response="200"`,
 			},
 		},
@@ -219,7 +218,6 @@ func TestAudit(t *testing.T) {
 				panic("kaboom")
 			},
 			[]string{
-				readOnlyShortRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				readOnlyShortRunningPrefix(auditinternal.StagePanic) + ` response="500"`,
 			},
 		},
@@ -293,7 +291,6 @@ func TestAudit(t *testing.T) {
 			"GET",
 			func(http.ResponseWriter, *http.Request) {},
 			[]string{
-				longRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				longRunningPrefix(auditinternal.StageResponseStarted) + ` response="200"`,
 				longRunningPrefix(auditinternal.StageResponseComplete) + ` response="200"`,
 			},
@@ -306,7 +303,6 @@ func TestAudit(t *testing.T) {
 				time.Sleep(delay)
 			},
 			[]string{
-				longRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				longRunningPrefix(auditinternal.StageResponseStarted) + ` response="200"`,
 				longRunningPrefix(auditinternal.StageResponseComplete) + ` response="200"`,
 			},
@@ -320,7 +316,6 @@ func TestAudit(t *testing.T) {
 				w.WriteHeader(403)
 			},
 			[]string{
-				longRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				longRunningPrefix(auditinternal.StageResponseStarted) + ` response="403"`,
 				longRunningPrefix(auditinternal.StageResponseComplete) + ` response="403"`,
 			},
@@ -333,7 +328,6 @@ func TestAudit(t *testing.T) {
 				w.Write([]byte("foo"))
 			},
 			[]string{
-				longRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				longRunningPrefix(auditinternal.StageResponseStarted) + ` response="200"`,
 				longRunningPrefix(auditinternal.StageResponseComplete) + ` response="200"`,
 			},
@@ -347,7 +341,6 @@ func TestAudit(t *testing.T) {
 				w.Write([]byte("foo"))
 			},
 			[]string{
-				longRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				longRunningPrefix(auditinternal.StageResponseStarted) + ` response="403"`,
 				longRunningPrefix(auditinternal.StageResponseComplete) + ` response="403"`,
 			},
@@ -360,7 +353,6 @@ func TestAudit(t *testing.T) {
 				panic("kaboom")
 			},
 			[]string{
-				longRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				longRunningPrefix(auditinternal.StagePanic) + ` response="500"`,
 			},
 		},
@@ -373,7 +365,6 @@ func TestAudit(t *testing.T) {
 				panic("kaboom")
 			},
 			[]string{
-				longRunningPrefix(auditinternal.StageRequestReceived) + ` response="<deferred>"`,
 				longRunningPrefix(auditinternal.StageResponseStarted) + ` response="200"`,
 				longRunningPrefix(auditinternal.StagePanic) + ` response="500"`,
 			},


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/46335