### PR TITLE
Disable gzip compression

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
@@ -84,6 +84,5 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/server/filters:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -1208,7 +1208,7 @@ func TestRequestsWithInvalidQuery(t *testing.T) {
 	}
 }
 
-func TestListCompresion(t *testing.T) {
+func XTestListCompresion(t *testing.T) {
 	testCases := []struct {
 		url            string
 		namespace      string
@@ -1619,7 +1619,7 @@ func TestGet(t *testing.T) {
 	}
 }
 
-func TestGetCompression(t *testing.T) {
+func XTestGetCompression(t *testing.T) {
 	storage := map[string]rest.Storage{}
 	simpleStorage := SimpleRESTStorage{
 		item: genericapitesting.Simple{

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
-	genericfilters "k8s.io/apiserver/pkg/server/filters"
 )
 
 const (
@@ -585,7 +584,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				handler = restfulGetResource(getter, exporter, reqScope)
 			}
 			handler = metrics.InstrumentRouteFunc(action.Verb, resource, subresource, handler)
-			handler = genericfilters.RestfulWithCompression(handler, a.group.Context)
+			// handler = genericfilters.RestfulWithCompression(handler, a.group.Context)
 			doc := "read the specified " + kind
 			if hasSubresource {
 				doc = "read " + subresource + " of the specified " + kind
@@ -615,7 +614,7 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 				doc = "list " + subresource + " of objects of kind " + kind
 			}
 			handler := metrics.InstrumentRouteFunc(action.Verb, resource, subresource, restfulListResource(lister, watcher, reqScope, false, a.minRequestTimeout))
-			handler = genericfilters.RestfulWithCompression(handler, a.group.Context)
+			// handler = genericfilters.RestfulWithCompression(handler, a.group.Context)
 			route := ws.GET(action.Path).To(handler).
 				Doc(doc).
 				Param(ws.QueryParameter("pretty", "If 'true', then the output is pretty printed.")).


### PR DESCRIPTION
Speculative disabling of gzip compression, since it was one of the few things to merge around when e2e runs got flaky

https://github.com/kubernetes/kubernetes/issues/47135
https://storage.googleapis.com/k8s-gubernator/triage/index.html?pr=1&text=Couldn%27t%20delete%20ns#5c121dd9347b4a1cbd0d