### PR TITLE
Fix unit test for kubectl create role

### DIFF
--- a/pkg/kubectl/cmd/create_role_test.go
+++ b/pkg/kubectl/cmd/create_role_test.go
@@ -344,8 +344,8 @@ func TestValidate(t *testing.T) {
 	for name, test := range tests {
 		test.roleOptions.Mapper, _ = f.Object()
 		err := test.roleOptions.Validate()
-		if test.expectErr && err != nil {
-			continue
+		if test.expectErr && err == nil {
+			t.Errorf("%s: expect error happens but validate passes.", name)
 		}
 		if !test.expectErr && err != nil {
 			t.Errorf("%s: unexpected error: %v", name, err)
@@ -492,8 +492,13 @@ func TestComplete(t *testing.T) {
 		if !test.expectErr && err != nil {
 			t.Errorf("%s: unexpected error: %v", name, err)
 		}
-		if test.expectErr && err != nil {
-			continue
+
+		if test.expectErr {
+			if err != nil {
+				continue
+			} else {
+				t.Errorf("%s: expect error happens but test passes.", name)
+			}
 		}
 
 		if test.roleOptions.Name != test.expected.Name {


### PR DESCRIPTION
When expected err is not nil but error deos not happen, we should report error in unit test.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
