### PR TITLE
Add deprecation notice to unused method

### DIFF
--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -433,6 +433,8 @@ type ValidateOptions struct {
 	EnableValidation bool
 }
 
+// ReadConfigDataFromReader is not used and may be deprecated in further releases
+// TODO: deprecate this function
 func ReadConfigDataFromReader(reader io.Reader, source string) ([]byte, error) {
 	data, err := ioutil.ReadAll(reader)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: The method ReadConfigDataFromReader is not being used
anymore in the codebase. Add a note that it may be deprecated in the future.

**Release note**:
`NONE`
