### PR TITLE
empty audit policy file is legal configuration

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/BUILD
@@ -34,6 +34,7 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/reader.go
@@ -25,6 +25,8 @@ import (
 	auditv1alpha1 "k8s.io/apiserver/pkg/apis/audit/v1alpha1"
 	"k8s.io/apiserver/pkg/apis/audit/validation"
 	"k8s.io/apiserver/pkg/audit"
+
+	"github.com/golang/glog"
 )
 
 func LoadPolicyFromFile(filePath string) (*auditinternal.Policy, error) {
@@ -35,9 +37,7 @@ func LoadPolicyFromFile(filePath string) (*auditinternal.Policy, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file path %q: %+v", filePath, err)
 	}
-	if len(policyDef) == 0 {
-		return nil, fmt.Errorf("file %q was empty", filePath)
-	}
+
 	policyVersioned := &auditv1alpha1.Policy{}
 
 	decoder := audit.Codecs.UniversalDecoder(auditv1alpha1.SchemeGroupVersion)
@@ -53,5 +53,7 @@ func LoadPolicyFromFile(filePath string) (*auditinternal.Policy, error) {
 	if err := validation.ValidatePolicy(policy); err != nil {
 		return nil, err.ToAggregate()
 	}
+
+	glog.V(4).Infof("Loaded %d audit policy rules from file %s\n", len(policy.Rules), filePath)
 	return policy, nil
 }


### PR DESCRIPTION
Empty audit policy file or policy file contains only comments means
using default audit level for all requests.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```

Part of https://github.com/kubernetes/features/issues/22