### PR TITLE
kubectl drain errors if pod is already deleted

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -544,7 +544,7 @@ func (o *DrainOptions) deletePods(pods []api.Pod, getPodFn func(namespace, name 
 	}
 	for _, pod := range pods {
 		err := o.deletePod(pod)
-		if err != nil {
+		if err != nil && !apierrors.IsNotFound(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
kubectl drain can throw an error if the pod it attempts to delete has already been deleted.

fixes https://github.com/kubernetes/kubectl/issues/28