### PR TITLE
Fix cross-build by having active deadline seconds use maxInt32

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2191,8 +2191,8 @@ func ValidatePodSpec(spec *api.PodSpec, fldPath *field.Path) field.ErrorList {
 
 	if spec.ActiveDeadlineSeconds != nil {
 		value := *spec.ActiveDeadlineSeconds
-		if value < 1 || value > math.MaxUint32 {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), value, validation.InclusiveRangeError(1, math.MaxUint32)))
+		if value < 1 || value > math.MaxInt32 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), value, validation.InclusiveRangeError(1, math.MaxInt32)))
 		}
 	}
 
@@ -2578,8 +2578,8 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) field.ErrorList {
 	// 2.  from a positive value to a lesser, non-negative value
 	if newPod.Spec.ActiveDeadlineSeconds != nil {
 		newActiveDeadlineSeconds := *newPod.Spec.ActiveDeadlineSeconds
-		if newActiveDeadlineSeconds < 0 || newActiveDeadlineSeconds > math.MaxUint32 {
-			allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newActiveDeadlineSeconds, validation.InclusiveRangeError(0, math.MaxUint32)))
+		if newActiveDeadlineSeconds < 0 || newActiveDeadlineSeconds > math.MaxInt32 {
+			allErrs = append(allErrs, field.Invalid(specPath.Child("activeDeadlineSeconds"), newActiveDeadlineSeconds, validation.InclusiveRangeError(0, math.MaxInt32)))
 			return allErrs
 		}
 		if oldPod.Spec.ActiveDeadlineSeconds != nil {

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2190,11 +2190,9 @@ func ValidatePodSpec(spec *api.PodSpec, fldPath *field.Path) field.ErrorList {
 	}
 
 	if spec.ActiveDeadlineSeconds != nil {
-		if spec.ActiveDeadlineSeconds != nil {
-			value := *spec.ActiveDeadlineSeconds
-			if value < 1 || value > math.MaxUint32 {
-				allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), value, validation.InclusiveRangeError(1, math.MaxUint32)))
-			}
+		value := *spec.ActiveDeadlineSeconds
+		if value < 1 || value > math.MaxUint32 {
+			allErrs = append(allErrs, field.Invalid(fldPath.Child("activeDeadlineSeconds"), value, validation.InclusiveRangeError(1, math.MaxUint32)))
 		}
 	}
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -3443,7 +3443,7 @@ func TestValidateDNSPolicy(t *testing.T) {
 
 func TestValidatePodSpec(t *testing.T) {
 	activeDeadlineSeconds := int64(30)
-	activeDeadlineSecondsMax := int64(math.MaxUint32)
+	activeDeadlineSecondsMax := int64(math.MaxInt32)
 
 	minUserID := types.UnixUserID(0)
 	maxUserID := types.UnixUserID(2147483647)
@@ -3559,7 +3559,7 @@ func TestValidatePodSpec(t *testing.T) {
 	}
 
 	activeDeadlineSeconds = int64(0)
-	activeDeadlineSecondsTooLarge := int64(math.MaxUint32 + 1)
+	activeDeadlineSecondsTooLarge := int64(math.MaxInt32 + 1)
 
 	minUserID = types.UnixUserID(-1)
 	maxUserID = types.UnixUserID(2147483648)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes cross build by having active deadline seconds use maxInt32 in validation.
In effect, this means the largest active deadline on a pod is ~68 years.  Long enough.
Removes a redundant if-block in the validation code path.

We need this to fix cross build.