### PR TITLE
add validate for advanced audit policy

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/BUILD
@@ -21,6 +21,7 @@ go_library(
     srcs = ["validation.go"],
     tags = ["automanaged"],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/validation/validation_test.go
@@ -32,7 +32,7 @@ func TestValidatePolicy(t *testing.T) {
 		}, { // Specific request
 			Level:      audit.LevelRequestResponse,
 			Verbs:      []string{"get"},
-			Resources:  []audit.GroupResources{{Resources: []string{"secrets"}}},
+			Resources:  []audit.GroupResources{{Group: "rbac.authorization.k8s.io", Resources: []string{"roles", "rolebindings"}}},
 			Namespaces: []string{"kube-system"},
 		}, { // Some non-resource URLs
 			Level:      audit.LevelMetadata,
@@ -41,6 +41,7 @@ func TestValidatePolicy(t *testing.T) {
 				"/logs*",
 				"/healthz*",
 				"/metrics",
+				"*",
 			},
 		},
 	}
@@ -73,6 +74,33 @@ func TestValidatePolicy(t *testing.T) {
 			Level:           audit.LevelMetadata,
 			Resources:       []audit.GroupResources{{Resources: []string{"secrets"}}},
 			NonResourceURLs: []string{"/logs*"},
+		}, { // invalid group name
+			Level:     audit.LevelMetadata,
+			Resources: []audit.GroupResources{{Group: "rbac.authorization.k8s.io/v1beta1", Resources: []string{"roles"}}},
+		}, { // invalid non-resource URLs
+			Level: audit.LevelMetadata,
+			NonResourceURLs: []string{
+				"logs",
+				"/healthz*",
+			},
+		}, { // empty non-resource URLs
+			Level: audit.LevelMetadata,
+			NonResourceURLs: []string{
+				"",
+				"/healthz*",
+			},
+		}, { // invalid non-resource URLs with multi "*"
+			Level: audit.LevelMetadata,
+			NonResourceURLs: []string{
+				"/logs/*/*",
+				"/metrics",
+			},
+		}, { // invalid non-resrouce URLs with "*" not in the end
+			Level: audit.LevelMetadata,
+			NonResourceURLs: []string{
+				"/logs/*.log",
+				"/metrics",
+			},
 		},
 	}
 	errorCases := []audit.Policy{}


### PR DESCRIPTION
This change checks group name and non-resrouce URLs format for audit
policy.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
add validate for advanced audit policy, kube-apiserver will do a stricter validation and will break existing users with invalid configs.
```
