### PR TITLE
Revert "Fix hardcoded CIDR in the validation_test"

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -7841,7 +7841,7 @@ func TestValidateServiceUpdate(t *testing.T) {
 				oldSvc.Spec.Type = api.ServiceTypeLoadBalancer
 				oldSvc.Spec.LoadBalancerSourceRanges = []string{"10.0.0.0/8"}
 				newSvc.Spec.Type = api.ServiceTypeLoadBalancer
-				newSvc.Spec.LoadBalancerSourceRanges = []string{"10.100.0.0/16"}
+				newSvc.Spec.LoadBalancerSourceRanges = []string{"10.180.0.0/16"}
 			},
 			numErrs: 0,
 		},

--- a/test/e2e_node/conformance/run_test.sh
+++ b/test/e2e_node/conformance/run_test.sh
@@ -150,7 +150,7 @@ allow_privileged=true
 serialize_image_pulls=false
 config_dir=`mktemp -d`
 file_check_frequency=10s
-pod_cidr=10.100.0.0/24
+pod_cidr=10.180.0.0/24
 log_level=4
 start_kubelet --api-servers $apiserver \
   --volume-stats-agg-period $volume_stats_agg_period \

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -137,12 +137,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--serialize-image-pulls", "false",
 		"--pod-manifest-path", manifestPath,
 		"--file-check-frequency", "10s", // Check file frequently so tests won't wait too long
-		// Assign a fixed CIDR to the node because there is no node controller.
-		//
-		// Note: this MUST be in sync with with the IP in
-		// - cluster/gce/config-test.sh and
-		// - test/e2e_node/conformance/run_test.sh.
-		"--pod-cidr", "10.100.0.0/24",
+		"--pod-cidr", "10.180.0.0/24", // Assign a fixed CIDR to the node because there is no node controller.
 		"--eviction-pressure-transition-period", "30s",
 		// Apply test framework feature gates by default. This could also be overridden
 		// by kubelet-flags.


### PR DESCRIPTION
Reverts kubernetes/kubernetes#47631

Together with https://github.com/kubernetes/kubernetes/pull/47735, it should address: https://github.com/kubernetes/kubernetes/issues/47379#issuecomment-309497289