### PR TITLE
correct the name of the script to generate swagger doc

### DIFF
--- a/hack/gen-swagger-doc/README.md
+++ b/hack/gen-swagger-doc/README.md
@@ -9,7 +9,7 @@ $ sudo docker build -t gcr.io/google_containers/gen-swagger-docs:v1 .
 To generate the html docs,
 
 ```
-$ ./run-gen-swagger-docs.sh <API version> <absolute output path, default to PWD>
+$ ./gen-swagger-docs.sh <API version> <absolute output path, default to PWD>
 ```
 
 The generated definitions.html and operations.html will be stored in output paths.


### PR DESCRIPTION
**What this PR does / why we need it**: The name of the script to generate swagger doc is not correct, this PR is to fix it.

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
