### PR TITLE
update NetworkPolicy e2e test for v1 semantics

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -128,6 +128,7 @@ go_library(
         "//pkg/apis/certificates/v1beta1:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//pkg/apis/networking:go_default_library",
         "//pkg/apis/rbac/v1beta1:go_default_library",
         "//pkg/apis/settings/v1alpha1:go_default_library",
         "//pkg/client/clientset_generated/clientset:go_default_library",


### PR DESCRIPTION
This makes the NetworkPolicy test at least correct for v1, although ideally we'll eventually add a few more tests... (So this covers about half of #46625.)

I've tested that this compiles, but not that it passes, since I don't have a v1-compatible NetworkPolicy implementation yet...

@caseydavenport @ozdanborne, maybe you're closer to having a testable plugin than I am?

**Release note**:
```release-note
NONE
```
