### PR TITLE
Fix etcd storage location for CRs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -401,7 +401,7 @@ func (t CRDRESTOptionsGetter) GetRESTOptions(resource schema.GroupResource) (gen
 		Decorator:               generic.UndecoratedStorage,
 		EnableGarbageCollection: t.EnableGarbageCollection,
 		DeleteCollectionWorkers: t.DeleteCollectionWorkers,
-		ResourcePrefix:          t.StoragePrefix + "/" + resource.Group + "/" + resource.Resource,
+		ResourcePrefix:          resource.Group + "/" + resource.Resource,
 	}
 	if t.EnableWatchCache {
 		ret.Decorator = genericregistry.StorageWithCacher(t.DefaultWatchCacheSize)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -382,7 +382,7 @@ func TestEtcdStorage(t *testing.T) {
 		expectedObject *metaObject
 	}{
 		"namespacedNoxuDefinition": {
-			etcdPath: path.Join("/", etcdPrefix, "apiextensions.k8s.io/customresourcedefinitions/noxus.mygroup.example.com"),
+			etcdPath: "apiextensions.k8s.io/customresourcedefinitions/noxus.mygroup.example.com",
 			expectedObject: &metaObject{
 				Kind:       "CustomResourceDefinition",
 				APIVersion: "apiextensions.k8s.io/v1beta1",
@@ -407,7 +407,7 @@ func TestEtcdStorage(t *testing.T) {
 		},
 
 		"clusteredCurletDefinition": {
-			etcdPath: path.Join("/", etcdPrefix, "apiextensions.k8s.io/customresourcedefinitions/curlets.mygroup.example.com"),
+			etcdPath: "apiextensions.k8s.io/customresourcedefinitions/curlets.mygroup.example.com",
 			expectedObject: &metaObject{
 				Kind:       "CustomResourceDefinition",
 				APIVersion: "apiextensions.k8s.io/v1beta1",

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -382,7 +382,7 @@ func TestEtcdStorage(t *testing.T) {
 		expectedObject *metaObject
 	}{
 		"namespacedNoxuDefinition": {
-			etcdPath: path.Join("/", etcdPrefix, "apiextensions.k8s.io/customresourcedefinitions/noxus.mygroup.example.com"), // TODO: Double check this, no namespace?
+			etcdPath: path.Join("/", etcdPrefix, "apiextensions.k8s.io/customresourcedefinitions/noxus.mygroup.example.com"),
 			expectedObject: &metaObject{
 				Kind:       "CustomResourceDefinition",
 				APIVersion: "apiextensions.k8s.io/v1beta1",
@@ -394,7 +394,7 @@ func TestEtcdStorage(t *testing.T) {
 			},
 		},
 		"namespacedNoxuInstance": {
-			etcdPath: path.Join("/", etcdPrefix, "mygroup.example.com/noxus/the-cruel-default/foo"),
+			etcdPath: "mygroup.example.com/noxus/the-cruel-default/foo",
 			expectedObject: &metaObject{
 				Kind:       "WishIHadChosenNoxu",
 				APIVersion: "mygroup.example.com/v1beta1",
@@ -420,7 +420,7 @@ func TestEtcdStorage(t *testing.T) {
 		},
 
 		"clusteredCurletInstance": {
-			etcdPath: path.Join("/", etcdPrefix, "mygroup.example.com/curlets/bar"),
+			etcdPath: "mygroup.example.com/curlets/bar",
 			expectedObject: &metaObject{
 				Kind:       "Curlet",
 				APIVersion: "mygroup.example.com/v1beta1",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -135,7 +135,7 @@ func (f *SimpleRestOptionsFactory) GetRESTOptions(resource schema.GroupResource)
 		Decorator:               generic.UndecoratedStorage,
 		EnableGarbageCollection: f.Options.EnableGarbageCollection,
 		DeleteCollectionWorkers: f.Options.DeleteCollectionWorkers,
-		ResourcePrefix:          f.Options.StorageConfig.Prefix + "/" + resource.Group + "/" + resource.Resource,
+		ResourcePrefix:          resource.Group + "/" + resource.Resource,
 	}
 	if f.Options.EnableWatchCache {
 		ret.Decorator = genericregistry.StorageWithCacher(f.Options.DefaultWatchCacheSize)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/46031

The first commit is easy, the second commit is hard.  

@sttts Read the second commit very carefully and search the repo to make sure that you agree this is only affecting aggregator and apiextensions.

@pmorie @derekwaynecarr make sure you check to see if service catalog is double prefixing.  Looks like we missed it in 1.6, but no one was using it.