### PR TITLE
Update openapi spec for v1.8.0

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
    "title": "Kubernetes",
-   "version": "v1.7.0"
+   "version": "v1.8.0"
   },
   "paths": {
    "/api/": {


### PR DESCRIPTION
This fixes the pull-kubernetes-verify job

```release-note
NONE
```
