### PR TITLE
Workaround for random build failure on fast nodes

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -324,7 +324,7 @@ function kube::release::create_docker_images_for_server() {
 
         kube::log::status "Deleting docker image ${docker_image_tag}"
         "${DOCKER[@]}" rmi ${docker_image_tag} 2>/dev/null || true
-      ) &
+      )
     done
 
     kube::util::wait-for-jobs || { kube::log::error "previous Docker build failed"; return 1; }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

The "docker build --pull ..." which is run in parallel
in multiple sessions simultationously will be multiple times
forcibly pulling template image image registry.
This creates situation which lead to error in "docker save"
step if it executed during another process finished pulling part.

Originally a contribution from @kad:
https://github.com/kad/kubernetes/commit/550b4cd13d4d0231e00b3fb1381d457a25d57481


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #40632

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
