### PR TITLE
Fix AppArmor test for docker 1.13

### DIFF
--- a/test/e2e/apparmor.go
+++ b/test/e2e/apparmor.go
@@ -26,13 +26,20 @@ import (
 var _ = framework.KubeDescribe("AppArmor", func() {
 	f := framework.NewDefaultFramework("apparmor")
 
-	BeforeEach(func() {
-		common.SkipIfAppArmorNotSupported()
-		common.LoadAppArmorProfiles(f)
-	})
+	Context("load AppArmor profiles", func() {
+		BeforeEach(func() {
+			common.SkipIfAppArmorNotSupported()
+			common.LoadAppArmorProfiles(f)
+		})
+		AfterEach(func() {
+			if !CurrentGinkgoTestDescription().Failed {
+				return
+			}
+			framework.LogFailedContainers(f.ClientSet, f.Namespace.Name, framework.Logf)
+		})
 
-	It("should enforce an AppArmor profile", func() {
-		common.CreateAppArmorTestPod(f, true)
-		framework.LogFailedContainers(f.ClientSet, f.Namespace.Name, framework.Logf)
+		It("should enforce an AppArmor profile", func() {
+			common.CreateAppArmorTestPod(f, true)
+		})
 	})
 })

--- a/test/e2e/common/apparmor.go
+++ b/test/e2e/common/apparmor.go
@@ -58,9 +58,9 @@ if touch %[1]s; then
 elif ! touch %[2]s; then
   echo "FAILURE: write to %[2]s should be allowed"
   exit 2
-elif ! grep "%[3]s" /proc/1/attr/current; then
+elif ! grep "%[3]s" /proc/self/attr/current; then
   echo "FAILURE: not running with expected profile %[3]s"
-  echo "found: $(cat /proc/1/attr/current)"
+  echo "found: $(cat /proc/self/attr/current)"
   exit 3
 fi`, appArmorDeniedPath, appArmorAllowedPath, appArmorProfilePrefix+f.Namespace.Name)
 

--- a/test/e2e/common/apparmor.go
+++ b/test/e2e/common/apparmor.go
@@ -60,6 +60,7 @@ elif ! touch %[2]s; then
   exit 2
 elif ! grep "%[3]s" /proc/1/attr/current; then
   echo "FAILURE: not running with expected profile %[3]s"
+  echo "found: $(cat /proc/1/attr/current)"
   exit 3
 fi`, appArmorDeniedPath, appArmorAllowedPath, appArmorProfilePrefix+f.Namespace.Name)
 


### PR DESCRIPTION
... & better debugging.

The issue is that we run the pod containers in a shared PID namespace with docker 1.13, so PID 1 is no longer the container's root process. Since it's messy to get the container's root process, I switched to using `/proc/self` to read the apparmor profile. While this wouldn't catch a regression that caused only the init process to run with the wrong profile, I think it's a good approximation.

/cc @aulanov @Amey-D 