### PR TITLE
Added example for status errors in go client

### DIFF
--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/BUILD
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/BUILD
@@ -19,6 +19,7 @@ go_library(
     srcs = ["main.go"],
     tags = ["automanaged"],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -43,6 +44,17 @@ func main() {
 			panic(err.Error())
 		}
 		fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
+
+		// Example for handling status errors
+		_, err = clientset.CoreV1().Pods("").Get("ExamplePodName", metav1.GetOptions{})
+		if statusError, isStatus := err.(*errors.StatusError); isStatus && statusError.Status().Reason == metav1.StatusReasonNotFound {
+			fmt.Printf("Pod not found\n")
+		} else if err != nil {
+			panic(err.Error())
+		} else {
+			fmt.Printf("Found pod\n")
+		}
+
 		time.Sleep(10 * time.Second)
 	}
 }

--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
@@ -45,10 +45,14 @@ func main() {
 		}
 		fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
 
-		// Example for handling status errors
+		// Examples for error handling:
+		// - Use helper functions like e.g. errors.IsNotFound()
+		// - And/or cast to StatusError and use its properties like e.g. ErrStatus.Message
 		_, err = clientset.CoreV1().Pods("").Get("ExamplePodName", metav1.GetOptions{})
-		if statusError, isStatus := err.(*errors.StatusError); isStatus && statusError.Status().Reason == metav1.StatusReasonNotFound {
+		if errors.IsNotFound(err) {
 			fmt.Printf("Pod not found\n")
+		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+			fmt.Printf("Error getting pod %v\n", statusError.ErrStatus.Message)
 		} else if err != nil {
 			panic(err.Error())
 		} else {

--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
@@ -48,7 +48,7 @@ func main() {
 		// Examples for error handling:
 		// - Use helper functions like e.g. errors.IsNotFound()
 		// - And/or cast to StatusError and use its properties like e.g. ErrStatus.Message
-		_, err = clientset.CoreV1().Pods("").Get("ExamplePodName", metav1.GetOptions{})
+		_, err = clientset.CoreV1().Pods("default").Get("example-xxxxx", metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			fmt.Printf("Pod not found\n")
 		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/BUILD
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/BUILD
@@ -19,6 +19,7 @@ go_library(
     srcs = ["main.go"],
     tags = ["automanaged"],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
@@ -59,10 +59,14 @@ func main() {
 		}
 		fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
 
-		// Example for handling status errors
+		// Examples for error handling:
+		// - Use helper functions like e.g. errors.IsNotFound()
+		// - And/or cast to StatusError and use its properties like e.g. ErrStatus.Message
 		_, err = clientset.CoreV1().Pods("").Get("ExamplePodName", metav1.GetOptions{})
-		if statusError, isStatus := err.(*errors.StatusError); isStatus && statusError.Status().Reason == metav1.StatusReasonNotFound {
+		if errors.IsNotFound(err) {
 			fmt.Printf("Pod not found\n")
+		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {
+			fmt.Printf("Error getting pod %v\n", statusError.ErrStatus.Message)
 		} else if err != nil {
 			panic(err.Error())
 		} else {

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
@@ -62,7 +62,7 @@ func main() {
 		// Examples for error handling:
 		// - Use helper functions like e.g. errors.IsNotFound()
 		// - And/or cast to StatusError and use its properties like e.g. ErrStatus.Message
-		_, err = clientset.CoreV1().Pods("").Get("ExamplePodName", metav1.GetOptions{})
+		_, err = clientset.CoreV1().Pods("default").Get("example-xxxxx", metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			fmt.Printf("Pod not found\n")
 		} else if statusError, isStatus := err.(*errors.StatusError); isStatus {

--- a/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/out-of-cluster-client-configuration/main.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -57,6 +58,17 @@ func main() {
 			panic(err.Error())
 		}
 		fmt.Printf("There are %d pods in the cluster\n", len(pods.Items))
+
+		// Example for handling status errors
+		_, err = clientset.CoreV1().Pods("").Get("ExamplePodName", metav1.GetOptions{})
+		if statusError, isStatus := err.(*errors.StatusError); isStatus && statusError.Status().Reason == metav1.StatusReasonNotFound {
+			fmt.Printf("Pod not found\n")
+		} else if err != nil {
+			panic(err.Error())
+		} else {
+			fmt.Printf("Found pod\n")
+		}
+
 		time.Sleep(10 * time.Second)
 	}
 }


### PR DESCRIPTION
This PR adds status error handling examples to the go client examples, for both in-cluster and out-of-cluster usage. Fixes https://github.com/kubernetes/client-go/issues/163