### PR TITLE
remove unused function and variable from audit backend

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
@@ -19,23 +19,20 @@ package log
 import (
 	"fmt"
 	"io"
-	"strings"
 
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/audit"
 )
 
 type backend struct {
-	out  io.Writer
-	sink chan *auditinternal.Event
+	out io.Writer
 }
 
 var _ audit.Backend = &backend{}
 
 func NewBackend(out io.Writer) *backend {
 	return &backend{
-		out:  out,
-		sink: make(chan *auditinternal.Event, 100),
+		out: out,
 	}
 }
 
@@ -54,12 +51,4 @@ func (b *backend) logEvent(ev *auditinternal.Event) {
 
 func (b *backend) Run(stopCh <-chan struct{}) error {
 	return nil
-}
-
-func auditStringSlice(inList []string) string {
-	quotedElements := make([]string, len(inList))
-	for i, in := range inList {
-		quotedElements[i] = fmt.Sprintf("%q", in)
-	}
-	return strings.Join(quotedElements, ",")
 }


### PR DESCRIPTION
auditStringSlice is not used here anymore.
sink variable is also not used.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
Fixes: #47114