### PR TITLE
Refresh cluster-proportional-autoscaler, fluentd-gcp, kube-addon-manager, and kube-dns addons

### DIFF
--- a/cluster/addons/addon-manager/CHANGELOG.md
+++ b/cluster/addons/addon-manager/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 6.4-beta.2  (Mon June 12 2017 Jeff Grafton <jgrafton@google.com>)
+ - Update kubectl to v1.6.4.
+ - Refresh base images.
+
 ### Version 6.4-beta.1  (Wed March 8 2017 Zihong Zheng <zihongz@google.com>)
  - Create EnsureExists class addons before Reconcile class addons.
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v6.4-beta.1
-KUBECTL_VERSION?=v1.6.0-beta.2
+VERSION=v6.4-beta.2
+KUBECTL_VERSION?=v1.6.4
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=bashell/alpine-bash

--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1-r2
+        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.1-r3
         resources:
             requests:
                 cpu: "20m"

--- a/cluster/addons/dns/kubedns-controller.yaml.base
+++ b/cluster/addons/dns/kubedns-controller.yaml.base
@@ -55,7 +55,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -107,7 +107,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kubedns-controller.yaml.in
+++ b/cluster/addons/dns/kubedns-controller.yaml.in
@@ -55,7 +55,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -107,7 +107,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kubedns-controller.yaml.sed
+++ b/cluster/addons/dns/kubedns-controller.yaml.sed
@@ -55,7 +55,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.4
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -106,7 +106,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.4
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -144,7 +144,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.4
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -26,7 +26,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.5
+        image: gcr.io/google-containers/fluentd-gcp:2.0.7
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
         # tries to send this message to the server => fails to send a chunk and so on.

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -13,7 +13,7 @@ spec:
     # - cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
     # - cluster/images/hyperkube/static-pods/addon-manager-multinode.json
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: gcr.io/google-containers/kube-addon-manager:v6.4-beta.1
+    image: gcr.io/google-containers/kube-addon-manager:v6.4-beta.2
     command:
     - /bin/bash
     - -c

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -89,7 +89,7 @@ spec:
           name: kube-proxy
 `
 
-	KubeDNSVersion = "1.14.2"
+	KubeDNSVersion = "1.14.4"
 
 	KubeDNSDeployment = `
 

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v6.4-alpha.3
+    image: {{kube_docker_registry}}/kube-addon-manager:v6.4-beta.2
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
**What this PR does / why we need it**: refreshes a number of addons with new base images:
* gcr.io/google-containers/cluster-proportional-autoscaler-amd64:1.1.1-r3 (rebuilt at 1.1.1)
* gcr.io/google-containers/fluentd-gcp:2.0.7 (https://github.com/kubernetes/contrib/pull/2633, https://github.com/kubernetes/contrib/pull/2640)
* gcr.io/google-containers/kube-addon-manager:v6.4-beta.2 (cherry-pick from #47389)
* gcr.io/google-containers/k8s-dns-*:1.14.4 (https://github.com/kubernetes/dns/pull/107, https://github.com/kubernetes/dns/pull/108, https://github.com/kubernetes/dns/pull/114, https://github.com/kubernetes/dns/pull/115)

These include upstream fixes to base images with fixes for the following CVEs:
* CVE-2016-9841
* CVE-2016-9843
* CVE-2017-2616
* CVE-2017-6512

Note: I did **not** update the fluentd-gcp version in `cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml`, which is currently 2.0.2. While there should be no functional changes 2.0.5 -> 2.0.7, I don't know about 2.0.2 -> 2.0.7. If we think this is safe, I can update that one too; otherwise, we may need to build a 2.0.2-r2 image.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update cluster-proportional-autoscaler, fluentd-gcp, and kube-addon-manager, and kube-dns addons with refreshed base images containing fixes for CVE-2016-9841, CVE-2016-9843, CVE-2017-2616, and CVE-2017-6512.
```
/release-note
/assign @timstclair @enisoc 
/cc @MrHohn @crassirostris 