### PR TITLE
Ignore 404s on evict

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -496,7 +496,7 @@ func (o *DrainOptions) evictPods(pods []api.Pod, policyGroupVersion string, getP
 					break
 				} else if apierrors.IsTooManyRequests(err) {
 					time.Sleep(5 * time.Second)
-				} else {
+				} else if !apierrors.IsNotFound(err) {
 					errCh <- fmt.Errorf("error when evicting pod %q: %v", pod.Name, err)
 					return
 				}


### PR DESCRIPTION
One of our upgrades failed with 
```
error: error when evicting pod \"boo-2-deploy\": pods \"boo-2-deploy\" not found"
```

@derekwaynecarr since you already fixed half of it 

cc: @kubernetes/sig-cli-bugs 

I failed terribly at adding a unit test mostly because draining involves discovery for the eviction API and the fake client stuff for discovery are far from functional - will spawn a separate issue about it.

fyi @jupierce

related: https://github.com/kubernetes/kubectl/issues/28