### PR TITLE
Fix rawextension decoding in update

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -862,7 +862,8 @@ func UpdateResource(r rest.Updater, scope RequestScope, typer runtime.ObjectType
 		defaultGVK := scope.Kind
 		original := r.New()
 		trace.Step("About to convert to expected version")
-		obj, gvk, err := scope.Serializer.DecoderToVersion(s.Serializer, defaultGVK.GroupVersion()).Decode(body, &defaultGVK, original)
+		decoder := scope.Serializer.DecoderToVersion(s.Serializer, schema.GroupVersion{Group: defaultGVK.Group, Version: runtime.APIVersionInternal})
+		obj, gvk, err := decoder.Decode(body, &defaultGVK, original)
 		if err != nil {
 			err = transformDecodeError(typer, err, original, gvk, body)
 			scope.err(err, w, req)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/47842

The `Create` handler was correctly decoding into the internal version, but the `Update` handler was not.

Top-level objects were not affected, because the type of the `New()` object returned by the rest handler governs the destination group/version/kind.

If a field within the object is of type `RawExtension`, and converts to a `runtime.Object` field in the internal object, the `runtime.Object` field provides no information about the desired group/version/kind, so the decoder's groupversioner governs.

This would manifest as the resthandler's Update function being given an internal top-level object with it's runtime.Object field containing an external object.