### PR TITLE
func parseEndpointWithFallbackProtocol should check if protocol of endpoint is empty

### DIFF
--- a/pkg/kubelet/util/util.go
+++ b/pkg/kubelet/util/util.go
@@ -39,7 +39,9 @@ func parseEndpoint(endpoint string) (string, string, error) {
 		return "tcp", u.Host, nil
 	} else if u.Scheme == "unix" {
 		return "unix", u.Path, nil
+	} else if u.Scheme == "" {
+		return "", "", fmt.Errorf("Using %q as endpoint is deprecated, please consider using full url format", endpoint)
 	} else {
-		return "", "", fmt.Errorf("protocol %q not supported", u.Scheme)
+		return u.Scheme, "", fmt.Errorf("protocol %q not supported", u.Scheme)
 	}
 }

--- a/pkg/kubelet/util/util_linux.go
+++ b/pkg/kubelet/util/util_linux.go
@@ -68,11 +68,11 @@ func dial(addr string, timeout time.Duration) (net.Conn, error) {
 }
 
 func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string) (protocol string, addr string, err error) {
-	if protocol, addr, err = parseEndpoint(endpoint); err != nil {
+	if protocol, addr, err = parseEndpoint(endpoint); err != nil && protocol == "" {
 		fallbackEndpoint := fallbackProtocol + "://" + endpoint
 		protocol, addr, err = parseEndpoint(fallbackEndpoint)
 		if err == nil {
-			glog.Warningf("Using %q as endpoint is depercated, please consider using full url format %q.", endpoint, fallbackEndpoint)
+			glog.Warningf("Using %q as endpoint is deprecated, please consider using full url format %q.", endpoint, fallbackEndpoint)
 		}
 	}
 	return

--- a/pkg/kubelet/util/util_test.go
+++ b/pkg/kubelet/util/util_test.go
@@ -40,8 +40,9 @@ func TestParseEndpoint(t *testing.T) {
 			expectedAddr:     "localhost:15880",
 		},
 		{
-			endpoint:    "tcp1://abc",
-			expectError: true,
+			endpoint:         "tcp1://abc",
+			expectedProtocol: "tcp1",
+			expectError:      true,
 		},
 		{
 			endpoint:    "a b c",
@@ -51,12 +52,12 @@ func TestParseEndpoint(t *testing.T) {
 
 	for _, test := range tests {
 		protocol, addr, err := parseEndpoint(test.endpoint)
+		assert.Equal(t, test.expectedProtocol, protocol)
 		if test.expectError {
 			assert.NotNil(t, err, "Expect error during parsing %q", test.endpoint)
 			continue
 		}
 		assert.Nil(t, err, "Expect no error during parsing %q", test.endpoint)
-		assert.Equal(t, test.expectedProtocol, protocol)
 		assert.Equal(t, test.expectedAddr, addr)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
func parseEndpointWithFallbackProtocol should check if protocol of endpoint is empty
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: part of #45927
NONE
**Special notes for your reviewer**:
NONE
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```