### PR TITLE
Update custom-resources example in client-go

### DIFF
--- a/staging/src/k8s.io/client-go/examples/README.md
+++ b/staging/src/k8s.io/client-go/examples/README.md
@@ -20,9 +20,12 @@ for client-go.
 - [**Work queues**](./workqueue): Create a hotloop-free controller with the
   rate-limited workqueue and the [informer framework][informer].
 - [**Third-party resources (deprecated)**](./third-party-resources-deprecated):
+  Register a third-party resource type with the API, create/update/query this third-party
+  type, and write a controller that drives the cluster state based on the changes to
+  the third-party resources.
+- [**Custom Resource Definition (successor of TPR)**](https://git.k8s.io/apiextensions-apiserver/examples/client-go):
   Register a custom resource type with the API, create/update/query this custom
-  type, and write a controller drives the cluster state based on the changes to
+  type, and write a controller that drives the cluster state based on the changes to
   the custom resources.
 
 [informer]: https://godoc.org/k8s.io/client-go/tools/cache#NewInformer
-

--- a/staging/src/k8s.io/client-go/examples/custom-resources/README.md
+++ b/staging/src/k8s.io/client-go/examples/custom-resources/README.md
@@ -1,7 +1,0 @@
-# Custom Resource Example
-
-**Note:** CustomResourceDefinition is the successor of the deprecated ThirdPartyResource.
-
-For a client-go example using CustomResourceDefinitions, go to
-
-  [k8s.io/apiextensions-apiserver/examples/client-go](https://git.k8s.io/apiextensions-apiserver/examples/client-go).


### PR DESCRIPTION
- Update client-go examples `README.md` to point to the CustomResources example instead of the deprecated TPR one.
- Delete `staging/src/k8s.io/client-go/examples/custom-resources`. 

Fixing #47743.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @ahmetb @sttts 