### PR TITLE
examples/volumes/flexvolume/nfs: check for jq and simplify quoting

### DIFF
--- a/examples/volumes/flexvolume/nfs
+++ b/examples/volumes/flexvolume/nfs
@@ -48,7 +48,7 @@ domount() {
 	SHARE=$(echo $2 | jq -r '.share')
 
 	if [ $(ismounted) -eq 1 ] ; then
-		log "{\"status\": \"Success\"}"
+		log '{"status": "Success"}'
 		exit 0
 	fi
 
@@ -59,14 +59,14 @@ domount() {
 		err "{ \"status\": \"Failure\", \"message\": \"Failed to mount ${NFS_SERVER}:${SHARE} at ${MNTPATH}\"}"
 		exit 1
 	fi
-	log "{\"status\": \"Success\"}"
+	log '{"status": "Success"}'
 	exit 0
 }
 
 unmount() {
 	MNTPATH=$1
 	if [ $(ismounted) -eq 0 ] ; then
-		log "{\"status\": \"Success\"}"
+		log '{"status": "Success"}'
 		exit 0
 	fi
 
@@ -76,14 +76,19 @@ unmount() {
 		exit 1
 	fi
 
-	log "{\"status\": \"Success\"}"
+	log '{"status": "Success"}'
 	exit 0
 }
 
 op=$1
 
+if ! command -v jq >/dev/null 2>&1; then
+	err "{ \"status\": \"Failure\", \"message\": \"'jq' binary not found. Please install jq package before using this driver\"}"
+	exit 1
+fi
+
 if [ "$op" = "init" ]; then
-	log "{\"status\": \"Success\", \"capabilities\": {\"attach\": false}}"
+	log '{"status": "Success", "capabilities": {"attach": false}}'
 	exit 0
 fi
 
@@ -101,7 +106,7 @@ case "$op" in
 		unmount $*
 		;;
 	*)
-		log "{ \"status\": \"Not supported\" }"
+		log '{"status": "Not supported"}'
 		exit 0
 esac
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR improves error reporting of the nfs flex plugin script. Before it output non-JSON error, when `jq` wasn't installed on the server:
```
$ /usr/libexec/kubernetes/kubelet-plugins/volume/exec/k8s~nfs/nfs getvolumename test
/usr/libexec/kubernetes/kubelet-plugins/volume/exec/k8s~nfs/nfs: line 87: jq: command not found
/usr/libexec/kubernetes/kubelet-plugins/volume/exec/k8s~nfs/nfs: line 88: jq: command not found
{"status": "Success", "volumeName": "/"}
```
K8s fails to unmarshal such output to show an error in the logs:
>E0606 19:32:30.196262   25700 driver-call.go:212] Failed to unmarshal output for command: getvolumename, output: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/k8s\~nfs/nfs: line 87: jq: command not found\n/usr/libexec/kubernetes/kubelet-plugins/volume/exec/k8s\~nfs/nfs: line 88: jq: command not found\n{\"status\": \"Success\", \"volumeName\": \"/\"}", error: invalid character '/' looking for beginning of value

After  this change:
```sh
$ /usr/libexec/kubernetes/kubelet-plugins/volume/exec/k8s~nfs/nfs getvolumename test
{ "status": "Failure", "message": "'jq' binary not found. Please install jq package before using this driver"}
```
and
> E0606 19:52:07.915594   25700 driver-call.go:219] getvolumename command failed, status: Failure, reason: 'jq' binary not found. Please install jq package before using this driver

Also this PR improves quoting a bit by using single quotes where it possible.

**Release note**:
```release-note
NONE
```

CC @mfojtik 