### PR TITLE
Separate serviceaccount and secret storage config

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -469,11 +469,20 @@ func BuildAuthenticator(s *options.ServerRunOptions, storageFactory serverstorag
 	if s.Authentication.ServiceAccounts.Lookup {
 		// we have to go direct to storage because the clientsets fail when they're initialized with some API versions excluded
 		// we should stop trying to control them like that.
-		storageConfig, err := storageFactory.NewConfig(api.Resource("serviceaccounts"))
+		storageConfigServiceAccounts, err := storageFactory.NewConfig(api.Resource("serviceaccounts"))
 		if err != nil {
 			return nil, nil, fmt.Errorf("unable to get serviceaccounts storage: %v", err)
 		}
-		authenticatorConfig.ServiceAccountTokenGetter = serviceaccountcontroller.NewGetterFromStorageInterface(storageConfig, storageFactory.ResourcePrefix(api.Resource("serviceaccounts")), storageFactory.ResourcePrefix(api.Resource("secrets")))
+		storageConfigSecrets, err := storageFactory.NewConfig(api.Resource("secrets"))
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to get secrets storage: %v", err)
+		}
+		authenticatorConfig.ServiceAccountTokenGetter = serviceaccountcontroller.NewGetterFromStorageInterface(
+			storageConfigServiceAccounts,
+			storageFactory.ResourcePrefix(api.Resource("serviceaccounts")),
+			storageConfigSecrets,
+			storageFactory.ResourcePrefix(api.Resource("secrets")),
+		)
 	}
 	if client == nil || reflect.ValueOf(client).IsNil() {
 		// TODO: Remove check once client can never be nil.

--- a/pkg/controller/serviceaccount/tokengetter.go
+++ b/pkg/controller/serviceaccount/tokengetter.go
@@ -85,9 +85,14 @@ func (r *registryGetter) GetSecret(namespace, name string) (*v1.Secret, error) {
 
 // NewGetterFromStorageInterface returns a ServiceAccountTokenGetter that
 // uses the specified storage to retrieve service accounts and secrets.
-func NewGetterFromStorageInterface(config *storagebackend.Config, saPrefix, secretPrefix string) serviceaccount.ServiceAccountTokenGetter {
-	saOpts := generic.RESTOptions{StorageConfig: config, Decorator: generic.UndecoratedStorage, ResourcePrefix: saPrefix}
-	secretOpts := generic.RESTOptions{StorageConfig: config, Decorator: generic.UndecoratedStorage, ResourcePrefix: secretPrefix}
+func NewGetterFromStorageInterface(
+	saConfig *storagebackend.Config,
+	saPrefix string,
+	secretConfig *storagebackend.Config,
+	secretPrefix string) serviceaccount.ServiceAccountTokenGetter {
+
+	saOpts := generic.RESTOptions{StorageConfig: saConfig, Decorator: generic.UndecoratedStorage, ResourcePrefix: saPrefix}
+	secretOpts := generic.RESTOptions{StorageConfig: secretConfig, Decorator: generic.UndecoratedStorage, ResourcePrefix: secretPrefix}
 	return NewGetterFromRegistries(
 		serviceaccountregistry.NewRegistry(serviceaccountstore.NewREST(saOpts)),
 		secret.NewRegistry(secretstore.NewREST(secretOpts)),


### PR DESCRIPTION
Fixes #47815, and is required in order to enable the secret encryption feature with a recommended configuration

This passes distinct storage options for serviceaccounts and secrets, since secrets can now have an encrypting transformer associated with them