### PR TITLE
Kubeadm - Make code OS-agnostic

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"path"
+	"path/filepath"
 	"strconv"
 	"text/template"
 
@@ -217,7 +217,7 @@ func (i *Init) Run(out io.Writer) error {
 		return err
 	}
 
-	adminKubeConfigPath := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.AdminKubeConfigFileName)
+	adminKubeConfigPath := filepath.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.AdminKubeConfigFileName)
 	client, err := kubemaster.CreateClientAndWaitForAPI(adminKubeConfigPath)
 	if err != nil {
 		return err
@@ -269,7 +269,7 @@ func (i *Init) Run(out io.Writer) error {
 	}
 
 	ctx := map[string]string{
-		"KubeConfigPath": path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.AdminKubeConfigFileName),
+		"KubeConfigPath": filepath.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.AdminKubeConfigFileName),
 		"KubeConfigName": kubeadmconstants.AdminKubeConfigFileName,
 		"Token":          i.cfg.Token,
 		"MasterIP":       i.cfg.API.AdvertiseAddress,

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -17,7 +17,7 @@ limitations under the License.
 package constants
 
 import (
-	"path"
+	"path/filepath"
 	"time"
 
 	"k8s.io/client-go/pkg/api/v1"
@@ -102,8 +102,8 @@ var (
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
-	AuthorizationPolicyPath        = path.Join(KubernetesDir, "abac_policy.json")
-	AuthorizationWebhookConfigPath = path.Join(KubernetesDir, "webhook_authz.conf")
+	AuthorizationPolicyPath        = filepath.Join(KubernetesDir, "abac_policy.json")
+	AuthorizationWebhookConfigPath = filepath.Join(KubernetesDir, "webhook_authz.conf")
 
 	// DefaultTokenUsages specifies the default functions a token will get
 	DefaultTokenUsages = []string{"signing", "authentication"}

--- a/cmd/kubeadm/app/master/manifests.go
+++ b/cmd/kubeadm/app/master/manifests.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -135,12 +135,12 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 		staticPodSpecs[etcd] = etcdPod
 	}
 
-	manifestsPath := path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, "manifests")
+	manifestsPath := filepath.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, "manifests")
 	if err := os.MkdirAll(manifestsPath, 0700); err != nil {
 		return fmt.Errorf("failed to create directory %q [%v]", manifestsPath, err)
 	}
 	for name, spec := range staticPodSpecs {
-		filename := path.Join(manifestsPath, name+".yaml")
+		filename := filepath.Join(manifestsPath, name+".yaml")
 		serialized, err := yaml.Marshal(spec)
 		if err != nil {
 			return fmt.Errorf("failed to marshal manifest for %q to YAML [%v]", name, err)
@@ -332,12 +332,12 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, selfHosted bool, k
 		"insecure-port":                     "0",
 		"admission-control":                 kubeadmconstants.DefaultAdmissionControl,
 		"service-cluster-ip-range":          cfg.Networking.ServiceSubnet,
-		"service-account-key-file":          path.Join(cfg.CertificatesDir, kubeadmconstants.ServiceAccountPublicKeyName),
-		"client-ca-file":                    path.Join(cfg.CertificatesDir, kubeadmconstants.CACertName),
-		"tls-cert-file":                     path.Join(cfg.CertificatesDir, kubeadmconstants.APIServerCertName),
-		"tls-private-key-file":              path.Join(cfg.CertificatesDir, kubeadmconstants.APIServerKeyName),
-		"kubelet-client-certificate":        path.Join(cfg.CertificatesDir, kubeadmconstants.APIServerKubeletClientCertName),
-		"kubelet-client-key":                path.Join(cfg.CertificatesDir, kubeadmconstants.APIServerKubeletClientKeyName),
+		"service-account-key-file":          filepath.Join(cfg.CertificatesDir, kubeadmconstants.ServiceAccountPublicKeyName),
+		"client-ca-file":                    filepath.Join(cfg.CertificatesDir, kubeadmconstants.CACertName),
+		"tls-cert-file":                     filepath.Join(cfg.CertificatesDir, kubeadmconstants.APIServerCertName),
+		"tls-private-key-file":              filepath.Join(cfg.CertificatesDir, kubeadmconstants.APIServerKeyName),
+		"kubelet-client-certificate":        filepath.Join(cfg.CertificatesDir, kubeadmconstants.APIServerKubeletClientCertName),
+		"kubelet-client-key":                filepath.Join(cfg.CertificatesDir, kubeadmconstants.APIServerKubeletClientKeyName),
 		"secure-port":                       fmt.Sprintf("%d", cfg.API.BindPort),
 		"allow-privileged":                  "true",
 		"experimental-bootstrap-token-auth": "true",
@@ -347,13 +347,13 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, selfHosted bool, k
 		"requestheader-username-headers":     "X-Remote-User",
 		"requestheader-group-headers":        "X-Remote-Group",
 		"requestheader-extra-headers-prefix": "X-Remote-Extra-",
-		"requestheader-client-ca-file":       path.Join(cfg.CertificatesDir, kubeadmconstants.FrontProxyCACertName),
+		"requestheader-client-ca-file":       filepath.Join(cfg.CertificatesDir, kubeadmconstants.FrontProxyCACertName),
 		"requestheader-allowed-names":        "front-proxy-client",
 	}
 	if k8sVersion.AtLeast(v170) {
 		// add options which allow the kube-apiserver to act as a front-proxy to aggregated API servers
-		defaultArguments["proxy-client-cert-file"] = path.Join(cfg.CertificatesDir, kubeadmconstants.FrontProxyClientCertName)
-		defaultArguments["proxy-client-key-file"] = path.Join(cfg.CertificatesDir, kubeadmconstants.FrontProxyClientKeyName)
+		defaultArguments["proxy-client-cert-file"] = filepath.Join(cfg.CertificatesDir, kubeadmconstants.FrontProxyClientCertName)
+		defaultArguments["proxy-client-key-file"] = filepath.Join(cfg.CertificatesDir, kubeadmconstants.FrontProxyClientKeyName)
 	}
 
 	command = getComponentBaseCommand(apiServer)
@@ -421,11 +421,11 @@ func getControllerManagerCommand(cfg *kubeadmapi.MasterConfiguration, selfHosted
 	defaultArguments := map[string]string{
 		"address":                                                  "127.0.0.1",
 		"leader-elect":                                             "true",
-		"kubeconfig":                                               path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.ControllerManagerKubeConfigFileName),
-		"root-ca-file":                                             path.Join(cfg.CertificatesDir, kubeadmconstants.CACertName),
-		"service-account-private-key-file":                         path.Join(cfg.CertificatesDir, kubeadmconstants.ServiceAccountPrivateKeyName),
-		"cluster-signing-cert-file":                                path.Join(cfg.CertificatesDir, kubeadmconstants.CACertName),
-		"cluster-signing-key-file":                                 path.Join(cfg.CertificatesDir, kubeadmconstants.CAKeyName),
+		"kubeconfig":                                               filepath.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.ControllerManagerKubeConfigFileName),
+		"root-ca-file":                                             filepath.Join(cfg.CertificatesDir, kubeadmconstants.CACertName),
+		"service-account-private-key-file":                         filepath.Join(cfg.CertificatesDir, kubeadmconstants.ServiceAccountPrivateKeyName),
+		"cluster-signing-cert-file":                                filepath.Join(cfg.CertificatesDir, kubeadmconstants.CACertName),
+		"cluster-signing-key-file":                                 filepath.Join(cfg.CertificatesDir, kubeadmconstants.CAKeyName),
 		"insecure-experimental-approve-all-kubelet-csrs-for-group": bootstrapapi.BootstrapGroup,
 		"use-service-account-credentials":                          "true",
 		"controllers":                                              "*,bootstrapsigner,tokencleaner",
@@ -463,7 +463,7 @@ func getSchedulerCommand(cfg *kubeadmapi.MasterConfiguration, selfHosted bool) [
 	defaultArguments := map[string]string{
 		"address":      "127.0.0.1",
 		"leader-elect": "true",
-		"kubeconfig":   path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.SchedulerKubeConfigFileName),
+		"kubeconfig":   filepath.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, kubeadmconstants.SchedulerKubeConfigFileName),
 	}
 
 	command = getComponentBaseCommand(scheduler)

