### PR TITLE
bazel: stamp multiple packages by using x_defs instead of linkstamp in go_binary rules

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -1,15 +1,15 @@
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "64294fd0e74d2aafa03ec3a1f2f9c167e27d17c9a5cf393e8bf79e43258de73d",
-    strip_prefix = "rules_go-a9df110cf04e167b33f10473c7e904d780d921e6",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/a9df110cf04e167b33f10473c7e904d780d921e6.tar.gz"],
+    sha256 = "a1596c14c799d5a1b5f49ca28fa948414c2242110d69ef324d6ed160ec890dbf",
+    strip_prefix = "rules_go-03c634753160632c00f506afeafc819fbea4c422",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/03c634753160632c00f506afeafc819fbea4c422.tar.gz"],
 )
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "8d1cff71523565996903076cec6cad8424afa6eb93a342d0d810a55c911e23c7",
-    strip_prefix = "repo-infra-61b7247ebf472398bdea148d8f67e3a1849d6de9",
-    urls = ["https://github.com/kubernetes/repo-infra/archive/61b7247ebf472398bdea148d8f67e3a1849d6de9.tar.gz"],
+    sha256 = "a9fb7027f060b868cdbd235a0de0971b557b9d26f9c89e422feb80f48d8c0e90",
+    strip_prefix = "repo-infra-9dedd5f4093884c133ad5ea73695b28338b954ab",
+    urls = ["https://github.com/kubernetes/repo-infra/archive/9dedd5f4093884c133ad5ea73695b28338b954ab.tar.gz"],
 )
 
 # This contains a patch to not prepend ./ to tarfiles produced by pkg_tar.

