### PR TITLE
extending DefaultExternalHost for any registred cloud provider

### DIFF
--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -54,8 +54,7 @@ func (s *CloudProviderOptions) DefaultExternalHost(genericoptions *genericoption
 		return nil
 	}
 
-	// TODO: extend for other providers
-	if s.CloudProvider == "gce" || s.CloudProvider == "aws" {
+	if cloudprovider.IsCloudProvider(s.CloudProvider) {
 		cloud, err := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
 		if err != nil {
 			return fmt.Errorf("%q cloud provider could not be initialized: %v", s.CloudProvider, err)


### PR DESCRIPTION
**What this PR does / why we need it**: this PR enables DefaultExternalHost to work with any registered cloud provider.

**Which issue this PR fixes** : fixes #46567 

**Special notes for your reviewer**:

**Release note**:

```release-note
When determining the default external host of the kube apiserver, any configured cloud provider is now consulted
```
