### PR TITLE
Switch gcloud compute copy-files to scp

### DIFF
--- a/cluster/log-dump.sh
+++ b/cluster/log-dump.sh
@@ -105,7 +105,7 @@ function copy-logs-from-node() {
         gce|gke|kubemark)
           # get-serial-port-output lets you ask for ports 1-4, but currently (11/21/2016) only port 1 contains useful information
           gcloud compute instances get-serial-port-output --project "${PROJECT}" --zone "${ZONE}" --port 1 "${node}" > "${dir}/serial-1.log" || true
-          gcloud compute copy-files --project "${PROJECT}" --zone "${ZONE}" "${node}:${scp_files}" "${dir}" > /dev/null || true
+          gcloud compute scp --recurse --project "${PROJECT}" --zone "${ZONE}" "${node}:${scp_files}" "${dir}" > /dev/null || true
           ;;
         aws)
           local ip=$(get_ssh_hostname "${node}")

--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -113,7 +113,7 @@ function execute-cmd-on-master-with-retries() {
 }
 
 function copy-files() {
-	run-gcloud-compute-with-retries copy-files --zone="${ZONE}" --project="${PROJECT}" $@
+	run-gcloud-compute-with-retries scp --recurse --zone="${ZONE}" --project="${PROJECT}" $@
 }
 
 function delete-master-instance-and-resources {


### PR DESCRIPTION
gcloud is deprecating `gcloud compute copy-files` and switching to `gcloud compute scp`. Make the change before things start to break.

https://cloud.google.com/sdk/gcloud/reference/compute/copy-files

Warnings we get: `W0529 10:28:59.097] WARNING: `gcloud compute copy-files` is deprecated.  Please use `gcloud compute scp` instead.  Note that `gcloud compute scp` does not have recursive copy on by default.  To turn on recursion, use the `--recurse` flag.`

/cc @jlowdermilk 
