### PR TITLE
nodeidentifier: require nodes to have wellformed usernames

### DIFF
--- a/pkg/auth/nodeidentifier/default.go
+++ b/pkg/auth/nodeidentifier/default.go
@@ -23,8 +23,9 @@ import (
 )
 
 // NewDefaultNodeIdentifier returns a default NodeIdentifier implementation,
-// which returns isNode=true if the user groups contain the system:nodes group,
-// and populates nodeName if isNode is true, and the user name is in the format system:node:<nodeName>
+// which returns isNode=true if the user groups contain the system:nodes group
+// and the user name matches the format system:node:<nodeName>, and populates
+// nodeName if isNode is true
 func NewDefaultNodeIdentifier() NodeIdentifier {
 	return defaultNodeIdentifier{}
 }
@@ -35,13 +36,21 @@ type defaultNodeIdentifier struct{}
 // nodeUserNamePrefix is the prefix for usernames in the form `system:node:<nodeName>`
 const nodeUserNamePrefix = "system:node:"
 
-// NodeIdentity returns isNode=true if the user groups contain the system:nodes group,
-// and populates nodeName if isNode is true, and the user name is in the format system:node:<nodeName>
+// NodeIdentity returns isNode=true if the user groups contain the system:nodes
+// group and the user name matches the format system:node:<nodeName>, and
+// populates nodeName if isNode is true
 func (defaultNodeIdentifier) NodeIdentity(u user.Info) (string, bool) {
 	// Make sure we're a node, and can parse the node name
 	if u == nil {
 		return "", false
 	}
+
+	userName := u.GetName()
+	if !strings.HasPrefix(userName, nodeUserNamePrefix) {
+		return "", false
+	}
+
+	nodeName := strings.TrimPrefix(userName, nodeUserNamePrefix)
 
 	isNode := false
 	for _, g := range u.GetGroups() {
@@ -52,12 +61,6 @@ func (defaultNodeIdentifier) NodeIdentity(u user.Info) (string, bool) {
 	}
 	if !isNode {
 		return "", false
-	}
-
-	userName := u.GetName()
-	nodeName := ""
-	if strings.HasPrefix(userName, nodeUserNamePrefix) {
-		nodeName = strings.TrimPrefix(userName, nodeUserNamePrefix)
 	}
 
 	return nodeName, isNode

--- a/pkg/auth/nodeidentifier/default_test.go
+++ b/pkg/auth/nodeidentifier/default_test.go
@@ -45,7 +45,7 @@ func TestDefaultNodeIdentifier_NodeIdentity(t *testing.T) {
 			name:           "node group without username",
 			user:           &user.DefaultInfo{Name: "foo", Groups: []string{"system:nodes"}},
 			expectNodeName: "",
-			expectIsNode:   true,
+			expectIsNode:   false,
 		},
 		{
 			name:           "node group and username",


### PR DESCRIPTION
xref #46999

Split @mikedanese's identifier change out from the GCE/GKE enablement in https://github.com/kubernetes/kubernetes/pull/46796, so the authorization/admission behavior works as intended for kubeadm, which already has it enabled