### PR TITLE
Make "kubectl version" json format output more readable.

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -315,7 +315,7 @@ kube::test::version::object_to_file() {
 kube::test::version::json_object_to_file() {
   flags=$1
   file=$2
-  kubectl version $flags --output json | sed -e s/'\"'/''/g -e s/'}'/''/g -e s/'{'/''/g -e s/'clientVersion:'/'clientVersion:,'/ -e s/'serverVersion:'/'serverVersion:,'/ | tr , '\n' > "${file}"
+  kubectl version $flags --output json | sed -e s/' '/''/g -e s/'\"'/''/g -e s/'}'/''/g -e s/'{'/''/g -e s/'clientVersion:'/'clientVersion:,'/ -e s/'serverVersion:'/'serverVersion:,'/ | tr , '\n' > "${file}"
 }
 
 kube::test::version::json_client_server_object_to_file() {

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -66,7 +66,7 @@ func NewCmdVersion(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 	cmd.Flags().BoolP("client", "c", false, "Client version only (no server required).")
 	cmd.Flags().BoolP("short", "", false, "Print just the version number.")
-	cmd.Flags().String("output", "", "one of 'yaml' or 'json'")
+	cmd.Flags().StringP("output", "o", "", "One of 'yaml' or 'json'.")
 	cmd.Flags().MarkShorthandDeprecated("client", "please use --client instead.")
 	return cmd
 }
@@ -117,7 +117,7 @@ func (o *VersionOptions) Run(f cmdutil.Factory, out io.Writer) error {
 		}
 		fmt.Fprintln(out, string(marshalled))
 	case "json":
-		marshalled, err := json.Marshal(&versionInfo)
+		marshalled, err := json.MarshalIndent(&versionInfo, "", "  ")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
##39858 adds a flag --output to `kubectl version`, but the json format output is displayed in one line. It's not so readable. This PR fixes it.

and

- adds a shorthand for `output`
- ~~refactors that: if `--short` is specified, `--output` will be ignored~~

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43750

**Special notes for your reviewer**:
/cc @php-coder @alejandroEsc 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
