### PR TITLE
jsonpath filter: allow intermediate missing keys

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -455,7 +455,10 @@ func (j *JSONPath) evalFilter(input []reflect.Value, node *FilterNode) ([]reflec
 			}
 
 			var left, right interface{}
-			if len(lefts) != 1 {
+			switch {
+			case len(lefts) == 0:
+				continue
+			case len(lefts) > 1:
 				return input, fmt.Errorf("can only compare one element at a time")
 			}
 			left = lefts[0].Interface()
@@ -464,7 +467,10 @@ func (j *JSONPath) evalFilter(input []reflect.Value, node *FilterNode) ([]reflec
 			if err != nil {
 				return input, err
 			}
-			if len(rights) != 1 {
+			switch {
+			case len(rights) == 0:
+				continue
+			case len(rights) > 1:
 				return input, fmt.Errorf("can only compare one element at a time")
 			}
 			right = rights[0].Interface()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
In jsonpath, when filtering a list, if allowMissingKeys is true, skip
over any items that are missing an intermediate key in the filter,
instead of returning a confusing error.

For example, if the filter is

{.items[?(@.metadata.annotations.foo=="bar")].metadata.name}

we should return all items where metadata.annotations.foo == bar, but if
an item in the list does not have metadata, metadata.annotations, or
metadata.annotations.foo, skip it instead of erroring.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #45546 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed a bug where a jsonpath filter would return an error if one of the items being evaluated did not contain all of the nested elements in the filter query.
```

cc @timothysc @smarterclayton @stevekuznetsov @mengqiy @liggitt @kubernetes/sig-api-machinery-pr-reviews 