### PR TITLE
hack/update-swagger-spec.sh: use posix regex syntax

### DIFF
--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -69,7 +69,7 @@ kube::log::status "Starting kube-apiserver"
   --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --advertise-address="10.10.10.10" \
   --cert-dir="${TMP_DIR}/certs" \
-  --runtime-config=$(echo "${KUBE_AVAILABLE_GROUP_VERSIONS}" | sed "s|\s|,|g") \
+  --runtime-config=$(echo "${KUBE_AVAILABLE_GROUP_VERSIONS}" | sed -E 's|[[:blank:]]+|,|g') \
   --service-cluster-ip-range="10.0.0.0/24" >/tmp/swagger-api-server.log 2>&1 &
 APISERVER_PID=$!
 


### PR DESCRIPTION
`\s` is a GNU extension, breaking builds with BSD sed.