### PR TITLE
Revert "Update fluentd-gcp to 2.0.6"

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.6
+        image: gcr.io/google-containers/fluentd-gcp:2.0.5
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
         # tries to send this message to the server => fails to send a chunk and so on.


### PR DESCRIPTION
This reverts commit 0bcc271b282a08e9b48cd964fefe3a2e2ab45c48.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: the new fluentd image appears to be crashlooping:
```
I0615 08:48:40.580] ENDLOG for container kube-system:fluentd-gcp-v2.0-8skw9:prometheus-to-sd-exporter
I0615 08:48:40.787] Jun 15 08:48:40.787: INFO: Logs of kube-system/fluentd-gcp-v2.0-mqrs8:fluentd-gcp on node bootstrap-e2e-minion-group-vp5d
I0615 08:48:40.787] Jun 15 08:48:40.787: INFO:  : STARTLOG
I0615 08:48:40.788] /var/lib/gems/2.1.0/gems/ffi-1.9.18/lib/ffi/library.rb:147:in `block in ffi_lib': Could not open library 'libsystemd.so.0': libcap.so.2: cannot open shared object file: No such file or directory. (LoadError)
I0615 08:48:40.788] Could not open library 'libsystemd.so': libcap.so.2: cannot open shared object file: No such file or directory.
I0615 08:48:40.788] Could not open library 'libsystemd-id128.so.0': libsystemd-id128.so.0: cannot open shared object file: No such file or directory.
I0615 08:48:40.788] Could not open library 'libsystemd-id128.so': libsystemd-id128.so: cannot open shared object file: No such file or directory
I0615 08:48:40.788] 	from /var/lib/gems/2.1.0/gems/ffi-1.9.18/lib/ffi/library.rb:100:in `map'
I0615 08:48:40.788] 	from /var/lib/gems/2.1.0/gems/ffi-1.9.18/lib/ffi/library.rb:100:in `ffi_lib'
I0615 08:48:40.789] 	from /var/lib/gems/2.1.0/gems/systemd-journal-1.2.3/lib/systemd/id128.rb:48:in `<module:Native>'
I0615 08:48:40.789] 	from /var/lib/gems/2.1.0/gems/systemd-journal-1.2.3/lib/systemd/id128.rb:45:in `<module:Id128>'
I0615 08:48:40.789] 	from /var/lib/gems/2.1.0/gems/systemd-journal-1.2.3/lib/systemd/id128.rb:6:in `<module:Systemd>'
I0615 08:48:40.789] 	from /var/lib/gems/2.1.0/gems/systemd-journal-1.2.3/lib/systemd/id128.rb:3:in `<top (required)>'
I0615 08:48:40.789] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
I0615 08:48:40.789] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
I0615 08:48:40.789] 	from /var/lib/gems/2.1.0/gems/systemd-journal-1.2.3/lib/systemd/journal/native.rb:1:in `<top (required)>'
I0615 08:48:40.790] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
I0615 08:48:40.790] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
I0615 08:48:40.790] 	from /var/lib/gems/2.1.0/gems/systemd-journal-1.2.3/lib/systemd/journal.rb:2:in `<top (required)>'
I0615 08:48:40.790] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
I0615 08:48:40.790] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
I0615 08:48:40.790] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
I0615 08:48:40.790] 	from /var/lib/gems/2.1.0/gems/fluent-plugin-systemd-0.0.8/lib/fluent/plugin/in_systemd.rb:1:in `<top (required)>'
I0615 08:48:40.791] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
I0615 08:48:40.791] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
I0615 08:48:40.791] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/plugin.rb:172:in `block in try_load_plugin'
I0615 08:48:40.791] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/plugin.rb:170:in `each'
I0615 08:48:40.791] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/plugin.rb:170:in `try_load_plugin'
I0615 08:48:40.791] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/plugin.rb:130:in `new_impl'
I0615 08:48:40.791] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/plugin.rb:55:in `new_input'
I0615 08:48:40.792] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/root_agent.rb:154:in `add_source'
I0615 08:48:40.792] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/root_agent.rb:95:in `block in configure'
I0615 08:48:40.792] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/root_agent.rb:92:in `each'
I0615 08:48:40.792] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/root_agent.rb:92:in `configure'
I0615 08:48:40.792] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/engine.rb:129:in `configure'
I0615 08:48:40.793] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/engine.rb:103:in `run_configure'
I0615 08:48:40.793] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/supervisor.rb:489:in `run_configure'
I0615 08:48:40.793] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/supervisor.rb:174:in `block in start'
I0615 08:48:40.793] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/supervisor.rb:366:in `call'
I0615 08:48:40.793] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/supervisor.rb:366:in `main_process'
I0615 08:48:40.794] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/supervisor.rb:170:in `start'
I0615 08:48:40.794] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/lib/fluent/command/fluentd.rb:173:in `<top (required)>'
I0615 08:48:40.794] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
I0615 08:48:40.794] 	from /usr/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
I0615 08:48:40.794] 	from /var/lib/gems/2.1.0/gems/fluentd-0.12.36/bin/fluentd:5:in `<top (required)>'
I0615 08:48:40.795] 	from /usr/local/bin/fluentd:23:in `load'
I0615 08:48:40.795] 	from /usr/local/bin/fluentd:23:in `<main>'
I0615 08:48:40.795] 
I0615 08:48:40.795] ENDLOG for container kube-system:fluentd-gcp-v2.0-mqrs8:fluentd-gcp
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47600 #47609 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
/release-note
/assign @saad-ali 
/cc @crassirostris 
