### PR TITLE
Use glog.*f when a format string is passed

### DIFF
--- a/federation/pkg/federatedtypes/scheduling.go
+++ b/federation/pkg/federatedtypes/scheduling.go
@@ -110,7 +110,7 @@ func (a *schedulingAdapter) GetSchedule(obj pkgruntime.Object, key string, clust
 
 	fedPref, err := replicapreferences.GetAllocationPreferences(obj, a.preferencesAnnotationName)
 	if err != nil {
-		glog.Info("Invalid workload-type specific preference, using default. object: %v, err: %v", obj, err)
+		glog.Infof("Invalid workload-type specific preference, using default. object: %v, err: %v", obj, err)
 	}
 	if fedPref == nil {
 		fedPref = &fedapi.ReplicaAllocationPreferences{

--- a/federation/pkg/kubefed/join.go
+++ b/federation/pkg/kubefed/join.go
@@ -209,7 +209,7 @@ func (j *joinFederation) Run(f cmdutil.Factory, cmdOut io.Writer, config util.Ad
 	glog.V(2).Info("Creating federation system namespace in joining cluster")
 	_, err = createFederationSystemNamespace(joiningClusterClientset, federationNamespace, federationName, joiningClusterName, dryRun)
 	if err != nil {
-		glog.V(2).Info("Error creating federation system namespace in joining cluster: %v", err)
+		glog.V(2).Infof("Error creating federation system namespace in joining cluster: %v", err)
 		return err
 	}
 	glog.V(2).Info("Created federation system namespace in joining cluster")
@@ -218,7 +218,7 @@ func (j *joinFederation) Run(f cmdutil.Factory, cmdOut io.Writer, config util.Ad
 	po.LoadingRules.ExplicitPath = kubeconfig
 	clientConfig, err := po.GetStartingConfig()
 	if err != nil {
-		glog.V(2).Info("Could not load clientConfig from %s: %v", kubeconfig, err)
+		glog.V(2).Infof("Could not load clientConfig from %s: %v", kubeconfig, err)
 		return err
 	}
 
@@ -662,7 +662,7 @@ func populateSecretInHostCluster(clusterClientset, hostClientset internalclients
 		return nil, err
 	}
 
-	glog.V(2).Info("Getting secret named: %s", sa.Secrets[0].Name)
+	glog.V(2).Infof("Getting secret named: %s", sa.Secrets[0].Name)
 	var secret *api.Secret
 	err = wait.PollImmediate(1*time.Second, serviceAccountSecretTimeout, func() (bool, error) {
 		var err error

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2201,7 +2201,7 @@ func (c *Cloud) addSecurityGroupIngress(securityGroupID string, addPermissions [
 	request.IpPermissions = changes
 	_, err = c.ec2.AuthorizeSecurityGroupIngress(request)
 	if err != nil {
-		glog.Warning("Error authorizing security group ingress %q", err)
+		glog.Warningf("Error authorizing security group ingress %q", err)
 		return false, fmt.Errorf("error authorizing security group ingress: %q", err)
 	}
 

--- a/pkg/cloudprovider/providers/gce/gce_routes.go
+++ b/pkg/cloudprovider/providers/gce/gce_routes.go
@@ -102,7 +102,7 @@ func (gce *GCECloud) CreateRoute(clusterName string, nameHint string, route *clo
 	}).Do()
 	if err != nil {
 		if isHTTPErrorCode(err, http.StatusConflict) {
-			glog.Info("Route %v already exists.")
+			glog.Infof("Route %v already exists.", routeName)
 			return nil
 		} else {
 			return mc.Observe(err)

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -187,7 +187,7 @@ func getVMIDbyIP(pc *PCCloud, IPAddress string) (string, error) {
 		} else {
 			task, err = photonClient.Tasks.Wait(task.ID)
 			if err != nil {
-				glog.Warning("Photon Cloud Provider: Wait task for GetNetworks failed for vm.ID %s, error [%v]", vm.ID, err)
+				glog.Warningf("Photon Cloud Provider: Wait task for GetNetworks failed for vm.ID %s, error [%v]", vm.ID, err)
 			} else {
 				networkConnections := task.ResourceProperties.(map[string]interface{})
 				networks := networkConnections["networkConnections"].([]interface{})
@@ -258,7 +258,7 @@ func getPhotonClient(pc *PCCloud) (*photon.Client, error) {
 		glog.Errorf("Photon Cloud Provider: new client creation failed. Error[%v]", err)
 		return nil, err
 	}
-	glog.V(2).Info("Photon Cloud Provider: Status of the new photon controller client: %v", status)
+	glog.V(2).Infof("Photon Cloud Provider: Status of the new photon controller client: %v", status)
 
 	return pc.photonClient, nil
 }

--- a/pkg/proxy/winuserspace/proxysocket.go
+++ b/pkg/proxy/winuserspace/proxysocket.go
@@ -281,7 +281,7 @@ func appendDNSSuffix(msg *dns.Msg, buffer []byte, length int, dnsSuffix string) 
 	msg.Question[0].Name = origName
 
 	if err != nil {
-		glog.Warning("Unable to pack DNS packet. Error is: %v", err)
+		glog.Warningf("Unable to pack DNS packet. Error is: %v", err)
 		return length, err
 	}
 
@@ -308,7 +308,7 @@ func recoverDNSQuestion(origName string, msg *dns.Msg, buffer []byte, length int
 	mbuf, err := msg.PackBuffer(buffer)
 
 	if err != nil {
-		glog.Warning("Unable to pack DNS packet. Error is: %v", err)
+		glog.Warningf("Unable to pack DNS packet. Error is: %v", err)
 		return length, err
 	}
 
@@ -419,7 +419,7 @@ func processDNSQueryPacket(
 	dnsSearch []string) (int, error) {
 	msg := &dns.Msg{}
 	if err := msg.Unpack(buffer[:length]); err != nil {
-		glog.Warning("Unable to unpack DNS packet. Error is: %v", err)
+		glog.Warningf("Unable to unpack DNS packet. Error is: %v", err)
 		return length, err
 	}
 
@@ -466,7 +466,7 @@ func processDNSResponsePacket(
 	var drop bool
 	msg := &dns.Msg{}
 	if err := msg.Unpack(buffer[:length]); err != nil {
-		glog.Warning("Unable to unpack DNS packet. Error is: %v", err)
+		glog.Warningf("Unable to unpack DNS packet. Error is: %v", err)
 		return drop, length, err
 	}
 

--- a/plugin/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/metadata.go
@@ -53,7 +53,7 @@ func (pfactory *PredicateMetadataFactory) GetMetadata(pod *v1.Pod, nodeNameToInf
 		matchingAntiAffinityTerms: matchingTerms,
 	}
 	for predicateName, precomputeFunc := range predicatePrecomputations {
-		glog.V(10).Info("Precompute: %v", predicateName)
+		glog.V(10).Infof("Precompute: %v", predicateName)
 		precomputeFunc(predicateMetadata)
 	}
 	return predicateMetadata

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -156,7 +156,7 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 			}
 			elements, err := fn(updated)
 			if err != nil {
-				glog.V(4).Info("Unable to calculate an index entry for mutation cache entry %s: %v", key, err)
+				glog.V(4).Infof("Unable to calculate an index entry for mutation cache entry %s: %v", key, err)
 				continue
 			}
 			for _, inIndex := range elements {

--- a/test/e2e_node/services/internal_services.go
+++ b/test/e2e_node/services/internal_services.go
@@ -94,7 +94,7 @@ func (es *e2eServices) stop() {
 	}
 
 	for _, d := range es.rmDirs {
-		glog.Info("Deleting directory %v", d)
+		glog.Infof("Deleting directory %v", d)
 		err := os.RemoveAll(d)
 		if err != nil {
 			glog.Errorf("Failed to delete directory %s.\n%v", d, err)


### PR DESCRIPTION
ref:
https://godoc.org/github.com/golang/glog

I use the following commands to search all the invalid usage:
$ grep "glog.Warning(" * -r | grep %
$ grep "glog.Info(" * -r | grep %
$ grep "glog.Error(" * -r | grep %
$ grep ").Info(" * -r | grep % | grep glog.V(

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
