### PR TITLE
Remove defer from util.go ch close call

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/watch/until.go
+++ b/staging/src/k8s.io/apimachinery/pkg/watch/until.go
@@ -45,7 +45,7 @@ func Until(timeout time.Duration, watcher Interface, conditions ...ConditionFunc
 		after = time.After(timeout)
 	} else {
 		ch := make(chan time.Time)
-		defer close(ch)
+		close(ch)
 		after = ch
 	}
 	var lastEvent *Event


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Attempt to resolve https://github.com/kubernetes/kubernetes/issues/40224

It appears that the `Until()` call within [`rollout_status.go`](https://github.com/kubernetes/kubernetes/blob/9498a1270f54b6f3353ceb70b53a3746e4f952e0/pkg/kubectl/cmd/rollout/rollout_status.go#L152) is
[exiting early](https://github.com/kubernetes/kubernetes/blob/e08dfeb7390db0432c2aa9817d66860c757b367f/staging/src/k8s.io/apimachinery/pkg/watch/until.go#L81-L82). It isn't clear how this case is being selected, but by closing the `after` channel early we can ensure that `case <- after` can never be selected when a `0` timeout is chosen.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #40224

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```