### PR TITLE
Remove e2e test for least requested prioirty function

### DIFF
--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -84,29 +84,6 @@ var _ = framework.KubeDescribe("SchedulerPriorities [Serial]", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("Pods should be scheduled to low resource use rate node", func() {
-		//Make sure all the schedulable nodes are balanced (have the same cpu/mem usage ratio)
-		By("Create pods on each node except the last one to raise cpu and memory usage to the same high level")
-		var expectedNodeName string
-		expectedNodeName = nodeList.Items[len(nodeList.Items)-1].Name
-		nodes := nodeList.Items[:len(nodeList.Items)-1]
-		// make the nodes except last have cpu,mem usage to 90%
-		createBalancedPodForNodes(f, cs, ns, nodes, podRequestedResource, 0.9)
-		By("Create a pod,pod should schedule to the least requested nodes")
-		createPausePod(f, pausePodConfig{
-			Name:      "priority-least-requested",
-			Labels:    map[string]string{"name": "priority-least-requested"},
-			Resources: podRequestedResource,
-		})
-		By("Wait for all the pods are running")
-		err := f.WaitForPodRunning("priority-least-requested")
-		framework.ExpectNoError(err)
-		By("Verify the pod is scheduled to the expected node")
-		testPod, err := cs.CoreV1().Pods(ns).Get("priority-least-requested", metav1.GetOptions{})
-		framework.ExpectNoError(err)
-		Expect(testPod.Spec.NodeName).Should(Equal(expectedNodeName))
-	})
-
 	It("Pods created by ReplicationController should spread to different node", func() {
 		By("Create a pod for each node to make the nodes have almost same cpu/mem usage ratio")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Deletes a flaky e2e test for "least requested" priority function of the scheduler. This priority function is tested more extensively in our unit tests.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47769 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
