### PR TITLE
update copyed doc for advanced audit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -34,21 +34,9 @@ import (
 )
 
 // WithAudit decorates a http.Handler with audit logging information for all the
-// requests coming to the server. If out is nil, no decoration takes place.
-// Each audit log contains two entries:
-// 1. the request line containing:
-//    - unique id allowing to match the response line (see 2)
-//    - source ip of the request
-//    - HTTP method being invoked
-//    - original user invoking the operation
-//    - original user's groups info
-//    - impersonated user for the operation
-//    - impersonated groups info
-//    - namespace of the request or <none>
-//    - uri is the full URI as requested
-// 2. the response line containing:
-//    - the unique id from 1
-//    - response code
+// requests coming to the server. Audit level is decided according to requests'
+// attributes and audit policy. Logs are emitted to the audit sink to
+// process events. If sink or audit policy is nil, no decoration takes place.
 func WithAudit(handler http.Handler, requestContextMapper request.RequestContextMapper, sink audit.Sink, policy policy.Checker, longRunningCheck request.LongRunningRequestCheck) http.Handler {
 	if sink == nil || policy == nil {
 		return handler

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/legacy_audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/legacy_audit.go
@@ -75,7 +75,7 @@ var _ http.CloseNotifier = &fancyLegacyResponseWriterDelegator{}
 var _ http.Flusher = &fancyLegacyResponseWriterDelegator{}
 var _ http.Hijacker = &fancyLegacyResponseWriterDelegator{}
 
-// WithAudit decorates a http.Handler with audit logging information for all the
+// WithLegacyAudit decorates a http.Handler with audit logging information for all the
 // requests coming to the server. If out is nil, no decoration takes place.
 // Each audit log contains two entries:
 // 1. the request line containing:


### PR DESCRIPTION
doc for WithAudit is copyed from WithLegacyAudit, it's out of date.
This change update doc for these two functions.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
