### PR TITLE
Fix typo in secretbox transformer prefix

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -37,7 +37,7 @@ import (
 const (
 	aesCBCTransformerPrefixV1    = "k8s:enc:aescbc:v1:"
 	aesGCMTransformerPrefixV1    = "k8s:enc:aesgcm:v1:"
-	secretboxTransformerPrefixV1 = "k8s:enc:secretbox:v1"
+	secretboxTransformerPrefixV1 = "k8s:enc:secretbox:v1:"
 )
 
 // GetTransformerOverrides returns the transformer overrides by reading and parsing the encryption provider configuration file


### PR DESCRIPTION
Introduced by #46916 via cherry picked commit [here](https://github.com/sakshamsharma/kubernetes/commit/12bb591dbf485dcedc87ffeba13bb7890e8fd515).

Urgent fix in my opinion, ideally should be merged before production.

@smarterclayton 