### PR TITLE
Let COS docker validation node test against gci-next-canary

### DIFF
--- a/test/e2e_node/jenkins/docker_validation/cos-docker-validation.properties
+++ b/test/e2e_node/jenkins/docker_validation/cos-docker-validation.properties
@@ -1,5 +1,5 @@
-GCI_IMAGE_PROJECT=cos-docker-validation
-GCI_IMAGE_FAMILY=validation-test
+GCI_IMAGE_PROJECT=container-vm-image-staging
+GCI_IMAGE_FAMILY=gci-next-canary
 GCI_IMAGE=$(gcloud compute images describe-from-family ${GCI_IMAGE_FAMILY} --project=${GCI_IMAGE_PROJECT} --format="value(name)")
 GCI_CLOUD_INIT=test/e2e_node/jenkins/gci-init.yaml
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This is for COS docker validation node test. We plan to use family gci-next-canary in container-vm-image-staging for future Docker upgration and validation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47134

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
