### PR TITLE
Did not check NodeAffinity selector's key and value every time.

### DIFF
--- a/pkg/api/helper/helpers.go
+++ b/pkg/api/helper/helpers.go
@@ -352,9 +352,11 @@ func containsAccessMode(modes []api.PersistentVolumeAccessMode, mode api.Persist
 	return false
 }
 
-// NodeSelectorRequirementsAsSelector converts the []NodeSelectorRequirement api type into a struct that implements
-// labels.Selector.
-func NodeSelectorRequirementsAsSelector(nsm []api.NodeSelectorRequirement) (labels.Selector, error) {
+type requirementBuilder func(key string, op selection.Operator, vals []string) (*labels.Requirement, error)
+
+// nodeSelectorRequirementsAsSelector converts the []NodeSelectorRequirement api type into a struct that implements
+// labels.Selector based on requirement builder.
+func nodeSelectorRequirementsAsSelector(nsm []api.NodeSelectorRequirement, reqBuilder requirementBuilder) (labels.Selector, error) {
 	if len(nsm) == 0 {
 		return labels.Nothing(), nil
 	}
@@ -377,13 +379,25 @@ func NodeSelectorRequirementsAsSelector(nsm []api.NodeSelectorRequirement) (labe
 		default:
 			return nil, fmt.Errorf("%q is not a valid node selector operator", expr.Operator)
 		}
-		r, err := labels.NewRequirement(expr.Key, op, expr.Values)
+		r, err := reqBuilder(expr.Key, op, expr.Values)
 		if err != nil {
 			return nil, err
 		}
 		selector = selector.Add(*r)
 	}
 	return selector, nil
+}
+
+// NodeSelectorRequirementsAsSelector converts the []NodeSelectorRequirement api type into a struct that implements
+// labels.Selector.
+func NodeSelectorRequirementsAsSelector(nsm []api.NodeSelectorRequirement) (labels.Selector, error) {
+	return nodeSelectorRequirementsAsSelector(nsm, labels.NewRequirement)
+}
+
+// NodeSelectorRequirementsAsSelectorWithougValidation converts the []NodeSelectorRequirement api type into a struct that implements
+// labels.Selector; it will NOT validate the key & values in the Requirement to improve performance.
+func NodeSelectorRequirementsAsSelectorWithoutValidation(nsm []api.NodeSelectorRequirement) (labels.Selector, error) {
+	return nodeSelectorRequirementsAsSelector(nsm, labels.NewRequirementWithoutValidation)
 }
 
 // GetTolerationsFromPodAnnotations gets the json serialized tolerations data from Pod.Annotations

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -624,7 +624,7 @@ func PodFitsResources(pod *v1.Pod, meta interface{}, nodeInfo *schedulercache.No
 // terms are ORed, and an empty list of terms will match nothing.
 func nodeMatchesNodeSelectorTerms(node *v1.Node, nodeSelectorTerms []v1.NodeSelectorTerm) bool {
 	for _, req := range nodeSelectorTerms {
-		nodeSelector, err := v1helper.NodeSelectorRequirementsAsSelector(req.MatchExpressions)
+		nodeSelector, err := v1helper.NodeSelectorRequirementsAsSelectorWithoutValidation(req.MatchExpressions)
 		if err != nil {
 			glog.V(10).Infof("Failed to parse MatchExpressions: %+v, regarding as not match.", req.MatchExpressions)
 			return false

--- a/plugin/pkg/scheduler/algorithm/priorities/node_affinity.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/node_affinity.go
@@ -59,7 +59,7 @@ func CalculateNodeAffinityPriorityMap(pod *v1.Pod, meta interface{}, nodeInfo *s
 			}
 
 			// TODO: Avoid computing it for all nodes if this becomes a performance problem.
-			nodeSelector, err := v1helper.NodeSelectorRequirementsAsSelector(preferredSchedulingTerm.Preference.MatchExpressions)
+			nodeSelector, err := v1helper.NodeSelectorRequirementsAsSelectorWithoutValidation(preferredSchedulingTerm.Preference.MatchExpressions)
 			if err != nil {
 				return schedulerapi.HostPriority{}, err
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -115,6 +115,7 @@ func NewRequirement(key string, op selection.Operator, vals []string) (*Requirem
 	if err := validateLabelKey(key); err != nil {
 		return nil, err
 	}
+
 	switch op {
 	case selection.In, selection.NotIn:
 		if len(vals) == 0 {
@@ -146,6 +147,13 @@ func NewRequirement(key string, op selection.Operator, vals []string) (*Requirem
 			return nil, err
 		}
 	}
+
+	return NewRequirementWithoutValidation(key, op, vals)
+}
+
+// NewRequirementWithoutValidation has the same behavior with `NewRequirement`, but without validation of
+// selector's key and value.
+func NewRequirementWithoutValidation(key string, op selection.Operator, vals []string) (*Requirement, error) {
 	sort.Strings(vals)
 	return &Requirement{key: key, operator: op, strValues: vals}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
In NodeAffinity predicates, it took about 10m to check 50k pods against 5k nodes. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: partially fixes #47318

**Special notes for your reviewer**:
This enhancement assume the NodeAffinity selector is checked by apiserver (#46952)

**Release note**:
```release-note-none
```
