### PR TITLE
Automated cherry pick of #47468

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.9.3
+  name: l7-lb-controller-v0.9.4
   namespace: kube-system
   labels:
     k8s-app: glbc
-    version: v0.9.3
+    version: v0.9.4
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/glbc:0.9.3
+  - image: gcr.io/google_containers/glbc:0.9.4
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Cherry pick of #47468 on release-1.6.

#47468: Bump GLBC version to 0.9.4
**Release note**:
```release-note
Bump GLBC version to 0.9.4
```