### PR TITLE
Delete federation system namespace from all the federated clusters.

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -411,6 +411,10 @@ function push-federation-images {
 }
 
 function cleanup-federation-api-objects {
+  # This is a cleanup function. We cannot stop on errors here. So disable
+  # errexit in this function.
+  set +o errexit
+
   echo "Cleaning Federation control plane objects"
   # Delete all resources with the federated-cluster label.
   $host_kubectl delete pods,svc,rc,deployment,secret -lapp=federated-cluster
@@ -423,10 +427,19 @@ function cleanup-federation-api-objects {
 
   # Delete all resources in FEDERATION_NAMESPACE.
   $host_kubectl delete pvc,pods,svc,rc,deployment,secret --namespace=${FEDERATION_NAMESPACE} --all
-  $host_kubectl delete ns ${FEDERATION_NAMESPACE}
 
-  # Poll until the namespace is completely gone.
-  while $host_kubectl get namespace ${FEDERATION_NAMESPACE} >/dev/null 2>&1; do
-    sleep 5
+  # This is a big hammer. We get rid of federation-system namespace from
+  # all the clusters
+  for context in $(federation_cluster_contexts); do
+    kube::log::status "Removing namespace \"${FEDERATION_NAMESPACE}\" from \"${context}\""
+    (
+      # Try deleting until the namespace is completely gone.
+      while $host_kubectl --context="${context}" delete namespace ${FEDERATION_NAMESPACE} >/dev/null 2>&1; do
+        sleep 5
+      done
+      kube::log::status "Removed namespace \"${FEDERATION_NAMESPACE}\" from \"${context}\""
+    ) &
   done
+  wait
+  set -o errexit
 }

--- a/federation/cluster/federation-down.sh
+++ b/federation/cluster/federation-down.sh
@@ -27,7 +27,7 @@ source "${KUBE_ROOT}/federation/cluster/common.sh"
 
 # federation_clusters returns a list of all the clusters in
 # federation, if at all the federation control plane exists
-# and there are any clusters registerd.
+# and there are any clusters registered.
 function federation_clusters() {
   if clusters=$("${KUBE_ROOT}/cluster/kubectl.sh" \
       --context="${FEDERATION_KUBE_CONTEXT}" \


### PR DESCRIPTION
This is a big hammer. `kubefed join` creates federation-system namespace in the joining clusters if they don't already exist. This namespace usually exists in the host cluster and hence cannot be deleted while unjoining. So in order to be safe, we don't delete the federation-system namespace from any federated cluster while unjoining them. This causes a problem in our test environment if certain resources are left in the namespace. Therefore we are deleting all federation-system namespace in all the clusters.

This is a short term fix for issue #46937.

**Release note**:
```release-note
NONE
```

/assign @perotinus @shashidharatd 

cc @csbell 