### PR TITLE
[Nginx] Run nginx ingress test in slow suite

### DIFF
--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -144,7 +144,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7", func() {
 	})
 
 	// Time: borderline 5m, slow by design
-	framework.KubeDescribe("Nginx", func() {
+	framework.KubeDescribe("[Slow] Nginx", func() {
 		var nginxController *framework.NginxIngressController
 
 		BeforeEach(func() {


### PR DESCRIPTION
Fixes #47362
I'm told that by adding "[Slow]" to the test name, it'll only be ran in the slow test suite.  

```release-note
NONE
```
