### PR TITLE
iSCSi plugin: Remove redundant nil check

### DIFF
--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -114,7 +114,7 @@ func waitForPathToExistInternal(devicePath *string, maxRetries int, deviceTransp
 			if err == nil {
 				return true
 			}
-			if err != nil && !os.IsNotExist(err) {
+			if !os.IsNotExist(err) {
 				return false
 			}
 			if i == maxRetries-1 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This patch is for cleanup of redundant nil check in iSCSI plugin.
This was mentioned at the code review on origin github thread.

https://github.com/openshift/origin/pull/14565

**Which issue this PR fixes** 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
