### PR TITLE
make the health check wait for ready apiservices

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -120,7 +120,10 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		for _, apiService := range apiServices {
 			found := false
 			for _, item := range items {
-				if item.Name == apiService.Name {
+				if item.Name != apiService.Name {
+					continue
+				}
+				if apiregistration.IsAPIServiceConditionTrue(item, apiregistration.Available) {
 					found = true
 					break
 				}


### PR DESCRIPTION
The health check for whether the core APIServices are present didn't update to respect the new status conditions, so it reported healthy before the controller marked them as good.

This should fix the kops flakiness.