### PR TITLE
Revert "Optimize selector for single-matching items"

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1135,16 +1135,7 @@ func (e *Store) Watch(ctx genericapirequest.Context, options *metainternalversio
 func (e *Store) WatchPredicate(ctx genericapirequest.Context, p storage.SelectionPredicate, resourceVersion string) (watch.Interface, error) {
 	if name, ok := p.MatchesSingle(); ok {
 		if key, err := e.KeyFunc(ctx, name); err == nil {
-			// For performance reasons, we can optimize the further computations of
-			// selector, by removing then "matches-single" fields, because they are
-			// already satisfied by choosing appropriate key.
-			sp, err := p.RemoveMatchesSingleRequirements()
-			if err != nil {
-				glog.Warningf("Couldn't remove matches-single requirements: %v", err)
-				// Since we couldn't optimize selector, reset to the original one.
-				sp = p
-			}
-			w, err := e.Storage.Watch(ctx, key, resourceVersion, sp)
+			w, err := e.Storage.Watch(ctx, key, resourceVersion, p)
 			if err != nil {
 				return nil, err
 			}

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
@@ -72,40 +72,14 @@ func (s *SelectionPredicate) MatchesObjectAttributes(l labels.Set, f fields.Set,
 	return matched
 }
 
-const matchesSingleField = "metadata.name"
-
-func removeMatchesSingleField(field, value string) (string, string, error) {
-	if field == matchesSingleField {
-		return "", "", nil
-	}
-	return field, value, nil
-}
-
 // MatchesSingle will return (name, true) if and only if s.Field matches on the object's
 // name.
 func (s *SelectionPredicate) MatchesSingle() (string, bool) {
-	if name, ok := s.Field.RequiresExactMatch(matchesSingleField); ok {
+	// TODO: should be namespace.name
+	if name, ok := s.Field.RequiresExactMatch("metadata.name"); ok {
 		return name, true
 	}
 	return "", false
-}
-
-func (s *SelectionPredicate) RemoveMatchesSingleRequirements() (SelectionPredicate, error) {
-	var fieldsSelector fields.Selector
-	if s.Field != nil {
-		var err error
-		fieldsSelector, err = s.Field.Transform(removeMatchesSingleField)
-		if err != nil {
-			return SelectionPredicate{}, err
-		}
-	}
-	return SelectionPredicate{
-		Label:                s.Label,
-		Field:                fieldsSelector,
-		IncludeUninitialized: s.IncludeUninitialized,
-		GetAttrs:             s.GetAttrs,
-		IndexFields:          s.IndexFields,
-	}, nil
 }
 
 // For any index defined by IndexFields, if a matcher can match only (a subset)


### PR DESCRIPTION
This reverts commit f93a270edcefc3780247ae89eea02cd13b81237b.

Fix: #46851

@smarterclayton 

The problem was that removing the requirement from the predicate resulted in not using "trigger" function in Cacher, which is super critical for performance. And this was messed up.