### PR TITLE
add last applied annotation to rbac reconcile

### DIFF
--- a/pkg/registry/rbac/reconciliation/BUILD
+++ b/pkg/registry/rbac/reconciliation/BUILD
@@ -36,11 +36,13 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/v1:go_default_library",
         "//pkg/apis/rbac:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion:go_default_library",
         "//pkg/registry/rbac/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )

--- a/pkg/registry/rbac/reconciliation/clusterrole_interfaces.go
+++ b/pkg/registry/rbac/reconciliation/clusterrole_interfaces.go
@@ -18,12 +18,17 @@ package reconciliation
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 )
 
 type ClusterRoleRuleOwner struct {
 	ClusterRole *rbac.ClusterRole
+}
+
+func (o ClusterRoleRuleOwner) GetObject() runtime.Object {
+	return o.ClusterRole
 }
 
 func (o ClusterRoleRuleOwner) GetNamespace() string {

--- a/pkg/registry/rbac/reconciliation/clusterrolebinding_interfaces.go
+++ b/pkg/registry/rbac/reconciliation/clusterrolebinding_interfaces.go
@@ -18,6 +18,7 @@ package reconciliation
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
@@ -25,6 +26,10 @@ import (
 
 type ClusterRoleBindingAdapter struct {
 	ClusterRoleBinding *rbac.ClusterRoleBinding
+}
+
+func (o ClusterRoleBindingAdapter) GetObject() runtime.Object {
+	return o.ClusterRoleBinding
 }
 
 func (o ClusterRoleBindingAdapter) GetNamespace() string {

--- a/pkg/registry/rbac/reconciliation/role_interfaces.go
+++ b/pkg/registry/rbac/reconciliation/role_interfaces.go
@@ -18,12 +18,17 @@ package reconciliation
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
 )
 
 type RoleRuleOwner struct {
 	Role *rbac.Role
+}
+
+func (o RoleRuleOwner) GetObject() runtime.Object {
+	return o.Role
 }
 
 func (o RoleRuleOwner) GetNamespace() string {

--- a/pkg/registry/rbac/reconciliation/rolebinding_interfaces.go
+++ b/pkg/registry/rbac/reconciliation/rolebinding_interfaces.go
@@ -18,6 +18,7 @@ package reconciliation
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion"
@@ -25,6 +26,10 @@ import (
 
 type RoleBindingAdapter struct {
 	RoleBinding *rbac.RoleBinding
+}
+
+func (o RoleBindingAdapter) GetObject() runtime.Object {
+	return o.RoleBinding
 }
 
 func (o RoleBindingAdapter) GetNamespace() string {


### PR DESCRIPTION
Set the last applied configuration annotation for the default rbac if the default role/rolebinding is updated. It can allow user to get the old configuration when the apiserver is upgrade.
@deads2k @liggitt 

