### PR TITLE
Fix hostconfig device map logic in dockershim.

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -138,6 +138,7 @@ func (ds *dockerService) CreateContainer(podSandboxID string, config *runtimeapi
 	}
 
 	hc := createConfig.HostConfig
+	ds.updateCreateConfig(&createConfig, config, sandboxConfig, podSandboxID, securityOptSep, apiVersion)
 	// Set devices for container.
 	devices := make([]dockercontainer.DeviceMapping, len(config.Devices))
 	for i, device := range config.Devices {
@@ -148,7 +149,6 @@ func (ds *dockerService) CreateContainer(podSandboxID string, config *runtimeapi
 		}
 	}
 	hc.Resources.Devices = devices
-	ds.updateCreateConfig(&createConfig, config, sandboxConfig, podSandboxID, securityOptSep, apiVersion)
 
 	securityOpts, err := ds.getSecurityOpts(config.Metadata.Name, sandboxConfig, securityOptSep)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes for device injection logic in dockershim , please help verify e2e run.

Should do updateCreateConfig before Resources assignment.

Related change:
https://github.com/kubernetes/kubernetes/pull/46744/files#diff-c7dd39479fd733354254e70845075db5L137


**Which issue this PR fixes**
https://github.com/kubernetes/kubernetes/issues/47216

**Special notes for your reviewer**:

**Release note**:
```release-note
```
