### PR TITLE
Don't delete docker image if building a release

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -320,10 +320,10 @@ function kube::release::create_docker_images_for_server() {
             "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
             "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
           fi
+        else
+          kube::log::status "Not a release, so deleting docker image ${docker_image_tag}"
+          "${DOCKER[@]}" rmi ${docker_image_tag} 2>/dev/null || true
         fi
-
-        kube::log::status "Deleting docker image ${docker_image_tag}"
-        "${DOCKER[@]}" rmi ${docker_image_tag} 2>/dev/null || true
       ) &
     done
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: before #44981, we used to build the various control plane images using a tag that was the md5sum of the encapsulated binary, save that image into a docker tarball, and then delete the image, since it was no longer needed. If an official release was being built, we would tag the images with the official version before deleting the md5sum tag.

After #44981, we use the git version when building the image, but left in the code path to delete the built image in all cases. As a result, we were only pushing the `-amd64` tags - not any of the other arches, and not the un-arched tag, either.

**Which issue this PR fixes**: fixes #47307

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @david-mcmahon 
/cc @luxas @dchen1107 