### PR TITLE
remove leaked socket file in unit test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -1837,7 +1837,8 @@ func newTestGenericStoreRegistry(t *testing.T, scheme *runtime.Scheme, hasCacheE
 
 func TestFinalizeDelete(t *testing.T) {
 	// Verify that it returns the expected Status.
-	_, s := NewTestGenericStoreRegistry(t)
+	destroyFunc, s := NewTestGenericStoreRegistry(t)
+	defer destroyFunc()
 	obj := &example.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "random-uid"},
 	}


### PR DESCRIPTION
Fixes #47301


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
