### PR TITLE
Turn off the alpha features by default

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -27,7 +27,6 @@ go_library(
         "//pkg/api/v1:go_default_library",
         "//pkg/apis/admission/install:go_default_library",
         "//pkg/apis/admissionregistration/install:go_default_library",
-        "//pkg/apis/admissionregistration/v1alpha1:go_default_library",
         "//pkg/apis/apps/install:go_default_library",
         "//pkg/apis/apps/v1beta1:go_default_library",
         "//pkg/apis/authentication/install:go_default_library",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/kubernetes/cmd/kube-apiserver/app/options"
 	"k8s.io/kubernetes/pkg/api"
 	apiv1 "k8s.io/kubernetes/pkg/api/v1"
-	admissionregistrationv1alpha1 "k8s.io/kubernetes/pkg/apis/admissionregistration/v1alpha1"
 	appsv1beta1 "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 	authenticationv1 "k8s.io/kubernetes/pkg/apis/authentication/v1"
 	authenticationv1beta1 "k8s.io/kubernetes/pkg/apis/authentication/v1beta1"
@@ -381,9 +380,9 @@ func (n nodeAddressProvider) externalAddresses() ([]string, error) {
 
 func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 	ret := serverstorage.NewResourceConfig()
+	// NOTE: GroupVersions listed here will be enabled by default. Don't put alpha versions in the list.
 	ret.EnableVersions(
 		apiv1.SchemeGroupVersion,
-		admissionregistrationv1alpha1.SchemeGroupVersion,
 		extensionsapiv1beta1.SchemeGroupVersion,
 		batchapiv1.SchemeGroupVersion,
 		authenticationv1.SchemeGroupVersion,
@@ -392,6 +391,10 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 		appsv1beta1.SchemeGroupVersion,
 		policyapiv1beta1.SchemeGroupVersion,
 		rbacv1beta1.SchemeGroupVersion,
+		// Don't copy this pattern. We enable rbac/v1alpha1 and settings/v1laph1
+		// by default only because they were enabled in previous releases.
+		// See https://github.com/kubernetes/kubernetes/pull/47690.
+		// TODO: disable rbac/v1alpha1 and settings/v1alpha1 by default in 1.8
 		rbacv1alpha1.SchemeGroupVersion,
 		settingv1alpha1.SchemeGroupVersion,
 		storageapiv1.SchemeGroupVersion,


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/47687.

@liggitt @sttts do you know if it's intentional to turn on rbac v1alpha1?

```release-note
The following alpha API groups were unintentionally enabled by default in previous releases, and will no longer be enabled by default in v1.8:
rbac.authorization.k8s.io/v1alpha1
settings.k8s.io/v1alpha1
If you wish to continue using them in v1.8, please enable them explicitly using the `--runtime-config` flag of the apiserver (for example, `--runtime-config="rbac.authorization.k8s.io/v1alpha1,settings.k8s.io/v1alpha1"`)
```