### PR TITLE
[advanced audit] fix invalid status code for hijacker

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -183,7 +183,7 @@ func (a *auditResponseWriter) processCode(code int) {
 }
 
 func (a *auditResponseWriter) Write(bs []byte) (int, error) {
-	a.processCode(200) // the Go library calls WriteHeader internally if no code was written yet. But this will go unnoticed for us
+	a.processCode(http.StatusOK) // the Go library calls WriteHeader internally if no code was written yet. But this will go unnoticed for us
 	return a.ResponseWriter.Write(bs)
 }
 
@@ -208,6 +208,8 @@ func (f *fancyResponseWriterDelegator) Flush() {
 }
 
 func (f *fancyResponseWriterDelegator) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	// fake a response status before protocol switch happens
+	f.processCode(http.StatusSwitchingProtocols)
 	return f.ResponseWriter.(http.Hijacker).Hijack()
 }
 


### PR DESCRIPTION
Fixes #47035

When using hijacker to take over the connection, the http status code
should be 101 not 200.

PS:
Use "kubectl exec" as an example to review this change.

Part of https://github.com/kubernetes/features/issues/22