### PR TITLE
add myself and liggitt to pkg/kubelet/certificats OWNERs

### DIFF
--- a/pkg/kubelet/certificate/OWNER
+++ b/pkg/kubelet/certificate/OWNER
@@ -1,0 +1,6 @@
+reviewers:
+- mikedanese
+- liggit
+approvers:
+- mikedanese
+- liggit


### PR DESCRIPTION
For as long a kubelet is using the internal client, this certificate
manager is bound to the kubelet. Once kubelet has moved to client-go we
plan to extract this library to be general purpose. In the meantime,
liggitt and I should handle reviews of this code.

@liggitt @timstclair 