### PR TITLE
Add fluentd.log to the list of rotated files in salt-based deployments

### DIFF
--- a/cluster/saltbase/salt/logrotate/init.sls
+++ b/cluster/saltbase/salt/logrotate/init.sls
@@ -2,7 +2,7 @@ logrotate:
   pkg:
     - installed
 
-{% set logrotate_files = ['kube-scheduler', 'kube-proxy', 'kubelet', 'kube-apiserver', 'kube-apiserver-audit', 'kube-controller-manager', 'kube-addons', 'docker'] %}
+{% set logrotate_files = ['kube-scheduler', 'kube-proxy', 'kubelet', 'kube-apiserver', 'kube-apiserver-audit', 'kube-controller-manager', 'kube-addons', 'docker', 'fluentd'] %}
 {% for file in logrotate_files %}
 /etc/logrotate.d/{{ file }}:
   file:


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/43772

/cc @piosz 