### PR TITLE
Implement kubectl get controllerrevisions

### DIFF
--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -23,6 +23,7 @@ go_test(
         "//pkg/api:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//pkg/api/v1:go_default_library",
+        "//pkg/apis/apps:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/extensions:go_default_library",


### PR DESCRIPTION
Before:
```console
$ kubectl get controllerrevisions 
error: unknown type &apps.ControllerRevision{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{....}...}
```
After:
```console
$ kubectl get controllerrevisions 
NAME          CONTROLLER       REVISION   AGE
foo-2312378   DaemonSet/foo    1          2d
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

@kubernetes/sig-apps-pr-reviews @kubernetes/sig-cli-maintainers 
