### PR TITLE
Expose vendor cni dir prefix

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -235,6 +235,7 @@ func (c *kubeletConfiguration) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.NetworkPluginDir, "network-plugin-dir", c.NetworkPluginDir, "<Warning: Alpha feature> The full path of the directory in which to search for network plugins or CNI config")
 	fs.StringVar(&c.CNIConfDir, "cni-conf-dir", c.CNIConfDir, "<Warning: Alpha feature> The full path of the directory in which to search for CNI config files. Default: /etc/cni/net.d")
 	fs.StringVar(&c.CNIBinDir, "cni-bin-dir", c.CNIBinDir, "<Warning: Alpha feature> The full path of the directory in which to search for CNI plugin binaries. Default: /opt/cni/bin")
+	fs.StringVar(&c.CNIVendorDirPrefix, "cni-vendor-dir-prefix", c.CNIVendorDirPrefix, "<Warning: Alpha feature> The full path of parent directory that houses all vendor CNI plugin binaries according to VendorCNIDirTemplate(\"<this-prefix>/opt/<cni-plugin-type>/bin\").  Default: \"\"")
 	fs.Int32Var(&c.NetworkPluginMTU, "network-plugin-mtu", c.NetworkPluginMTU, "<Warning: Alpha feature> The MTU to be passed to the network plugin, to override the default. Set to 0 to use the default 1460 MTU.")
 	fs.StringVar(&c.VolumePluginDir, "volume-plugin-dir", c.VolumePluginDir, "<Warning: Alpha feature> The full path of the directory in which to search for additional third party volume plugins")
 	fs.StringVar(&c.CloudProvider, "cloud-provider", c.CloudProvider, "The provider for cloud services. By default, kubelet will attempt to auto-detect the cloud provider. Specify empty string for running with no cloud provider.")

--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -99,7 +99,7 @@ func ProbeVolumePlugins(pluginDir string) []volume.VolumePlugin {
 }
 
 // ProbeNetworkPlugins collects all compiled-in plugins
