### PR TITLE
kubectl plugins: export API through proxy

### DIFF
--- a/build/visible_to/BUILD
+++ b/build/visible_to/BUILD
@@ -120,6 +120,7 @@ package_group(
         "//pkg/kubectl/cmd/testing",
         "//pkg/kubectl/cmd/util",
         "//pkg/kubectl/cmd/util/editor",
+        "//pkg/kubectl/plugins",
     ],
 )
 

--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4552,6 +4552,14 @@ runTests() {
 
   record_command run_plugins_tests
 
+  # plugin proxy
+  output_message=$(KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin proxy unauthorized -v 8 2>&1)
+  kube::test::if_has_string "${output_message}" 'Proxy\-Authorization required'
+   output_message=$(KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin proxy authorized -v 8 2>&1)
+  kube::test::if_has_string "${output_message}" 'Starting to serve API proxy for plugin'
+  kube::test::if_has_string "${output_message}" '"kind":\s\+"APIGroupList"'
+  kube::test::if_has_string "${output_message}" 'Closing API proxy for plugin'
+
   #################
   # Impersonation #
   #################

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -1,5 +1,6 @@
 accept-hosts
 accept-paths
+accept-proxy-authorizations
 admission-control
 admission-control-config-file
 advertise-address

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -87,6 +87,7 @@ func NewCmdProxy(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().String("reject-paths", kubectl.DefaultPathRejectRE, "Regular expression for paths that the proxy should reject. Paths specified here will be rejected even accepted by --accept-paths.")
 	cmd.Flags().String("accept-hosts", kubectl.DefaultHostAcceptRE, "Regular expression for hosts that the proxy should accept.")
 	cmd.Flags().String("reject-methods", kubectl.DefaultMethodRejectRE, "Regular expression for HTTP methods that the proxy should reject (example --reject-methods='POST,PUT,PATCH'). ")
+	cmd.Flags().String("accept-proxy-authorizations", kubectl.DefaultProxyAuthorizationAcceptRE, "Regular expression for the Proxy-Authorization headers that the proxy should accept.")
 	cmd.Flags().IntP("port", "p", defaultPort, "The port on which to run the proxy. Set to 0 to pick a random port.")
 	cmd.Flags().StringP("address", "", "127.0.0.1", "The IP address on which to serve on.")
 	cmd.Flags().Bool("disable-filter", false, "If true, disable request filtering in the proxy. This is dangerous, and can leave you vulnerable to XSRF attacks, when used with an accessible port.")
@@ -127,10 +128,11 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 		apiProxyPrefix += "/"
 	}
 	filter := &kubectl.FilterServer{
-		AcceptPaths:   kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "accept-paths")),
-		RejectPaths:   kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "reject-paths")),
-		AcceptHosts:   kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "accept-hosts")),
-		RejectMethods: kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "reject-methods")),
+		AcceptPaths:              kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "accept-paths")),
+		RejectPaths:              kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "reject-paths")),
+		AcceptHosts:              kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "accept-hosts")),
+		RejectMethods:            kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "reject-methods")),
+		AcceptProxyAuthorization: kubectl.MakeRegexpArrayOrDie(cmdutil.GetFlagString(cmd, "accept-proxy-authorizations")),
 	}
 	if cmdutil.GetFlagBool(cmd, "disable-filter") {
 		if path == "" {

--- a/pkg/kubectl/plugins/BUILD
+++ b/pkg/kubectl/plugins/BUILD
@@ -14,13 +14,16 @@ go_library(
         "env.go",
         "loader.go",
         "plugins.go",
+        "proxier.go",
         "runner.go",
     ],
     tags = ["automanaged"],
     deps = [
+        "//pkg/kubectl:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )
@@ -44,9 +47,13 @@ go_test(
         "env_test.go",
         "loader_test.go",
         "plugins_test.go",
+        "proxier_test.go",
         "runner_test.go",
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
+    deps = [
+        "//vendor/github.com/ghodss/yaml:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+    ],
 )

--- a/pkg/kubectl/plugins/plugins.go
+++ b/pkg/kubectl/plugins/plugins.go
@@ -36,6 +36,7 @@ type Description struct {
 	LongDesc  string    `json:"longDesc,omitempty"`
 	Example   string    `json:"example,omitempty"`
 	Command   string    `json:"command"`
+	ProxyAPI  bool      `json:"proxyAPI,omitempty"`
 	Tree      []*Plugin `json:"tree,omitempty"`
 }
 

--- a/pkg/kubectl/plugins/plugins_test.go
+++ b/pkg/kubectl/plugins/plugins_test.go
@@ -17,8 +17,11 @@ limitations under the License.
 package plugins
 
 import (
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/ghodss/yaml"
 )
 
 func TestPlugin(t *testing.T) {
@@ -65,6 +68,62 @@ func TestPlugin(t *testing.T) {
 			}
 		} else if err != nil {
 			t.Errorf("%s: expected no error, got %v", test.plugin.Name, err)
+		}
+	}
+}
+
+func TestUnmarshalPlugin(t *testing.T) { // just in case
+	tests := []struct {
+		src      string
+		expected *Plugin
+	}{
+		{
+			src: `name: "test"
+shortDesc: "A test"
+command: "echo 1"
+proxyAPI: false`,
+			expected: &Plugin{
+				Description: Description{
+					Name:      "test",
+					ShortDesc: "A test",
+					Command:   "echo 1",
+				},
+			},
+		},
+		{
+			src: `name: "test"
+shortDesc: "A test"
+command: "echo 2"`,
+			expected: &Plugin{
+				Description: Description{
+					Name:      "test",
+					ShortDesc: "A test",
+					Command:   "echo 2",
+				},
+			},
+		},
+		{
+			src: `name: "test"
+shortDesc: "A test"
+command: "echo 3"
+proxyAPI: true`,
+			expected: &Plugin{
+				Description: Description{
+					Name:      "test",
+					ShortDesc: "A test",
+					Command:   "echo 3",
+					ProxyAPI:  true,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		plugin := &Plugin{}
+		if err := yaml.Unmarshal([]byte(test.src), plugin); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if !reflect.DeepEqual(test.expected, plugin) {
+			t.Errorf("Expected %v, got %v", test.expected, plugin)
 		}
 	}
 }

--- a/pkg/kubectl/plugins/proxier.go
+++ b/pkg/kubectl/plugins/proxier.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/golang/glog"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/kubernetes/pkg/kubectl"
+)
+
+// Proxier encapsulates a proxy server to the REST API that can be explicitly started/stopped.
+type Proxier interface {
+	Start(started chan bool) error
+	Stop() error
+}
+
+type bearerProxier struct {
+	clientConfig *restclient.Config
+	listener     net.Listener
+	ip           string
+	port         int
+	started      bool
+	bearer       string
+}
+
+// NewBearerProxier creates a proxier that requires a bearer token to access the API. The
+// token is not the same used in the underlying authentication, it's specific for the proxy
+// and the token value is exposed in the Env() method.
+func NewBearerProxier(clientConfig *restclient.Config) *bearerProxier {
+	return &bearerProxier{
+		clientConfig: clientConfig,
+		ip:           "127.0.0.1",
+	}
+}
+
+func (p *bearerProxier) Start(started chan bool) error {
+	token, err := generateBearer()
+	if err != nil {
+		return err
+	}
+	p.bearer = token
+
+	filter := &kubectl.FilterServer{
+		AcceptPaths:              kubectl.MakeRegexpArrayOrDie(kubectl.DefaultPathAcceptRE),
+		RejectPaths:              kubectl.MakeRegexpArrayOrDie(kubectl.DefaultPathRejectRE),
+		AcceptHosts:              kubectl.MakeRegexpArrayOrDie(kubectl.DefaultHostAcceptRE),
+		RejectMethods:            kubectl.MakeRegexpArrayOrDie(kubectl.DefaultMethodRejectRE),
+		AcceptProxyAuthorization: kubectl.MakeRegexpArrayOrDie(fmt.Sprintf("^Bearer %s$", p.bearer)),
+	}
+
+	server, err := kubectl.NewProxyServer("", "/", "", filter, p.clientConfig)
+	if err != nil {
+		return err
+	}
+
+	p.listener, err = server.Listen(p.ip, p.port)
+	if err != nil {
+		return err
+	}
+	p.started = true
+
+	glog.V(8).Infof("Starting to serve API proxy for plugin on: %s", p.listener.Addr())
+	go func() {
+		started <- true
+		err := server.ServeOnListenerState(p.listener, func(conn net.Conn, state http.ConnState) {
+			glog.V(9).Infof("API proxy is: %s", state)
+		})
+		if err != nil {
+			glog.Fatal(fmt.Errorf("Unable to start API proxy: %v", err))
+		}
+	}()
+
+	return nil
+}
+
+func (p *bearerProxier) Stop() error {
+	glog.V(8).Infof("Closing API proxy for plugin: %s", p.listener.Addr())
+	err := p.listener.Close()
+	p.started = false
+	return err
+}
+
+func (p *bearerProxier) Env() (EnvList, error) {
+	if !p.started {
+		return EnvList{}, nil
+	}
+
+	return EnvList{
+		{"KUBECTL_PLUGINS_API_PROXY_ADDR", p.listener.Addr().String()},
+		{"KUBECTL_PLUGINS_API_PROXY_AUTH_TOKEN", p.bearer},
+		{"KUBECTL_PLUGINS_API_PROXY_AUTH_HEADER", fmt.Sprintf("Proxy-Authorization: Bearer %s", p.bearer)},
+	}, nil
+}
+
+func generateBearer() (string, error) {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/pkg/kubectl/plugins/proxier_test.go
+++ b/pkg/kubectl/plugins/proxier_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package plugins
+
+import (
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestProxierAsEnvProvider(t *testing.T) {
+	tests := []struct {
+		p           *bearerProxier
+		expectedEnv EnvList
+	}{
+		{
+			p: &bearerProxier{
+				listener: mockListener{},
+				started:  false,
+			},
+			expectedEnv: EnvList{},
+		},
+		{
+			p: &bearerProxier{
+				listener: mockListener{},
+				started:  true,
+				bearer:   "123abc",
+			},
+			expectedEnv: EnvList{
+				{"KUBECTL_PLUGINS_API_PROXY_ADDR", "127.0.0.1:8181"},
+				{"KUBECTL_PLUGINS_API_PROXY_AUTH_TOKEN", "123abc"},
+				{"KUBECTL_PLUGINS_API_PROXY_AUTH_HEADER", "Proxy-Authorization: Bearer 123abc"},
+			},
+		},
+	}
+	for _, test := range tests {
+		if env, _ := test.p.Env(); !reflect.DeepEqual(env, test.expectedEnv) {
+			t.Errorf("Incorrect env list provided by proxier, wanted %v, got %v %s", test.expectedEnv, env, []byte("127.0.0.1"))
+		}
+	}
+}
+
+type mockListener struct{}
+
+func (m mockListener) Accept() (net.Conn, error) {
+	return nil, nil
+}
+
+func (m mockListener) Close() error {
+	return nil
+}
+
+func (m mockListener) Addr() net.Addr {
+	return &net.TCPAddr{
+		IP:   net.IPv4(127, 0, 0, 1),
+		Port: 8181,
+	}
+}

--- a/pkg/kubectl/proxy_server.go
+++ b/pkg/kubectl/proxy_server.go
@@ -225,6 +225,15 @@ func (s *ProxyServer) ServeOnListener(l net.Listener) error {
 	return server.Serve(l)
 }
 
+// Serve starts the server using given listener, loops forever.
+func (s *ProxyServer) ServeOnListenerState(l net.Listener, state func(net.Conn, http.ConnState)) error {
+	server := http.Server{
+		Handler:   s.handler,
+		ConnState: state,
+	}
+	return server.Serve(l)
+}
+
 func newProxy(target *url.URL) *httputil.ReverseProxy {
 	director := func(req *http.Request) {
 		req.URL.Scheme = target.Scheme

--- a/pkg/kubectl/proxy_server_test.go
+++ b/pkg/kubectl/proxy_server_test.go
@@ -267,6 +267,54 @@ func TestAccept(t *testing.T) {
 	}
 }
 
+func TestAuthorize(t *testing.T) {
+	tests := []struct {
+		acceptProxyAuthorization string
+		proxyAuthorizationHeader []string
+		expectAuthorize          bool
+	}{
+		{
+			acceptProxyAuthorization: "^Bearer 123abc$",
+			proxyAuthorizationHeader: []string{"Bearer 123abc"},
+			expectAuthorize:          true,
+		},
+		{
+			acceptProxyAuthorization: "^Bearer 123ab$",
+			proxyAuthorizationHeader: []string{"Bearer 123abc"},
+			expectAuthorize:          false,
+		},
+		{
+			acceptProxyAuthorization: "^Bearer 123abc$",
+			proxyAuthorizationHeader: []string{"Bearer invalid", "Bearer 123abc"},
+			expectAuthorize:          true,
+		},
+		{
+			acceptProxyAuthorization: "^.*",
+			proxyAuthorizationHeader: []string{"Bearer whatever"},
+			expectAuthorize:          true,
+		},
+		{
+			acceptProxyAuthorization: "^.*",
+			proxyAuthorizationHeader: []string{},
+			expectAuthorize:          true,
+		},
+		{
+			acceptProxyAuthorization: "^Bearer 123abc$",
+			proxyAuthorizationHeader: []string{},
+			expectAuthorize:          false,
+		},
+	}
+	for _, test := range tests {
+		filter := &FilterServer{
+			AcceptProxyAuthorization: MakeRegexpArrayOrDie(test.acceptProxyAuthorization),
+		}
+		authorize := filter.authorize(test.proxyAuthorizationHeader)
+		if authorize != test.expectAuthorize {
+			t.Errorf("expected: %v, got %v for %#v", test.expectAuthorize, authorize, test)
+		}
+	}
+}
+
 func TestRegexpMatch(t *testing.T) {
 	tests := []struct {
 		str         string

--- a/test/fixtures/pkg/kubectl/plugins/proxy/authorized.sh
+++ b/test/fixtures/pkg/kubectl/plugins/proxy/authorized.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+curl -H "$KUBECTL_PLUGINS_API_PROXY_AUTH_HEADER" "http://$KUBECTL_PLUGINS_API_PROXY_ADDR/apis"

--- a/test/fixtures/pkg/kubectl/plugins/proxy/plugin.yaml
+++ b/test/fixtures/pkg/kubectl/plugins/proxy/plugin.yaml
@@ -1,0 +1,11 @@
+name: proxy
+shortDesc: "The API aware proxy overlord"
+tree: 
+  - name: authorized
+    shortDesc: "Authorized proxy plugin"
+    command: "./authorized.sh"
+    proxyAPI: true
+  - name: unauthorized
+    shortDesc: "Unauthorized proxy plugin"
+    command: "./unauthorized.sh"
+    proxyAPI: true

--- a/test/fixtures/pkg/kubectl/plugins/proxy/unauthorized.sh
+++ b/test/fixtures/pkg/kubectl/plugins/proxy/unauthorized.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+curl "http://$KUBECTL_PLUGINS_API_PROXY_ADDR/apis"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

Starts a proxy to the API and exposes it to every plugin that declares `proxyAPI: true` in the plugin descriptor. This allows plugins to easily access the API without being aware of authentication or configuration details. Plugins get the proxy address through the `KUBECTL_PLUGINS_API_PROXY_ADDR` env var. Underlying this makes use of the proxy server provided by `kubectl proxy`. Creates a session token specifically for proxying.

**What this PR does / why we need it**:

**Release note**:
```release-note
Expose a proxy to allow kubectl plugins to access the API directly.
```

@monopole
