### PR TITLE
kubeadm: Start using Tolerations in yaml code again and unit-test

### DIFF
--- a/cmd/kubeadm/app/phases/addons/addons.go
+++ b/cmd/kubeadm/app/phases/addons/addons.go
@@ -110,7 +110,6 @@ func CreateKubeProxyAddon(configMapBytes, daemonSetbytes []byte, client *clients
 	if err := kuberuntime.DecodeInto(api.Codecs.UniversalDecoder(), daemonSetbytes, kubeproxyDaemonSet); err != nil {
 		return fmt.Errorf("unable to decode kube-proxy daemonset %v", err)
 	}
-	kubeproxyDaemonSet.Spec.Template.Spec.Tolerations = []v1.Toleration{kubeadmconstants.MasterToleration}
 
 	if _, err := client.ExtensionsV1beta1().DaemonSets(metav1.NamespaceSystem).Create(kubeproxyDaemonSet); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
@@ -128,13 +127,6 @@ func CreateKubeDNSAddon(deploymentBytes, serviceBytes []byte, client *clientset.
 	kubednsDeployment := &extensions.Deployment{}
 	if err := kuberuntime.DecodeInto(api.Codecs.UniversalDecoder(), deploymentBytes, kubednsDeployment); err != nil {
 		return fmt.Errorf("unable to decode kube-dns deployment %v", err)
-	}
-	kubednsDeployment.Spec.Template.Spec.Tolerations = []v1.Toleration{
-		kubeadmconstants.MasterToleration,
-		{
-			Key:      "CriticalAddonsOnly",
-			Operator: "Exists",
-		},
 	}
 
 	if _, err := client.ExtensionsV1beta1().Deployments(metav1.NamespaceSystem).Create(kubednsDeployment); err != nil {

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -79,10 +79,9 @@ spec:
           name: kube-proxy
       hostNetwork: true
       serviceAccountName: kube-proxy
-      # TODO: Why doesn't the Decoder recognize this new field and decode it properly? Right now it's ignored
-      # tolerations:
-      # - key: {{ .MasterTaintKey }}
-      #   effect: NoSchedule
+      tolerations:
+      - key: {{ .MasterTaintKey }}
+        effect: NoSchedule
       volumes:
       - name: kube-proxy
         configMap:
@@ -92,7 +91,6 @@ spec:
 	KubeDNSVersion = "1.14.2"
 
 	KubeDNSDeployment = `
-
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -116,8 +114,6 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       volumes:
       - name: kube-dns-config
@@ -243,12 +239,11 @@ spec:
             cpu: 10m
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns
-      # TODO: Why doesn't the Decoder recognize this new field and decode it properly? Right now it's ignored
-      # tolerations:
-      # - key: CriticalAddonsOnly
-      #   operator: Exists
-      # - key: {{ .MasterTaintKey }}
-      #   effect: NoSchedule
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: {{ .MasterTaintKey }}
+        effect: NoSchedule
       # TODO: Remove this affinity field as soon as we are using manifest lists
       affinity:
         nodeAffinity:


### PR DESCRIPTION
**What this PR does / why we need it**:

- Earlier there was a problem with decoding Tolerations from yaml. Seems to be fixed now.
- Added an unit test to catch such a failure if that regression ever happens again

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Targets v1.8

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @timothysc 