### PR TITLE
kubelet: fix disk space check on btrfs (issue 47046)

### DIFF
--- a/vendor/github.com/google/cadvisor/fs/fs.go
+++ b/vendor/github.com/google/cadvisor/fs/fs.go
@@ -79,6 +79,8 @@ type RealFsInfo struct {
 	// Map from label to block device path.
 	// Labels are intent-specific tags that are auto-detected.
 	labels map[string]string
+	// Map from mountpoint to mount information.
+	mounts map[string]*mount.Info
 	// devicemapper client
 	dmsetup devicemapper.DmsetupClient
 }
@@ -106,7 +108,12 @@ func NewFsInfo(context Context) (FsInfo, error) {
 	fsInfo := &RealFsInfo{
 		partitions: processMounts(mounts, excluded),
 		labels:     make(map[string]string, 0),
+		mounts:     make(map[string]*mount.Info, 0),
 		dmsetup:    devicemapper.NewDmsetupClient(),
+	}
+
+	for _, mount := range mounts {
+		fsInfo.mounts[mount.Mountpoint] = mount
 	}
 
 	fsInfo.addRktImagesLabel(context, mounts)
@@ -152,25 +159,12 @@ func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) ma
 		// btrfs fix: following workaround fixes wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.
 		// instead of using values from /proc/self/mountinfo we use stat to get Ids from btrfs mount point
 		if mount.Fstype == "btrfs" && mount.Major == 0 && strings.HasPrefix(mount.Source, "/dev/") {
-
-			buf := new(syscall.Stat_t)
-			err := syscall.Stat(mount.Source, buf)
+			major, minor, err := getBtrfsMajorMinorIds(mount)
 			if err != nil {
-				glog.Warningf("stat failed on %s with error: %s", mount.Source, err)
+				glog.Warningf("%s", err)
 			} else {
-				glog.Infof("btrfs mount %#v", mount)
-				if buf.Mode&syscall.S_IFMT == syscall.S_IFBLK {
-					err := syscall.Stat(mount.Mountpoint, buf)
-					if err != nil {
-						glog.Warningf("stat failed on %s with error: %s", mount.Mountpoint, err)
-					} else {
-						glog.Infof("btrfs dev major:minor %d:%d\n", int(major(buf.Dev)), int(minor(buf.Dev)))
-						glog.Infof("btrfs rdev major:minor %d:%d\n", int(major(buf.Rdev)), int(minor(buf.Rdev)))
-
-						mount.Major = int(major(buf.Dev))
-						mount.Minor = int(minor(buf.Dev))
-					}
-				}
+				mount.Major = major
+				mount.Minor = minor
 			}
 		}
 
@@ -444,11 +438,22 @@ func (self *RealFsInfo) GetDirFsDevice(dir string) (*DeviceInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("stat failed on %s with error: %s", dir, err)
 	}
+
 	major := major(buf.Dev)
 	minor := minor(buf.Dev)
 	for device, partition := range self.partitions {
 		if partition.major == major && partition.minor == minor {
 			return &DeviceInfo{device, major, minor}, nil
+		}
+	}
+
+	mount, found := self.mounts[dir]
+	if found && mount.Fstype == "btrfs" && mount.Major == 0 && strings.HasPrefix(mount.Source, "/dev/") {
+		major, minor, err := getBtrfsMajorMinorIds(mount)
+		if err != nil {
+			glog.Warningf("%s", err)
+		} else {
+			return &DeviceInfo{mount.Source, uint(major), uint(minor)}, nil
 		}
 	}
 	return nil, fmt.Errorf("could not find device with major: %d, minor: %d in cached partitions map", major, minor)
@@ -635,4 +640,33 @@ type byteCounter struct{ bytesWritten uint64 }
 func (b *byteCounter) Write(p []byte) (int, error) {
 	b.bytesWritten += uint64(len(p))
 	return len(p), nil
+}
+
+// Get major and minor Ids for a mount point using btrfs as filesystem.
+func getBtrfsMajorMinorIds(mount *mount.Info) (int, int, error) {
+	// btrfs fix: following workaround fixes wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.
+	// instead of using values from /proc/self/mountinfo we use stat to get Ids from btrfs mount point
+
+	buf := new(syscall.Stat_t)
+	err := syscall.Stat(mount.Source, buf)
+	if err != nil {
+		err = fmt.Errorf("stat failed on %s with error: %s", mount.Source, err)
+		return 0, 0, err
+	}
+
+	glog.Infof("btrfs mount %#v", mount)
+	if buf.Mode&syscall.S_IFMT == syscall.S_IFBLK {
+		err := syscall.Stat(mount.Mountpoint, buf)
+		if err != nil {
+			err = fmt.Errorf("stat failed on %s with error: %s", mount.Mountpoint, err)
+			return 0, 0, err
+		}
+
+		glog.Infof("btrfs dev major:minor %d:%d\n", int(major(buf.Dev)), int(minor(buf.Dev)))
+		glog.Infof("btrfs rdev major:minor %d:%d\n", int(major(buf.Rdev)), int(minor(buf.Rdev)))
+
+		return int(major(buf.Dev)), int(minor(buf.Dev)), nil
+	} else {
+		return 0, 0, fmt.Errorf("%s is not a block device", mount.Source)
+	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the warning messages reported by kubelet when checking for the disk space on a btrfs `/` which has `/var/lib/kubelet` inside of a btrfs sub-volume.

This fix follows the same principle adopted to fix issue #38337 with commit https://github.com/kubernetes/kubernetes/commit/dc8b6cc996ecacf8854871bd31f73afbb3ad95c1.

**Which issue this PR fixes**: fixes #47046

**Special notes for your reviewer**:

I'm going to submit the same fix also to [cadvisor](https://github.com/google/cadvisor).