### PR TITLE
Let hardcoded auth options override AuthProvider in kubectl.

### DIFF
--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -59,7 +59,11 @@ func HTTPWrappersForConfig(config *Config, rt http.RoundTripper) (http.RoundTrip
 // TransportConfig converts a client config to an appropriate transport config.
 func (c *Config) TransportConfig() (*transport.Config, error) {
 	wt := c.WrapTransport
-	if c.AuthProvider != nil {
+	if c.AuthProvider != nil &&
+		len(c.BearerToken) == 0 &&
+		len(c.Username) == 0 &&
+		len(c.KeyFile) == 0 &&
+		len(c.KeyData) == 0 {
 		provider, err := GetAuthProvider(c.Host, c.AuthProvider, c.AuthConfigPersister)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**: 
If authorization options are hard-coded (either through config or command-line), let them override the AuthProvider config.
AuthProviders are usually specified in a kubeconfig file, but it is useful to be able to easily override things on the command line (e.g. `kubectl --token ...`). 

**Which issue this PR fixes**: fixes #44476

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Explicit client authorization options (e.g. BearerToken, Username, KeyFile/KeyData) now override a specified AuthProvider.
```
