### PR TITLE
Allow NetworkPolicy.spec updates

### DIFF
--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -17,8 +17,6 @@ limitations under the License.
 package validation
 
 import (
-	"reflect"
-
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -92,8 +90,6 @@ func ValidateNetworkPolicy(np *networking.NetworkPolicy) field.ErrorList {
 func ValidateNetworkPolicyUpdate(update, old *networking.NetworkPolicy) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&update.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	if !reflect.DeepEqual(update.Spec, old.Spec) {
-		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to networkpolicy spec are forbidden."))
-	}
+	allErrs = append(allErrs, ValidateNetworkPolicySpec(&update.Spec, field.NewPath("spec"))...)
 	return allErrs
 }


### PR DESCRIPTION
ValidateNetworkPolicyUpdate currently prohibits changes to `spec` in an existing NetworkPolicy. We were going to fix this for 1.7 but I forgot to submit this PR after the main PR merged. Too late for 1.7? @thockin @caseydavenport @cmluciano 

This only changes networking.NetworkPolicy validation at the moment... Should I change extensions.NetworkPolicy validation too?

Fixes #35911

We should add a test to the e2e NetworkPolicy test for this too if this is going to merge.

**Release note**:
```release-note
As part of the NetworkPolicy "v1" changes, it is also now
possible to update the spec field of an existing
NetworkPolicy. (Previously you had to delete and recreate a
NetworkPolicy if you wanted to change it.)
```
