### PR TITLE
Incorrect output in kubefed init

### DIFF
--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -385,7 +385,7 @@ func (i *initFederation) Run(cmdOut io.Writer, config util.AdminConfig) error {
 		return err
 	}
 	glog.V(4).Info("Successfully created federation controller manager deployment")
-	fmt.Println(cmdOut, " done")
+	fmt.Fprintln(cmdOut, " done")
 
 	fmt.Fprint(cmdOut, "Updating kubeconfig...")
 	glog.V(4).Info("Updating kubeconfig")


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes incorrect output in `kubefed init`.

fixes https://github.com/kubernetes/kubernetes/issues/47291

**Special notes for your reviewer**:
none

**Release note**:
```release-note
NONE
```
