### PR TITLE
Allow UDP for kubectl create service.

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -228,6 +228,28 @@ func NameFromCommandArgs(cmd *cobra.Command, args []string) (string, error) {
 	return args[0], nil
 }
 
+// PortsFromCommandArgs is a function to gather ports config from args. It supports deprecating "--tcp" arg.
+func PortsFromCommandArgs(cmd *cobra.Command) ([]string, error) {
+	var (
+		ports []string
+		err error
+	)
+	if ports = cmdutil.GetFlagStringSlice(cmd, "ports"); len(ports) == 0 {
+		ports = cmdutil.GetFlagStringSlice(cmd, "tcp")
+		if len(ports) == 0 {
+			err = cmdutil.UsageError(cmd, "PORTS or TCP is required")
+		} else {
+			// Use "tcp:" prefix
+			var temp []string
+			for _, item := range ports {
+				temp = append(temp, "tcp:" + item)
+			}
+			ports = temp
+		}
+	}
+	return ports, err
+}
+
 // CreateSubcommandOptions is an options struct to support create subcommands
 type CreateSubcommandOptions struct {
 	// Name of resource being created

--- a/pkg/kubectl/cmd/create_service.go
+++ b/pkg/kubectl/cmd/create_service.go
@@ -59,6 +59,8 @@ var (
 )
 
 func addPortFlags(cmd *cobra.Command) {
+	cmd.Flags().StringSlice("tcp", []string{}, "Port pairs can be specified as '<port>:<targetPort>'.")
+	cmd.Flags().MarkDeprecated("tcp", "It will be removed in the future, please use --ports instead")
 	cmd.Flags().StringSlice("ports", []string{}, "Protocol and port pairs can be specified as '<protocol>:<port>:<targetPort>'.")
 }
 
@@ -92,9 +94,13 @@ func CreateServiceClusterIP(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Comm
 	var generator kubectl.StructuredGenerator
 	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
 	case cmdutil.ServiceClusterIPGeneratorV1Name:
+		ports, err := PortsFromCommandArgs(cmd)
+		if err != nil {
+			return err
+		}
 		generator = &kubectl.ServiceCommonGeneratorV1{
 			Name:      name,
-			Ports:     cmdutil.GetFlagStringSlice(cmd, "ports"),
+			Ports:     ports,
 			Type:      api.ServiceTypeClusterIP,
 			ClusterIP: cmdutil.GetFlagString(cmd, "clusterip"),
 		}
@@ -148,9 +154,13 @@ func CreateServiceNodePort(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Comma
 	var generator kubectl.StructuredGenerator
 	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
 	case cmdutil.ServiceNodePortGeneratorV1Name:
+		ports, err := PortsFromCommandArgs(cmd)
+		if err != nil {
+			return err
+		}
 		generator = &kubectl.ServiceCommonGeneratorV1{
 			Name:      name,
-			Ports:     cmdutil.GetFlagStringSlice(cmd, "ports"),
+			Ports:     ports,
 			Type:      api.ServiceTypeNodePort,
 			ClusterIP: "",
 			NodePort:  cmdutil.GetFlagInt(cmd, "node-port"),
@@ -204,9 +214,13 @@ func CreateServiceLoadBalancer(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.C
 	var generator kubectl.StructuredGenerator
 	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
 	case cmdutil.ServiceLoadBalancerGeneratorV1Name:
+		ports, err := PortsFromCommandArgs(cmd)
+		if err != nil {
+			return err
+		}
 		generator = &kubectl.ServiceCommonGeneratorV1{
 			Name:      name,
-			Ports:     cmdutil.GetFlagStringSlice(cmd, "ports"),
+			Ports:     ports,
 			Type:      api.ServiceTypeLoadBalancer,
 			ClusterIP: "",
 		}

--- a/pkg/kubectl/cmd/create_service.go
+++ b/pkg/kubectl/cmd/create_service.go
@@ -52,20 +52,20 @@ var (
 
 	serviceClusterIPExample = templates.Examples(i18n.T(`
     # Create a new clusterIP service named my-cs
-    kubectl create service clusterip my-cs --tcp=5678:8080
+    kubectl create service clusterip my-cs --ports=tcp:5678:8080
 
     # Create a new clusterIP service named my-cs (in headless mode)
     kubectl create service clusterip my-cs --clusterip="None"`))
 )
 
 func addPortFlags(cmd *cobra.Command) {
-	cmd.Flags().StringSlice("tcp", []string{}, "Port pairs can be specified as '<port>:<targetPort>'.")
+	cmd.Flags().StringSlice("ports", []string{}, "Protocol and port pairs can be specified as '<protocol>:<port>:<targetPort>'.")
 }
 
 // NewCmdCreateServiceClusterIP is a command to create a clusterIP service
 func NewCmdCreateServiceClusterIP(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run]",
+		Use:     "clusterip NAME [--ports=<protocol>:<port>:<targetPort>] [--dry-run]",
 		Short:   i18n.T("Create a clusterIP service."),
 		Long:    serviceClusterIPLong,
 		Example: serviceClusterIPExample,
@@ -94,7 +94,7 @@ func CreateServiceClusterIP(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Comm
 	case cmdutil.ServiceClusterIPGeneratorV1Name:
 		generator = &kubectl.ServiceCommonGeneratorV1{
 			Name:      name,
-			TCP:       cmdutil.GetFlagStringSlice(cmd, "tcp"),
+			Ports:     cmdutil.GetFlagStringSlice(cmd, "ports"),
 			Type:      api.ServiceTypeClusterIP,
 			ClusterIP: cmdutil.GetFlagString(cmd, "clusterip"),
 		}
@@ -115,13 +115,13 @@ var (
 
 	serviceNodePortExample = templates.Examples(i18n.T(`
     # Create a new nodeport service named my-ns
-    kubectl create service nodeport my-ns --tcp=5678:8080`))
+    kubectl create service nodeport my-ns --ports=tcp:5678:8080`))
 )
 
 // NewCmdCreateServiceNodePort is a macro command for creating a NodePort service
 func NewCmdCreateServiceNodePort(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "nodeport NAME [--tcp=port:targetPort] [--dry-run]",
+		Use:     "nodeport NAME [--ports=protocol:port:targetPort] [--dry-run]",
 		Short:   i18n.T("Create a NodePort service."),
 		Long:    serviceNodePortLong,
 		Example: serviceNodePortExample,
@@ -150,7 +150,7 @@ func CreateServiceNodePort(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Comma
 	case cmdutil.ServiceNodePortGeneratorV1Name:
 		generator = &kubectl.ServiceCommonGeneratorV1{
 			Name:      name,
-			TCP:       cmdutil.GetFlagStringSlice(cmd, "tcp"),
+			Ports:     cmdutil.GetFlagStringSlice(cmd, "ports"),
 			Type:      api.ServiceTypeNodePort,
 			ClusterIP: "",
 			NodePort:  cmdutil.GetFlagInt(cmd, "node-port"),
@@ -172,13 +172,13 @@ var (
 
 	serviceLoadBalancerExample = templates.Examples(i18n.T(`
     # Create a new LoadBalancer service named my-lbs
-    kubectl create service loadbalancer my-lbs --tcp=5678:8080`))
+    kubectl create service loadbalancer my-lbs --ports=tcp:5678:8080`))
 )
 
 // NewCmdCreateServiceLoadBalancer is a macro command for creating a LoadBalancer service
 func NewCmdCreateServiceLoadBalancer(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "loadbalancer NAME [--tcp=port:targetPort] [--dry-run]",
+		Use:     "loadbalancer NAME [--ports=protocol:port:targetPort] [--dry-run]",
 		Short:   i18n.T("Create a LoadBalancer service."),
 		Long:    serviceLoadBalancerLong,
 		Example: serviceLoadBalancerExample,
@@ -206,7 +206,7 @@ func CreateServiceLoadBalancer(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.C
 	case cmdutil.ServiceLoadBalancerGeneratorV1Name:
 		generator = &kubectl.ServiceCommonGeneratorV1{
 			Name:      name,
-			TCP:       cmdutil.GetFlagStringSlice(cmd, "tcp"),
+			Ports:     cmdutil.GetFlagStringSlice(cmd, "ports"),
 			Type:      api.ServiceTypeLoadBalancer,
 			ClusterIP: "",
 		}

--- a/pkg/kubectl/cmd/create_service_test.go
+++ b/pkg/kubectl/cmd/create_service_test.go
@@ -26,63 +26,123 @@ import (
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
-func TestCreateService(t *testing.T) {
-	service := &api.Service{}
-	service.Name = "my-service"
-	f, tf, codec, negSer := cmdtesting.NewAPIFactory()
-	tf.Printer = &testPrinter{}
-	tf.Client = &fake.RESTClient{
-		APIRegistry:          api.Registry,
-		NegotiatedSerializer: negSer,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == "POST":
-				return &http.Response{StatusCode: 201, Header: defaultHeader(), Body: objBody(codec, service)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-				return nil, nil
-			}
-		}),
-	}
-	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdCreateServiceClusterIP(f, buf)
-	cmd.Flags().Set("output", "name")
-	cmd.Flags().Set("ports", "tcp:8080:8000")
-	cmd.Run(cmd, []string{service.Name})
-	expectedOutput := "service/" + service.Name + "\n"
-	if buf.String() != expectedOutput {
-		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
+var tests = []struct {
+	name           string
+	flag           string
+	value	string
+	expected       string
+	expectErr      bool
+}{
+	{
+		name: "portsTCP",
+		flag: "ports",
+		value: "tcp:8080:8000",
+		expected: "service/portsTCP"+"\n",
+		expectErr: false,
+	},
+	{
+		name: "portsUDP",
+		flag: "ports",
+		value: "udp:8080:8000",
+		expected: "service/portsUDP"+"\n",
+		expectErr: false,
+	},
+	{
+		name: "deprecatedTCP",
+		flag: "tcp",
+		value: "8080:8000",
+		expected: "service/deprecatedTCP"+"\n",
+		expectErr: false,
+	},
+	{
+		name: "mismatching-name",
+		flag: "tcp",
+		value: "8080:8000",
+		expected: "service/mismatching"+"\n",
+		expectErr: true,
+	},
+	{
+		name: "invalid-protocol",
+		flag: "ports",
+		value: "x25:8080:8000",
+		expected: "service/invalid-protocol"+"\n",
+		expectErr: true,
+	},
+}
+
+func TestCreateService(t *testing.T, ) {
+	for index, test := range tests {
+		service := &api.Service{}
+		service.Name = test.name
+		f, tf, codec, negSer := cmdtesting.NewAPIFactory()
+		tf.Printer = &testPrinter{}
+		tf.Client = &fake.RESTClient{
+			APIRegistry:          api.Registry,
+			NegotiatedSerializer: negSer,
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				switch p, m := req.URL.Path, req.Method; {
+				case p == "/namespaces/test/services" && m == "POST":
+					return &http.Response{StatusCode: 201, Header: defaultHeader(), Body: objBody(codec, service)}, nil
+				default:
+					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					return nil, nil
+				}
+			}),
+		}
+		tf.Namespace = "test"
+		buf := bytes.NewBuffer([]byte{})
+		cmd := NewCmdCreateServiceClusterIP(f, buf)
+		cmd.Flags().Set("output", "name")
+		cmd.Flags().Set(test.flag, test.value)
+		cmd.Run(cmd, []string{service.Name})
+		testPass := buf.String() == test.expected
+		if test.expectErr && !testPass {
+			continue
+		}
+		if test.expectErr && testPass {
+			t.Errorf("testdata index: %d, this test must fail but it passed", index)
+		}
+		if !testPass {
+			t.Errorf("testdata index: %d, expected output: %s, but got: %s", index, test.expected, buf.String())
+		}
 	}
 }
 
 func TestCreateServiceNodePort(t *testing.T) {
-	service := &api.Service{}
-	service.Name = "my-node-port-service"
-	f, tf, codec, negSer := cmdtesting.NewAPIFactory()
-	tf.Printer = &testPrinter{}
-	tf.Client = &fake.RESTClient{
-		APIRegistry:          api.Registry,
-		NegotiatedSerializer: negSer,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == http.MethodPost:
-				return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, service)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-				return nil, nil
-			}
-		}),
-	}
-	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdCreateServiceNodePort(f, buf)
-	cmd.Flags().Set("output", "name")
-	cmd.Flags().Set("ports", "tcp:30000:8000")
-	cmd.Run(cmd, []string{service.Name})
-	expectedOutput := "service/" + service.Name + "\n"
-	if buf.String() != expectedOutput {
-		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
+	for index, test := range tests {
+		service := &api.Service{}
+		service.Name = test.name
+		f, tf, codec, negSer := cmdtesting.NewAPIFactory()
+		tf.Printer = &testPrinter{}
+		tf.Client = &fake.RESTClient{
+			APIRegistry:          api.Registry,
+			NegotiatedSerializer: negSer,
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				switch p, m := req.URL.Path, req.Method; {
+				case p == "/namespaces/test/services" && m == http.MethodPost:
+					return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, service)}, nil
+				default:
+					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					return nil, nil
+				}
+			}),
+		}
+		tf.Namespace = "test"
+		buf := bytes.NewBuffer([]byte{})
+		cmd := NewCmdCreateServiceNodePort(f, buf)
+		cmd.Flags().Set("output", "name")
+		cmd.Flags().Set(test.flag, test.value)
+		cmd.Run(cmd, []string{service.Name})
+		testPass := buf.String() == test.expected
+		if test.expectErr && !testPass {
+			continue
+		}
+		if test.expectErr && testPass {
+			t.Errorf("testdata index: %d, this test must fail but it passed", index)
+		}
+		if !testPass {
+			t.Errorf("testdata index: %d, expected output: %s, but got: %s", index, test.expected, buf.String())
+		}
 	}
 }
 

