### PR TITLE
bazel: update debian-iptables-amd64 digest

### DIFF
--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= gcr.io/google-containers
 IMAGE ?= debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= 0.1.0
+TAG ?= 0.1
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64
@@ -69,6 +69,9 @@ endif
 	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(TAR_FILE)
 	docker build -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
+
+push: build
+	gcloud docker -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
 
 clean:
 	docker rmi -f $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) || true

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -62,7 +62,7 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:adde513f7b3561042cd2d2af4d2d355189bbb2f579584b5766e7d07be4f7e71e",  # v7
+    digest = "sha256:bfc7cc030258f53495b5dacf1e1d750db9b8687577a8648a3c8e245f8d7d2c52",  # v7
     registry = "gcr.io",
     repository = "google-containers/debian-iptables-amd64",
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: upstream debian has fixed several CVEs recently, so we should apply those fixes:
* CVE-2017-2616
* CVE-2017-6512

x-ref #47386

**Special notes for your reviewer**: nothing has been pushed yet, so this will likely fail many of the tests.

Do you think these version numbers make sense? We also need to fix debian-iptables v5, and I don't know what to do there. (v5.1?)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/assign @timstclair 