### PR TITLE
Don't bother with a mutable transformer for identity

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -58,7 +58,7 @@ func newETCD3Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, e
 	}
 	transformer := c.Transformer
 	if transformer == nil {
-		transformer = value.NewMutableTransformer(value.IdentityTransformer)
+		transformer = value.IdentityTransformer
 	}
 	if c.Quorum {
 		return etcd3.New(client, c.Codec, c.Prefix, transformer), destroyFunc, nil


### PR DESCRIPTION
The default value transformer can safely be the identity transformer - mutability is not required if the caller doesn't need transformation.