### PR TITLE
AWS: Remove blackhole routes in our managed range

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -150,6 +150,9 @@ type Route struct {
 	// DestinationCIDR is the CIDR format IP range that this routing rule
 	// applies to.
 	DestinationCIDR string
+	// Blackhole is set to true if this is a blackhole route
+	// The node controller will delete the route if it is in the managed range.
+	Blackhole bool
 }
 
 // Routes is an abstract, pluggable interface for advanced routing rules.

--- a/pkg/controller/route/routecontroller_test.go
+++ b/pkg/controller/route/routecontroller_test.go
@@ -97,12 +97,12 @@ func TestReconcile(t *testing.T) {
 				&node2,
 			},
 			initialRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
-				{cluster + "-02", "node-2", "10.120.1.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
 			},
 			expectedRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
-				{cluster + "-02", "node-2", "10.120.1.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
 			},
 			expectedNetworkUnavailable: []bool{true, true},
 			clientset:                  fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1, node2}}),
@@ -114,11 +114,11 @@ func TestReconcile(t *testing.T) {
 				&node2,
 			},
 			initialRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
 			},
 			expectedRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
-				{cluster + "-02", "node-2", "10.120.1.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
 			},
 			expectedNetworkUnavailable: []bool{true, true},
 			clientset:                  fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1, node2}}),
@@ -131,8 +131,8 @@ func TestReconcile(t *testing.T) {
 			},
 			initialRoutes: []*cloudprovider.Route{},
 			expectedRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
-				{cluster + "-02", "node-2", "10.120.1.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
 			},
 			expectedNetworkUnavailable: []bool{true, true},
 			clientset:                  fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1, node2}}),
@@ -144,14 +144,14 @@ func TestReconcile(t *testing.T) {
 				&node2,
 			},
 			initialRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
-				{cluster + "-02", "node-2", "10.120.1.0/24"},
-				{cluster + "-03", "node-3", "10.120.2.0/24"},
-				{cluster + "-04", "node-4", "10.120.3.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
+				{cluster + "-03", "node-3", "10.120.2.0/24", false},
+				{cluster + "-04", "node-4", "10.120.3.0/24", false},
 			},
 			expectedRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
-				{cluster + "-02", "node-2", "10.120.1.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
 			},
 			expectedNetworkUnavailable: []bool{true, true},
 			clientset:                  fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1, node2}}),
@@ -163,12 +163,12 @@ func TestReconcile(t *testing.T) {
 				&node2,
 			},
 			initialRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
-				{cluster + "-03", "node-3", "10.120.2.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-03", "node-3", "10.120.2.0/24", false},
 			},
 			expectedRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
-				{cluster + "-02", "node-2", "10.120.1.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
 			},
 			expectedNetworkUnavailable: []bool{true, true},
 			clientset:                  fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1, node2}}),
@@ -181,10 +181,47 @@ func TestReconcile(t *testing.T) {
 			},
 			initialRoutes: []*cloudprovider.Route{},
 			expectedRoutes: []*cloudprovider.Route{
-				{cluster + "-01", "node-1", "10.120.0.0/24"},
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
 			},
 			expectedNetworkUnavailable: []bool{true, false},
 			clientset:                  fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1, nodeNoCidr}}),
+		},
+		// 2 nodes, an extra blackhole route in our range
+		{
+			nodes: []*v1.Node{
+				&node1,
+				&node2,
+			},
+			initialRoutes: []*cloudprovider.Route{
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
+				{cluster + "-03", "", "10.120.2.0/24", true},
+			},
+			expectedRoutes: []*cloudprovider.Route{
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
+			},
+			expectedNetworkUnavailable: []bool{true, true},
+			clientset:                  fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1, node2}}),
+		},
+		// 2 nodes, an extra blackhole route not in our range
+		{
+			nodes: []*v1.Node{
+				&node1,
+				&node2,
+			},
+			initialRoutes: []*cloudprovider.Route{
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
+				{cluster + "-03", "", "10.1.2.0/24", true},
+			},
+			expectedRoutes: []*cloudprovider.Route{
+				{cluster + "-01", "node-1", "10.120.0.0/24", false},
+				{cluster + "-02", "node-2", "10.120.1.0/24", false},
+				{cluster + "-03", "", "10.1.2.0/24", true},
+			},
+			expectedNetworkUnavailable: []bool{true, true},
+			clientset:                  fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{node1, node2}}),
 		},
 	}
 	for i, testCase := range testCases {


### PR DESCRIPTION
Blackhole routes otherwise acccumulate unboundedly.  We also are careful
to ensure that we do so only within the managed range, which requires
enlisting the help of the routecontroller.

Fix #47524

```release-note
AWS: clean up blackhole routes when using kubenet
```
