### PR TITLE
Provide a way to setup the limit NO files for rkt Pods

### DIFF
--- a/pkg/kubelet/rkt/BUILD
+++ b/pkg/kubelet/rkt/BUILD
@@ -82,6 +82,7 @@ go_test(
         "//vendor/github.com/appc/spec/schema:go_default_library",
         "//vendor/github.com/appc/spec/schema/types:go_default_library",
         "//vendor/github.com/coreos/go-systemd/dbus:go_default_library",
+        "//vendor/github.com/coreos/go-systemd/unit:go_default_library",
         "//vendor/github.com/coreos/rkt/api/v1alpha:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows to customize the Systemd unit files for rkt pods.
We start with the `systemd-unit-option.rkt.kubernetes.io/LimitNOFILE` to allows to run workloads like etcd, ES in kubernetes with rkt.

**Special notes for your reviewer**:

Once again, I followed @yifan-gu guidelines.
I made a basic check over the values given inside the `systemd-unit-option.rkt.kubernetes.io/LimitNOFILE` (integer and > 0).
If this check fails: I simply ignore the field.
The other implementation would be to fail the whole SetUpPod.

We discussed using a key like `rkt.kubernetes.io/systemd-unit-option/LimitNOFILE` but the validation only allows a single `/` in this field:
```The Deployment "tiller" is invalid: spec.template.annotations: Invalid value: "rkt.kubernetes.io/systemd-unit-option/LimitNOFILE": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')```

**Release note**:

```release-note 
NONE
```
