### PR TITLE
azure file volume: allow provisioner to create stoarge account secret in different namespace

### DIFF
--- a/examples/persistent-volume-provisioning/README.md
+++ b/examples/persistent-volume-provisioning/README.md
@@ -336,9 +336,11 @@ parameters:
   skuName: Standard_LRS
   location: eastus
   storageAccount: azure_storage_account_name
+  secretNamespace: kube-system
 ```
 
-The parameters are the same as those used by [Azure Disk](#azure-disk)
+* `secretNamespace`: Namespace to store Azure storage account secret. Default is the same namespace that the PersistentVolumeClaim is in.
+Other parameters are the same as those used by [Azure Disk](#azure-disk)
 
 ### User provisioning requests
 

--- a/pkg/volume/azure_file/BUILD
+++ b/pkg/volume/azure_file/BUILD
@@ -19,6 +19,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api/v1:go_default_library",
+        "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/cloudprovider:go_default_library",
         "//pkg/cloudprovider/providers/azure:go_default_library",
         "//pkg/util/mount:go_default_library",

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -188,9 +188,10 @@ func init() {
 			// glusterfs
 			rbac.NewRule("get", "list", "watch").Groups(storageGroup).Resources("storageclasses").RuleOrDie(),
 			rbac.NewRule("get", "create", "delete").Groups(legacyGroup).Resources("services", "endpoints").RuleOrDie(),
-			rbac.NewRule("get").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
 			// openstack
 			rbac.NewRule("get", "list").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+			// Azure File
+			rbac.NewRule("create", "get").Groups(legacyGroup).Resources("secrets").RuleOrDie(),
 
 			// recyclerClient.WatchPod
 			rbac.NewRule("watch").Groups(legacyGroup).Resources("events").RuleOrDie(),

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -675,16 +675,17 @@ items:
   - apiGroups:
     - ""
     resources:
-    - secrets
-    verbs:
-    - get
-  - apiGroups:
-    - ""
-    resources:
     - nodes
     verbs:
     - get
     - list
+  - apiGroups:
+    - ""
+    resources:
+    - secrets
+    verbs:
+    - create
+    - get
   - apiGroups:
     - ""
     resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
allow provisioner to create stoarge account secret in different namespace
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47452 

**Special notes for your reviewer**:
@liggitt @brendandburns 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
allow provisioner to create stoarge account secret in different namespace
```
