### PR TITLE
[GCE] Decouple Nvidia GPU driver installer from the COS base image

### DIFF
--- a/cluster/gce/gci/nvidia-gpus/Dockerfile
+++ b/cluster/gce/gci/nvidia-gpus/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:16.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq update
-RUN apt-get install -qq pciutils gcc g++ git make dpkg-dev bc module-init-tools curl 
+RUN apt-get install -qq pciutils gcc g++ git make dpkg-dev bc module-init-tools curl
 
 RUN mkdir /lakitu-kernel
 RUN git clone https://chromium.googlesource.com/chromiumos/third_party/kernel /lakitu-kernel

--- a/cluster/gce/gci/nvidia-gpus/Makefile
+++ b/cluster/gce/gci/nvidia-gpus/Makefile
@@ -21,7 +21,7 @@ all: container
 container:
 	docker build --pull -t ${REGISTRY}/${IMAGE}:${TAG} .
 
-push: 
+push:
 	gcloud docker -- push ${REGISTRY}/${IMAGE}:${TAG}
 
 .PHONY: all container push

--- a/cluster/gce/gci/nvidia-gpus/Makefile
+++ b/cluster/gce/gci/nvidia-gpus/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-TAG?=v0.1
+TAG?=v0.2
 REGISTRY?=gcr.io/google_containers
 IMAGE=cos-nvidia-driver-install
 

--- a/cluster/gce/gci/nvidia-gpus/cos-installer-daemonset.yaml
+++ b/cluster/gce/gci/nvidia-gpus/cos-installer-daemonset.yaml
@@ -27,7 +27,7 @@ spec:
         hostPath:
           path: /proc/sysrq-trigger
       containers:
-      - image: gcr.io/google_containers/cos-nvidia-driver-install@sha256:ad83ede6e0c6d768bf7cf69a7dec972aa5e8f88778142ca46afd3286ad58cfc8
+      - image: gcr.io/google_containers/cos-nvidia-driver-install@sha256:685628e8a57375c593102f6332db6f250ed7d04f0ce3cdd4f34acb67bf609a10
         command: ["/bin/sh", "-c"]
         args: ["usr/bin/nvidia-installer.sh && sleep infinity"]
         env:

--- a/cluster/gce/gci/nvidia-gpus/installer.sh
+++ b/cluster/gce/gci/nvidia-gpus/installer.sh
@@ -147,22 +147,22 @@ verify_base_image() {
 }
 
 setup_overlay_mounts() {
-    mkdir -p ${USR_WRITABLE_DIR} ${USR_WORK_DIR} ${LIB_WRITABLE_DIR} ${LIB_WORK_DIR} 
+    mkdir -p ${USR_WRITABLE_DIR} ${USR_WORK_DIR} ${LIB_WRITABLE_DIR} ${LIB_WORK_DIR}
     mount -t overlay -o lowerdir=/usr,upperdir=${USR_WRITABLE_DIR},workdir=${USR_WORK_DIR} none /usr
     mount -t overlay -o lowerdir=/lib,upperdir=${LIB_WRITABLE_DIR},workdir=${LIB_WORK_DIR} none /lib
 }
 
 exit_if_install_not_needed() {
     if nvidia-smi; then
-	echo "nvidia drivers already installed. Skipping installation"
+        echo "nvidia drivers already installed. Skipping installation"
         post_installation_sequence
-	exit 0
+        exit 0
     fi
 }
 
 restart_kubelet() {
     echo "Sending SIGTERM to kubelet"
-    pkill -SIGTERM kubelet
+    pkill -SIGTERM kubelet || true
 }
 
 # Copy user space libraries and debug utilities to a special output directory on the host.
@@ -190,7 +190,7 @@ main() {
     check_nvidia_device
     # Setup overlay mounts to capture nvidia driver artificats in a more permanent storage on the host.
     setup_overlay_mounts
-    # Disable a critical security feature in COS that will allow for dynamically loading Nvidia drivers 
+    # Disable a critical security feature in COS that will allow for dynamically loading Nvidia drivers
     unlock_loadpin_and_reboot_if_needed
     # Exit if installation is not required (for idempotency)
     exit_if_install_not_needed

--- a/test/e2e_node/jenkins/gci-init-gpu.yaml
+++ b/test/e2e_node/jenkins/gci-init-gpu.yaml
@@ -16,4 +16,4 @@ runcmd:
   - mount --bind /dev /home/kubernetes/containerized_mounter/rootfs/dev
   - rm /tmp/mounter.tar
   - modprobe configs
-  - docker run -v /dev:/dev -v /home/kubernetes/bin/nvidia:/rootfs/nvidia -v /etc/os-release:/rootfs/etc/os-release -v /proc/sysrq-trigger:/sysrq -e LAKITU_KERNEL_SHA1=26481563cb3788ad254c2bf2126b843c161c7e48 -e BASE_DIR=/rootfs/nvidia --privileged gcr.io/google_containers/cos-nvidia-driver-install@sha256:ad83ede6e0c6d768bf7cf69a7dec972aa5e8f88778142ca46afd3286ad58cfc8
+  - docker run -v /dev:/dev -v /home/kubernetes/bin/nvidia:/rootfs/nvidia -v /etc/os-release:/rootfs/etc/os-release -v /proc/sysrq-trigger:/sysrq -e LAKITU_KERNEL_SHA1=26481563cb3788ad254c2bf2126b843c161c7e48 -e BASE_DIR=/rootfs/nvidia --privileged gcr.io/google_containers/cos-nvidia-driver-install@sha256:685628e8a57375c593102f6332db6f250ed7d04f0ce3cdd4f34acb67bf609a10


### PR DESCRIPTION
Attempt to consume kernel commit ID from /etc/os-release while installing Nvidia drivers on COS

This is GCE only and does not affect Kubernetes proper. Once the GCE cluster setup logic moves off of the core, such PRs will not show up post code freeze.

Tested manually using e2es.

cc @dchen1107 @mindprince @Amey-D 