### PR TITLE
PodSecurityPolicy should respect and validate user-supplied RunAsNonR…

### DIFF
--- a/pkg/security/podsecuritypolicy/provider.go
+++ b/pkg/security/podsecuritypolicy/provider.go
@@ -165,7 +165,7 @@ func (s *simpleProvider) CreateContainerSecurityContext(pod *api.Pod, container 
 	// if we're using the non-root strategy set the marker that this container should not be
 	// run as root which will signal to the kubelet to do a final check either on the runAsUser
 	// or, if runAsUser is not set, the image UID will be checked.
-	if s.psp.Spec.RunAsUser.Rule == extensions.RunAsUserStrategyMustRunAsNonRoot {
+	if sc.RunAsNonRoot == nil && s.psp.Spec.RunAsUser.Rule == extensions.RunAsUserStrategyMustRunAsNonRoot {
 		nonRoot := true
 		sc.RunAsNonRoot = &nonRoot
 	}

--- a/pkg/security/podsecuritypolicy/user/nonroot_test.go
+++ b/pkg/security/podsecuritypolicy/user/nonroot_test.go
@@ -52,30 +52,70 @@ func TestNonRootGenerate(t *testing.T) {
 func TestNonRootValidate(t *testing.T) {
 	goodUID := types.UnixUserID(1)
 	badUID := types.UnixUserID(0)
+	untrue := false
+	unfalse := true
 	s, err := NewRunAsNonRoot(&extensions.RunAsUserStrategyOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error initializing NewMustRunAs %v", err)
 	}
-	container := &api.Container{
-		SecurityContext: &api.SecurityContext{
-			RunAsUser: &badUID,
+	tests := []struct {
+		container   *api.Container
+		expectedErr bool
+		msg         string
+	}{
+		{
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: &badUID,
+				},
+			},
+			expectedErr: true,
+			msg:         "in test case %d, expected errors from root uid but got none: %v",
+		},
+		{
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsUser: &goodUID,
+				},
+			},
+			expectedErr: false,
+			msg:         "in test case %d, expected no errors from non-root uid but got %v",
+		},
+		{
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsNonRoot: &untrue,
+				},
+			},
+			expectedErr: true,
+			msg:         "in test case %d, expected errors from RunAsNonRoot but got none: %v",
+		},
+		{
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsNonRoot: &unfalse,
+					RunAsUser:    &goodUID,
+				},
+			},
+			expectedErr: false,
+			msg:         "in test case %d, expected no errors from non-root uid but got %v",
+		},
+		{
+			container: &api.Container{
+				SecurityContext: &api.SecurityContext{
+					RunAsNonRoot: &unfalse,
+					RunAsUser:    &badUID,
+				},
+			},
+			expectedErr: true,
+			msg:         "in test case %d, expected errors from root uid but got %v",
 		},
 	}
 
-	errs := s.Validate(nil, container)
-	if len(errs) == 0 {
-		t.Errorf("expected errors from root uid but got none")
-	}
-
-	container.SecurityContext.RunAsUser = &goodUID
-	errs = s.Validate(nil, container)
-	if len(errs) != 0 {
-		t.Errorf("expected no errors from non-root uid but got %v", errs)
-	}
-
-	container.SecurityContext.RunAsUser = nil
-	errs = s.Validate(nil, container)
-	if len(errs) != 0 {
-		t.Errorf("expected no errors from nil uid but got %v", errs)
+	for i, tc := range tests {
+		errs := s.Validate(nil, tc.container)
+		if (len(errs) == 0) == tc.expectedErr {
+			t.Errorf(tc.msg, i, errs)
+		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**: PodSecurityPolicies overwrite and then fail to validate the RunAsNonRoot field in the container security context.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47071

**Special notes for your reviewer**: gce/gke don't use this in 1.6. You'll need to speak up if you think this is important enough to patch. It should almost certainly go into 1.7.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
PodSecurityPolicy now recognizes pods that specify `runAsNonRoot: false` in their security context and does not overwrite the specified value
```
