### PR TITLE
PD e2e test: Ready node check now uses the most up-to-date node count.

### DIFF
--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -43,7 +43,7 @@ import (
 const (
 	gcePDDetachTimeout  = 10 * time.Minute
 	gcePDDetachPollTime = 10 * time.Second
-	nodeStatusTimeout   = 3 * time.Minute
+	nodeStatusTimeout   = 5 * time.Minute
 	nodeStatusPollTime  = 1 * time.Second
 	maxReadRetry        = 3
 )
@@ -429,6 +429,7 @@ var _ = framework.KubeDescribe("Pod Disks", func() {
 			podClient.Delete(host0Pod.Name, metav1.NewDeleteOptions(0))
 			detachAndDeletePDs(diskName, []types.NodeName{host0Name})
 			framework.WaitForNodeToBeReady(f.ClientSet, string(host0Name), nodeStatusTimeout)
+			nodes = framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 			Expect(len(nodes.Items)).To(Equal(initialGroupSize))
 		}()
 
@@ -488,6 +489,7 @@ var _ = framework.KubeDescribe("Pod Disks", func() {
 			framework.ExpectNoError(err, "Unable to re-create the deleted node")
 			framework.ExpectNoError(framework.WaitForGroupSize(framework.TestContext.CloudConfig.NodeInstanceGroup, int32(initialGroupSize)), "Unable to get the node group back to the original size")
 			framework.WaitForNodeToBeReady(f.ClientSet, nodeToDelete.Name, nodeStatusTimeout)
+			nodes = framework.GetReadySchedulableNodesOrDie(f.ClientSet)
 			if len(nodes.Items) != originalCount {
 				return fmt.Errorf("The node count is not back to original count")
 			}


### PR DESCRIPTION
Follow-up to PR #46746 

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
