### PR TITLE
Added API node ready check after PD test deleting a GCE instance.

### DIFF
--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -43,7 +43,7 @@ import (
 const (
 	gcePDDetachTimeout  = 10 * time.Minute
 	gcePDDetachPollTime = 10 * time.Second
-	nodeStatusTimeout   = 1 * time.Minute
+	nodeStatusTimeout   = 3 * time.Minute
 	nodeStatusPollTime  = 1 * time.Second
 	maxReadRetry        = 3
 )
@@ -428,6 +428,8 @@ var _ = framework.KubeDescribe("Pod Disks", func() {
 			By("Cleaning up PD-RW test env")
 			podClient.Delete(host0Pod.Name, metav1.NewDeleteOptions(0))
 			detachAndDeletePDs(diskName, []types.NodeName{host0Name})
+			framework.WaitForNodeToBeReady(f.ClientSet, string(host0Name), nodeStatusTimeout)
+			Expect(len(nodes.Items)).To(Equal(initialGroupSize))
 		}()
 
 		By("submitting host0Pod to kubernetes")


### PR DESCRIPTION
- The test checks whether the deleted GCE instance is recovered in the end, but it does not check whether the node is registered with Kubernetes.
- Need to ensure that all nodes are ready, i.e. back to the state before the test.
- Increased node status timeout to account for the longer time needed for kubelet to register on startup.

If the same error persists, try increasing nodeStatusTimeout to give the recovered node more time to become ready.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: one of the issues in #46651 

<!-- **Release note**: -->
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
