### PR TITLE
Add an additional annotation for ingress path

### DIFF
--- a/test/e2e/testing-manifests/ingress/http/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http/ing.yaml
@@ -2,6 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: echomap
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
   - host: foo.bar.com


### PR DESCRIPTION
The path of ingress do not work without the following annotations on latest ingress controller(0.8.4):
annotations:
    ingress.kubernetes.io/rewrite-target: /
https://github.com/kubernetes/ingress/blob/master/controllers/nginx/configuration.md#rewrite