### PR TITLE
kubectl config get-contexts: sort output

### DIFF
--- a/pkg/kubectl/cmd/config/get_contexts.go
+++ b/pkg/kubectl/cmd/config/get_contexts.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"text/tabwriter"
 
@@ -138,6 +139,7 @@ func (o GetContextsOptions) RunGetContexts() error {
 		}
 	}
 
+	sort.Strings(toPrint)
 	for _, name := range toPrint {
 		err = printContext(name, config.Contexts[name], out, o.nameOnly, config.CurrentContext == name)
 		if err != nil {

--- a/pkg/kubectl/cmd/config/get_contexts_test.go
+++ b/pkg/kubectl/cmd/config/get_contexts_test.go
@@ -66,6 +66,27 @@ func TestGetContextsAllNoHeader(t *testing.T) {
 	test.run(t)
 }
 
+func TestGetContextsAllSorted(t *testing.T) {
+	tconf := clientcmdapi.Config{
+		CurrentContext: "shaker-context",
+		Contexts: map[string]*clientcmdapi.Context{
+			"shaker-context": {AuthInfo: "blue-user", Cluster: "big-cluster", Namespace: "saw-ns"},
+			"abc":            {AuthInfo: "blue-user", Cluster: "abc-cluster", Namespace: "kube-system"},
+			"xyz":            {AuthInfo: "blue-user", Cluster: "xyz-cluster", Namespace: "default"}}}
+	test := getContextsTest{
+		startingConfig: tconf,
+		names:          []string{},
+		noHeader:       false,
+		nameOnly:       false,
+		expectedOut: `CURRENT   NAME             CLUSTER       AUTHINFO    NAMESPACE
+          abc              abc-cluster   blue-user   kube-system
+*         shaker-context   big-cluster   blue-user   saw-ns
+          xyz              xyz-cluster   blue-user   default
+`,
+	}
+	test.run(t)
+}
+
 func TestGetContextsAllName(t *testing.T) {
 	tconf := clientcmdapi.Config{
 		Contexts: map[string]*clientcmdapi.Context{


### PR DESCRIPTION
This sorts the output of kubectl config get-contexts because the ordering is otherwise non-stable and makes it harder to find the context you're looking for when you have more than a few.

```release-note
The output of kubectl config get-contexts is now sorted alphabetically by the context name.
```
