### PR TITLE
Fix incorrect username

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,7 +10,7 @@ approvers:
   - brendandburns
   - dchen1107
   - jbeda
-  - jregan # To modify BUILD files per proposal #598
+  - monopole # To modify BUILD files per proposal #598
   - lavalamp
   - smarterclayton
   - thockin


### PR DESCRIPTION
For work on issue #598
My mistake - used goog username rather than github.  Duh.
Wish we had a federated identity authority we all trusted :P

```release-note
NONE
```
