### PR TITLE
Fix minor bugs in setting API call metrics with subresource

### DIFF
--- a/test/e2e/framework/metrics_util.go
+++ b/test/e2e/framework/metrics_util.go
@@ -224,7 +224,7 @@ func (a *APIResponsiveness) Less(i, j int) bool {
 // Only 0.5, 0.9 and 0.99 quantiles are supported.
 func (a *APIResponsiveness) addMetricRequestLatency(resource, subresource, verb string, quantile float64, latency time.Duration) {
 	for i, apicall := range a.APICalls {
-		if apicall.Resource == resource && apicall.Verb == verb {
+		if apicall.Resource == resource && apicall.Subresource == subresource && apicall.Verb == verb {
 			a.APICalls[i] = setQuantileAPICall(apicall, quantile, latency)
 			return
 		}
@@ -255,7 +255,7 @@ func setQuantile(metric *LatencyMetric, quantile float64, latency time.Duration)
 // Add request count to the APICall metric entry (creating one if necessary).
 func (a *APIResponsiveness) addMetricRequestCount(resource, subresource, verb string, count int) {
 	for i, apicall := range a.APICalls {
-		if apicall.Resource == resource && apicall.Verb == verb {
+		if apicall.Resource == resource && apicall.Subresource == subresource && apicall.Verb == verb {
 			a.APICalls[i].Count += count
 			return
 		}

--- a/test/e2e/framework/perf_util.go
+++ b/test/e2e/framework/perf_util.go
@@ -41,9 +41,10 @@ func ApiCallToPerfData(apicalls *APIResponsiveness) *perftype.PerfData {
 			},
 			Unit: "ms",
 			Labels: map[string]string{
-				"Verb":     apicall.Verb,
-				"Resource": apicall.Resource,
-				"Count":    fmt.Sprintf("%v", apicall.Count),
+				"Verb":        apicall.Verb,
+				"Resource":    apicall.Resource,
+				"Subresource": apicall.Subresource,
+				"Count":       fmt.Sprintf("%v", apicall.Count),
 			},
 		}
 		perfData.DataItems = append(perfData.DataItems, item)


### PR DESCRIPTION
Based on changes from https://github.com/kubernetes/kubernetes/pull/46354

/cc @wojtek-t @smarterclayton 