### PR TITLE
Lower etcd compacted loglevel

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/compact.go
@@ -156,6 +156,6 @@ func compact(ctx context.Context, client *clientv3.Client, t, rev int64) (int64,
 	if _, err = client.Compact(ctx, rev); err != nil {
 		return curTime, curRev, err
 	}
-	glog.Infof("etcd: compacted rev (%d), endpoints (%v)", rev, client.Endpoints())
+	glog.V(4).Infof("etcd: compacted rev (%d), endpoints (%v)", rev, client.Endpoints())
 	return curTime, curRev, nil
 }


### PR DESCRIPTION
Fixes #47941

When we run apiserver, it will consistently produce logs like:

> I0620 15:27:44.627978    2765 compact.go:159] etcd: compacted rev (7825), endpoints ([http://127.0.0.1:2379])
I0620 15:32:44.632311    2765 compact.go:159] etcd: compacted rev (8193), endpoints ([http://127.0.0.1:2379])
I0620 15:37:44.643658    2765 compact.go:159] etcd: compacted rev (8552), endpoints ([http://127.0.0.1:2379])
...

which does not mean much overall, we may change the loglevel and lower the frequency.

**Release note**:
-->
```release-note
NONE
```
