### PR TITLE
Add event exporter deployment to the fluentd-gcp addon

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: event-exporter-sa
+  namespace: kube-system
+  labels:
+    k8s-app: event-exporter
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: event-exporter-rb
+  namespace: kube-system
+  labels:
+    k8s-app: event-exporter
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: event-exporter-sa
+  namespace: kube-system
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: event-exporter-v0.1.0
+  namespace: kube-system
+  labels:
+    k8s-app: event-exporter
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: event-exporter
+    spec:
+      serviceAccountName: event-exporter-sa
+      containers:
+      # TODO: Add resources in 1.8
+      - name: event-exporter
+        image: gcr.io/google-containers/event-exporter:v0.1.0
+        command:
+        - '/event-exporter'
+      - name: prometheus-to-sd-exporter
+        image: gcr.io/google-containers/prometheus-to-sd:v0.1.2
+        command:
+          - /monitor
+          - --component=event_exporter
+          - --stackdriver-prefix=container.googleapis.com/internal/addons
+          - --whitelisted-metrics=stackdriver_sink_received_entry_count,stackdriver_sink_request_count,stackdriver_sink_successfully_sent_entry_count
+        volumeMounts:
+        - name: ssl-certs
+          mountPath: /etc/ssl/certs
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: ssl-certs
+        hostPath:
+          path: /etc/ssl/certs


### PR DESCRIPTION
Introduce event exporter deployment to the fluentd-gcp addon so that by default if logging to Stackdriver is enabled, events will be available there also.

In this release, event exporter is a non-critical pod in BestEffort QoS class to avoid preempting actual workload in tightly loaded clusters. It will become critical in one of the future releases.


```release-note
Stackdriver cluster logging now deploys a new component to export Kubernetes events.
```