### PR TITLE
deprecate created-by annotation for pod drain

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -84,6 +84,7 @@ go_library(
         "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion:go_default_library",
         "//pkg/client/unversioned:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd/auth:go_default_library",
         "//pkg/kubectl/cmd/config:go_default_library",

--- a/pkg/kubectl/cmd/drain_test.go
+++ b/pkg/kubectl/cmd/drain_test.go
@@ -58,6 +58,8 @@ const (
 var node *api.Node
 var cordoned_node *api.Node
 
+func boolptr(b bool) *bool { return &b }
+
 func TestMain(m *testing.M) {
 	// Create a node.
 	node = &api.Node{
@@ -244,7 +246,18 @@ func TestDrain(t *testing.T) {
 			Namespace:         "default",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
 			Labels:            labels,
+			SelfLink:          testapi.Default.SelfLink("pods", "bar"),
 			Annotations:       rc_anno,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "ReplicationController",
+					Name:               "rc",
+					UID:                "123",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: api.PodSpec{
 			NodeName: "node",
@@ -256,7 +269,7 @@ func TestDrain(t *testing.T) {
 			Name:              "ds",
 			Namespace:         "default",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
-			SelfLink:          "/apis/extensions/v1beta1/namespaces/default/daemonsets/ds",
+			SelfLink:          testapi.Default.SelfLink("daemonsets", "ds"),
 		},
 		Spec: extensions.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -272,7 +285,17 @@ func TestDrain(t *testing.T) {
 			Namespace:         "default",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
 			Labels:            labels,
+			SelfLink:          testapi.Default.SelfLink("pods", "bar"),
 			Annotations:       ds_anno,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "extensions/v1beta1",
+					Kind:               "DaemonSet",
+					Name:               "ds",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: api.PodSpec{
 			NodeName: "node",
@@ -284,7 +307,7 @@ func TestDrain(t *testing.T) {
 			Name:              "missing-ds",
 			Namespace:         "default",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
-			SelfLink:          "/apis/extensions/v1beta1/namespaces/default/daemonsets/missing-ds",
+			SelfLink:          testapi.Default.SelfLink("daemonsets", "missing-ds"),
 		},
 		Spec: extensions.DaemonSetSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -300,7 +323,17 @@ func TestDrain(t *testing.T) {
 			Namespace:         "default",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
 			Labels:            labels,
+			SelfLink:          testapi.Default.SelfLink("pods", "bar"),
 			Annotations:       missing_ds_anno,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "extensions/v1beta1",
+					Kind:               "DaemonSet",
+					Name:               "missing-ds",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: api.PodSpec{
 			NodeName: "node",
@@ -312,7 +345,7 @@ func TestDrain(t *testing.T) {
 			Name:              "job",
 			Namespace:         "default",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
-			SelfLink:          "/apis/batch/v1/namespaces/default/jobs/job",
+			SelfLink:          testapi.Default.SelfLink("jobs", "job"),
 		},
 		Spec: batch.JobSpec{
 			Selector: &metav1.LabelSelector{MatchLabels: labels},
@@ -325,7 +358,17 @@ func TestDrain(t *testing.T) {
 			Namespace:         "default",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
 			Labels:            labels,
+			SelfLink:          testapi.Default.SelfLink("pods", "bar"),
 			Annotations:       map[string]string{api.CreatedByAnnotation: refJson(t, &job)},
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "Job",
+					Name:               "job",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 	}
 
@@ -351,7 +394,17 @@ func TestDrain(t *testing.T) {
 			Namespace:         "default",
 			CreationTimestamp: metav1.Time{Time: time.Now()},
 			Labels:            labels,
+			SelfLink:          testapi.Default.SelfLink("pods", "bar"),
 			Annotations:       rs_anno,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion:         "v1",
+					Kind:               "ReplicaSet",
+					Name:               "rs",
+					BlockOwnerDeletion: boolptr(true),
+					Controller:         boolptr(true),
+				},
+			},
 		},
 		Spec: api.PodSpec{
 			NodeName: "node",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This PR deprecates created-by annotation for pod drain. This is required as we now have ControllerRef.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: xref #44407

**Special notes for your reviewer**: This is the second PR for deprecating created-by annotation. Other PRs can be found here: https://github.com/kubernetes/kubernetes/pull/47469 , #47475 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
