### PR TITLE
Change port on which fluentd exposes its metrics

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -295,7 +295,7 @@ data:
     # Prometheus monitoring
     <source>
       @type prometheus
-      port 80
+      port 31337
     </source>
 
     <source>

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -94,6 +94,7 @@ spec:
         command:
           - /monitor
           - --component=fluentd
+          - --target-port=31337
           - --stackdriver-prefix=container.googleapis.com/internal/addons
           - --whitelisted-metrics=logging_line_count,logging_entry_count
         volumeMounts:


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/47397

/cc @Q-Lee @nicksardo

```release-note
Stackdriver Logging deployment exposes metrics on node port 31337 when enabled.
```