### PR TITLE
Fix unit test TestCertsTLS

### DIFF
--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -1418,7 +1418,7 @@ func tlsHandshake(t *testing.T, sCfg, cCfg *tls.Config) error {
 	// clients hang. Since TCP is non-blocking we use that as transport
 	// instead. One could have as well used a Unix Domain Socket, but TCP is
 	// more portable.
-	s, err := tls.Listen("tcp", "", sCfg)
+	s, err := tls.Listen("tcp4", "", sCfg) // specify tcp4 for the guys who disable ipv6
 	if err != nil {
 		return fmt.Errorf("failed to create a test TLS server: %v", err)
 	}
@@ -1444,7 +1444,7 @@ func tlsHandshake(t *testing.T, sCfg, cCfg *tls.Config) error {
 		}
 	}()
 
-	c, err := tls.Dial("tcp", s.Addr().String(), cCfg)
+	c, err := tls.Dial("tcp4", s.Addr().String(), cCfg)
 	if err != nil {
 		// Intentionally not serializing the error received because we want to
 		// test for the failure case in the caller test function.


### PR DESCRIPTION
fixes #47304 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