--- a/cmd/kubeadm/app/master/selfhosted.go
+++ b/cmd/kubeadm/app/master/selfhosted.go
@@ -19,7 +19,7 @@ package master
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -338,5 +338,5 @@ func getSchedulerDeployment(cfg *kubeadmapi.MasterConfiguration, volumes []v1.Vo
 }
 
 func buildStaticManifestFilepath(name string) string {
-	return path.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, "manifests", name+".yaml")
+	return filepath.Join(kubeadmapi.GlobalEnvParams.KubernetesDir, "manifests", name+".yaml")
 }

--- a/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"time"
 
 	certutil "k8s.io/client-go/util/cert"
@@ -198,13 +198,13 @@ func pathsForCertAndKey(pkiPath, name string) (string, string) {
 }
 
 func pathForCert(pkiPath, name string) string {
-	return path.Join(pkiPath, fmt.Sprintf("%s.crt", name))
+	return filepath.Join(pkiPath, fmt.Sprintf("%s.crt", name))
 }
 
 func pathForKey(pkiPath, name string) string {
-	return path.Join(pkiPath, fmt.Sprintf("%s.key", name))
+	return filepath.Join(pkiPath, fmt.Sprintf("%s.key", name))
 }
 
 func pathForPublicKey(pkiPath, name string) string {
-	return path.Join(pkiPath, fmt.Sprintf("%s.pub", name))
+	return filepath.Join(pkiPath, fmt.Sprintf("%s.pub", name))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes just got Windows Containers alpha support, opening the opportunity for kubeadm to also be used to setup, at least, Windows Server 2016 or newer worker nodes. With that in mind, we should take the effort of writing OS-agnostic code whenever possible, e.g. when dealing with the filesystem.

**Which issue this PR fixes** 
https://github.com/kubernetes/kubeadm/issues/108

**Special notes for your reviewer**:

**Release note**:
