### PR TITLE
fixed the logging of which conversions.

### DIFF
--- a/pkg/api/serialization_test.go
+++ b/pkg/api/serialization_test.go
@@ -137,7 +137,7 @@ func TestSetControllerConversion(t *testing.T) {
 // debug issues that arise while adding a new API type.
 func TestSpecificKind(t *testing.T) {
 	// Uncomment the following line to enable logging of which conversions
-	// api.scheme.Log(t)
+	// api.Scheme.Log(t)
 	internalGVK := schema.GroupVersionKind{Group: "extensions", Version: runtime.APIVersionInternal, Kind: "DaemonSet"}
 
 	seed := rand.Int63()


### PR DESCRIPTION
Hi Guys,

After enable the function of logging of which conversions at [TestSpecificKind](https://github.com/jianzhangbjz/kubernetes/blob/d31a7cb301468323d91b962cb7aefeea9101e107/pkg/api/serialization_test.go#L140), I got the below errors:
```
pkg/api/serialization_test.go:140: cannot refer to unexported name api.scheme
pkg/api/serialization_test.go:140: undefined: api.scheme in api.scheme.Log
ok  	k8s.io/kubernetes/cmd/genutils	0.066s
```
So, this PR will fix that.