### PR TITLE
Local storage capacity isolation: replacing relevant instances of ResourceStorage attribute with ResourceStorageScratch.

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -728,7 +728,7 @@ func makeSignalObservations(summaryProvider stats.SummaryProvider, nodeProvider 
 		}
 	}
 
-	if storageScratchAllocatableCapacity, ok := node.Status.Allocatable[v1.ResourceStorage]; ok {
+	if storageScratchAllocatableCapacity, ok := node.Status.Allocatable[v1.ResourceStorageScratch]; ok {
 		storageScratchAllocatable := storageScratchAllocatableCapacity.Copy()
 		for _, pod := range pods {
 			podStat, ok := statsFunc(pod)

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -80,24 +80,24 @@ var (
 func makeResources(milliCPU, memory, nvidiaGPUs, pods, opaqueA, storage int64) v1.NodeResources {
 	return v1.NodeResources{
 		Capacity: v1.ResourceList{
-			v1.ResourceCPU:       *resource.NewMilliQuantity(milliCPU, resource.DecimalSI),
-			v1.ResourceMemory:    *resource.NewQuantity(memory, resource.BinarySI),
-			v1.ResourcePods:      *resource.NewQuantity(pods, resource.DecimalSI),
-			v1.ResourceNvidiaGPU: *resource.NewQuantity(nvidiaGPUs, resource.DecimalSI),
-			opaqueResourceA:      *resource.NewQuantity(opaqueA, resource.DecimalSI),
-			v1.ResourceStorage:   *resource.NewQuantity(storage, resource.BinarySI),
+			v1.ResourceCPU:            *resource.NewMilliQuantity(milliCPU, resource.DecimalSI),
+			v1.ResourceMemory:         *resource.NewQuantity(memory, resource.BinarySI),
+			v1.ResourcePods:           *resource.NewQuantity(pods, resource.DecimalSI),
+			v1.ResourceNvidiaGPU:      *resource.NewQuantity(nvidiaGPUs, resource.DecimalSI),
+			opaqueResourceA:           *resource.NewQuantity(opaqueA, resource.DecimalSI),
+			v1.ResourceStorageScratch: *resource.NewQuantity(storage, resource.BinarySI),
 		},
 	}
 }
 
 func makeAllocatableResources(milliCPU, memory, nvidiaGPUs, pods, opaqueA, storage int64) v1.ResourceList {
 	return v1.ResourceList{
-		v1.ResourceCPU:       *resource.NewMilliQuantity(milliCPU, resource.DecimalSI),
-		v1.ResourceMemory:    *resource.NewQuantity(memory, resource.BinarySI),
-		v1.ResourcePods:      *resource.NewQuantity(pods, resource.DecimalSI),
-		v1.ResourceNvidiaGPU: *resource.NewQuantity(nvidiaGPUs, resource.DecimalSI),
-		opaqueResourceA:      *resource.NewQuantity(opaqueA, resource.DecimalSI),
-		v1.ResourceStorage:   *resource.NewQuantity(storage, resource.BinarySI),
+		v1.ResourceCPU:            *resource.NewMilliQuantity(milliCPU, resource.DecimalSI),
+		v1.ResourceMemory:         *resource.NewQuantity(memory, resource.BinarySI),
+		v1.ResourcePods:           *resource.NewQuantity(pods, resource.DecimalSI),
+		v1.ResourceNvidiaGPU:      *resource.NewQuantity(nvidiaGPUs, resource.DecimalSI),
+		opaqueResourceA:           *resource.NewQuantity(opaqueA, resource.DecimalSI),
+		v1.ResourceStorageScratch: *resource.NewQuantity(storage, resource.BinarySI),
 	}
 }
 

--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -97,7 +97,7 @@ func (r *Resource) Add(rl v1.ResourceList) {
 			r.NvidiaGPU += rQuant.Value()
 		case v1.ResourcePods:
 			r.AllowedPodNumber += int(rQuant.Value())
-		case v1.ResourceStorage:
+		case v1.ResourceStorageScratch:
 			r.StorageScratch += rQuant.Value()
 		case v1.ResourceStorageOverlay:
 			r.StorageOverlay += rQuant.Value()
@@ -116,7 +116,7 @@ func (r *Resource) ResourceList() v1.ResourceList {
 		v1.ResourceNvidiaGPU:      *resource.NewQuantity(r.NvidiaGPU, resource.DecimalSI),
 		v1.ResourcePods:           *resource.NewQuantity(int64(r.AllowedPodNumber), resource.BinarySI),
 		v1.ResourceStorageOverlay: *resource.NewQuantity(r.StorageOverlay, resource.BinarySI),
-		v1.ResourceStorage:        *resource.NewQuantity(r.StorageScratch, resource.BinarySI),
+		v1.ResourceStorageScratch: *resource.NewQuantity(r.StorageScratch, resource.BinarySI),
 	}
 	for rName, rQuant := range r.OpaqueIntResources {
 		result[rName] = *resource.NewQuantity(rQuant, resource.DecimalSI)

--- a/test/e2e_node/local_storage_allocatable_eviction_test.go
+++ b/test/e2e_node/local_storage_allocatable_eviction_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = framework.KubeDescribe("LocalStorageAllocatableEviction [Slow] [Serial] [Disruptive] [Flaky]", func() {
 	f := framework.NewDefaultFramework("localstorageallocatable-eviction-test")
-	evictionTestTimeout := 15 * time.Minute
+	evictionTestTimeout := 25 * time.Minute
 	testCondition := "Evict pod due to local storage allocatable violation"
 	conditionType := v1.NodeDiskPressure
 	var podTestSpecs []podTestSpec


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This is a continuation of PR #47819 . The previous PR replaced several instances of the ResourceStorage attribute with ResourceStorageScratch, but some replacements were missed and they could potentially cause a problem. The replacements are added here.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47809 

**Special notes for your reviewer**: Verified with the pod eviction e2e test. Increasing the test's timeout to 25min because I've had runs with ~19min. @vishh could you confirm these replacements are necessary?
