### PR TITLE
dockershim: checkpoint HostNetwork property

### DIFF
--- a/pkg/kubelet/dockershim/docker_checkpoint.go
+++ b/pkg/kubelet/dockershim/docker_checkpoint.go
@@ -50,6 +50,7 @@ type PortMapping struct {
 // CheckpointData contains all types of data that can be stored in the checkpoint.
 type CheckpointData struct {
 	PortMappings []*PortMapping `json:"port_mappings,omitempty"`
+	HostNetwork  bool           `json:"host_network,omitempty"`
 }
 
 // PodSandboxCheckpoint is the checkpoint structure for a sandbox

--- a/pkg/kubelet/dockershim/docker_checkpoint_test.go
+++ b/pkg/kubelet/dockershim/docker_checkpoint_test.go
@@ -48,18 +48,22 @@ func TestPersistentCheckpointHandler(t *testing.T) {
 			&port443,
 		},
 	}
+	checkpoint1.Data.HostNetwork = true
 
 	checkpoints := []struct {
-		podSandboxID string
-		checkpoint   *PodSandboxCheckpoint
+		podSandboxID      string
+		checkpoint        *PodSandboxCheckpoint
+		expectHostNetwork bool
 	}{
 		{
 			"id1",
 			checkpoint1,
+			true,
 		},
 		{
 			"id2",
 			NewPodSandboxCheckpoint("ns2", "sandbox2"),
+			false,
 		},
 	}
 
@@ -72,6 +76,7 @@ func TestPersistentCheckpointHandler(t *testing.T) {
 		checkpoint, err := handler.GetCheckpoint(tc.podSandboxID)
 		assert.NoError(t, err)
 		assert.Equal(t, *checkpoint, *tc.checkpoint)
+		assert.Equal(t, checkpoint.Data.HostNetwork, tc.expectHostNetwork)
 	}
 	// Test ListCheckpoints
 	keys, err := handler.ListCheckpoints()


### PR DESCRIPTION
To ensure kubelet doesn't attempt network teardown on HostNetwork
containers that no longer exist but are still checkpointed, make
sure we preserve the HostNetwork property in checkpoints.  If
the checkpoint indicates the container was a HostNetwork one,
don't tear down the network since that would fail anyway.

Related: https://github.com/kubernetes/kubernetes/issues/44307#issuecomment-299548609

@freehan @kubernetes/sig-network-misc 