### PR TITLE
Populate endpoints for headless service with no ports

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -4012,12 +4012,10 @@ func validateEndpointSubsets(subsets []api.EndpointSubset, oldSubsets []api.Endp
 		ss := &subsets[i]
 		idxPath := fldPath.Index(i)
 
+		// EndpointSubsets must include endpoint address. For headless service, we allow its endpoints not to have ports.
 		if len(ss.Addresses) == 0 && len(ss.NotReadyAddresses) == 0 {
 			//TODO: consider adding a RequiredOneOf() error for this and similar cases
 			allErrs = append(allErrs, field.Required(idxPath, "must specify `addresses` or `notReadyAddresses`"))
-		}
-		if len(ss.Ports) == 0 {
-			allErrs = append(allErrs, field.Required(idxPath.Child("ports"), ""))
 		}
 		for addr := range ss.Addresses {
 			allErrs = append(allErrs, validateEndpointAddress(&ss.Addresses[addr], idxPath.Child("addresses").Index(addr), ipToNodeName)...)

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -9463,6 +9463,14 @@ func TestValidateEndpoints(t *testing.T) {
 				},
 			},
 		},
+		"empty ports": {
+			ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
+			Subsets: []api.EndpointSubset{
+				{
+					Addresses: []api.EndpointAddress{{IP: "10.10.3.3"}},
+				},
+			},
+		},
 	}
 
 	for k, v := range successCases {
@@ -9500,17 +9508,6 @@ func TestValidateEndpoints(t *testing.T) {
 				Subsets: []api.EndpointSubset{
 					{
 						Ports: []api.EndpointPort{{Name: "a", Port: 93, Protocol: "TCP"}},
-					},
-				},
-			},
-			errorType: "FieldValueRequired",
-		},
-		"empty ports": {
-			endpoints: api.Endpoints{
-				ObjectMeta: metav1.ObjectMeta{Name: "mysvc", Namespace: "namespace"},
-				Subsets: []api.EndpointSubset{
-					{
-						Addresses: []api.EndpointAddress{{IP: "10.10.3.3"}},
 					},
 				},
 			},

--- a/pkg/kubectl/service_basic.go
+++ b/pkg/kubectl/service_basic.go
@@ -179,6 +179,7 @@ func (s ServiceExternalNameGeneratorV1) Generate(params map[string]interface{}) 
 }
 
 // validate validates required fields are set to support structured generation
+// TODO(xiangpengzhao): validate ports are identity mapped for headless service when we enforce that in validation.validateServicePort.
 func (s ServiceCommonGeneratorV1) validate() error {
 	if len(s.Name) == 0 {
 		return fmt.Errorf("name must be specified")
@@ -188,9 +189,6 @@ func (s ServiceCommonGeneratorV1) validate() error {
 	}
 	if s.ClusterIP == api.ClusterIPNone && s.Type != api.ServiceTypeClusterIP {
 		return fmt.Errorf("ClusterIP=None can only be used with ClusterIP service type")
-	}
-	if s.ClusterIP == api.ClusterIPNone && len(s.TCP) > 0 {
-		return fmt.Errorf("can not map ports with clusterip=None")
 	}
 	if s.ClusterIP != api.ClusterIPNone && len(s.TCP) == 0 && s.Type != api.ServiceTypeExternalName {
 		return fmt.Errorf("at least one tcp port specifier must be provided")

--- a/pkg/kubectl/service_basic_test.go
+++ b/pkg/kubectl/service_basic_test.go
@@ -58,13 +58,6 @@ func TestServiceBasicGenerate(t *testing.T) {
 			expectErr:   true,
 		},
 		{
-			name:        "clusterip-none and port mapping",
-			tcp:         []string{"456:9898"},
-			clusterip:   "None",
-			serviceType: api.ServiceTypeClusterIP,
-			expectErr:   true,
-		},
-		{
 			name:        "clusterip-none-wrong-type",
 			tcp:         []string{},
 			clusterip:   "None",
@@ -84,6 +77,23 @@ func TestServiceBasicGenerate(t *testing.T) {
 				Spec: api.ServiceSpec{Type: "ClusterIP",
 					Ports:     []api.ServicePort{},
 					Selector:  map[string]string{"app": "clusterip-none-ok"},
+					ClusterIP: "None", ExternalIPs: []string(nil), LoadBalancerIP: ""},
+			},
+			expectErr: false,
+		},
+		{
+			name:        "clusterip-none-and-port-mapping",
+			tcp:         []string{"456:9898"},
+			clusterip:   "None",
+			serviceType: api.ServiceTypeClusterIP,
+			expected: &api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "clusterip-none-and-port-mapping",
+					Labels: map[string]string{"app": "clusterip-none-and-port-mapping"},
+				},
+				Spec: api.ServiceSpec{Type: "ClusterIP",
+					Ports:     []api.ServicePort{{Name: "456-9898", Protocol: "TCP", Port: 456, TargetPort: intstr.IntOrString{Type: 0, IntVal: 9898, StrVal: ""}, NodePort: 0}},
+					Selector:  map[string]string{"app": "clusterip-none-and-port-mapping"},
 					ClusterIP: "None", ExternalIPs: []string(nil), LoadBalancerIP: ""},
 			},
 			expectErr: false,

--- a/pkg/kubectl/service_test.go
+++ b/pkg/kubectl/service_test.go
@@ -560,6 +560,26 @@ func TestGenerateService(t *testing.T) {
 				},
 			},
 		},
+		{
+			generator: ServiceGeneratorV2{},
+			params: map[string]interface{}{
+				"selector":   "foo=bar",
+				"name":       "test",
+				"cluster-ip": "None",
+			},
+			expected: api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+				Spec: api.ServiceSpec{
+					Selector: map[string]string{
+						"foo": "bar",
+					},
+					Ports:     []api.ServicePort{},
+					ClusterIP: api.ClusterIPNone,
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		obj, err := test.generator.Generate(test.params)

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1154,6 +1154,10 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 			svc.Spec.ClusterIP = api.ClusterIPNone
 			svc.Spec.Ports = addTestPort(svc.Spec.Ports, "rpc", "UDP", 1234, 0, 0)
 		}),
+		makeTestService("somewhere-else", "headless-without-port", func(svc *api.Service) {
+			svc.Spec.Type = api.ServiceTypeClusterIP
+			svc.Spec.ClusterIP = api.ClusterIPNone
+		}),
 	)
 
 	// Headless service should be ignored


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
- populate endpoints with headless service (thanks @fraenkel for the original PR!)
- allow ports with headless service
- nits

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #32796 https://github.com/kubernetes/kubernetes/issues/32796#issuecomment-270462724

**Special notes for your reviewer**:
/cc @thockin @fraenkel 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
