### PR TITLE
[POC] Update status manager concurrency model

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1938,6 +1938,7 @@ func (kl *Kubelet) HandlePodAdditions(pods []*v1.Pod) {
 		kl.podManager.AddPod(pod)
 
 		if kubepod.IsMirrorPod(pod) {
+			kl.statusManager.Reconcile(types.UID(kl.podManager.TranslatePodUID(pod.UID)))
 			kl.handleMirrorPod(pod, start)
 			continue
 		}
@@ -2002,9 +2003,8 @@ func (kl *Kubelet) HandlePodRemoves(pods []*v1.Pod) {
 // that should be reconciled.
 func (kl *Kubelet) HandlePodReconcile(pods []*v1.Pod) {
 	for _, pod := range pods {
-		// Update the pod in pod manager, status manager will do periodically reconcile according
-		// to the pod manager.
 		kl.podManager.UpdatePod(pod)
+		kl.statusManager.Reconcile(pod.UID)
 
 		// After an evicted pod is synced, all dead containers in the pod can be removed.
 		if eviction.PodIsEvicted(pod.Status) {

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -875,19 +875,6 @@ func (kl *Kubelet) filterOutTerminatedPods(pods []*v1.Pod) []*v1.Pod {
 	return filteredPods
 }
 
-// removeOrphanedPodStatuses removes obsolete entries in podStatus where
-// the pod is no longer considered bound to this node.
-func (kl *Kubelet) removeOrphanedPodStatuses(pods []*v1.Pod, mirrorPods []*v1.Pod) {
-	podUIDs := make(map[types.UID]bool)
-	for _, pod := range pods {
-		podUIDs[pod.UID] = true
-	}
-	for _, pod := range mirrorPods {
-		podUIDs[pod.UID] = true
-	}
-	kl.statusManager.RemoveOrphanedStatuses(podUIDs)
-}
-
 // HandlePodCleanups performs a series of cleanup work, including terminating
 // pod workers, killing unwanted pods, and removing orphaned volumes/pod
 // directories.
@@ -910,7 +897,7 @@ func (kl *Kubelet) HandlePodCleanups() error {
 		}
 	}
 
-	allPods, mirrorPods := kl.podManager.GetPodsAndMirrorPods()
+	allPods, _ := kl.podManager.GetPodsAndMirrorPods()
 	// Pod phase progresses monotonically. Once a pod has reached a final state,
 	// it should never leave regardless of the restart policy. The statuses
 	// of such pods should not be changed, and there is no need to sync them.
@@ -943,7 +930,7 @@ func (kl *Kubelet) HandlePodCleanups() error {
 		}
 	}
 
-	kl.removeOrphanedPodStatuses(allPods, mirrorPods)
+	kl.statusManager.RemoveOrphanedStatuses()
 	// Note that we just killed the unwanted pods. This may not have reflected
 	// in the cache. We need to bypass the cache to get the latest set of
 	// running pods to clean up the volumes.

--- a/pkg/kubelet/status/BUILD
+++ b/pkg/kubelet/status/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "generate.go",
         "status_manager.go",
+        "update_set.go",
     ],
     deps = [
         "//pkg/api/v1/pod:go_default_library",
@@ -24,8 +25,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
     ],
@@ -36,6 +35,7 @@ go_test(
     srcs = [
         "generate_test.go",
         "status_manager_test.go",
+        "update_set_test.go",
     ],
     library = ":go_default_library",
     deps = [
@@ -54,6 +54,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",

--- a/pkg/kubelet/status/update_set.go
+++ b/pkg/kubelet/status/update_set.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// Invariants:
+// 		A UID in the "set" must also be in the "cache"
+// 		A UID in the "channel" must also be in the "set"
+// 		Two identical UIDs are never in the "channel" at once
+type updateSet struct {
+	lock    sync.RWMutex
+	cache   map[types.UID]v1.PodStatus
+	set     map[types.UID]struct{}
+	channel chan types.UID
+}
+
+type Update struct {
+	UID    types.UID
+	Status v1.PodStatus
+}
+
+// UpdateSet is a thread-safe representation of a set of updates.  It can be thought of as a combination of
+// a key-value store, and a deduplicated channel of keys.  In our case, the key is a UID, and the value is the PodStatus.
+type UpdateSet interface {
+	// Get returns the status provided by the most recent Set call to the given UID.
+	// If no such call has been made, or Delete has been called since the last Set, return false.
+	Get(uid types.UID) (v1.PodStatus, bool)
+
+	// Set sets the most recent status for that uid, causing subsequent Get calls to return that status.
+	// The uid whose status is set is guaranteed to come out of the Update channel in an update, although
+	// the status passed here may be replaced by a more recent one.
+	Set(uid types.UID, status v1.PodStatus)
+
+	// Retry guarantees that the provided uid comes out of the Update channel in an Update,
+	// along with the most recent status passed to Set.
+	// Setting a delay other than NoDelay causes the update to be placed in the Update channel after a delay.
+	Retry(uid types.UID, delay time.Duration)
+
+	// Updates provides a channel of Update structs.  The Status of the update is the status most recently provided to Set.
+	// An update is placed in the channel after a Set or Retry, but multiple Sets or Retrys before drawing from the channel
+	// will only result in one Update.  The returned channel from Updates is meant to be consumed in parallel with Set and Retry calls,
+	// and continuously provides updates based on those Set and Retry calls.
+	Updates() <-chan Update
+
+	// Delete causes the next call to Get (without a call to Set) for the given UID
+	// to return false, and not to return a status.  After a Delete, the deleted UID will not
+	// emerge from the channel returned by Updates().
+	Delete(uid types.UID)
+
+	// GarbageCollect causes subsequent calls ot Get (without a call to Set)
+	// for UIDs not included in the remainingUIDSet to return false.
+	GarbageCollect(remainingUIDSet map[types.UID]struct{})
+}
+
+func NewUpdateSet() UpdateSet {
+	return &updateSet{
+		cache:   make(map[types.UID]v1.PodStatus),
+		set:     make(map[types.UID]struct{}),
+		channel: make(chan types.UID, 1000),
+	}
+}
+
+func (u *updateSet) Get(uid types.UID) (v1.PodStatus, bool) {
+	u.lock.Lock()
+	defer u.lock.Unlock()
+	status, ok := u.cache[uid]
+	return status, ok
+}
+
+func (u *updateSet) Set(uid types.UID, status v1.PodStatus) {
+	u.lock.Lock()
+	defer u.lock.Unlock()
+	u.cache[uid] = status
+	_, inSet := u.set[uid]
+	u.set[uid] = struct{}{}
+	if !inSet {
+		u.channel <- uid
+	}
+}
+
+const NoDelay = 0 * time.Second
+
+func (u *updateSet) Retry(uid types.UID, delay time.Duration) {
+	u.lock.Lock()
+	defer u.lock.Unlock()
+	_, inCache := u.cache[uid]
+	_, inSet := u.set[uid]
+	u.set[uid] = struct{}{}
+	if !inSet && inCache {
+		if delay == NoDelay {
+			u.channel <- uid
+		} else {
+			go func() {
+				time.Sleep(delay)
+				u.channel <- uid
+			}()
+		}
+	}
+	return
+}
+
+func (u *updateSet) Updates() <-chan Update {
+	outputChan := make(chan Update)
+	go func() {
+		for uid := range u.channel {
+			u.lock.Lock()
+			delete(u.set, uid)
+			status, ok := u.cache[uid]
+			u.lock.Unlock()
+			if ok {
+				outputChan <- Update{
+					UID:    uid,
+					Status: status,
+				}
+			}
+		}
+	}()
+	return outputChan
+}
+
+func (u *updateSet) Delete(uid types.UID) {
+	u.lock.Lock()
+	defer u.lock.Unlock()
+	delete(u.set, uid)
+	delete(u.cache, uid)
+}
+
+func (u *updateSet) GarbageCollect(remainingUIDSet map[types.UID]struct{}) {
+	u.lock.Lock()
+	defer u.lock.Unlock()
+	for key := range u.cache {
+		if _, ok := remainingUIDSet[key]; !ok {
+			glog.V(5).Infof("Removing %q from status update set.", key)
+			delete(u.set, key)
+			delete(u.cache, key)
+		}
+	}
+}

--- a/pkg/kubelet/status/update_set_test.go
+++ b/pkg/kubelet/status/update_set_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func newTestUpdateSet() *updateSet {
+	u := NewUpdateSet()
+	return u.(*updateSet)
+}
+
+// updateList returns a list of updates in the same way that Updates would provide
+// them in the channel.  This is useful for testing because it is deterministic.
+func (u *updateSet) updateList() (updates []Update) {
+	for {
+		select {
+		case uid := <-u.channel:
+			u.lock.Lock()
+			delete(u.set, uid)
+			status, ok := u.cache[uid]
+			u.lock.Unlock()
+			if ok {
+				updates = append(updates, Update{UID: uid, Status: status})
+			}
+		default:
+			return
+		}
+	}
+}
+
+func expectEqualUpdates(t *testing.T, actualUpdates []Update, expectedUpdates []Update) {
+	err := fmt.Errorf("Actual Updates: %+v is different from Expected Updates: %+v", actualUpdates, expectedUpdates)
+	if len(actualUpdates) != len(expectedUpdates) {
+		t.Error(err)
+	}
+	for i, expected := range expectedUpdates {
+		if expected.UID != actualUpdates[i].UID || !isStatusEqual(&expected.Status, &actualUpdates[i].Status) {
+			t.Error(err)
+		}
+	}
+}
+
+func (u *updateSet) expectGetStatus(t *testing.T, uid types.UID, expectedFound bool, expectedStatus v1.PodStatus) {
+	actualStatus, found := u.Get(uid)
+	if !found && expectedFound {
+		t.Errorf("Expected to get a status for uid: %v, but did not", uid)
+	} else if found && !expectedFound {
+		t.Errorf("Did not expect to get a status for uid: %v, but got status: %+v", uid, actualStatus)
+	} else if found && expectedFound && !isStatusEqual(&actualStatus, &expectedStatus) {
+		t.Errorf("Actual Status: %+v was not equalto Expected Status: %+v", actualStatus, expectedStatus)
+	}
+}
+
+func TestNoUpdates(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testUpdateSet.expectGetStatus(t, types.UID("uidThatDoesntExist"), false, v1.PodStatus{})
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{})
+}
+
+func TestSingleUpdate(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testStatus := getRandomPodStatus()
+	testUID := types.UID("abc")
+	testUpdateSet.Set(testUID, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID, true, testStatus)
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{
+		{
+			UID:    testUID,
+			Status: testStatus,
+		},
+	})
+}
+
+func TestMultipleUpdatesToSameUID(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testStatus := getRandomPodStatus()
+	testUID := types.UID("abc")
+	testUpdateSet.Set(testUID, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID, true, testStatus)
+	// Change the status before we draw from the queue
+	testStatus = getRandomPodStatus()
+	testUpdateSet.Set(testUID, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID, true, testStatus)
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{
+		{
+			UID: testUID,
+			// expect to see only the most recent update
+			Status: testStatus,
+		},
+	})
+}
+
+func TestSingleUpdateToMultipleUID(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testStatus := getRandomPodStatus()
+	testUID1 := types.UID("abc")
+	testUID2 := types.UID("123")
+	testUpdateSet.Set(testUID1, testStatus)
+	testUpdateSet.Set(testUID2, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID1, true, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID2, true, testStatus)
+	// Expect to see the first update in the channel before the second update.
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{
+		{
+			UID:    testUID1,
+			Status: testStatus,
+		},
+		{
+			UID:    testUID2,
+			Status: testStatus,
+		},
+	})
+}
+
+func TestMultipleUpdateToMultipleUID(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testStatus1 := getRandomPodStatus()
+	testStatus2 := getRandomPodStatus()
+	testUID1 := types.UID("abc")
+	testUID2 := types.UID("123")
+	testUpdateSet.Set(testUID1, testStatus1)
+	testUpdateSet.Set(testUID2, testStatus2)
+	testUpdateSet.expectGetStatus(t, testUID1, true, testStatus1)
+	testUpdateSet.expectGetStatus(t, testUID2, true, testStatus2)
+	testStatus1 = getRandomPodStatus()
+	testStatus2 = getRandomPodStatus()
+	// Reverse the ordering, but the updates should come out of the channel in the original ordering
+	testUpdateSet.Set(testUID2, testStatus2)
+	testUpdateSet.Set(testUID1, testStatus1)
+	testUpdateSet.expectGetStatus(t, testUID1, true, testStatus1)
+	testUpdateSet.expectGetStatus(t, testUID2, true, testStatus2)
+	// Expect to see the first update in the channel before the second update.
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{
+		{
+			UID:    testUID1,
+			Status: testStatus1,
+		},
+		{
+			UID:    testUID2,
+			Status: testStatus2,
+		},
+	})
+
+}
+
+func TestDeletedUIDUpdate(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testStatus := getRandomPodStatus()
+	testUID := types.UID("abc")
+	testUpdateSet.Set(testUID, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID, true, testStatus)
+	testUpdateSet.Delete(testUID)
+	testUpdateSet.expectGetStatus(t, testUID, false, v1.PodStatus{})
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{})
+}
+
+func TestRetryUpdate(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testStatus := getRandomPodStatus()
+	testUID := types.UID("abc")
+	testUpdateSet.Set(testUID, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID, true, testStatus)
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{
+		{
+			UID:    testUID,
+			Status: testStatus,
+		},
+	})
+	// We should have consumed the update in the previous updateList
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{})
+	testUpdateSet.Retry(testUID, NoDelay)
+	// After the retry, we expect to see another update!
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{
+		{
+			UID:    testUID,
+			Status: testStatus,
+		},
+	})
+}
+
+func TestRetryDeletedUpdate(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testStatus := getRandomPodStatus()
+	testUID := types.UID("abc")
+	testUpdateSet.Set(testUID, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID, true, testStatus)
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{
+		{
+			UID:    testUID,
+			Status: testStatus,
+		},
+	})
+	// We should have consumed the update in the previous updateList
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{})
+	testUpdateSet.Retry(testUID, NoDelay)
+	testUpdateSet.Delete(testUID)
+	// Even after the retry, we do not expect to see an update because of the delete
+	expectEqualUpdates(t, testUpdateSet.updateList(), []Update{})
+}
+
+func TestGarbageCollect(t *testing.T) {
+	testUpdateSet := newTestUpdateSet()
+	testStatus := getRandomPodStatus()
+	testUID1 := types.UID("abc")
+	testUID2 := types.UID("123")
+	testUID3 := types.UID("abc123")
+	testUpdateSet.Set(testUID1, testStatus)
+	testUpdateSet.Set(testUID2, testStatus)
+	testUpdateSet.Set(testUID3, testStatus)
+	remaining := make(map[types.UID]struct{})
+	remaining[testUID2] = struct{}{}
+	testUpdateSet.GarbageCollect(remaining)
+	testUpdateSet.expectGetStatus(t, testUID1, false, v1.PodStatus{})
+	testUpdateSet.expectGetStatus(t, testUID2, true, testStatus)
+	testUpdateSet.expectGetStatus(t, testUID3, false, v1.PodStatus{})
+}


### PR DESCRIPTION
This is meant to demonstrate a different model for updating pod statuses to the API server.  This PR should help the kubelet perform substantially better when it needs to do large numbers of status updates (for example on batch pod creation or deletion).  I will try and provide some benchmarks to demonstrate this in the future.

The current model queues the pod UID and pod status together in a channel, and then handles them 1 by 1.  If the status manager gets behind (due to QPS limits, for example), then this channel becomes effectively useless, as it is hopelessly far behind.  As a fallback, the status manager has a syncBatch method that iterates through all pods, and updates those that need to be updated.  This does not become outdated as it always looks at the most recent status.

The new model, which this PR demonstrates, is to only enqueue the pod UID in a channel, and keep a set of pod UIDs that are in the channel to avoid placing the same UID in the channel, when it is already enqueued.  When the UID is withdrawn from the channel, we get the most recent status, and update to that status.  In situations where the status manager falls behind, it will always update to the most recent status.  This eliminates the need for the periodic syncbatch, although pod reconciliation needed to be modified.  In addition, I added a retry mechanism to retry failed status syncs.

To make this concurrency setup easier to reason about, I moved it to its own file.  update_set.go