### PR TITLE
Fixed kubectl cp copying of paths ending with slash

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -188,6 +188,10 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 }
 
 func makeTar(filepath string, writer io.Writer) error {
+	if strings.HasSuffix(filepath, "/") {
+		filepath = filepath[:len(filepath)-1]
+	}
+
 	// TODO: use compression here?
 	tarWriter := tar.NewWriter(writer)
 	defer tarWriter.Close()

--- a/pkg/kubectl/cmd/cp_test.go
+++ b/pkg/kubectl/cmd/cp_test.go
@@ -104,6 +104,10 @@ func TestTarUntar(t *testing.T) {
 		t.Errorf("unexpected error: %v | %v", err, err2)
 		t.FailNow()
 	}
+
+	// makeTar should remove trailing slash
+	dir = dir + "/"
+
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Errorf("Unexpected error cleaning up: %v", err)


### PR DESCRIPTION
Fixed a bug when trying to copy a local directory ending with slash to a container using kubectl cp it will fail because of wrong parsing of the path.
This is caused by a strange behavior of go: both path.Dir("mydir/") and path.Base("mydir/") returns "mydir".

Example:
kubectl cp mydir/ mycontainer:/
error: stat mydir/mydir: no such file or directory