### PR TITLE
Improve validation of active deadline seconds

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/golang/glog"
 
+	"math"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -2188,8 +2190,11 @@ func ValidatePodSpec(spec *api.PodSpec, fldPath *field.Path) field.ErrorList {
 	}
 
 	if spec.ActiveDeadlineSeconds != nil {
-		if *spec.ActiveDeadlineSeconds <= 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), spec.ActiveDeadlineSeconds, "must be greater than 0"))
+		if spec.ActiveDeadlineSeconds != nil {
+			value := *spec.ActiveDeadlineSeconds
+			if value < 1 || value > math.MaxUint32 {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), value, validation.InclusiveRangeError(1, math.MaxUint32)))
+			}
 		}
 	}
 
@@ -2575,8 +2580,8 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) field.ErrorList {
 	// 2.  from a positive value to a lesser, non-negative value
 	if newPod.Spec.ActiveDeadlineSeconds != nil {
 		newActiveDeadlineSeconds := *newPod.Spec.ActiveDeadlineSeconds
-		if newActiveDeadlineSeconds < 0 {
-			allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newActiveDeadlineSeconds, isNegativeErrorMsg))
+		if newActiveDeadlineSeconds < 0 || newActiveDeadlineSeconds > math.MaxUint32 {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newActiveDeadlineSeconds, validation.InclusiveRangeError(0, math.MaxUint32)))
 			return allErrs
 		}
 		if oldPod.Spec.ActiveDeadlineSeconds != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Improve validation of active deadline seconds to not allow it to be larger than max uint32.

If users choose a value that is too large, the conversion of that value to a duration in seconds can cause an overflow.  I see no practical benefit of having a value larger than uint32 at this time.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1456156

**Release note**:
```release-note
Restrict active deadline seconds max allowed value to be maximum uint32
```
