### PR TITLE
Added sig leads alias to OWNERS_ALIAS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -79,3 +79,5 @@ aliases:
   sig-apps-api-approvers:
     - erictune
     - smarterclayton
+  sig-leads:
+    - spiffxp


### PR DESCRIPTION
**What this PR does / why we need it**:

Add sig leads section to OWNERS_ALIASES so sig leads without maintainers access can add status labels to issues (important to 1.7 milestone)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Let me know you know of additional sig leads that should be added.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
