### PR TITLE
Made WaitForReplicas and EnsureDesiredReplicas use PollImmediate and improved logging.

### DIFF
--- a/test/e2e/common/autoscaling_utils.go
+++ b/test/e2e/common/autoscaling_utils.go
@@ -332,27 +332,33 @@ func (rc *ResourceConsumer) GetReplicas() int {
 }
 
 func (rc *ResourceConsumer) WaitForReplicas(desiredReplicas int) {
-	timeout := 15 * time.Minute
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(20 * time.Second) {
-		if desiredReplicas == rc.GetReplicas() {
-			framework.Logf("%s: current replicas number is equal to desired replicas number: %d", rc.kind, desiredReplicas)
-			return
-		} else {
-			framework.Logf("%s: current replicas number %d waiting to be %d", rc.kind, rc.GetReplicas(), desiredReplicas)
-		}
-	}
-	framework.Failf("timeout waiting %v for pods size to be %d", timeout, desiredReplicas)
+	duration := 15 * time.Minute
+	interval := 20 * time.Second
+	err := wait.PollImmediate(interval, duration, func() (bool, error) {
+		replicas := rc.GetReplicas()
+		framework.Logf("waiting for %d replicas (current: %d)", desiredReplicas, replicas)
+		return replicas == desiredReplicas, nil // Expected number of replicas found. Exit.
+	})
+	framework.ExpectNoErrorWithOffset(1, err, "timeout waiting %v for %d replicas", duration, desiredReplicas)
 }
 
-func (rc *ResourceConsumer) EnsureDesiredReplicas(desiredReplicas int, timeout time.Duration) {
-	for start := time.Now(); time.Since(start) < timeout; time.Sleep(10 * time.Second) {
-		actual := rc.GetReplicas()
-		if desiredReplicas != actual {
-			framework.Failf("Number of replicas has changed: expected %v, got %v", desiredReplicas, actual)
+func (rc *ResourceConsumer) EnsureDesiredReplicas(desiredReplicas int, duration time.Duration) {
+	interval := 10 * time.Second
+	err := wait.PollImmediate(interval, duration, func() (bool, error) {
+		replicas := rc.GetReplicas()
+		framework.Logf("expecting there to be %d replicas (are: %d)", desiredReplicas, replicas)
+		if replicas != desiredReplicas {
+			return false, fmt.Errorf("number of replicas changed unexpectedly")
+		} else {
+			return false, nil // Expected number of replicas found. Continue polling until timeout.
 		}
-		framework.Logf("Number of replicas is as expected")
+	})
+	// The call above always returns an error, but if it is timeout, it's OK (condition satisfied all the time).
+	if err == wait.ErrWaitTimeout {
+		framework.Logf("Number of replicas was stable over %v", duration)
+		return
 	}
-	framework.Logf("Number of replicas was stable over %v", timeout)
+	framework.ExpectNoErrorWithOffset(1, err)
 }
 
 // Pause stops background goroutines responsible for consuming resources.

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -286,9 +286,15 @@ func Logf(format string, args ...interface{}) {
 }
 
 func Failf(format string, args ...interface{}) {
+	FailfWithOffset(1, format, args...)
+}
+
+// FailfWithOffset calls "Fail" and logs the error at "offset" levels above its caller
+// (for example, for call chain f -> g -> FailfWithOffset(1, ...) error would be logged for "f").
+func FailfWithOffset(offset int, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	log("INFO", msg)
-	Fail(nowStamp()+": "+msg, 1)
+	Fail(nowStamp()+": "+msg, 1 + offset)
 }
 
 func Skipf(format string, args ...interface{}) {
@@ -1917,10 +1923,16 @@ func randomSuffix() string {
 }
 
 func ExpectNoError(err error, explain ...interface{}) {
+	ExpectNoErrorWithOffset(1, err, explain...)
+}
+
+// ExpectNoErrorWithOffset checks if "err" is set, and if so, fails assertion while logging the error at "offset" levels above its caller
+// (for example, for call chain f -> g -> ExpectNoErrorWithOffset(1, ...) error would be logged for "f").
+func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
 	if err != nil {
 		Logf("Unexpected error occurred: %v", err)
 	}
-	ExpectWithOffset(1, err).NotTo(HaveOccurred(), explain...)
+	ExpectWithOffset(1 + offset, err).NotTo(HaveOccurred(), explain...)
 }
 
 func ExpectNoErrorWithRetries(fn func() error, maxRetries int, explain ...interface{}) {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -294,7 +294,7 @@ func Failf(format string, args ...interface{}) {
 func FailfWithOffset(offset int, format string, args ...interface{}) {
 	msg := fmt.Sprintf(format, args...)
 	log("INFO", msg)
-	Fail(nowStamp()+": "+msg, 1 + offset)
+	Fail(nowStamp()+": "+msg, 1+offset)
 }
 
 func Skipf(format string, args ...interface{}) {
@@ -1932,7 +1932,7 @@ func ExpectNoErrorWithOffset(offset int, err error, explain ...interface{}) {
 	if err != nil {
 		Logf("Unexpected error occurred: %v", err)
 	}
-	ExpectWithOffset(1 + offset, err).NotTo(HaveOccurred(), explain...)
+	ExpectWithOffset(1+offset, err).NotTo(HaveOccurred(), explain...)
 }
 
 func ExpectNoErrorWithRetries(fn func() error, maxRetries int, explain ...interface{}) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Most importantly, this results in better logging: timeout is logged at the level of the caller, not the helper function, helping debugging.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
