### PR TITLE
Install unique ssh firewall rule per cluster.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -735,12 +735,13 @@ function create-network() {
       --target-tags "${NODE_TAG}"&
   fi
 
-  if ! gcloud compute firewall-rules describe --project "${PROJECT}" "${NETWORK}-default-ssh" &>/dev/null; then
-    gcloud compute firewall-rules create "${NETWORK}-default-ssh" \
+  if ! gcloud compute firewall-rules describe --project "${PROJECT}" "${CLUSTER_NAME}-default-ssh" &>/dev/null; then
+    gcloud compute firewall-rules create "${CLUSTER_NAME}-default-ssh" \
       --project "${PROJECT}" \
       --network "${NETWORK}" \
       --source-ranges "0.0.0.0/0" \
-      --allow "tcp:22" &
+      --allow "tcp:22" \
+      --target-tags "${MASTER_TAG},${NODE_TAG}" &
   fi
 }
 
@@ -1578,7 +1579,7 @@ function kube-down() {
     delete-firewall-rules \
       "${CLUSTER_NAME}-default-internal-master" \
       "${CLUSTER_NAME}-default-internal-node" \
-      "${NETWORK}-default-ssh" \
+      "${CLUSTER_NAME}-default-ssh" \
       "${NETWORK}-default-internal"  # Pre-1.5 clusters
 
     delete-subnetworks


### PR DESCRIPTION
The current mode of creating a single firewall rule for all the VMs in a network doesn't work for federation because a federation might contain multiple federated clusters. kube-up installs a single firewall rule to allow ssh access when turning up clusters that applies to all the VMs in the project. That means when any cluster is torn down, the firewall rule is removed as well blocking access to other cluster VMs that are not torn down.

This change fixes the problem by installing a unique firewall rule for each cluster.

**Release note**:
```release-note
NONE
```

/assign @jszczepkowski @shashidharatd 
/sig federation
