### PR TITLE
hyperkube: add ceph-common for rdb backend support

### DIFF
--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -30,6 +30,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     git \
     jq \
     nfs-common \
+    ceph-common \
     glusterfs-client \
     cifs-utils \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This PR add `ceph-common` to the hyperkube image, so that ceph can be used as a storage option similar to gluster/nfs (which are already included).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # it does not "fix" an issue, however it does mean that users for projects such as kolla-kubernetes and openstack-helm (both openstack projects) as well as others who require ceph storage can use an upstream hyperkube image.

**Special notes for your reviewer**:
i understand both viewpoints (having and not having this PR). to be clear, when i noticed other options available (gluster/nfs) in the image, i figured that reviewers *may* be open to accepting this small change. hopefully this is the case, as it would make it a lot easier for for users who require ceph. i appreciate any consideration made for this PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
