### PR TITLE
client-go: GetOptions for dynamic client

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -218,7 +218,7 @@ func (gc *GarbageCollector) isDangling(reference metav1.OwnerReference, item *no
 	// TODO: It's only necessary to talk to the API server if the owner node
 	// is a "virtual" node. The local graph could lag behind the real
 	// status, but in practice, the difference is small.
-	owner, err = client.Resource(resource, item.identity.Namespace).Get(reference.Name)
+	owner, err = client.Resource(resource, item.identity.Namespace).Get(reference.Name, metav1.GetOptions{})
 	switch {
 	case errors.IsNotFound(err):
 		gc.absentOwnerCache.Add(reference.UID)

--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -69,7 +69,7 @@ func (gc *GarbageCollector) getObject(item objectReference) (*unstructured.Unstr
 	if err != nil {
 		return nil, err
 	}
-	return client.Resource(resource, item.Namespace).Get(item.Name)
+	return client.Resource(resource, item.Namespace).Get(item.Name, metav1.GetOptions{})
 }
 
 func (gc *GarbageCollector) updateObject(item objectReference, obj *unstructured.Unstructured) (*unstructured.Unstructured, error) {

--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -192,7 +192,7 @@ func (g *genericDescriber) Describe(namespace, name string, describerSettings pr
 		Namespaced: g.mapping.Scope.Name() == meta.RESTScopeNameNamespace,
 		Kind:       g.mapping.GroupVersionKind.Kind,
 	}
-	obj, err := g.dynamic.Resource(apiResource, namespace).Get(name)
+	obj, err := g.dynamic.Resource(apiResource, namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -142,7 +142,7 @@ func testSimpleCRUD(t *testing.T, ns string, noxuDefinition *apiextensionsv1beta
 		t.Errorf("missing watch event")
 	}
 
-	gottenNoxuInstance, err := noxuResourceClient.Get("foo")
+	gottenNoxuInstance, err := noxuResourceClient.Get("foo", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -55,7 +55,7 @@ func TestFinalization(t *testing.T) {
 
 	// Deleting something with a finalizer sets deletion timestamp to a not-nil value but does not
 	// remove the object from the API server. Here we read it to confirm this.
-	gottenNoxuInstance, err := noxuResourceClient.Get(name)
+	gottenNoxuInstance, err := noxuResourceClient.Get(name, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	require.NotNil(t, gottenNoxuInstance.GetDeletionTimestamp())
@@ -79,7 +79,7 @@ func TestFinalization(t *testing.T) {
 		if !errors.IsConflict(err) {
 			require.NoError(t, err) // Fail on unexpected error
 		}
-		gottenNoxuInstance, err = noxuResourceClient.Get(name)
+		gottenNoxuInstance, err = noxuResourceClient.Get(name, metav1.GetOptions{})
 		require.NoError(t, err)
 	}
 
@@ -92,7 +92,7 @@ func TestFinalization(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check that the object is actually gone.
-	_, err = noxuResourceClient.Get(name)
+	_, err = noxuResourceClient.Get(name, metav1.GetOptions{})
 	require.Error(t, err)
 	require.True(t, errors.IsNotFound(err), "%#v", err)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -141,7 +141,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 	}
 
 	for key, val := range instances {
-		gottenNoxuInstace, err := noxuNamespacedResourceClient.Get(key)
+		gottenNoxuInstace, err := noxuNamespacedResourceClient.Get(key, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -217,7 +217,7 @@ func TestMultipleRegistration(t *testing.T) {
 		t.Fatalf("unable to create noxu Instance:%v", err)
 	}
 
-	gottenNoxuInstance, err := noxuNamespacedResourceClient.Get(sameInstanceName)
+	gottenNoxuInstance, err := noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +235,7 @@ func TestMultipleRegistration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create noxu Instance:%v", err)
 	}
-	gottenCurletInstance, err := curletNamespacedResourceClient.Get(sameInstanceName)
+	gottenCurletInstance, err := curletNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestMultipleRegistration(t *testing.T) {
 	}
 
 	// now re-GET noxu
-	gottenNoxuInstance2, err := noxuNamespacedResourceClient.Get(sameInstanceName)
+	gottenNoxuInstance2, err := noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +280,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if _, err = noxuNamespacedResourceClient.List(metav1.ListOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
-		if _, err = noxuNamespacedResourceClient.Get("foo"); err == nil || !errors.IsNotFound(err) {
+		if _, err = noxuNamespacedResourceClient.Get("foo", metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
 	}()
@@ -298,7 +298,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err = noxuNamespacedResourceClient.Get(sameInstanceName); err == nil || !errors.IsNotFound(err) {
+		if _, err = noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
 		if e, a := 0, len(initialList.(*unstructured.UnstructuredList).Items); e != a {
@@ -308,7 +308,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		gottenNoxuInstance, err := noxuNamespacedResourceClient.Get(sameInstanceName)
+		gottenNoxuInstance, err := noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -329,7 +329,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if err := noxuNamespacedResourceClient.Delete(sameInstanceName, nil); err != nil {
 			t.Fatal(err)
 		}
-		if _, err = noxuNamespacedResourceClient.Get(sameInstanceName); err == nil || !errors.IsNotFound(err) {
+		if _, err = noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
 		listWithoutItem, err := noxuNamespacedResourceClient.List(metav1.ListOptions{})

--- a/staging/src/k8s.io/client-go/dynamic/client.go
+++ b/staging/src/k8s.io/client-go/dynamic/client.go
@@ -126,11 +126,16 @@ func (rc *ResourceClient) List(opts metav1.ListOptions) (runtime.Object, error) 
 }
 
 // Get gets the resource with the specified name.
-func (rc *ResourceClient) Get(name string) (*unstructured.Unstructured, error) {
+func (rc *ResourceClient) Get(name string, opts metav1.GetOptions) (*unstructured.Unstructured, error) {
+	parameterEncoder := rc.parameterCodec
+	if parameterEncoder == nil {
+		parameterEncoder = defaultParameterEncoder
+	}
 	result := new(unstructured.Unstructured)
 	err := rc.cl.Get().
 		NamespaceIfScoped(rc.ns, rc.resource.Namespaced).
 		Resource(rc.resource.Name).
+		VersionedParams(&opts, parameterEncoder).
 		Name(name).
 		Do().
 		Into(result)

--- a/staging/src/k8s.io/client-go/dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_test.go
@@ -191,7 +191,7 @@ func TestGet(t *testing.T) {
 		}
 		defer srv.Close()
 
-		got, err := cl.Resource(resource, tc.namespace).Get(tc.name)
+		got, err := cl.Resource(resource, tc.namespace).Get(tc.name, metav1.GetOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when getting %q: %v", tc.name, err)
 			continue

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -114,7 +114,7 @@ func TestDynamicClient(t *testing.T) {
 	}
 
 	// check dynamic get
-	unstruct, err := dynamicClient.Resource(&resource, ns.Name).Get(actual.Name)
+	unstruct, err := dynamicClient.Resource(&resource, ns.Name).Get(actual.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error when getting pod %q: %v", actual.Name, err)
 	}


### PR DESCRIPTION
Looks like `GetOptions` were forgotten in the dynamic client. Without them it's hard to write a dynamic initializer controller (useful for custom resources).