### PR TITLE
Speed up PV integration tests

### DIFF
--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -48,14 +48,14 @@ import (
 // KUBE_INTEGRATION_PV_OBJECTS - nr. of PVs/PVCs to be created
 //      (100 by default)
 // KUBE_INTEGRATION_PV_SYNC_PERIOD - volume controller sync period
-//      (10s by default)
+//      (1s by default)
 // KUBE_INTEGRATION_PV_END_SLEEP - for how long should
 //      TestPersistentVolumeMultiPVsPVCs sleep when it's finished (0s by
 //      default). This is useful to test how long does it take for periodic sync
 //      to process bound PVs/PVCs.
 //
 const defaultObjectCount = 100
-const defaultSyncPeriod = 10 * time.Second
+const defaultSyncPeriod = 1 * time.Second
 
 const provisionerPluginName = "kubernetes.io/mock-provisioner"
 


### PR DESCRIPTION
Integration tests are ~20 seconds shorter. Before (with #47645 applied):
```
--- PASS: TestPodDeletionWithDswp (3.70s)
--- PASS: TestPodUpdateWithWithADC (3.61s)
--- PASS: TestPodUpdateWithKeepTerminatedPodVolumes (3.59s)
--- PASS: TestPodAddedByDswp (5.69s)
--- PASS: TestPersistentVolumeRecycler (2.68s)
--- PASS: TestPersistentVolumeDeleter (12.61s)
--- PASS: TestPersistentVolumeBindRace (12.53s)
--- PASS: TestPersistentVolumeClaimLabelSelector (12.52s)
--- PASS: TestPersistentVolumeClaimLabelSelectorMatchExpressions (2.62s)
--- PASS: TestPersistentVolumeMultiPVs (3.98s)
--- PASS: TestPersistentVolumeMultiPVsPVCs (3.67s)
--- PASS: TestPersistentVolumeControllerStartup (7.41s)
--- PASS: TestPersistentVolumeProvisionMultiPVCs (4.85s)
--- PASS: TestPersistentVolumeMultiPVsDiffAccessModes (2.71s)
ok  	k8s.io/kubernetes/test/integration/volume	82.304s
```

After:
```
--- PASS: TestPodDeletionWithDswp (3.70s)
--- PASS: TestPodUpdateWithWithADC (3.61s)
--- PASS: TestPodUpdateWithKeepTerminatedPodVolumes (3.63s)
--- PASS: TestPodAddedByDswp (5.73s)
--- PASS: TestPersistentVolumeRecycler (3.53s)
--- PASS: TestPersistentVolumeDeleter (4.56s)
--- PASS: TestPersistentVolumeBindRace (3.52s)
--- PASS: TestPersistentVolumeClaimLabelSelector (3.52s)
--- PASS: TestPersistentVolumeClaimLabelSelectorMatchExpressions (3.49s)
--- PASS: TestPersistentVolumeMultiPVs (3.07s)
--- PASS: TestPersistentVolumeMultiPVsPVCs (3.94s)
--- PASS: TestPersistentVolumeControllerStartup (7.64s)
--- PASS: TestPersistentVolumeProvisionMultiPVCs (6.25s)
--- PASS: TestPersistentVolumeMultiPVsDiffAccessModes (3.55s)
ok  	k8s.io/kubernetes/test/integration/volume	59.945s
```

/assign @gnufied 
@kubernetes/sig-storage-pr-reviews 

Release note
```release-note
NONE
```
