### PR TITLE
Remove timestamps from docs/api-reference/*/*.html

### DIFF
--- a/docs/api-reference/admissionregistration.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/admissionregistration.k8s.io/v1alpha1/definitions.html
@@ -1757,7 +1757,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:24:50 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/admissionregistration.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/admissionregistration.k8s.io/v1alpha1/operations.html
@@ -2957,7 +2957,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-25 18:54:30 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/apps/v1beta1/definitions.html
+++ b/docs/api-reference/apps/v1beta1/definitions.html
@@ -6807,7 +6807,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-12 15:33:31 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/apps/v1beta1/operations.html
+++ b/docs/api-reference/apps/v1beta1/operations.html
@@ -6634,7 +6634,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-25 21:02:39 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/authentication.k8s.io/v1/definitions.html
+++ b/docs/api-reference/authentication.k8s.io/v1/definitions.html
@@ -1264,7 +1264,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:01 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/authentication.k8s.io/v1/operations.html
+++ b/docs/api-reference/authentication.k8s.io/v1/operations.html
@@ -558,7 +558,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-07 05:41:02 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/authentication.k8s.io/v1beta1/definitions.html
+++ b/docs/api-reference/authentication.k8s.io/v1beta1/definitions.html
@@ -1264,7 +1264,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:06 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/authentication.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/authentication.k8s.io/v1beta1/operations.html
@@ -558,7 +558,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-12-03 22:06:49 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/authorization.k8s.io/v1/definitions.html
+++ b/docs/api-reference/authorization.k8s.io/v1/definitions.html
@@ -1525,7 +1525,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:11 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/authorization.k8s.io/v1/operations.html
+++ b/docs/api-reference/authorization.k8s.io/v1/operations.html
@@ -788,7 +788,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-02-02 02:26:17 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/authorization.k8s.io/v1beta1/definitions.html
+++ b/docs/api-reference/authorization.k8s.io/v1beta1/definitions.html
@@ -1525,7 +1525,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:16 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/authorization.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/authorization.k8s.io/v1beta1/operations.html
@@ -788,7 +788,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-12-03 22:06:55 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/autoscaling/v1/definitions.html
+++ b/docs/api-reference/autoscaling/v1/definitions.html
@@ -1505,7 +1505,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:21 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/autoscaling/v1/operations.html
+++ b/docs/api-reference/autoscaling/v1/operations.html
@@ -2467,7 +2467,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:24:56 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/autoscaling/v2alpha1/definitions.html
+++ b/docs/api-reference/autoscaling/v2alpha1/definitions.html
@@ -1958,7 +1958,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:26 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/autoscaling/v2alpha1/operations.html
+++ b/docs/api-reference/autoscaling/v2alpha1/operations.html
@@ -2467,7 +2467,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:01 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/batch/v1/definitions.html
+++ b/docs/api-reference/batch/v1/definitions.html
@@ -5788,7 +5788,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-10 04:37:24 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/batch/v1/operations.html
+++ b/docs/api-reference/batch/v1/operations.html
@@ -2467,7 +2467,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:06 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/batch/v2alpha1/definitions.html
+++ b/docs/api-reference/batch/v2alpha1/definitions.html
@@ -5884,7 +5884,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-10 04:37:30 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/batch/v2alpha1/operations.html
+++ b/docs/api-reference/batch/v2alpha1/operations.html
@@ -4487,7 +4487,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:11 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/certificates.k8s.io/v1beta1/definitions.html
+++ b/docs/api-reference/certificates.k8s.io/v1beta1/definitions.html
@@ -1501,7 +1501,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:42 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/certificates.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/certificates.k8s.io/v1beta1/operations.html
@@ -1940,7 +1940,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:16 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -8224,7 +8224,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-10 04:37:41 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/extensions/v1beta1/operations.html
+++ b/docs/api-reference/extensions/v1beta1/operations.html
@@ -13942,7 +13942,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:20 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/networking.k8s.io/v1/definitions.html
+++ b/docs/api-reference/networking.k8s.io/v1/definitions.html
@@ -1590,7 +1590,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:53 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/networking.k8s.io/v1/operations.html
+++ b/docs/api-reference/networking.k8s.io/v1/operations.html
@@ -2088,7 +2088,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-27 18:54:54 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/policy/v1beta1/definitions.html
+++ b/docs/api-reference/policy/v1beta1/definitions.html
@@ -1546,7 +1546,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:25:58 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/policy/v1beta1/operations.html
+++ b/docs/api-reference/policy/v1beta1/operations.html
@@ -2467,7 +2467,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:27 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/definitions.html
@@ -1860,7 +1860,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:26:08 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1alpha1/operations.html
@@ -6175,7 +6175,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:35 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1beta1/definitions.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1beta1/definitions.html
@@ -1860,7 +1860,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:26:03 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/rbac.authorization.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/rbac.authorization.k8s.io/v1beta1/operations.html
@@ -6175,7 +6175,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:31 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/settings.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/settings.k8s.io/v1alpha1/definitions.html
@@ -4026,7 +4026,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-07 15:14:57 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/settings.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/settings.k8s.io/v1alpha1/operations.html
@@ -2088,7 +2088,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:40 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/storage.k8s.io/v1/definitions.html
+++ b/docs/api-reference/storage.k8s.io/v1/definitions.html
@@ -1343,7 +1343,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:26:24 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/storage.k8s.io/v1/operations.html
+++ b/docs/api-reference/storage.k8s.io/v1/operations.html
@@ -1702,7 +1702,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:48 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/storage.k8s.io/v1beta1/definitions.html
+++ b/docs/api-reference/storage.k8s.io/v1beta1/definitions.html
@@ -1343,7 +1343,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-06 04:26:19 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/storage.k8s.io/v1beta1/operations.html
+++ b/docs/api-reference/storage.k8s.io/v1beta1/operations.html
@@ -1702,7 +1702,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:25:44 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -10250,7 +10250,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-10 04:36:27 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/v1/operations.html
+++ b/docs/api-reference/v1/operations.html
@@ -35281,7 +35281,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-25 03:55:25 UTC
+
 </div>
 </div>
 </body>

--- a/federation/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/federation/docs/api-reference/extensions/v1beta1/definitions.html
@@ -7294,7 +7294,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-10 06:05:28 UTC
+
 </div>
 </div>
 </body>

--- a/federation/docs/api-reference/extensions/v1beta1/operations.html
+++ b/federation/docs/api-reference/extensions/v1beta1/operations.html
@@ -9412,7 +9412,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:26:29 UTC
+
 </div>
 </div>
 </body>

--- a/federation/docs/api-reference/federation/v1beta1/definitions.html
+++ b/federation/docs/api-reference/federation/v1beta1/definitions.html
@@ -1573,7 +1573,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-04 01:49:42 UTC
+
 </div>
 </div>
 </body>

--- a/federation/docs/api-reference/federation/v1beta1/operations.html
+++ b/federation/docs/api-reference/federation/v1beta1/operations.html
@@ -1821,7 +1821,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-17 22:26:20 UTC
+
 </div>
 </div>
 </body>

--- a/federation/docs/api-reference/v1/definitions.html
+++ b/federation/docs/api-reference/v1/definitions.html
@@ -2338,7 +2338,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-06-04 01:49:49 UTC
+
 </div>
 </div>
 </body>

--- a/federation/docs/api-reference/v1/operations.html
+++ b/federation/docs/api-reference/v1/operations.html
@@ -8968,7 +8968,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-05-25 03:59:22 UTC
+
 </div>
 </div>
 </body>

--- a/hack/lib/swagger.sh
+++ b/hack/lib/swagger.sh
@@ -127,13 +127,25 @@ kube::swagger::gen_api_ref_docs() {
   find . -type f | cut -sd / -f 2- | LC_ALL=C sort > .generated_html
   popd > /dev/null
 
+  if LANG=C sed --help 2>&1 | grep -q GNU; then
+    SED="sed"
+  elif which gsed &>/dev/null; then
+    SED="gsed"
+  else
+    echo "Failed to find GNU sed as sed or gsed. If you are on Mac: brew install gnu-sed." >&2
+    exit 1
+  fi
+
   while read file; do
     if [[ -e "${output_dir}/${file}" && -e "${output_tmp}/${file}" ]]; then
       echo "comparing ${output_dir}/${file} with ${output_tmp}/${file}"
 
+      # Remove the timestamp to reduce conflicts in PR(s)
+      $SED -i 's/^Last updated.*$//' "${output_tmp}/${file}"
+
       # By now, the contents should be normalized and stripped of any
       # auto-managed content.
-      if diff -NauprB -I 'Last update' "${output_dir}/${file}" "${output_tmp}/${file}" >/dev/null; then
+      if diff -NauprB "${output_dir}/${file}" "${output_tmp}/${file}" >/dev/null; then
         # actual contents same, overwrite generated with original.
         cp "${output_dir}/${file}" "${output_tmp}/${file}"
       fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

If there are 2 or more PR(s) in the queue, they will end up with
conflicts (and rechecks). So let us remove the timestamp entirely
when we generate the files.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #46814

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
