### PR TITLE
Standardize on home/kubernetes/bin for CNI

### DIFF
--- a/cluster/saltbase/salt/cni/init.sls
+++ b/cluster/saltbase/salt/cni/init.sls
@@ -1,4 +1,4 @@
-/opt/cni:
+/home/kubernetes:
   file.directory:
     - user: root
     - group: root
@@ -17,21 +17,21 @@ cni-tar:
   archive:
     - extracted
     - user: root
-    - name: /opt/cni
+    - name: /home/kubernetes
     - makedirs: True
     - source: https://storage.googleapis.com/kubernetes-release/network-plugins/cni-0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff.tar.gz
     - tar_options: v
     - source_hash: md5=afbb526e7d976f98353ac96f73043031
     - archive_format: tar
-    - if_missing: /opt/cni/bin
+    - if_missing: /home/kubernetes/bin
 
 {% if grains['cloud'] is defined and grains.cloud in [ 'vagrant' ]  %}
 # Install local CNI network plugins in a Vagrant environment
 cmd-local-cni-plugins:
    cmd.run:
       - name: |
-         cp -v /vagrant/cluster/network-plugins/cni/bin/* /opt/cni/bin/.
-         chmod +x /opt/cni/bin/*
+         cp -v /vagrant/cluster/network-plugins/cni/bin/* /home/kubernetes/bin/.
+         chmod +x /home/kubernetes/bin/*
 cmd-local-cni-config:
    cmd.run:
       - name: |

--- a/cluster/saltbase/salt/kubelet/default
+++ b/cluster/saltbase/salt/kubelet/default
@@ -135,11 +135,11 @@
 {% if pillar.get('network_provider', '').lower() == 'opencontrail' %}
   {% set network_plugin = "--network-plugin=opencontrail" %}
 {% elif pillar.get('network_provider', '').lower() == 'cni' %}
-  {% set network_plugin = "--network-plugin=cni --cni-bin-dir=/etc/cni/net.d/" %}
-{%elif pillar.get('network_policy_provider', '').lower() == 'calico' and grains['roles'][0] != 'kubernetes-master' -%}
+  {% set network_plugin = "--network-plugin=cni --cni-conf-dir=/etc/cni/net.d/ --cni-bin-dir=/home/kubernetes/bin/" %}
+{% elif pillar.get('network_policy_provider', '').lower() == 'calico' and grains['roles'][0] != 'kubernetes-master' %}
   {% set network_plugin = "--network-plugin=cni --cni-conf-dir=/etc/cni/net.d/ --cni-bin-dir=/home/kubernetes/bin/" %}
 {% elif pillar.get('network_provider', '').lower() == 'kubenet' %}
-  {% set network_plugin = "--network-plugin=kubenet" -%}
+  {% set network_plugin = "--network-plugin=kubenet --network-plugin-dir=/home/kubernetes/bin/" -%}
 {% endif -%}
 
 # Don't pipe the --hairpin-mode flag by default. This allows the kubelet to pick


### PR DESCRIPTION

**What this PR does / why we need it**:

Standardizes where CNI plugins get installed on GCE.

**Which issue this PR fixes** 

Fixes: https://github.com/kubernetes/kubernetes/issues/47453

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
