### PR TITLE
disable GC for custom resources

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
@@ -105,11 +105,13 @@ func (o CustomResourceDefinitionsServerOptions) Config() (*apiserver.Config, err
 
 func NewCRDRESTOptionsGetter(etcdOptions genericoptions.EtcdOptions) genericregistry.RESTOptionsGetter {
 	ret := apiserver.CRDRESTOptionsGetter{
-		StorageConfig:           etcdOptions.StorageConfig,
-		StoragePrefix:           etcdOptions.StorageConfig.Prefix,
-		EnableWatchCache:        etcdOptions.EnableWatchCache,
-		DefaultWatchCacheSize:   etcdOptions.DefaultWatchCacheSize,
-		EnableGarbageCollection: etcdOptions.EnableGarbageCollection,
+		StorageConfig:         etcdOptions.StorageConfig,
+		StoragePrefix:         etcdOptions.StorageConfig.Prefix,
+		EnableWatchCache:      etcdOptions.EnableWatchCache,
+		DefaultWatchCacheSize: etcdOptions.DefaultWatchCacheSize,
+		// garbage collection for custom resources is forced off until GC works with CRs.
+		// When GC is enabled, this turns back into etcdOptions.EnableGarbageCollection
+		EnableGarbageCollection: false,
 		DeleteCollectionWorkers: etcdOptions.DeleteCollectionWorkers,
 	}
 	ret.StorageConfig.Codec = unstructured.UnstructuredJSONScheme


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/issues/47431

This prevents GC on CustomResources so you don't get an uncleared finalizer that prevents deletion