### PR TITLE
Deleting kubectl.ServiceReaper since there is no special service deletion logic

### DIFF
--- a/pkg/kubectl/stop.go
+++ b/pkg/kubectl/stop.go
@@ -82,9 +82,6 @@ func ReaperFor(kind schema.GroupKind, c internalclientset.Interface) (Reaper, er
 	case api.Kind("Pod"):
 		return &PodReaper{c.Core()}, nil
 
-	case api.Kind("Service"):
-		return &ServiceReaper{c.Core()}, nil
-
 	case batch.Kind("Job"):
 		return &JobReaper{c.Batch(), c.Core(), Interval, Timeout}, nil
 
@@ -126,9 +123,6 @@ type DeploymentReaper struct {
 }
 type PodReaper struct {
 	client coreclient.PodsGetter
-}
-type ServiceReaper struct {
-	client coreclient.ServicesGetter
 }
 type StatefulSetReaper struct {
 	client                appsclient.StatefulSetsGetter
@@ -521,15 +515,4 @@ func (reaper *PodReaper) Stop(namespace, name string, timeout time.Duration, gra
 		return err
 	}
 	return pods.Delete(name, gracePeriod)
-}
-
-func (reaper *ServiceReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
-	services := reaper.client.Services(namespace)
-	_, err := services.Get(name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	falseVar := false
-	deleteOptions := &metav1.DeleteOptions{OrphanDependents: &falseVar}
-	return services.Delete(name, deleteOptions)
 }


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/pull/46471 #42594

ServiceReaper does not have any special deletion logic so we dont need it. The generic deletion logic should be enough.
By removing this reaper, service deletion also gets the new wait logic from https://github.com/kubernetes/kubernetes/pull/46471

cc @kubernetes/sig-cli-misc 