### PR TITLE
Fix bad check in node e2e tests for GPUs.

### DIFF
--- a/test/e2e_node/gpus.go
+++ b/test/e2e_node/gpus.go
@@ -161,7 +161,7 @@ func makePod(gpus int64, name string) *v1.Pod {
 			v1.ResourceNvidiaGPU: *resource.NewQuantity(gpus, resource.DecimalSI),
 		},
 	}
-	gpuverificationCmd := fmt.Sprintf("if [[ %d -ne $(ls /dev/ | egrep '^nvidia[0-9]+$') ]]; then exit 1; fi; echo Success", gpus)
+	gpuverificationCmd := fmt.Sprintf("if [[ %d -ne $(ls /dev/ | egrep '^nvidia[0-9]+$' | wc -l) ]]; then exit 1; else echo Success; fi", gpus)
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,


### PR DESCRIPTION
When no nvidia device was attached, the -ne check had a syntax error:

    sh: -ne: argument expected

This resulted in `Success` being echoed and the test passing incorrectly.
This was found while debugging issue #47216

/release-note-none
/sig node
/area node-e2e
/kind bug