### PR TITLE
fix systemd service file for custom args.

### DIFF
--- a/cluster/centos/master/scripts/scheduler.sh
+++ b/cluster/centos/master/scripts/scheduler.sh
@@ -41,7 +41,7 @@ KUBE_SCHEDULER_OPTS="   \${KUBE_LOGTOSTDERR}     \\
                         \${KUBE_LOG_LEVEL}       \\
                         \${KUBE_MASTER}          \\
                         \${KUBE_LEADER_ELECT}    \\
-                        \${KUBE_SCHEDULER_ARGS}"
+                        \$KUBE_SCHEDULER_ARGS"
 
 cat <<EOF >/usr/lib/systemd/system/kube-scheduler.service
 [Unit]

--- a/cluster/centos/node/scripts/kubelet.sh
+++ b/cluster/centos/node/scripts/kubelet.sh
@@ -61,7 +61,7 @@ KUBE_PROXY_OPTS="   \${KUBE_LOGTOSTDERR}     \\
                     \${KUBE_ALLOW_PRIV}      \\
                     \${KUBELET__DNS_IP}      \\
                     \${KUBELET_DNS_DOMAIN}      \\
-                    \${KUBELET_ARGS}"
+                    \$KUBELET_ARGS"
 
 cat <<EOF >/usr/lib/systemd/system/kubelet.service
 [Unit]


### PR DESCRIPTION
`KUBE_SCHEDULER_ARGS` and `KUBELET_ARGS` are used to custom args for scheduler or kubelet by users. 
But if there are more than one params in `KUBELET_ARGS`, for example, if I set  KUBELET_ARGS="--cgroups-per-qos=false --enforce-node-allocatable=", the kubelet will judge the `false --enforce-node-allocatable=` as the value of `cgroups-per-qos`.  Because `${KUBELET_ARGS}` in kubelet.service will expands the variable into one word. And if I take `$KUBELET_ARGS` instead, kubelet will worker perfectly.
For more info, please click [EnvironmentFiles and support for /etc/sysconfig files](http://fedoraproject.org/wiki/Packaging:Systemd#EnvironmentFiles_and_support_for_.2Fetc.2Fsysconfig_files). This bug is reported by @huanxingyouyoutoo. And I make this PR for her to fix it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```