### PR TITLE
kuberuntime: check the value of RunAsNonRoot when verifying

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -228,7 +228,7 @@ func TestGenerateContainerConfig(t *testing.T) {
 	assert.Equal(t, expectedConfig, containerConfig, "generate container config for kubelet runtime v1.")
 
 	runAsUser := types.UnixUserID(0)
-	RunAsNonRoot := false
+	runAsNonRootTrue := true
 	podWithContainerSecurityContext := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",
@@ -244,7 +244,7 @@ func TestGenerateContainerConfig(t *testing.T) {
 					Command:         []string{"testCommand"},
 					WorkingDir:      "testWorkingDir",
 					SecurityContext: &v1.SecurityContext{
-						RunAsNonRoot: &RunAsNonRoot,
+						RunAsNonRoot: &runAsNonRootTrue,
 						RunAsUser:    &runAsUser,
 					},
 				},

--- a/pkg/kubelet/kuberuntime/security_context.go
+++ b/pkg/kubelet/kuberuntime/security_context.go
@@ -72,7 +72,8 @@ func (m *kubeGenericRuntimeManager) determineEffectiveSecurityContext(pod *v1.Po
 // verifyRunAsNonRoot verifies RunAsNonRoot.
 func verifyRunAsNonRoot(pod *v1.Pod, container *v1.Container, uid int64) error {
 	effectiveSc := securitycontext.DetermineEffectiveSecurityContext(pod, container)
-	if effectiveSc == nil || effectiveSc.RunAsNonRoot == nil {
+	// If the option is not set, or if running as root is allowed, return nil.
+	if effectiveSc == nil || effectiveSc.RunAsNonRoot == nil || !*effectiveSc.RunAsNonRoot {
 		return nil
 	}
 

--- a/pkg/kubelet/kuberuntime/security_context_test.go
+++ b/pkg/kubelet/kuberuntime/security_context_test.go
@@ -48,31 +48,44 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 	rootUser := types.UnixUserID(0)
 	runAsNonRootTrue := true
 	runAsNonRootFalse := false
-
+	imageRootUser := int64(0)
+	imageNonRootUser := int64(123)
 	for _, test := range []struct {
-		desc   string
-		sc     *v1.SecurityContext
-		errStr string
+		desc      string
+		sc        *v1.SecurityContext
+		imageUser int64
+		fail      bool
 	}{
 		{
-			desc:   "Pass if SecurityContext is not set",
-			sc:     nil,
-			errStr: "",
+			desc:      "Pass if SecurityContext is not set",
+			sc:        nil,
+			imageUser: imageRootUser,
+			fail:      false,
 		},
 		{
 			desc: "Pass if RunAsNonRoot is not set",
 			sc: &v1.SecurityContext{
 				RunAsUser: &rootUser,
 			},
-			errStr: "",
+			imageUser: imageRootUser,
+			fail:      false,
 		},
 		{
-			desc: "Pass if RunAsNonRoot is false",
+			desc: "Pass if RunAsNonRoot is false (image user is root)",
+			sc: &v1.SecurityContext{
+				RunAsNonRoot: &runAsNonRootFalse,
+			},
+			imageUser: imageRootUser,
+			fail:      false,
+		},
+		{
+			desc: "Pass if RunAsNonRoot is false (RunAsUser is root)",
 			sc: &v1.SecurityContext{
 				RunAsNonRoot: &runAsNonRootFalse,
 				RunAsUser:    &rootUser,
 			},
-			errStr: "",
+			imageUser: imageNonRootUser,
+			fail:      false,
 		},
 		{
 			desc: "Fail if container's RunAsUser is root and RunAsNonRoot is true",
@@ -80,22 +93,24 @@ func TestVerifyRunAsNonRoot(t *testing.T) {
 				RunAsNonRoot: &runAsNonRootTrue,
 				RunAsUser:    &rootUser,
 			},
-			errStr: "container's runAsUser breaks non-root policy",
+			imageUser: imageNonRootUser,
+			fail:      true,
 		},
 		{
 			desc: "Fail if image's user is root and RunAsNonRoot is true",
 			sc: &v1.SecurityContext{
 				RunAsNonRoot: &runAsNonRootTrue,
 			},
-			errStr: "container has runAsNonRoot and image will run as root",
+			imageUser: imageRootUser,
+			fail:      true,
 		},
 	} {
 		pod.Spec.Containers[0].SecurityContext = test.sc
 		err := verifyRunAsNonRoot(pod, &pod.Spec.Containers[0], int64(0))
-		if len(test.errStr) == 0 {
-			assert.NoError(t, err, test.desc)
+		if test.fail {
+			assert.Error(t, err, test.desc)
 		} else {
-			assert.EqualError(t, err, test.errStr, test.desc)
+			assert.NoError(t, err, test.desc)
 		}
 	}
 }


### PR DESCRIPTION
The verification function is fixed to check the value of RunAsNonRoot,
not just the existence of it. Also adds unit tests to verify the correct
behavior.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #46996

**Release note**:

```release-note
Fix the bug where container cannot run as root when SecurityContext.RunAsNonRoot is false.
```
