### PR TITLE
Fix race condition of kubectl logs

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_logs.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_logs.go
@@ -280,15 +280,14 @@ func parseCRILog(log []byte, msg *logMessage) error {
 	return nil
 }
 
-// dockerJSONLog is the JSON log buffer used in parseDockerJSONLog.
-var dockerJSONLog = &jsonlog.JSONLog{}
-
 // parseDockerJSONLog parses logs in Docker JSON log format. Docker JSON log format
 // example:
 //   {"log":"content 1","stream":"stdout","time":"2016-10-20T18:39:20.57606443Z"}
 //   {"log":"content 2","stream":"stderr","time":"2016-10-20T18:39:20.57606444Z"}
 func parseDockerJSONLog(log []byte, msg *logMessage) error {
-	dockerJSONLog.Reset()
+	// dockerJSONLog is the JSON log buffer used in parseDockerJSONLog.
+	var dockerJSONLog = &jsonlog.JSONLog{}
+
 	l := dockerJSONLog
 	// TODO: JSON decoding is fairly expensive, we should evaluate this.
 	if err := json.Unmarshal(log, l); err != nil {


### PR DESCRIPTION
Fixes #47165

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
