### PR TITLE
Flag support in kubectl plugins

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4068,13 +4068,20 @@ run_plugins_tests() {
   kube::test::if_has_not_string "${output_message}" 'The first child'
 
   # plugin env
-  output_message=$(KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin env 2>&1)
+  output_message=$(KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin env -h 2>&1)
+  kube::test::if_has_string "${output_message}" "This is a flag 1"
+  kube::test::if_has_string "${output_message}" "This is a flag 2"
+  kube::test::if_has_string "${output_message}" "This is a flag 3"
+  output_message=$(KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin env --test1=value1 -t value2 2>&1)
   kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_CURRENT_NAMESPACE'
   kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_CALLER'
   kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_DESCRIPTOR_COMMAND=./env.sh'
   kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_DESCRIPTOR_SHORT_DESC=The plugin envs plugin'
   kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_GLOBAL_FLAG_KUBECONFIG'
   kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_GLOBAL_FLAG_REQUEST_TIMEOUT=0'
+  kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_LOCAL_FLAG_TEST1=value1'
+  kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_LOCAL_FLAG_TEST2=value2'
+  kube::test::if_has_string "${output_message}" 'KUBECTL_PLUGINS_LOCAL_FLAG_TEST3=default'
 
   set +o nounset
   set +o errexit

--- a/pkg/kubectl/cmd/plugin.go
+++ b/pkg/kubectl/cmd/plugin.go
@@ -114,6 +114,10 @@ func NewCmdForPlugin(f cmdutil.Factory, plugin *plugins.Plugin, runner plugins.P
 		},
 	}
 
+	for _, flag := range plugin.Flags {
+		cmd.Flags().StringP(flag.Name, flag.Shorthand, flag.DefValue, flag.Desc)
+	}
+
 	for _, childPlugin := range plugin.Tree {
 		cmd.AddCommand(NewCmdForPlugin(f, childPlugin, runner, in, out, errout))
 	}
@@ -126,10 +130,14 @@ type flagsPluginEnvProvider struct {
 }
 
 func (p *flagsPluginEnvProvider) Env() (plugins.EnvList, error) {
-	prefix := "KUBECTL_PLUGINS_GLOBAL_FLAG_"
+	globalPrefix := "KUBECTL_PLUGINS_GLOBAL_FLAG_"
 	env := plugins.EnvList{}
-	p.cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-		env = append(env, plugins.FlagToEnv(flag, prefix))
+	p.cmd.InheritedFlags().VisitAll(func(flag *pflag.Flag) {
+		env = append(env, plugins.FlagToEnv(flag, globalPrefix))
+	})
+	localPrefix := "KUBECTL_PLUGINS_LOCAL_FLAG_"
+	p.cmd.LocalFlags().VisitAll(func(flag *pflag.Flag) {
+		env = append(env, plugins.FlagToEnv(flag, localPrefix))
 	})
 	return env, nil
 }

--- a/pkg/kubectl/plugins/loader_test.go
+++ b/pkg/kubectl/plugins/loader_test.go
@@ -232,7 +232,10 @@ func setupValidPlugins(nPlugins, nChildren int) (string, error) {
 		descriptor := fmt.Sprintf(`
 name: %[1]s
 shortDesc: The %[1]s test plugin
-command: echo %[1]s`, name)
+command: echo %[1]s
+flags:
+  - name: %[1]s-flag
+    desc: A flag for %[1]s`, name)
 
 		if nChildren > 0 {
 			descriptor += `

--- a/test/fixtures/pkg/kubectl/plugins/env/plugin.yaml
+++ b/test/fixtures/pkg/kubectl/plugins/env/plugin.yaml
@@ -1,3 +1,12 @@
 name: env
 shortDesc: "The plugin envs plugin"
 command: "./env.sh"
+flags: 
+  - name: "test1"
+    desc: "This is a flag 1"
+  - name: "test2"
+    desc: "This is a flag 2"
+    shorthand: "t"
+  - name: "test3"
+    desc: "This is a flag 3"
+    defValue: "default"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

Adds support to flags in `kubectl` plugins. Flags are declared in the plugin descriptor and are passed to plugins through env vars, similar to global flags (which already works).

Fixes https://github.com/kubernetes/kubernetes/issues/49122

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added flag support to kubectl plugins
```
PTAL @monopole @kubernetes/sig-cli-pr-reviews 