### PR TITLE
Add validation for overlapping mountpoints

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1925,6 +1925,17 @@ func ValidateVolumeMounts(mounts []api.VolumeMount, volumes sets.String, contain
 		if !path.IsAbs(mnt.MountPath) {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("mountPath"), mnt.MountPath, "must be an absolute path"))
 		}
+		for _, apath := range mountpoints.List() {
+			rel, err := filepath.Rel(mnt.MountPath, apath)
+			if err != nil {
+				// returns error if target path can't be made relative to basepath, which means no conflict
+				continue
+			}
+			if !strings.Contains(rel, "../") {
+				errorString := fmt.Sprintf("conflicts with volumeMount:'%v', volumeMounts may not overlap one another", apath)
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("mountPath"), mnt.MountPath, errorString))
+			}
+		}
 		mountpoints.Insert(mnt.MountPath)
 		if len(mnt.SubPath) > 0 {
 			allErrs = append(allErrs, validateLocalDescendingPath(mnt.SubPath, fldPath.Child("subPath"))...)

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -3662,6 +3662,7 @@ func TestValidateVolumeMounts(t *testing.T) {
 		"subpath contains ..":                    {{Name: "abc", MountPath: "/bar", SubPath: "baz/../bat"}},
 		"subpath ends in ..":                     {{Name: "abc", MountPath: "/bar", SubPath: "./.."}},
 		"disabled MountPropagation feature gate": {{Name: "abc", MountPath: "/bar", MountPropagation: &propagation}},
+		"subpath conflict":                       {{Name: "abc", MountPath: "/levelone"}, {Name: "123", MountPath: "/levelone/leveltwo"}},
 	}
 	for k, v := range errorCases {
 		if errs := ValidateVolumeMounts(v, volumes, &container, field.NewPath("field")); len(errs) == 0 {


### PR DESCRIPTION
Currently when using overlapping paths, only one of the paths end up in the
container. Instead of letting the container start in this state, provide an
error message with the disallowed overlapping paths.

Release note:
```release-note
Add validation for overlapping mount points so that a container won't start with not all of the volumes present in the container.
```