### PR TITLE
bump the gke-cert-controller wokers to match it's qps

### DIFF
--- a/cmd/gke-certificates-controller/app/gke_certificates_controller.go
+++ b/cmd/gke-certificates-controller/app/gke_certificates_controller.go
@@ -87,6 +87,6 @@ func Run(s *GKECertificatesController) error {
 	}
 
 	sharedInformers.Start(nil)
-	controller.Run(1, nil) // runs forever
-	return nil
+	controller.Run(5, nil) // runs forever
+	panic("unreachable")
 }


### PR DESCRIPTION
This increases Issuance per second from 2.5 csrs to 5 csrs which is the theoretical limit with the current client side rate limiting.

Issue https://github.com/kubernetes/kubernetes/issues/47855