### PR TITLE
Added logging around GCE API calls #46969

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -668,7 +668,10 @@ func getRegionInURL(urlStr string) string {
 }
 
 func getNetworkNameViaMetadata() (string, error) {
-	result, err := metadata.Get("instance/network-interfaces/0/network")
+	path := "instance/network-interfaces/0/network"
+	glog.V(4).Infof("metadata.Get(%s): start", path)
+	result, err := metadata.Get(path)
+	glog.V(4).Infof("metadata.Get(%s): end", path)
 	if err != nil {
 		return "", err
 	}
@@ -681,12 +684,17 @@ func getNetworkNameViaMetadata() (string, error) {
 
 // getNetwork returns a GCP network
 func getNetwork(svc *compute.Service, networkProjectID, networkID string) (*compute.Network, error) {
-	return svc.Networks.Get(networkProjectID, networkID).Do()
+	glog.V(4).Infof("Networks.Get(%s, %s): start", networkProjectID, networkID)
+	network, err := svc.Networks.Get(networkProjectID, networkID).Do()
+	glog.V(4).Infof("Networks.Get(%s, %s): end", networkProjectID, networkID)
+	return network, err
 }
 
 // getProjectID returns the project's string ID given a project number or string
 func getProjectID(svc *compute.Service, projectNumberOrID string) (string, error) {
+	glog.V(4).Infof("Projects.Get(%s): start", projectNumberOrID)
 	proj, err := svc.Projects.Get(projectNumberOrID).Do()
+	glog.V(4).Infof("Projects.Get(%s): end", projectNumberOrID)
 	if err != nil {
 		return "", err
 	}
@@ -696,7 +704,9 @@ func getProjectID(svc *compute.Service, projectNumberOrID string) (string, error
 
 func getZonesForRegion(svc *compute.Service, projectID, region string) ([]string, error) {
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("Zones.List(%s): start", projectID)
 	listCall := svc.Zones.List(projectID)
+	glog.V(4).Infof("Zones.List(%s): end", projectID)
 
 	// Filtering by region doesn't seem to work
 	// (tested in https://cloud.google.com/compute/docs/reference/latest/zones/list)

--- a/pkg/cloudprovider/providers/gce/gce_addresses.go
+++ b/pkg/cloudprovider/providers/gce/gce_addresses.go
@@ -40,7 +40,9 @@ func newAddressMetricContextWithVersion(request, region, version string) *metric
 // ephemeral IP associated with a global forwarding rule.
 func (gce *GCECloud) ReserveGlobalAddress(addr *compute.Address) error {
 	mc := newAddressMetricContext("reserve", "")
+	glog.V(4).Infof("GlobalAddresses.Insert(%s, %v): start", gce.projectID, addr)
 	op, err := gce.service.GlobalAddresses.Insert(gce.projectID, addr).Do()
+	glog.V(4).Infof("GlobalAddresses.Insert(%s, %v): end", gce.projectID, addr)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -50,7 +52,9 @@ func (gce *GCECloud) ReserveGlobalAddress(addr *compute.Address) error {
 // DeleteGlobalAddress deletes a global address by name.
 func (gce *GCECloud) DeleteGlobalAddress(name string) error {
 	mc := newAddressMetricContext("delete", "")
+	glog.V(4).Infof("GlobalAddresses.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.GlobalAddresses.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("GlobalAddresses.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -60,14 +64,18 @@ func (gce *GCECloud) DeleteGlobalAddress(name string) error {
 // GetGlobalAddress returns the global address by name.
 func (gce *GCECloud) GetGlobalAddress(name string) (*compute.Address, error) {
 	mc := newAddressMetricContext("get", "")
+	glog.V(4).Infof("GlobalAddresses.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.GlobalAddresses.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("GlobalAddresses.Get(%s, %s): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
 // ReserveRegionAddress creates a region address
 func (gce *GCECloud) ReserveRegionAddress(addr *compute.Address, region string) error {
 	mc := newAddressMetricContext("reserve", region)
+	glog.V(4).Infof("Addresses.Insert(%s, %s, %v): start", gce.projectID, region, addr)
 	op, err := gce.service.Addresses.Insert(gce.projectID, region, addr).Do()
+	glog.V(4).Infof("Addresses.Insert(%s, %s, %v): end", gce.projectID, region, addr)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -77,7 +85,9 @@ func (gce *GCECloud) ReserveRegionAddress(addr *compute.Address, region string) 
 // ReserveAlphaRegionAddress creates an Alpha, regional address.
 func (gce *GCECloud) ReserveAlphaRegionAddress(addr *computealpha.Address, region string) error {
 	mc := newAddressMetricContextWithVersion("reserve", region, computeAlphaVersion)
+	glog.V(4).Infof("Alpha Addresses.Insert(%s, %s, %v): start", gce.projectID, region, addr)
 	op, err := gce.serviceAlpha.Addresses.Insert(gce.projectID, region, addr).Do()
+	glog.V(4).Infof("Alpha Addresses.Insert(%s, %s, %v): start", gce.projectID, region, addr)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -87,7 +97,9 @@ func (gce *GCECloud) ReserveAlphaRegionAddress(addr *computealpha.Address, regio
 // ReserveBetaRegionAddress creates a beta region address
 func (gce *GCECloud) ReserveBetaRegionAddress(addr *computebeta.Address, region string) error {
 	mc := newAddressMetricContextWithVersion("reserve", region, computeBetaVersion)
+	glog.V(4).Infof("Beta Addresses.Insert(%s, %s, %v): start", gce.projectID, region, addr)
 	op, err := gce.serviceBeta.Addresses.Insert(gce.projectID, region, addr).Do()
+	glog.V(4).Infof("Beta Addresses.Insert(%s, %s, %v): end", gce.projectID, region, addr)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -97,7 +109,9 @@ func (gce *GCECloud) ReserveBetaRegionAddress(addr *computebeta.Address, region 
 // DeleteRegionAddress deletes a region address by name.
 func (gce *GCECloud) DeleteRegionAddress(name, region string) error {
 	mc := newAddressMetricContext("delete", region)
+	glog.V(4).Infof("GlobalAddresses.Delete(%s, %s, %s): start", gce.projectID, region, name)
 	op, err := gce.service.Addresses.Delete(gce.projectID, region, name).Do()
+	glog.V(4).Infof("GlobalAddresses.Delete(%s, %s, %s): end", gce.projectID, region, name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -107,28 +121,36 @@ func (gce *GCECloud) DeleteRegionAddress(name, region string) error {
 // GetRegionAddress returns the region address by name
 func (gce *GCECloud) GetRegionAddress(name, region string) (*compute.Address, error) {
 	mc := newAddressMetricContext("get", region)
+	glog.V(4).Infof("GlobalAddresses.Get(%s, %s, %s): start", gce.projectID, region, name)
 	v, err := gce.service.Addresses.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("GlobalAddresses.Get(%s, %s, %s): end", gce.projectID, region, name)
 	return v, mc.Observe(err)
 }
 
 // GetAlphaRegionAddress returns the Alpha, regional address by name.
 func (gce *GCECloud) GetAlphaRegionAddress(name, region string) (*computealpha.Address, error) {
 	mc := newAddressMetricContextWithVersion("get", region, computeAlphaVersion)
+	glog.V(4).Infof("Alpha Addresses.Get(%s, %s, %s): start", gce.projectID, region, name)
 	v, err := gce.serviceAlpha.Addresses.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("Alpha Addresses.Get(%s, %s, %s): end", gce.projectID, region, name)
 	return v, mc.Observe(err)
 }
 
 // GetBetaRegionAddress returns the beta region address by name
 func (gce *GCECloud) GetBetaRegionAddress(name, region string) (*computebeta.Address, error) {
 	mc := newAddressMetricContextWithVersion("get", region, computeBetaVersion)
+	glog.V(4).Infof("Beta Addresses.Get(%s, %s, %s): start", gce.projectID, region, name)
 	v, err := gce.serviceBeta.Addresses.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("Beta Addresses.Get(%s, %s, %s): end", gce.projectID, region, name)
 	return v, mc.Observe(err)
 }
 
 // GetRegionAddressByIP returns the regional address matching the given IP address.
 func (gce *GCECloud) GetRegionAddressByIP(region, ipAddress string) (*compute.Address, error) {
 	mc := newAddressMetricContext("list", region)
+	glog.V(4).Infof("Addresses.List(%s, %s): start", gce.projectID, region)
 	addrs, err := gce.service.Addresses.List(gce.projectID, region).Filter("address eq " + ipAddress).Do()
+	glog.V(4).Infof("Addresses.List(%s, %s): end", gce.projectID, region)
 	// Record the metrics for the call.
 	mc.Observe(err)
 	if err != nil {
@@ -154,7 +176,9 @@ func (gce *GCECloud) GetRegionAddressByIP(region, ipAddress string) (*compute.Ad
 // GetBetaRegionAddressByIP returns the beta regional address matching the given IP address.
 func (gce *GCECloud) GetBetaRegionAddressByIP(region, ipAddress string) (*computebeta.Address, error) {
 	mc := newAddressMetricContext("list", region)
+	glog.V(4).Infof("Beta Addresses.List(%s, %s): start", gce.projectID, region)
 	addrs, err := gce.serviceBeta.Addresses.List(gce.projectID, region).Filter("address eq " + ipAddress).Do()
+	glog.V(4).Infof("Beta Addresses.List(%s, %s): end", gce.projectID, region)
 	// Record the metrics for the call.
 	mc.Observe(err)
 	if err != nil {

--- a/pkg/cloudprovider/providers/gce/gce_backendservice.go
+++ b/pkg/cloudprovider/providers/gce/gce_backendservice.go
@@ -21,6 +21,8 @@ import (
 
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	compute "google.golang.org/api/compute/v1"
+
+	"github.com/golang/glog"
 )
 
 func newBackendServiceMetricContext(request, region string) *metricContext {
@@ -34,7 +36,9 @@ func newBackendServiceMetricContextWithVersion(request, region, version string) 
 // GetGlobalBackendService retrieves a backend by name.
 func (gce *GCECloud) GetGlobalBackendService(name string) (*compute.BackendService, error) {
 	mc := newBackendServiceMetricContext("get", "")
+	glog.V(4).Infof("BackendServices.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.BackendServices.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("BackendServices.Get(%s, %s): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
@@ -48,7 +52,9 @@ func (gce *GCECloud) GetAlphaGlobalBackendService(name string) (*computealpha.Ba
 // UpdateGlobalBackendService applies the given BackendService as an update to an existing service.
 func (gce *GCECloud) UpdateGlobalBackendService(bg *compute.BackendService) error {
 	mc := newBackendServiceMetricContext("update", "")
+	glog.V(4).Infof("BackendServices.Update(%s, %s, %v): start", gce.projectID, bg.Name, bg)
 	op, err := gce.service.BackendServices.Update(gce.projectID, bg.Name, bg).Do()
+	glog.V(4).Infof("BackendServices.Update(%s, %s, %v): end", gce.projectID, bg.Name, bg)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -70,7 +76,9 @@ func (gce *GCECloud) UpdateAlphaGlobalBackendService(bg *computealpha.BackendSer
 // DeleteGlobalBackendService deletes the given BackendService by name.
 func (gce *GCECloud) DeleteGlobalBackendService(name string) error {
 	mc := newBackendServiceMetricContext("delete", "")
+	glog.V(4).Infof("BackendServices.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.BackendServices.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("BackendServices.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return nil
@@ -84,7 +92,9 @@ func (gce *GCECloud) DeleteGlobalBackendService(name string) error {
 // CreateGlobalBackendService creates the given BackendService.
 func (gce *GCECloud) CreateGlobalBackendService(bg *compute.BackendService) error {
 	mc := newBackendServiceMetricContext("create", "")
+	glog.V(4).Infof("BackendServices.Insert(%s, %v): start", gce.projectID, bg)
 	op, err := gce.service.BackendServices.Insert(gce.projectID, bg).Do()
+	glog.V(4).Infof("BackendServices.Insert(%s, %v): end", gce.projectID, bg)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -107,7 +117,9 @@ func (gce *GCECloud) CreateAlphaGlobalBackendService(bg *computealpha.BackendSer
 func (gce *GCECloud) ListGlobalBackendServices() (*compute.BackendServiceList, error) {
 	mc := newBackendServiceMetricContext("list", "")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("BackendServices.List(%s): start", gce.projectID)
 	v, err := gce.service.BackendServices.List(gce.projectID).Do()
+	glog.V(4).Infof("BackendServices.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }
 
@@ -117,21 +129,27 @@ func (gce *GCECloud) ListGlobalBackendServices() (*compute.BackendServiceList, e
 func (gce *GCECloud) GetGlobalBackendServiceHealth(name string, instanceGroupLink string) (*compute.BackendServiceGroupHealth, error) {
 	mc := newBackendServiceMetricContext("get_health", "")
 	groupRef := &compute.ResourceGroupReference{Group: instanceGroupLink}
+	glog.V(4).Infof("BackendServices.GetHealth(%s, %s, %v): start", gce.projectID, name, groupRef)
 	v, err := gce.service.BackendServices.GetHealth(gce.projectID, name, groupRef).Do()
+	glog.V(4).Infof("BackendServices.GetHealth(%s, %s, %v): end", gce.projectID, name, groupRef)
 	return v, mc.Observe(err)
 }
 
 // GetRegionBackendService retrieves a backend by name.
 func (gce *GCECloud) GetRegionBackendService(name, region string) (*compute.BackendService, error) {
 	mc := newBackendServiceMetricContext("get", region)
+	glog.V(4).Infof("RegionBackendServices.Get(%s, %s, %s): start", gce.projectID, region, name)
 	v, err := gce.service.RegionBackendServices.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("RegionBackendServices.Get(%s, %s, %s): end", gce.projectID, region, name)
 	return v, mc.Observe(err)
 }
 
 // UpdateRegionBackendService applies the given BackendService as an update to an existing service.
 func (gce *GCECloud) UpdateRegionBackendService(bg *compute.BackendService, region string) error {
 	mc := newBackendServiceMetricContext("update", region)
+	glog.V(4).Infof("RegionBackendServices.Update(%s, %s, %v): start", gce.projectID, region, bg.Name)
 	op, err := gce.service.RegionBackendServices.Update(gce.projectID, region, bg.Name, bg).Do()
+	glog.V(4).Infof("RegionBackendServices.Update(%s, %s, %v): end", gce.projectID, region, bg.Name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -142,7 +160,9 @@ func (gce *GCECloud) UpdateRegionBackendService(bg *compute.BackendService, regi
 // DeleteRegionBackendService deletes the given BackendService by name.
 func (gce *GCECloud) DeleteRegionBackendService(name, region string) error {
 	mc := newBackendServiceMetricContext("delete", region)
+	glog.V(4).Infof("RegionBackendServices.Delete(%s, %s, %s): start", gce.projectID, region, name)
 	op, err := gce.service.RegionBackendServices.Delete(gce.projectID, region, name).Do()
+	glog.V(4).Infof("RegionBackendServices.Delete(%s, %s, %s): end", gce.projectID, region, name)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return nil
@@ -156,7 +176,9 @@ func (gce *GCECloud) DeleteRegionBackendService(name, region string) error {
 // CreateRegionBackendService creates the given BackendService.
 func (gce *GCECloud) CreateRegionBackendService(bg *compute.BackendService, region string) error {
 	mc := newBackendServiceMetricContext("create", region)
+	glog.V(4).Infof("RegionBackendServices.Insert(%s, %s, %v): start", gce.projectID, region, bg)
 	op, err := gce.service.RegionBackendServices.Insert(gce.projectID, region, bg).Do()
+	glog.V(4).Infof("RegionBackendServices.Insert(%s, %s, %v): end", gce.projectID, region, bg)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -168,7 +190,9 @@ func (gce *GCECloud) CreateRegionBackendService(bg *compute.BackendService, regi
 func (gce *GCECloud) ListRegionBackendServices(region string) (*compute.BackendServiceList, error) {
 	mc := newBackendServiceMetricContext("list", region)
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("RegionBackendServices.List(%s, %s): start", gce.projectID, region)
 	v, err := gce.service.RegionBackendServices.List(gce.projectID, region).Do()
+	glog.V(4).Infof("RegionBackendServices.List(%s, %s): end", gce.projectID, region)
 	return v, mc.Observe(err)
 }
 
@@ -178,6 +202,8 @@ func (gce *GCECloud) ListRegionBackendServices(region string) (*compute.BackendS
 func (gce *GCECloud) GetRegionalBackendServiceHealth(name, region string, instanceGroupLink string) (*compute.BackendServiceGroupHealth, error) {
 	mc := newBackendServiceMetricContext("get_health", region)
 	groupRef := &compute.ResourceGroupReference{Group: instanceGroupLink}
+	glog.V(4).Infof("RegionBackendServices.GetHealth(%s, %s, %s, %v): start", gce.projectID, region, name, groupRef)
 	v, err := gce.service.RegionBackendServices.GetHealth(gce.projectID, region, name, groupRef).Do()
+	glog.V(4).Infof("RegionBackendServices.GetHealth(%s, %s, %s, %v): end", gce.projectID, region, name, groupRef)
 	return v, mc.Observe(err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_cert.go
+++ b/pkg/cloudprovider/providers/gce/gce_cert.go
@@ -19,6 +19,7 @@ package gce
 import (
 	"net/http"
 
+	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -29,14 +30,18 @@ func newCertMetricContext(request string) *metricContext {
 // GetSslCertificate returns the SslCertificate by name.
 func (gce *GCECloud) GetSslCertificate(name string) (*compute.SslCertificate, error) {
 	mc := newCertMetricContext("get")
+	glog.V(4).Infof("SslCertificates.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.SslCertificates.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("SslCertificates.Get(%s, %s): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
 // CreateSslCertificate creates and returns a SslCertificate.
 func (gce *GCECloud) CreateSslCertificate(sslCerts *compute.SslCertificate) (*compute.SslCertificate, error) {
 	mc := newCertMetricContext("create")
+	glog.V(4).Infof("SslCertificates.Insert(%s, %v): start", gce.projectID, sslCerts)
 	op, err := gce.service.SslCertificates.Insert(gce.projectID, sslCerts).Do()
+	glog.V(4).Infof("SslCertificates.Insert(%s, %v): end", gce.projectID, sslCerts)
 
 	if err != nil {
 		return nil, mc.Observe(err)
@@ -52,7 +57,9 @@ func (gce *GCECloud) CreateSslCertificate(sslCerts *compute.SslCertificate) (*co
 // DeleteSslCertificate deletes the SslCertificate by name.
 func (gce *GCECloud) DeleteSslCertificate(name string) error {
 	mc := newCertMetricContext("delete")
+	glog.V(4).Infof("SslCertificates.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.SslCertificates.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("SslCertificates.Delete(%s, %s): end", gce.projectID, name)
 
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
@@ -69,6 +76,8 @@ func (gce *GCECloud) DeleteSslCertificate(name string) error {
 func (gce *GCECloud) ListSslCertificates() (*compute.SslCertificateList, error) {
 	mc := newCertMetricContext("list")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("SslCertificates.List(%s): start", gce.projectID)
 	v, err := gce.service.SslCertificates.List(gce.projectID).Do()
+	glog.V(4).Infof("SslCertificates.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_clusters.go
+++ b/pkg/cloudprovider/providers/gce/gce_clusters.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package gce
 
+import "github.com/golang/glog"
+
 func newClustersMetricContext(request, zone string) *metricContext {
 	return newGenericMetricContext("clusters", request, unusedMetricLabel, zone, computeV1Version)
 }
@@ -42,7 +44,9 @@ func (gce *GCECloud) Master(clusterName string) (string, error) {
 func (gce *GCECloud) listClustersInZone(zone string) ([]string, error) {
 	mc := newClustersMetricContext("list_zone", zone)
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(2).Infof("Projects.Zones.Clusters.List(%s, %s): start", gce.projectID, zone)
 	list, err := gce.containerService.Projects.Zones.Clusters.List(gce.projectID, zone).Do()
+	glog.V(2).Infof("Projects.Zones.Clusters.List(%s, %s): end", gce.projectID, zone)
 	if err != nil {
 		return nil, mc.Observe(err)
 	}

--- a/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -127,8 +127,11 @@ func (manager *gceServiceManager) CreateDiskOnCloudProvider(
 			Type:        diskTypeURI,
 		}
 
-		return manager.gce.serviceAlpha.Disks.Insert(
+		glog.V(4).Infof("Alpha Disks.Insert(%s, %s, %v): start", manager.gce.projectID, zone, diskToCreateAlpha)
+		obj, err := manager.gce.serviceAlpha.Disks.Insert(
 			manager.gce.projectID, zone, diskToCreateAlpha).Do()
+		glog.V(4).Infof("Alpha Disks.Insert(%s, %s, %v): end", manager.gce.projectID, zone, diskToCreateAlpha)
+		return obj, err
 	}
 
 	diskToCreateV1 := &compute.Disk{
@@ -137,8 +140,11 @@ func (manager *gceServiceManager) CreateDiskOnCloudProvider(
 		Description: tagsStr,
 		Type:        diskTypeURI,
 	}
-	return manager.gce.service.Disks.Insert(
+	glog.V(4).Infof("Disks.Insert(%s, %s, %v): start", manager.gce.projectID, zone, diskToCreateV1)
+	obj, err := manager.gce.service.Disks.Insert(
 		manager.gce.projectID, zone, diskToCreateV1).Do()
+	glog.V(4).Infof("Disks.Insert(%s, %s, %v): start", manager.gce.projectID, zone, diskToCreateV1)
+	return obj, err
 }
 
 func (manager *gceServiceManager) CreateRegionalDiskOnCloudProvider(
@@ -165,8 +171,11 @@ func (manager *gceServiceManager) CreateRegionalDiskOnCloudProvider(
 			Type:         diskTypeURI,
 			ReplicaZones: fullyQualifiedReplicaZones,
 		}
-		return manager.gce.serviceAlpha.RegionDisks.Insert(
+		glog.V(4).Infof("Alpha RegionDisks.Insert(%s, %s, %v): start", manager.gce.projectID, manager.gce.region, diskToCreateAlpha)
+		obj, err := manager.gce.serviceAlpha.RegionDisks.Insert(
 			manager.gce.projectID, manager.gce.region, diskToCreateAlpha).Do()
+		glog.V(4).Infof("Alpha RegionDisks.Insert(%s, %s, %v): end", manager.gce.projectID, manager.gce.region, diskToCreateAlpha)
+		return obj, err
 	}
 
 	return nil, fmt.Errorf("The regional PD feature is only available via the GCE Alpha API. Enable \"GCEDiskAlphaAPI\" in the list of \"alpha-features\" in \"gce.conf\" to use the feature.")
@@ -190,8 +199,11 @@ func (manager *gceServiceManager) AttachDiskOnCloudProvider(
 			Source:     source,
 			Type:       diskTypePersistent,
 		}
-		return manager.gce.serviceAlpha.Instances.AttachDisk(
+		glog.V(4).Infof("Alpha Instances.AttachDisk(%s, %s, %s, %v): start", manager.gce.projectID, instanceZone, instanceName, attachedDiskAlpha)
+		obj, err := manager.gce.serviceAlpha.Instances.AttachDisk(
 			manager.gce.projectID, instanceZone, instanceName, attachedDiskAlpha).Do()
+		glog.V(4).Infof("Alpha Instances.AttachDisk(%s, %s, %s, %v): end", manager.gce.projectID, instanceZone, instanceName, attachedDiskAlpha)
+		return obj, err
 	}
 
 	attachedDiskV1 := &compute.AttachedDisk{
@@ -201,8 +213,11 @@ func (manager *gceServiceManager) AttachDiskOnCloudProvider(
 		Source:     source,
 		Type:       disk.Type,
 	}
-	return manager.gce.service.Instances.AttachDisk(
+	glog.V(4).Infof("Instances.AttachDisk(%s, %s, %s, %v): start", manager.gce.projectID, instanceZone, instanceName, attachedDiskV1)
+	obj, err := manager.gce.service.Instances.AttachDisk(
 		manager.gce.projectID, instanceZone, instanceName, attachedDiskV1).Do()
+	glog.V(4).Infof("Instances.AttachDisk(%s, %s, %s, %v): end", manager.gce.projectID, instanceZone, instanceName, attachedDiskV1)
+	return obj, err
 }
 
 func (manager *gceServiceManager) DetachDiskOnCloudProvider(
@@ -210,12 +225,17 @@ func (manager *gceServiceManager) DetachDiskOnCloudProvider(
 	instanceName string,
 	devicePath string) (gceObject, error) {
 	if manager.gce.AlphaFeatureGate.Enabled(AlphaFeatureGCEDisk) {
+		glog.V(4).Infof("Alpha Instances.DetachDisk(%s, %s, %s, %s): start", manager.gce.projectID, instanceZone, instanceName, devicePath)
 		manager.gce.serviceAlpha.Instances.DetachDisk(
 			manager.gce.projectID, instanceZone, instanceName, devicePath).Do()
+		glog.V(4).Infof("Alpha Instances.DetachDisk(%s, %s, %s, %s): end", manager.gce.projectID, instanceZone, instanceName, devicePath)
 	}
 
-	return manager.gce.service.Instances.DetachDisk(
+	glog.V(4).Infof("Instances.DetachDisk(%s, %s, %s, %s): start", manager.gce.projectID, instanceZone, instanceName, devicePath)
+	obj, err := manager.gce.service.Instances.DetachDisk(
 		manager.gce.projectID, instanceZone, instanceName, devicePath).Do()
+	glog.V(4).Infof("Instances.DetachDisk(%s, %s, %s, %s): end", manager.gce.projectID, instanceZone, instanceName, devicePath)
+	return obj, err
 }
 
 func (manager *gceServiceManager) GetDiskFromCloudProvider(
@@ -230,8 +250,10 @@ func (manager *gceServiceManager) GetDiskFromCloudProvider(
 	}
 
 	if manager.gce.AlphaFeatureGate.Enabled(AlphaFeatureGCEDisk) {
+		glog.V(4).Infof("Alpha Disks.Get(%s, %s, %s): start", manager.gce.projectID, zone, diskName)
 		diskAlpha, err := manager.gce.serviceAlpha.Disks.Get(
 			manager.gce.projectID, zone, diskName).Do()
+		glog.V(4).Infof("Alpha Disks.Get(%s, %s, %s): end", manager.gce.projectID, zone, diskName)
 		if err != nil {
 			return nil, err
 		}
@@ -267,8 +289,10 @@ func (manager *gceServiceManager) GetDiskFromCloudProvider(
 		}, nil
 	}
 
+	glog.V(4).Infof("Disks.Get(%s, %s, %s): start", manager.gce.projectID, zone, diskName)
 	diskStable, err := manager.gce.service.Disks.Get(
 		manager.gce.projectID, zone, diskName).Do()
+	glog.V(4).Infof("Disks.Get(%s, %s, %s): end", manager.gce.projectID, zone, diskName)
 	if err != nil {
 		return nil, err
 	}
@@ -296,8 +320,10 @@ func (manager *gceServiceManager) GetRegionalDiskFromCloudProvider(
 	diskName string) (*GCEDisk, error) {
 
 	if manager.gce.AlphaFeatureGate.Enabled(AlphaFeatureGCEDisk) {
+		glog.V(4).Infof("Alpha RegionDisks.Get(%s, %s, %s): start", manager.gce.projectID, manager.gce.region, diskName)
 		diskAlpha, err := manager.gce.serviceAlpha.RegionDisks.Get(
 			manager.gce.projectID, manager.gce.region, diskName).Do()
+		glog.V(4).Infof("Alpha RegionDisks.Get(%s, %s, %s): end", manager.gce.projectID, manager.gce.region, diskName)
 		if err != nil {
 			return nil, err
 		}
@@ -324,19 +350,28 @@ func (manager *gceServiceManager) DeleteDiskOnCloudProvider(
 	diskName string) (gceObject, error) {
 
 	if manager.gce.AlphaFeatureGate.Enabled(AlphaFeatureGCEDisk) {
-		return manager.gce.serviceAlpha.Disks.Delete(
+		glog.V(4).Infof("Alpha Disks.Delete(%s, %s, %s): start", manager.gce.projectID, zone, diskName)
+		obj, err := manager.gce.serviceAlpha.Disks.Delete(
 			manager.gce.projectID, zone, diskName).Do()
+		glog.V(4).Infof("Alpha Disks.Delete(%s, %s, %s): end", manager.gce.projectID, zone, diskName)
+		return obj, err
 	}
 
-	return manager.gce.service.Disks.Delete(
+	glog.V(4).Infof("Disks.Delete(%s, %s, %s): start", manager.gce.projectID, zone, diskName)
+	obj, err := manager.gce.service.Disks.Delete(
 		manager.gce.projectID, zone, diskName).Do()
+	glog.V(4).Infof("Disks.Delete(%s, %s, %s): end", manager.gce.projectID, zone, diskName)
+	return obj, err
 }
 
 func (manager *gceServiceManager) DeleteRegionalDiskOnCloudProvider(
 	diskName string) (gceObject, error) {
 	if manager.gce.AlphaFeatureGate.Enabled(AlphaFeatureGCEDisk) {
-		return manager.gce.serviceAlpha.RegionDisks.Delete(
+		glog.V(4).Infof("Alpha RegionDisks.Delete(%s, %s, %s): start", manager.gce.projectID, manager.gce.region, diskName)
+		obj, err := manager.gce.serviceAlpha.RegionDisks.Delete(
 			manager.gce.projectID, manager.gce.region, diskName).Do()
+		glog.V(4).Infof("Alpha RegionDisks.Delete(%s, %s, %s): end", manager.gce.projectID, manager.gce.region, diskName)
+		return obj, err
 	}
 
 	return nil, fmt.Errorf("DeleteRegionalDiskOnCloudProvider is a regional PD feature and is only available via the GCE Alpha API. Enable \"GCEDiskAlphaAPI\" in the list of \"alpha-features\" in \"gce.conf\" to use the feature.")

--- a/pkg/cloudprovider/providers/gce/gce_firewall.go
+++ b/pkg/cloudprovider/providers/gce/gce_firewall.go
@@ -18,6 +18,8 @@ package gce
 
 import (
 	compute "google.golang.org/api/compute/v1"
+
+	"github.com/golang/glog"
 )
 
 func newFirewallMetricContext(request string) *metricContext {
@@ -27,14 +29,18 @@ func newFirewallMetricContext(request string) *metricContext {
 // GetFirewall returns the Firewall by name.
 func (gce *GCECloud) GetFirewall(name string) (*compute.Firewall, error) {
 	mc := newFirewallMetricContext("get")
+	glog.V(4).Infof("Firewalls.Get(%s, %s): start", gce.NetworkProjectID(), name)
 	v, err := gce.service.Firewalls.Get(gce.NetworkProjectID(), name).Do()
+	glog.V(4).Infof("Firewalls.Get(%s, %s): end", gce.NetworkProjectID(), name)
 	return v, mc.Observe(err)
 }
 
 // CreateFirewall creates the passed firewall
 func (gce *GCECloud) CreateFirewall(f *compute.Firewall) error {
 	mc := newFirewallMetricContext("create")
+	glog.V(4).Infof("Firewalls.Insert(%s, %v): start", gce.NetworkProjectID(), f)
 	op, err := gce.service.Firewalls.Insert(gce.NetworkProjectID(), f).Do()
+	glog.V(4).Infof("Firewalls.Insert(%s, %v): end", gce.NetworkProjectID(), f)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -45,7 +51,9 @@ func (gce *GCECloud) CreateFirewall(f *compute.Firewall) error {
 // DeleteFirewall deletes the given firewall rule.
 func (gce *GCECloud) DeleteFirewall(name string) error {
 	mc := newFirewallMetricContext("delete")
+	glog.V(4).Infof("Firewalls.Delete(%s, %s): start", gce.NetworkProjectID(), name)
 	op, err := gce.service.Firewalls.Delete(gce.NetworkProjectID(), name).Do()
+	glog.V(4).Infof("Firewalls.Delete(%s, %s): end", gce.NetworkProjectID(), name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -55,7 +63,9 @@ func (gce *GCECloud) DeleteFirewall(name string) error {
 // UpdateFirewall applies the given firewall as an update to an existing service.
 func (gce *GCECloud) UpdateFirewall(f *compute.Firewall) error {
 	mc := newFirewallMetricContext("update")
+	glog.V(4).Infof("Firewalls.Update(%s, %s, %v): start", gce.NetworkProjectID(), f.Name, f)
 	op, err := gce.service.Firewalls.Update(gce.NetworkProjectID(), f.Name, f).Do()
+	glog.V(4).Infof("Firewalls.Update(%s, %s, %v): end", gce.NetworkProjectID(), f.Name, f)
 	if err != nil {
 		return mc.Observe(err)
 	}

--- a/pkg/cloudprovider/providers/gce/gce_forwardingrule.go
+++ b/pkg/cloudprovider/providers/gce/gce_forwardingrule.go
@@ -19,6 +19,8 @@ package gce
 import (
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	compute "google.golang.org/api/compute/v1"
+
+	"github.com/golang/glog"
 )
 
 func newForwardingRuleMetricContext(request, region string) *metricContext {
@@ -31,7 +33,9 @@ func newForwardingRuleMetricContextWithVersion(request, region, version string) 
 // CreateGlobalForwardingRule creates the passed GlobalForwardingRule
 func (gce *GCECloud) CreateGlobalForwardingRule(rule *compute.ForwardingRule) error {
 	mc := newForwardingRuleMetricContext("create", "")
+	glog.V(4).Infof("GlobalForwardingRules.Insert(%s, %v): start", gce.projectID, rule)
 	op, err := gce.service.GlobalForwardingRules.Insert(gce.projectID, rule).Do()
+	glog.V(4).Infof("GlobalForwardingRules.Insert(%s, %v): end", gce.projectID, rule)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -42,8 +46,11 @@ func (gce *GCECloud) CreateGlobalForwardingRule(rule *compute.ForwardingRule) er
 // targetProxyLink is the SelfLink of a TargetHttp(s)Proxy.
 func (gce *GCECloud) SetProxyForGlobalForwardingRule(forwardingRuleName, targetProxyLink string) error {
 	mc := newForwardingRuleMetricContext("set_proxy", "")
+	target := compute.TargetReference{Target: targetProxyLink}
+	glog.V(4).Infof("GlobalForwardingRules.SetTarget(%s, %s, %v): start", gce.projectID, forwardingRuleName, target)
 	op, err := gce.service.GlobalForwardingRules.SetTarget(
-		gce.projectID, forwardingRuleName, &compute.TargetReference{Target: targetProxyLink}).Do()
+		gce.projectID, forwardingRuleName, &target).Do()
+	glog.V(4).Infof("GlobalForwardingRules.SetTarget(%s, %s, %v): end", gce.projectID, forwardingRuleName, target)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -54,7 +61,9 @@ func (gce *GCECloud) SetProxyForGlobalForwardingRule(forwardingRuleName, targetP
 // DeleteGlobalForwardingRule deletes the GlobalForwardingRule by name.
 func (gce *GCECloud) DeleteGlobalForwardingRule(name string) error {
 	mc := newForwardingRuleMetricContext("delete", "")
+	glog.V(4).Infof("GlobalForwardingRules.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.GlobalForwardingRules.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("GlobalForwardingRules.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -65,7 +74,9 @@ func (gce *GCECloud) DeleteGlobalForwardingRule(name string) error {
 // GetGlobalForwardingRule returns the GlobalForwardingRule by name.
 func (gce *GCECloud) GetGlobalForwardingRule(name string) (*compute.ForwardingRule, error) {
 	mc := newForwardingRuleMetricContext("get", "")
+	glog.V(4).Infof("GlobalForwardingRules.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.GlobalForwardingRules.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("GlobalForwardingRules.Get(%s, %s): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
@@ -73,21 +84,27 @@ func (gce *GCECloud) GetGlobalForwardingRule(name string) (*compute.ForwardingRu
 func (gce *GCECloud) ListGlobalForwardingRules() (*compute.ForwardingRuleList, error) {
 	mc := newForwardingRuleMetricContext("list", "")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("GlobalForwardingRules.List(%s): start", gce.projectID)
 	v, err := gce.service.GlobalForwardingRules.List(gce.projectID).Do()
+	glog.V(4).Infof("GlobalForwardingRules.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }
 
 // GetRegionForwardingRule returns the RegionalForwardingRule by name & region.
 func (gce *GCECloud) GetRegionForwardingRule(name, region string) (*compute.ForwardingRule, error) {
 	mc := newForwardingRuleMetricContext("get", region)
+	glog.V(4).Infof("ForwardingRules.Get(%s, %s, %s): start", gce.projectID, region, name)
 	v, err := gce.service.ForwardingRules.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("ForwardingRules.Get(%s, %s, %s): end", gce.projectID, region, name)
 	return v, mc.Observe(err)
 }
 
 // GetAlphaRegionForwardingRule returns the Alpha forwarding rule by name & region.
 func (gce *GCECloud) GetAlphaRegionForwardingRule(name, region string) (*computealpha.ForwardingRule, error) {
 	mc := newForwardingRuleMetricContextWithVersion("get", region, computeAlphaVersion)
+	glog.V(4).Infof("Alpha ForwardingRules.Get(%s, %s, %s): start", gce.projectID, region, name)
 	v, err := gce.serviceAlpha.ForwardingRules.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("Alpha ForwardingRules.Get(%s, %s, %s): end", gce.projectID, region, name)
 	return v, mc.Observe(err)
 }
 
@@ -95,7 +112,9 @@ func (gce *GCECloud) GetAlphaRegionForwardingRule(name, region string) (*compute
 func (gce *GCECloud) ListRegionForwardingRules(region string) (*compute.ForwardingRuleList, error) {
 	mc := newForwardingRuleMetricContext("list", region)
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("ForwardingRules.List(%s, %s): start", gce.projectID, region)
 	v, err := gce.service.ForwardingRules.List(gce.projectID, region).Do()
+	glog.V(4).Infof("ForwardingRules.List(%s, %s): end", gce.projectID, region)
 	return v, mc.Observe(err)
 }
 
@@ -103,7 +122,9 @@ func (gce *GCECloud) ListRegionForwardingRules(region string) (*compute.Forwardi
 func (gce *GCECloud) ListAlphaRegionForwardingRules(region string) (*computealpha.ForwardingRuleList, error) {
 	mc := newForwardingRuleMetricContextWithVersion("list", region, computeAlphaVersion)
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("ForwardingRules.List(%s, %s): start", gce.projectID, region)
 	v, err := gce.serviceAlpha.ForwardingRules.List(gce.projectID, region).Do()
+	glog.V(4).Infof("ForwardingRules.List(%s, %s): end", gce.projectID, region)
 	return v, mc.Observe(err)
 }
 
@@ -111,7 +132,9 @@ func (gce *GCECloud) ListAlphaRegionForwardingRules(region string) (*computealph
 // RegionalForwardingRule that points to the given BackendService
 func (gce *GCECloud) CreateRegionForwardingRule(rule *compute.ForwardingRule, region string) error {
 	mc := newForwardingRuleMetricContext("create", region)
+	glog.V(4).Infof("ForwardingRules.Insert(%s, %s, %v): start", gce.projectID, region, rule)
 	op, err := gce.service.ForwardingRules.Insert(gce.projectID, region, rule).Do()
+	glog.V(4).Infof("ForwardingRules.Insert(%s, %s, %v): end", gce.projectID, region, rule)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -123,7 +146,9 @@ func (gce *GCECloud) CreateRegionForwardingRule(rule *compute.ForwardingRule, re
 // forwarding fule in the given region.
 func (gce *GCECloud) CreateAlphaRegionForwardingRule(rule *computealpha.ForwardingRule, region string) error {
 	mc := newForwardingRuleMetricContextWithVersion("create", region, computeAlphaVersion)
+	glog.V(4).Infof("Alpha ForwardingRules.Insert(%s, %s, %v): start", gce.projectID, region, rule)
 	op, err := gce.serviceAlpha.ForwardingRules.Insert(gce.projectID, region, rule).Do()
+	glog.V(4).Infof("Alpha ForwardingRules.Insert(%s, %s, %v): end", gce.projectID, region, rule)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -134,7 +159,9 @@ func (gce *GCECloud) CreateAlphaRegionForwardingRule(rule *computealpha.Forwardi
 // DeleteRegionForwardingRule deletes the RegionalForwardingRule by name & region.
 func (gce *GCECloud) DeleteRegionForwardingRule(name, region string) error {
 	mc := newForwardingRuleMetricContext("delete", region)
+	glog.V(4).Infof("ForwardingRules.Delete(%s, %s, %s): start", gce.projectID, region, name)
 	op, err := gce.service.ForwardingRules.Delete(gce.projectID, region, name).Do()
+	glog.V(4).Infof("ForwardingRules.Delete(%s, %s, %s): end", gce.projectID, region, name)
 	if err != nil {
 		return mc.Observe(err)
 	}

--- a/pkg/cloudprovider/providers/gce/gce_healthchecks.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks.go
@@ -54,14 +54,18 @@ func newHealthcheckMetricContextWithVersion(request, version string) *metricCont
 // GetHttpHealthCheck returns the given HttpHealthCheck by name.
 func (gce *GCECloud) GetHttpHealthCheck(name string) (*compute.HttpHealthCheck, error) {
 	mc := newHealthcheckMetricContext("get_legacy")
+	glog.V(4).Infof("HttpHealthChecks.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.HttpHealthChecks.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("HttpHealthChecks.Get(%s, %s): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
 // UpdateHttpHealthCheck applies the given HttpHealthCheck as an update.
 func (gce *GCECloud) UpdateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 	mc := newHealthcheckMetricContext("update_legacy")
+	glog.V(4).Infof("HttpHealthChecks.Update(%s, %s, %v): start", gce.projectID, hc.Name, hc)
 	op, err := gce.service.HttpHealthChecks.Update(gce.projectID, hc.Name, hc).Do()
+	glog.V(4).Infof("HttpHealthChecks.Update(%s, %s, %v): end", gce.projectID, hc.Name, hc)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -72,7 +76,9 @@ func (gce *GCECloud) UpdateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 // DeleteHttpHealthCheck deletes the given HttpHealthCheck by name.
 func (gce *GCECloud) DeleteHttpHealthCheck(name string) error {
 	mc := newHealthcheckMetricContext("delete_legacy")
+	glog.V(4).Infof("HttpHealthChecks.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.HttpHealthChecks.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("HttpHealthChecks.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -83,7 +89,9 @@ func (gce *GCECloud) DeleteHttpHealthCheck(name string) error {
 // CreateHttpHealthCheck creates the given HttpHealthCheck.
 func (gce *GCECloud) CreateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 	mc := newHealthcheckMetricContext("create_legacy")
+	glog.V(4).Infof("HttpHealthChecks.Insert(%s, %v): start", gce.projectID, hc)
 	op, err := gce.service.HttpHealthChecks.Insert(gce.projectID, hc).Do()
+	glog.V(4).Infof("HttpHealthChecks.Insert(%s, %v): end", gce.projectID, hc)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -95,7 +103,9 @@ func (gce *GCECloud) CreateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 func (gce *GCECloud) ListHttpHealthChecks() (*compute.HttpHealthCheckList, error) {
 	mc := newHealthcheckMetricContext("list_legacy")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("HttpHealthChecks.List(%s): start", gce.projectID)
 	v, err := gce.service.HttpHealthChecks.List(gce.projectID).Do()
+	glog.V(4).Infof("HttpHealthChecks.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }
 
@@ -104,7 +114,9 @@ func (gce *GCECloud) ListHttpHealthChecks() (*compute.HttpHealthCheckList, error
 // GetHttpsHealthCheck returns the given HttpsHealthCheck by name.
 func (gce *GCECloud) GetHttpsHealthCheck(name string) (*compute.HttpsHealthCheck, error) {
 	mc := newHealthcheckMetricContext("get_legacy")
+	glog.V(4).Infof("HttpsHealthChecks.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.HttpsHealthChecks.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("HttpsHealthChecks.Get(%s, %s): end", gce.projectID, name)
 	mc.Observe(err)
 	return v, err
 }
@@ -112,7 +124,9 @@ func (gce *GCECloud) GetHttpsHealthCheck(name string) (*compute.HttpsHealthCheck
 // UpdateHttpsHealthCheck applies the given HttpsHealthCheck as an update.
 func (gce *GCECloud) UpdateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error {
 	mc := newHealthcheckMetricContext("update_legacy")
+	glog.V(4).Infof("HttpsHealthChecks.Update(%s, %s, %v): start", gce.projectID, hc.Name, hc)
 	op, err := gce.service.HttpsHealthChecks.Update(gce.projectID, hc.Name, hc).Do()
+	glog.V(4).Infof("HttpsHealthChecks.Update(%s, %s, %v): end", gce.projectID, hc.Name, hc)
 	if err != nil {
 		mc.Observe(err)
 		return err
@@ -124,7 +138,9 @@ func (gce *GCECloud) UpdateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error 
 // DeleteHttpsHealthCheck deletes the given HttpsHealthCheck by name.
 func (gce *GCECloud) DeleteHttpsHealthCheck(name string) error {
 	mc := newHealthcheckMetricContext("delete_legacy")
+	glog.V(4).Infof("HttpsHealthChecks.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.HttpsHealthChecks.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("HttpsHealthChecks.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -135,7 +151,9 @@ func (gce *GCECloud) DeleteHttpsHealthCheck(name string) error {
 // CreateHttpsHealthCheck creates the given HttpsHealthCheck.
 func (gce *GCECloud) CreateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error {
 	mc := newHealthcheckMetricContext("create_legacy")
+	glog.V(4).Infof("HttpsHealthChecks.Insert(%s, %v): start", gce.projectID, hc)
 	op, err := gce.service.HttpsHealthChecks.Insert(gce.projectID, hc).Do()
+	glog.V(4).Infof("HttpsHealthChecks.Insert(%s, %v): end", gce.projectID, hc)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -147,7 +165,9 @@ func (gce *GCECloud) CreateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error 
 func (gce *GCECloud) ListHttpsHealthChecks() (*compute.HttpsHealthCheckList, error) {
 	mc := newHealthcheckMetricContext("list_legacy")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("HttpsHealthChecks.List(%s): start", gce.projectID)
 	v, err := gce.service.HttpsHealthChecks.List(gce.projectID).Do()
+	glog.V(4).Infof("HttpsHealthChecks.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }
 
@@ -156,7 +176,9 @@ func (gce *GCECloud) ListHttpsHealthChecks() (*compute.HttpsHealthCheckList, err
 // GetHealthCheck returns the given HealthCheck by name.
 func (gce *GCECloud) GetHealthCheck(name string) (*compute.HealthCheck, error) {
 	mc := newHealthcheckMetricContext("get")
+	glog.V(4).Infof("HttpsHealthChecks.List(%s, %v): start", gce.projectID, name)
 	v, err := gce.service.HealthChecks.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("HttpsHealthChecks.List(%s, %v): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
@@ -170,7 +192,9 @@ func (gce *GCECloud) GetAlphaHealthCheck(name string) (*computealpha.HealthCheck
 // UpdateHealthCheck applies the given HealthCheck as an update.
 func (gce *GCECloud) UpdateHealthCheck(hc *compute.HealthCheck) error {
 	mc := newHealthcheckMetricContext("update")
+	glog.V(4).Infof("HealthChecks.Update(%s, %s, %v): start", gce.projectID, hc.Name, hc)
 	op, err := gce.service.HealthChecks.Update(gce.projectID, hc.Name, hc).Do()
+	glog.V(4).Infof("HealthChecks.Update(%s, %s, %v): end", gce.projectID, hc.Name, hc)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -192,7 +216,9 @@ func (gce *GCECloud) UpdateAlphaHealthCheck(hc *computealpha.HealthCheck) error 
 // DeleteHealthCheck deletes the given HealthCheck by name.
 func (gce *GCECloud) DeleteHealthCheck(name string) error {
 	mc := newHealthcheckMetricContext("delete")
+	glog.V(4).Infof("HealthChecks.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.HealthChecks.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("HealthChecks.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -203,7 +229,9 @@ func (gce *GCECloud) DeleteHealthCheck(name string) error {
 // CreateHealthCheck creates the given HealthCheck.
 func (gce *GCECloud) CreateHealthCheck(hc *compute.HealthCheck) error {
 	mc := newHealthcheckMetricContext("create")
+	glog.V(4).Infof("HealthChecks.Insert(%s, %v): start", gce.projectID, hc)
 	op, err := gce.service.HealthChecks.Insert(gce.projectID, hc).Do()
+	glog.V(4).Infof("HealthChecks.Insert(%s, %v): end", gce.projectID, hc)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -226,7 +254,9 @@ func (gce *GCECloud) CreateAlphaHealthCheck(hc *computealpha.HealthCheck) error 
 func (gce *GCECloud) ListHealthChecks() (*compute.HealthCheckList, error) {
 	mc := newHealthcheckMetricContext("list")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("HealthChecks.List(%s): start", gce.projectID)
 	v, err := gce.service.HealthChecks.List(gce.projectID).Do()
+	glog.V(4).Infof("HealthChecks.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }
 

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
@@ -321,7 +321,9 @@ func (gce *GCECloud) updateExternalLoadBalancer(clusterName string, service *v1.
 	}
 
 	loadBalancerName := cloudprovider.GetLoadBalancerName(service)
+	glog.V(4).Infof("TargetPools.Get(%s, %s, %s): start", gce.projectID, gce.region, loadBalancerName)
 	pool, err := gce.service.TargetPools.Get(gce.projectID, gce.region, loadBalancerName).Do()
+	glog.V(4).Infof("TargetPools.Get(%s, %s, %s): stop", gce.projectID, gce.region, loadBalancerName)
 	if err != nil {
 		return err
 	}
@@ -636,7 +638,9 @@ func (gce *GCECloud) ensureHttpHealthCheck(name, path string, port int32) (hc *c
 // Returns whether the forwarding rule exists, whether it needs to be updated,
 // what its IP address is (if it exists), and any error we encountered.
 func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, loadBalancerIP string, ports []v1.ServicePort) (exists bool, needsUpdate bool, ipAddress string, err error) {
+	glog.V(4).Infof("ForwardingRules.Get(%s, %s, %s): start", gce.projectID, region, name)
 	fwd, err := gce.service.ForwardingRules.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("ForwardingRules.Get(%s, %s, %s): stop", gce.projectID, region, name)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return false, true, "", nil
@@ -675,7 +679,9 @@ func (gce *GCECloud) forwardingRuleNeedsUpdate(name, region string, loadBalancer
 // Doesn't check whether the hosts have changed, since host updating is handled
 // separately.
 func (gce *GCECloud) targetPoolNeedsUpdate(name, region string, affinityType v1.ServiceAffinity) (exists bool, needsUpdate bool, err error) {
+	glog.V(4).Infof("TargetPools.Get(%s, %s, %s): start", gce.projectID, region, name)
 	tp, err := gce.service.TargetPools.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("TargetPools.Get(%s, %s, %s): stop", gce.projectID, region, name)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return false, true, nil
@@ -761,7 +767,10 @@ func translateAffinityType(affinityType v1.ServiceAffinity) string {
 }
 
 func (gce *GCECloud) firewallNeedsUpdate(name, serviceName, region, ipAddress string, ports []v1.ServicePort, sourceRanges netsets.IPNet) (exists bool, needsUpdate bool, err error) {
-	fw, err := gce.service.Firewalls.Get(gce.NetworkProjectID(), MakeFirewallName(name)).Do()
+	firewallName := MakeFirewallName(name)
+	glog.V(4).Infof("Firewalls.Get(%s, %s): start", gce.projectID, firewallName)
+	fw, err := gce.service.Firewalls.Get(gce.NetworkProjectID(), firewallName).Do()
+	glog.V(4).Infof("Firewalls.Get(%s, %s): stop", gce.projectID, firewallName)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return false, true, nil
@@ -808,7 +817,9 @@ func (gce *GCECloud) ensureHttpHealthCheckFirewall(svc *v1.Service, serviceName,
 	ports := []v1.ServicePort{{Protocol: "tcp", Port: hcPort}}
 
 	fwName := MakeHealthCheckFirewallName(clusterID, hcName, isNodesHealthCheck)
+	glog.V(4).Infof("Firewalls.Get(%s, %s): start", gce.projectID, fwName)
 	fw, err := gce.service.Firewalls.Get(gce.NetworkProjectID(), fwName).Do()
+	glog.V(4).Infof("Firewalls.Get(%s, %s): stop", gce.projectID, fwName)
 	if err != nil {
 		if !isHTTPErrorCode(err, http.StatusNotFound) {
 			return fmt.Errorf("error getting firewall for health checks: %v", err)

--- a/pkg/cloudprovider/providers/gce/gce_op.go
+++ b/pkg/cloudprovider/providers/gce/gce_op.go
@@ -108,17 +108,24 @@ func (gce *GCECloud) waitForGlobalOpInProject(op gceObject, projectID string, mc
 	switch v := op.(type) {
 	case *computealpha.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			glog.V(4).Infof("Alpha GlobalOperations.Get(%s, %s): start", projectID, operationName)
 			op, err := gce.serviceAlpha.GlobalOperations.Get(projectID, operationName).Do()
+			glog.V(4).Infof("Alpha GlobalOperations.Get(%s, %s): end", projectID, operationName)
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computebeta.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			glog.V(4).Infof("Beta GlobalOperations.Get(%s, %s): start", projectID, operationName)
 			op, err := gce.serviceBeta.GlobalOperations.Get(projectID, operationName).Do()
+			glog.V(4).Infof("Beta GlobalOperations.Get(%s, %s): end", projectID, operationName)
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computev1.Operation:
 		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
-			return gce.service.GlobalOperations.Get(projectID, operationName).Do()
+			glog.V(4).Infof("GlobalOperations.Get(%s, %s): start", projectID, operationName)
+			op, err := gce.service.GlobalOperations.Get(projectID, operationName).Do()
+			glog.V(4).Infof("GlobalOperations.Get(%s, %s): end", projectID, operationName)
+			return op, err
 		}, mc)
 	default:
 		return fmt.Errorf("unexpected type: %T", v)
@@ -129,17 +136,24 @@ func (gce *GCECloud) waitForRegionOpInProject(op gceObject, projectID, region st
 	switch v := op.(type) {
 	case *computealpha.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			glog.V(4).Infof("Alpha RegionOperations.Get(%s, %s, %s): start", projectID, region, operationName)
 			op, err := gce.serviceAlpha.RegionOperations.Get(projectID, region, operationName).Do()
+			glog.V(4).Infof("Alpha RegionOperations.Get(%s, %s, %s): end", projectID, region, operationName)
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computebeta.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			glog.V(4).Infof("Beta RegionOperations.Get(%s, %s, %s): start", projectID, region, operationName)
 			op, err := gce.serviceBeta.RegionOperations.Get(projectID, region, operationName).Do()
+			glog.V(4).Infof("Beta RegionOperations.Get(%s, %s, %s): end", projectID, region, operationName)
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computev1.Operation:
 		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
-			return gce.service.RegionOperations.Get(projectID, region, operationName).Do()
+			glog.V(4).Infof("RegionOperations.Get(%s, %s, %s): start", projectID, region, operationName)
+			op, err := gce.service.RegionOperations.Get(projectID, region, operationName).Do()
+			glog.V(4).Infof("RegionOperations.Get(%s, %s, %s): end", projectID, region, operationName)
+			return op, err
 		}, mc)
 	default:
 		return fmt.Errorf("unexpected type: %T", v)
@@ -150,17 +164,24 @@ func (gce *GCECloud) waitForZoneOpInProject(op gceObject, projectID, zone string
 	switch v := op.(type) {
 	case *computealpha.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			glog.V(4).Infof("ZoneOperations.Get(%s, %s, %s): start", projectID, zone, operationName)
 			op, err := gce.serviceAlpha.ZoneOperations.Get(projectID, zone, operationName).Do()
+			glog.V(4).Infof("ZoneOperations.Get(%s, %s, %s): end", projectID, zone, operationName)
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computebeta.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			glog.V(4).Infof("ZoneOperations.Get(%s, %s, %s): start", projectID, zone, operationName)
 			op, err := gce.serviceBeta.ZoneOperations.Get(projectID, zone, operationName).Do()
+			glog.V(4).Infof("ZoneOperations.Get(%s, %s, %s): end", projectID, zone, operationName)
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computev1.Operation:
 		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
-			return gce.service.ZoneOperations.Get(projectID, zone, operationName).Do()
+			glog.V(4).Infof("ZoneOperations.Get(%s, %s, %s): start", projectID, zone, operationName)
+			op, err := gce.service.ZoneOperations.Get(projectID, zone, operationName).Do()
+			glog.V(4).Infof("ZoneOperations.Get(%s, %s, %s): end", projectID, zone, operationName)
+			return op, err
 		}, mc)
 	default:
 		return fmt.Errorf("unexpected type: %T", v)

--- a/pkg/cloudprovider/providers/gce/gce_targetpool.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetpool.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package gce
 
-import compute "google.golang.org/api/compute/v1"
+import (
+	compute "google.golang.org/api/compute/v1"
+
+	"github.com/golang/glog"
+)
 
 func newTargetPoolMetricContext(request, region string) *metricContext {
 	return newGenericMetricContext("targetpool", request, region, unusedMetricLabel, computeV1Version)
@@ -25,14 +29,18 @@ func newTargetPoolMetricContext(request, region string) *metricContext {
 // GetTargetPool returns the TargetPool by name.
 func (gce *GCECloud) GetTargetPool(name, region string) (*compute.TargetPool, error) {
 	mc := newTargetPoolMetricContext("get", region)
+	glog.V(4).Infof("TargetPools.Get(%s, %s, %s): start", gce.projectID, region, name)
 	v, err := gce.service.TargetPools.Get(gce.projectID, region, name).Do()
+	glog.V(4).Infof("TargetPools.Get(%s, %s, %s): end", gce.projectID, region, name)
 	return v, mc.Observe(err)
 }
 
 // CreateTargetPool creates the passed TargetPool
 func (gce *GCECloud) CreateTargetPool(tp *compute.TargetPool, region string) error {
 	mc := newTargetPoolMetricContext("create", region)
+	glog.V(4).Infof("TargetPools.Insert(%s, %s, %v): start", gce.projectID, region, tp)
 	op, err := gce.service.TargetPools.Insert(gce.projectID, region, tp).Do()
+	glog.V(4).Infof("TargetPools.Insert(%s, %s, %v): end", gce.projectID, region, tp)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -43,7 +51,9 @@ func (gce *GCECloud) CreateTargetPool(tp *compute.TargetPool, region string) err
 // DeleteTargetPool deletes TargetPool by name.
 func (gce *GCECloud) DeleteTargetPool(name, region string) error {
 	mc := newTargetPoolMetricContext("delete", region)
+	glog.V(4).Infof("TargetPools.Delete(%s, %s, %s): start", gce.projectID, region, name)
 	op, err := gce.service.TargetPools.Delete(gce.projectID, region, name).Do()
+	glog.V(4).Infof("TargetPools.Delete(%s, %s, %s): end", gce.projectID, region, name)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -54,7 +64,9 @@ func (gce *GCECloud) DeleteTargetPool(name, region string) error {
 func (gce *GCECloud) AddInstancesToTargetPool(name, region string, instanceRefs []*compute.InstanceReference) error {
 	add := &compute.TargetPoolsAddInstanceRequest{Instances: instanceRefs}
 	mc := newTargetPoolMetricContext("add_instances", region)
+	glog.V(4).Infof("TargetPools.AddInstance(%s, %s, %s, %v): start", gce.projectID, region, name, add)
 	op, err := gce.service.TargetPools.AddInstance(gce.projectID, region, name, add).Do()
+	glog.V(4).Infof("TargetPools.AddInstance(%s, %s, %s, %v): end", gce.projectID, region, name, add)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -65,7 +77,9 @@ func (gce *GCECloud) AddInstancesToTargetPool(name, region string, instanceRefs 
 func (gce *GCECloud) RemoveInstancesFromTargetPool(name, region string, instanceRefs []*compute.InstanceReference) error {
 	remove := &compute.TargetPoolsRemoveInstanceRequest{Instances: instanceRefs}
 	mc := newTargetPoolMetricContext("remove_instances", region)
+	glog.V(4).Infof("TargetPools.RemoveInstance(%s, %s, %s, %v): start", gce.projectID, region, name, remove)
 	op, err := gce.service.TargetPools.RemoveInstance(gce.projectID, region, name, remove).Do()
+	glog.V(4).Infof("TargetPools.RemoveInstance(%s, %s, %s, %v): end", gce.projectID, region, name, remove)
 	if err != nil {
 		return mc.Observe(err)
 	}

--- a/pkg/cloudprovider/providers/gce/gce_targetproxy.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetproxy.go
@@ -19,6 +19,7 @@ package gce
 import (
 	"net/http"
 
+	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -29,14 +30,18 @@ func newTargetProxyMetricContext(request string) *metricContext {
 // GetTargetHttpProxy returns the UrlMap by name.
 func (gce *GCECloud) GetTargetHttpProxy(name string) (*compute.TargetHttpProxy, error) {
 	mc := newTargetProxyMetricContext("get")
+	glog.V(4).Infof("TargetHttpProxies.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.TargetHttpProxies.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("TargetHttpProxies.Get(%s, %s): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
 // CreateTargetHttpProxy creates a TargetHttpProxy
 func (gce *GCECloud) CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error {
 	mc := newTargetProxyMetricContext("create")
+	glog.V(4).Infof("TargetHttpProxies.Insert(%s, %v): start", gce.projectID, proxy)
 	op, err := gce.service.TargetHttpProxies.Insert(gce.projectID, proxy).Do()
+	glog.V(4).Infof("TargetHttpProxies.Insert(%s, %v): end", gce.projectID, proxy)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -46,8 +51,10 @@ func (gce *GCECloud) CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error
 // SetUrlMapForTargetHttpProxy sets the given UrlMap for the given TargetHttpProxy.
 func (gce *GCECloud) SetUrlMapForTargetHttpProxy(proxy *compute.TargetHttpProxy, urlMap *compute.UrlMap) error {
 	mc := newTargetProxyMetricContext("set_url_map")
-	op, err := gce.service.TargetHttpProxies.SetUrlMap(
-		gce.projectID, proxy.Name, &compute.UrlMapReference{UrlMap: urlMap.SelfLink}).Do()
+	uMap := compute.UrlMapReference{UrlMap: urlMap.SelfLink}
+	glog.V(4).Infof("TargetHttpProxies.SetUrlMap(%s, %s, %v): start", gce.projectID, proxy.Name, uMap)
+	op, err := gce.service.TargetHttpProxies.SetUrlMap(gce.projectID, proxy.Name, &uMap).Do()
+	glog.V(4).Infof("TargetHttpProxies.SetUrlMap(%s, %s, %v): end", gce.projectID, proxy.Name, uMap)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -57,7 +64,9 @@ func (gce *GCECloud) SetUrlMapForTargetHttpProxy(proxy *compute.TargetHttpProxy,
 // DeleteTargetHttpProxy deletes the TargetHttpProxy by name.
 func (gce *GCECloud) DeleteTargetHttpProxy(name string) error {
 	mc := newTargetProxyMetricContext("delete")
+	glog.V(4).Infof("TargetHttpProxies.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.TargetHttpProxies.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("TargetHttpProxies.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return nil
@@ -71,7 +80,9 @@ func (gce *GCECloud) DeleteTargetHttpProxy(name string) error {
 func (gce *GCECloud) ListTargetHttpProxies() (*compute.TargetHttpProxyList, error) {
 	mc := newTargetProxyMetricContext("list")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("TargetHttpProxies.List(%s): start", gce.projectID)
 	v, err := gce.service.TargetHttpProxies.List(gce.projectID).Do()
+	glog.V(4).Infof("TargetHttpProxies.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }
 
@@ -80,14 +91,18 @@ func (gce *GCECloud) ListTargetHttpProxies() (*compute.TargetHttpProxyList, erro
 // GetTargetHttpsProxy returns the UrlMap by name.
 func (gce *GCECloud) GetTargetHttpsProxy(name string) (*compute.TargetHttpsProxy, error) {
 	mc := newTargetProxyMetricContext("get")
+	glog.V(4).Infof("TargetHttpProxies.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.TargetHttpsProxies.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("TargetHttpProxies.Get(%s, %s): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
 // CreateTargetHttpsProxy creates a TargetHttpsProxy
 func (gce *GCECloud) CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) error {
 	mc := newTargetProxyMetricContext("create")
+	glog.V(4).Infof("TargetHttpProxies.Insert(%s, %v): start", gce.projectID, proxy)
 	op, err := gce.service.TargetHttpsProxies.Insert(gce.projectID, proxy).Do()
+	glog.V(4).Infof("TargetHttpProxies.Insert(%s, %v): end", gce.projectID, proxy)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -97,8 +112,10 @@ func (gce *GCECloud) CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) err
 // SetUrlMapForTargetHttpsProxy sets the given UrlMap for the given TargetHttpsProxy.
 func (gce *GCECloud) SetUrlMapForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, urlMap *compute.UrlMap) error {
 	mc := newTargetProxyMetricContext("set_url_map")
-	op, err := gce.service.TargetHttpsProxies.SetUrlMap(
-		gce.projectID, proxy.Name, &compute.UrlMapReference{UrlMap: urlMap.SelfLink}).Do()
+	uMap := compute.UrlMapReference{UrlMap: urlMap.SelfLink}
+	glog.V(4).Infof("TargetHttpProxies.SetUrlMap(%s, %s, %v): start", gce.projectID, proxy, uMap)
+	op, err := gce.service.TargetHttpsProxies.SetUrlMap(gce.projectID, proxy.Name, &uMap).Do()
+	glog.V(4).Infof("TargetHttpProxies.SetUrlMap(%s, %s, %v): end", gce.projectID, proxy, uMap)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -108,8 +125,10 @@ func (gce *GCECloud) SetUrlMapForTargetHttpsProxy(proxy *compute.TargetHttpsProx
 // SetSslCertificateForTargetHttpsProxy sets the given SslCertificate for the given TargetHttpsProxy.
 func (gce *GCECloud) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetHttpsProxy, sslCert *compute.SslCertificate) error {
 	mc := newTargetProxyMetricContext("set_ssl_cert")
-	op, err := gce.service.TargetHttpsProxies.SetSslCertificates(
-		gce.projectID, proxy.Name, &compute.TargetHttpsProxiesSetSslCertificatesRequest{SslCertificates: []string{sslCert.SelfLink}}).Do()
+	request := compute.TargetHttpsProxiesSetSslCertificatesRequest{SslCertificates: []string{sslCert.SelfLink}}
+	glog.V(4).Infof("TargetHttpProxies.SetSslCertificates(%s, %s, %v): start", gce.projectID, proxy, request)
+	op, err := gce.service.TargetHttpsProxies.SetSslCertificates(gce.projectID, proxy.Name, &request).Do()
+	glog.V(4).Infof("TargetHttpProxies.SetSslCertificates(%s, %s, %v): end", gce.projectID, proxy, request)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -119,7 +138,9 @@ func (gce *GCECloud) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetH
 // DeleteTargetHttpsProxy deletes the TargetHttpsProxy by name.
 func (gce *GCECloud) DeleteTargetHttpsProxy(name string) error {
 	mc := newTargetProxyMetricContext("delete")
+	glog.V(4).Infof("TargetHttpProxies.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.TargetHttpsProxies.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("TargetHttpProxies.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return nil
@@ -133,6 +154,8 @@ func (gce *GCECloud) DeleteTargetHttpsProxy(name string) error {
 func (gce *GCECloud) ListTargetHttpsProxies() (*compute.TargetHttpsProxyList, error) {
 	mc := newTargetProxyMetricContext("list")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("TargetHttpProxies.List(%s): start", gce.projectID)
 	v, err := gce.service.TargetHttpsProxies.List(gce.projectID).Do()
+	glog.V(4).Infof("TargetHttpProxies.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_urlmap.go
+++ b/pkg/cloudprovider/providers/gce/gce_urlmap.go
@@ -19,6 +19,7 @@ package gce
 import (
 	"net/http"
 
+	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -29,14 +30,18 @@ func newUrlMapMetricContext(request string) *metricContext {
 // GetUrlMap returns the UrlMap by name.
 func (gce *GCECloud) GetUrlMap(name string) (*compute.UrlMap, error) {
 	mc := newUrlMapMetricContext("get")
+	glog.V(4).Infof("UrlMaps.Get(%s, %s): start", gce.projectID, name)
 	v, err := gce.service.UrlMaps.Get(gce.projectID, name).Do()
+	glog.V(4).Infof("UrlMaps.Get(%s, %s): end", gce.projectID, name)
 	return v, mc.Observe(err)
 }
 
 // CreateUrlMap creates a url map
 func (gce *GCECloud) CreateUrlMap(urlMap *compute.UrlMap) error {
 	mc := newUrlMapMetricContext("create")
+	glog.V(4).Infof("UrlMaps.Insert(%s, %v): start", gce.projectID, urlMap)
 	op, err := gce.service.UrlMaps.Insert(gce.projectID, urlMap).Do()
+	glog.V(4).Infof("UrlMaps.Insert(%s, %v): end", gce.projectID, urlMap)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -46,7 +51,9 @@ func (gce *GCECloud) CreateUrlMap(urlMap *compute.UrlMap) error {
 // UpdateUrlMap applies the given UrlMap as an update
 func (gce *GCECloud) UpdateUrlMap(urlMap *compute.UrlMap) error {
 	mc := newUrlMapMetricContext("update")
+	glog.V(4).Infof("UrlMaps.Update(%s, %s, %v): start", gce.projectID, urlMap.Name, urlMap)
 	op, err := gce.service.UrlMaps.Update(gce.projectID, urlMap.Name, urlMap).Do()
+	glog.V(4).Infof("UrlMaps.Update(%s, %s, %v): end", gce.projectID, urlMap.Name, urlMap)
 	if err != nil {
 		return mc.Observe(err)
 	}
@@ -56,7 +63,9 @@ func (gce *GCECloud) UpdateUrlMap(urlMap *compute.UrlMap) error {
 // DeleteUrlMap deletes a url map by name.
 func (gce *GCECloud) DeleteUrlMap(name string) error {
 	mc := newUrlMapMetricContext("delete")
+	glog.V(4).Infof("UrlMaps.Delete(%s, %s): start", gce.projectID, name)
 	op, err := gce.service.UrlMaps.Delete(gce.projectID, name).Do()
+	glog.V(4).Infof("UrlMaps.Delete(%s, %s): end", gce.projectID, name)
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusNotFound) {
 			return nil
@@ -70,6 +79,8 @@ func (gce *GCECloud) DeleteUrlMap(name string) error {
 func (gce *GCECloud) ListUrlMaps() (*compute.UrlMapList, error) {
 	mc := newUrlMapMetricContext("list")
 	// TODO: use PageToken to list all not just the first 500
+	glog.V(4).Infof("UrlMaps.List(%s): start", gce.projectID)
 	v, err := gce.service.UrlMaps.List(gce.projectID).Do()
+	glog.V(4).Infof("UrlMaps.List(%s): end", gce.projectID)
 	return v, mc.Observe(err)
 }

--- a/pkg/cloudprovider/providers/gce/gce_zones.go
+++ b/pkg/cloudprovider/providers/gce/gce_zones.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
 	compute "google.golang.org/api/compute/v1"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -73,7 +74,9 @@ func (gce *GCECloud) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Z
 func (gce *GCECloud) ListZonesInRegion(region string) ([]*compute.Zone, error) {
 	mc := newZonesMetricContext("list", region)
 	filter := fmt.Sprintf("region eq %v", gce.getRegionLink(region))
+	glog.V(4).Infof("Zones.List(%s): start", gce.projectID)
 	list, err := gce.service.Zones.List(gce.projectID).Filter(filter).Do()
+	glog.V(4).Infof("Zones.List(%s): end", gce.projectID)
 	if err != nil {
 		return nil, mc.Observe(err)
 	}


### PR DESCRIPTION
Additionally logging of when GCE API calls start and end to help diagnose problems with kubelet on cloud provider nodes not reporting node status periodically.  There's some inconsistency in logging around this PR we should discuss.

IMO, the API logging should be at a higher level than most other types of logging as you would probably only want it in limited instances.  For most cases that is easy enough to do, but there are some calls which have some logging around them already, namely in the instance groups.  My preference would be to keep the existing logging as it and just add the new API logs around the API call.

@saad-ali @jingxu97 