### PR TITLE
Support custom domains in the cockroachdb example's init container

### DIFF
--- a/examples/cockroachdb/cockroachdb-statefulset.yaml
+++ b/examples/cockroachdb/cockroachdb-statefulset.yaml
@@ -88,9 +88,12 @@ spec:
       # has to decide what command-line flags to use when starting CockroachDB.
       # This only matters when a pod's persistent volume is empty - if it has
       # data from a previous execution, that data will always be used.
+      #
+      # If your Kubernetes cluster uses a custom DNS domain, you will have
+      # to add an additional arg to this pod: "-domain=<your-custom-domain>"
       initContainers:
       - name: bootstrap
-        image: cockroachdb/cockroach-k8s-init:0.1
+        image: cockroachdb/cockroach-k8s-init:0.2
         imagePullPolicy: IfNotPresent
         args:
         - "-on-start=/on-start.sh"
@@ -117,7 +120,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: cockroachdb
-        image: cockroachdb/cockroach:v1.0
+        image: cockroachdb/cockroach:v1.0.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 26257


### PR DESCRIPTION
This switches from using v0.1 of the peer-finder image to a version that
includes https://github.com/kubernetes/contrib/pull/2013

While I'm here, switch the version of cockroachdb from 1.0 to 1.0.1

```release-note
NONE
```

@tschottdorf 