### PR TITLE
Make fluentd log to stdio instead of a dedicated file

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -27,7 +27,10 @@ spec:
         command:
           - '/bin/sh'
           - '-c'
-          - '/usr/sbin/td-agent 2>&1 >> /var/log/fluentd.log'
+          - '/usr/sbin/td-agent $FLUENTD_ARGS'
+        env:
+        - name: FLUENTD_AGRS
+          value: -q
         resources:
           limits:
             memory: 200Mi

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -36,10 +36,10 @@ spec:
         command:
           - '/bin/sh'
           - '-c'
-          - '/run.sh $FLUENTD_ARGS 2>&1 >>/var/log/fluentd.log'
+          - '/run.sh $FLUENTD_ARGS'
         env:
         - name: FLUENTD_ARGS
-          value: --no-supervisor
+          value: --no-supervisor -q
         resources:
           limits:
             memory: 300Mi


### PR DESCRIPTION
Lower verbosity also, to reduce volume of system logs exported to the backend.

Fix https://github.com/kubernetes/kubernetes/issues/43772

/cc @piosz