### PR TITLE
owners: remove euank from sig-node-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -45,7 +45,6 @@ aliases:
     - dchen1107
     - derekwaynecarr
     - dims
-    - euank
     - feiskyer
     - mtaufen
     - ncdc


### PR DESCRIPTION
I'm already in more specific lists for things related to Container Linux
or rkt and my current role doesn't leave me enough cycles to do
sig-node reviewing justice.

Please do still ping me on any specific items.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
