### PR TITLE
Fix Reaper timeout bug

### DIFF
--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -323,14 +323,16 @@ func (reaper *StatefulSetReaper) Stop(namespace, name string, timeout time.Durat
 	if err != nil {
 		return err
 	}
+
 	if timeout == 0 {
 		numReplicas := ss.Spec.Replicas
-
-		// BUG: this timeout is never used.
+		// See discussion of this behavior here:
+		// https://github.com/kubernetes/kubernetes/pull/46468#discussion_r118589512
 		timeout = Timeout + time.Duration(10*numReplicas)*time.Second
 	}
+
 	retry := NewRetryParams(reaper.pollInterval, reaper.timeout)
-	waitForStatefulSet := NewRetryParams(reaper.pollInterval, reaper.timeout)
+	waitForStatefulSet := NewRetryParams(reaper.pollInterval, timeout)
 	if err = scaler.Scale(namespace, name, 0, nil, retry, waitForStatefulSet); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR is an fix to the issue [noticed](https://github.com/kubernetes/kubernetes/pull/46468#discussion_r118589512) in a previous PR.

Previous behavior was to calculate a timeout but then ignore it, using `reaper.timeout` instead.
New behavior is to use the calculated timeout for `waitForStatefulSet`, which is passed to the Scaler.

Thanks to @foxish and @apelisse for pointing me in the right direction.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
