### PR TITLE
Bump up npd version to v0.4.0

### DIFF
--- a/cluster/addons/node-problem-detector/npd.yaml
+++ b/cluster/addons/node-problem-detector/npd.yaml
@@ -26,11 +26,11 @@ subjects:
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: npd-v0.3.0
+  name: npd-v0.4.0
   namespace: kube-system
   labels:
     k8s-app: node-problem-detector
-    version: v0.3.0
+    version: v0.4.0
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -38,12 +38,12 @@ spec:
     metadata:
       labels:
         k8s-app: node-problem-detector
-        version: v0.3.0
+        version: v0.4.0
         kubernetes.io/cluster-service: "true"
     spec:
       containers:
       - name: node-problem-detector
-        image: gcr.io/google_containers/node-problem-detector:v0.3.0
+        image: gcr.io/google_containers/node-problem-detector:v0.4.0
         command:
         - "/bin/sh"
         - "-c"

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -135,8 +135,8 @@ function install-node-problem-detector {
       local -r npd_version="${NODE_PROBLEM_DETECTOR_VERSION}"
       local -r npd_sha1="${NODE_PROBLEM_DETECTOR_TAR_HASH}"
   else
-      local -r npd_version="v0.3.0"
-      local -r npd_sha1="2e6423c5798e14464271d9c944e56a637ee5a4bc"
+      local -r npd_version="v0.4.0"
+      local -r npd_sha1="e56eda32121c1c23e839556443f21d04f41b0269"
   fi
   local -r npd_release_path="https://storage.googleapis.com/kubernetes-release"
   local -r npd_tar="node-problem-detector-${npd_version}.tar.gz"

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -49,7 +49,7 @@ var NodeImageWhiteList = sets.NewString(
 	"gcr.io/google-containers/stress:v1",
 	"gcr.io/google_containers/busybox:1.24",
 	"gcr.io/google_containers/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff",
-	"gcr.io/google_containers/node-problem-detector:v0.3.0",
+	"gcr.io/google_containers/node-problem-detector:v0.4.0",
 	"gcr.io/google_containers/nginx-slim:0.7",
 	"gcr.io/google_containers/serve_hostname:v1.4",
 	"gcr.io/google_containers/netexec:1.7",

--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -45,7 +45,7 @@ var _ = framework.KubeDescribe("NodeProblemDetector", func() {
 		pollInterval   = 1 * time.Second
 		pollConsistent = 5 * time.Second
 		pollTimeout    = 1 * time.Minute
-		image          = "gcr.io/google_containers/node-problem-detector:v0.3.0"
+		image          = "gcr.io/google_containers/node-problem-detector:v0.4.0"
 	)
 	f := framework.NewDefaultFramework("node-problem-detector")
 	var c clientset.Interface

--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -91,7 +91,7 @@ spec:
             cpu: {{HOLLOW_PROXY_CPU}}m
             memory: {{HOLLOW_PROXY_MEM}}Ki
       - name: hollow-node-problem-detector
-        image: gcr.io/google_containers/node-problem-detector:v0.3.0
+        image: gcr.io/google_containers/node-problem-detector:v0.4.0
         env:
         - name: NODE_NAME
           valueFrom:


### PR DESCRIPTION
Fixes #47070.

Bump up npd version to [v0.4.0](https://github.com/kubernetes/node-problem-detector/releases/tag/v0.4.0).

```release-note
Bump up Node Problem Detector version to v0.4.0, which added support of parsing log from /dev/kmsg and ABRT.
```

/cc @dchen1107 @ajitak 