### PR TITLE
[gke-slow always fails] Defer DeleteGCEStaticIP before asserting error

### DIFF
--- a/test/e2e/service.go
+++ b/test/e2e/service.go
@@ -556,7 +556,6 @@ var _ = framework.KubeDescribe("Services", func() {
 			By("creating a static load balancer IP")
 			staticIPName = fmt.Sprintf("e2e-external-lb-test-%s", framework.RunId)
 			requestedIP, err = framework.CreateGCEStaticIP(staticIPName)
-			Expect(err).NotTo(HaveOccurred())
 			defer func() {
 				if staticIPName != "" {
 					// Release GCE static IP - this is not kube-managed and will not be automatically released.
@@ -565,6 +564,7 @@ var _ = framework.KubeDescribe("Services", func() {
 					}
 				}
 			}()
+			Expect(err).NotTo(HaveOccurred())
 			framework.Logf("Allocated static load balancer IP: %s", requestedIP)
 		}
 


### PR DESCRIPTION
From https://github.com/kubernetes/kubernetes/issues/46918.

I'm getting close to the root cause: During tests, CreateGCEStaticIP() in fact successfully created static IP, but the parser we wrote in test mistakenly think we failed, probably because the gcloud output format was changed recently (or not). I'm still looking into fixing that.

This PR defer the delete function before asserting the error so that we can stop consistently leaking static IP in every run.

/assign @krzyzacy @dchen1107 

```release-note
NONE
```
