### PR TITLE
kubeadm: Fix kube-proxy regression caused by #46372

### DIFF
--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -72,6 +72,8 @@ spec:
         - /usr/local/bin/kube-proxy
         - --kubeconfig=/var/lib/kube-proxy/kubeconfig.conf
         {{ .ClusterCIDR }}
+        securityContext:
+          privileged: true
         volumeMounts:
         - mountPath: /var/lib/kube-proxy
           name: kube-proxy
@@ -79,8 +81,6 @@ spec:
         - mountPath: /run/xtables.lock
           name: xtables-lock
           readOnly: false
-      securityContext:
-        privileged: true
       hostNetwork: true
       serviceAccountName: kube-proxy
       # TODO: Why doesn't the Decoder recognize this new field and decode it properly? Right now it's ignored


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes: https://github.com/kubernetes/kubeadm/issues/306

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Required for kubeadm v1.7 to work

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @cmluciano 