### PR TITLE
Adding alpha feature gate to node statuses from local storage capacity isolation.

### DIFF
--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -37,7 +37,7 @@ func CapacityFromMachineInfo(info *cadvisorapi.MachineInfo) v1.ResourceList {
 
 func StorageScratchCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceList {
 	c := v1.ResourceList{
-		v1.ResourceStorage: *resource.NewQuantity(
+		v1.ResourceStorageScratch: *resource.NewQuantity(
 			int64(info.Capacity),
 			resource.BinarySI),
 	}

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -208,16 +208,14 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 				KubeProxyVersion:        version.Get().String(),
 			},
 			Capacity: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(2000, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(10E9, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(10E9, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 			Allocatable: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(1800, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(9900E6, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(1800, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(9900E6, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 			Addresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "127.0.0.1"},
@@ -363,16 +361,14 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 				},
 			},
 			Capacity: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(3000, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(20E9, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(3000, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(20E9, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 			Allocatable: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(2800, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(19900E6, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(2800, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(19900E6, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 		},
 	}
@@ -448,16 +444,14 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 				KubeProxyVersion:        version.Get().String(),
 			},
 			Capacity: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(2000, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(20E9, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(20E9, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 			Allocatable: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(1800, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(19900E6, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(1800, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(19900E6, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 			Addresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "127.0.0.1"},
@@ -661,9 +655,8 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 	kubelet.containerManager = &localCM{
 		ContainerManager: cm.NewStubContainerManager(),
 		allocatable: v1.ResourceList{
-			v1.ResourceCPU:     *resource.NewMilliQuantity(200, resource.DecimalSI),
-			v1.ResourceMemory:  *resource.NewQuantity(100E6, resource.BinarySI),
-			v1.ResourceStorage: *resource.NewQuantity(200*mb, resource.BinarySI),
+			v1.ResourceCPU:    *resource.NewMilliQuantity(200, resource.DecimalSI),
+			v1.ResourceMemory: *resource.NewQuantity(100E6, resource.BinarySI),
 		},
 	}
 
@@ -734,16 +727,14 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 				KubeProxyVersion:        version.Get().String(),
 			},
 			Capacity: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(2000, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(10E9, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(10E9, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 			Allocatable: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(1800, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(9900E6, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(300*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(1800, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(9900E6, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 			Addresses: []v1.NodeAddress{
 				{Type: v1.NodeInternalIP, Address: "127.0.0.1"},
@@ -1150,16 +1141,14 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 		Spec:       v1.NodeSpec{},
 		Status: v1.NodeStatus{
 			Capacity: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(2000, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(10E9, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(2000, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(10E9, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 			Allocatable: v1.ResourceList{
-				v1.ResourceCPU:     *resource.NewMilliQuantity(0, resource.DecimalSI),
-				v1.ResourceMemory:  *resource.NewQuantity(10E9, resource.BinarySI),
-				v1.ResourceStorage: *resource.NewQuantity(500*mb, resource.BinarySI),
-				v1.ResourcePods:    *resource.NewQuantity(0, resource.DecimalSI),
+				v1.ResourceCPU:    *resource.NewMilliQuantity(0, resource.DecimalSI),
+				v1.ResourceMemory: *resource.NewQuantity(10E9, resource.BinarySI),
+				v1.ResourcePods:   *resource.NewQuantity(0, resource.DecimalSI),
 			},
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: The Capacity.storage node attribute should not be exposed since it's part of an alpha feature. Added an feature gate.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47809 

There should be a test for new statuses in the alpha feature. Will include in a different PR.
