### PR TITLE
Allow persistent-volume-binder to List Nodes/Zones Available in the Cluster

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -192,6 +192,11 @@ func init() {
 			// recyclerClient.WatchPod
 			rbac.NewRule("watch").Groups(legacyGroup).Resources("events").RuleOrDie(),
 
+			// Cinder, AWS and GCE provisioners need to get list of nodes in order
+			// to get list of available zones in the cluster in order to choose a zone
+			// in case it's not configured in corresponding Storage Class
+			rbac.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+
 			eventsRule(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -670,6 +670,14 @@ items:
   - apiGroups:
     - ""
     resources:
+    - nodes
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
     - events
     verbs:
     - create


### PR DESCRIPTION
Cinder, AWS and GCE provisioners choose a zone from the list of zones available in the cluster in case no zone is specified in the corresponding Storage Class. However, currently the provisioner (persistent-volume-binder) do not have right to get the list of nodes/zones available in the cluster.

That's why the pv-binder-controller is being given permission to list and watch nodes in the cluster.

@deads2k @enj @liggitt PTAL

```
NONE
```