--- a/cmd/cloud-controller-manager/BUILD
+++ b/cmd/cloud-controller-manager/BUILD
@@ -7,6 +7,7 @@ load(
     "go_binary",
     "go_library",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "cloud-controller-manager",
@@ -17,8 +18,8 @@ go_binary(
         "-static",
     ],
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_library(

--- a/cmd/hyperkube/BUILD
+++ b/cmd/hyperkube/BUILD
@@ -8,12 +8,13 @@ load(
     "go_library",
     "go_test",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "hyperkube",
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_test(

--- a/cmd/kube-apiserver/BUILD
+++ b/cmd/kube-apiserver/BUILD
@@ -7,6 +7,7 @@ load(
     "go_binary",
     "go_library",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kube-apiserver",
@@ -17,8 +18,8 @@ go_binary(
         "-static",
     ],
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_library(

--- a/cmd/kube-controller-manager/BUILD
+++ b/cmd/kube-controller-manager/BUILD
@@ -7,6 +7,7 @@ load(
     "go_binary",
     "go_library",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kube-controller-manager",
@@ -17,8 +18,8 @@ go_binary(
         "-static",
     ],
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_library(

--- a/cmd/kube-proxy/BUILD
+++ b/cmd/kube-proxy/BUILD
@@ -7,6 +7,7 @@ load(
     "go_binary",
     "go_library",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kube-proxy",
@@ -17,8 +18,8 @@ go_binary(
         "-static",
     ],
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_library(

--- a/cmd/kubeadm/BUILD
+++ b/cmd/kubeadm/BUILD
@@ -7,6 +7,7 @@ load(
     "go_binary",
     "go_library",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kubeadm",
@@ -17,8 +18,8 @@ go_binary(
         "-static",
     ],
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_library(

--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -5,6 +5,7 @@ load(
     "go_binary",
     "go_library",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kubectl",
@@ -15,11 +16,11 @@ go_binary(
         "-static",
     ],
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
     visibility = [
         "//build/visible_to:COMMON_release",
     ],
+    x_defs = version_x_defs(),
 )
 
 go_library(

--- a/cmd/kubelet/BUILD
+++ b/cmd/kubelet/BUILD
@@ -7,12 +7,13 @@ load(
     "go_binary",
     "go_library",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kubelet",
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_library(

--- a/hack/BUILD
+++ b/hack/BUILD
@@ -27,21 +27,23 @@ sh_test(
     tags = ["manual"],
 )
 
-sh_test(
-    name = "verify-gofmt",
-    srcs = ["verify-gofmt.sh"],
-    data = [
-        "//:all-srcs",
-        "@io_bazel_rules_go_toolchain//:toolchain",
-    ],
-    tags = ["manual"],
-)
+# Disable gofmt test until we can figure out how to access the gofmt binary.
+# https://github.com/bazelbuild/rules_go/issues/511
+#sh_test(
+#    name = "verify-gofmt",
+#    srcs = ["verify-gofmt.sh"],
+#    data = [
+#        "//:all-srcs",
+#        "@io_bazel_rules_go_toolchain//:toolchain",
+#    ],
+#    tags = ["manual"],
+#)
 
 test_suite(
     name = "verify-all",
     tags = ["manual"],
     tests = [
         "verify-boilerplate",
-        "verify-gofmt",
+        #        "verify-gofmt",
     ],
 )

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -118,12 +118,15 @@ kube::version::ldflag() {
   local key=${1}
   local val=${2}
 
+  # If you update these, also update the list pkg/version/def.bzl.
   echo "-X ${KUBE_GO_PACKAGE}/pkg/version.${key}=${val}"
   echo "-X ${KUBE_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.${key}=${val}"
 }
 
 # Prints the value that needs to be passed to the -ldflags parameter of go build
 # in order to set the Kubernetes based on the git tree status.
+# IMPORTANT: if you update any of these, also update the lists in
+# pkg/version/def.bzl and hack/print-workspace-status.sh.
 kube::version::ldflags() {
   kube::version::get_version_vars
 

--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -29,6 +29,8 @@ kube::version::get_version_vars
 # instead of volatile-status.txt.
 # Stamped rules will be retriggered by changes to stable-status.txt, but not by
 # changes to volatile-status.txt.
+# IMPORTANT: the camelCase vars should match the lists in hack/lib/version.sh
+# and pkg/version/def.bzl.
 cat <<EOF
 STABLE_BUILD_GIT_COMMIT ${KUBE_GIT_COMMIT-}
 STABLE_BUILD_SCM_STATUS ${KUBE_GIT_TREE_STATE-}

--- a/pkg/version/def.bzl
+++ b/pkg/version/def.bzl
@@ -1,0 +1,24 @@
+# Implements hack/lib/version.sh's kube::version::ldflags() for Bazel.
+def version_x_defs():
+  # This should match the list of packages in kube::version::ldflag
+  stamp_pkgs = [
+      "k8s.io/kubernetes/pkg/version",
+      # In hack/lib/version.sh, this has a vendor/ prefix. That isn't needed here?
+      "k8s.io/client-go/pkg/version",
+      ]
+  # This should match the list of vars in kube::version::ldflags
+  # It should also match the list of vars set in hack/print-workspace-status.sh.
+  stamp_vars = [
+      "buildDate",
+      "gitCommit",
+      "gitMajor",
+      "gitMinor",
+      "gitTreeState",
+      "gitVersion",
+  ]
+  # Generate the cross-product.
+  x_defs = {}
+  for pkg in stamp_pkgs:
+    for var in stamp_vars:
+      x_defs["%s.%s" % (pkg, var)] = "{%s}" % var
+  return x_defs

--- a/plugin/cmd/kube-scheduler/BUILD
+++ b/plugin/cmd/kube-scheduler/BUILD
@@ -7,6 +7,7 @@ load(
     "go_binary",
     "go_library",
 )
+load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kube-scheduler",
@@ -17,8 +18,8 @@ go_binary(
         "-static",
     ],
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_library(

--- a/staging/src/k8s.io/client-go/pkg/version/def.bzl
+++ b/staging/src/k8s.io/client-go/pkg/version/def.bzl
@@ -1,0 +1,24 @@
+# Implements hack/lib/version.sh's kube::version::ldflags() for Bazel.
+def version_x_defs():
+  # This should match the list of packages in kube::version::ldflag
+  stamp_pkgs = [
+      "k8s.io/kubernetes/pkg/version",
+      # In hack/lib/version.sh, this has a vendor/ prefix. That isn't needed here?
+      "k8s.io/client-go/pkg/version",
+      ]
+  # This should match the list of vars in kube::version::ldflags
+  # It should also match the list of vars set in hack/print-workspace-status.sh.
+  stamp_vars = [
+      "buildDate",
+      "gitCommit",
+      "gitMajor",
+      "gitMinor",
+      "gitTreeState",
+      "gitVersion",
+  ]
+  # Generate the cross-product.
+  x_defs = {}
+  for pkg in stamp_pkgs:
+    for var in stamp_vars:
+      x_defs["%s.%s" % (pkg, var)] = "{%s}" % var
+  return x_defs

--- a/staging/src/k8s.io/kube-aggregator/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/BUILD
@@ -7,6 +7,7 @@ load(
     "go_binary",
     "go_library",
 )
+load("//vendor/k8s.io/client-go/pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kube-aggregator",
@@ -17,8 +18,8 @@ go_binary(
         "-static",
     ],
     library = ":go_default_library",
-    linkstamp = "k8s.io/kubernetes/pkg/version",
     tags = ["automanaged"],
+    x_defs = version_x_defs(),
 )
 
 go_library(


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes regression introduced sometime in the last few months that prevented bazel-built clusters from identifying version properly. 

It does so by updating the bazelbuild/rules_go and kubernetes/repo-infra dependencies to support using stamp values in `go_binary` `x_defs`, and then changing our `go_binary` rules to use `x_defs` instead of `linkstamp`.

This whole charade is necessary because we need to stamp version information in multiple packages.

This pretty much only affects the bazel build, so it should be low risk.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #45298

**Special notes for your reviewer**: depends on https://github.com/kubernetes/repo-infra/pull/18; should not be merged before it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @spxtr @mikedanese 