### PR TITLE
make fluentd liveness probe more flexible

### DIFF
--- a/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
@@ -63,15 +63,14 @@ spec:
         - >
           LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
           STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
-          if [ ! -e /var/log/fluentd-buffers ];
-          then
-            exit 1;
-          fi;
-          LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
+          LAST_MODIFIED_DATE=`stat /var/log/gcp-containers.log.pos | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
           LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
           if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
           then
-            rm -rf /var/log/fluentd-buffers;
+            if [ ! -e /var/log/fluentd-buffers ];
+            then
+              rm -rf /var/log/fluentd-buffers;
+            fi;
             exit 1;
           fi;
           if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ];

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -54,15 +54,14 @@ spec:
         - >
           LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
           STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
-          if [ ! -e /var/log/fluentd-buffers ];
-          then
-            exit 1;
-          fi;
-          LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
+          LAST_MODIFIED_DATE=`stat /var/log/gcp-containers.log.pos | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
           LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
           if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
           then
-            rm -rf /var/log/fluentd-buffers;
+            if [ ! -e /var/log/fluentd-buffers ];
+            then
+              rm -rf /var/log/fluentd-buffers;
+            fi;
             exit 1;
           fi;
           if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ];


### PR DESCRIPTION
It makes fluentd livenessprobe much more generic, if buffering to files is not used but in-memory instead it allows to use this liveness probe which is based on `gcp-containers.log.pos` which I think is changed most often because of the amount of logs from all containers on the node. I have removed first condition to be compatible with people which are not using file buffering.

Don't know what is the purpose of two differen `envs` as with default values the last condition will never occur even if we will set `LIVENESS_THRESHOLD_SECONDS` it will be barely possible, please correct me if I am wrong.

CC @roberthbailey @piosz @mwielgus @crassirostris 