### PR TITLE
Update addons with upstream CVE fixes

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -62,7 +62,7 @@ http_file(
 
 docker_pull(
     name = "debian-iptables-amd64",
-    digest = "sha256:bfc7cc030258f53495b5dacf1e1d750db9b8687577a8648a3c8e245f8d7d2c52",  # v7
+    digest = "sha256:bc20977ac38abfb43071b4c61c4b7edb30af894c05eb06758dd61d05118d2842",  # v7
     registry = "gcr.io",
     repository = "google-containers/debian-iptables-amd64",
 )

--- a/cluster/addons/dns/kubedns-controller.yaml.base
+++ b/cluster/addons/dns/kubedns-controller.yaml.base
@@ -55,7 +55,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.3
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -106,7 +106,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.3
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -144,7 +144,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.3
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kubedns-controller.yaml.in
+++ b/cluster/addons/dns/kubedns-controller.yaml.in
@@ -55,7 +55,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.3
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -106,7 +106,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.3
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -144,7 +144,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.3
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kubedns-controller.yaml.sed
+++ b/cluster/addons/dns/kubedns-controller.yaml.sed
@@ -55,7 +55,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.3
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -106,7 +106,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.3
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -144,7 +144,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.2
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.3
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -46,11 +46,11 @@ spec:
       containers:
       # TODO: Add resources in 1.8
       - name: event-exporter
-        image: gcr.io/google-containers/event-exporter:v0.1.0
+        image: gcr.io/google-containers/event-exporter:v0.1.0-r2
         command:
         - '/event-exporter'
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.1.2
+        image: gcr.io/google-containers/prometheus-to-sd:v0.1.2-r2
         command:
           - /monitor
           - --component=event_exporter

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.5
+        image: gcr.io/google-containers/fluentd-gcp:2.0.7
         # If fluentd consumes its own logs, the following situation may happen:
         # fluentd fails to send a chunk to the server => writes it to the log =>
         # tries to send this message to the server => fails to send a chunk and so on.

--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -17,7 +17,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: gcr.io/google-containers/ip-masq-agent-amd64:v2.0.1
+        image: gcr.io/google-containers/ip-masq-agent-amd64:v2.0.2
         resources:
           limits:
             cpu: 100m

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: metadata-proxy
-        image: gcr.io/google-containers/metadata-proxy:0.1.1
+        image: gcr.io/google-containers/metadata-proxy:0.1.2
         imagePullPolicy: Always
         securityContext:
           privileged: true

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -96,7 +96,7 @@ spec:
           path: /run/xtables.lock
 `
 
-	KubeDNSVersion = "1.14.2"
+	KubeDNSVersion = "1.14.3"
 
 	KubeDNSDeployment = `
 


### PR DESCRIPTION
**What this PR does / why we need it**: refreshes the kube-dns, metadata-proxy, and fluentd-gcp, event-exporter, prometheus-to-sd, and ip-masq-agent addons with new base images containing fixes for the following vulnerabilities:
* CVE-2016-4448
* CVE-2016-9841
* CVE-2016-9843
* CVE-2017-1000366
* CVE-2017-2616
* CVE-2017-9526

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47386 (yay!)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update kube-dns, metadata-proxy, and fluentd-gcp, event-exporter, prometheus-to-sd, and ip-masq-agent addons with new base images containing fixes for CVE-2016-4448, CVE-2016-9841, CVE-2016-9843,  CVE-2017-1000366, CVE-2017-2616, and CVE-2017-9526.
```
/assign @bowei @MrHohn @Q-Lee @crassirostris @dnardo 
/cc @dchen1107 @timstclair 