### PR TITLE
Changes node e2e tests to use the new Ubuntu image

### DIFF
--- a/test/e2e_node/jenkins/image-config-serial.yaml
+++ b/test/e2e_node/jenkins/image-config-serial.yaml
@@ -2,12 +2,9 @@
 # `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
-  ubuntu-docker10:
-    image: e2e-node-ubuntu-trusty-docker10-v2-image # docker 1.10.3
-    project: kubernetes-node-e2e-images
-  ubuntu-docker12:
-    image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
-    project: kubernetes-node-e2e-images
+  ubuntu:
+    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    project: ubuntu-os-gke-cloud
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
     project: coreos-cloud

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -2,12 +2,9 @@
 # `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
-  ubuntu-docker10:
-    image: e2e-node-ubuntu-trusty-docker10-v2-image # docker 1.10.3
-    project: kubernetes-node-e2e-images
-  ubuntu-docker12:
-    image: e2e-node-ubuntu-trusty-docker12-v2-image # docker 1.12.6
-    project: kubernetes-node-e2e-images
+  ubuntu:
+    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    project: ubuntu-os-gke-cloud
   coreos-alpha:
     image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
     project: coreos-cloud


### PR DESCRIPTION
ref: https://github.com/kubernetes/kubernetes/issues/46891

`ubuntu-docker10` and `ubuntu-docker12` images are deprecated in favor of the new one.

**Release note**:
```
None
```
/sig node
/area node-e2e
/assign @dchen1107 