### PR TITLE
kubectl drain should print progress when it is attempting evictions

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -495,8 +495,10 @@ func (o *DrainOptions) evictPods(pods []api.Pod, policyGroupVersion string, getP
 				if err == nil {
 					break
 				} else if apierrors.IsTooManyRequests(err) {
-					time.Sleep(5 * time.Second)
-				} else {
+					retryInterval := 5
+					fmt.Fprintf(o.ErrOut, "Cannot evict pod as it would violate the pod's disruption budget. Retry in %v seconds\n", retryInterval)
+					time.Sleep(time.Duration(retryInterval) * time.Second)
+				} else if !apierrors.IsNotFound(err) {
 					errCh <- fmt.Errorf("error when evicting pod %q: %v", pod.Name, err)
 					return
 				}


### PR DESCRIPTION

fixes #46361

**Special notes for your reviewer**: Let me know if fmt.Printf is appropriate way to show the interim message. I did not find this type of pattern in cmd/kubectl/

**Release note**:NONE

