### PR TITLE
Automated cherry pick of #47779

### DIFF
--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -30,8 +30,6 @@ spec:
         volumeMounts:
           - name: config
             mountPath: /etc/config
-      nodeSelector:
-        beta.kubernetes.io/masq-agent-ds-ready: "true"            
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
Cherry pick of #47779 on release-1.7.

#47779: Revert "Require a label to indicate ip-masq-agent readiness.