### PR TITLE
kubelet should let cloud-controller-manager set the node addresses

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -420,7 +420,10 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		glog.V(2).Infof("Using node IP: %q", kl.nodeIP.String())
 	}
 
-	if kl.cloud != nil {
+	if kl.externalCloudProvider {
+		// We rely on the external cloud provider to supply the addresses.
+		return nil
+	} else if kl.cloud != nil {
 		instances, ok := kl.cloud.Instances()
 		if !ok {
 			return fmt.Errorf("failed to get instances from cloud provider")


### PR DESCRIPTION
*Before this change:*

1. cloud-controller-manager sets all the addresses for a node.
2. kubelet on that node replaces these addresses with an incomplete set. (i.e. replace InternalIP and Hostname and delete all other addresses--ExternalIP, etc.)

*After this change:*

kubelet doesn't touch its node's addresses when there is an external cloudprovider.

Fixes #47155

```release-note
NONE
```