### PR TITLE
debian-base: don't remove libcap2

### DIFF
--- a/build/debian-base/Dockerfile.build
+++ b/build/debian-base/Dockerfile.build
@@ -32,7 +32,7 @@ RUN apt-get update \
     && apt-get dist-upgrade -y
 
 # Hold required packages to avoid breaking the installation of packages
-RUN apt-mark hold apt gnupg adduser passwd libsemanage1
+RUN apt-mark hold apt gnupg adduser passwd libsemanage1 libcap2
 
 # Remove unnecessary packages.
 # This list was generated manually by listing the installed packages (`apt list --installed`),


### PR DESCRIPTION
**What this PR does / why we need it**: when I updated the `debian-base` image earlier this week, it apparently removed the libcap2 libraries needed for some dependent images (e.g. fluentd-gcp, #47600).

By holding this package, the library isn't removed from the base image. I've verified by running https://github.com/moul/docker-diff against the `debian-base` image from 2017-02-24.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: x-ref #47386

**Special notes for your reviewer**: nothing is pushed yet.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @timstclair @dchen1107 @luxas @kubernetes/sig-release-misc 