### PR TITLE
actually check for a live discovery endpoint before aggregating

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -207,6 +207,8 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		c.GenericConfig.SharedInformerFactory.Core().V1().Services(),
 		c.GenericConfig.SharedInformerFactory.Core().V1().Endpoints(),
 		apiregistrationClient.Apiregistration(),
+		c.ExtraConfig.ProxyTransport,
+		s.serviceResolver,
 	)
 
 	s.GenericAPIServer.AddPostStartHook("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {


### PR DESCRIPTION
Aggregation doesn't work without being able to hit a discovery endpoint.  This adds a simple status check for whether the discovery endpoint is reachable.  The actual status code doesn't matter, we just need to be able to make the connection.