### PR TITLE
Shorten issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,53 +1,29 @@
-<!-- Thanks for filing an issue! Before hitting the button, please answer these questions.-->
+<!-- This form is for bug reports and feature requests ONLY! 
 
-**Is this a request for help?** (If yes, you should use our troubleshooting guide and community support channels, see https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/.):
-
-**Note:** Please file issues for subcomponents under the appropriate repo
-
-| Component | Repo                                                               |
-| --------- | ------------------------------------------------------------------ |
-| kubectl   | [kubernetes/kubectl](https://github.com/kubernetes/kubectl/issues/new) |
-| kubeadm   | [kubernetes/kubeadm](https://github.com/kubernetes/kubeadm/issues/new) |
-
-**What keywords did you search in Kubernetes issues before filing this one?** (If you have found any duplicates, you should instead reply there.):
-
----
-
-**Is this a BUG REPORT or FEATURE REQUEST?** (choose one):
-
-<!--
-If this is a BUG REPORT, please:
-  - Fill in as much of the template below as you can.  If you leave out
-    information, we can't help you as well.
-
-If this is a FEATURE REQUEST, please:
-  - Describe *in detail* the feature/behavior/change you'd like to see.
-
-In both cases, be ready for followup questions, and please respond in a timely
-manner.  If we can't reproduce a bug or think a feature already exists, we
-might close your issue.  If we're wrong, PLEASE feel free to reopen it and
-explain why.
+If you're looking for help check [Stack Overflow](https://stackoverflow.com/questions/tagged/kubernetes) and the [troubleshooting guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/).
 -->
 
-**Kubernetes version** (use `kubectl version`):
+**Is this a BUG REPORT or FEATURE REQUEST?**:
 
-
-**Environment**:
-- **Cloud provider or hardware configuration**:
-- **OS** (e.g. from /etc/os-release):
-- **Kernel** (e.g. `uname -a`):
-- **Install tools**:
-- **Others**:
+> Uncomment only one, leave it on its own line: 
+>
+> /kind bug
+> /kind feature
 
 
 **What happened**:
 
-
 **What you expected to happen**:
 
+**How to reproduce it (as minimally and precisely as possible)**:
 
-**How to reproduce it** (as minimally and precisely as possible):
 
+**Anything else we need to know?**:
 
-**Anything else we need to know**:
-
+**Environment**:
+- Kubernetes version (use `kubectl version`):
+- Cloud provider or hardware configuration**:
+- OS (e.g. from /etc/os-release):
+- Kernel (e.g. `uname -a`):
+- Install tools:
+- Others:


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed on contrib-ex, this shortens the github issue template. 

- Be more explicit about sending people to stackoverflow for support
- Add boilerplate for setting an issue as a bug or feature
- Add boilerplate for setting a SIG
- Cut out the rest for brevity.