### PR TITLE
Add files specified in the kube config as a potential source of cert/…

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -457,7 +457,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.KubeletDeps) (err error) {
 				if err != nil {
 					return err
 				}
-				clientCertificateManager, err = initializeClientCertificateManager(s.CertDirectory, nodeName, clientConfig.CertData, clientConfig.KeyData)
+				clientCertificateManager, err = initializeClientCertificateManager(s.CertDirectory, nodeName, clientConfig.CertData, clientConfig.KeyData, clientConfig.CertFile, clientConfig.KeyFile)
 				if err != nil {
 					return err
 				}
@@ -664,13 +664,13 @@ func updateTransport(clientConfig *restclient.Config, clientCertificateManager c
 // client that can be used to sign new certificates (or rotate). It answers with
 // whatever certificate it is initialized with. If a CSR client is set later, it
 // may begin rotating/renewing the client cert
-func initializeClientCertificateManager(certDirectory string, nodeName types.NodeName, certData []byte, keyData []byte) (certificate.Manager, error) {
+func initializeClientCertificateManager(certDirectory string, nodeName types.NodeName, certData []byte, keyData []byte, certFile string, keyFile string) (certificate.Manager, error) {
 	certificateStore, err := certificate.NewFileStore(
 		"kubelet-client",
 		certDirectory,
 		certDirectory,
-		"",
-		"")
+		certFile,
+		keyFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize certificate store: %v", err)
 	}


### PR DESCRIPTION
Fixes #47208

Add files specified in the kube config as a potential source of cert/key data.

Without this change, the kubelet won't use certificates that are specified using file paths in the kubeconfig file. This specifically affects GCE clusters started with kube-up.sh with the RotateKubelet*Certificate feature gate flags enabled, but may affect other configurations.

This change only affects feature gated alpha code.