### PR TITLE
Automated cherry pick of #46997

### DIFF
--- a/test/e2e/framework/google_compute.go
+++ b/test/e2e/framework/google_compute.go
@@ -48,7 +48,7 @@ func CreateGCEStaticIP(name string) (string, error) {
 	for attempts := 0; attempts < 4; attempts++ {
 		outputBytes, err = exec.Command("gcloud", "compute", "addresses", "create",
 			name, "--project", TestContext.CloudConfig.ProjectID,
-			"--region", region, "-q").CombinedOutput()
+			"--region", region, "-q", "--format=yaml").CombinedOutput()
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
Cherry pick of #46997 on release-1.6.

#46997: Don't parse human-readable output from gcloud in tests

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
