### PR TITLE
jsonpath: don't recurse into structs that are not actually nested

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -297,11 +297,11 @@ func (j *JSONPath) findFieldInValue(value *reflect.Value, node *FieldNode) (refl
 	var inlineValue *reflect.Value
 	for ix := 0; ix < t.NumField(); ix++ {
 		f := t.Field(ix)
-		jsonTag := f.Tag.Get("json")
-		parts := strings.Split(jsonTag, ",")
-		if len(parts) == 0 {
+		jsonTag, found := f.Tag.Lookup("json")
+		if !found {
 			continue
 		}
+		parts := strings.Split(jsonTag, ",")
 		if parts[0] == node.Value {
 			return value.Field(ix), nil
 		}

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath_test.go
@@ -116,6 +116,10 @@ type bicycle struct {
 	IsNew bool
 }
 
+type nested struct {
+	Name string
+}
+
 type empName string
 type job string
 type store struct {
@@ -124,6 +128,7 @@ type store struct {
 	Name      string
 	Labels    map[string]int
 	Employees map[empName]job
+	Nested    nested
 }
 
 func TestStructInput(t *testing.T) {
@@ -131,7 +136,7 @@ func TestStructInput(t *testing.T) {
 	storeData := store{
 		Name: "jsonpath",
 		Book: []book{
-			{"reference", "Nigel Rees", "Sayings of the Centurey", 8.95},
+			{"reference", "Nigel Rees", "Sayings of the Century", 8.95},
 			{"fiction", "Evelyn Waugh", "Sword of Honour", 12.99},
 			{"fiction", "Herman Melville", "Moby Dick", 8.99},
 		},
@@ -140,13 +145,16 @@ func TestStructInput(t *testing.T) {
 			{"green", 20.01, false},
 		},
 		Labels: map[string]int{
-			"engieer":  10,
+			"engineer": 10,
 			"web/html": 15,
 			"k8s-app":  20,
 		},
 		Employees: map[empName]job{
 			"jason": "manager",
 			"dan":   "clerk",
+		},
+		Nested: nested{
+			Name: "nested-name",
 		},
 	}
 


### PR DESCRIPTION
Without this fix, jsonpath incorrectly recurses into structs that are not marked as json:",inline".  Wrong results can be returned if an inner struct has a field with the same name as a field in an outer struct.  Example: on the following object:

```golang
	obj := struct {
		Int    int
		Nested struct {
			Int int
		}
	}{
		Int: 1,
		Nested: struct {
			Int int
		}{
			Int: 2,
		},
	}
```

the jsonpath query "{.Int}" should return "1", but it currently returns "2".  This PR resolves this.

```release-note
NONE
```