### PR TITLE
Delete the redundant parameter flag

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -219,7 +219,7 @@ func (kl *Kubelet) getPodVolumePathListFromDisk(podUID types.UID) ([]string, err
 	if pathExists, pathErr := volumeutil.PathExists(podVolDir); pathErr != nil {
 		return volumes, fmt.Errorf("Error checking if path %q exists: %v", podVolDir, pathErr)
 	} else if !pathExists {
-		glog.Warningf("Warning: path %q does not exist: %q", podVolDir)
+		glog.Warningf("Path %q does not exist", podVolDir)
 		return volumes, nil
 	}
 


### PR DESCRIPTION
What this PR does / why we need it:

  Delete redundant parameter flag, otherwise the log will be show like:

  Warning: path "/var/lib/kubelet/pods/3c6c4869-4d02-11e7-9685-fa163eeda0fa/volumes" does not exist: %!q(MISSING)

  thank you!
