### PR TITLE
Create e2e test of cluster autoscaler working with pod anti-affinity

### DIFF
--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -111,6 +111,7 @@ type RunObjectConfig interface {
 }
 
 type RCConfig struct {
+	Affinity       *v1.Affinity
 	Client         clientset.Interface
 	InternalClient internalclientset.Interface
 	Image          string
@@ -519,6 +520,7 @@ func (config *RCConfig) create() error {
 					Labels: map[string]string{"name": config.Name},
 				},
 				Spec: v1.PodSpec{
+					Affinity: config.Affinity,
 					Containers: []v1.Container{
 						{
 							Name:           config.Name,


### PR DESCRIPTION
Test to verify cluster is scaled up when there are pending pods that cannot be scheduled due to anti-affinity, issue: kubernetes/autoscaler#30