### PR TITLE
Fix Juju kubernetes-master idle status never being set

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -284,9 +284,9 @@ def set_app_version():
     hookenv.application_version_set(version.split(b' v')[-1].rstrip())
 
 
-@when('cdk-addons.configured', 'kube-api-endpoint.connected',
+@when('cdk-addons.configured', 'kube-api-endpoint.available',
       'kube-control.connected')
-def idle_status():
+def idle_status(kube_api, kube_control):
     ''' Signal at the end of the run that we are running. '''
     if not all_kube_system_pods_running():
         hookenv.status_set('waiting', 'Waiting for kube-system pods to start')


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a problem with the kubernetes-master charm where the "Kubernetes master running." status message never gets set.

This happens because the `kube-api-endpoint.connected` state that it's waiting for doesn't exist. The state we need is `kube-api-endpoint.available` as seen [here](https://github.com/juju-solutions/interface-http/blob/master/provides.py#L12).

Additionally, we need to add the relation arguments to idle_status so it doesn't break when called.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47676

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix Juju kubernetes-master idle status never being set
```
