### PR TITLE
Fix link to apiextensions client-go example

### DIFF
--- a/staging/src/k8s.io/client-go/examples/custom-resources/README.md
+++ b/staging/src/k8s.io/client-go/examples/custom-resources/README.md
@@ -4,4 +4,4 @@
 
 For a client-go example using CustomResourceDefinitions, go to
 
-  [k8s.io/apiextensions-apiserver/examples/client-go](https://git.k8s.io/apiextentions-apiserver/examples/client-go).
+  [k8s.io/apiextensions-apiserver/examples/client-go](https://git.k8s.io/apiextensions-apiserver/examples/client-go).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

Fixes link to client-go example for apiextensions-apiserver.

Fixing #47211.

**Special notes for your reviewer**:

When I run `hack/update-staging-client-go.sh`, I get this error:

```
!!! Error in staging/copy.sh:132
    Error in staging/copy.sh:132. 'git commit -q -m "Snapshot" > /dev/null' exited with status 1
  Call stack:
    1: staging/copy.sh:132 main(...)
  Exiting with status 1
```

What am I missing here?
/cc @caesarxuchao @sttts 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
