### PR TITLE
deflake CRD watch tests

### DIFF
--- a/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/kube-apiextensions-server/pkg/apiserver/customresource_handler.go
@@ -275,17 +275,6 @@ func (r *crdHandler) getServingInfoFor(crd *apiextensions.CustomResourceDefiniti
 		r.restOptionsGetter,
 	)
 
-	// When new REST storage is created, the storage cacher for the CR starts asynchronously.
-	// REST API operations return like list use the RV of etcd, but the storage cacher's reflector's list
-	// can get a different RV because etcd can be touched in between the initial list operation (if that's what you're doing first)
-	// and the storage cache reflector starting.
-	// Later, you can issue a watch with the REST apis list.RV and end up earlier than the storage cacher.
-	// The time window is really narrow, but it can happen.  The simplest "solution" is to wait
-	// briefly for the storage cache to start before we return out new storage so its more likely that we'll have valid
-	// resource versions for the watch cache.  We don't expose cache status outside of the caching layer
-	// so I can't think of way to determine it reliably.
-	time.Sleep(1 * time.Second)
-
 	parameterScheme := runtime.NewScheme()
 	parameterScheme.AddUnversionedTypes(schema.GroupVersion{Group: crd.Spec.Group, Version: crd.Spec.Version},
 		&metav1.ListOptions{},

--- a/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/BUILD
+++ b/staging/src/k8s.io/kube-apiextensions-server/test/integration/testserver/BUILD
@@ -17,10 +17,12 @@ go_library(
     deps = [
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizerfactory:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/46446. Again...

This flake window is caused by the watch cache starting late.  This pull updates the test to do fancy list/create/watch/delete semantics to catch the problem.  In the field, this should be treated the same as any other "resourceVersion tool old" error and handled with a list/watch.  The test cannot be level driven, it is actually testing the edge behavior, so we have to do something weird like this.

@sttts @liggitt let's try this again...