### PR TITLE
[GCE] Bump GLBC version to 0.9.5

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.9.4
+  name: l7-lb-controller-v0.9.5
   namespace: kube-system
   labels:
     k8s-app: glbc
-    version: v0.9.4
+    version: v0.9.5
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/glbc:0.9.4
+  - image: gcr.io/google_containers/glbc:0.9.5
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Fixes #47559 
```release-note
Bump GLBC version to 0.9.5 - fixes [loss of manually modified GCLB health check settings](https://github.com/kubernetes/kubernetes/issues/47559) upon upgrade from pre-1.6.4 to either 1.6.4 or 1.6.5.
```
