### PR TITLE
copy the fix (#38519) to the staging folder in release-1.5

### DIFF
--- a/staging/src/k8s.io/client-go/rest/url_utils.go
+++ b/staging/src/k8s.io/client-go/rest/url_utils.go
@@ -33,10 +33,7 @@ func DefaultServerURL(host, apiPath string, groupVersion unversioned.GroupVersio
 	}
 	base := host
 	hostURL, err := url.Parse(base)
-	if err != nil {
-		return nil, "", err
-	}
-	if hostURL.Scheme == "" || hostURL.Host == "" {
+	if err != nil || hostURL.Scheme == "" || hostURL.Host == "" {
 		scheme := "http://"
 		if defaultTLS {
 			scheme = "https://"


### PR DESCRIPTION
Copy the fix in https://github.com/kubernetes/kubernetes/pull/38519/files to the staging/client-go in kubernetes release 1.5.

Fixes https://github.com/kubernetes/test-infra/issues/2847#issuecomment-305651464

I updated the publishing robot to use go 1.8. Without the PR, the test will fail for client-go 2.0 (copied from kubernetes release-1.5) and the publishing robot will stop publishing.