### PR TITLE
AWS: Fix suspicious loop comparing permissions

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2030,17 +2030,22 @@ func ipPermissionExists(newPermission, existing *ec2.IpPermission, compareGroupU
 				break
 			}
 		}
-		if found == false {
+		if !found {
 			return false
 		}
 	}
+
 	for _, leftPair := range newPermission.UserIdGroupPairs {
+		found := false
 		for _, rightPair := range existing.UserIdGroupPairs {
 			if isEqualUserGroupPair(leftPair, rightPair, compareGroupUserIDs) {
-				return true
+				found = true
+				break
 			}
 		}
-		return false
+		if !found {
+			return false
+		}
 	}
 
 	return true

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -877,6 +877,18 @@ func TestIpPermissionExistsHandlesMultipleGroupIds(t *testing.T) {
 	if equals {
 		t.Errorf("Should have not been considered equal since first is not in the second array of groups")
 	}
+
+	// The first pair matches, but the second does not
+	newIpPermission2 := ec2.IpPermission{
+		UserIdGroupPairs: []*ec2.UserIdGroupPair{
+			{GroupId: aws.String("firstGroupId")},
+			{GroupId: aws.String("fourthGroupId")},
+		},
+	}
+	equals = ipPermissionExists(&newIpPermission2, &oldIpPermission, false)
+	if equals {
+		t.Errorf("Should have not been considered equal since first is not in the second array of groups")
+	}
 }
 
 func TestIpPermissionExistsHandlesRangeSubsets(t *testing.T) {


### PR DESCRIPTION
Because we only ever call it with a single UserId/GroupId, this would
not have been a problem in practice, but this fixes the code.

Fix #36902 

```release-note
NONE
```
