### PR TITLE
Update addon-resizer version

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -78,7 +78,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:2.0
           name: heapster-nanny
           resources:
             limits:
@@ -102,12 +102,10 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
-            - --threshold=5
             - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
-            - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:2.0
           name: eventer-nanny
           resources:
             limits:
@@ -131,11 +129,9 @@ spec:
             - --extra-cpu=0m
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
-            - --threshold=5
             - --deployment=heapster-v1.4.0
             - --container=eventer
             - --poll-period=300000
-            - --estimator=exponential
       volumes:
         - name: ssl-certs
           hostPath:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -79,7 +79,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:2.0
           name: heapster-nanny
           resources:
             limits:
@@ -103,12 +103,10 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
-            - --threshold=5
             - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
-            - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:2.0
           name: eventer-nanny
           resources:
             limits:
@@ -132,11 +130,9 @@ spec:
             - --extra-cpu=0m
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
-            - --threshold=5
             - --deployment=heapster-v1.4.0
             - --container=eventer
             - --poll-period=300000
-            - --estimator=exponential
       volumes:
         - name: ssl-certs
           hostPath:

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -64,7 +64,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:2.0
           name: heapster-nanny
           resources:
             limits:
@@ -88,12 +88,10 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
-            - --threshold=5
             - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
-            - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:2.0
           name: eventer-nanny
           resources:
             limits:
@@ -117,11 +115,9 @@ spec:
             - --extra-cpu=0m
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
-            - --threshold=5
             - --deployment=heapster-v1.4.0
             - --container=eventer
             - --poll-period=300000
-            - --estimator=exponential
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -64,7 +64,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:2.0
           name: heapster-nanny
           resources:
             limits:
@@ -88,11 +88,9 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
-            - --threshold=5
             - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
-            - --estimator=exponential
       volumes:
         - name: ssl-certs
           hostPath:

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -55,7 +55,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:2.0
           name: heapster-nanny
           resources:
             limits:
@@ -79,11 +79,9 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
-            - --threshold=5
             - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
-            - --estimator=exponential
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"


### PR DESCRIPTION
Update addon-resizer version and remove the flags that have been deprecated in the new version.

**What this PR does / why we need it**:
ref kubernetes/contrib#2623

**Special notes for your reviewer**:
Need to wait for merging kubernetes/contrib#2623 first.

**Release note**:
~~addon-resizer flapping behavior was removed.~~

