### PR TITLE
decode deleteoptions consistently for delete and deletecollection

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -3380,6 +3380,16 @@ runTests() {
   fi
 
   ###########################
+  # Delete collection body  #
+  ###########################
+  # test the old way with a version
+  curl -k -H "Content-Type:" http://localhost:8080/apis/apps/v1beta1/namespaces/default/deployments -XDELETE -d'{"apiVersion":"v1","kind":"DeleteOptions","orphanDependents":false}'
+  # test the new way without a version
+  curl -k -H "Content-Type:" http://localhost:8080/apis/apps/v1beta1/namespaces/default/deployments -XDELETE -d'{"orphanDependents":false}'
+  # test the old way with a version
+  curl -k -H "Content-Type:" http://localhost:8080/apis/apps/v1beta1/namespaces/default/deployments -XDELETE -d'{"apiVersion":"apps/v1beta1","kind":"DeleteOptions","orphanDependents":false}'
+
+  ###########################
   # POD creation / deletion #
   ###########################
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -1098,13 +1098,13 @@ func DeleteCollection(r rest.CollectionDeleter, checkBody bool, scope RequestSco
 				return
 			}
 			if len(body) > 0 {
-				s, err := negotiation.NegotiateInputSerializer(req, scope.Serializer)
+				s, err := negotiation.NegotiateInputSerializer(req, metainternalversion.Codecs)
 				if err != nil {
 					scope.err(err, w, req)
 					return
 				}
 				defaultGVK := scope.Kind.GroupVersion().WithKind("DeleteOptions")
-				obj, _, err := scope.Serializer.DecoderToVersion(s.Serializer, defaultGVK.GroupVersion()).Decode(body, &defaultGVK, options)
+				obj, _, err := metainternalversion.Codecs.DecoderToVersion(s.Serializer, defaultGVK.GroupVersion()).Decode(body, &defaultGVK, options)
 				if err != nil {
 					scope.err(err, w, req)
 					return


### PR DESCRIPTION
This makes the deletecollection decoding match the delete decoding: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go#L953 . I'm not sure why they were different.

@smarterclayton ptal
@enisoc this fixes the namespace cleanup problem for me.