### PR TITLE
Adds --insecure to cockroachdb client command

### DIFF
--- a/examples/cockroachdb/README.md
+++ b/examples/cockroachdb/README.md
@@ -57,7 +57,7 @@ Start up a client pod and open up an interactive, (mostly) Postgres-flavor
 SQL shell using:
 
 ```console
-$ kubectl run -it --rm cockroach-client --image=cockroachdb/cockroach --restart=Never --command -- ./cockroach sql --host cockroachdb-public
+$ kubectl run -it --rm cockroach-client --image=cockroachdb/cockroach --restart=Never --command -- ./cockroach sql --host cockroachdb-public --insecure
 ```
 
 You can see example SQL statements for inserting and querying data in the

--- a/examples/cockroachdb/demo.sh
+++ b/examples/cockroachdb/demo.sh
@@ -21,6 +21,7 @@ function sql() {
   # output?
   kubectl exec "cockroachdb-${1}" -- /cockroach/cockroach sql \
       --host "cockroachdb-${1}.cockroachdb" \
+      --insecure \
       -e "$(cat /dev/stdin)"
 }
 


### PR DESCRIPTION
Cockroach errors out when using said command:

```shell
▶  kubectl run -it --rm cockroach-client --image=cockroachdb/cockroach --restart=Never --command -- ./cockroach sql --host cockroachdb-public
Waiting for pod default/cockroach-client to be running, status is Pending, pod ready: false
Waiting for pod default/cockroach-client to be running, status is Pending, pod ready: false
Waiting for pod default/cockroach-client to be running, status is Pending, pod ready: false
If you don't see a command prompt, try pressing enter.
                                                      Error attaching, falling back to logs: unable to upgrade connection: container cockroach-client not found in pod cockroach-client_default
Error: problem using security settings, did you mean to use --insecure?: problem with CA certificate: not found
Failed running "sql"
Waiting for pod default/cockroach-client to terminate, status is Running
pod "cockroach-client" deleted
```

This PR updates the README.md to include --insecure in the client command