### PR TITLE
defaultDeepCopy: don't recurse to deepCopy() for simple compound types

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/conversion/deep_copy_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/deep_copy_test.go
@@ -90,11 +90,17 @@ func TestDeepCopyArraySeparate(t *testing.T) {
 }
 
 func TestDeepCopyMapSeparate(t *testing.T) {
-	x := map[string]int{"foo": 5}
-	y := copyOrDie(t, x).(map[string]int)
-	x["foo"] = 3
-	if y["foo"] == 3 {
-		t.Errorf("deep copy wasn't deep: %#q %#q", x, y)
+	i := 1
+	j := 1
+
+	x := map[*int]*int{&i: &j}
+	y := copyOrDie(t, x).(map[*int]*int)
+
+	i, j = 2, 2
+	for k, v := range y {
+		if *k != 1 || *v != 1 {
+			t.Errorf("deep copy wasn't deep: %#q %#q", x, y)
+		}
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The main motivation for this PR is that I found when copying any object containing a []byte somewhere under it, defaultDeepCopy will end up calling deepCopy for every byte in the slice.  This is time-consuming and causes pressure on the GC.  This PR checks when copying compound types to see if their element type is a value type.  If so, it takes deepCopy out of the loop, even calling reflect.Copy direct where it can.

In the process, I also found a bug which is that when deep copying maps, the map keys are not currently deep copied - so anything of the form map[struct something]thing would not be deep copied correctly (by defaultDeepCopy).  This PR should fix that.

**Release note**:
```release-note
NONE
```
