### PR TITLE
Create output_dir if doesn't exist

### DIFF
--- a/hack/lib/swagger.sh
+++ b/hack/lib/swagger.sh
@@ -142,6 +142,9 @@ kube::swagger::gen_api_ref_docs() {
 
   echo "Moving api reference docs from ${output_tmp} to ${output_dir}"
 
+  # Create output_dir if doesn't exist. Prevents error on copy.
+  mkdir -p "${output_dir}"
+
   cp -af "${output_tmp}"/* "${output_dir}"
   rm -r "${output_tmp}"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Minor fix to the swagger spec gen, that if the directory doesn't exist, create it before copying.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
