### PR TITLE
Directly grab map values instead of using loop-clause variables when setting up federated sync controller tests.

### DIFF
--- a/test/e2e_federation/crud.go
+++ b/test/e2e_federation/crud.go
@@ -32,7 +32,9 @@ var _ = framework.KubeDescribe("Federated types [Feature:Federation][Experimenta
 
 	f := fedframework.NewDefaultFederatedFramework("federated-types")
 
-	for name, fedType := range federatedtypes.FederatedTypes() {
+	fedTypes := federatedtypes.FederatedTypes()
+	for name := range fedTypes {
+		fedType := fedTypes[name]
 		Describe(fmt.Sprintf("Federated %q resources", name), func() {
 			It("should be created, read, updated and deleted successfully", func() {
 				fedframework.SkipUnlessFederated(f.ClientSet)


### PR DESCRIPTION
Go's loop-clause variables are allocated once and the items are copied to that variable while iterating through the loop. This means, these variables can't escape the scope since closures are bound to loop-clause variables whose value change during each iteration. Doing so would lead to undesired behavior. For more on this topic see: https://github.com/golang/go/wiki/CommonMistakes

So in order to workaround this problem in sync controller e2e tests, we iterate through the map and copy the map value to a variable inside the loop before using it in closures.

Fixes issue: #47059

**Release note**:
```release-note
NONE
```

/assign @marun @shashidharatd @perotinus 

cc @csbell @nikhiljindal 

/sig federation