### PR TITLE
cni: Don't try and map ports with an unset HostPort

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -339,6 +339,9 @@ func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string
 	}
 	portMappingsParam := make([]cniPortMapping, 0, len(portMappings))
 	for _, p := range portMappings {
+		if p.HostPort <= 0 {
+			continue
+		}
 		portMappingsParam = append(portMappingsParam, cniPortMapping{
 			HostPort:      p.HostPort,
 			ContainerPort: p.ContainerPort,


### PR DESCRIPTION
The CNI Host function GetPodPortMappings also includes unmapped ports (this is apparently by design). This is normal, and the CNI network plugin invoker should not attempt to map these ports.

This matches the functionality in the kubenet hostport mapper.

Fixes: #47529