### PR TITLE
Don't parse human-readable output from gcloud in tests

### DIFF
--- a/test/e2e/framework/google_compute.go
+++ b/test/e2e/framework/google_compute.go
@@ -48,7 +48,7 @@ func CreateGCEStaticIP(name string) (string, error) {
 	for attempts := 0; attempts < 4; attempts++ {
 		outputBytes, err = exec.Command("gcloud", "compute", "addresses", "create",
 			name, "--project", TestContext.CloudConfig.ProjectID,
-			"--region", region, "-q").CombinedOutput()
+			"--region", region, "-q", "--format=yaml").CombinedOutput()
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
This is the reason  `[k8s.io] Services should be able to change the type and ports of a service [Slow]` is currently failing on GKE e2e tests. For GKE jobs we run a prerelease version of gcloud, in which the default command output was changed.

gcloud's default output for commands is human readable, and is subject to change. Anything scripting against gcloud should always pass `--format=json|yaml|value(...)`  so you get standardized output.

fixes: #46918