### PR TITLE
AWS for cloud-controller-manager

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -69,7 +69,6 @@ func GetLoadBalancerName(service *v1.Service) string {
 }
 
 // GetInstanceProviderID builds a ProviderID for a node in a cloud.
-// TODO: The name and placement of this method suggests that it is a canonical definition of ProviderID. This doesn't seem to be true. e.g. The AWS implementation uses undecorated InstanceID as the ProviderID.
 func GetInstanceProviderID(cloud Interface, nodeName types.NodeName) (string, error) {
 	instances, ok := cloud.Instances()
 	if !ok {

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -68,6 +68,8 @@ func GetLoadBalancerName(service *v1.Service) string {
 	return ret
 }
 
+// GetInstanceProviderID builds a ProviderID for a node in a cloud.
+// TODO: The name and placement of this method suggests that it is a canonical definition of ProviderID. This doesn't seem to be true. e.g. The AWS implementation uses undecorated InstanceID as the ProviderID.
 func GetInstanceProviderID(cloud Interface, nodeName types.NodeName) (string, error) {
 	instances, ok := cloud.Instances()
 	if !ok {

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -3583,7 +3583,7 @@ var providerIDRegexp = regexp.MustCompile(`^aws://([^/]+)$`)
 
 func instanceIDFromProviderID(providerID string) (instanceID string, err error) {
 	matches := providerIDRegexp.FindStringSubmatch(providerID)
-	if len(matches) != 1 {
+	if len(matches) != 2 {
 		return "", fmt.Errorf("ProviderID \"%s\" didn't match expected format \"aws://InstanceID\"", providerID)
 	}
 

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -322,6 +322,12 @@ func (self *FakeEC2) DescribeInstances(request *ec2.DescribeInstancesInput) ([]*
 	return matches, nil
 }
 
+func (self *FakeEC2) DescribeAddresses(request *ec2.DescribeAddressesInput) ([]*ec2.Address, error) {
+	addresses := []*ec2.Address{}
+
+	return addresses, nil
+}
+
 type FakeMetadata struct {
 	aws *FakeAWSServices
 }
@@ -1347,6 +1353,40 @@ func TestGetLoadBalancerAdditionalTags(t *testing.T) {
 				t.Errorf("%s != %s", tagTest.Tags[k], v)
 				continue
 			}
+		}
+	}
+}
+
+func TestInstanceIDFromProviderID(t *testing.T) {
+	testCases := []struct {
+		providerID string
+		instanceID string
+		fail       bool
+	}{
+		{
+			providerID: "aws://i-0194bbdb81a49b169",
+			instanceID: "i-0194bbdb81a49b169",
+			fail:       false,
+		},
+		{
+			providerID: "i-0194bbdb81a49b169",
+			instanceID: "",
+			fail:       true,
+		},
+	}
+
+	for _, test := range testCases {
+		instanceID, err := instanceIDFromProviderID(test.providerID)
+		if (err != nil) != test.fail {
+			t.Errorf("%s yielded `err != nil` as %t. expected %t", test.providerID, (err != nil), test.fail)
+		}
+
+		if test.fail {
+			continue
+		}
+
+		if instanceID != test.instanceID {
+			t.Errorf("%s yielded %s. expected %s", test.providerID, instanceID, test.instanceID)
 		}
 	}
 }


### PR DESCRIPTION
fixes #47214

This implements the NodeAddressesByProviderID and InstanceTypeByProviderID methods used by the cloud-controller-manager for the AWS provider.

NodeAddressesByProvider uses DescribeInstances (for normal addresses) and DescribeAddresses (for Elastic IP addresses).

InstanceTypeByProviderID uses DescribeInstances.

```release-note
NONE
```
