### PR TITLE
es discovery support args apiserver-host and kubeconfig

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/es-image/run.sh
@@ -23,7 +23,7 @@ export HTTP_PORT=${HTTP_PORT:-9200}
 export TRANSPORT_PORT=${TRANSPORT_PORT:-9300}
 export MINIMUM_MASTER_NODES=${MINIMUM_MASTER_NODES:-2}
 
-/elasticsearch_logging_discovery >> /elasticsearch/config/elasticsearch.yml
+/elasticsearch_logging_discovery $* >> /elasticsearch/config/elasticsearch.yml
 
 chown -R elasticsearch:elasticsearch /data
 

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export API_HOST=$(ip route get 8.8.8.8 | awk 'NR==1 {print $NF}')
+export API_HOST_IP=$(ip route get 8.8.8.8 | awk 'NR==1 {print $NF}')
+export PATH=/home/yqguo/project/src/k8s.io/kubernetes/third_party/etcd:${PATH}
+export KUBE_ENABLE_CLUSTER_DNS=true
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 # This command builds and runs a local kubernetes cluster.

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -14,11 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export API_HOST=$(ip route get 8.8.8.8 | awk 'NR==1 {print $NF}')
-export API_HOST_IP=$(ip route get 8.8.8.8 | awk 'NR==1 {print $NF}')
-export PATH=/home/yqguo/project/src/k8s.io/kubernetes/third_party/etcd:${PATH}
-export KUBE_ENABLE_CLUSTER_DNS=true
-
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 # This command builds and runs a local kubernetes cluster.


### PR DESCRIPTION
Now discovery elasticsearch through kubernetes client,but now does not support specifying the apiserver-host or kubeconfig create client.