### PR TITLE
Set ENABLE_LEGACY_ABAC to false in GCE/GKE.

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -252,7 +252,7 @@ SCHEDULING_ALGORITHM_PROVIDER="${SCHEDULING_ALGORITHM_PROVIDER:-}"
 ENABLE_DEFAULT_STORAGE_CLASS="${ENABLE_DEFAULT_STORAGE_CLASS:-true}"
 
 # Optional: Enable legacy ABAC policy that makes all service accounts superusers.
-ENABLE_LEGACY_ABAC="${ENABLE_LEGACY_ABAC:-true}" # true, false
+ENABLE_LEGACY_ABAC="${ENABLE_LEGACY_ABAC:-false}" # true, false
 
 # TODO(dawn1107): Remove this once the flag is built into CVM image.
 # Kernel panic upon soft lockup issue

--- a/cluster/gke/config-default.sh
+++ b/cluster/gke/config-default.sh
@@ -47,3 +47,6 @@ KUBE_DELETE_NETWORK=${KUBE_DELETE_NETWORK:-false}
 # authentication) in metadata should be treated as canonical, and therefore disk
 # copies ought to be recreated/clobbered.
 METADATA_CLOBBERS_CONFIG=true
+
+# Default the ABAC authorizer to off
+ENABLE_LEGACY_ABAC="${ENABLE_LEGACY_ABAC:-false}" # true, false

--- a/cluster/gke/config-test.sh
+++ b/cluster/gke/config-test.sh
@@ -26,3 +26,6 @@ KUBE_DELETE_NETWORK=${KUBE_DELETE_NETWORK:-true}
 # For ease of maintenance, extract any pieces that do not vary between default
 # and test in a common config.
 source $(dirname "${BASH_SOURCE}")/config-common.sh
+
+# Default the ABAC authorizer to off
+ENABLE_LEGACY_ABAC="${ENABLE_LEGACY_ABAC:-false}" # true, false


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables the legacy ABAC authorizer by default on GCE/GKE clusters using kube-up.sh (and upgrades on GCE clusters using upgrade.sh).

**Release note**:
```release-note
New GCE or GKE clusters created with `cluster/kube-up.sh` will not enable the legacy ABAC authorizer by default. GCE clusters upgraded using `cluster/gce/upgrade.sh` will also disable the legacy ABAC authorizer. If you would like to enable the legacy ABAC authorizer, set ENABLE_LEGACY_ABAC to "true" before running `cluster/kube-up.sh` or `cluster/gce/upgrade.sh`.
```
