### PR TITLE
Don't test the debug /logs endpoint on GKE.

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -59,11 +59,13 @@ var _ = framework.KubeDescribe("Networking", func() {
 			{path: "/healthz"},
 			{path: "/api"},
 			{path: "/apis"},
-			{path: "/logs"},
 			{path: "/metrics"},
 			{path: "/swaggerapi"},
 			{path: "/version"},
 			// TODO: test proxy links here
+		}
+		if !framework.ProviderIs("gke") {
+			tests = append(tests, struct{ path string }{path: "/logs"})
 		}
 		for _, test := range tests {
 			By(fmt.Sprintf("testing: %s", test.path))


### PR DESCRIPTION
GKE will not enable the /logs endpoint in 1.7. I'd like this test to still test the other cluster level endpoints.