### PR TITLE
test/e2e: fix empty namespace being passed to wait

### DIFF
--- a/test/e2e/namespace.go
+++ b/test/e2e/namespace.go
@@ -145,7 +145,7 @@ func ensurePodsAreRemovedWhenNamespaceIsDeleted(f *framework.Framework) {
 		// This error is ok, beacuse we will delete the pod before it completes initialization
 		framework.Logf("error from create uninitialized namespace: %v", err)
 	}()
-	podB = waitForPodInNamespace(f.ClientSet, podB.Namespace, podB.Name)
+	podB = waitForPodInNamespace(f.ClientSet, namespace.Name, podB.Name)
 
 	By("Deleting the namespace")
 	err = f.ClientSet.Core().Namespaces().Delete(namespace.Name, nil)


### PR DESCRIPTION
The current test is failing due to the pod namespace string being empty. Use the namespace.Name instead.

~~Haven't run this locally yet.~~ can reproduce locally, and this does fix it.

Fixes https://github.com/kubernetes/kubernetes/issues/47350

/cc @derekwaynecarr @smarterclayton @kubernetes/sig-api-machinery-bugs 

```release-note
None
```