### PR TITLE
Prevent default cert pool from rejecting cert in secondary cert pool

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -73,6 +73,10 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool,
 
 	chains, err := req.TLS.PeerCertificates[0].Verify(optsCopy)
 	if err != nil {
+		switch err.(type) {
+		case x509.UnknownAuthorityError:
+			return nil, false, nil
+		}
 		return nil, false, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Sample-APIServer has an authentication chain which looks like:-
1 - UnionFailOnError
    1.1 - AuthenticatedGroupAdder
        1.1.1 - UnionDon'tFailOnError
            1.1.1.1 - RequestHeader - with CABundle1
            1.1.1.2 - ClientCert - with CABundle2
            1.1.1.3 - TokenAccessReview
    1.2 - Anonymous

This ends up invoking two different cert pools, the main default and
the one set up in the requestheader.go file from the
extension-apiserver-authentication
configmap(requestheader-client-ca-file). This means that the default
cert pool does not have the requestheader CA. So when it fails to
validate the signature it returns an UnknownAuthorityError. This is then
causes the UnionFailOnError to blow up. Special casing
UnknownAuthorityError to not get propogated upwards as it is not the
case the a known bad certificate, it is just an unknown state.

**Which issue this PR fixes**: fixes #47194

**Special notes for your reviewer**:
Requires pull/47094 to test.
