### PR TITLE
validate nonResourceURL in create clusterrole

### DIFF
--- a/pkg/kubectl/cmd/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create_clusterrole.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -131,6 +132,20 @@ func (c *CreateClusterRoleOptions) Validate() error {
 		for _, v := range c.Verbs {
 			if !arrayContains(validNonResourceVerbs, v) {
 				return fmt.Errorf("invalid verb: '%s' for nonResourceURL", v)
+			}
+		}
+
+		for _, nonResourceURL := range c.NonResourceURLs {
+			if nonResourceURL == "*" {
+				continue
+			}
+
+			if nonResourceURL == "" || !strings.HasPrefix(nonResourceURL, "/") {
+				return fmt.Errorf("nonResourceURL should start with /")
+			}
+
+			if strings.ContainsRune(nonResourceURL[:len(nonResourceURL)-1], '*') {
+				return fmt.Errorf("nonResourceURL only supports wildcard matches when '*' is at the end")
 			}
 		}
 	}

--- a/pkg/kubectl/cmd/create_clusterrole_test.go
+++ b/pkg/kubectl/cmd/create_clusterrole_test.go
@@ -375,6 +375,46 @@ func TestClusterRoleValidate(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		"test-invalid-empty-non-resource-url": {
+			clusterRoleOptions: &CreateClusterRoleOptions{
+				CreateRoleOptions: &CreateRoleOptions{
+					Name:  "my-clusterrole",
+					Verbs: []string{"create"},
+				},
+				NonResourceURLs: []string{""},
+			},
+			expectErr: true,
+		},
+		"test-invalid-non-resource-url": {
+			clusterRoleOptions: &CreateClusterRoleOptions{
+				CreateRoleOptions: &CreateRoleOptions{
+					Name:  "my-clusterrole",
+					Verbs: []string{"create"},
+				},
+				NonResourceURLs: []string{"logs"},
+			},
+			expectErr: true,
+		},
+		"test-invalid-non-resource-url-with-*": {
+			clusterRoleOptions: &CreateClusterRoleOptions{
+				CreateRoleOptions: &CreateRoleOptions{
+					Name:  "my-clusterrole",
+					Verbs: []string{"create"},
+				},
+				NonResourceURLs: []string{"/logs/*/"},
+			},
+			expectErr: true,
+		},
+		"test-invalid-non-resource-url-with-multiple-*": {
+			clusterRoleOptions: &CreateClusterRoleOptions{
+				CreateRoleOptions: &CreateRoleOptions{
+					Name:  "my-clusterrole",
+					Verbs: []string{"create"},
+				},
+				NonResourceURLs: []string{"/logs*/*"},
+			},
+			expectErr: true,
+		},
 		"test-invalid-verb-for-non-resource-url": {
 			clusterRoleOptions: &CreateClusterRoleOptions{
 				CreateRoleOptions: &CreateRoleOptions{
@@ -397,7 +437,7 @@ func TestClusterRoleValidate(t *testing.T) {
 						},
 					},
 				},
-				NonResourceURLs: []string{"/logs/"},
+				NonResourceURLs: []string{"/logs/", "/logs/*"},
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
