### PR TITLE
Add some initial resource limits to the ip-masq-agent.

### DIFF
--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -21,6 +21,13 @@ spec:
       containers:
       - name: ip-masq-agent
         image: gcr.io/google-containers/ip-masq-agent-amd64:v2.0.1
+        resources:
+          limits:
+            cpu: 100m
+            memory: 8Mi
+          requests:
+            cpu: 10m
+            memory: 8Mi
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
These limits were based on observing  the agent over roughly a day RES was typically  ~4M for me but I'd like to make sure we have some headroom.  If there was a huge config map then this could increase  slightly but not significantly since we only allow 64 entries. 

VmPeak:    11164 kB
VmSize:    11164 kB
VmLck:         0 kB
VmPin:         0 kB
VmHWM:      7652 kB
VmRSS:      4260 kB
VmData:     7612 kB
VmStk:       136 kB
VmExe:      1856 kB
VmLib:         0 kB
VmPTE:        40 kB
VmPMD:        20 kB
VmSwap:        0 kB
