### PR TITLE
cmd/create_deployment: refactor long function

### DIFF
--- a/pkg/kubectl/cmd/create_deployment_test.go
+++ b/pkg/kubectl/cmd/create_deployment_test.go
@@ -27,8 +27,38 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/kubectl"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
+
+func Test_generatorFromName(t *testing.T) {
+	const (
+		nonsenseName   = "not-a-real-generator-name"
+		basicName      = cmdutil.DeploymentBasicV1Beta1GeneratorName
+		basicAppsName  = cmdutil.DeploymentBasicAppsV1Beta1GeneratorName
+		deploymentName = "deployment-name"
+	)
+	imageNames := []string{"image-1", "image-2"}
+
+	generator, ok := generatorFromName(nonsenseName, imageNames, deploymentName)
+	assert.Nil(t, generator)
+	assert.False(t, ok)
+
+	generator, ok = generatorFromName(basicName, imageNames, deploymentName)
+	assert.True(t, ok)
+	assert.Equal(t, &kubectl.DeploymentBasicGeneratorV1{
+		Name:   deploymentName,
+		Images: imageNames,
+	}, generator)
+
+	generator, ok = generatorFromName(basicAppsName, imageNames, deploymentName)
+	assert.True(t, ok)
+	assert.Equal(t, &kubectl.DeploymentBasicAppsGeneratorV1{
+		Name:   deploymentName,
+		Images: imageNames,
+	}, generator)
+}
 
 func TestCreateDeployment(t *testing.T) {
 	depName := "jonny-dep"

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -23,7 +23,6 @@ import (
 	"github.com/docker/distribution/reference"
 	"github.com/spf13/cobra"
 
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv2alpha1 "k8s.io/api/batch/v2alpha1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -233,12 +232,7 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 	}
 
 	// TODO: this should be removed alongside with extensions/v1beta1 depployments generator
-	if generatorName == cmdutil.DeploymentAppsV1Beta1GeneratorName &&
-		!contains(resourcesList, appsv1beta1.SchemeGroupVersion.WithResource("deployments")) {
-		fmt.Fprintf(cmdErr, "WARNING: New deployments generator specified (%s), but apps/v1beta1.Deployments are not available, falling back to the old one (%s).\n",
-			cmdutil.DeploymentAppsV1Beta1GeneratorName, cmdutil.DeploymentV1Beta1GeneratorName)
-		generatorName = cmdutil.DeploymentV1Beta1GeneratorName
-	}
+	generatorName = fallbackGeneratorNameIfNecessary(generatorName, resourcesList, cmdErr)
 
 	if generatorName == cmdutil.CronJobV2Alpha1GeneratorName &&
 		!contains(resourcesList, batchv2alpha1.SchemeGroupVersion.WithResource("cronjobs")) {


### PR DESCRIPTION
Refactor the `createDeployment` function under `pkg/kubectl/cmd`.

- [x] Behavior has been extracted to two helper functions.
- [x] Behavior remains identical.
- [x] Logic has been made explicit through function naming and comments.

This is essentially the pattern I've been following in my larger branches (the ones that are pending the merge of #46468). Want to get some design feedback before I get too far away from `master`.

Thanks!

cc @apelisse @mengqiy @droot 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
