### PR TITLE
Federation: Revamp dns-controller unit testing

### DIFF
--- a/federation/pkg/dnsprovider/providers/google/clouddns/clouddns.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/clouddns.go
@@ -107,7 +107,7 @@ func NewFakeInterface() (dnsprovider.Interface, error) {
 	interface_ := newInterfaceWithStub("", service)
 	zones := service.ManagedZones_
 	// Add a fake zone to test against.
-	zone := &stubs.ManagedZone{Service: zones, Name_: "example.com", Rrsets: []stubs.ResourceRecordSet{}, Id_: 1}
+	zone := &stubs.ManagedZone{Name_: "example.com", Rrsets: []stubs.ResourceRecordSet{}, Id_: 1}
 	call := zones.Create(interface_.project(), zone)
 	if _, err := call.Do(); err != nil {
 		return nil, err

--- a/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/clouddns_test.go
@@ -27,11 +27,11 @@ import (
 	"k8s.io/kubernetes/federation/pkg/dnsprovider/tests"
 )
 
-func newTestInterface() (dnsprovider.Interface, error) {
+func newTestInterface(zones []string) (dnsprovider.Interface, error) {
 	// Use this to test the real cloud service - insert appropriate project-id.  Default token source will be used.  See
 	// https://github.com/golang/oauth2/blob/master/google/default.go for details.
 	// return dnsprovider.GetDnsProvider(ProviderName, strings.NewReader("\n[global]\nproject-id = federation0-cluster00"))
-	return NewFakeInterface() // Use this to stub out the entire cloud service
+	return NewFakeInterface(zones) // Use this to stub out the entire cloud service
 }
 
 var interface_ dnsprovider.Interface
@@ -39,7 +39,7 @@ var interface_ dnsprovider.Interface
 func TestMain(m *testing.M) {
 	flag.Parse()
 	var err error
-	interface_, err = newTestInterface()
+	interface_, err = newTestInterface([]string{"example.com"})
 	if err != nil {
 		fmt.Printf("Error creating interface: %v", err)
 		os.Exit(1)
@@ -128,7 +128,7 @@ func TestZonesID(t *testing.T) {
 	zone := firstZone(t)
 
 	zoneID := zone.ID()
-	if zoneID != "1" {
+	if zoneID != "0" {
 		t.Fatalf("Unexpected zone id: %q", zoneID)
 	}
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_create_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_create_call.go
@@ -39,6 +39,8 @@ func hashKey(set interfaces.ResourceRecordSet) string {
 }
 
 func (c ChangesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.Change, error) {
+	c.Service.Service.Lock()
+	defer c.Service.Service.Unlock()
 	if c.Error != nil {
 		return nil, c.Error
 	}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/changes_service.go
@@ -26,9 +26,13 @@ type ChangesService struct {
 }
 
 func (c *ChangesService) Create(project string, managedZone string, change interfaces.Change) interfaces.ChangesCreateCall {
+	c.Service.Lock()
+	defer c.Service.Unlock()
 	return &ChangesCreateCall{c, project, managedZone, change, nil}
 }
 
 func (c *ChangesService) NewChange(additions, deletions []interfaces.ResourceRecordSet) interfaces.Change {
+	c.Service.Lock()
+	defer c.Service.Unlock()
 	return &Change{c, additions, deletions}
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone.go
@@ -22,10 +22,9 @@ import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/i
 var _ interfaces.ManagedZone = ManagedZone{}
 
 type ManagedZone struct {
-	Service *ManagedZonesService
-	Name_   string
-	Id_     uint64
-	Rrsets  []ResourceRecordSet
+	Name_  string
+	Id_    uint64
+	Rrsets []ResourceRecordSet
 }
 
 func (m ManagedZone) Name() string {

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zone_create_call.go
@@ -34,6 +34,8 @@ type ManagedZonesCreateCall struct {
 }
 
 func (call ManagedZonesCreateCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZone, error) {
+	call.Service.Service.Lock()
+	defer call.Service.Service.Unlock()
 	if call.Error != nil {
 		return nil, *call.Error
 	}

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_delete_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_delete_call.go
@@ -34,6 +34,8 @@ type ManagedZonesDeleteCall struct {
 }
 
 func (call ManagedZonesDeleteCall) Do(opts ...googleapi.CallOption) error {
+	call.Service.Service.Lock()
+	defer call.Service.Service.Unlock()
 	if call.Error != nil { // Return the override value
 		return *call.Error
 	} else { // Just try to delete it from the in-memory array.

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_get_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_get_call.go
@@ -34,6 +34,8 @@ type ManagedZonesGetCall struct {
 }
 
 func (call ManagedZonesGetCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZone, error) {
+	call.Service.Service.Lock()
+	defer call.Service.Service.Unlock()
 	if call.Response != nil {
 		return call.Response, *call.Error
 	} else {

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_call.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_call.go
@@ -35,6 +35,8 @@ type ManagedZonesListCall struct {
 }
 
 func (call *ManagedZonesListCall) Do(opts ...googleapi.CallOption) (interfaces.ManagedZonesListResponse, error) {
+	call.Service.Service.Lock()
+	defer call.Service.Service.Unlock()
 	if call.Response != nil {
 		return *call.Response, *call.Error
 	} else {
@@ -43,17 +45,19 @@ func (call *ManagedZonesListCall) Do(opts ...googleapi.CallOption) (interfaces.M
 			return nil, fmt.Errorf("Project %s not found.", call.Project)
 		}
 		if call.DnsName_ != "" {
-			return &ManagedZonesListResponse{[]interfaces.ManagedZone{proj[call.DnsName_]}}, nil
+			return &ManagedZonesListResponse{call.Service, []interfaces.ManagedZone{proj[call.DnsName_]}}, nil
 		}
 		list := []interfaces.ManagedZone{}
 		for _, zone := range proj {
 			list = append(list, zone)
 		}
-		return &ManagedZonesListResponse{list}, nil
+		return &ManagedZonesListResponse{call.Service, list}, nil
 	}
 }
 
 func (call *ManagedZonesListCall) DnsName(dnsName string) interfaces.ManagedZonesListCall {
+	call.Service.Service.Lock()
+	defer call.Service.Service.Unlock()
 	call.DnsName_ = dnsName
 	return call
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_response.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_list_response.go
@@ -21,8 +21,13 @@ import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/i
 // Compile time check for interface adherence
 var _ interfaces.ManagedZonesListResponse = &ManagedZonesListResponse{}
 
-type ManagedZonesListResponse struct{ ManagedZones_ []interfaces.ManagedZone }
+type ManagedZonesListResponse struct {
+	Service       *ManagedZonesService
+	ManagedZones_ []interfaces.ManagedZone
+}
 
 func (response *ManagedZonesListResponse) ManagedZones() []interfaces.ManagedZone {
+	response.Service.Service.Lock()
+	defer response.Service.Service.Unlock()
 	return response.ManagedZones_
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/managed_zones_service.go
@@ -22,25 +22,36 @@ import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/i
 var _ interfaces.ManagedZonesService = &ManagedZonesService{}
 
 type ManagedZonesService struct {
-	Impl map[string]map[string]interfaces.ManagedZone
+	Service *Service
+	Impl    map[string]map[string]interfaces.ManagedZone
 }
 
 func (m *ManagedZonesService) Create(project string, managedzone interfaces.ManagedZone) interfaces.ManagedZonesCreateCall {
+	m.Service.Lock()
+	defer m.Service.Unlock()
 	return &ManagedZonesCreateCall{nil, m, project, managedzone.(*ManagedZone)}
 }
 
 func (m *ManagedZonesService) Delete(project string, managedZone string) interfaces.ManagedZonesDeleteCall {
+	m.Service.Lock()
+	defer m.Service.Unlock()
 	return &ManagedZonesDeleteCall{m, project, managedZone, nil}
 }
 
 func (m *ManagedZonesService) Get(project string, managedZone string) interfaces.ManagedZonesGetCall {
+	m.Service.Lock()
+	defer m.Service.Unlock()
 	return &ManagedZonesGetCall{m, project, managedZone, nil, nil, ""}
 }
 
 func (m *ManagedZonesService) List(project string) interfaces.ManagedZonesListCall {
+	m.Service.Lock()
+	defer m.Service.Unlock()
 	return &ManagedZonesListCall{m, project, nil, nil, ""}
 }
 
 func (m *ManagedZonesService) NewManagedZone(dnsName string) interfaces.ManagedZone {
-	return &ManagedZone{Service: m, Name_: dnsName}
+	m.Service.Lock()
+	defer m.Service.Unlock()
+	return &ManagedZone{Name_: dnsName}
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/rrsets_service.go
@@ -44,6 +44,8 @@ func (s ResourceRecordSetsService) managedZone(project, managedZone string) (*Ma
 }
 
 func (s ResourceRecordSetsService) List(project string, managedZone string) interfaces.ResourceRecordSetsListCall {
+	s.Service.Lock()
+	defer s.Service.Unlock()
 	if s.ListCall != nil {
 		return s.ListCall
 	}
@@ -60,6 +62,8 @@ func (s ResourceRecordSetsService) List(project string, managedZone string) inte
 }
 
 func (s ResourceRecordSetsService) Get(project, managedZone, name string) interfaces.ResourceRecordSetsListCall {
+	s.Service.Lock()
+	defer s.Service.Unlock()
 	if s.ListCall != nil {
 		return s.ListCall
 	}
@@ -77,7 +81,9 @@ func (s ResourceRecordSetsService) Get(project, managedZone, name string) interf
 	return &ResourceRecordSetsListCall{Response_: response}
 }
 
-func (service ResourceRecordSetsService) NewResourceRecordSet(name string, rrdatas []string, ttl int64, type_ rrstype.RrsType) interfaces.ResourceRecordSet {
+func (s ResourceRecordSetsService) NewResourceRecordSet(name string, rrdatas []string, ttl int64, type_ rrstype.RrsType) interfaces.ResourceRecordSet {
+	s.Service.Lock()
+	defer s.Service.Unlock()
 	rrset := ResourceRecordSet{Name_: name, Rrdatas_: rrdatas, Ttl_: ttl, Type_: string(type_)}
 	return rrset
 }

--- a/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/service.go
+++ b/federation/pkg/dnsprovider/providers/google/clouddns/internal/stubs/service.go
@@ -16,12 +16,17 @@ limitations under the License.
 
 package stubs
 
-import "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+import (
+	"sync"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces"
+)
 
 // Compile time check for interface adherence
 var _ interfaces.Service = &Service{}
 
 type Service struct {
+	sync.Mutex
 	Changes_      *ChangesService
 	ManagedZones_ *ManagedZonesService
 	Projects_     *ProjectsService
@@ -29,9 +34,9 @@ type Service struct {
 }
 
 func NewService() *Service {
-	s := &Service{}
+	s := &Service{sync.Mutex{}, nil, nil, nil, nil}
 	s.Changes_ = &ChangesService{s}
-	s.ManagedZones_ = &ManagedZonesService{}
+	s.ManagedZones_ = &ManagedZonesService{s, nil}
 	s.Projects_ = &ProjectsService{}
 	s.Rrsets_ = &ResourceRecordSetsService{s, nil}
 	return s

--- a/federation/pkg/federation-controller/service/dns/BUILD
+++ b/federation/pkg/federation-controller/service/dns/BUILD
@@ -13,12 +13,20 @@ go_test(
     deps = [
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset/fake:go_default_library",
+        "//federation/pkg/dnsprovider:go_default_library",
         "//federation/pkg/dnsprovider/providers/google/clouddns:go_default_library",
         "//federation/pkg/federation-controller/service/ingress:go_default_library",
         "//federation/pkg/federation-controller/util/test:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Revamped the existing dns-controller unit tests.
- Add more test cases. Increased the unit test coverage.
- Made fake clouddns dns provider to be called from multiple goroutines


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR is just for test improvement and to cover more test cases.

```release-note
NONE
```

cc @kubernetes/sig-federation-pr-reviews