### PR TITLE
Fix broken command in registry addon document

### DIFF
--- a/cluster/addons/registry/README.md
+++ b/cluster/addons/registry/README.md
@@ -249,7 +249,7 @@ You can use `kubectl` to set up a port-forward from your local node to a
 running Pod:
 
 ```console
-$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry \
+$ POD=$(kubectl get pods --namespace kube-system -l k8s-app=kube-registry-upstream \
             -o template --template '{{range .items}}{{.metadata.name}} {{.status.phase}}{{"\n"}}{{end}}' \
             | grep Running | head -1 | cut -f1 -d' ')
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a command example in registry addon document so it matches the example yaml above.

