### PR TITLE
Regenerate openapi for 1.8

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
    "title": "Kubernetes",
-   "version": "v1.7.0"
+   "version": "v1.8.0"
   },
   "paths": {
    "/api/": {

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
    "title": "Generic API Server",
-   "version": "v1.7.0"
+   "version": "v1.8.0"
   },
   "paths": {
    "/api/": {


### PR DESCRIPTION
With the 1.7 branch cut and a new tag in master, the [generated openapi spec validation is failing](https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-verify?). This fixes it.