### PR TITLE
kubeadm: Remove v1.6 version gates, cleanup unused code, etc.

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -107,11 +107,5 @@ var (
 	DefaultTokenUsages = []string{"signing", "authentication"}
 
 	// MinimumControlPlaneVersion specifies the minimum control plane version kubeadm can deploy
-	MinimumControlPlaneVersion = version.MustParseSemantic("v1.6.0")
-
-	// MinimumCSRSARApproverVersion specifies the minimum kubernetes version that can be used for enabling the new-in-v1.7 CSR approver based on a SubjectAccessReview
-	MinimumCSRSARApproverVersion = version.MustParseSemantic("v1.7.0-beta.0")
-
-	// MinimumAPIAggregationVersion specifies the minimum kubernetes version that can be used enabling the API aggregation in the apiserver and the front proxy flags
-	MinimumAPIAggregationVersion = version.MustParseSemantic("v1.7.0-alpha.1")
+	MinimumControlPlaneVersion = version.MustParseSemantic("v1.7.0")
 )

--- a/cmd/kubeadm/app/master/BUILD
+++ b/cmd/kubeadm/app/master/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
-        "//pkg/bootstrap/api:go_default_library",
         "//pkg/kubeapiserver/authorizer/modes:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubelet/types:go_default_library",

--- a/cmd/kubeadm/app/master/manifests_test.go
+++ b/cmd/kubeadm/app/master/manifests_test.go
@@ -478,35 +478,6 @@ func TestComponentPod(t *testing.T) {
 	}
 }
 
-func TestGetComponentBaseCommand(t *testing.T) {
-	var tests = []struct {
-		c        string
-		expected []string
-	}{
-		{
-			c:        "foo",
-			expected: []string{"kube-foo", "--v=2"},
-		},
-		{
-			c:        "bar",
-			expected: []string{"kube-bar", "--v=2"},
-		},
-	}
-
-	for _, rt := range tests {
-		actual := getComponentBaseCommand(rt.c)
-		for i := range actual {
-			if actual[i] != rt.expected[i] {
-				t.Errorf(
-					"failed getComponentBaseCommand:\n\texpected: %s\n\t  actual: %s",
-					rt.expected[i],
-					actual[i],
-				)
-			}
-		}
-	}
-}
-
 func TestGetAPIServerCommand(t *testing.T) {
 	var tests = []struct {
 		cfg      *kubeadmapi.MasterConfiguration
@@ -567,9 +538,9 @@ func TestGetAPIServerCommand(t *testing.T) {
 				"--secure-port=123",
 				"--allow-privileged=true",
 				"--kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname",
+				"--experimental-bootstrap-token-auth=true",
 				"--proxy-client-cert-file=/var/lib/certs/front-proxy-client.crt",
 				"--proxy-client-key-file=/var/lib/certs/front-proxy-client.key",
-				"--experimental-bootstrap-token-auth=true",
 				"--requestheader-username-headers=X-Remote-User",
 				"--requestheader-group-headers=X-Remote-Group",
 				"--requestheader-extra-headers-prefix=X-Remote-Extra-",
@@ -724,25 +695,6 @@ func TestGetControllerManagerCommand(t *testing.T) {
 				"--cluster-signing-key-file=" + testCertsDir + "/ca.key",
 				"--use-service-account-credentials=true",
 				"--controllers=*,bootstrapsigner,tokencleaner",
-			},
-		},
-		{
-			cfg: &kubeadmapi.MasterConfiguration{
-				CertificatesDir:   testCertsDir,
-				KubernetesVersion: "v1.6.4",
-			},
-			expected: []string{
-				"kube-controller-manager",
-				"--address=127.0.0.1",
-				"--leader-elect=true",
-				"--kubeconfig=" + kubeadmapi.GlobalEnvParams.KubernetesDir + "/controller-manager.conf",
-				"--root-ca-file=" + testCertsDir + "/ca.crt",
-				"--service-account-private-key-file=" + testCertsDir + "/sa.key",
-				"--cluster-signing-cert-file=" + testCertsDir + "/ca.crt",
-				"--cluster-signing-key-file=" + testCertsDir + "/ca.key",
-				"--use-service-account-credentials=true",
-				"--controllers=*,bootstrapsigner,tokencleaner",
-				"--insecure-experimental-approve-all-kubelet-csrs-for-group=system:bootstrappers",
 			},
 		},
 		{
@@ -995,21 +947,6 @@ func TestGetExtraParameters(t *testing.T) {
 		sort.Strings(rt.expected)
 		if !reflect.DeepEqual(actual, rt.expected) {
 			t.Errorf("failed getExtraParameters:\nexpected:\n%v\nsaw:\n%v", rt.expected, actual)
-		}
-	}
-}
-
-func TestVersionCompare(t *testing.T) {
-	versions := []string{
-		"v1.7.0-alpha.1",
-		"v1.7.0-beta.0",
-		"v1.7.0-rc.0",
-		"v1.7.0",
-		"v1.7.1",
-	}
-	for _, v := range versions {
-		if !version.MustParseSemantic(v).AtLeast(kubeadmconstants.MinimumAPIAggregationVersion) {
-			t.Errorf("err")
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

 - Removes v1.6 version gates and requires a control plane version of v1.7.0 and above
 - Removes unused/unnecessary functions that got freed up as a consequence of that


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes: kubernetes/kubeadm#327

**Special notes for your reviewer**:

This PR targets v1.8, can be merged first when the code freeze is lifted

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @timothysc @mikedanese @pipejakob 