### PR TITLE
Adds support for multiple kubelets to unit test.

### DIFF
--- a/pkg/kubelet/kubelet_cadvisor_test.go
+++ b/pkg/kubelet/kubelet_cadvisor_test.go
@@ -186,7 +186,7 @@ func TestGetContainerInfo(t *testing.T) {
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnablec */)
 		defer testKubelet.Cleanup()
 		fakeRuntime := testKubelet.fakeRuntime
-		kubelet := testKubelet.kubelet
+		kubelet := testKubelet.kubelet[0]
 		cadvisorReq := &cadvisorapi.ContainerInfoRequest{}
 		mockCadvisor := testKubelet.fakeCadvisor
 		if tc.expectDockerContainerCall {
@@ -214,7 +214,7 @@ func TestGetRawContainerInfoRoot(t *testing.T) {
 	}
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	mockCadvisor := testKubelet.fakeCadvisor
 	cadvisorReq := &cadvisorapi.ContainerInfoRequest{}
 	mockCadvisor.On("ContainerInfo", containerPath, cadvisorReq).Return(containerInfo, nil)
@@ -240,7 +240,7 @@ func TestGetRawContainerInfoSubcontainers(t *testing.T) {
 	}
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	mockCadvisor := testKubelet.fakeCadvisor
 	cadvisorReq := &cadvisorapi.ContainerInfoRequest{}
 	mockCadvisor.On("SubcontainerInfo", containerPath, cadvisorReq).Return(containerInfo, nil)

--- a/pkg/kubelet/kubelet_getters_test.go
+++ b/pkg/kubelet/kubelet_getters_test.go
@@ -29,7 +29,7 @@ import (
 func TestKubeletDirs(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	root := kubelet.rootDirectory
 
 	var exp, got string
@@ -74,7 +74,7 @@ func TestKubeletDirs(t *testing.T) {
 func TestKubeletDirsCompat(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	root := kubelet.rootDirectory
 	require.NoError(t, os.MkdirAll(root, 0750), "can't mkdir(%q)", root)
 

--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -31,7 +31,7 @@ import (
 func TestNodeIPParam(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	tests := []struct {
 		nodeIP   string
 		success  bool
@@ -101,7 +101,7 @@ func TestParseResolvConf(t *testing.T) {
 	}
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	for i, tc := range testCases {
 		ns, srch, err := kubelet.parseResolvConf(strings.NewReader(tc.data))
 		require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestParseResolvConf(t *testing.T) {
 func TestComposeDNSSearch(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	recorder := record.NewFakeRecorder(20)
 	kubelet.recorder = recorder

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -132,7 +132,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 	testKubelet := newTestKubeletWithImageList(
 		t, inputImageList, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubelet.containerManager = &localCM{
 		ContainerManager: cm.NewStubContainerManager(),
 		allocatable: v1.ResourceList{
@@ -259,7 +259,7 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 func TestUpdateNewNodeOutOfDiskStatusWithTransitionFrequency(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubelet.containerManager = &localCM{
 		ContainerManager: cm.NewStubContainerManager(),
 		allocatable: v1.ResourceList{
@@ -333,7 +333,7 @@ func TestUpdateNewNodeOutOfDiskStatusWithTransitionFrequency(t *testing.T) {
 func TestUpdateExistingNodeStatus(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubelet.containerManager = &localCM{
 		ContainerManager: cm.NewStubContainerManager(),
 		allocatable: v1.ResourceList{
@@ -527,7 +527,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 func TestUpdateExistingNodeOutOfDiskStatusWithTransitionFrequency(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubelet.containerManager = &localCM{
 		ContainerManager: cm.NewStubContainerManager(),
 		allocatable: v1.ResourceList{
@@ -688,7 +688,7 @@ func TestUpdateExistingNodeOutOfDiskStatusWithTransitionFrequency(t *testing.T) 
 func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubelet.containerManager = &localCM{
 		ContainerManager: cm.NewStubContainerManager(),
 		allocatable: v1.ResourceList{
@@ -899,7 +899,7 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 func TestUpdateNodeStatusError(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	// No matching node for the kubelet
 	testKubelet.fakeKubeClient.ReactionChain = fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{}}).ReactionChain
 	assert.Error(t, kubelet.updateNodeStatus())
@@ -909,7 +909,7 @@ func TestUpdateNodeStatusError(t *testing.T) {
 func TestRegisterWithApiServer(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubeClient := testKubelet.fakeKubeClient
 	kubeClient.AddReactor("create", "nodes", func(action core.Action) (bool, runtime.Object, error) {
 		// Return an error on create.
@@ -1090,7 +1090,7 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 	for _, tc := range cases {
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled is a don't-care for this test */)
 		defer testKubelet.Cleanup()
-		kubelet := testKubelet.kubelet
+		kubelet := testKubelet.kubelet[0]
 		kubeClient := testKubelet.fakeKubeClient
 
 		kubeClient.AddReactor("create", "nodes", func(action core.Action) (bool, runtime.Object, error) {
@@ -1148,7 +1148,7 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 	testKubelet := newTestKubeletWithImageList(
 		t, inputImageList, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubelet.containerManager = &localCM{
 		ContainerManager: cm.NewStubContainerManager(),
 		allocatable: v1.ResourceList{

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -268,7 +268,7 @@ fe00::2	ip6-allrouters
 func TestRunInContainerNoSuchPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	fakeRuntime := testKubelet.fakeRuntime
 	fakeRuntime.PodList = []*containertest.FakePod{}
 
@@ -288,7 +288,7 @@ func TestRunInContainer(t *testing.T) {
 	for _, testError := range []error{nil, errors.New("bar")} {
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 		defer testKubelet.Cleanup()
-		kubelet := testKubelet.kubelet
+		kubelet := testKubelet.kubelet[0]
 		fakeRuntime := testKubelet.fakeRuntime
 		fakeCommandRunner := containertest.FakeContainerCommandRunner{
 			Err:    testError,
@@ -322,7 +322,7 @@ func TestRunInContainer(t *testing.T) {
 func TestGenerateRunContainerOptions_DNSConfigurationParams(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	clusterNS := "203.0.113.1"
 	kubelet.clusterDomain = "kubernetes.io"
@@ -1261,9 +1261,9 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 	for _, tc := range testCases {
 		fakeRecorder := record.NewFakeRecorder(1)
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-		testKubelet.kubelet.recorder = fakeRecorder
+		testKubelet.kubelet[0].recorder = fakeRecorder
 		defer testKubelet.Cleanup()
-		kl := testKubelet.kubelet
+		kl := testKubelet.kubelet[0]
 		kl.masterServiceNamespace = tc.masterServiceNs
 		if tc.nilLister {
 			kl.serviceLister = nil
@@ -1750,7 +1750,7 @@ func TestExec(t *testing.T) {
 	for _, tc := range testcases {
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 		defer testKubelet.Cleanup()
-		kubelet := testKubelet.kubelet
+		kubelet := testKubelet.kubelet[0]
 		testKubelet.fakeRuntime.PodList = []*containertest.FakePod{
 			{Pod: &kubecontainer.Pod{
 				ID:        podUID,
@@ -1841,7 +1841,7 @@ func TestPortForward(t *testing.T) {
 	for _, tc := range testcases {
 		testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 		defer testKubelet.Cleanup()
-		kubelet := testKubelet.kubelet
+		kubelet := testKubelet.kubelet[0]
 		testKubelet.fakeRuntime.PodList = []*containertest.FakePod{
 			{Pod: &kubecontainer.Pod{
 				ID:        podUID,
@@ -1992,7 +1992,7 @@ func TestHasHostMountPVC(t *testing.T) {
 			return true, volumeToReturn, v.pvError
 		})
 
-		actual := testKubelet.kubelet.hasHostMountPVC(pod)
+		actual := testKubelet.kubelet[0].hasHostMountPVC(pod)
 		if actual != v.expected {
 			t.Errorf("%s expected %t but got %t", k, v.expected, actual)
 		}

--- a/pkg/kubelet/kubelet_resources_test.go
+++ b/pkg/kubelet/kubelet_resources_test.go
@@ -41,11 +41,11 @@ func TestPodResourceLimitsDefaulting(t *testing.T) {
 	}, nil)
 	tk.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	tk.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	tk.kubelet.nodeInfo = &testNodeInfo{
+	tk.kubelet[0].nodeInfo = &testNodeInfo{
 		nodes: []*v1.Node{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: string(tk.kubelet.nodeName),
+					Name: string(tk.kubelet[0].nodeName),
 				},
 				Status: v1.NodeStatus{
 					Allocatable: v1.ResourceList{
@@ -79,7 +79,7 @@ func TestPodResourceLimitsDefaulting(t *testing.T) {
 	}
 	as := assert.New(t)
 	for idx, tc := range cases {
-		actual, _, err := tk.kubelet.defaultPodLimitsForDownwardApi(tc.pod, nil)
+		actual, _, err := tk.kubelet[0].defaultPodLimitsForDownwardApi(tc.pod, nil)
 		as.Nil(err, "failed to default pod limits: %v", err)
 		if !apiequality.Semantic.DeepEqual(tc.expected, actual) {
 			as.Fail("test case [%d] failed.  Expected: %+v, Got: %+v", idx, tc.expected, actual)

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -100,7 +100,7 @@ func (f *fakeImageGCManager) GetImageList() ([]kubecontainer.Image, error) {
 }
 
 type TestKubelet struct {
-	kubelet          *Kubelet
+	kubelet          []*Kubelet
 	fakeRuntime      *containertest.FakeRuntime
 	fakeCadvisor     *cadvisortest.Mock
 	fakeKubeClient   *fake.Clientset
@@ -111,8 +111,8 @@ type TestKubelet struct {
 }
 
 func (tk *TestKubelet) Cleanup() {
-	if tk.kubelet != nil {
-		os.RemoveAll(tk.kubelet.rootDirectory)
+	if tk.kubelet[0] != nil {
+		os.RemoveAll(tk.kubelet[0].rootDirectory)
 	}
 }
 
@@ -151,160 +151,162 @@ func newTestKubeletWithImageList(
 
 	fakeRecorder := &record.FakeRecorder{}
 	fakeKubeClient := &fake.Clientset{}
+	mockCadvisor := &cadvisortest.Mock{}
+	fakeMirrorClient := podtest.NewFakeMirrorClient()
+	fakeClock := clock.NewFakeClock(time.Now())
+	plug := &volumetest.FakeVolumePlugin{PluginName: "fake", Host: nil}
 	kubelet := &Kubelet{}
-	kubelet.recorder = fakeRecorder
-	kubelet.kubeClient = fakeKubeClient
-	kubelet.os = &containertest.FakeOS{}
+	kubelets := []*Kubelet{kubelet}
+	for _, kubelet := range kubelets {
+		kubelet.recorder = fakeRecorder
+		kubelet.kubeClient = fakeKubeClient
+		kubelet.os = &containertest.FakeOS{}
 
-	kubelet.hostname = testKubeletHostname
-	kubelet.nodeName = types.NodeName(testKubeletHostname)
-	kubelet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
-	kubelet.runtimeState.setNetworkState(nil)
-	kubelet.networkPlugin, _ = network.InitNetworkPlugin([]network.NetworkPlugin{}, "", nettest.NewFakeHost(nil), componentconfig.HairpinNone, "", 1440)
-	if tempDir, err := ioutil.TempDir("/tmp", "kubelet_test."); err != nil {
-		t.Fatalf("can't make a temp rootdir: %v", err)
-	} else {
-		kubelet.rootDirectory = tempDir
-	}
-	if err := os.MkdirAll(kubelet.rootDirectory, 0750); err != nil {
-		t.Fatalf("can't mkdir(%q): %v", kubelet.rootDirectory, err)
-	}
-	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.String) bool { return true })
-	kubelet.masterServiceNamespace = metav1.NamespaceDefault
-	kubelet.serviceLister = testServiceLister{}
-	kubelet.nodeInfo = testNodeInfo{
-		nodes: []*v1.Node{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: string(kubelet.nodeName),
-				},
-				Status: v1.NodeStatus{
-					Conditions: []v1.NodeCondition{
-						{
-							Type:    v1.NodeReady,
-							Status:  v1.ConditionTrue,
-							Reason:  "Ready",
-							Message: "Node ready",
-						},
+		kubelet.hostname = testKubeletHostname
+		kubelet.nodeName = types.NodeName(testKubeletHostname)
+		kubelet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
+		kubelet.runtimeState.setNetworkState(nil)
+		kubelet.networkPlugin, _ = network.InitNetworkPlugin([]network.NetworkPlugin{}, "", nettest.NewFakeHost(nil), componentconfig.HairpinNone, "", 1440)
+		if tempDir, err := ioutil.TempDir("/tmp", "kubelet_test."); err != nil {
+			t.Fatalf("can't make a temp rootdir: %v", err)
+		} else {
+			kubelet.rootDirectory = tempDir
+		}
+		if err := os.MkdirAll(kubelet.rootDirectory, 0750); err != nil {
+			t.Fatalf("can't mkdir(%q): %v", kubelet.rootDirectory, err)
+		}
+		kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.String) bool { return true })
+		kubelet.masterServiceNamespace = metav1.NamespaceDefault
+		kubelet.serviceLister = testServiceLister{}
+		kubelet.nodeInfo = testNodeInfo{
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: string(kubelet.nodeName),
 					},
-					Addresses: []v1.NodeAddress{
-						{
-							Type:    v1.NodeInternalIP,
-							Address: testKubeletHostIP,
+					Status: v1.NodeStatus{
+						Conditions: []v1.NodeCondition{
+							{
+								Type:    v1.NodeReady,
+								Status:  v1.ConditionTrue,
+								Reason:  "Ready",
+								Message: "Node ready",
+							},
+						},
+						Addresses: []v1.NodeAddress{
+							{
+								Type:    v1.NodeInternalIP,
+								Address: testKubeletHostIP,
+							},
 						},
 					},
 				},
 			},
-		},
+		}
+		kubelet.recorder = fakeRecorder
+		if err := kubelet.setupDataDirs(); err != nil {
+			t.Fatalf("can't initialize kubelet data dirs: %v", err)
+		}
+		kubelet.daemonEndpoints = &v1.NodeDaemonEndpoints{}
+
+		kubelet.cadvisor = mockCadvisor
+
+		secretManager := secret.NewSimpleSecretManager(kubelet.kubeClient)
+		kubelet.secretManager = secretManager
+		configMapManager := configmap.NewSimpleConfigMapManager(kubelet.kubeClient)
+		kubelet.configMapManager = configMapManager
+		kubelet.podManager = kubepod.NewBasicPodManager(fakeMirrorClient, kubelet.secretManager, kubelet.configMapManager)
+		kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{})
+		diskSpaceManager, err := newDiskSpaceManager(mockCadvisor, DiskSpacePolicy{})
+		if err != nil {
+			t.Fatalf("can't initialize disk space manager: %v", err)
+		}
+		kubelet.diskSpaceManager = diskSpaceManager
+
+		kubelet.containerRuntime = fakeRuntime
+		kubelet.runtimeCache = containertest.NewFakeRuntimeCache(kubelet.containerRuntime)
+		kubelet.reasonCache = NewReasonCache()
+		kubelet.podCache = containertest.NewFakeCache(kubelet.containerRuntime)
+		kubelet.podWorkers = &fakePodWorkers{
+			syncPodFn: kubelet.syncPod,
+			cache:     kubelet.podCache,
+			t:         t,
+		}
+
+		kubelet.probeManager = probetest.FakeManager{}
+		kubelet.livenessManager = proberesults.NewManager()
+		kubelet.containerManager = cm.NewStubContainerManager()
+		fakeNodeRef := &clientv1.ObjectReference{
+			Kind:      "Node",
+			Name:      testKubeletHostname,
+			UID:       types.UID(testKubeletHostname),
+			Namespace: "",
+		}
+		fakeImageGCPolicy := images.ImageGCPolicy{
+			HighThresholdPercent: 90,
+			LowThresholdPercent:  80,
+		}
+		imageGCManager, err := images.NewImageGCManager(fakeRuntime, mockCadvisor, fakeRecorder, fakeNodeRef, fakeImageGCPolicy)
+		assert.NoError(t, err)
+		kubelet.imageManager = &fakeImageGCManager{
+			fakeImageService: fakeRuntime,
+			ImageGCManager:   imageGCManager,
+		}
+		kubelet.backOff = flowcontrol.NewBackOff(time.Second, time.Minute)
+		kubelet.backOff.Clock = fakeClock
+		kubelet.podKillingCh = make(chan *kubecontainer.PodPair, 20)
+		kubelet.resyncInterval = 10 * time.Second
+		kubelet.workQueue = queue.NewBasicWorkQueue(fakeClock)
+		// Relist period does not affect the tests.
+		kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, 100, time.Hour, nil, clock.RealClock{})
+		kubelet.clock = fakeClock
+		kubelet.setNodeStatusFuncs = kubelet.defaultNodeStatusFuncs()
+
+		// TODO: Factor out "StatsProvider" from Kubelet so we don't have a cyclic dependency
+		volumeStatsAggPeriod := time.Second * 10
+		kubelet.resourceAnalyzer = stats.NewResourceAnalyzer(kubelet, volumeStatsAggPeriod, kubelet.containerRuntime)
+		nodeRef := &clientv1.ObjectReference{
+			Kind:      "Node",
+			Name:      string(kubelet.nodeName),
+			UID:       types.UID(kubelet.nodeName),
+			Namespace: "",
+		}
+		// setup eviction manager
+		evictionManager, evictionAdmitHandler := eviction.NewManager(kubelet.resourceAnalyzer, eviction.Config{}, killPodNow(kubelet.podWorkers, fakeRecorder), kubelet.imageManager, kubelet.containerGC, fakeRecorder, nodeRef, kubelet.clock)
+
+		kubelet.evictionManager = evictionManager
+		kubelet.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)
+		// Add this as cleanup predicate pod admitter
+		kubelet.admitHandlers.AddPodAdmitHandler(lifecycle.NewPredicateAdmitHandler(kubelet.getNodeAnyWay, lifecycle.NewAdmissionFailureHandlerStub()))
+
+		kubelet.volumePluginMgr, err =
+			NewInitializedVolumePluginMgr(kubelet, kubelet.secretManager, kubelet.configMapManager, []volume.VolumePlugin{plug})
+		require.NoError(t, err, "Failed to initialize VolumePluginMgr")
+
+		kubelet.mounter = &mount.FakeMounter{}
+		kubelet.volumeManager = kubeletvolume.NewVolumeManager(
+			controllerAttachDetachEnabled,
+			kubelet.nodeName,
+			kubelet.podManager,
+			kubelet.statusManager,
+			fakeKubeClient,
+			kubelet.volumePluginMgr,
+			fakeRuntime,
+			kubelet.mounter,
+			kubelet.getPodsDir(),
+			kubelet.recorder,
+			false, /* experimentalCheckNodeCapabilitiesBeforeMount*/
+			false /* keepTerminatedPodVolumes */)
+
+		// enable active deadline handler
+		activeDeadlineHandler, err := newActiveDeadlineHandler(kubelet.statusManager, kubelet.recorder, kubelet.clock)
+		require.NoError(t, err, "Can't initialize active deadline handler")
+
+		kubelet.AddPodSyncLoopHandler(activeDeadlineHandler)
+		kubelet.AddPodSyncHandler(activeDeadlineHandler)
+		kubelet.gpuManager = gpu.NewGPUManagerStub()
 	}
-	kubelet.recorder = fakeRecorder
-	if err := kubelet.setupDataDirs(); err != nil {
-		t.Fatalf("can't initialize kubelet data dirs: %v", err)
-	}
-	kubelet.daemonEndpoints = &v1.NodeDaemonEndpoints{}
-
-	mockCadvisor := &cadvisortest.Mock{}
-	kubelet.cadvisor = mockCadvisor
-
-	fakeMirrorClient := podtest.NewFakeMirrorClient()
-	secretManager := secret.NewSimpleSecretManager(kubelet.kubeClient)
-	kubelet.secretManager = secretManager
-	configMapManager := configmap.NewSimpleConfigMapManager(kubelet.kubeClient)
-	kubelet.configMapManager = configMapManager
-	kubelet.podManager = kubepod.NewBasicPodManager(fakeMirrorClient, kubelet.secretManager, kubelet.configMapManager)
-	kubelet.statusManager = status.NewManager(fakeKubeClient, kubelet.podManager, &statustest.FakePodDeletionSafetyProvider{})
-	diskSpaceManager, err := newDiskSpaceManager(mockCadvisor, DiskSpacePolicy{})
-	if err != nil {
-		t.Fatalf("can't initialize disk space manager: %v", err)
-	}
-	kubelet.diskSpaceManager = diskSpaceManager
-
-	kubelet.containerRuntime = fakeRuntime
-	kubelet.runtimeCache = containertest.NewFakeRuntimeCache(kubelet.containerRuntime)
-	kubelet.reasonCache = NewReasonCache()
-	kubelet.podCache = containertest.NewFakeCache(kubelet.containerRuntime)
-	kubelet.podWorkers = &fakePodWorkers{
-		syncPodFn: kubelet.syncPod,
-		cache:     kubelet.podCache,
-		t:         t,
-	}
-
-	kubelet.probeManager = probetest.FakeManager{}
-	kubelet.livenessManager = proberesults.NewManager()
-
-	kubelet.containerManager = cm.NewStubContainerManager()
-	fakeNodeRef := &clientv1.ObjectReference{
-		Kind:      "Node",
-		Name:      testKubeletHostname,
-		UID:       types.UID(testKubeletHostname),
-		Namespace: "",
-	}
-	fakeImageGCPolicy := images.ImageGCPolicy{
-		HighThresholdPercent: 90,
-		LowThresholdPercent:  80,
-	}
-	imageGCManager, err := images.NewImageGCManager(fakeRuntime, mockCadvisor, fakeRecorder, fakeNodeRef, fakeImageGCPolicy)
-	assert.NoError(t, err)
-	kubelet.imageManager = &fakeImageGCManager{
-		fakeImageService: fakeRuntime,
-		ImageGCManager:   imageGCManager,
-	}
-	fakeClock := clock.NewFakeClock(time.Now())
-	kubelet.backOff = flowcontrol.NewBackOff(time.Second, time.Minute)
-	kubelet.backOff.Clock = fakeClock
-	kubelet.podKillingCh = make(chan *kubecontainer.PodPair, 20)
-	kubelet.resyncInterval = 10 * time.Second
-	kubelet.workQueue = queue.NewBasicWorkQueue(fakeClock)
-	// Relist period does not affect the tests.
-	kubelet.pleg = pleg.NewGenericPLEG(fakeRuntime, 100, time.Hour, nil, clock.RealClock{})
-	kubelet.clock = fakeClock
-	kubelet.setNodeStatusFuncs = kubelet.defaultNodeStatusFuncs()
-
-	// TODO: Factor out "StatsProvider" from Kubelet so we don't have a cyclic dependency
-	volumeStatsAggPeriod := time.Second * 10
-	kubelet.resourceAnalyzer = stats.NewResourceAnalyzer(kubelet, volumeStatsAggPeriod, kubelet.containerRuntime)
-	nodeRef := &clientv1.ObjectReference{
-		Kind:      "Node",
-		Name:      string(kubelet.nodeName),
-		UID:       types.UID(kubelet.nodeName),
-		Namespace: "",
-	}
-	// setup eviction manager
-	evictionManager, evictionAdmitHandler := eviction.NewManager(kubelet.resourceAnalyzer, eviction.Config{}, killPodNow(kubelet.podWorkers, fakeRecorder), kubelet.imageManager, kubelet.containerGC, fakeRecorder, nodeRef, kubelet.clock)
-
-	kubelet.evictionManager = evictionManager
-	kubelet.admitHandlers.AddPodAdmitHandler(evictionAdmitHandler)
-	// Add this as cleanup predicate pod admitter
-	kubelet.admitHandlers.AddPodAdmitHandler(lifecycle.NewPredicateAdmitHandler(kubelet.getNodeAnyWay, lifecycle.NewAdmissionFailureHandlerStub()))
-
-	plug := &volumetest.FakeVolumePlugin{PluginName: "fake", Host: nil}
-	kubelet.volumePluginMgr, err =
-		NewInitializedVolumePluginMgr(kubelet, kubelet.secretManager, kubelet.configMapManager, []volume.VolumePlugin{plug})
-	require.NoError(t, err, "Failed to initialize VolumePluginMgr")
-
-	kubelet.mounter = &mount.FakeMounter{}
-	kubelet.volumeManager = kubeletvolume.NewVolumeManager(
-		controllerAttachDetachEnabled,
-		kubelet.nodeName,
-		kubelet.podManager,
-		kubelet.statusManager,
-		fakeKubeClient,
-		kubelet.volumePluginMgr,
-		fakeRuntime,
-		kubelet.mounter,
-		kubelet.getPodsDir(),
-		kubelet.recorder,
-		false, /* experimentalCheckNodeCapabilitiesBeforeMount*/
-		false /* keepTerminatedPodVolumes */)
-
-	// enable active deadline handler
-	activeDeadlineHandler, err := newActiveDeadlineHandler(kubelet.statusManager, kubelet.recorder, kubelet.clock)
-	require.NoError(t, err, "Can't initialize active deadline handler")
-
-	kubelet.AddPodSyncLoopHandler(activeDeadlineHandler)
-	kubelet.AddPodSyncHandler(activeDeadlineHandler)
-	kubelet.gpuManager = gpu.NewGPUManagerStub()
-	return &TestKubelet{kubelet, fakeRuntime, mockCadvisor, fakeKubeClient, fakeMirrorClient, fakeClock, nil, plug}
+	return &TestKubelet{kubelets, fakeRuntime, mockCadvisor, fakeKubeClient, fakeMirrorClient, fakeClock, nil, plug}
 }
 
 func newTestPods(count int) []*v1.Pod {
@@ -329,7 +331,7 @@ func TestSyncLoopAbort(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubelet.runtimeState.setRuntimeSync(time.Now())
 	// The syncLoop waits on time.After(resyncInterval), set it really big so that we don't race for
 	// the channel close
@@ -353,7 +355,7 @@ func TestSyncPodsStartPod(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	fakeRuntime := testKubelet.fakeRuntime
 	pods := []*v1.Pod{
 		podWithUidNameNsSpec("12345678", "foo", "new", v1.PodSpec{
@@ -376,7 +378,7 @@ func TestSyncPodsDeletesWhenSourcesAreReady(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubelet.sourcesReady = config.NewSourcesReady(func(_ sets.String) bool { return ready })
 
 	fakeRuntime.PodList = []*containertest.FakePod{
@@ -425,7 +427,7 @@ func (ls testNodeLister) List(selector labels.Selector) ([]*v1.Node, error) {
 func TestHandlePortConflicts(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
@@ -470,7 +472,7 @@ func TestHandlePortConflicts(t *testing.T) {
 func TestHandleHostNameConflicts(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
@@ -512,7 +514,7 @@ func TestHandleHostNameConflicts(t *testing.T) {
 func TestHandleNodeSelector(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	nodes := []*v1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname, Labels: map[string]string{"key": "B"}},
@@ -552,7 +554,7 @@ func TestHandleNodeSelector(t *testing.T) {
 func TestHandleMemExceeded(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	nodes := []*v1.Node{
 		{ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname},
 			Status: v1.NodeStatus{Capacity: v1.ResourceList{}, Allocatable: v1.ResourceList{
@@ -611,7 +613,7 @@ func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 	}
 	testKubelet.fakeCadvisor.On("VersionInfo").Return(versionInfo, nil)
 
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	pods := []*v1.Pod{
 		{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: "1234"}, Spec: v1.PodSpec{Containers: []v1.Container{{Ports: []v1.ContainerPort{{HostPort: 80}}}}}},
 		{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: "4567"}, Spec: v1.PodSpec{Containers: []v1.Container{{Ports: []v1.ContainerPort{{HostPort: 80}}}}}},
@@ -633,7 +635,7 @@ func TestPurgingObsoleteStatusMapEntries(t *testing.T) {
 func TestValidateContainerLogStatus(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	containerName := "x"
 	testCases := []struct {
 		statuses []v1.ContainerStatus
@@ -766,7 +768,7 @@ func TestCreateMirrorPod(t *testing.T) {
 		testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 		testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-		kl := testKubelet.kubelet
+		kl := testKubelet.kubelet[0]
 		manager := testKubelet.fakeMirrorClient
 		pod := podWithUidNameNs("12345678", "bar", "foo")
 		pod.Annotations[kubetypes.ConfigSourceAnnotationKey] = "file"
@@ -793,7 +795,7 @@ func TestDeleteOutdatedMirrorPod(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	manager := testKubelet.fakeMirrorClient
 	pod := podWithUidNameNsSpec("12345678", "foo", "ns", v1.PodSpec{
 		Containers: []v1.Container{
@@ -835,7 +837,7 @@ func TestDeleteOrphanedMirrorPods(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	manager := testKubelet.fakeMirrorClient
 	orphanPods := []*v1.Pod{
 		{
@@ -926,7 +928,7 @@ func TestGetContainerInfoForMirrorPods(t *testing.T) {
 	mockCadvisor := testKubelet.fakeCadvisor
 	cadvisorReq := &cadvisorapi.ContainerInfoRequest{}
 	mockCadvisor.On("DockerContainer", containerID, cadvisorReq).Return(containerInfo, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	fakeRuntime.PodList = []*containertest.FakePod{
 		{Pod: &kubecontainer.Pod{
@@ -959,7 +961,7 @@ func TestHostNetworkAllowed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	capabilities.SetForTests(capabilities.Capabilities{
 		PrivilegedSources: capabilities.PrivilegedSources{
@@ -992,7 +994,7 @@ func TestHostNetworkDisallowed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	capabilities.SetForTests(capabilities.Capabilities{
 		PrivilegedSources: capabilities.PrivilegedSources{
@@ -1024,7 +1026,7 @@ func TestHostPIDAllowed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	capabilities.SetForTests(capabilities.Capabilities{
 		PrivilegedSources: capabilities.PrivilegedSources{
@@ -1057,7 +1059,7 @@ func TestHostPIDDisallowed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	capabilities.SetForTests(capabilities.Capabilities{
 		PrivilegedSources: capabilities.PrivilegedSources{
@@ -1089,7 +1091,7 @@ func TestHostIPCAllowed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	capabilities.SetForTests(capabilities.Capabilities{
 		PrivilegedSources: capabilities.PrivilegedSources{
@@ -1122,7 +1124,7 @@ func TestHostIPCDisallowed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	capabilities.SetForTests(capabilities.Capabilities{
 		PrivilegedSources: capabilities.PrivilegedSources{
@@ -1154,7 +1156,7 @@ func TestPrivilegeContainerAllowed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	capabilities.SetForTests(capabilities.Capabilities{
 		AllowPrivileged: true,
@@ -1182,7 +1184,7 @@ func TestPrivilegedContainerDisallowed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	capabilities.SetForTests(capabilities.Capabilities{
 		AllowPrivileged: false,
@@ -1209,7 +1211,7 @@ func TestNetworkErrorsWithoutHostNetwork(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	kubelet.runtimeState.setNetworkState(fmt.Errorf("simulated network error"))
 	capabilities.SetForTests(capabilities.Capabilities{
@@ -1247,7 +1249,7 @@ func TestNetworkErrorsWithoutHostNetwork(t *testing.T) {
 func TestFilterOutTerminatedPods(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	pods := newTestPods(5)
 	pods[0].Status.Phase = v1.PodFailed
 	pods[1].Status.Phase = v1.PodSucceeded
@@ -1265,7 +1267,7 @@ func TestSyncPodsSetStatusToFailedForPodsThatRunTooLong(t *testing.T) {
 	defer testKubelet.Cleanup()
 	fakeRuntime := testKubelet.fakeRuntime
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	now := metav1.Now()
 	startTime := metav1.NewTime(now.Time.Add(-1 * time.Minute))
@@ -1318,7 +1320,7 @@ func TestSyncPodsDoesNotSetPodsThatDidNotRunTooLongToFailed(t *testing.T) {
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	now := metav1.Now()
 	startTime := metav1.NewTime(now.Time.Add(-1 * time.Minute))
@@ -1386,7 +1388,7 @@ func TestDeletePodDirsForDeletedPods(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	pods := []*v1.Pod{
 		podWithUidNameNs("12345678", "pod1", "ns"),
 		podWithUidNameNs("12345679", "pod2", "ns"),
@@ -1407,7 +1409,7 @@ func TestDeletePodDirsForDeletedPods(t *testing.T) {
 }
 
 func syncAndVerifyPodDir(t *testing.T, testKubelet *TestKubelet, pods []*v1.Pod, podsToCheck []*v1.Pod, shouldExist bool) {
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 
 	kl.podManager.SetPods(pods)
 	kl.HandlePodSyncs(pods)
@@ -1426,7 +1428,7 @@ func TestDoesNotDeletePodDirsForTerminatedPods(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	pods := []*v1.Pod{
 		podWithUidNameNs("12345678", "pod1", "ns"),
 		podWithUidNameNs("12345679", "pod2", "ns"),
@@ -1477,7 +1479,7 @@ func TestDoesNotDeletePodDirsIfContainerIsRunning(t *testing.T) {
 func TestGetPodsToSync(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	clock := testKubelet.fakeClock
 	pods := newTestPods(5)
 
@@ -1512,7 +1514,7 @@ func TestGenerateAPIPodStatusWithSortedContainers(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	numContainers := 10
 	expectedOrder := []string{}
 	cStatuses := []*kubecontainer.ContainerStatus{}
@@ -1575,7 +1577,7 @@ func TestGenerateAPIPodStatusWithReasonCache(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	pod := podWithUidNameNs("12345678", "foo", "new")
 	pod.Spec = v1.PodSpec{RestartPolicy: v1.RestartPolicyOnFailure}
 
@@ -1765,7 +1767,7 @@ func TestGenerateAPIPodStatusWithDifferentRestartPolicies(t *testing.T) {
 	testKubelet.fakeCadvisor.On("MachineInfo").Return(&cadvisorapi.MachineInfo{}, nil)
 	testKubelet.fakeCadvisor.On("ImagesFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
 	testKubelet.fakeCadvisor.On("RootFsInfo").Return(cadvisorapiv2.FsInfo{}, nil)
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	pod := podWithUidNameNs("12345678", "foo", "new")
 	containers := []v1.Container{{Name: "succeed"}, {Name: "failed"}}
 	podStatus := &kubecontainer.PodStatus{
@@ -1928,7 +1930,7 @@ func (a *testPodAdmitHandler) Admit(attrs *lifecycle.PodAdmitAttributes) lifecyc
 func TestHandlePodAdditionsInvokesPodAdmitHandlers(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	kl.nodeInfo = testNodeInfo{nodes: []*v1.Node{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: string(kl.nodeName)},
@@ -1998,7 +2000,7 @@ func (a *testPodSyncLoopHandler) ShouldSync(pod *v1.Pod) bool {
 func TestGetPodsToSyncInvokesPodSyncLoopHandlers(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	pods := newTestPods(5)
 	expected := []*v1.Pod{pods[0]}
 	kubelet.AddPodSyncLoopHandler(&testPodSyncLoopHandler{expected})
@@ -2034,7 +2036,7 @@ func (a *testPodSyncHandler) ShouldEvict(pod *v1.Pod) lifecycle.ShouldEvictRespo
 func TestGenerateAPIPodStatusInvokesPodSyncHandlers(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	pod := newTestPods(1)[0]
 	podsToEvict := []*v1.Pod{pod}
 	kubelet.AddPodSyncHandler(&testPodSyncHandler{podsToEvict, "Evicted", "because"})
@@ -2052,7 +2054,7 @@ func TestGenerateAPIPodStatusInvokesPodSyncHandlers(t *testing.T) {
 func TestSyncPodKillPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kl := testKubelet.kubelet
+	kl := testKubelet.kubelet[0]
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID:       "12345678",

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -34,7 +34,7 @@ import (
 func TestListVolumesForPod(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	pod := podWithUidNameNsSpec("12345678", "foo", "test", v1.PodSpec{
 		Volumes: []v1.Volume{
@@ -82,7 +82,7 @@ func TestListVolumesForPod(t *testing.T) {
 func TestPodVolumesExist(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	pods := []*v1.Pod{
 		{
@@ -161,7 +161,7 @@ func TestPodVolumesExist(t *testing.T) {
 func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	pod := podWithUidNameNsSpec("12345678", "foo", "test", v1.PodSpec{
 		Volumes: []v1.Volume{
@@ -207,7 +207,7 @@ func TestVolumeAttachAndMountControllerDisabled(t *testing.T) {
 func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 
 	pod := podWithUidNameNsSpec("12345678", "foo", "test", v1.PodSpec{
 		Volumes: []v1.Volume{
@@ -278,7 +278,7 @@ func TestVolumeUnmountAndDetachControllerDisabled(t *testing.T) {
 func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 	testKubelet := newTestKubelet(t, true /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubeClient := testKubelet.fakeKubeClient
 	kubeClient.AddReactor("get", "nodes",
 		func(action core.Action) (bool, runtime.Object, error) {
@@ -347,7 +347,7 @@ func TestVolumeAttachAndMountControllerEnabled(t *testing.T) {
 func TestVolumeUnmountAndDetachControllerEnabled(t *testing.T) {
 	testKubelet := newTestKubelet(t, true /* controllerAttachDetachEnabled */)
 	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
+	kubelet := testKubelet.kubelet[0]
 	kubeClient := testKubelet.fakeKubeClient
 	kubeClient.AddReactor("get", "nodes",
 		func(action core.Action) (bool, runtime.Object, error) {

--- a/pkg/kubelet/networks_test.go
+++ b/pkg/kubelet/networks_test.go
@@ -23,7 +23,7 @@ import (
 func TestNetworkHostGetsPodNotFound(t *testing.T) {
 	testKubelet := newTestKubelet(t, true)
 	defer testKubelet.Cleanup()
-	nh := networkHost{testKubelet.kubelet}
+	nh := networkHost{testKubelet.kubelet[0]}
 
 	actualPod, _ := nh.GetPodByName("", "")
 	if actualPod != nil {
@@ -34,7 +34,7 @@ func TestNetworkHostGetsPodNotFound(t *testing.T) {
 func TestNetworkHostGetsKubeClient(t *testing.T) {
 	testKubelet := newTestKubelet(t, true)
 	defer testKubelet.Cleanup()
-	nh := networkHost{testKubelet.kubelet}
+	nh := networkHost{testKubelet.kubelet[0]}
 
 	if nh.GetKubeClient() != testKubelet.fakeKubeClient {
 		t.Fatalf("NetworkHost client does not match testKubelet's client")
@@ -44,7 +44,7 @@ func TestNetworkHostGetsKubeClient(t *testing.T) {
 func TestNetworkHostGetsRuntime(t *testing.T) {
 	testKubelet := newTestKubelet(t, true)
 	defer testKubelet.Cleanup()
-	nh := networkHost{testKubelet.kubelet}
+	nh := networkHost{testKubelet.kubelet[0]}
 
 	if nh.GetRuntime() != testKubelet.fakeRuntime {
 		t.Fatalf("NetworkHost runtime does not match testKubelet's runtime")
@@ -54,7 +54,7 @@ func TestNetworkHostGetsRuntime(t *testing.T) {
 func TestNetworkHostSupportsLegacyFeatures(t *testing.T) {
 	testKubelet := newTestKubelet(t, true)
 	defer testKubelet.Cleanup()
-	nh := networkHost{testKubelet.kubelet}
+	nh := networkHost{testKubelet.kubelet[0]}
 
 	if nh.SupportsLegacyFeatures() == false {
 		t.Fatalf("SupportsLegacyFeatures should not be false")


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates unit tests to support multiple Kubelets per test case. For example, an IPv6 Kubelet, a dual-stack Kubelet, etc.. Currently, all Kubelet unit tests are based off an IPv4 Kubelet. Supporting multiple types of Kubelets in unit tests is required to reduce breakage while adding IPv6 features to Kubernetes.

**Which issue this PR fixes**
Partially fixes issue #46712. A future PR will be submitted that builds off this PR, adding an IPv6 Kubelet to the test cases.

**Special notes for your reviewer**:
In support of the larger effort to add IPv6 to Kubernetes identified in issue #1433

**Release note**:
```NONE
```
