### PR TITLE
Add check to avoid panic

### DIFF
--- a/pkg/controller/bootstrap/util.go
+++ b/pkg/controller/bootstrap/util.go
@@ -43,7 +43,7 @@ func getSecretString(secret *v1.Secret, key string) string {
 // parseSecretName parses the name of the secret to extract the secret ID.
 func parseSecretName(name string) (secretID string, ok bool) {
 	r := nameRegExp.FindStringSubmatch(name)
-	if r == nil {
+	if r == nil || len(r) != 2 {
 		return "", false
 	}
 	return r[1], true
@@ -93,10 +93,10 @@ func validateSecretForSigning(secret *v1.Secret) (tokenID, tokenSecret string, o
 func isSecretExpired(secret *v1.Secret) bool {
 	expiration := getSecretString(secret, bootstrapapi.BootstrapTokenExpirationKey)
 	if len(expiration) > 0 {
-		expTime, err2 := time.Parse(time.RFC3339, expiration)
-		if err2 != nil {
+		expTime, err := time.Parse(time.RFC3339, expiration)
+		if err != nil {
 			glog.V(3).Infof("Unparseable expiration time (%s) in %s/%s Secret: %v. Treating as expired.",
-				expiration, secret.Namespace, secret.Name, err2)
+				expiration, secret.Namespace, secret.Name, err)
 			return true
 		}
 		if time.Now().After(expTime) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
If len(r) != 2, otherwise r[1] does not exist, it may panic.
Secondly, err2 is odd.  err  instead would be better.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
