### PR TITLE
Reduce Cluster Autoscaler cpu request to 10m

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -43,7 +43,7 @@
                 # TODO: Make resource requirements depend on the size of the cluster
                 "resources": {
                     "requests": {
-                        "cpu": "20m",
+                        "cpu": "10m",
                         "memory": "300Mi"
                     }
                 },


### PR DESCRIPTION
We are super tight on 1 cpu master node. With the recent changes we cannot fit to the master if request is bigger than 10m. 

cc: @gmarek @MaciekPytel @aleksandra-malinowska 