--- a/pkg/kubectl/cmd/create_service_test.go
+++ b/pkg/kubectl/cmd/create_service_test.go
@@ -48,7 +48,7 @@ func TestCreateService(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdCreateServiceClusterIP(f, buf)
 	cmd.Flags().Set("output", "name")
-	cmd.Flags().Set("tcp", "8080:8000")
+	cmd.Flags().Set("ports", "tcp:8080:8000")
 	cmd.Run(cmd, []string{service.Name})
 	expectedOutput := "service/" + service.Name + "\n"
 	if buf.String() != expectedOutput {
@@ -78,7 +78,7 @@ func TestCreateServiceNodePort(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	cmd := NewCmdCreateServiceNodePort(f, buf)
 	cmd.Flags().Set("output", "name")
-	cmd.Flags().Set("tcp", "30000:8000")
+	cmd.Flags().Set("ports", "tcp:30000:8000")
 	cmd.Run(cmd, []string{service.Name})
 	expectedOutput := "service/" + service.Name + "\n"
 	if buf.String() != expectedOutput {

--- a/pkg/kubectl/service_basic_test.go
+++ b/pkg/kubectl/service_basic_test.go
@@ -29,14 +29,14 @@ func TestServiceBasicGenerate(t *testing.T) {
 	tests := []struct {
 		name        string
 		serviceType api.ServiceType
-		tcp         []string
+		ports       []string
 		clusterip   string
 		expected    *api.Service
 		expectErr   bool
 	}{
 		{
 			name:        "clusterip-ok",
-			tcp:         []string{"456", "321:908"},
+			ports:       []string{"tcp:456", "tcp:321:908"},
 			clusterip:   "",
 			serviceType: api.ServiceTypeClusterIP,
 			expected: &api.Service{
@@ -59,21 +59,21 @@ func TestServiceBasicGenerate(t *testing.T) {
 		},
 		{
 			name:        "clusterip-none and port mapping",
-			tcp:         []string{"456:9898"},
+			ports:       []string{"tcp:456:9898"},
 			clusterip:   "None",
 			serviceType: api.ServiceTypeClusterIP,
 			expectErr:   true,
 		},
 		{
 			name:        "clusterip-none-wrong-type",
-			tcp:         []string{},
+			ports:       []string{},
 			clusterip:   "None",
 			serviceType: api.ServiceTypeNodePort,
 			expectErr:   true,
 		},
 		{
 			name:        "clusterip-none-ok",
-			tcp:         []string{},
+			ports:       []string{},
 			clusterip:   "None",
 			serviceType: api.ServiceTypeClusterIP,
 			expected: &api.Service{
@@ -90,7 +90,7 @@ func TestServiceBasicGenerate(t *testing.T) {
 		},
 		{
 			name:        "loadbalancer-ok",
-			tcp:         []string{"456:9898"},
+			ports:       []string{"tcp:456:9898"},
 			clusterip:   "",
 			serviceType: api.ServiceTypeLoadBalancer,
 			expected: &api.Service{
@@ -112,7 +112,7 @@ func TestServiceBasicGenerate(t *testing.T) {
 	for _, test := range tests {
 		generator := ServiceCommonGeneratorV1{
 			Name:      test.name,
-			TCP:       test.tcp,
+			Ports:     test.ports,
 			Type:      test.serviceType,
 			ClusterIP: test.clusterip,
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
TCP is hardcoded in 'kubectl create service' however UDP should be supported too.
**Which issue this PR fixes**: 
fixes #47337

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```