### PR TITLE
Reduce scheduler CPU request to 75m

### DIFF
--- a/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
+++ b/cluster/saltbase/salt/kube-scheduler/kube-scheduler.manifest
@@ -45,7 +45,7 @@
     "image": "{{pillar['kube_docker_registry']}}/kube-scheduler:{{pillar['kube-scheduler_docker_tag']}}",
     "resources": {
       "requests": {
-        "cpu": "100m"
+        "cpu": "75m"
       }
     },
     "command": [


### PR DESCRIPTION
On a 1 cpu master we are over budget with CPU requests. Components like npd or cluster autoscaler don't have *any* space to run. We need to reduce some requests.

cc: @gmarek @mikedanese @roberthbailey @davidopp @dchen1107 