### PR TITLE
Insert Cynerva and Kjackal to approvers list

### DIFF
--- a/cluster/juju/OWNERS
+++ b/cluster/juju/OWNERS
@@ -3,6 +3,8 @@ approvers:
 - chuckbutler
 - marcoceppi
 - mbruzek
+- Cynerva
+- ktsakalozos
 reviewers:
 - chuckbutler
 - marcoceppi
@@ -15,3 +17,5 @@ reviewers:
 - Cynerva
 - wwwtyro
 - tvansteenburgh
+- ktsakalozos
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Per the membership reviews, we're looking to promote Konstantinos and
George to approvers to help distribute the review/bug load for the `cluster/juju` code
tree.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:
cc @marcoceppi and @tvansteenburgh 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
