### PR TITLE
Kubelet max enforce active deadline

### DIFF
--- a/pkg/kubelet/active_deadline.go
+++ b/pkg/kubelet/active_deadline.go
@@ -18,6 +18,7 @@ package kubelet
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/clock"
@@ -94,5 +95,9 @@ func (m *activeDeadlineHandler) pastActiveDeadline(pod *v1.Pod) bool {
 	start := podStatus.StartTime.Time
 	duration := m.clock.Since(start)
 	allowedDuration := time.Duration(*pod.Spec.ActiveDeadlineSeconds) * time.Second
+	// check for an overflow, and if overflows, enforce the actual allowed max
+	if int64(allowedDuration) < int64(0) {
+		allowedDuration = time.Duration(math.MaxInt64)
+	}
 	return duration >= allowedDuration
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The kubelet detects if an overflow occurred when enforcing an active deadline.  If so, it sets the enforced active deadline to the maximum supported value.  This stops pods with really large active deadlines from being killed immediately since the overflow results in a negative value.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1456156

**Special notes for your reviewer**:
Ideally, we can tighten validation per https://github.com/kubernetes/kubernetes/pull/46640

I still think its useful for the kubelet to protect locally as well.