### PR TITLE
Don't audit log tokens in TokenReviews

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -568,12 +568,14 @@ rules:
       - group: "" # core
         resources: ["events"]
 
-  # Secrets & ConfigMaps can contain sensitive & binary data,
+  # Secrets, ConfigMaps, and TokenReviews can contain sensitive & binary data,
   # so only log at the Metadata level.
   - level: Metadata
     resources:
       - group: "" # core
         resources: ["secrets", "configmaps"]
+      - group: authentication.k8s.io
+        resources: ["tokenreviews"]
   # Get repsonses can be large; skip them.
   - level: Request
     verbs: ["get", "list", "watch"]


### PR DESCRIPTION
We don't want to leak auth tokens in the audit logs, so only log TokenReview requests at the metadata level.

Issue: kubernetes/features#22