### PR TITLE
Automated cherry pick of #47478

### DIFF
--- a/test/e2e/networking.go
+++ b/test/e2e/networking.go
@@ -56,11 +56,13 @@ var _ = framework.KubeDescribe("Networking", func() {
 			{path: "/healthz"},
 			{path: "/api"},
 			{path: "/apis"},
-			{path: "/logs"},
 			{path: "/metrics"},
 			{path: "/swaggerapi"},
 			{path: "/version"},
 			// TODO: test proxy links here
+		}
+		if !framework.ProviderIs("gke") {
+			tests = append(tests, struct{ path string }{path: "/logs"})
 		}
 		for _, test := range tests {
 			By(fmt.Sprintf("testing: %s", test.path))


### PR DESCRIPTION
Cherry pick of #47478 on release-1.6.

#47478: Don't test the debug /logs endpoint on GKE.

Fix https://github.com/kubernetes/kubernetes/issues/47755