### PR TITLE
Add NodeInternalIP as a fallback to federation api-server nodeport service

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -496,6 +496,7 @@ func createService(cmdOut io.Writer, clientset client.Interface, namespace, svcN
 func getClusterNodeIPs(clientset client.Interface) ([]string, error) {
 	preferredAddressTypes := []api.NodeAddressType{
 		api.NodeExternalIP,
+		api.NodeInternalIP,
 	}
 	nodeList, err := clientset.Core().Nodes().List(metav1.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
Previously NodeLegacyHostIP was used as a fallback (see #41243) but in 1.7 it was removed (#44830)
Now clusters where nodes have not set ExternalIP can not be used by kubefed to setup federation.

cc @shashidharatd 

```release-note
kubefed will now configure NodeInternalIP as the federation API server endpoint when NodeExternalIP is unavailable for federation API servers exposed as NodePort services
```

