### PR TITLE
Replace capacity with allocatable to calculate pod resource

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -151,15 +151,15 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 	// It assumes that cluster add-on pods stay stable and cannot be run in parallel with any other test that touches Nodes or Pods.
 	// It is so because we need to have precise control on what's running in the cluster.
 	It("validates resource limits of pods that are allowed to run [Conformance]", func() {
-		nodeMaxCapacity := int64(0)
+		nodeMaxAllocatable := int64(0)
 
-		nodeToCapacityMap := make(map[string]int64)
+		nodeToAllocatableMap := make(map[string]int64)
 		for _, node := range nodeList.Items {
-			capacity, found := node.Status.Capacity["cpu"]
+			allocatable, found := node.Status.Allocatable["cpu"]
 			Expect(found).To(Equal(true))
-			nodeToCapacityMap[node.Name] = capacity.MilliValue()
-			if nodeMaxCapacity < capacity.MilliValue() {
-				nodeMaxCapacity = capacity.MilliValue()
+			nodeToAllocatableMap[node.Name] = allocatable.MilliValue()
+			if nodeMaxAllocatable < allocatable.MilliValue() {
+				nodeMaxAllocatable = allocatable.MilliValue()
 			}
 		}
 		framework.WaitForStableCluster(cs, masterNodes)
@@ -167,21 +167,21 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 		pods, err := cs.Core().Pods(metav1.NamespaceAll).List(metav1.ListOptions{})
 		framework.ExpectNoError(err)
 		for _, pod := range pods.Items {
-			_, found := nodeToCapacityMap[pod.Spec.NodeName]
+			_, found := nodeToAllocatableMap[pod.Spec.NodeName]
 			if found && pod.Status.Phase != v1.PodSucceeded && pod.Status.Phase != v1.PodFailed {
 				framework.Logf("Pod %v requesting resource cpu=%vm on Node %v", pod.Name, getRequestedCPU(pod), pod.Spec.NodeName)
-				nodeToCapacityMap[pod.Spec.NodeName] -= getRequestedCPU(pod)
+				nodeToAllocatableMap[pod.Spec.NodeName] -= getRequestedCPU(pod)
 			}
 		}
 
 		var podsNeededForSaturation int
 
-		milliCpuPerPod := nodeMaxCapacity / maxNumberOfPods
+		milliCpuPerPod := nodeMaxAllocatable / maxNumberOfPods
 		if milliCpuPerPod < minPodCPURequest {
 			milliCpuPerPod = minPodCPURequest
 		}
 		framework.Logf("Using pod capacity: %vm", milliCpuPerPod)
-		for name, leftCapacity := range nodeToCapacityMap {
+		for name, leftCapacity := range nodeToAllocatableMap {
 			framework.Logf("Node: %v has cpu capacity: %vm", name, leftCapacity)
 			podsNeededForSaturation += (int)(leftCapacity / milliCpuPerPod)
 		}

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -183,7 +183,7 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 		framework.Logf("Using pod capacity: %vm", milliCpuPerPod)
 		for name, leftAllocatable := range nodeToAllocatableMap {
 			framework.Logf("Node: %v has cpu allocatable: %vm", name, leftAllocatable)
-			podsNeededForSaturation += (int)(leftleftAllocatable / milliCpuPerPod)
+			podsNeededForSaturation += (int)(leftAllocatable / milliCpuPerPod)
 		}
 
 		By(fmt.Sprintf("Starting additional %v Pods to fully saturate the cluster CPU and trying to start another one", podsNeededForSaturation))

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -181,9 +181,9 @@ var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
 			milliCpuPerPod = minPodCPURequest
 		}
 		framework.Logf("Using pod capacity: %vm", milliCpuPerPod)
-		for name, leftCapacity := range nodeToAllocatableMap {
-			framework.Logf("Node: %v has cpu capacity: %vm", name, leftCapacity)
-			podsNeededForSaturation += (int)(leftCapacity / milliCpuPerPod)
+		for name, leftAllocatable := range nodeToAllocatableMap {
+			framework.Logf("Node: %v has cpu allocatable: %vm", name, leftAllocatable)
+			podsNeededForSaturation += (int)(leftleftAllocatable / milliCpuPerPod)
 		}
 
 		By(fmt.Sprintf("Starting additional %v Pods to fully saturate the cluster CPU and trying to start another one", podsNeededForSaturation))


### PR DESCRIPTION
It is not accurate to use capacity to do the calculation.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
The currently cpu resource calculation for a pod in end2end test is incorrect.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #47627

**Special notes for your reviewer**:
More details about capacity and allocatable:
https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
NONE
