### PR TITLE
Use ip-masq-agent for MASQUERADE when using Calico policy

### DIFF
--- a/cluster/addons/calico-policy-controller/README.md
+++ b/cluster/addons/calico-policy-controller/README.md
@@ -3,13 +3,6 @@
 
 Calico is an implementation of the Kubernetes network policy API.  The provided manifest installs a DaemonSet which runs Calico on each node in the cluster.
 
-### Templating
-
-The provided `calico-node.yaml` manifest includes the following placeholders which are populated
-via templating.
-
-- `__CLUSTER_CIDR__`: The IP range from which Pod IP addresses are assigned.
-
 ### Learn More
 
 Learn more about Calico at http://docs.projectcalico.org

--- a/cluster/addons/calico-policy-controller/calico-node.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node.yaml
@@ -32,10 +32,6 @@ spec:
               value: "true"
             - name: CALICO_NETWORKING_BACKEND
               value: "none"
-            - name: CALICO_IPV4POOL_CIDR
-              value: "__CLUSTER_CIDR__"
-            - name: CALICO_IPV4POOL_IPIP
-              value: "off"
             - name: DATASTORE_TYPE
               value: "kubernetes"
             - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
@@ -48,6 +44,8 @@ spec:
               value: "true"
             - name: IP
               value: ""
+            - name: NO_DEFAULT_POOLS
+              value: "true"
             - name: NODENAME
               valueFrom:
                 fieldRef:

--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -1211,10 +1211,6 @@ function start-kube-addons {
   fi
   if [[ "${NETWORK_POLICY_PROVIDER:-}" == "calico" ]]; then
     setup-addon-manifests "addons" "calico-policy-controller"
-
-    # Replace the cluster cidr.
-    local -r calico_file="${dst_dir}/calico-policy-controller/calico-node.yaml"
-    sed -i -e "s@__CLUSTER_CIDR__@${CLUSTER_IP_RANGE}@g" "${calico_file}"
   fi
   if [[ "${ENABLE_DEFAULT_STORAGE_CLASS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "storage-class/gce"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1574,10 +1574,6 @@ function start-kube-addons {
   fi
   if [[ "${NETWORK_POLICY_PROVIDER:-}" == "calico" ]]; then
     setup-addon-manifests "addons" "calico-policy-controller"
-
-    # Replace the cluster cidr.
-    local -r calico_file="${dst_dir}/calico-policy-controller/calico-node.yaml"
-    sed -i -e "s@__CLUSTER_CIDR__@${CLUSTER_IP_RANGE}@g" "${calico_file}"
   fi
   if [[ "${ENABLE_DEFAULT_STORAGE_CLASS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "storage-class/gce"


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes Calico's MASQUERADE implementation in favor of the `ip-masq-agent`.

CC @dnardo 

**Release note**:
```release-note
NONE
```
