### PR TITLE
add ContainerRuntimeVersion to `kubectl get nodes -o=wide` output

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -71,7 +71,7 @@ var (
 	statefulSetColumns               = []string{"NAME", "DESIRED", "CURRENT", "AGE"}
 	endpointColumns                  = []string{"NAME", "ENDPOINTS", "AGE"}
 	nodeColumns                      = []string{"NAME", "STATUS", "AGE", "VERSION"}
-	nodeWideColumns                  = []string{"EXTERNAL-IP", "OS-IMAGE", "KERNEL-VERSION"}
+	nodeWideColumns                  = []string{"EXTERNAL-IP", "OS-IMAGE", "KERNEL-VERSION", "CONTAINER-RUNTIME"}
 	daemonSetColumns                 = []string{"NAME", "DESIRED", "CURRENT", "READY", "UP-TO-DATE", "AVAILABLE", "NODE-SELECTOR", "AGE"}
 	daemonSetWideColumns             = []string{"CONTAINER(S)", "IMAGE(S)", "SELECTOR"}
 	eventColumns                     = []string{"LASTSEEN", "FIRSTSEEN", "COUNT", "NAME", "KIND", "SUBOBJECT", "TYPE", "REASON", "SOURCE", "MESSAGE"}
@@ -1127,14 +1127,17 @@ func printNode(node *api.Node, w io.Writer, options printers.PrintOptions) error
 	}
 
 	if options.Wide {
-		osImage, kernelVersion := node.Status.NodeInfo.OSImage, node.Status.NodeInfo.KernelVersion
+		osImage, kernelVersion, crVersion := node.Status.NodeInfo.OSImage, node.Status.NodeInfo.KernelVersion, node.Status.NodeInfo.ContainerRuntimeVersion
 		if osImage == "" {
 			osImage = "<unknown>"
 		}
 		if kernelVersion == "" {
 			kernelVersion = "<unknown>"
 		}
-		if _, err := fmt.Fprintf(w, "\t%s\t%s\t%s", getNodeExternalIP(node), osImage, kernelVersion); err != nil {
+		if crVersion == "" {
+			crVersion = "<unknown>"
+		}
+		if _, err := fmt.Fprintf(w, "\t%s\t%s\t%s\t%s", getNodeExternalIP(node), osImage, kernelVersion, crVersion); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: adds container runtime version to `kubectl get nodes -o=wide` output as a way to surface more node-level information

When upgrading to a new container runtime version (docker 1.11 -> docker 1.12) or when experimenting with a different container runtime version (experimenting with rkt in a docker cluster), it's useful for cluster operators to see which nodes are running which container runtime version. `kubectl get nodes -o=wide` already provides kernel and OS version, and I believe adding container runtime version would be good.

**Release note**:
```release-note
container runtime version has been added to the output of `kubectl get nodes -o=wide` as `CONTAINER-RUNTIME`
```