### PR TITLE
Make the storage-backend flag mandatory

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -60,6 +60,7 @@ kube::log::status "Starting kube-apiserver"
   --insecure-bind-address="${API_HOST}" \
   --bind-address="${API_HOST}" \
   --insecure-port="${API_PORT}" \
+  --storage-backend=etcd3 \
   --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --advertise-address="10.10.10.10" \
   --cert-dir="${TMP_DIR}/certs" \

--- a/hack/update-swagger-spec.sh
+++ b/hack/update-swagger-spec.sh
@@ -66,6 +66,7 @@ kube::log::status "Starting kube-apiserver"
   --insecure-bind-address="${API_HOST}" \
   --bind-address="${API_HOST}" \
   --insecure-port="${API_PORT}" \
+  --storage-backend=etcd3 \
   --etcd-servers="http://${ETCD_HOST}:${ETCD_PORT}" \
   --advertise-address="10.10.10.10" \
   --cert-dir="${TMP_DIR}/certs" \

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -88,7 +88,7 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 		"Enable watch caching in the apiserver")
 
 	fs.StringVar(&s.StorageConfig.Type, "storage-backend", s.StorageConfig.Type,
-		"The storage backend for persistence. Options: 'etcd3' (default), 'etcd2'.")
+		"The storage backend for persistence. Options: 'etcd2', 'etcd3'.")
 
 	fs.IntVar(&s.StorageConfig.DeserializationCacheSize, "deserialization-cache-size", s.StorageConfig.DeserializationCacheSize,
 		"Number of deserialized json objects to cache in memory.")

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -29,7 +29,7 @@ const (
 
 // Config is configuration for creating a storage backend.
 type Config struct {
-	// Type defines the type of storage backend, e.g. "etcd2", etcd3". Default ("") is "etcd3".
+	// Type defines the type of storage backend, e.g. "etcd2", etcd3".
 	Type string
 	// Prefix is the prefix to all keys passed to storage.Interface methods.
 	Prefix string

--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/factory.go
@@ -28,15 +28,22 @@ type DestroyFunc func()
 
 // Create creates a storage backend based on given config.
 func Create(c storagebackend.Config) (storage.Interface, DestroyFunc, error) {
+	// Warning: changing the interpretation of the default (StorageTypeUnset)
+	// is a breaking change for users, and is subject to the kubernetes
+	// deprecation policy.  Also note that it's probably a bad idea, because
+	// then we end up with API servers whose default varies depending on when
+	// they were built.  More details in #45457.
 	switch c.Type {
 	case storagebackend.StorageTypeETCD2:
 		return newETCD2Storage(c)
-	case storagebackend.StorageTypeUnset, storagebackend.StorageTypeETCD3:
+	case storagebackend.StorageTypeETCD3:
 		// TODO: We have the following features to implement:
 		// - Support secure connection by using key, cert, and CA files.
 		// - Honor "https" scheme to support secure connection in gRPC.
 		// - Support non-quorum read.
 		return newETCD3Storage(c)
+	case storagebackend.StorageTypeUnset:
+		return nil, nil, fmt.Errorf("storage type must be set (use --storage-backend flag)")
 	default:
 		return nil, nil, fmt.Errorf("unknown storage type: %s", c.Type)
 	}


### PR DESCRIPTION
The default value has changed in the past, which was a violation of our
deprecation policy, but also shows that we can't have a default while
maintaining both sensible defaults and a deprecation policy.

As such, make the flag mandatory: the installer knows best which version
of etcd or other storage backend they are choosing to install.

Fix #45457



```release-note
The --storage-backend flag must now be passed to apiserver.  It is not possible to both have a sensible default and respect the deprecation policy, so the storage-backend must be specified.
```
