### PR TITLE
If error continue for loop

### DIFF
--- a/pkg/kubelet/config/config.go
+++ b/pkg/kubelet/config/config.go
@@ -505,6 +505,7 @@ func (s *podStorage) MergedState() interface{} {
 			pod, err := api.Scheme.Copy(podRef)
 			if err != nil {
 				glog.Errorf("unable to copy pod: %v", err)
+				continue
 			}
 			pods = append(pods, pod.(*v1.Pod))
 		}
@@ -519,6 +520,7 @@ func copyPods(sourcePods []*v1.Pod) []*v1.Pod {
 		pod, err := api.Scheme.Copy(source)
 		if err != nil {
 			glog.Errorf("unable to copy pod: %v", err)
+			continue
 		}
 		pods = append(pods, pod.(*v1.Pod))
 	}


### PR DESCRIPTION
If err does not add continue, type conversion will be error.
If do not add continue, pod. (* V1.Pod) may cause panic to run.
**Release note**:
```release-note
NONE
```
