### PR TITLE
Fix restart action on juju kubernetes-master

### DIFF
--- a/cluster/juju/layers/kubernetes-master/actions/restart
+++ b/cluster/juju/layers/kubernetes-master/actions/restart
@@ -4,14 +4,11 @@ set +ex
 
 # Restart the apiserver, controller-manager, and scheduler
 
-systemctl restart kube-apiserver
+systemctl restart snap.kube-apiserver.daemon
+action-set apiserver.status='restarted'
 
-action-set 'apiserver.status' 'restarted'
+systemctl restart snap.kube-controller-manager.daemon
+action-set controller-manager.status='restarted'
 
-systemctl restart kube-controller-manager
-
-action-set 'controller-manager.status' 'restarted'
-
-systemctl restart kube-scheduler
-
-action-set 'kube-scheduler.status' 'restarted'
+systemctl restart snap.kube-scheduler.daemon
+action-set kube-scheduler.status='restarted'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Restart action of kubernetes-master of Juju is not functioning. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/299

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix: Restart action of juju's kubernetes-master restarts the respective snap based services
```
