### PR TITLE
[DO NOT MERGE] node authorizer tracing

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -225,7 +225,7 @@ fi
 
 # Admission Controllers to invoke prior to persisting objects in cluster
 # If we included ResourceQuota, we should keep it at the end of the list to prevent incrementing quota usage prematurely.
-ADMISSION_CONTROL=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota
+ADMISSION_CONTROL=Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota
 
 # Optional: if set to true kube-up will automatically check for existing resources and clean them up.
 KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -255,7 +255,7 @@ if [ ${ENABLE_IP_ALIASES} = true ]; then
 fi
 
 # If we included ResourceQuota, we should keep it at the end of the list to prevent incrementing quota usage prematurely.
-ADMISSION_CONTROL="${KUBE_ADMISSION_CONTROL:-Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,PodPreset,DefaultStorageClass,DefaultTolerationSeconds,ResourceQuota}"
+ADMISSION_CONTROL="${KUBE_ADMISSION_CONTROL:-Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,PodPreset,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,ResourceQuota}"
 
 # Optional: if set to true kube-up will automatically check for existing resources and clean them up.
 KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1251,7 +1251,7 @@ function start-kube-apiserver {
   fi
 
 
-  local authorization_mode="RBAC"
+  local authorization_mode="Node,RBAC"
   local -r src_dir="${KUBE_HOME}/kube-manifests/kubernetes/gci-trusty"
 
   # Enable ABAC mode unless the user explicitly opts out with ENABLE_LEGACY_ABAC=false

--- a/pkg/auth/nodeidentifier/default.go
+++ b/pkg/auth/nodeidentifier/default.go
@@ -23,8 +23,9 @@ import (
 )
 
 // NewDefaultNodeIdentifier returns a default NodeIdentifier implementation,
-// which returns isNode=true if the user groups contain the system:nodes group,
-// and populates nodeName if isNode is true, and the user name is in the format system:node:<nodeName>
+// which returns isNode=true if the user groups contain the system:nodes group
+// and the user name matches the format system:node:<nodeName>, and populates
+// nodeName if isNode is true
 func NewDefaultNodeIdentifier() NodeIdentifier {
 	return defaultNodeIdentifier{}
 }
@@ -35,13 +36,21 @@ type defaultNodeIdentifier struct{}
 // nodeUserNamePrefix is the prefix for usernames in the form `system:node:<nodeName>`
 const nodeUserNamePrefix = "system:node:"
 
-// NodeIdentity returns isNode=true if the user groups contain the system:nodes group,
-// and populates nodeName if isNode is true, and the user name is in the format system:node:<nodeName>
+// NodeIdentity returns isNode=true if the user groups contain the system:nodes
+// group and the user name matches the format system:node:<nodeName>, and
+// populates nodeName if isNode is true
 func (defaultNodeIdentifier) NodeIdentity(u user.Info) (string, bool) {
 	// Make sure we're a node, and can parse the node name
 	if u == nil {
 		return "", false
 	}
+
+	userName := u.GetName()
+	if !strings.HasPrefix(userName, nodeUserNamePrefix) {
+		return "", false
+	}
+
+	nodeName := strings.TrimPrefix(userName, nodeUserNamePrefix)
 
 	isNode := false
 	for _, g := range u.GetGroups() {
@@ -52,12 +61,6 @@ func (defaultNodeIdentifier) NodeIdentity(u user.Info) (string, bool) {
 	}
 	if !isNode {
 		return "", false
-	}
-
-	userName := u.GetName()
-	nodeName := ""
-	if strings.HasPrefix(userName, nodeUserNamePrefix) {
-		nodeName = strings.TrimPrefix(userName, nodeUserNamePrefix)
 	}
 
 	return nodeName, isNode

--- a/pkg/auth/nodeidentifier/default_test.go
+++ b/pkg/auth/nodeidentifier/default_test.go
@@ -45,7 +45,7 @@ func TestDefaultNodeIdentifier_NodeIdentity(t *testing.T) {
 			name:           "node group without username",
 			user:           &user.DefaultInfo{Name: "foo", Groups: []string{"system:nodes"}},
 			expectNodeName: "",
-			expectIsNode:   true,
+			expectIsNode:   false,
 		},
 		{
 			name:           "node group and username",

--- a/plugin/pkg/auth/authorizer/node/BUILD
+++ b/plugin/pkg/auth/authorizer/node/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/trace:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/plugin/pkg/auth/authorizer/node/graph.go
+++ b/plugin/pkg/auth/authorizer/node/graph.go
@@ -17,8 +17,11 @@ limitations under the License.
 package node
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
+	utiltrace "k8s.io/apiserver/pkg/util/trace"
 	"k8s.io/kubernetes/pkg/api"
 	pvutil "k8s.io/kubernetes/pkg/api/persistentvolume"
 	podutil "k8s.io/kubernetes/pkg/api/pod"
@@ -203,6 +206,9 @@ func (g *Graph) deleteVertex_locked(vertexType vertexType, namespace, name strin
 //   configmap -> pod
 //   pvc       -> pod
 func (g *Graph) AddPod(pod *api.Pod) {
+	trace := utiltrace.New(fmt.Sprintf("Graph.AddPod: namespace=%s,name=%s", pod.Namespace, pod.Name))
+	defer trace.LogIfLong(100 * time.Millisecond)
+
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
@@ -228,6 +234,9 @@ func (g *Graph) AddPod(pod *api.Pod) {
 	}
 }
 func (g *Graph) DeletePod(name, namespace string) {
+	trace := utiltrace.New(fmt.Sprintf("Graph.DeletePod: namespace=%s,name=%s", namespace, name))
+	defer trace.LogIfLong(100 * time.Millisecond)
+
 	g.lock.Lock()
 	defer g.lock.Unlock()
 	g.deleteVertex_locked(podVertexType, namespace, name)
@@ -239,6 +248,9 @@ func (g *Graph) DeletePod(name, namespace string) {
 //
 //   pv -> pvc
 func (g *Graph) AddPV(pv *api.PersistentVolume) {
+	trace := utiltrace.New(fmt.Sprintf("Graph.AddPV: name=%s", pv.Name))
+	defer trace.LogIfLong(100 * time.Millisecond)
+
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
@@ -259,6 +271,9 @@ func (g *Graph) AddPV(pv *api.PersistentVolume) {
 	}
 }
 func (g *Graph) DeletePV(name string) {
+	trace := utiltrace.New(fmt.Sprintf("Graph.DeletePV: name=%s", name))
+	defer trace.LogIfLong(100 * time.Millisecond)
+
 	g.lock.Lock()
 	defer g.lock.Unlock()
 	g.deleteVertex_locked(pvVertexType, "", name)

--- a/plugin/pkg/auth/authorizer/node/graph_populator.go
+++ b/plugin/pkg/auth/authorizer/node/graph_populator.go
@@ -64,7 +64,8 @@ func (g *graphPopulator) updatePod(oldObj, obj interface{}) {
 			return
 		}
 	}
-	glog.V(4).Infof("updatePod %s/%s for node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+	glog.V(2).Infof("updatePod > %s/%s for node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+	defer glog.V(2).Infof("updatePod < %s/%s for node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 	g.graph.AddPod(pod)
 }
 
@@ -81,7 +82,8 @@ func (g *graphPopulator) deletePod(obj interface{}) {
 		glog.V(5).Infof("deletePod %s/%s, no node", pod.Namespace, pod.Name)
 		return
 	}
-	glog.V(4).Infof("deletePod %s/%s for node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+	glog.V(2).Infof("deletePod > %s/%s for node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
+	defer glog.V(2).Infof("deletePod < %s/%s for node %s", pod.Namespace, pod.Name, pod.Spec.NodeName)
 	g.graph.DeletePod(pod.Name, pod.Namespace)
 }
 

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -18,11 +18,13 @@ package node
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	utiltrace "k8s.io/apiserver/pkg/util/trace"
 	"k8s.io/kubernetes/pkg/api"
 	rbacapi "k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
@@ -106,6 +108,9 @@ func (r *NodeAuthorizer) authorizeGet(nodeName string, startingType vertexType, 
 		glog.V(2).Infof("NODE DENY: %s %#v", nodeName, attrs)
 		return false, "cannot get subresource", nil
 	}
+
+	trace := utiltrace.New(fmt.Sprintf("NodeAuthorizer.authorizeGet: node=%s,type=%s,namespace=%s,name=%s", nodeName, vertexTypes[startingType], attrs.GetNamespace(), attrs.GetName()))
+	defer trace.LogIfLong(100 * time.Millisecond)
 
 	ok, err := r.hasPathFrom(nodeName, startingType, attrs.GetNamespace(), attrs.GetName())
 	if err != nil {


### PR DESCRIPTION
adds tracing to the node authorizer PR... seeing an odd 1 second delay on the local pod watch (the kubelet watch sees the pod binding in ~.01 seconds, the local watch via a shared informer feeding the authorizer sees it in ~1 second), which makes the first couple requests for secrets from the node get forbidden