### PR TITLE
append KUBE-HOSTPORTS to system chains instead of prepend

### DIFF
--- a/pkg/kubelet/network/hostport/hostport.go
+++ b/pkg/kubelet/network/hostport/hostport.go
@@ -184,7 +184,10 @@ func ensureKubeHostportChains(iptables utiliptables.Interface, natInterfaceName 
 		"-m", "addrtype", "--dst-type", "LOCAL",
 		"-j", string(kubeHostportsChain)}
 	for _, tc := range tableChainsNeedJumpServices {
-		if _, err := iptables.EnsureRule(utiliptables.Prepend, tc.table, tc.chain, args...); err != nil {
+		// KUBE-HOSTPORTS chain needs to be appended to the system chains.
+		// This ensures KUBE-SERVICES chain gets processed first.
+		// Since rules in KUBE-HOSTPORTS chain matches broader cases, allow the more specific rules to be processed first.
+		if _, err := iptables.EnsureRule(utiliptables.Append, tc.table, tc.chain, args...); err != nil {
 			return fmt.Errorf("Failed to ensure that %s chain %s jumps to %s: %v", tc.table, tc.chain, kubeHostportsChain, err)
 		}
 	}


### PR DESCRIPTION
Bug fix for conflicting iptables rules between hostport and kube-proxy