### PR TITLE
Fix a typo in deletion log of apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -991,7 +991,7 @@ func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope RequestSco
 			}
 		}
 
-		trace.Step("About do delete object from database")
+		trace.Step("About to delete object from database")
 		wasDeleted := true
 		result, err := finishRequest(timeout, func() (runtime.Object, error) {
 			obj, deleted, err := r.Delete(ctx, name, options)


### PR DESCRIPTION
**What this PR does / why we need it**:
I just fix a typo in a log message. Nothing more :smile: 

**Which issue this PR fixes**
apiserver sometimes log this message "About do delete object from database". It seems that there is a typo for `to`.

```release-note
Fix a typo in apiserver log message
```
