### PR TITLE
iscsi storage plugin: bkpPortal should be initialized beforehand

### DIFF
--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -334,6 +334,7 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
 				// If the iscsi disk config is not found, fall back to the original behavior.
 				// This portal/iqn/iface is no longer referenced, log out.
 				// Extract the portal and iqn from device path.
+				bkpPortal = make([]string, 1)
 				bkpPortal[0], iqn, err = extractPortalAndIqn(device)
 				if err != nil {
 					return err


### PR DESCRIPTION
**What this PR does / why we need it**:
This patch is a follow up patch for the PR #46239.
The bkpPortal in DetachDisk() path should be initialized before using it.

**Special notes for your reviewer**:
/cc @rootfs @childsb 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
