### PR TITLE
Bump cluster-proportional-autoscaler to 1.1.2

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1-r2
+        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
         resources:
             requests:
                 cpu: "20m"


### PR DESCRIPTION
From https://github.com/kubernetes-incubator/cluster-proportional-autoscaler/pull/33.

/assign @bowei 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
