### PR TITLE
Additional e2e for StatefulSet Update

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -488,17 +488,9 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 	}
 	// we terminate the Pod with the largest ordinal that does not match the update revision.
 	for target := len(replicas) - 1; target >= updateMin; target-- {
-		// all replicas should be healthy before an update progresses we allow termination of the firstUnhealthy
-		// Pod in any state allow for rolling back a failed update.
-		if !isRunningAndReady(replicas[target]) && replicas[target] != firstUnhealthyPod {
-			glog.V(4).Infof(
-				"StatefulSet %s/%s is waiting for Pod %s to be Running and Ready prior to update",
-				set.Namespace,
-				set.Name,
-				firstUnhealthyPod.Name)
-			return &status, nil
-		}
-		if getPodRevision(replicas[target]) != updateRevision.Name {
+
+		// delete the Pod if it is not already terminating and does not match the update revision.
+		if getPodRevision(replicas[target]) != updateRevision.Name && !isTerminating(replicas[target]) {
 			glog.V(4).Infof("StatefulSet %s/%s terminating Pod %s for update",
 				set.Namespace,
 				set.Name,
@@ -507,6 +499,17 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 			status.CurrentReplicas--
 			return &status, err
 		}
+
+		// wait for unhealthy Pods on update
+		if !isHealthy(replicas[target]) {
+			glog.V(4).Infof(
+				"StatefulSet %s/%s is waiting for Pod %s to update",
+				set.Namespace,
+				set.Name,
+				replicas[target].Name)
+			return &status, nil
+		}
+
 	}
 	return &status, nil
 }

--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -19,6 +19,8 @@ package framework
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -33,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
@@ -94,6 +97,15 @@ type StatefulSetTester struct {
 // NewStatefulSetTester creates a StatefulSetTester that uses c to interact with the API server.
 func NewStatefulSetTester(c clientset.Interface) *StatefulSetTester {
 	return &StatefulSetTester{c}
+}
+
+// GetStatefulSet gets the StatefulSet named name in namespace.
+func (s *StatefulSetTester) GetStatefulSet(namespace, name string) *apps.StatefulSet {
+	ss, err := s.c.Apps().StatefulSets(namespace).Get(name, metav1.GetOptions{})
+	if err != nil {
+		Failf("Failed to get StatefulSet %s/%s: %v", namespace, name, err)
+	}
+	return ss
 }
 
 // CreateStatefulSet creates a StatefulSet from the manifest at manifestPath in the Namespace ns using kubectl create.
@@ -324,8 +336,21 @@ func (s *StatefulSetTester) WaitForState(ss *apps.StatefulSet, until func(*apps.
 			return until(ssGet, podList)
 		})
 	if pollErr != nil {
-		Failf("Failed waiting for pods to enter running: %v", pollErr)
+		Failf("Failed waiting for state update: %v", pollErr)
 	}
+}
+
+// WaitForStatus waits for the StatefulSetStatus's ObservedGeneration to be greater than or equal to set's Generation.
+// The returned StatefulSet contains such a StatefulSetStatus
+func (s *StatefulSetTester) WaitForStatus(set *apps.StatefulSet) *apps.StatefulSet {
+	s.WaitForState(set, func(set2 *apps.StatefulSet, pods *v1.PodList) (bool, error) {
+		if set2.Status.ObservedGeneration != nil && *set2.Status.ObservedGeneration >= set.Generation {
+			set = set2
+			return true, nil
+		}
+		return false, nil
+	})
+	return set
 }
 
 // WaitForRunningAndReady waits for numStatefulPods in ss to be Running and Ready.
@@ -333,12 +358,141 @@ func (s *StatefulSetTester) WaitForRunningAndReady(numStatefulPods int32, ss *ap
 	s.waitForRunning(numStatefulPods, ss, true)
 }
 
+// WaitForPodReady waits for the Pod named podName in set to exist and have a Ready condition.
+func (s *StatefulSetTester) WaitForPodReady(set *apps.StatefulSet, podName string) (*apps.StatefulSet, *v1.PodList) {
+	var pods *v1.PodList
+	s.WaitForState(set, func(set2 *apps.StatefulSet, pods2 *v1.PodList) (bool, error) {
+		set = set2
+		pods = pods2
+		for i := range pods.Items {
+			if pods.Items[i].Name == podName {
+				return podutil.IsPodReady(&pods.Items[i]), nil
+			}
+		}
+		return false, nil
+	})
+	return set, pods
+
+}
+
+// WaitForPodNotReady waist for the Pod named podName in set to exist and to not have a Ready condition.
+func (s *StatefulSetTester) WaitForPodNotReady(set *apps.StatefulSet, podName string) (*apps.StatefulSet, *v1.PodList) {
+	var pods *v1.PodList
+	s.WaitForState(set, func(set2 *apps.StatefulSet, pods2 *v1.PodList) (bool, error) {
+		set = set2
+		pods = pods2
+		for i := range pods.Items {
+			if pods.Items[i].Name == podName {
+				return !podutil.IsPodReady(&pods.Items[i]), nil
+			}
+		}
+		return false, nil
+	})
+	return set, pods
+
+}
+
+// WaitForRollingUpdate waits for all Pods in set to exist and have the correct revision and for the RollingUpdate to
+// complete. set must have a RollingUpdateStatefulSetStrategyType.
+func (s *StatefulSetTester) WaitForRollingUpdate(set *apps.StatefulSet) (*apps.StatefulSet, *v1.PodList) {
+	var pods *v1.PodList
+	if set.Spec.UpdateStrategy.Type != apps.RollingUpdateStatefulSetStrategyType {
+		Failf("StatefulSet %s/%s attempt to wait for rolling update with updateStrategy %s",
+			set.Namespace,
+			set.Name,
+			set.Spec.UpdateStrategy.Type)
+	}
+	s.WaitForState(set, func(set2 *apps.StatefulSet, pods2 *v1.PodList) (bool, error) {
+		set = set2
+		pods = pods2
+		if len(pods.Items) < int(*set.Spec.Replicas) {
+			return false, nil
+		}
+		if set.Status.UpdateRevision != set.Status.CurrentRevision {
+			Logf("Waiting for StatefulSet %s/%s to complete update",
+				set.Namespace,
+				set.Name,
+			)
+			s.SortStatefulPods(pods)
+			for i := range pods.Items {
+				if pods.Items[i].Labels[apps.StatefulSetRevisionLabel] != set.Status.UpdateRevision {
+					Logf("Waiting for Pod %s/%s to have revision %s update revision %s",
+						pods.Items[i].Namespace,
+						pods.Items[i].Name,
+						set.Status.UpdateRevision,
+						pods.Items[i].Labels[apps.StatefulSetRevisionLabel])
+				}
+			}
+			return false, nil
+		}
+		return true, nil
+	})
+	return set, pods
+}
+
+// WaitForPartitionedRollingUpdate waits for all Pods in set to exist and have the correct revision. set must have
+// a RollingUpdateStatefulSetStrategyType with a non-nil RollingUpdate and Partition. All Pods with ordinals less
+// than or equal to the Partition are expected to be at set's current revision. All other Pods are expected to be
+// at its update revision.
+func (s *StatefulSetTester) WaitForPartitionedRollingUpdate(set *apps.StatefulSet) (*apps.StatefulSet, *v1.PodList) {
+	var pods *v1.PodList
+	if set.Spec.UpdateStrategy.Type != apps.RollingUpdateStatefulSetStrategyType {
+		Failf("StatefulSet %s/%s attempt to wait for partitioned update with updateStrategy %s",
+			set.Namespace,
+			set.Name,
+			set.Spec.UpdateStrategy.Type)
+	}
+	if set.Spec.UpdateStrategy.RollingUpdate == nil || set.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
+		Failf("StatefulSet %s/%s attempt to wait for partitioned update with nil RollingUpdate or nil Partition",
+			set.Namespace,
+			set.Name)
+	}
+	s.WaitForState(set, func(set2 *apps.StatefulSet, pods2 *v1.PodList) (bool, error) {
+		set = set2
+		pods = pods2
+		partition := int(*set.Spec.UpdateStrategy.RollingUpdate.Partition)
+		if len(pods.Items) < int(*set.Spec.Replicas) {
+			return false, nil
+		}
+		if partition <= 0 && set.Status.UpdateRevision != set.Status.CurrentRevision {
+			Logf("Waiting for StatefulSet %s/%s to complete update",
+				set.Namespace,
+				set.Name,
+			)
+			s.SortStatefulPods(pods)
+			for i := range pods.Items {
+				if pods.Items[i].Labels[apps.StatefulSetRevisionLabel] != set.Status.UpdateRevision {
+					Logf("Waiting for Pod %s/%s to have revision %s update revision %s",
+						pods.Items[i].Namespace,
+						pods.Items[i].Name,
+						set.Status.UpdateRevision,
+						pods.Items[i].Labels[apps.StatefulSetRevisionLabel])
+				}
+			}
+			return false, nil
+		} else {
+			for i := int(*set.Spec.Replicas) - 1; i >= partition; i-- {
+				if pods.Items[i].Labels[apps.StatefulSetRevisionLabel] != set.Status.UpdateRevision {
+					Logf("Waiting for Pod %s/%s to have revision %s update revision %s",
+						pods.Items[i].Namespace,
+						pods.Items[i].Name,
+						set.Status.UpdateRevision,
+						pods.Items[i].Labels[apps.StatefulSetRevisionLabel])
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	})
+	return set, pods
+}
+
 // WaitForRunningAndReady waits for numStatefulPods in ss to be Running and not Ready.
 func (s *StatefulSetTester) WaitForRunningAndNotReady(numStatefulPods int32, ss *apps.StatefulSet) {
 	s.waitForRunning(numStatefulPods, ss, false)
 }
 
-// BreakProbe breaks the readiness probe for Nginx StatefulSet containers.
+// BreakProbe breaks the readiness probe for Nginx StatefulSet containers in ss.
 func (s *StatefulSetTester) BreakProbe(ss *apps.StatefulSet, probe *v1.Probe) error {
 	path := probe.HTTPGet.Path
 	if path == "" {
@@ -348,7 +502,19 @@ func (s *StatefulSetTester) BreakProbe(ss *apps.StatefulSet, probe *v1.Probe) er
 	return s.ExecInStatefulPods(ss, cmd)
 }
 
-// RestoreProbe restores the readiness probe for Nginx StatefulSet containers.
+// BreakProbe breaks the readiness probe for Nginx StatefulSet containers in pod.
+func (s *StatefulSetTester) BreakPodProbe(ss *apps.StatefulSet, pod *v1.Pod, probe *v1.Probe) error {
+	path := probe.HTTPGet.Path
+	if path == "" {
+		return fmt.Errorf("Path expected to be not empty: %v", path)
+	}
+	cmd := fmt.Sprintf("mv -v /usr/share/nginx/html%v /tmp/", path)
+	stdout, err := RunHostCmd(pod.Namespace, pod.Name, cmd)
+	Logf("stdout of %v on %v: %v", cmd, pod.Name, stdout)
+	return err
+}
+
+// RestoreProbe restores the readiness probe for Nginx StatefulSet containers in ss.
 func (s *StatefulSetTester) RestoreProbe(ss *apps.StatefulSet, probe *v1.Probe) error {
 	path := probe.HTTPGet.Path
 	if path == "" {
@@ -356,6 +522,18 @@ func (s *StatefulSetTester) RestoreProbe(ss *apps.StatefulSet, probe *v1.Probe) 
 	}
 	cmd := fmt.Sprintf("mv -v /tmp%v /usr/share/nginx/html/", path)
 	return s.ExecInStatefulPods(ss, cmd)
+}
+
+// RestoreProbe restores the readiness probe for Nginx StatefulSet containers in pod.
+func (s *StatefulSetTester) RestorePodProbe(ss *apps.StatefulSet, pod *v1.Pod, probe *v1.Probe) error {
+	path := probe.HTTPGet.Path
+	if path == "" {
+		return fmt.Errorf("Path expected to be not empty: %v", path)
+	}
+	cmd := fmt.Sprintf("mv -v /tmp%v /usr/share/nginx/html/", path)
+	stdout, err := RunHostCmd(pod.Namespace, pod.Name, cmd)
+	Logf("stdout of %v on %v: %v", cmd, pod.Name, stdout)
+	return err
 }
 
 // SetHealthy updates the StatefulSet InitAnnotation to true in order to set a StatefulSet Pod to be Running and Ready.
@@ -441,6 +619,11 @@ func (p *StatefulSetTester) CheckServiceName(ss *apps.StatefulSet, expectedServi
 	}
 
 	return nil
+}
+
+// SortStatefulPods sorts pods by their ordinals
+func (s *StatefulSetTester) SortStatefulPods(pods *v1.PodList) {
+	sort.Sort(statefulPodsByOrdinal(pods.Items))
 }
 
 // DeleteAllStatefulSets deletes all StatefulSet API Objects in Namespace ns.
@@ -612,4 +795,32 @@ func NewStatefulSet(name, ns, governingSvcName string, replicas int32, statefulP
 // SetStatefulSetInitializedAnnotation sets teh StatefulSetInitAnnotation to value.
 func SetStatefulSetInitializedAnnotation(ss *apps.StatefulSet, value string) {
 	ss.Spec.Template.ObjectMeta.Annotations["pod.alpha.kubernetes.io/initialized"] = value
+}
+
+var statefulPodRegex = regexp.MustCompile("(.*)-([0-9]+)$")
+
+func getStatefulPodOrdinal(pod *v1.Pod) int {
+	ordinal := -1
+	subMatches := statefulPodRegex.FindStringSubmatch(pod.Name)
+	if len(subMatches) < 3 {
+		return ordinal
+	}
+	if i, err := strconv.ParseInt(subMatches[2], 10, 32); err == nil {
+		ordinal = int(i)
+	}
+	return ordinal
+}
+
+type statefulPodsByOrdinal []v1.Pod
+
+func (sp statefulPodsByOrdinal) Len() int {
+	return len(sp)
+}
+
+func (sp statefulPodsByOrdinal) Swap(i, j int) {
+	sp[i], sp[j] = sp[j], sp[i]
+}
+
+func (sp statefulPodsByOrdinal) Less(i, j int) bool {
+	return getStatefulPodOrdinal(&sp[i]) < getStatefulPodOrdinal(&sp[j])
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds additional e2e tests for StatefulSet update

fixes: #46942

```release-note
NONE
```
