### PR TITLE
Don't start any Typha instances if not using Calico

### DIFF
--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -66,6 +66,10 @@ function get-calico-typha-replicas {
   if [[ "${NUM_NODES}" -gt "500" ]]; then
     typha_count=5
   fi
+  if [[ "${NETWORK_POLICY_PROVIDER:-}" != "calico" ]]; then
+    # We're not configured to use Calico, so don't start any Typhas.
+    typha_count=0
+  fi
   echo "${typha_count}"
 }
 

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -64,6 +64,10 @@ function get-calico-typha-replicas {
   if [[ "${NUM_NODES}" -gt "500" ]]; then
     typha_count=5
   fi
+  if [[ "${NETWORK_POLICY_PROVIDER:-}" != "calico" ]]; then
+    # We're not configured to use Calico, so don't start any Typhas.
+    typha_count=0
+  fi
   echo "${typha_count}"
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't start any Typha instances if Calico isn't being used.  A recent change now includes all add-ons on the master, but we don't always want a Typha replica.

**Which issue this PR fixes**

Fixes https://github.com/kubernetes/kubernetes/issues/47622

**Release note**:
```release-note
NONE
```


cc @dnardo 