### PR TITLE
Install jq in kube-cross image

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -37,7 +37,7 @@ RUN for platform in ${KUBE_CROSSPLATFORMS}; do GOOS=${platform%/*} GOARCH=${plat
 
 # Install g++, then download and install protoc for generating protobuf output
 RUN apt-get update \
-  && apt-get install -y g++ rsync apt-utils file patch \
+  && apt-get install -y g++ rsync apt-utils file patch jq \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /usr/local/src/protobuf \


### PR DESCRIPTION
I've noticed that running `build/run.sh hack/make-rules/test-cmd.sh` fails with `jq: command not found` (being on latest master sha `df1e28`):

```
$ build/run.sh hack/make-rules/test-cmd.sh
[..]
+++ [0611 20:07:50] Testing kubectl version: verify json output
/go/src/k8s.io/kubernetes/hack/lib/test.sh: line 325: jq: command not found
!!! [0611 20:07:50] Call tree:
!!! [0611 20:07:50]  1: /go/src/k8s.io/kubernetes/hack/make-rules/test-cmd-util.sh:254 kube::test::version::json_client_server_object_to_file(...)
!!! [0611 20:07:50]  2: /go/src/k8s.io/kubernetes/hack/make-rules/test-cmd-util.sh:3178 run_kubectl_version_tests(...)
!!! [0611 20:07:50]  3: hack/make-rules/test-cmd.sh:103 runTests(...)
!!! Error in /go/src/k8s.io/kubernetes/hack/lib/test.sh:325
  Error in /go/src/k8s.io/kubernetes/hack/lib/test.sh:325. '((i<5-1))' exited with status 141 127 0
Call stack:
  1: /go/src/k8s.io/kubernetes/hack/lib/test.sh:325 kube::test::version::json_client_server_object_to_file(...)
  2: /go/src/k8s.io/kubernetes/hack/make-rules/test-cmd-util.sh:254 run_kubectl_version_tests(...)
  3: /go/src/k8s.io/kubernetes/hack/make-rules/test-cmd-util.sh:3178 runTests(...)
  4: hack/make-rules/test-cmd.sh:103 main(...)
Exiting with status 1
/go/src/k8s.io/kubernetes/hack/lib/etcd.sh: line 81:  8421 Terminated              "${KUBE_OUTPUT_HOSTBIN}/kube-controller-manager" --port="${CTLRMGR_PORT}" --kube-api-content-type="${KUBE_TEST_API_TYPE-}" --master="127.0.0.1:${API_PORT}" 1>&2
+++ [0611 20:07:50] Clean up complete
!!! [0611 20:07:50] Call tree:
!!! [0611 20:07:50]  1: build/../build/common.sh:513 kube::build::run_build_command_ex(...)
!!! [0611 20:07:50]  2: build/run.sh:30 kube::build::run_build_command(...)
!!! Error in build/../build/common.sh:581
  Error in build/../build/common.sh:581. '((i<4-1))' exited with status 1
Call stack:
  1: build/../build/common.sh:581 kube::build::run_build_command_ex(...)
  2: build/../build/common.sh:513 kube::build::run_build_command(...)
  3: build/run.sh:30 main(...)
Exiting with status 1
```

Installing it into parent docker container should fix the issue.