### PR TITLE
Adding proxier test that uses "iptables-restore --test" to validate i…

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -198,11 +198,22 @@ func (d *timeoutDialer) Dial(network, addr string, config *ssh.ClientConfig) (*s
 // host as specific user, along with any SSH-level error.
 // If user=="", it will default (like SSH) to os.Getenv("USER")
 func RunSSHCommand(cmd, user, host string, signer ssh.Signer) (string, string, int, error) {
-	return runSSHCommand(realTimeoutDialer, cmd, user, host, signer, true)
+	return runSSHCommand(realTimeoutDialer, cmd, user, host, nil, signer, true)
+}
+
+// RunSSHCommandWithStdin sends input as stdin and returns the stdout, stderr, and exit code from running cmd on
+// host as specific user, along with any SSH-level error.
+// If user=="", it will default (like SSH) to os.Getenv("USER")
+func RunSSHCommandWithStdin(input, cmd, user, host string, signer ssh.Signer) (string, string, int, error) {
+	var inputreader io.Reader
+	if input != "" {
+		inputreader = strings.NewReader(input)
+	}
+	return runSSHCommand(realTimeoutDialer, cmd, user, host, inputreader, signer, true)
 }
 
 // Internal implementation of runSSHCommand, for testing
-func runSSHCommand(dialer sshDialer, cmd, user, host string, signer ssh.Signer, retry bool) (string, string, int, error) {
+func runSSHCommand(dialer sshDialer, cmd, user, host string, input io.Reader, signer ssh.Signer, retry bool) (string, string, int, error) {
 	if user == "" {
 		user = os.Getenv("USER")
 	}
@@ -234,6 +245,7 @@ func runSSHCommand(dialer sshDialer, cmd, user, host string, signer ssh.Signer, 
 	code := 0
 	var bout, berr bytes.Buffer
 	session.Stdout, session.Stderr = &bout, &berr
+	session.Stdin = input
 	if err = session.Run(cmd); err != nil {
 		// Check whether the command failed to run or didn't complete.
 		if exiterr, ok := err.(*ssh.ExitError); ok {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3696,6 +3696,30 @@ func SSH(cmd, host, provider string) (SSHResult, error) {
 	return result, err
 }
 
+func SSHWithStdin(input, cmd, host, provider string) (SSHResult, error) {
+	result := SSHResult{Host: host, Cmd: cmd}
+
+	// Get a signer for the provider.
+	signer, err := GetSigner(provider)
+	if err != nil {
+		return result, fmt.Errorf("error getting signer for provider %s: '%v'", provider, err)
+	}
+
+	// RunSSHCommand will default to Getenv("USER") if user == "", but we're
+	// defaulting here as well for logging clarity.
+	result.User = os.Getenv("KUBE_SSH_USER")
+	if result.User == "" {
+		result.User = os.Getenv("USER")
+	}
+
+	stdout, stderr, code, err := sshutil.RunSSHCommandWithStdin(input, cmd, result.User, host, signer)
+	result.Stdout = stdout
+	result.Stderr = stderr
+	result.Code = code
+
+	return result, err
+}
+
 func LogSSHResult(result SSHResult) {
 	remote := fmt.Sprintf("%s@%s", result.User, result.Host)
 	Logf("ssh %s: command:   %s", remote, result.Cmd)
@@ -3705,6 +3729,10 @@ func LogSSHResult(result SSHResult) {
 }
 
 func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult, error) {
+	return IssueSSHCommandWithResultAndInput("", cmd, provider, node)
+}
+
+func IssueSSHCommandWithResultAndInput(input, cmd, provider string, node *v1.Node) (*SSHResult, error) {
 	Logf("Getting external IP address for %s", node.Name)
 	host := ""
 	for _, a := range node.Status.Addresses {
@@ -3719,7 +3747,7 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult,
 	}
 
 	Logf("SSH %q on %s(%s)", cmd, node.Name, host)
-	result, err := SSH(cmd, host, provider)
+	result, err := SSHWithStdin(input, cmd, host, provider)
 	LogSSHResult(result)
 
 	if result.Code != 0 || err != nil {

--- a/test/e2e/proxier.go
+++ b/test/e2e/proxier.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"net"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/proxy"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/pkg/proxy/iptables"
+	"k8s.io/kubernetes/pkg/util/exec"
+	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	iptablestest "k8s.io/kubernetes/pkg/util/iptables/testing"
+)
+
+func makeNSN(namespace, name string) types.NamespacedName {
+	return types.NamespacedName{Namespace: namespace, Name: name}
+}
+
+type fakeSysctl struct{}
+
+func (f *fakeSysctl) GetSysctl(sysctl string) (int, error) {
+	return 1, nil
+}
+func (f *fakeSysctl) SetSysctl(sysctl string, newVal int) error {
+	return nil
+}
+
+type fakeEventRecorder struct{}
+
+func (f *fakeEventRecorder) Event(object pkgruntime.Object, eventtype, reason, message string) {}
+func (f *fakeEventRecorder) Eventf(object pkgruntime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+func (f *fakeEventRecorder) PastEventf(object pkgruntime.Object, timestamp metav1.Time, eventtype, reason, messageFmt string, args ...interface{}) {
+}
+
+type fakeHealthzUpdater struct{}
+
+func (f *fakeHealthzUpdater) UpdateTimestamp() {}
+
+func NewFakeProxier(ipt utiliptables.Interface) *iptables.Proxier {
+	p, err := iptables.NewProxier(ipt,
+		&fakeSysctl{},
+		&exec.FakeExec{},
+		time.Microsecond,
+		time.Microsecond,
+		false,
+		0,
+		"10.0.0.0/24",
+		"testHostname",
+		net.ParseIP("127.0.0.1"),
+		&fakeEventRecorder{},
+		&fakeHealthzUpdater{},
+	)
+
+	if err != nil {
+		panic("can't create proxy!")
+	}
+	return p
+}
+
+func makeEndpointsMap(proxier *iptables.Proxier, allEndpoints ...*api.Endpoints) {
+	for i := range allEndpoints {
+		proxier.OnEndpointsAdd(allEndpoints[i])
+	}
+
+	proxier.OnEndpointsSynced()
+}
+
+func makeTestService(namespace, name string, svcFunc func(*api.Service)) *api.Service {
+	svc := &api.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: map[string]string{},
+		},
+		Spec:   api.ServiceSpec{},
+		Status: api.ServiceStatus{},
+	}
+	svcFunc(svc)
+	return svc
+}
+
+func makeServiceMap(proxier *iptables.Proxier, allServices ...*api.Service) {
+	for i := range allServices {
+		proxier.OnServiceAdd(allServices[i])
+	}
+
+	proxier.OnServiceSynced()
+}
+
+var _ = framework.KubeDescribe("Network", func() {
+
+	fr := framework.NewDefaultFramework("network")
+
+	It("should sync valid iptables rules", func() {
+		nodes := framework.GetReadySchedulableNodesOrDie(fr.ClientSet)
+
+		if len(nodes.Items) < 1 {
+			framework.Skipf(
+				"Test requires >= 1 Ready nodes, but there are only %v nodes",
+				len(nodes.Items))
+		}
+
+		selectNode := &nodes.Items[0]
+
+		ipt := iptablestest.NewFake()
+		fp := NewFakeProxier(ipt)
+
+		svcPortName := proxy.ServicePortName{
+			NamespacedName: makeNSN("ns1", "svc1"),
+			Port:           "p80",
+		}
+
+		svcIP := "10.20.30.41"
+		svcPort := 80
+		svcExternalIPs := "50.60.70.81"
+
+		makeServiceMap(fp,
+			makeTestService(svcPortName.Namespace, svcPortName.Name, func(svc *api.Service) {
+				svc.Spec.Type = "ClusterIP"
+				svc.Spec.ClusterIP = svcIP
+				svc.Spec.ExternalIPs = []string{svcExternalIPs}
+				svc.Spec.Ports = []api.ServicePort{{
+					Name:       svcPortName.Port,
+					Port:       int32(svcPort),
+					Protocol:   api.ProtocolTCP,
+					TargetPort: intstr.FromInt(svcPort),
+				}}
+			}),
+		)
+		makeEndpointsMap(fp)
+
+		By("Syncing iptables rules")
+		fp.Sync()
+
+		// grab the lines from the ipt and test them in the node
+
+		By("Checking rules are valid with iptables restore test")
+		// If test flakes occur here, then this check should be performed
+		// in a loop as there may be a race with the client connecting.
+		result, err := framework.IssueSSHCommandWithResultAndInput(
+			string(ipt.Lines), "sudo iptables-restore --test",
+			framework.TestContext.Provider,
+			selectNode)
+
+		framework.ExpectNoError(err)
+		Expect(result.Code).To(Equal(0))
+
+	})
+})


### PR DESCRIPTION
…ptables rules.

fixes kubernetes/kubernetes/#36850

**What this PR does / why we need it**:
This PR tests iptable rules of the proxier on a live node, to make sure they are syntactically valid.

**Which issue this PR fixes**: 

fixes #36850

**Special notes for your reviewer**:

**Release note**:

```release-note
Adding an e2e test to test the iptables proxier tools
```