-func ProbeNetworkPlugins(pluginDir, cniConfDir, cniBinDir string) []network.NetworkPlugin {
+func ProbeNetworkPlugins(pluginDir, cniConfDir, cniBinDir, cniVendorDirPrefix string) []network.NetworkPlugin {
 	allPlugins := []network.NetworkPlugin{}
 
 	// for backwards-compat, allow pluginDir as a source of CNI config files
@@ -112,7 +112,7 @@ func ProbeNetworkPlugins(pluginDir, cniConfDir, cniBinDir string) []network.Netw
 		binDir = pluginDir
 	}
 	// for each existing plugin, add to the list
-	allPlugins = append(allPlugins, cni.ProbeNetworkPlugins(cniConfDir, binDir)...)
+	allPlugins = append(allPlugins, cni.ProbeNetworkPlugins(cniConfDir, binDir, cniVendorDirPrefix)...)
 	allPlugins = append(allPlugins, kubenet.NewPlugin(binDir))
 
 	return allPlugins

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -160,7 +160,7 @@ func UnsecuredKubeletDeps(s *options.KubeletServer) (*kubelet.KubeletDeps, error
 		KubeClient:         nil,
 		ExternalKubeClient: nil,
 		Mounter:            mounter,
-		NetworkPlugins:     ProbeNetworkPlugins(s.NetworkPluginDir, s.CNIConfDir, s.CNIBinDir),
+		NetworkPlugins:     ProbeNetworkPlugins(s.NetworkPluginDir, s.CNIConfDir, s.CNIBinDir, s.CNIVendorDirPrefix),
 		OOMAdjuster:        oom.NewOOMAdjuster(),
 		OSInterface:        kubecontainer.RealOS{},
 		Writer:             writer,

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -112,6 +112,7 @@ cluster-signing-key-file
 cluster-tag
 cni-bin-dir
 cni-conf-dir
+cni-vendor-dir-prefix
 concurrent-deployment-syncs
 concurrent-endpoint-syncs
 concurrent-gc-syncs

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -332,6 +332,10 @@ type KubeletConfiguration struct {
 	// CNIBinDir is the full path of the directory in which to search for
 	// CNI plugin binaries
 	CNIBinDir string
+	// CNIVendorDirPrefix is full path of parent directory that houses all
+	// vendor CNI binaries according to VendorCNIDirTemplate
+	// ("<this-prefix>/opt/<plugin-type>/bin").  Default: ""
+	CNIVendorDirPrefix string
 	// volumePluginDir is the full path of the directory in which to search
 	// for additional third party volume plugins
 	VolumePluginDir string

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -403,6 +403,10 @@ type KubeletConfiguration struct {
 	// CNIBinDir is the full path of the directory in which to search for
 	// CNI plugin binaries
 	CNIBinDir string `json:"cniBinDir"`
+	// CNIVendorDirPrefix is full path of parent directory that houses all
+	// vendor CNI binaries according to VendorCNIDirTemplate
+	// ("<this-prefix>/opt/<plugin-type>/bin").  Default: ""
+	CNIVendorDirPrefix string `json:"cniVendorDirPrefix"`
 	// networkPluginMTU is the MTU to be passed to the network plugin,
 	// and overrides the default MTU for cases where it cannot be automatically
 	// computed (such as IPSEC).

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -435,6 +435,7 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_componentconfig_KubeletConfigu
 	out.NetworkPluginDir = in.NetworkPluginDir
 	out.CNIConfDir = in.CNIConfDir
 	out.CNIBinDir = in.CNIBinDir
+	out.CNIVendorDirPrefix = in.CNIVendorDirPrefix
 	out.NetworkPluginMTU = in.NetworkPluginMTU
 	out.VolumePluginDir = in.VolumePluginDir
 	out.CloudProvider = in.CloudProvider
@@ -632,6 +633,7 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 	out.NetworkPluginDir = in.NetworkPluginDir
 	out.CNIConfDir = in.CNIConfDir
 	out.CNIBinDir = in.CNIBinDir
+	out.CNIVendorDirPrefix = in.CNIVendorDirPrefix
 	out.VolumePluginDir = in.VolumePluginDir
 	out.CloudProvider = in.CloudProvider
 	out.CloudConfigFile = in.CloudConfigFile

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -94,6 +94,10 @@ type NetworkPluginSettings struct {
 	NonMasqueradeCIDR string
 	// PluginName is the name of the plugin, runtime shim probes for
 	PluginName string
+	// PluginVendorDirPrefix is full path of parent directory that houses all
+	// vendor CNI binaries according to VendorCNIDirTemplate
+	// ("<this-prefix>/opt/<plugin-type>/bin").  Default: ""
+	PluginVendorDirPrefix string
 	// PluginBinDir is the directory in which the binaries for the plugin with
 	// PluginName is kept. The admin is responsible for provisioning these
 	// binaries before-hand.
@@ -191,7 +195,7 @@ func NewDockerService(client libdocker.Interface, seccompProfileRoot string, pod
 		}
 	}
 	// dockershim currently only supports CNI plugins.
-	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDir, pluginSettings.PluginBinDir)
+	cniPlugins := cni.ProbeNetworkPlugins(pluginSettings.PluginConfDir, pluginSettings.PluginBinDir, pluginSettings.PluginVendorDirPrefix)
 	cniPlugins = append(cniPlugins, kubenet.NewPlugin(pluginSettings.PluginBinDir))
 	netHost := &dockerNetworkHost{
 		pluginSettings.LegacyRuntimeHost,

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -506,12 +506,13 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Kub
 		binDir = kubeCfg.NetworkPluginDir
 	}
 	pluginSettings := dockershim.NetworkPluginSettings{
-		HairpinMode:       hairpinMode,
-		NonMasqueradeCIDR: kubeCfg.NonMasqueradeCIDR,
-		PluginName:        kubeCfg.NetworkPluginName,
-		PluginConfDir:     kubeCfg.CNIConfDir,
-		PluginBinDir:      binDir,
-		MTU:               int(kubeCfg.NetworkPluginMTU),
+		HairpinMode:           hairpinMode,
+		NonMasqueradeCIDR:     kubeCfg.NonMasqueradeCIDR,
+		PluginName:            kubeCfg.NetworkPluginName,
+		PluginConfDir:         kubeCfg.CNIConfDir,
+		PluginBinDir:          binDir,
+		PluginVendorDirPrefix: kubeCfg.CNIVendorDirPrefix,
+		MTU: int(kubeCfg.NetworkPluginMTU),
 	}
 
 	// Remote runtime shim just cannot talk back to kubelet, so it doesn't

--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -88,8 +88,8 @@ func probeNetworkPluginsWithVendorCNIDirPrefix(pluginDir, binDir, vendorCNIDirPr
 	return []network.NetworkPlugin{plugin}
 }
 
-func ProbeNetworkPlugins(pluginDir, binDir string) []network.NetworkPlugin {
-	return probeNetworkPluginsWithVendorCNIDirPrefix(pluginDir, binDir, "")
+func ProbeNetworkPlugins(pluginDir, binDir, vendorDirPrefix string) []network.NetworkPlugin {
+	return probeNetworkPluginsWithVendorCNIDirPrefix(pluginDir, binDir, vendorDirPrefix)
 }
 
 func getDefaultCNINetwork(pluginDir, binDir, vendorCNIDirPrefix string) (*cniNetwork, error) {


### PR DESCRIPTION
Adds #46610 
**What this PR does / why we need it**:
- It adds `cni-vendor-dir-prefix` flag to kubelet to expose `cniVendorDirPrefix` for `VendorCNIDirTemplate` in https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/network/cni/cni.go#L39

- also makes changes to kubelet/dockershim to use the `cni-vendor-dir-prefix`