### PR TITLE
Add support for using an externalName es kubernetes service

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -53,16 +53,18 @@ type ServerRunOptions struct {
 	StorageSerialization    *kubeoptions.StorageSerializationOptions
 	APIEnablement           *kubeoptions.APIEnablementOptions
 
-	AllowPrivileged           bool
-	EnableLogsHandler         bool
-	EventTTL                  time.Duration
-	KubeletConfig             kubeletclient.KubeletClientConfig
-	KubernetesServiceNodePort int
-	MaxConnectionBytesPerSec  int64
-	ServiceClusterIPRange     net.IPNet // TODO: make this a list
-	ServiceNodePortRange      utilnet.PortRange
-	SSHKeyfile                string
-	SSHUser                   string
+	AllowPrivileged               bool
+	EnableLogsHandler             bool
+	EventTTL                      time.Duration
+	KubeletConfig                 kubeletclient.KubeletClientConfig
+	KubernetesServicePort         int
+	KubernetesServiceNodePort     int
+	KubernetesServiceExternalName string
+	MaxConnectionBytesPerSec      int64
+	ServiceClusterIPRange         net.IPNet // TODO: make this a list
+	ServiceNodePortRange          utilnet.PortRange
+	SSHKeyfile                    string
+	SSHUser                       string
 
 	ProxyClientCertFile string
 	ProxyClientKeyFile  string
@@ -111,7 +113,7 @@ func NewServerRunOptions() *ServerRunOptions {
 			EnableHttps: true,
 			HTTPTimeout: time.Duration(5) * time.Second,
 		},
-		ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange,
+		ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange, KubernetesServicePort: 443,
 	}
 	// Overwrite the default for storage data format.
 	s.Etcd.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
@@ -175,6 +177,14 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 		"If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be "+
 		"of type NodePort, using this as the value of the port. If zero, the Kubernetes master "+
 		"service will be of type ClusterIP.")
