### PR TITLE
bazel: base kube-proxy image on debian-iptables instead of busybox + iptables

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -34,18 +34,6 @@ docker_build(
     },
 )
 
-docker_build(
-    name = "busybox-net",
-    base = ":busybox",
-    debs = [
-        "@libc_deb//file",
-        "@iptables_deb//file",
-        "@iproute2_deb//file",
-        "@libnetlink_deb//file",
-        "@libxtables_deb//file",
-    ],
-)
-
 # This list should roughly match kube::build::get_docker_wrapped_binaries()
 # in build/common.sh.
 DOCKERIZED_BINARIES = {
@@ -66,7 +54,7 @@ DOCKERIZED_BINARIES = {
         "target": "//plugin/cmd/kube-scheduler:kube-scheduler",
     },
     "kube-proxy": {
-        "base": ":busybox-net",
+        "base": "@debian-iptables-amd64//image:image.tar",
         "target": "//cmd/kube-proxy:kube-proxy",
     },
 }

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -30,7 +30,7 @@ http_archive(
 )
 
 load("@io_bazel_rules_go//go:def.bzl", "go_repositories")
-load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories")
+load("@io_bazel_rules_docker//docker:docker.bzl", "docker_repositories", "docker_pull")
 
 go_repositories(
     go_version = "1.8.3",
@@ -46,36 +46,6 @@ debs = (
         "http://ftp.us.debian.org/debian/pool/main/b/busybox/busybox-static_1.22.0-19+b3_amd64.deb",
         "https://storage.googleapis.com/kubernetes-release/debs/busybox-static_1.22.0-19+b3_amd64.deb",
     ),
-    (
-        "libc_deb",
-        "372aac4a9ce9dbb26a08de0b9c41b0500ba019430295d29f39566483f5f32732",
-        "http://ftp.us.debian.org/debian/pool/main/g/glibc/libc6_2.24-10_amd64.deb",
-        "https://storage.googleapis.com/kubernetes-release/debs/libc6_2.24-10_amd64.deb",
-    ),
-    (
-        "iptables_deb",
-        "7747388a97ba71fede302d70361c81d486770a2024185514c18b5d8eab6aaf4e",
-        "http://ftp.us.debian.org/debian/pool/main/i/iptables/iptables_1.4.21-2+b1_amd64.deb",
-        "https://storage.googleapis.com/kubernetes-release/debs/iptables_1.4.21-2+b1_amd64.deb",
-    ),
-    (
-        "libnetlink_deb",
-        "5d486022cd9e047e9afbb1617cf4519c0decfc3d2c1fad7e7fe5604943dbbf37",
-        "http://ftp.us.debian.org/debian/pool/main/libn/libnfnetlink/libnfnetlink0_1.0.1-3_amd64.deb",
-        "https://storage.googleapis.com/kubernetes-release/debs/libnfnetlink0_1.0.1-3_amd64.deb",
-    ),
-    (
-        "libxtables_deb",
-        "6783f316af4cbf3ada8b9a2b7bb5f53a87c0c2575c1903ce371fdbd45d3626c6",
-        "http://ftp.us.debian.org/debian/pool/main/i/iptables/libxtables10_1.4.21-2+b1_amd64.deb",
-        "https://storage.googleapis.com/kubernetes-release/debs/libxtables10_1.4.21-2+b1_amd64.deb",
-    ),
-    (
-        "iproute2_deb",
-        "3ce9cb1d03a2a1359cbdd4f863b15d0c906096bf713e8eb688149da2f4e350bc",
-        "http://ftp.us.debian.org/debian/pool/main/i/iproute2/iproute_3.16.0-2_all.deb",
-        "https://storage.googleapis.com/kubernetes-release/debs/iproute_3.16.0-2_all.deb",
-    ),
 )
 
 [http_file(
@@ -88,4 +58,11 @@ http_file(
     name = "kubernetes_cni",
     sha256 = "05ab3937bc68562e989dc143362ec4d4275262ba9f359338aed720fc914457a5",
     url = "https://storage.googleapis.com/kubernetes-release/network-plugins/cni-amd64-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz",
+)
+
+docker_pull(
+    name = "debian-iptables-amd64",
+    digest = "sha256:adde513f7b3561042cd2d2af4d2d355189bbb2f579584b5766e7d07be4f7e71e",  # v7
+    registry = "gcr.io",
+    repository = "google-containers/debian-iptables-amd64",
 )


### PR DESCRIPTION
**What this PR does / why we need it**: the bazel-built kube-proxy image currently uses a custom base image made up of scratch + busybox + iptables + a few dependencies, while the official kube-proxy image is based off of the debian-iptables image.

This difference seems to cause some weird issues such as #46103, since the container layout doesn't look the same.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #46103, probably?

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @mikedanese @spxtr @pipejakob 
/cc @Q-Lee @thockin @cblecker 