### PR TITLE
Update to kube-addon-manager:v6.4-beta.2: kubectl v1.6.4 and refreshed base images

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 6.4-beta.2  (Mon June 12 2017 Jeff Grafton <jgrafton@google.com>)
+ - Update kubectl to v1.6.4.
+ - Refresh base images.
+
 ### Version 6.4-beta.1  (Wed March 8 2017 Zihong Zheng <zihongz@google.com>)
  - Create EnsureExists class addons before Reconcile class addons.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v6.4-beta.1
-KUBECTL_VERSION?=v1.6.0-beta.2
+VERSION=v6.4-beta.2
+KUBECTL_VERSION?=v1.6.4
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=bashell/alpine-bash

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -13,7 +13,7 @@ spec:
     # - cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
     # - cluster/images/hyperkube/static-pods/addon-manager-multinode.json
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: gcr.io/google-containers/kube-addon-manager:v6.4-beta.1
+    image: gcr.io/google-containers/kube-addon-manager:v6.4-beta.2
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v6.4-beta.1
+    image: {{kube_docker_registry}}/kube-addon-manager:v6.4-beta.2
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
**What this PR does / why we need it**: refreshes base images for kube-addon-manager with fixes for CVE-2016-9841 and CVE-2016-9843.

x-ref https://github.com/kubernetes/kubernetes/issues/47386

**Special notes for your reviewer**: the updated images are not yet pushed, so tests will fail until that's done.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/assign @MrHohn