### PR TITLE
make fluentd liveness probe more generic

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -57,7 +57,8 @@ spec:
             - >
               LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
               STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
-              LAST_MODIFIED_DATE=`stat /var/log/es-containers.log.pos | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
+              POS_FILE=${POS_FILE:-/var/log/es-containers.log.pos}
+              LAST_MODIFIED_DATE=`stat ${POS_FILE} | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
               LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
               if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
               then

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -40,6 +40,37 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        # Liveness probe is aimed to help in situarions where fluentd
+        # silently hangs for no apparent reasons until manual restart.
+        # The idea of this probe is that if fluentd is not queueing or
+        # flushing chunks for 5 minutes, something is not right. If
+        # you want to change the fluentd configuration, reducing amount of
+        # logs fluentd collects, consider changing the threshold or turning
+        # liveness probe off completely.
+        livenessProbe:
+          initialDelaySeconds: 600
+          periodSeconds: 60
+          exec:
+            command:
+            - '/bin/sh'
+            - '-c'
+            - >
+              LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
+              STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
+              LAST_MODIFIED_DATE=`stat /var/log/es-containers.log.pos | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
+              LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
+              if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
+              then
+                if [ ! -e /var/log/fluentd-buffers ];
+                then
+                  rm -rf /var/log/fluentd-buffers;
+                fi;
+                exit 1;
+              fi;
+              if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ];
+              then
+                exit 1;
+              fi;
       nodeSelector:
         beta.kubernetes.io/fluentd-ds-ready: "true"
       terminationGracePeriodSeconds: 30

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -74,15 +74,15 @@ spec:
             - >
               LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
               STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
-              if [ ! -e /var/log/fluentd-buffers ];
-              then
-                exit 1;
-              fi;
-              LAST_MODIFIED_DATE=`stat /var/log/fluentd-buffers | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
+              POS_FILE=${POS_FILE:-/var/log/gcp-containers.log.pos}
+              LAST_MODIFIED_DATE=`stat /var/log/${POS_FILE} | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
               LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
               if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
               then
-                rm -rf /var/log/fluentd-buffers;
+                if [ ! -e /var/log/fluentd-buffers ];
+                then
+                  rm -rf /var/log/fluentd-buffers;
+                fi;
                 exit 1;
               fi;
               if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $LIVENESS_THRESHOLD_SECONDS` ];

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -75,7 +75,7 @@ spec:
               LIVENESS_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-300};
               STUCK_THRESHOLD_SECONDS=${LIVENESS_THRESHOLD_SECONDS:-900};
               POS_FILE=${POS_FILE:-/var/log/gcp-containers.log.pos}
-              LAST_MODIFIED_DATE=`stat /var/log/${POS_FILE} | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
+              LAST_MODIFIED_DATE=`stat ${POS_FILE} | grep Modify | sed -r "s/Modify: (.*)/\1/"`;
               LAST_MODIFIED_TIMESTAMP=`date -d "$LAST_MODIFIED_DATE" +%s`;
               if [ `date +%s` -gt `expr $LAST_MODIFIED_TIMESTAMP + $STUCK_THRESHOLD_SECONDS` ];
               then


### PR DESCRIPTION
It makes fluentd livenessprobe much more generic, if buffering to files is not used but in-memory instead it allows to use this liveness probe which is based on gcp-containers.log.pos which I think is changed most often because of the amount of logs from all containers on the node. I have removed first condition to be compatible with people which are not using file buffering.

Don't know what is the purpose of two differen envs as with default values the last condition will never occur even if we will set LIVENESS_THRESHOLD_SECONDS it will be barely possible, please correct me if I am wrong.

I have added extra `env` variable `POS_FILE` which allows to set specific `.pos` file or even overwrite it with buffer file like `/var/log/fluentd-buffers` if anyone like.

CC @piosz @crassirostris