### PR TITLE
Delete redundant continue

### DIFF
--- a/pkg/kubectl/cmd/cp_test.go
+++ b/pkg/kubectl/cmd/cp_test.go
@@ -57,11 +57,9 @@ func TestExtractFileSpec(t *testing.T) {
 		spec, err := extractFileSpec(test.spec)
 		if test.expectErr && err == nil {
 			t.Errorf("unexpected non-error")
-			continue
 		}
 		if err != nil && !test.expectErr {
 			t.Errorf("unexpected error: %v", err)
-			continue
 		}
 		if spec.PodName != test.expectedPod {
 			t.Errorf("expected: %s, saw: %s", test.expectedPod, spec.PodName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
It seems that "continue" is redundant.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
