### PR TITLE
Bump Cluster Autoscaler to 0.6.0-beta1

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.0-alpha2",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.0-beta1",
                 "command": [
                     "./run.sh",
                     "--kubernetes=http://127.0.0.1:8080?inClusterConfig=f",


### PR DESCRIPTION
This is a part of the release process of CA 0.6 with K8S 1.7. This version fixes bugs spotted in CA 0.6.0-alpha2.