### PR TITLE
Instrument advanced auditing

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/audit/BUILD
@@ -11,6 +11,8 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "format.go",
+        "metrics.go",
         "request.go",
         "scheme.go",
         "types.go",
@@ -20,6 +22,7 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/audit/format.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/format.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+)
+
+// EventString creates a 1-line text representation of an audit event, using a subset of the
+// information in the event struct.
+func EventString(ev *auditinternal.Event) string {
+	username := "<none>"
+	groups := "<none>"
+	if len(ev.User.Username) > 0 {
+		username = ev.User.Username
+		if len(ev.User.Groups) > 0 {
+			groups = auditStringSlice(ev.User.Groups)
+		}
+	}
+	asuser := "<self>"
+	asgroups := "<lookup>"
+	if ev.ImpersonatedUser != nil {
+		asuser = ev.ImpersonatedUser.Username
+		if ev.ImpersonatedUser.Groups != nil {
+			asgroups = auditStringSlice(ev.ImpersonatedUser.Groups)
+		}
+	}
+
+	namespace := "<none>"
+	if ev.ObjectRef != nil && len(ev.ObjectRef.Namespace) != 0 {
+		namespace = ev.ObjectRef.Namespace
+	}
+
+	response := "<deferred>"
+	if ev.ResponseStatus != nil {
+		response = strconv.Itoa(int(ev.ResponseStatus.Code))
+	}
+
+	ip := "<unknown>"
+	if len(ev.SourceIPs) > 0 {
+		ip = ev.SourceIPs[0]
+	}
+
+	return fmt.Sprintf("%s AUDIT: id=%q stage=%q ip=%q method=%q user=%q groups=%q as=%q asgroups=%q namespace=%q uri=%q response=\"%s\"\n",
+		ev.Timestamp.Format(time.RFC3339Nano), ev.AuditID, ev.Stage, ip, ev.Verb, username, groups, asuser, asgroups, namespace, ev.RequestURI, response)
+}
+
+func auditStringSlice(inList []string) string {
+	quotedElements := make([]string, len(inList))
+	for i, in := range inList {
+		quotedElements[i] = fmt.Sprintf("%q", in)
+	}
+	return strings.Join(quotedElements, ",")
+}

--- a/staging/src/k8s.io/apiserver/pkg/audit/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/metrics.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+)
+
+const (
+	subsystem = "apiserver_audit"
+)
+
+var (
+	eventCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "event_count",
+			Help:      "Counter of audit events generated and sent to the audit backend.",
+		})
+	errorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "error_count",
+			Help: "Counter of audit events that failed to be audited properly. " +
+				"Plugin identifies the plugin affected by the error.",
+		},
+		[]string{"plugin"},
+	)
+	levelCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Subsystem: subsystem,
+			Name:      "level_count",
+			Help:      "Counter of policy levels for audit events (1 per request).",
+		},
+		[]string{"level"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(eventCounter)
+	prometheus.MustRegister(errorCounter)
+	prometheus.MustRegister(levelCounter)
+}
+
+// ObserveEvent updates the relevant prometheus metrics for the generated audit event.
+func ObserveEvent() {
+	eventCounter.Inc()
+}
+
+// ObservePolicyLevel updates the relevant prometheus metrics with the audit level for a request.
+func ObservePolicyLevel(level auditinternal.Level) {
+	levelCounter.WithLabelValues(string(level)).Inc()
+}
+
+// HandlePluginError handles an error that occurred in an audit plugin. This method should only be
+// used if the error may have prevented the audit event from being properly recorded. The events are
+// modified.
+func HandlePluginError(plugin string, err error, impacted ...*auditinternal.Event) {
+	// Count the error.
+	errorCounter.WithLabelValues(plugin).Add(float64(len(impacted)))
+
+	// Log the audit events to the debug log.
+	msg := fmt.Sprintf("Error in audit plugin '%s' affecting %d audit events: %v\nImpacted events:\n",
+		plugin, len(impacted), err)
+	for _, ev := range impacted {
+		msg = msg + EventString(ev) + "\n"
+	}
+	glog.Error(msg)
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
@@ -12,7 +12,6 @@ go_library(
     srcs = ["backend.go"],
     tags = ["automanaged"],
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
     ],


### PR DESCRIPTION
Add prometheus metrics for audit logging, including:

- A total count of audit events generated and sent to the output backend
- A count of audit events that failed to be audited due to an error (per backend)
- A count of request audit levels (1 per request)

For https://github.com/kubernetes/features/issues/22

- [x] TODO: Call `HandlePluginError` from the webhook backend, once https://github.com/kubernetes/kubernetes/pull/45919 merges (in this or a separate PR, depending on timing of the merge)

/cc @ihmccreery @sttts @soltysh @ericchiang 