### PR TITLE
Fixes kubectl cached discovery on Windows

### DIFF
--- a/pkg/kubectl/cmd/util/cached_discovery.go
+++ b/pkg/kubectl/cmd/util/cached_discovery.go
@@ -196,7 +196,7 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 		return err
 	}
 
-	err = f.Chmod(0755)
+	err = os.Chmod(f.Name(), 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubectl/issues/18

The `kubectl` cached discovery makes use of `func (f *File) Chmod(mode FileMode) error` which is not supported and errors out on Windows, making `kubectl get` and potentially a number of other commands to fail miserably on that platform. `os.Chmod` by file name, on the other hand, does not error out and should be used instead.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@deads2k @brendandburns @kubernetes/sig-cli-pr-reviews 