+
+	fs.StringVar(&s.KubernetesServiceExternalName, "kubernetes-service-external-name", s.KubernetesServiceExternalName, ""+
+		"If non-empty, the Kubernetes master service (which apiserver creates/maintains) will be "+
+		"of type ExternalName, using this as the value of the externalName. "+
+		"Useful if the apiserver(s) is/are running behind a load balancer which does not have a static ip")
+
+	fs.IntVar(&s.KubernetesServicePort, "apiserver-service-port", s.KubernetesServicePort, ""+
+		"Port of the apiserver service.")
 
 	fs.IPNetVar(&s.ServiceClusterIPRange, "service-cluster-ip-range", s.ServiceClusterIPRange, ""+
 		"A CIDR notation IP range from which to assign service cluster IPs. This must not "+

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -49,6 +49,7 @@ func TestAddFlags(t *testing.T) {
 		"--alpha-endpoint-reconciler-type=" + string(reconcilers.MasterCountReconcilerType),
 		"--anonymous-auth=false",
 		"--apiserver-count=5",
+		"--apiserver-service-port=443",
 		"--audit-log-maxage=11",
 		"--audit-log-maxbackup=12",
 		"--audit-log-maxsize=13",
@@ -91,10 +92,9 @@ func TestAddFlags(t *testing.T) {
 
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerRunOptions{
-		ServiceNodePortRange:   kubeoptions.DefaultServiceNodePortRange,
-		MasterCount:            5,
-		EndpointReconcilerType: string(reconcilers.MasterCountReconcilerType),
-		AllowPrivileged:        false,
+		ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange,
+		MasterCount:          5,EndpointReconcilerType: string(reconcilers.MasterCountReconcilerType),
+		AllowPrivileged:      false,KubernetesServicePort: 443,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -293,7 +293,7 @@ func CreateKubeAPIServerConfig(s *options.ServerRunOptions, nodeTunneler tunnele
 		PerConnectionBandwidthLimitBytesPerSec: s.MaxConnectionBytesPerSec,
 	})
 
-	serviceIPRange, apiServerServiceIP, err := master.DefaultServiceIPRange(s.ServiceClusterIPRange)
+	serviceIPRange, kubernetesServiceIP, err := master.DefaultServiceIPRange(s.ServiceClusterIPRange)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
@@ -335,12 +335,11 @@ func CreateKubeAPIServerConfig(s *options.ServerRunOptions, nodeTunneler tunnele
 
 			Tunneler: nodeTunneler,
 
-			ServiceIPRange:       serviceIPRange,
-			APIServerServiceIP:   apiServerServiceIP,
-			APIServerServicePort: 443,
-
+			ServiceIPRange:            serviceIPRange,
 			ServiceNodePortRange:      s.ServiceNodePortRange,
-			KubernetesServiceNodePort: s.KubernetesServiceNodePort,
+			KubernetesServiceIP:       kubernetesServiceIP,
+			KubernetesServicePort:     s.KubernetesServicePort,
+			KubernetesServiceNodePort: s.KubernetesServiceNodePort, KubernetesServiceExternalName: s.KubernetesServiceExternalName,
 
 			EndpointReconcilerType: reconcilers.Type(s.EndpointReconcilerType),
 			MasterCount:            s.MasterCount,

--- a/pkg/kubelet/envvars/envvars_test.go
+++ b/pkg/kubelet/envvars/envvars_test.go
@@ -60,26 +60,6 @@ func TestFromServices(t *testing.T) {
 			},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "svrc-clusterip-none"},
-			Spec: v1.ServiceSpec{
-				Selector:  map[string]string{"bar": "baz"},
-				ClusterIP: "None",
-				Ports: []v1.ServicePort{
-					{Port: 8082, Protocol: "TCP"},
-				},
-			},
-		},
-		{
-			ObjectMeta: metav1.ObjectMeta{Name: "svrc-clusterip-empty"},
-			Spec: v1.ServiceSpec{
-				Selector:  map[string]string{"bar": "baz"},
-				ClusterIP: "",
-				Ports: []v1.ServicePort{
-					{Port: 8082, Protocol: "TCP"},
-				},
-			},
-		},
-		{
 			ObjectMeta: metav1.ObjectMeta{Name: "super-ipv6"},
 			Spec: v1.ServiceSpec{
 				Selector:  map[string]string{"bar": "baz"},

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -66,12 +66,13 @@ type Controller struct {
 	PublicIP net.IP
 
 	// ServiceIP indicates where the kubernetes service will live.  It may not be nil.
-	ServiceIP                 net.IP
-	ServicePort               int
-	ExtraServicePorts         []api.ServicePort
-	ExtraEndpointPorts        []api.EndpointPort
-	PublicServicePort         int
-	KubernetesServiceNodePort int
+	ServiceIP                     net.IP
+	ServicePort                   int
+	ExtraServicePorts             []api.ServicePort
+	ExtraEndpointPorts            []api.EndpointPort
+	PublicServicePort             int
+	KubernetesServiceNodePort     int
+	KubernetesServiceExternalName string
 
 	runner *async.Runner
 }
@@ -98,12 +99,13 @@ func (c *completedConfig) NewBootstrapController(legacyRESTStorage corerest.Lega
 
 		PublicIP: c.GenericConfig.PublicAddress,
 
-		ServiceIP:                 c.ExtraConfig.APIServerServiceIP,
-		ServicePort:               c.ExtraConfig.APIServerServicePort,
+		ServiceIP:                 c.ExtraConfig.KubernetesServiceIP,
+		ServicePort:               c.ExtraConfig.KubernetesServicePort,
 		ExtraServicePorts:         c.ExtraConfig.ExtraServicePorts,
 		ExtraEndpointPorts:        c.ExtraConfig.ExtraEndpointPorts,
 		PublicServicePort:         c.GenericConfig.ReadWritePort,
 		KubernetesServiceNodePort: c.ExtraConfig.KubernetesServiceNodePort,
+		KubernetesServiceExternalName: c.ExtraConfig.KubernetesServiceExternalName,
 	}
 }
 
@@ -187,8 +189,8 @@ func (c *Controller) UpdateKubernetesService(reconcile bool) error {
 		return err
 	}
 
-	servicePorts, serviceType := createPortAndServiceSpec(c.ServicePort, c.PublicServicePort, c.KubernetesServiceNodePort, "https", c.ExtraServicePorts)
-	if err := c.CreateOrUpdateMasterServiceIfNeeded(kubernetesServiceName, c.ServiceIP, servicePorts, serviceType, reconcile); err != nil {
+	servicePorts, serviceType := createPortAndServiceSpec(c.ServicePort, c.PublicServicePort, c.KubernetesServiceNodePort, "https", c.KubernetesServiceExternalName, c.ExtraServicePorts)
+	if err := c.CreateOrUpdateMasterServiceIfNeeded(kubernetesServiceName, c.ServiceIP, servicePorts, serviceType, c.KubernetesServiceExternalName, reconcile); err != nil {
 		return err
 	}
 	endpointPorts := createEndpointPortSpec(c.PublicServicePort, "https", c.ExtraEndpointPorts)
@@ -219,7 +221,7 @@ func (c *Controller) CreateNamespaceIfNeeded(ns string) error {
 
 // createPortAndServiceSpec creates an array of service ports.
 // If the NodePort value is 0, just the servicePort is used, otherwise, a node port is exposed.
-func createPortAndServiceSpec(servicePort int, targetServicePort int, nodePort int, servicePortName string, extraServicePorts []api.ServicePort) ([]api.ServicePort, api.ServiceType) {
+func createPortAndServiceSpec(servicePort int, targetServicePort int, nodePort int, servicePortName string, externalName string, extraServicePorts []api.ServicePort) ([]api.ServicePort, api.ServiceType) {
 	//Use the Cluster IP type for the service port if NodePort isn't provided.
 	//Otherwise, we will be binding the master service to a NodePort.
 	servicePorts := []api.ServicePort{{Protocol: api.ProtocolTCP,
@@ -230,6 +232,8 @@ func createPortAndServiceSpec(servicePort int, targetServicePort int, nodePort i
 	if nodePort > 0 {
 		servicePorts[0].NodePort = int32(nodePort)
 		serviceType = api.ServiceTypeNodePort
+	} else if externalName != "" {
+		serviceType = api.ServiceTypeExternalName
 	}
 	if extraServicePorts != nil {
 		servicePorts = append(servicePorts, extraServicePorts...)
@@ -251,11 +255,11 @@ func createEndpointPortSpec(endpointPort int, endpointPortName string, extraEndp
 
 // CreateMasterServiceIfNeeded will create the specified service if it
 // doesn't already exist.
-func (c *Controller) CreateOrUpdateMasterServiceIfNeeded(serviceName string, serviceIP net.IP, servicePorts []api.ServicePort, serviceType api.ServiceType, reconcile bool) error {
+func (c *Controller) CreateOrUpdateMasterServiceIfNeeded(serviceName string, serviceIP net.IP, servicePorts []api.ServicePort, serviceType api.ServiceType, externalName string, reconcile bool) error {
 	if s, err := c.ServiceClient.Services(metav1.NamespaceDefault).Get(serviceName, metav1.GetOptions{}); err == nil {
 		// The service already exists.
 		if reconcile {
-			if svc, updated := reconcilers.GetMasterServiceUpdateIfNeeded(s, servicePorts, serviceType); updated {
+			if svc, updated := reconcilers.GetMasterServiceUpdateIfNeeded(s, servicePorts, externalName, serviceType); updated {
 				glog.Warningf("Resetting master service %q to %#v", serviceName, svc)
 				_, err := c.ServiceClient.Services(metav1.NamespaceDefault).Update(svc)
 				return err
@@ -279,9 +283,14 @@ func (c *Controller) CreateOrUpdateMasterServiceIfNeeded(serviceName string, ser
 		},
 	}
 
+	if serviceType == api.ServiceTypeExternalName {
+		svc.Spec.ClusterIP = ""
+		svc.Spec.ExternalName = externalName
+	}
+
 	_, err := c.ServiceClient.Services(metav1.NamespaceDefault).Create(svc)
 	if errors.IsAlreadyExists(err) {
-		return c.CreateOrUpdateMasterServiceIfNeeded(serviceName, serviceIP, servicePorts, serviceType, reconcile)
+		return c.CreateOrUpdateMasterServiceIfNeeded(serviceName, serviceIP, servicePorts, serviceType, externalName, reconcile)
 	}
 	return err
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -115,9 +115,9 @@ type ExtraConfig struct {
 	// The range of IPs to be assigned to services with type=ClusterIP or greater
 	ServiceIPRange net.IPNet
 	// The IP address for the GenericAPIServer service (must be inside ServiceIPRange)
-	APIServerServiceIP net.IP
+	KubernetesServiceIP net.IP
 	// Port for the apiserver service.
-	APIServerServicePort int
+	KubernetesServicePort int
 
 	// TODO, we can probably group service related items into a substruct to make it easier to configure
 	// the API server items and `Extra*` fields likely fit nicely together.
@@ -137,6 +137,8 @@ type ExtraConfig struct {
 	ExtraEndpointPorts []api.EndpointPort
 	// If non-zero, the "kubernetes" services uses this port as NodePort.
 	KubernetesServiceNodePort int
+	// If non-empty, the "kubernetes" services uses this name as externalName.
+	KubernetesServiceExternalName string
 
 	// Number of masters running; all masters must be started with the
 	// same value for this field. (Numbers > 1 currently untested.)
@@ -249,13 +251,13 @@ func (cfg *Config) Complete(informers informers.SharedInformerFactory) Completed
 	if c.ExtraConfig.ServiceIPRange.IP == nil {
 		c.ExtraConfig.ServiceIPRange = serviceIPRange
 	}
-	if c.ExtraConfig.APIServerServiceIP == nil {
-		c.ExtraConfig.APIServerServiceIP = apiServerServiceIP
+	if c.ExtraConfig.KubernetesServiceIP == nil {
+		c.ExtraConfig.KubernetesServiceIP = apiServerServiceIP
 	}
 
 	discoveryAddresses := discovery.DefaultAddresses{DefaultAddress: c.GenericConfig.ExternalAddress}
 	discoveryAddresses.CIDRRules = append(discoveryAddresses.CIDRRules,
-		discovery.CIDRRule{IPRange: c.ExtraConfig.ServiceIPRange, Address: net.JoinHostPort(c.ExtraConfig.APIServerServiceIP.String(), strconv.Itoa(c.ExtraConfig.APIServerServicePort))})
+		discovery.CIDRRule{IPRange: c.ExtraConfig.ServiceIPRange, Address: net.JoinHostPort(c.ExtraConfig.KubernetesServiceIP.String(), strconv.Itoa(c.ExtraConfig.KubernetesServicePort))})
 	c.GenericConfig.DiscoveryAddresses = discoveryAddresses
 
 	if c.ExtraConfig.ServiceNodePortRange.Size == 0 {

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -76,10 +76,9 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, informers.SharedI
 		GenericConfig: genericapiserver.NewConfig(legacyscheme.Codecs),
 		ExtraConfig: ExtraConfig{
 			APIResourceConfigSource: DefaultAPIResourceConfigSource(),
-			APIServerServicePort:    443,
+			KubernetesServicePort:    443,
 			MasterCount:             1,
-			EndpointReconcilerType:  reconcilers.MasterCountReconcilerType,
-		},
+		EndpointReconcilerType:  reconcilers.MasterCountReconcilerType,},
 	}
 
 	resourceEncoding := serverstorage.NewDefaultResourceEncodingConfig(legacyscheme.Registry)

--- a/pkg/master/reconcilers/mastercount.go
+++ b/pkg/master/reconcilers/mastercount.go
@@ -214,7 +214,7 @@ func checkEndpointSubsetFormat(e *api.Endpoints, ip string, ports []api.Endpoint
 // * All apiservers MUST use GetMasterServiceUpdateIfNeeded and only
 //     GetMasterServiceUpdateIfNeeded to manage service attributes
 // * updateMasterService is called periodically from all apiservers.
-func GetMasterServiceUpdateIfNeeded(svc *api.Service, servicePorts []api.ServicePort, serviceType api.ServiceType) (s *api.Service, updated bool) {
+func GetMasterServiceUpdateIfNeeded(svc *api.Service, servicePorts []api.ServicePort, externalName string, serviceType api.ServiceType) (s *api.Service, updated bool) {
 	// Determine if the service is in the format we expect
 	// (servicePorts are present and service type matches)
 	formatCorrect := checkServiceFormat(svc, servicePorts, serviceType)
@@ -223,6 +223,7 @@ func GetMasterServiceUpdateIfNeeded(svc *api.Service, servicePorts []api.Service
 	}
 	svc.Spec.Ports = servicePorts
 	svc.Spec.Type = serviceType
+	svc.Spec.ExternalName = externalName
 	return svc, true
 }
 

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -358,15 +358,13 @@ func NewMasterConfig() *master.Config {
 	}
 
 	return &master.Config{
-		GenericConfig: genericConfig,
-		ExtraConfig: master.ExtraConfig{
-			APIResourceConfigSource: master.DefaultAPIResourceConfigSource(),
-			StorageFactory:          storageFactory,
-			EnableCoreControllers:   true,
-			KubeletClientConfig:     kubeletclient.KubeletClientConfig{Port: 10250},
-			APIServerServicePort:    443,
-			MasterCount:             1,
-		},
+		GenericConfig:           genericConfig,
+		ExtraConfig: master.ExtraConfig{APIResourceConfigSource: master.DefaultAPIResourceConfigSource(),
+		StorageFactory:          storageFactory,
+		EnableCoreControllers:   true,
+		KubeletClientConfig:     kubeletclient.KubeletClientConfig{Port: 10250},
+		KubernetesServicePort:    443,
+		MasterCount:             1,},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This lets you set the kubernetes default service as externalName.
When setting up a HA setup on AWS, this gives you the possibility to utilize the ELB for cluster-internal communication. Which you otherwise cant, since the ELB does not have a static IP.

More info:
https://github.com/coreos/tectonic-installer/issues/384
https://stackoverflow.com/questions/35313134/assigning-static-ip-address-to-aws-load-balancer

**Release note:**
```release-note
Add support for ExternalName for kubernetes default service
```
