### PR TITLE
Fix invalid filename in kubelet log

### DIFF
--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -44,6 +45,9 @@ type sourceFile struct {
 }
 
 func NewSourceFile(path string, nodeName types.NodeName, period time.Duration, updates chan<- interface{}) {
+	// "golang.org/x/exp/inotify" requires a path without trailing "/"
+	path = strings.TrimRight(path, string(os.PathSeparator))
+
 	config := new(path, nodeName, period, updates)
 	glog.V(1).Infof("Watching path %q", path)
 	go wait.Forever(config.run, period)


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/47641
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
