### PR TITLE
Lookup --no-headers flag safely in PrinterForCommand function

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -115,8 +115,13 @@ func PrinterForCommand(cmd *cobra.Command, outputOpts *printers.OutputOptions, m
 		outputOpts = extractOutputOptions(cmd)
 	}
 
-	printer, err := printers.GetStandardPrinter(outputOpts,
-		GetFlagBool(cmd, "no-headers"), mapper, typer, encoder, decoders, options)
+	// this function may be invoked by a command that did not call AddPrinterFlags first, so we need
+	// to be safe about how we access the no-headers flag
+	noHeaders := false
+	if cmd.Flags().Lookup("no-headers") != nil {
+		noHeaders = GetFlagBool(cmd, "no-headers")
+	}
+	printer, err := printers.GetStandardPrinter(outputOpts, noHeaders, mapper, typer, encoder, decoders, options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If this was invoked by a command that did not call AddPrinterFlags first, it ended up with fatal error on `GetFlagBool(cmd, "no-headers")`. This is causing a bug in OpenShift's command reusing this code and not actually having a flag `--no-headers`.