### PR TITLE
removing unnecessary shallow copy on SyncService

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -338,9 +338,7 @@ func (e *EndpointController) syncService(key string) error {
 
 	readyEps := 0
 	notReadyEps := 0
-	for i := range pods {
-		// TODO: Do we need to copy here?
-		pod := &(*pods[i])
+	for _, pod := range pods {
 
 		for i := range service.Spec.Ports {
 			servicePort := &service.Spec.Ports[i]


### PR DESCRIPTION
**What this PR does / why we need it**: remove shallow copy + avoid using same index name as the nested loop

**Which issue this PR fixes**: fixes #46703 

**Special notes for your reviewer**:

**Release note**:

```release-note
```
