### PR TITLE
Change Container permissions to Private for provisioned Azure Volumes

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_blob.go
+++ b/pkg/cloudprovider/providers/azure/azure_blob.go
@@ -45,7 +45,7 @@ func (az *Cloud) createVhdBlob(accountName, accountKey, name string, sizeGB int6
 		// if container doesn't exist, create one and retry PutPageBlob
 		detail := err.Error()
 		if strings.Contains(detail, errContainerNotFound) {
-			err = blobClient.CreateContainer(vhdContainerName, azs.ContainerAccessTypeContainer)
+			err = blobClient.CreateContainer(vhdContainerName, azs.ContainerAccessTypePrivate)
 			if err == nil {
 				err = blobClient.PutPageBlob(vhdContainerName, name, vhdSize, tags)
 			}


### PR DESCRIPTION
@rootfs @philips #47611 

Fixes CVE-2017-1002100

```release-note
Azure: Change container permissions to private for provisioned volumes. If you have existing Azure volumes that were created by Kubernetes v1.6.0-v1.6.5, you should change the permissions on them manually.
```