### PR TITLE
Extract validateNodeIP test to node status test file.

### DIFF
--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package kubelet
 
 import (
-	"fmt"
-	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,97 +89,6 @@ func TestNoOpHostSupportsLegacyFeatures(t *testing.T) {
 	nh := NoOpLegacyHost{}
 	if nh.SupportsLegacyFeatures() != false {
 		t.Fatalf("noOpLegacyHost legacy features expected to be false")
-	}
-}
-
-func TestNodeIPParam(t *testing.T) {
-	type test struct {
-		nodeIP   string
-		success  bool
-		testName string
-	}
-	tests := []test{
-		{
-			nodeIP:   "",
-			success:  false,
-			testName: "IP not set",
-		},
-		{
-			nodeIP:   "127.0.0.1",
-			success:  false,
-			testName: "IPv4 loopback address",
-		},
-		{
-			nodeIP:   "::1",
-			success:  false,
-			testName: "IPv6 loopback address",
-		},
-		{
-			nodeIP:   "224.0.0.1",
-			success:  false,
-			testName: "multicast IPv4 address",
-		},
-		{
-			nodeIP:   "ff00::1",
-			success:  false,
-			testName: "multicast IPv6 address",
-		},
-		{
-			nodeIP:   "169.254.0.1",
-			success:  false,
-			testName: "IPv4 link-local unicast address",
-		},
-		{
-			nodeIP:   "fe80::0202:b3ff:fe1e:8329",
-			success:  false,
-			testName: "IPv6 link-local unicast address",
-		},
-		{
-			nodeIP:   "0.0.0.0",
-			success:  false,
-			testName: "Unspecified IPv4 address",
-		},
-		{
-			nodeIP:   "::",
-			success:  false,
-			testName: "Unspecified IPv6 address",
-		},
-		{
-			nodeIP:   "1.2.3.4",
-			success:  false,
-			testName: "IPv4 address that doesn't belong to host",
-		},
-	}
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		assert.Error(t, err, fmt.Sprintf(
-			"Unable to obtain a list of the node's unicast interface addresses."))
-	}
-	for _, addr := range addrs {
-		var ip net.IP
-		switch v := addr.(type) {
-		case *net.IPNet:
-			ip = v.IP
-		case *net.IPAddr:
-			ip = v.IP
-		}
-		if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
-			break
-		}
-		successTest := test{
-			nodeIP:   ip.String(),
-			success:  true,
-			testName: fmt.Sprintf("Success test case for address %s", ip.String()),
-		}
-		tests = append(tests, successTest)
-	}
-	for _, test := range tests {
-		err := validateNodeIP(net.ParseIP(test.nodeIP))
-		if test.success {
-			assert.NoError(t, err, "test %s", test.testName)
-		} else {
-			assert.Error(t, err, fmt.Sprintf("test %s", test.testName))
-		}
 	}
 }
 

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -1416,3 +1416,94 @@ func TestUpdateDefaultLabels(t *testing.T) {
 		assert.Equal(t, tc.finalLabels, tc.existingNode.Labels, tc.name)
 	}
 }
+
+func TestValidateNodeIPParam(t *testing.T) {
+	type test struct {
+		nodeIP   string
+		success  bool
+		testName string
+	}
+	tests := []test{
+		{
+			nodeIP:   "",
+			success:  false,
+			testName: "IP not set",
+		},
+		{
+			nodeIP:   "127.0.0.1",
+			success:  false,
+			testName: "IPv4 loopback address",
+		},
+		{
+			nodeIP:   "::1",
+			success:  false,
+			testName: "IPv6 loopback address",
+		},
+		{
+			nodeIP:   "224.0.0.1",
+			success:  false,
+			testName: "multicast IPv4 address",
+		},
+		{
+			nodeIP:   "ff00::1",
+			success:  false,
+			testName: "multicast IPv6 address",
+		},
+		{
+			nodeIP:   "169.254.0.1",
+			success:  false,
+			testName: "IPv4 link-local unicast address",
+		},
+		{
+			nodeIP:   "fe80::0202:b3ff:fe1e:8329",
+			success:  false,
+			testName: "IPv6 link-local unicast address",
+		},
+		{
+			nodeIP:   "0.0.0.0",
+			success:  false,
+			testName: "Unspecified IPv4 address",
+		},
+		{
+			nodeIP:   "::",
+			success:  false,
+			testName: "Unspecified IPv6 address",
+		},
+		{
+			nodeIP:   "1.2.3.4",
+			success:  false,
+			testName: "IPv4 address that doesn't belong to host",
+		},
+	}
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		assert.Error(t, err, fmt.Sprintf(
+			"Unable to obtain a list of the node's unicast interface addresses."))
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+		if ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+			break
+		}
+		successTest := test{
+			nodeIP:   ip.String(),
+			success:  true,
+			testName: fmt.Sprintf("Success test case for address %s", ip.String()),
+		}
+		tests = append(tests, successTest)
+	}
+	for _, test := range tests {
+		err := validateNodeIP(net.ParseIP(test.nodeIP))
+		if test.success {
+			assert.NoError(t, err, "test %s", test.testName)
+		} else {
+			assert.Error(t, err, fmt.Sprintf("test %s", test.testName))
+		}
+	}
+}


### PR DESCRIPTION
The function of `validateNodeIP` is belong to kubelet_node_status,
so the unit test of this function should be in node status test file.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
