### PR TITLE
Update the fluentd-gcp image

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -26,7 +26,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.4
+        image: gcr.io/google-containers/fluentd-gcp:2.0.5
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
         # tries to send this message to the server => fails to send a chunk and so on.


### PR DESCRIPTION
Rolled back fluentd version to 0.12 to avoid performance problems and unnecessary noise in logs: https://github.com/kubernetes/contrib/pull/2625

Fixes https://github.com/kubernetes/kubernetes/issues/46990