### PR TITLE
Add jregan to OWNERS for kubectl isolation work.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,6 +10,7 @@ approvers:
   - brendandburns
   - dchen1107
   - jbeda
+  - jregan # To modify BUILD files per proposal #598
   - lavalamp
   - smarterclayton
   - thockin


### PR DESCRIPTION
The kubectl decoupling project (#598) requires many BUILD edits.

Even relatively simple PR's involve many OWNER files, e.g. #46317 involves five.

We plan to script-generate some PRs, and those may involve _hundreds_ of BUILD files.

This project will take many PRs, and collecting all approvals for each will be very time consuming.

**Release note**:
```release-note
NONE
```
