### PR TITLE
Add access control support to advanced audit

### DIFF
--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -42,10 +42,12 @@ apiserver-count
 apiserver-enable-basic-auth
 apiserver-enable-token-auth
 attach-detach-reconcile-sync-period
+audit-grouped-by-user
 audit-log-maxage
 audit-log-maxbackup
 audit-log-maxsize
 audit-log-path
+audit-policy-file
 audit-webhook-config-file
 audit-webhook-mode
 authentication-kubeconfig

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -380,7 +380,7 @@ func TestAudit(t *testing.T) {
 		},
 	} {
 		var buf bytes.Buffer
-		backend := pluginlog.NewBackend(&buf)
+		backend := pluginlog.NewBackend(&buf, "", 0, 0, 0, false)
 		policyChecker := policy.FakeChecker(auditinternal.LevelRequestResponse)
 		handler := WithAudit(http.HandlerFunc(test.handler), &fakeRequestContextMapper{
 			user: &user.DefaultInfo{Name: "admin"},

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["backend.go"],
     tags = ["automanaged"],
     deps = [
+        "//vendor/gopkg.in/natefinch/lumberjack.v2:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
@@ -20,23 +20,42 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
+
+	"gopkg.in/natefinch/lumberjack.v2"
 
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	"k8s.io/apiserver/pkg/audit"
 )
 
 type backend struct {
-	out  io.Writer
+	out           io.Writer
+	path          string
+	maxAge        int
+	maxBackups    int
+	maxSize       int
+	groupedByUser bool
+	writers       map[string]io.Writer
+	sync.Mutex
 	sink chan *auditinternal.Event
 }
 
 var _ audit.Backend = &backend{}
 
-func NewBackend(out io.Writer) *backend {
-	return &backend{
-		out:  out,
-		sink: make(chan *auditinternal.Event, 100),
+func NewBackend(out io.Writer, path string, maxAge, maxBackups, maxSize int, groupedByUser bool) *backend {
+	b := &backend{
+		path:          path,
+		maxAge:        maxAge,
+		maxBackups:    maxBackups,
+		maxSize:       maxSize,
+		groupedByUser: groupedByUser,
+		writers:       make(map[string]io.Writer),
+		sink:          make(chan *auditinternal.Event, 100),
 	}
+	if path == "-" || !groupedByUser {
+		b.out = out
+	}
+	return b
 }
 
 func (b *backend) ProcessEvents(events ...*auditinternal.Event) {
@@ -46,10 +65,34 @@ func (b *backend) ProcessEvents(events ...*auditinternal.Event) {
 }
 
 func (b *backend) logEvent(ev *auditinternal.Event) {
+	out := b.getWriter(ev.User.Username)
 	line := audit.EventString(ev)
-	if _, err := fmt.Fprintln(b.out, line); err != nil {
+	if _, err := fmt.Fprintln(out, line); err != nil {
 		audit.HandlePluginError("log", err, ev)
 	}
+}
+
+func (b *backend) getWriter(username string) (out io.Writer) {
+	if b.path == "-" || !b.groupedByUser {
+		return b.out
+	}
+
+	path := b.path + "-user-" + username
+	if out, ok := b.writers[path]; ok {
+		return out
+	}
+	b.Lock()
+	defer b.Unlock()
+	if out, ok := b.writers[path]; ok {
+		return out
+	}
+	b.writers[path] = &lumberjack.Logger{
+		Filename:   path,
+		MaxAge:     b.maxAge,
+		MaxBackups: b.maxBackups,
+		MaxSize:    b.maxSize,
+	}
+	return b.writers[path]
 }
 
 func (b *backend) Run(stopCh <-chan struct{}) error {


### PR DESCRIPTION
This change allows cluster administrator to split advanced audit into multi
files. Different users will be able to have their own audit file.
The use case of this change:
If a user wants to read his own access audit, the cluster adminstrator needs
the three steps:
1. split audit by username into different files in dir /var/log with
   --audit-log-path=/var/log/audit --audit-grouped-by-user=true
2. enable RBAC authorization mode
3. grant permissions to a users to read his own audit
   3.1 create a clusterrole to read jane's audit
        apiVersion: rbac.authorization.k8s.io/v1beta1
        kind: ClusterRole
        metadata:
          name: audit-reader-jane
        rules:
        - nonResourceURLs: ["/logs/audit-user-jane*"]
          verbs: ["get"]
   3.2 bind this cluster role to jane
        apiVersion: rbac.authorization.k8s.io/v1beta1
        kind: ClusterRoleBinding
        metadata:
          name: audit-reader-jane
        roleRef:
          apiGroup: rbac.authorization.k8s.io
          kind: ClusterRole
          name: audit-reader-jane
        subjects:
        - apiGroup: rbac.authorization.k8s.io
          kind: User
          name: jane

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add access control supporat to advanced audit, use --audit-grouped-by-user=true to split apiserver's audit into different files.
```
